### PR TITLE
Fix kubernetes type hints

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -323,7 +323,12 @@ class PodLauncher(LoggingMixin):
         return None
 
     def process_status(self, pod_name: str, pod_phase: str) -> TaskInstanceState:
-        """Process status information for the JOB"""
+        """
+        Convert a K8S Pod phase to Airflow task state.
+        :param pod_name: Name of the pod
+        :param pod_phase: Phase of the pod
+        :return: Airflow task state corresponding to the pod phase
+        """
         pod_phase = pod_phase.lower()
         if pod_phase == PodStatus.PENDING:
             return State.QUEUED


### PR DESCRIPTION
Was doing work on the KubernetesPodOperator and encountered several incorrect type hints. Created a separate PR to avoid changing too much in one PR.

Also renamed `_task_status()` to `_pod_state_to_task_state()` for clarity sake. Since it's an "internal" method, I don't think that should cause any issues.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
