### PR TITLE
Standardize AWS Redshift naming

### DIFF
--- a/airflow/providers/amazon/aws/sensors/redshift.py
+++ b/airflow/providers/amazon/aws/sensors/redshift.py
@@ -17,7 +17,7 @@
 # under the License.
 import warnings
 
-from airflow.providers.amazon.aws.sensors.redshift_cluster import AwsRedshiftClusterSensor
+from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensor
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.redshift_cluster`.",
@@ -25,4 +25,4 @@ warnings.warn(
     stacklevel=2,
 )
 
-__all__ = ["AwsRedshiftClusterSensor"]
+__all__ = ["RedshiftClusterSensor"]

--- a/airflow/providers/amazon/aws/sensors/redshift.py
+++ b/airflow/providers/amazon/aws/sensors/redshift.py
@@ -19,10 +19,12 @@ import warnings
 
 from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensor
 
+AwsRedshiftClusterSensor = RedshiftClusterSensor
+
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.redshift_cluster`.",
     DeprecationWarning,
     stacklevel=2,
 )
 
-__all__ = ["RedshiftClusterSensor"]
+__all__ = ["AwsRedshiftClusterSensor", "RedshiftClusterSensor"]

--- a/airflow/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/sensors/redshift_cluster.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import warnings
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class AwsRedshiftClusterSensor(BaseSensorOperator):
+class RedshiftClusterSensor(BaseSensorOperator):
     """
     Waits for a Redshift cluster to reach a specific status.
 
@@ -61,3 +61,19 @@ class AwsRedshiftClusterSensor(BaseSensorOperator):
 
         self.hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
         return self.hook
+
+
+class AwsRedshiftClusterSensor(RedshiftClusterSensor):
+    """
+    This sensor is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.sensors.redshift_cluster.RedshiftClusterSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. Please use"
+            ":class:`airflow.providers.amazon.aws.sensors.redshift_cluster.RedshiftClusterSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/sensors/redshift_cluster.py
@@ -61,19 +61,3 @@ class RedshiftClusterSensor(BaseSensorOperator):
 
         self.hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
         return self.hook
-
-
-class AwsRedshiftClusterSensor(RedshiftClusterSensor):
-    """
-    This sensor is deprecated.
-    Please use :class:`airflow.providers.amazon.aws.sensors.redshift_cluster.RedshiftClusterSensor`.
-    """
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "This sensor is deprecated. Please use"
-            ":class:`airflow.providers.amazon.aws.sensors.redshift_cluster.RedshiftClusterSensor`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/sensors/redshift_cluster.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import warnings
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2187,6 +2187,11 @@ KNOWN_DEPRECATED_DIRECT_IMPORTS: Set[str] = {
     'This module is deprecated. Please use `airflow.providers.amazon.aws.hooks.emr`.',
     'This module is deprecated. Please use `airflow.providers.opsgenie.hooks.opsgenie`.',
     'This module is deprecated. Please use `airflow.providers.opsgenie.operators.opsgenie`.',
+    'This module is deprecated. Please use `airflow.hooks.redshift_sql` '
+    'or `airflow.hooks.redshift_cluster` as appropriate.',
+    'This module is deprecated. Please use `airflow.providers.amazon.aws.operators.redshift_sql` or '
+    '`airflow.providers.amazon.aws.operators.redshift_cluster` as appropriate.',
+    'This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.redshift_cluster`.',
 }
 
 

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1784,6 +1784,10 @@ SENSORS = [
         "airflow.providers.amazon.aws.sensors.s3.S3PrefixSensor",
         "airflow.providers.amazon.aws.sensors.s3_prefix.S3PrefixSensor",
     ),
+    (
+        "airflow.providers.amazon.aws.sensors.redshift_cluster.RedshiftClusterSensor",
+        "airflow.providers.amazon.aws.sensors.redshift.RedshiftClusterSensor",
+    ),
 ]
 
 TRANSFERS = [

--- a/tests/providers/amazon/aws/sensors/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/sensors/test_redshift_cluster.py
@@ -19,7 +19,7 @@ import unittest
 
 import boto3
 
-from airflow.providers.amazon.aws.sensors.redshift_cluster import AwsRedshiftClusterSensor
+from airflow.providers.amazon.aws.sensors.redshift_cluster import RedshiftClusterSensor
 
 try:
     from moto import mock_redshift
@@ -27,7 +27,7 @@ except ImportError:
     mock_redshift = None
 
 
-class TestAwsRedshiftClusterSensor(unittest.TestCase):
+class TestRedshiftClusterSensor(unittest.TestCase):
     @staticmethod
     def _create_cluster():
         client = boto3.client('redshift', region_name='us-east-1')
@@ -44,7 +44,7 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
     @mock_redshift
     def test_poke(self):
         self._create_cluster()
-        op = AwsRedshiftClusterSensor(
+        op = RedshiftClusterSensor(
             task_id='test_cluster_sensor',
             poke_interval=1,
             timeout=5,
@@ -52,13 +52,13 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
             cluster_identifier='test_cluster',
             target_status='available',
         )
-        assert op.poke(None)
+        assert op.poke({})
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
     @mock_redshift
     def test_poke_false(self):
         self._create_cluster()
-        op = AwsRedshiftClusterSensor(
+        op = RedshiftClusterSensor(
             task_id='test_cluster_sensor',
             poke_interval=1,
             timeout=5,
@@ -67,13 +67,13 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
             target_status='available',
         )
 
-        assert not op.poke(None)
+        assert not op.poke({})
 
     @unittest.skipIf(mock_redshift is None, 'mock_redshift package not present')
     @mock_redshift
     def test_poke_cluster_not_found(self):
         self._create_cluster()
-        op = AwsRedshiftClusterSensor(
+        op = RedshiftClusterSensor(
             task_id='test_cluster_sensor',
             poke_interval=1,
             timeout=5,
@@ -82,4 +82,4 @@ class TestAwsRedshiftClusterSensor(unittest.TestCase):
             target_status='cluster_not_found',
         )
 
-        assert op.poke(None)
+        assert op.poke({})


### PR DESCRIPTION
Part of [#20296](https://github.com/apache/airflow/issues/20296)

Also changed `poke(None)` to `poke({})` because IDE type hinting warnings (expected dict, received NoneType)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
