### PR TITLE
Standardize AWS Glue naming

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -17,13 +17,14 @@
 # under the License.
 
 import time
+import warnings
 from typing import Dict, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
-class AwsGlueJobHook(AwsBaseHook):
+class GlueJobHook(AwsBaseHook):
     """
     Interact with AWS Glue - create job, trigger, crawler
 
@@ -222,3 +223,19 @@ class AwsGlueJobHook(AwsBaseHook):
             except Exception as general_error:
                 self.log.error("Failed to create aws glue job, error: %s", general_error)
                 raise
+
+
+class AwsGlueJobHook(GlueJobHook):
+    """
+    This hook is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.hooks.glue.GlueJobHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This hook is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.hooks.glue.GlueJobHook`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/hooks/glue_catalog.py
+++ b/airflow/providers/amazon/aws/hooks/glue_catalog.py
@@ -17,12 +17,13 @@
 # under the License.
 
 """This module contains AWS Glue Catalog Hook"""
+import warnings
 from typing import Optional, Set
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
-class AwsGlueCatalogHook(AwsBaseHook):
+class GlueCatalogHook(AwsBaseHook):
     """
     Interact with AWS Glue Catalog
 
@@ -93,7 +94,7 @@ class AwsGlueCatalogHook(AwsBaseHook):
         :type expression: str
         :rtype: bool
 
-        >>> hook = AwsGlueCatalogHook()
+        >>> hook = GlueCatalogHook()
         >>> t = 'static_babynames_partitioned'
         >>> hook.check_for_partition('airflow', t, "ds='2015-01-01'")
         True
@@ -112,7 +113,7 @@ class AwsGlueCatalogHook(AwsBaseHook):
         :type table_name: str
         :rtype: dict
 
-        >>> hook = AwsGlueCatalogHook()
+        >>> hook = GlueCatalogHook()
         >>> r = hook.get_table('db', 'table_foo')
         >>> r['Name'] = 'table_foo'
         """
@@ -133,3 +134,19 @@ class AwsGlueCatalogHook(AwsBaseHook):
         table = self.get_table(database_name, table_name)
 
         return table['StorageDescriptor']['Location']
+
+
+class AwsGlueCatalogHook(GlueCatalogHook):
+    """
+    This hook is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.hooks.glue_catalog.GlueCatalogHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This hook is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.hooks.glue_catalog.GlueCatalogHook`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/hooks/glue_crawler.py
+++ b/airflow/providers/amazon/aws/hooks/glue_crawler.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import sys
+import warnings
 from time import sleep
 
 if sys.version_info >= (3, 8):
@@ -27,7 +28,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
-class AwsGlueCrawlerHook(AwsBaseHook):
+class GlueCrawlerHook(AwsBaseHook):
     """
     Interacts with AWS Glue Crawler.
 
@@ -171,3 +172,19 @@ class AwsGlueCrawlerHook(AwsBaseHook):
                     self.log.info("Crawler should finish soon")
 
                 sleep(poll_interval)
+
+
+class AwsGlueCrawlerHook(GlueCrawlerHook):
+    """
+    This hook is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.hooks.glue_crawler.GlueCrawlerHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This hook is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.hooks.glue_crawler.GlueCrawlerHook`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -17,14 +17,15 @@
 # under the License.
 
 import os.path
+import warnings
 from typing import Optional
 
 from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
+from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 
-class AwsGlueJobOperator(BaseOperator):
+class GlueJobOperator(BaseOperator):
     """
     Creates an AWS Glue Job. AWS Glue is a serverless Spark
     ETL service for running Spark Jobs on the AWS cloud.
@@ -118,7 +119,7 @@ class AwsGlueJobOperator(BaseOperator):
             s3_script_location = f"s3://{self.s3_bucket}/{self.s3_artifacts_prefix}{script_name}"
         else:
             s3_script_location = self.script_location
-        glue_job = AwsGlueJobHook(
+        glue_job = GlueJobHook(
             job_name=self.job_name,
             desc=self.job_desc,
             concurrent_run_limit=self.concurrent_run_limit,
@@ -148,3 +149,19 @@ class AwsGlueJobOperator(BaseOperator):
         else:
             self.log.info("AWS Glue Job: %s. Run Id: %s", self.job_name, glue_job_run['JobRunId'])
         return glue_job_run['JobRunId']
+
+
+class AwsGlueJobOperator(GlueJobOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.glue.GlueJobOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.operators.glue.GlueJobOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/glue_crawler.py
+++ b/airflow/providers/amazon/aws/operators/glue_crawler.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import sys
+import warnings
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -23,10 +24,10 @@ else:
     from cached_property import cached_property
 
 from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.glue_crawler import AwsGlueCrawlerHook
+from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 
 
-class AwsGlueCrawlerOperator(BaseOperator):
+class GlueCrawlerOperator(BaseOperator):
     """
     Creates, updates and triggers an AWS Glue Crawler. AWS Glue Crawler is a serverless
     service that manages a catalog of metadata tables that contain the inferred
@@ -55,9 +56,9 @@ class AwsGlueCrawlerOperator(BaseOperator):
         self.config = config
 
     @cached_property
-    def hook(self) -> AwsGlueCrawlerHook:
-        """Create and return an AwsGlueCrawlerHook."""
-        return AwsGlueCrawlerHook(self.aws_conn_id)
+    def hook(self) -> GlueCrawlerHook:
+        """Create and return an GlueCrawlerHook."""
+        return GlueCrawlerHook(self.aws_conn_id)
 
     def execute(self, context):
         """
@@ -77,3 +78,19 @@ class AwsGlueCrawlerOperator(BaseOperator):
         self.hook.wait_for_crawler_completion(crawler_name=crawler_name, poll_interval=self.poll_interval)
 
         return crawler_name
+
+
+class AwsGlueCrawlerOperator(GlueCrawlerOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.glue_crawler.GlueCrawlerOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.operators.glue_crawler.GlueCrawlerOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/glue.py
+++ b/airflow/providers/amazon/aws/sensors/glue.py
@@ -15,13 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
+from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.sensors.base import BaseSensorOperator
 
 
-class AwsGlueJobSensor(BaseSensorOperator):
+class GlueJobSensor(BaseSensorOperator):
     """
     Waits for an AWS Glue Job to reach any of the status below
     'FAILED', 'STOPPED', 'SUCCEEDED'
@@ -43,7 +44,7 @@ class AwsGlueJobSensor(BaseSensorOperator):
         self.errored_states = ['FAILED', 'STOPPED', 'TIMEOUT']
 
     def poke(self, context):
-        hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
+        hook = GlueJobHook(aws_conn_id=self.aws_conn_id)
         self.log.info("Poking for job run status :for Glue Job %s and ID %s", self.job_name, self.run_id)
         job_state = hook.get_job_state(job_name=self.job_name, run_id=self.run_id)
         if job_state in self.success_states:
@@ -54,3 +55,19 @@ class AwsGlueJobSensor(BaseSensorOperator):
             raise AirflowException(job_error_message)
         else:
             return False
+
+
+class AwsGlueJobSensor(GlueJobSensor):
+    """
+    This sensor is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.sensors.glue.GlueJobSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.sensors.glue.GlueJobSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
+++ b/airflow/providers/amazon/aws/sensors/glue_catalog_partition.py
@@ -15,13 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 from typing import Optional
 
-from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
+from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 from airflow.sensors.base import BaseSensorOperator
 
 
-class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
+class GlueCatalogPartitionSensor(BaseSensorOperator):
     """
     Waits for a partition to show up in AWS Glue Catalog.
 
@@ -72,7 +73,7 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
         self.table_name = table_name
         self.expression = expression
         self.database_name = database_name
-        self.hook: Optional[AwsGlueCatalogHook] = None
+        self.hook: Optional[GlueCatalogHook] = None
 
     def poke(self, context):
         """Checks for existence of the partition in the AWS Glue Catalog table"""
@@ -84,10 +85,26 @@ class AwsGlueCatalogPartitionSensor(BaseSensorOperator):
 
         return self.get_hook().check_for_partition(self.database_name, self.table_name, self.expression)
 
-    def get_hook(self) -> AwsGlueCatalogHook:
-        """Gets the AwsGlueCatalogHook"""
+    def get_hook(self) -> GlueCatalogHook:
+        """Gets the GlueCatalogHook"""
         if self.hook:
             return self.hook
 
-        self.hook = AwsGlueCatalogHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
+        self.hook = GlueCatalogHook(aws_conn_id=self.aws_conn_id, region_name=self.region_name)
         return self.hook
+
+
+class AwsGlueCatalogPartitionSensor(GlueCatalogPartitionSensor):
+    """
+    This sensor is deprecated. Please use
+    :class:`airflow.providers.amazon.aws.sensors.glue_catalog_partition.GlueCatalogPartitionSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.sensors.glue_catalog_partition.GlueCatalogPartitionSensor`.",  # noqa: 501
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/glue_crawler.py
+++ b/airflow/providers/amazon/aws/sensors/glue_crawler.py
@@ -15,14 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 from typing import Optional
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.glue_crawler import AwsGlueCrawlerHook
+from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 from airflow.sensors.base import BaseSensorOperator
 
 
-class AwsGlueCrawlerSensor(BaseSensorOperator):
+class GlueCrawlerSensor(BaseSensorOperator):
     """
     Waits for an AWS Glue crawler to reach any of the statuses below
     'FAILED', 'CANCELLED', 'SUCCEEDED'
@@ -39,7 +40,7 @@ class AwsGlueCrawlerSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.success_statuses = 'SUCCEEDED'
         self.errored_statuses = ('FAILED', 'CANCELLED')
-        self.hook: Optional[AwsGlueCrawlerHook] = None
+        self.hook: Optional[GlueCrawlerHook] = None
 
     def poke(self, context):
         hook = self.get_hook()
@@ -56,10 +57,26 @@ class AwsGlueCrawlerSensor(BaseSensorOperator):
         else:
             return False
 
-    def get_hook(self) -> AwsGlueCrawlerHook:
-        """Returns a new or pre-existing AwsGlueCrawlerHook"""
+    def get_hook(self) -> GlueCrawlerHook:
+        """Returns a new or pre-existing GlueCrawlerHook"""
         if self.hook:
             return self.hook
 
-        self.hook = AwsGlueCrawlerHook(aws_conn_id=self.aws_conn_id)
+        self.hook = GlueCrawlerHook(aws_conn_id=self.aws_conn_id)
         return self.hook
+
+
+class AwsGlueCrawlerSensor(GlueCrawlerSensor):
+    """
+    This sensor is deprecated. Please use
+    :class:`airflow.providers.amazon.aws.sensors.glue_crawler.GlueCrawlerSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.sensors.glue_crawler.GlueCrawlerSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -19,7 +19,7 @@ import json
 import unittest
 from unittest import mock
 
-from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
+from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 
 try:
     from moto import mock_iam
@@ -34,7 +34,7 @@ class TestGlueJobHook(unittest.TestCase):
     @unittest.skipIf(mock_iam is None, 'mock_iam package not present')
     @mock_iam
     def test_get_iam_execution_role(self):
-        hook = AwsGlueJobHook(
+        hook = GlueJobHook(
             job_name='aws_test_glue_job', s3_bucket='some_bucket', iam_role_name='my_test_role'
         )
         iam_role = hook.get_client_type('iam').create_role(
@@ -57,15 +57,15 @@ class TestGlueJobHook(unittest.TestCase):
         assert "Arn" in iam_role['Role']
         assert iam_role['Role']['Arn'] == "arn:aws:iam::123456789012:role/my_test_role"
 
-    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
-    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    @mock.patch.object(GlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(GlueJobHook, "get_conn")
     def test_get_or_create_glue_job(self, mock_get_conn, mock_get_iam_execution_role):
         mock_get_iam_execution_role.return_value = mock.MagicMock(Role={'RoleName': 'my_test_role'})
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
         mock_glue_job = mock_get_conn.return_value.get_job()['Job']['Name']
-        glue_job = AwsGlueJobHook(
+        glue_job = GlueJobHook(
             job_name='aws_test_glue_job',
             desc='This is test case job from Airflow',
             script_location=some_script,
@@ -75,15 +75,15 @@ class TestGlueJobHook(unittest.TestCase):
         ).get_or_create_glue_job()
         assert glue_job == mock_glue_job
 
-    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
-    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    @mock.patch.object(GlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(GlueJobHook, "get_conn")
     def test_get_or_create_glue_job_worker_type(self, mock_get_conn, mock_get_iam_execution_role):
         mock_get_iam_execution_role.return_value = mock.MagicMock(Role={'RoleName': 'my_test_role'})
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
         mock_glue_job = mock_get_conn.return_value.get_job()['Job']['Name']
-        glue_job = AwsGlueJobHook(
+        glue_job = GlueJobHook(
             job_name='aws_test_glue_job',
             desc='This is test case job from Airflow',
             script_location=some_script,
@@ -94,8 +94,8 @@ class TestGlueJobHook(unittest.TestCase):
         ).get_or_create_glue_job()
         assert glue_job == mock_glue_job
 
-    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
-    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    @mock.patch.object(GlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(GlueJobHook, "get_conn")
     def test_init_worker_type_value_error(self, mock_get_conn, mock_get_iam_execution_role):
         mock_get_iam_execution_role.return_value = mock.MagicMock(Role={'RoleName': 'my_test_role'})
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
@@ -105,7 +105,7 @@ class TestGlueJobHook(unittest.TestCase):
             ValueError,
             msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
         ):
-            AwsGlueJobHook(
+            GlueJobHook(
                 job_name='aws_test_glue_job',
                 desc='This is test case job from Airflow',
                 script_location=some_script,
@@ -116,9 +116,9 @@ class TestGlueJobHook(unittest.TestCase):
                 create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
             )
 
-    @mock.patch.object(AwsGlueJobHook, "get_job_state")
-    @mock.patch.object(AwsGlueJobHook, "get_or_create_glue_job")
-    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    @mock.patch.object(GlueJobHook, "get_job_state")
+    @mock.patch.object(GlueJobHook, "get_or_create_glue_job")
+    @mock.patch.object(GlueJobHook, "get_conn")
     def test_initialize_job(self, mock_get_conn, mock_get_or_create_glue_job, mock_get_job_state):
         some_data_path = "s3://glue-datasets/examples/medicare/SampleData.csv"
         some_script_arguments = {"--s3_input_data_path": some_data_path}
@@ -130,7 +130,7 @@ class TestGlueJobHook(unittest.TestCase):
         mock_get_conn.return_value.start_job_run()
 
         mock_job_run_state = mock_get_job_state.return_value
-        glue_job_hook = AwsGlueJobHook(
+        glue_job_hook = GlueJobHook(
             job_name='aws_test_glue_job',
             desc='This is test case job from Airflow',
             iam_role_name='my_test_role',

--- a/tests/providers/amazon/aws/hooks/test_glue_catalog.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_catalog.py
@@ -22,7 +22,7 @@ from unittest import mock
 import boto3
 import pytest
 
-from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
+from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
 
 try:
     from moto import mock_glue
@@ -41,38 +41,38 @@ TABLE_INPUT = {
 
 
 @unittest.skipIf(mock_glue is None, "Skipping test because moto.mock_glue is not available")
-class TestAwsGlueCatalogHook(unittest.TestCase):
+class TestGlueCatalogHook(unittest.TestCase):
     @mock_glue
     def setUp(self):
         self.client = boto3.client('glue', region_name='us-east-1')
-        self.hook = AwsGlueCatalogHook(region_name="us-east-1")
+        self.hook = GlueCatalogHook(region_name="us-east-1")
 
     @mock_glue
     def test_get_conn_returns_a_boto3_connection(self):
-        hook = AwsGlueCatalogHook(region_name="us-east-1")
+        hook = GlueCatalogHook(region_name="us-east-1")
         assert hook.get_conn() is not None
 
     @mock_glue
     def test_conn_id(self):
-        hook = AwsGlueCatalogHook(aws_conn_id='my_aws_conn_id', region_name="us-east-1")
+        hook = GlueCatalogHook(aws_conn_id='my_aws_conn_id', region_name="us-east-1")
         assert hook.aws_conn_id == 'my_aws_conn_id'
 
     @mock_glue
     def test_region(self):
-        hook = AwsGlueCatalogHook(region_name="us-west-2")
+        hook = GlueCatalogHook(region_name="us-west-2")
         assert hook.region_name == 'us-west-2'
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'get_conn')
+    @mock.patch.object(GlueCatalogHook, 'get_conn')
     def test_get_partitions_empty(self, mock_get_conn):
         response = set()
         mock_get_conn.get_paginator.paginate.return_value = response
-        hook = AwsGlueCatalogHook(region_name="us-east-1")
+        hook = GlueCatalogHook(region_name="us-east-1")
 
         assert hook.get_partitions('db', 'tbl') == set()
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'get_conn')
+    @mock.patch.object(GlueCatalogHook, 'get_conn')
     def test_get_partitions(self, mock_get_conn):
         response = [{'Partitions': [{'Values': ['2015-01-01']}]}]
         mock_paginator = mock.Mock()
@@ -80,7 +80,7 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
         mock_conn = mock.Mock()
         mock_conn.get_paginator.return_value = mock_paginator
         mock_get_conn.return_value = mock_conn
-        hook = AwsGlueCatalogHook(region_name="us-east-1")
+        hook = GlueCatalogHook(region_name="us-east-1")
         result = hook.get_partitions('db', 'tbl', expression='foo=bar', page_size=2, max_items=3)
 
         assert result == {('2015-01-01',)}
@@ -93,19 +93,19 @@ class TestAwsGlueCatalogHook(unittest.TestCase):
         )
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'get_partitions')
+    @mock.patch.object(GlueCatalogHook, 'get_partitions')
     def test_check_for_partition(self, mock_get_partitions):
         mock_get_partitions.return_value = {('2018-01-01',)}
-        hook = AwsGlueCatalogHook(region_name="us-east-1")
+        hook = GlueCatalogHook(region_name="us-east-1")
 
         assert hook.check_for_partition('db', 'tbl', 'expr')
         mock_get_partitions.assert_called_once_with('db', 'tbl', 'expr', max_items=1)
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'get_partitions')
+    @mock.patch.object(GlueCatalogHook, 'get_partitions')
     def test_check_for_partition_false(self, mock_get_partitions):
         mock_get_partitions.return_value = set()
-        hook = AwsGlueCatalogHook(region_name="us-east-1")
+        hook = GlueCatalogHook(region_name="us-east-1")
 
         assert not hook.check_for_partition('db', 'tbl', 'expr')
 

--- a/tests/providers/amazon/aws/hooks/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_crawler.py
@@ -19,7 +19,7 @@ import unittest
 from copy import deepcopy
 from unittest import mock
 
-from airflow.providers.amazon.aws.hooks.glue_crawler import AwsGlueCrawlerHook
+from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 
 mock_crawler_name = 'test-crawler'
 mock_role_name = 'test-role'
@@ -81,21 +81,21 @@ mock_config = {
 }
 
 
-class TestAwsGlueCrawlerHook(unittest.TestCase):
+class TestGlueCrawlerHook(unittest.TestCase):
     @classmethod
     def setUp(cls):
-        cls.hook = AwsGlueCrawlerHook(aws_conn_id="aws_default")
+        cls.hook = GlueCrawlerHook(aws_conn_id="aws_default")
 
     def test_init(self):
         self.assertEqual(self.hook.aws_conn_id, "aws_default")
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_has_crawler(self, mock_get_conn):
         response = self.hook.has_crawler(mock_crawler_name)
         self.assertEqual(response, True)
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_has_crawler_crawled_doesnt_exists(self, mock_get_conn):
         class MockException(Exception):
             pass
@@ -106,7 +106,7 @@ class TestAwsGlueCrawlerHook(unittest.TestCase):
         self.assertEqual(response, False)
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_update_crawler_needed(self, mock_get_conn):
         mock_get_conn.return_value.get_crawler.return_value = {'Crawler': mock_config}
 
@@ -117,14 +117,14 @@ class TestAwsGlueCrawlerHook(unittest.TestCase):
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
         mock_get_conn.return_value.update_crawler.assert_called_once_with(**mock_config_two)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_update_crawler_not_needed(self, mock_get_conn):
         mock_get_conn.return_value.get_crawler.return_value = {'Crawler': mock_config}
         response = self.hook.update_crawler(**mock_config)
         self.assertEqual(response, False)
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_create_crawler(self, mock_get_conn):
         mock_get_conn.return_value.create_crawler.return_value = {'Crawler': {'Name': mock_crawler_name}}
         glue_crawler = self.hook.create_crawler(**mock_config)
@@ -132,15 +132,15 @@ class TestAwsGlueCrawlerHook(unittest.TestCase):
         self.assertIn("Name", glue_crawler["Crawler"])
         self.assertEqual(glue_crawler["Crawler"]["Name"], mock_crawler_name)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_start_crawler(self, mock_get_conn):
         result = self.hook.start_crawler(mock_crawler_name)
         self.assertEqual(result, mock_get_conn.return_value.start_crawler.return_value)
 
         mock_get_conn.return_value.start_crawler.assert_called_once_with(Name=mock_crawler_name)
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_crawler")
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_crawler")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_wait_for_crawler_completion_instant_ready(self, mock_get_conn, mock_get_crawler):
         mock_get_crawler.side_effect = [
             {'State': 'READY', 'LastCrawl': {'Status': 'MOCK_STATUS'}},
@@ -170,8 +170,8 @@ class TestAwsGlueCrawlerHook(unittest.TestCase):
             ]
         )
 
-    @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
-    @mock.patch.object(AwsGlueCrawlerHook, "get_crawler")
+    @mock.patch.object(GlueCrawlerHook, "get_conn")
+    @mock.patch.object(GlueCrawlerHook, "get_crawler")
     @mock.patch('airflow.providers.amazon.aws.hooks.glue_crawler.sleep')
     def test_wait_for_crawler_completion_retry_two_times(self, mock_sleep, mock_get_crawler, mock_get_conn):
         mock_get_crawler.side_effect = [

--- a/tests/providers/amazon/aws/operators/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/operators/test_glue_crawler.py
@@ -18,7 +18,7 @@
 import unittest
 from unittest import mock
 
-from airflow.providers.amazon.aws.operators.glue_crawler import AwsGlueCrawlerOperator
+from airflow.providers.amazon.aws.operators.glue_crawler import GlueCrawlerOperator
 
 mock_crawler_name = 'test-crawler'
 mock_role_name = 'test-role'
@@ -80,14 +80,14 @@ mock_config = {
 }
 
 
-class TestAwsGlueCrawlerOperator(unittest.TestCase):
+class TestGlueCrawlerOperator(unittest.TestCase):
     def setUp(self):
-        self.glue = AwsGlueCrawlerOperator(task_id='test_glue_crawler_operator', config=mock_config)
+        self.glue = GlueCrawlerOperator(task_id='test_glue_crawler_operator', config=mock_config)
 
-    @mock.patch('airflow.providers.amazon.aws.operators.glue_crawler.AwsGlueCrawlerHook')
+    @mock.patch('airflow.providers.amazon.aws.operators.glue_crawler.GlueCrawlerHook')
     def test_execute_without_failure(self, mock_hook):
         mock_hook.return_value.has_crawler.return_value = True
-        self.glue.execute(None)
+        self.glue.execute({})
 
         mock_hook.assert_has_calls(
             [

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -19,20 +19,20 @@ import unittest
 from unittest import mock
 
 from airflow import configuration
-from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
-from airflow.providers.amazon.aws.sensors.glue import AwsGlueJobSensor
+from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
+from airflow.providers.amazon.aws.sensors.glue import GlueJobSensor
 
 
-class TestAwsGlueJobSensor(unittest.TestCase):
+class TestGlueJobSensor(unittest.TestCase):
     def setUp(self):
         configuration.load_test_config()
 
-    @mock.patch.object(AwsGlueJobHook, 'get_conn')
-    @mock.patch.object(AwsGlueJobHook, 'get_job_state')
+    @mock.patch.object(GlueJobHook, 'get_conn')
+    @mock.patch.object(GlueJobHook, 'get_job_state')
     def test_poke(self, mock_get_job_state, mock_conn):
         mock_conn.return_value.get_job_run()
         mock_get_job_state.return_value = 'SUCCEEDED'
-        op = AwsGlueJobSensor(
+        op = GlueJobSensor(
             task_id='test_glue_job_sensor',
             job_name='aws_test_glue_job',
             run_id='5152fgsfsjhsh61661',
@@ -40,14 +40,14 @@ class TestAwsGlueJobSensor(unittest.TestCase):
             timeout=5,
             aws_conn_id='aws_default',
         )
-        assert op.poke(None)
+        assert op.poke({})
 
-    @mock.patch.object(AwsGlueJobHook, 'get_conn')
-    @mock.patch.object(AwsGlueJobHook, 'get_job_state')
+    @mock.patch.object(GlueJobHook, 'get_conn')
+    @mock.patch.object(GlueJobHook, 'get_job_state')
     def test_poke_false(self, mock_get_job_state, mock_conn):
         mock_conn.return_value.get_job_run()
         mock_get_job_state.return_value = 'RUNNING'
-        op = AwsGlueJobSensor(
+        op = GlueJobSensor(
             task_id='test_glue_job_sensor',
             job_name='aws_test_glue_job',
             run_id='5152fgsfsjhsh61661',
@@ -55,7 +55,7 @@ class TestAwsGlueJobSensor(unittest.TestCase):
             timeout=5,
             aws_conn_id='aws_default',
         )
-        assert not op.poke(None)
+        assert not op.poke({})
 
 
 if __name__ == '__main__':

--- a/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
@@ -19,8 +19,8 @@
 import unittest
 from unittest import mock
 
-from airflow.providers.amazon.aws.hooks.glue_catalog import AwsGlueCatalogHook
-from airflow.providers.amazon.aws.sensors.glue_catalog_partition import AwsGlueCatalogPartitionSensor
+from airflow.providers.amazon.aws.hooks.glue_catalog import GlueCatalogHook
+from airflow.providers.amazon.aws.sensors.glue_catalog_partition import GlueCatalogPartitionSensor
 
 try:
     from moto import mock_glue
@@ -29,37 +29,37 @@ except ImportError:
 
 
 @unittest.skipIf(mock_glue is None, "Skipping test because moto.mock_glue is not available")
-class TestAwsGlueCatalogPartitionSensor(unittest.TestCase):
+class TestGlueCatalogPartitionSensor(unittest.TestCase):
 
     task_id = 'test_glue_catalog_partition_sensor'
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')
+    @mock.patch.object(GlueCatalogHook, 'check_for_partition')
     def test_poke(self, mock_check_for_partition):
         mock_check_for_partition.return_value = True
-        op = AwsGlueCatalogPartitionSensor(task_id=self.task_id, table_name='tbl')
-        assert op.poke(None)
+        op = GlueCatalogPartitionSensor(task_id=self.task_id, table_name='tbl')
+        assert op.poke({})
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')
+    @mock.patch.object(GlueCatalogHook, 'check_for_partition')
     def test_poke_false(self, mock_check_for_partition):
         mock_check_for_partition.return_value = False
-        op = AwsGlueCatalogPartitionSensor(task_id=self.task_id, table_name='tbl')
-        assert not op.poke(None)
+        op = GlueCatalogPartitionSensor(task_id=self.task_id, table_name='tbl')
+        assert not op.poke({})
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')
+    @mock.patch.object(GlueCatalogHook, 'check_for_partition')
     def test_poke_default_args(self, mock_check_for_partition):
         table_name = 'test_glue_catalog_partition_sensor_tbl'
-        op = AwsGlueCatalogPartitionSensor(task_id=self.task_id, table_name=table_name)
-        op.poke(None)
+        op = GlueCatalogPartitionSensor(task_id=self.task_id, table_name=table_name)
+        op.poke({})
 
         assert op.hook.region_name is None
         assert op.hook.aws_conn_id == 'aws_default'
         mock_check_for_partition.assert_called_once_with('default', table_name, "ds='{{ ds }}'")
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')
+    @mock.patch.object(GlueCatalogHook, 'check_for_partition')
     def test_poke_nondefault_args(self, mock_check_for_partition):
         table_name = 'my_table'
         expression = 'col=val'
@@ -68,7 +68,7 @@ class TestAwsGlueCatalogPartitionSensor(unittest.TestCase):
         database_name = 'my_db'
         poke_interval = 2
         timeout = 3
-        op = AwsGlueCatalogPartitionSensor(
+        op = GlueCatalogPartitionSensor(
             task_id=self.task_id,
             table_name=table_name,
             expression=expression,
@@ -78,7 +78,7 @@ class TestAwsGlueCatalogPartitionSensor(unittest.TestCase):
             poke_interval=poke_interval,
             timeout=timeout,
         )
-        op.poke(None)
+        op.poke({})
 
         assert op.hook.region_name == region_name
         assert op.hook.aws_conn_id == aws_conn_id
@@ -87,10 +87,10 @@ class TestAwsGlueCatalogPartitionSensor(unittest.TestCase):
         mock_check_for_partition.assert_called_once_with(database_name, table_name, expression)
 
     @mock_glue
-    @mock.patch.object(AwsGlueCatalogHook, 'check_for_partition')
+    @mock.patch.object(GlueCatalogHook, 'check_for_partition')
     def test_dot_notation(self, mock_check_for_partition):
         db_table = 'my_db.my_tbl'
-        op = AwsGlueCatalogPartitionSensor(task_id=self.task_id, table_name=db_table)
-        op.poke(None)
+        op = GlueCatalogPartitionSensor(task_id=self.task_id, table_name=db_table)
+        op.poke({})
 
         mock_check_for_partition.assert_called_once_with('my_db', 'my_tbl', "ds='{{ ds }}'")

--- a/tests/providers/amazon/aws/sensors/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_crawler.py
@@ -18,13 +18,13 @@
 import unittest
 from unittest import mock
 
-from airflow.providers.amazon.aws.hooks.glue_crawler import AwsGlueCrawlerHook
-from airflow.providers.amazon.aws.sensors.glue_crawler import AwsGlueCrawlerSensor
+from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
+from airflow.providers.amazon.aws.sensors.glue_crawler import GlueCrawlerSensor
 
 
-class TestAwsGlueCrawlerSensor(unittest.TestCase):
+class TestGlueCrawlerSensor(unittest.TestCase):
     def setUp(self):
-        self.sensor = AwsGlueCrawlerSensor(
+        self.sensor = GlueCrawlerSensor(
             task_id='test_glue_crawler_sensor',
             crawler_name='aws_test_glue_crawler',
             poke_interval=1,
@@ -32,22 +32,22 @@ class TestAwsGlueCrawlerSensor(unittest.TestCase):
             aws_conn_id='aws_default',
         )
 
-    @mock.patch.object(AwsGlueCrawlerHook, 'get_crawler')
+    @mock.patch.object(GlueCrawlerHook, 'get_crawler')
     def test_poke_success(self, mock_get_crawler):
         mock_get_crawler.return_value['LastCrawl']['Status'] = "SUCCEEDED"
-        self.assertFalse(self.sensor.poke(None))
+        self.assertFalse(self.sensor.poke({}))
         mock_get_crawler.assert_called_once_with('aws_test_glue_crawler')
 
-    @mock.patch.object(AwsGlueCrawlerHook, 'get_crawler')
+    @mock.patch.object(GlueCrawlerHook, 'get_crawler')
     def test_poke_failed(self, mock_get_crawler):
         mock_get_crawler.return_value['LastCrawl']['Status'] = "FAILED"
-        self.assertFalse(self.sensor.poke(None))
+        self.assertFalse(self.sensor.poke({}))
         mock_get_crawler.assert_called_once_with('aws_test_glue_crawler')
 
-    @mock.patch.object(AwsGlueCrawlerHook, 'get_crawler')
+    @mock.patch.object(GlueCrawlerHook, 'get_crawler')
     def test_poke_cancelled(self, mock_get_crawler):
         mock_get_crawler.return_value['LastCrawl']['Status'] = "CANCELLED"
-        self.assertFalse(self.sensor.poke(None))
+        self.assertFalse(self.sensor.poke({}))
         mock_get_crawler.assert_called_once_with('aws_test_glue_crawler')
 
 


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/20296

Also changed `execute(None)` and `poke(None)` to `execute({})` and `poke({})` because IDE gave a type hinting warning (expected dict, received NoneType)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
