### PR TITLE
Add support for BeamGoPipelineOperator

### DIFF
--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 
 from airflow import models
 from airflow.providers.apache.beam.operators.beam import (
+    BeamRunGoPipelineOperator,
     BeamRunJavaPipelineOperator,
     BeamRunPythonPipelineOperator,
 )
@@ -43,7 +44,10 @@ GCS_PYTHON = os.environ.get('APACHE_BEAM_PYTHON', 'gs://INVALID BUCKET NAME/word
 GCS_PYTHON_DATAFLOW_ASYNC = os.environ.get(
     'APACHE_BEAM_PYTHON_DATAFLOW_ASYNC', 'gs://INVALID BUCKET NAME/wordcount_debugging.py'
 )
-
+GCS_GO = os.environ.get('APACHE_BEAM_GO', 'gs://INVALID BUCKET NAME/wordcount_debugging.go')
+GCS_GO_DATAFLOW_ASYNC = os.environ.get(
+    'APACHE_BEAM_GO_DATAFLOW_ASYNC', 'gs://INVALID BUCKET NAME/wordcount_debugging.go'
+)
 GCS_JAR_DIRECT_RUNNER = os.environ.get(
     'APACHE_BEAM_DIRECT_RUNNER_JAR',
     'gs://INVALID BUCKET NAME/tests/dataflow-templates-bundled-java=11-beam-v2.25.0-DirectRunner.jar',
@@ -323,3 +327,111 @@ with models.DAG(
 
     start_python_job_dataflow_runner_async >> wait_for_python_job_dataflow_runner_async_done
     # [END howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
+
+
+with models.DAG(
+    "example_beam_native_go",
+    start_date=START_DATE,
+    schedule_interval="@once",
+    catchup=False,
+    default_args=DEFAULT_ARGS,
+    tags=['example'],
+) as dag_native_go:
+
+    # [START howto_operator_start_go_direct_runner_pipeline_local_file]
+    start_go_pipeline_local_direct_runner = BeamRunGoPipelineOperator(
+        task_id="start_go_pipeline_local_direct_runner",
+        go_file='files/apache_beam/examples/wordcount.go',
+    )
+    # [END howto_operator_start_go_direct_runner_pipeline_local_file]
+
+    # [START howto_operator_start_go_direct_runner_pipeline_gcs_file]
+    start_go_pipeline_direct_runner = BeamRunGoPipelineOperator(
+        task_id="start_go_pipeline_direct_runner",
+        go_file=GCS_GO,
+        pipeline_options={"output": GCS_OUTPUT},
+    )
+    # [END howto_operator_start_go_direct_runner_pipeline_gcs_file]
+
+    # [START howto_operator_start_go_dataflow_runner_pipeline_gcs_file]
+    start_go_pipeline_dataflow_runner = BeamRunGoPipelineOperator(
+        task_id="start_go_pipeline_dataflow_runner",
+        runner="DataflowRunner",
+        go_file=GCS_GO,
+        pipeline_options={
+            'tempLocation': GCS_TMP,
+            'stagingLocation': GCS_STAGING,
+            'output': GCS_OUTPUT,
+            'WorkerHarnessContainerImage': "apache/beam_go_sdk:latest",
+        },
+        dataflow_config=DataflowConfiguration(
+            job_name='{{task.task_id}}', project_id=GCP_PROJECT_ID, location="us-central1"
+        ),
+    )
+    # [END howto_operator_start_go_dataflow_runner_pipeline_gcs_file]
+
+    start_go_pipeline_local_spark_runner = BeamRunGoPipelineOperator(
+        task_id="start_go_pipeline_local_spark_runner",
+        go_file='/files/apache_beam/examples/wordcount.go',
+        runner="SparkRunner",
+        pipeline_options={
+            'endpoint': '/your/spark/endpoint',
+        },
+    )
+
+    start_go_pipeline_local_flink_runner = BeamRunGoPipelineOperator(
+        task_id="start_go_pipeline_local_flink_runner",
+        go_file='/files/apache_beam/examples/wordcount.go',
+        runner="FlinkRunner",
+        pipeline_options={
+            'output': '/tmp/start_go_pipeline_local_flink_runner',
+        },
+    )
+
+    (
+        [
+            start_go_pipeline_local_direct_runner,
+            start_go_pipeline_direct_runner,
+        ]
+        >> start_go_pipeline_local_flink_runner
+        >> start_go_pipeline_local_spark_runner
+    )
+
+
+with models.DAG(
+    "example_beam_native_go_dataflow_async",
+    default_args=DEFAULT_ARGS,
+    start_date=START_DATE,
+    schedule_interval="@once",
+    catchup=False,
+    tags=['example'],
+) as dag_native_go_dataflow_async:
+    # [START howto_operator_start_go_dataflow_runner_pipeline_async_gcs_file]
+    start_go_job_dataflow_runner_async = BeamRunGoPipelineOperator(
+        task_id="start_go_job_dataflow_runner_async",
+        runner="DataflowRunner",
+        go_file=GCS_GO_DATAFLOW_ASYNC,
+        pipeline_options={
+            'tempLocation': GCS_TMP,
+            'stagingLocation': GCS_STAGING,
+            'output': GCS_OUTPUT,
+            'WorkerHarnessContainerImage': "apache/beam_go_sdk:latest",
+        },
+        dataflow_config=DataflowConfiguration(
+            job_name='{{task.task_id}}',
+            project_id=GCP_PROJECT_ID,
+            location="us-central1",
+            wait_until_finished=False,
+        ),
+    )
+
+    wait_for_go_job_dataflow_runner_async_done = DataflowJobStatusSensor(
+        task_id="wait-for-go-job-async-done",
+        job_id="{{task_instance.xcom_pull('start_go_job_dataflow_runner_async')['dataflow_job_id']}}",
+        expected_statuses={DataflowJobStatus.JOB_STATE_DONE},
+        project_id=GCP_PROJECT_ID,
+        location='us-central1',
+    )
+
+    start_go_job_dataflow_runner_async >> wait_for_go_job_dataflow_runner_async_done
+    # [END howto_operator_start_go_dataflow_runner_pipeline_async_gcs_file]

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -17,10 +17,12 @@
 # under the License.
 """This module contains Apache Beam operators."""
 import copy
-from abc import ABCMeta
+import tempfile
+from abc import ABC, ABCMeta
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Tuple, Union
 
+from airflow import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.beam.hooks.beam import BeamHook, BeamRunnerType
 from airflow.providers.google.cloud.hooks.dataflow import (
@@ -39,8 +41,9 @@ if TYPE_CHECKING:
 class BeamDataflowMixin(metaclass=ABCMeta):
     """
     Helper class to store common, Dataflow specific logic for both
-    :class:`~airflow.providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` and
-    :class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`.
+    :class:`~airflow.providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator`,
+    :class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` and
+    :class:`~airflow.providers.apache.beam.operators.beam.BeamRunGoPipelineOperator`.
     """
 
     dataflow_hook: Optional[DataflowHook]
@@ -49,7 +52,9 @@ class BeamDataflowMixin(metaclass=ABCMeta):
     delegate_to: Optional[str]
 
     def _set_dataflow(
-        self, pipeline_options: dict, job_name_variable_key: Optional[str] = None
+        self,
+        pipeline_options: dict,
+        job_name_variable_key: Optional[str] = None,
     ) -> Tuple[str, dict, Callable[[str], None]]:
         self.dataflow_hook = self.__set_dataflow_hook()
         self.dataflow_config.project_id = self.dataflow_config.project_id or self.dataflow_hook.project_id
@@ -99,7 +104,102 @@ class BeamDataflowMixin(metaclass=ABCMeta):
         )
 
 
-class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
+class BeamBasePipelineOperator(BaseOperator, BeamDataflowMixin, ABC):
+    """
+    Abstract base class for Beam Pipeline Operators.
+
+    :param runner: Runner on which pipeline will be run. By default "DirectRunner" is being used.
+        Other possible options: DataflowRunner, SparkRunner, FlinkRunner, PortableRunner.
+        See: :class:`~providers.apache.beam.hooks.beam.BeamRunnerType`
+        See: https://beam.apache.org/documentation/runners/capability-matrix/
+
+    :type runner: str
+    :param default_pipeline_options: Map of default pipeline options.
+    :type default_pipeline_options: dict
+    :param pipeline_options: Map of pipeline options.The key must be a dictionary.
+        The value can contain different types:
+
+        * If the value is None, the single option - ``--key`` (without value) will be added.
+        * If the value is False, this option will be skipped
+        * If the value is True, the single option - ``--key`` (without value) will be added.
+        * If the value is list, the many options will be added for each key.
+          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key=B`` options
+          will be left
+        * Other value types will be replaced with the Python textual representation.
+
+        When defining labels (labels option), you can also provide a dictionary.
+    :type pipeline_options: dict
+    :param gcp_conn_id: Optional.
+        The connection ID to use connecting to Google Cloud Storage if python file is on GCS.
+    :type gcp_conn_id: str
+    :param delegate_to:  Optional.
+        The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param dataflow_config: Dataflow configuration, used when runner type is set to DataflowRunner,
+        (optional) defaults to None.
+    :type dataflow_config: DataflowConfiguration
+    """
+
+    def __init__(
+        self,
+        *,
+        runner: str = "DirectRunner",
+        default_pipeline_options: Optional[dict] = None,
+        pipeline_options: Optional[dict] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        delegate_to: Optional[str] = None,
+        dataflow_config: Optional[Union[DataflowConfiguration, dict]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.runner = runner
+        self.default_pipeline_options = default_pipeline_options or {}
+        self.pipeline_options = pipeline_options or {}
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        if isinstance(dataflow_config, dict):
+            self.dataflow_config = DataflowConfiguration(**dataflow_config)
+        else:
+            self.dataflow_config = dataflow_config or DataflowConfiguration()
+        self.beam_hook: Optional[BeamHook] = None
+        self.dataflow_hook: Optional[DataflowHook] = None
+        self.dataflow_job_id: Optional[str] = None
+
+        if self.dataflow_config and self.runner.lower() != BeamRunnerType.DataflowRunner.lower():
+            self.log.warning(
+                "dataflow_config is defined but runner is different than DataflowRunner (%s)", self.runner
+            )
+
+    def _init_pipeline_options(
+        self,
+        format_pipeline_options: bool = False,
+        job_name_variable_key: Optional[str] = None,
+    ) -> Tuple[bool, Optional[str], dict, Optional[Callable[[str], None]]]:
+        self.beam_hook = BeamHook(runner=self.runner)
+        pipeline_options = self.default_pipeline_options.copy()
+        process_line_callback: Optional[Callable[[str], None]] = None
+        is_dataflow = self.runner.lower() == BeamRunnerType.DataflowRunner.lower()
+        dataflow_job_name: Optional[str] = None
+        if is_dataflow:
+            dataflow_job_name, pipeline_options, process_line_callback = self._set_dataflow(
+                pipeline_options=pipeline_options,
+                job_name_variable_key=job_name_variable_key,
+            )
+
+        pipeline_options.update(self.pipeline_options)
+
+        if format_pipeline_options:
+            snake_case_pipeline_options = {
+                convert_camel_to_snake(key): pipeline_options[key] for key in pipeline_options
+            }
+            return is_dataflow, dataflow_job_name, snake_case_pipeline_options, process_line_callback
+
+        return is_dataflow, dataflow_job_name, pipeline_options, process_line_callback
+
+
+class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
     """
     Launching Apache Beam pipelines written in Python. Note that both
     ``default_pipeline_options`` and ``pipeline_options`` will be merged to specify pipeline
@@ -117,25 +217,7 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
 
     :param py_file: Reference to the python Apache Beam pipeline file.py, e.g.,
         /some/local/file/path/to/your/python/pipeline/file. (templated)
-    :param runner: Runner on which pipeline will be run. By default "DirectRunner" is being used.
-        Other possible options: DataflowRunner, SparkRunner, FlinkRunner.
-        See: :class:`~providers.apache.beam.hooks.beam.BeamRunnerType`
-        See: https://beam.apache.org/documentation/runners/capability-matrix/
-
     :param py_options: Additional python options, e.g., ["-m", "-v"].
-    :param default_pipeline_options: Map of default pipeline options.
-    :param pipeline_options: Map of pipeline options.The key must be a dictionary.
-        The value can contain different types:
-
-        * If the value is None, the single option - ``--key`` (without value) will be added.
-        * If the value is False, this option will be skipped
-        * If the value is True, the single option - ``--key`` (without value) will be added.
-        * If the value is list, the many options will be added for each key.
-          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` options
-          will be left
-        * Other value types will be replaced with the Python textual representation.
-
-        When defining labels (``labels`` option), you can also provide a dictionary.
     :param py_interpreter: Python version of the beam pipeline.
         If None, this defaults to the python3.
         To track python versions supported by beam and related
@@ -150,13 +232,6 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
         See virtualenv documentation for more information.
 
         This option is only relevant if the ``py_requirements`` parameter is not None.
-    :param gcp_conn_id: Optional.
-        The connection ID to use connecting to Google Cloud Storage if python file is on GCS.
-    :param delegate_to:  Optional.
-        The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
-    :param dataflow_config: Dataflow configuration, used when runner type is set to DataflowRunner
     """
 
     template_fields: Sequence[str] = (
@@ -184,56 +259,36 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
         dataflow_config: Optional[Union[DataflowConfiguration, dict]] = None,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
+        super().__init__(
+            runner=runner,
+            default_pipeline_options=default_pipeline_options,
+            pipeline_options=pipeline_options,
+            gcp_conn_id=gcp_conn_id,
+            delegate_to=delegate_to,
+            dataflow_config=dataflow_config,
+            **kwargs,
+        )
 
         self.py_file = py_file
-        self.runner = runner
         self.py_options = py_options or []
-        self.default_pipeline_options = default_pipeline_options or {}
-        self.pipeline_options = pipeline_options or {}
-        self.pipeline_options.setdefault("labels", {}).update(
-            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
-        )
         self.py_interpreter = py_interpreter
         self.py_requirements = py_requirements
         self.py_system_site_packages = py_system_site_packages
-        self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
-        self.beam_hook: Optional[BeamHook] = None
-        self.dataflow_hook: Optional[DataflowHook] = None
-        self.dataflow_job_id: Optional[str] = None
-
-        if dataflow_config is None:
-            self.dataflow_config = DataflowConfiguration()
-        elif isinstance(dataflow_config, dict):
-            self.dataflow_config = DataflowConfiguration(**dataflow_config)
-        else:
-            self.dataflow_config = dataflow_config
-
-        if self.dataflow_config and self.runner.lower() != BeamRunnerType.DataflowRunner.lower():
-            self.log.warning(
-                "dataflow_config is defined but runner is different than DataflowRunner (%s)", self.runner
-            )
+        self.pipeline_options.setdefault("labels", {}).update(
+            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+        )
 
     def execute(self, context: 'Context'):
         """Execute the Apache Beam Pipeline."""
-        self.beam_hook = BeamHook(runner=self.runner)
-        pipeline_options = self.default_pipeline_options.copy()
-        process_line_callback: Optional[Callable] = None
-        is_dataflow = self.runner.lower() == BeamRunnerType.DataflowRunner.lower()
-        dataflow_job_name: Optional[str] = None
+        (
+            is_dataflow,
+            dataflow_job_name,
+            snake_case_pipeline_options,
+            process_line_callback,
+        ) = self._init_pipeline_options(format_pipeline_options=True, job_name_variable_key="job_name")
 
-        if is_dataflow:
-            dataflow_job_name, pipeline_options, process_line_callback = self._set_dataflow(
-                pipeline_options=pipeline_options, job_name_variable_key="job_name"
-            )
-
-        pipeline_options.update(self.pipeline_options)
-
-        # Convert argument names from lowerCamelCase to snake case.
-        formatted_pipeline_options = {
-            convert_camel_to_snake(key): pipeline_options[key] for key in pipeline_options
-        }
+        if not self.beam_hook:
+            raise AirflowException("Beam hook is not defined.")
 
         with ExitStack() as exit_stack:
             if self.py_file.lower().startswith("gs://"):
@@ -244,7 +299,7 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
             if is_dataflow and self.dataflow_hook:
                 with self.dataflow_hook.provide_authorized_gcloud():
                     self.beam_hook.start_python_pipeline(
-                        variables=formatted_pipeline_options,
+                        variables=snake_case_pipeline_options,
                         py_file=self.py_file,
                         py_options=self.py_options,
                         py_interpreter=self.py_interpreter,
@@ -260,10 +315,10 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
                         job_id=self.dataflow_job_id,
                         multiple_jobs=False,
                     )
-
+                return {"dataflow_job_id": self.dataflow_job_id}
             else:
                 self.beam_hook.start_python_pipeline(
-                    variables=formatted_pipeline_options,
+                    variables=snake_case_pipeline_options,
                     py_file=self.py_file,
                     py_options=self.py_options,
                     py_interpreter=self.py_interpreter,
@@ -271,8 +326,6 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
                     py_system_site_packages=self.py_system_site_packages,
                     process_line_callback=process_line_callback,
                 )
-
-        return {"dataflow_job_id": self.dataflow_job_id}
 
     def on_kill(self) -> None:
         if self.dataflow_hook and self.dataflow_job_id:
@@ -283,7 +336,7 @@ class BeamRunPythonPipelineOperator(BaseOperator, BeamDataflowMixin):
             )
 
 
-class BeamRunJavaPipelineOperator(BaseOperator, BeamDataflowMixin):
+class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
     """
     Launching Apache Beam pipelines written in Java.
 
@@ -307,29 +360,8 @@ class BeamRunJavaPipelineOperator(BaseOperator, BeamDataflowMixin):
     Use ``pipeline_options`` to pass on pipeline_options to your job.
 
     :param jar: The reference to a self executing Apache Beam jar (templated).
-    :param runner: Runner on which pipeline will be run. By default "DirectRunner" is being used.
-        See:
-        https://beam.apache.org/documentation/runners/capability-matrix/
     :param job_class: The name of the Apache Beam pipeline class to be executed, it
         is often not the main class configured in the pipeline jar file.
-    :param default_pipeline_options: Map of default job pipeline_options.
-    :param pipeline_options: Map of job specific pipeline_options.The key must be a dictionary.
-        The value can contain different types:
-
-        * If the value is None, the single option - ``--key`` (without value) will be added.
-        * If the value is False, this option will be skipped
-        * If the value is True, the single option - ``--key`` (without value) will be added.
-        * If the value is list, the many pipeline_options will be added for each key.
-          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` pipeline_options
-          will be left
-        * Other value types will be replaced with the Python textual representation.
-
-        When defining labels (``labels`` option), you can also provide a dictionary.
-    :param gcp_conn_id: The connection ID to use connecting to Google Cloud Storage if jar is on GCS
-    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
-        if any. For this to work, the service account making the request must have
-        domain-wide delegation enabled.
-    :param dataflow_config: Dataflow configuration, used when runner type is set to DataflowRunner
     """
 
     template_fields: Sequence[str] = (
@@ -356,46 +388,29 @@ class BeamRunJavaPipelineOperator(BaseOperator, BeamDataflowMixin):
         dataflow_config: Optional[Union[DataflowConfiguration, dict]] = None,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
-
+        super().__init__(
+            runner=runner,
+            default_pipeline_options=default_pipeline_options,
+            pipeline_options=pipeline_options,
+            gcp_conn_id=gcp_conn_id,
+            delegate_to=delegate_to,
+            dataflow_config=dataflow_config,
+            **kwargs,
+        )
         self.jar = jar
-        self.runner = runner
-        self.default_pipeline_options = default_pipeline_options or {}
-        self.pipeline_options = pipeline_options or {}
         self.job_class = job_class
-        self.gcp_conn_id = gcp_conn_id
-        self.delegate_to = delegate_to
-        self.dataflow_job_id = None
-        self.dataflow_hook: Optional[DataflowHook] = None
-        self.beam_hook: Optional[BeamHook] = None
-        self._dataflow_job_name: Optional[str] = None
-
-        if dataflow_config is None:
-            self.dataflow_config = DataflowConfiguration()
-        elif isinstance(dataflow_config, dict):
-            self.dataflow_config = DataflowConfiguration(**dataflow_config)
-        else:
-            self.dataflow_config = dataflow_config
-
-        if self.dataflow_config and self.runner.lower() != BeamRunnerType.DataflowRunner.lower():
-            self.log.warning(
-                "dataflow_config is defined but runner is different than DataflowRunner (%s)", self.runner
-            )
 
     def execute(self, context: 'Context'):
         """Execute the Apache Beam Pipeline."""
-        self.beam_hook = BeamHook(runner=self.runner)
-        pipeline_options = self.default_pipeline_options.copy()
-        process_line_callback: Optional[Callable] = None
-        is_dataflow = self.runner.lower() == BeamRunnerType.DataflowRunner.lower()
-        dataflow_job_name: Optional[str] = None
+        (
+            is_dataflow,
+            dataflow_job_name,
+            pipeline_options,
+            process_line_callback,
+        ) = self._init_pipeline_options()
 
-        if is_dataflow:
-            dataflow_job_name, pipeline_options, process_line_callback = self._set_dataflow(
-                pipeline_options=pipeline_options, job_name_variable_key=None
-            )
-
-        pipeline_options.update(self.pipeline_options)
+        if not self.beam_hook:
+            raise AirflowException("Beam hook is not defined.")
 
         with ExitStack() as exit_stack:
             if self.jar.lower().startswith("gs://"):
@@ -450,6 +465,7 @@ class BeamRunJavaPipelineOperator(BaseOperator, BeamDataflowMixin):
                             multiple_jobs=multiple_jobs,
                             project_id=self.dataflow_config.project_id,
                         )
+                return {"dataflow_job_id": self.dataflow_job_id}
             else:
                 self.beam_hook.start_java_pipeline(
                     variables=pipeline_options,
@@ -458,7 +474,118 @@ class BeamRunJavaPipelineOperator(BaseOperator, BeamDataflowMixin):
                     process_line_callback=process_line_callback,
                 )
 
-        return {"dataflow_job_id": self.dataflow_job_id}
+    def on_kill(self) -> None:
+        if self.dataflow_hook and self.dataflow_job_id:
+            self.log.info('Dataflow job with id: `%s` was requested to be cancelled.', self.dataflow_job_id)
+            self.dataflow_hook.cancel_job(
+                job_id=self.dataflow_job_id,
+                project_id=self.dataflow_config.project_id,
+            )
+
+
+class BeamRunGoPipelineOperator(BeamBasePipelineOperator):
+    """
+    Launching Apache Beam pipelines written in Go. Note that both
+    ``default_pipeline_options`` and ``pipeline_options`` will be merged to specify pipeline
+    execution parameter, and ``default_pipeline_options`` is expected to save
+    high-level options, for instances, project and zone information, which
+    apply to all beam operators in the DAG.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BeamRunGoPipelineOperator`
+
+    .. seealso::
+        For more detail on Apache Beam have a look at the reference:
+        https://beam.apache.org/documentation/
+
+    :param go_file: Reference to the Go Apache Beam pipeline e.g.,
+        /some/local/file/path/to/your/go/pipeline/file.go
+    """
+
+    template_fields = [
+        "go_file",
+        "runner",
+        "pipeline_options",
+        "default_pipeline_options",
+        "dataflow_config",
+    ]
+    template_fields_renderers = {'dataflow_config': 'json', 'pipeline_options': 'json'}
+
+    def __init__(
+        self,
+        *,
+        go_file: str,
+        runner: str = "DirectRunner",
+        default_pipeline_options: Optional[dict] = None,
+        pipeline_options: Optional[dict] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        delegate_to: Optional[str] = None,
+        dataflow_config: Optional[Union[DataflowConfiguration, dict]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            runner=runner,
+            default_pipeline_options=default_pipeline_options,
+            pipeline_options=pipeline_options,
+            gcp_conn_id=gcp_conn_id,
+            delegate_to=delegate_to,
+            dataflow_config=dataflow_config,
+            **kwargs,
+        )
+
+        self.go_file = go_file
+        self.should_init_go_module = False
+        self.pipeline_options.setdefault("labels", {}).update(
+            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+        )
+
+    def execute(self, context: 'Context'):
+        """Execute the Apache Beam Pipeline."""
+        (
+            is_dataflow,
+            dataflow_job_name,
+            snake_case_pipeline_options,
+            process_line_callback,
+        ) = self._init_pipeline_options(format_pipeline_options=True, job_name_variable_key="job_name")
+
+        if not self.beam_hook:
+            raise AirflowException("Beam hook is not defined.")
+
+        with ExitStack() as exit_stack:
+            if self.go_file.lower().startswith("gs://"):
+                gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
+
+                with tempfile.TemporaryDirectory(prefix="apache-beam-go") as tmp_dir:
+                    tmp_gcs_file = exit_stack.enter_context(
+                        gcs_hook.provide_file(object_url=self.go_file, dir=tmp_dir)
+                    )
+                    self.go_file = tmp_gcs_file.name
+                    self.should_init_go_module = True
+
+            if is_dataflow and self.dataflow_hook:
+                with self.dataflow_hook.provide_authorized_gcloud():
+                    self.beam_hook.start_go_pipeline(
+                        variables=snake_case_pipeline_options,
+                        go_file=self.go_file,
+                        process_line_callback=process_line_callback,
+                        should_init_module=self.should_init_go_module,
+                    )
+                if dataflow_job_name and self.dataflow_config.location:
+                    self.dataflow_hook.wait_for_done(
+                        job_name=dataflow_job_name,
+                        location=self.dataflow_config.location,
+                        job_id=self.dataflow_job_id,
+                        multiple_jobs=False,
+                    )
+                return {"dataflow_job_id": self.dataflow_job_id}
+            else:
+                self.beam_hook.start_go_pipeline(
+                    variables=snake_case_pipeline_options,
+                    go_file=self.go_file,
+                    process_line_callback=process_line_callback,
+                    should_init_module=self.should_init_go_module,
+                )
 
     def on_kill(self) -> None:
         if self.dataflow_hook and self.dataflow_job_id:

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -113,9 +113,7 @@ class BeamBasePipelineOperator(BaseOperator, BeamDataflowMixin, ABC):
         See: :class:`~providers.apache.beam.hooks.beam.BeamRunnerType`
         See: https://beam.apache.org/documentation/runners/capability-matrix/
 
-    :type runner: str
     :param default_pipeline_options: Map of default pipeline options.
-    :type default_pipeline_options: dict
     :param pipeline_options: Map of pipeline options.The key must be a dictionary.
         The value can contain different types:
 
@@ -128,18 +126,14 @@ class BeamBasePipelineOperator(BaseOperator, BeamDataflowMixin, ABC):
         * Other value types will be replaced with the Python textual representation.
 
         When defining labels (labels option), you can also provide a dictionary.
-    :type pipeline_options: dict
     :param gcp_conn_id: Optional.
         The connection ID to use connecting to Google Cloud Storage if python file is on GCS.
-    :type gcp_conn_id: str
     :param delegate_to:  Optional.
         The account to impersonate using domain-wide delegation of authority,
         if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
-    :type delegate_to: str
     :param dataflow_config: Dataflow configuration, used when runner type is set to DataflowRunner,
         (optional) defaults to None.
-    :type dataflow_config: DataflowConfiguration
     """
 
     def __init__(

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -1014,7 +1014,7 @@ class DataflowHook(GoogleBaseHook):
                 DeprecationWarning,
                 stacklevel=3,
             )
-            on_new_job_id_callback(job["id"])
+            on_new_job_id_callback(cast(str, job.get("id")))
 
         if on_new_job_callback:
             on_new_job_callback(job)

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -383,6 +383,7 @@ class GCSHook(GoogleBaseHook):
         bucket_name: str = PROVIDE_BUCKET,
         object_name: Optional[str] = None,
         object_url: Optional[str] = None,
+        dir: Optional[str] = None,
     ):
         """
         Downloads the file to a temporary directory and returns a file handle
@@ -393,12 +394,13 @@ class GCSHook(GoogleBaseHook):
         :param bucket_name: The bucket to fetch from.
         :param object_name: The object to fetch.
         :param object_url: File reference url. Must start with "gs: //"
+        :param dir: The tmp sub directory to download the file to. (passed to NamedTemporaryFile)
         :return: File handler
         """
         if object_name is None:
             raise ValueError("Object name can not be empty")
         _, _, file_name = object_name.rpartition("/")
-        with NamedTemporaryFile(suffix=file_name) as tmp_file:
+        with NamedTemporaryFile(suffix=file_name, dir=dir) as tmp_file:
             self.download(bucket_name=bucket_name, object_name=object_name, filename=tmp_file.name)
             tmp_file.flush()
             yield tmp_file

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -81,7 +81,7 @@ class DataflowConfiguration:
         instead of canceling during killing task instance. See:
         https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline
     :param cancel_timeout: How long (in seconds) operator should wait for the pipeline to be
-        successfully cancelled when task is being killed.
+        successfully cancelled when task is being killed. (optional) default to 300s
     :param wait_until_finished: (Optional)
         If True, wait for the end of pipeline execution before exiting.
         If False, only submits job.
@@ -221,7 +221,7 @@ class DataflowCreateJavaJobOperator(BaseOperator):
         * If the value is False, this option will be skipped
         * If the value is True, the single option - ``--key`` (without value) will be added.
         * If the value is list, the many options will be added for each key.
-          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` options
+          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key=B`` options
           will be left
         * Other value types will be replaced with the Python textual representation.
 
@@ -913,7 +913,7 @@ class DataflowCreatePythonJobOperator(BaseOperator):
         * If the value is False, this option will be skipped
         * If the value is True, the single option - ``--key`` (without value) will be added.
         * If the value is list, the many options will be added for each key.
-          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` options
+          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key=B`` options
           will be left
         * Other value types will be replaced with the Python textual representation.
 

--- a/airflow/providers/google/go_module_utils.py
+++ b/airflow/providers/google/go_module_utils.py
@@ -27,9 +27,7 @@ def init_module(go_module_name: str, go_module_path: str) -> None:
     will do nothing.
 
     :param go_module_name: The name of the Go module to initialize.
-    :type go_module_name: str
     :param go_module_path: The path to the directory containing the Go module.
-    :type go_module_path: str
     :return:
     """
     if os.path.isfile(os.path.join(go_module_path, "go.mod")):
@@ -42,7 +40,6 @@ def install_dependencies(go_module_path: str) -> None:
     """Install dependencies for a Go module.
 
     :param go_module_path: The path to the directory containing the Go module.
-    :type go_module_path: str
     :return:
     """
     go_mod_tidy = ["go", "mod", "tidy"]

--- a/airflow/providers/google/go_module_utils.py
+++ b/airflow/providers/google/go_module_utils.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Utilities initializing and managing Go modules."""
+import os
+
+from airflow.utils.process_utils import execute_in_subprocess
+
+
+def init_module(go_module_name: str, go_module_path: str) -> None:
+    """Initialize a Go module. If a ``go.mod`` file already exists, this function
+    will do nothing.
+
+    :param go_module_name: The name of the Go module to initialize.
+    :type go_module_name: str
+    :param go_module_path: The path to the directory containing the Go module.
+    :type go_module_path: str
+    :return:
+    """
+    if os.path.isfile(os.path.join(go_module_path, "go.mod")):
+        return
+    go_mod_init_cmd = ["go", "mod", "init", go_module_name]
+    execute_in_subprocess(go_mod_init_cmd, cwd=go_module_path)
+
+
+def install_dependencies(go_module_path: str) -> None:
+    """Install dependencies for a Go module.
+
+    :param go_module_path: The path to the directory containing the Go module.
+    :type go_module_path: str
+    :return:
+    """
+    go_mod_tidy = ["go", "mod", "tidy"]
+    execute_in_subprocess(go_mod_tidy, cwd=go_module_path)

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -34,7 +34,7 @@ if not IS_WINDOWS:
     import pty
 
 from contextlib import contextmanager
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import psutil
 from lockfile.pidlockfile import PIDLockFile
@@ -155,15 +155,16 @@ def reap_process_group(
     return returncodes
 
 
-def execute_in_subprocess(cmd: List[str]):
+def execute_in_subprocess(cmd: List[str], cwd: Optional[str] = None) -> None:
     """
     Execute a process and stream output to logger
 
     :param cmd: command and arguments to run
+    :param cwd: Current working directory passed to the Popen constructor
     """
     log.info("Executing cmd: %s", " ".join(shlex.quote(c) for c in cmd))
     with subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, bufsize=0, close_fds=True, cwd=cwd
     ) as proc:
         log.info("Output:")
         if proc.stdout:
@@ -176,7 +177,7 @@ def execute_in_subprocess(cmd: List[str]):
         raise subprocess.CalledProcessError(exit_code, cmd)
 
 
-def execute_interactive(cmd: List[str], **kwargs):
+def execute_interactive(cmd: List[str], **kwargs) -> None:
     """
     Runs the new command as a subprocess and ensures that the terminal's state is restored to its original
     state after the process is completed e.g. if the subprocess hides the cursor, it will be restored after

--- a/docs/apache-airflow-providers-apache-beam/operators.rst
+++ b/docs/apache-airflow-providers-apache-beam/operators.rst
@@ -113,7 +113,7 @@ Java Pipelines with DataflowRunner
 .. _howto/operator:BeamRunGoPipelineOperator:
 
 Run Go Pipelines in Apache Beam
-===================================
+===============================
 
 The ``go_file`` argument must be specified for
 :class:`~airflow.providers.apache.beam.operators.beam.BeamRunGoPipelineOperator`
@@ -123,7 +123,7 @@ from the local filesystem the equivalent will be ``go run <go_file>``. If pullin
 init the module and install dependencies with ``go run init example.com/main`` and ``go mod tidy``.
 
 Go Pipelines with DirectRunner
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
     :language: python
@@ -138,7 +138,7 @@ Go Pipelines with DirectRunner
     :end-before: [END howto_operator_start_go_direct_runner_pipeline_gcs_file]
 
 Go Pipelines with DataflowRunner
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
     :language: python

--- a/docs/apache-airflow-providers-apache-beam/operators.rst
+++ b/docs/apache-airflow-providers-apache-beam/operators.rst
@@ -76,6 +76,9 @@ Python Pipelines with DataflowRunner
     :start-after: [START howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
     :end-before: [END howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
 
+|
+|
+
 .. _howto/operator:BeamRunJavaPipelineOperator:
 
 Run Java Pipelines in Apache Beam
@@ -103,6 +106,51 @@ Java Pipelines with DataflowRunner
     :dedent: 4
     :start-after: [START howto_operator_start_java_dataflow_runner_pipeline]
     :end-before: [END howto_operator_start_java_dataflow_runner_pipeline
+
+|
+|
+
+.. _howto/operator:BeamRunGoPipelineOperator:
+
+Run Go Pipelines in Apache Beam
+===================================
+
+The ``go_file`` argument must be specified for
+:class:`~airflow.providers.apache.beam.operators.beam.BeamRunGoPipelineOperator`
+as it contains the pipeline to be executed by Beam. The Go file can be available on GCS that Airflow
+has the ability to download or available on the local filesystem (provide the absolute path to it). When running
+from the local filesystem the equivalent will be ``go run <go_file>``. If pulling from GCS bucket, beforehand it will
+init the module and install dependencies with ``go run init example.com/main`` and ``go mod tidy``.
+
+Go Pipelines with DirectRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_go_direct_runner_pipeline_local_file]
+    :end-before: [END howto_operator_start_go_direct_runner_pipeline_local_file]
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_go_direct_runner_pipeline_gcs_file]
+    :end-before: [END howto_operator_start_go_direct_runner_pipeline_gcs_file]
+
+Go Pipelines with DataflowRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_go_dataflow_runner_pipeline_gcs_file]
+    :end-before: [END howto_operator_start_go_dataflow_runner_pipeline_gcs_file]
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_go_dataflow_runner_pipeline_async_gcs_file]
+    :end-before: [END howto_operator_start_go_dataflow_runner_pipeline_async_gcs_file]
 
 Reference
 ^^^^^^^^^

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -115,6 +115,7 @@ Deserialize
 Deserialized
 DevOps
 Dingding
+DirectRunner
 Dlp
 DlpJob
 DlpServiceClient

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ amazon = [
     pandas_requirement,
 ]
 apache_beam = [
-    'apache-beam>=2.20.0',
+    'apache-beam>=2.33.0',
 ]
 asana = ['asana>=0.10']
 async_packages = [

--- a/tests/providers/apache/beam/hooks/test_beam.py
+++ b/tests/providers/apache/beam/hooks/test_beam.py
@@ -17,6 +17,7 @@
 #
 
 import copy
+import os
 import subprocess
 import unittest
 from unittest import mock
@@ -33,6 +34,7 @@ JOB_CLASS = 'com.example.UnitTest'
 PY_OPTIONS = ['-m']
 TEST_JOB_ID = 'test-job-id'
 
+GO_FILE = '/path/to/file.go'
 DEFAULT_RUNNER = "DirectRunner"
 BEAM_STRING = 'airflow.providers.apache.beam.hooks.beam.{}'
 BEAM_VARIABLES_PY = {'output': 'gs://test/output', 'labels': {'foo': 'bar'}}
@@ -40,6 +42,7 @@ BEAM_VARIABLES_JAVA = {
     'output': 'gs://test/output',
     'labels': {'foo': 'bar'},
 }
+BEAM_VARIABLES_GO = {'output': 'gs://test/output', 'labels': {'foo': 'bar'}}
 
 APACHE_BEAM_V_2_14_0_JAVA_SDK_LOG = f""""\
 Dataflow SDK version: 2.14.0
@@ -75,7 +78,9 @@ class TestBeamHook(unittest.TestCase):
             '--output=gs://test/output',
             '--labels=foo=bar',
         ]
-        mock_runner.assert_called_once_with(cmd=expected_cmd, process_line_callback=process_line_callback)
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=None
+        )
         wait_for_done.assert_called_once_with()
 
     @parameterized.expand(
@@ -108,7 +113,9 @@ class TestBeamHook(unittest.TestCase):
             '--output=gs://test/output',
             '--labels=foo=bar',
         ]
-        mock_runner.assert_called_once_with(cmd=expected_cmd, process_line_callback=process_line_callback)
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=None
+        )
         wait_for_done.assert_called_once_with()
 
     @parameterized.expand(
@@ -145,7 +152,9 @@ class TestBeamHook(unittest.TestCase):
             '--output=gs://test/output',
             '--labels=foo=bar',
         ]
-        mock_runner.assert_called_once_with(cmd=expected_cmd, process_line_callback=process_line_callback)
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=None
+        )
         wait_for_done.assert_called_once_with()
         mock_virtualenv.assert_called_once_with(
             venv_directory=mock.ANY,
@@ -192,7 +201,9 @@ class TestBeamHook(unittest.TestCase):
             '--output=gs://test/output',
             '--labels={"foo":"bar"}',
         ]
-        mock_runner.assert_called_once_with(cmd=expected_cmd, process_line_callback=process_line_callback)
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=None
+        )
         wait_for_done.assert_called_once_with()
 
     @mock.patch(BEAM_STRING.format('BeamCommandRunner'))
@@ -217,7 +228,36 @@ class TestBeamHook(unittest.TestCase):
             '--output=gs://test/output',
             '--labels={"foo":"bar"}',
         ]
-        mock_runner.assert_called_once_with(cmd=expected_cmd, process_line_callback=process_line_callback)
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=None
+        )
+        wait_for_done.assert_called_once_with()
+
+    @mock.patch(BEAM_STRING.format('BeamCommandRunner'))
+    def test_start_go_pipeline(self, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+        process_line_callback = MagicMock()
+
+        hook.start_go_pipeline(
+            go_file=GO_FILE,
+            variables=copy.deepcopy(BEAM_VARIABLES_GO),
+            process_line_callback=process_line_callback,
+        )
+
+        basename = os.path.basename(GO_FILE)
+        go_workspace = os.path.dirname(GO_FILE)
+        expected_cmd = [
+            'go',
+            'run',
+            basename,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels={"foo":"bar"}',
+        ]
+        mock_runner.assert_called_once_with(
+            cmd=expected_cmd, process_line_callback=process_line_callback, working_directory=go_workspace
+        )
         wait_for_done.assert_called_once_with()
 
 
@@ -247,11 +287,7 @@ class TestBeamRunner(unittest.TestCase):
         beam = BeamCommandRunner(cmd)
         mock_logging.info.assert_called_once_with('Running command: %s', " ".join(cmd))
         mock_popen.assert_called_once_with(
-            cmd,
-            shell=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            close_fds=True,
+            cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True, cwd=None
         )
         self.assertRaises(Exception, beam.wait_for_done)
 

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -17,8 +17,10 @@
 #
 import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 
 from airflow.providers.apache.beam.operators.beam import (
+    BeamRunGoPipelineOperator,
     BeamRunJavaPipelineOperator,
     BeamRunPythonPipelineOperator,
 )
@@ -34,6 +36,7 @@ JOB_CLASS = 'com.test.NotMain'
 PY_FILE = 'gs://my-bucket/my-object.py'
 PY_INTERPRETER = 'python3'
 PY_OPTIONS = ['-m']
+GO_FILE = 'gs://my-bucket/example/main.go'
 DEFAULT_OPTIONS_PYTHON = DEFAULT_OPTIONS_JAVA = {
     'project': 'test',
     'stagingLocation': 'gs://test/staging',
@@ -256,6 +259,145 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
     def test_on_kill_dataflow_runner(self, dataflow_hook_mock, _, __):
         self.operator.runner = "DataflowRunner"
         dataflow_hook_mock.return_value.is_job_dataflow_running.return_value = False
+        dataflow_cancel_job = dataflow_hook_mock.return_value.cancel_job
+        self.operator.execute(None)
+        self.operator.dataflow_job_id = JOB_ID
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_called_once_with(
+            job_id=JOB_ID, project_id=self.operator.dataflow_config.project_id
+        )
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_on_kill_direct_runner(self, _, dataflow_mock, __):
+        dataflow_cancel_job = dataflow_mock.return_value.cancel_job
+        self.operator.execute(None)
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_not_called()
+
+
+class TestBeamRunGoPipelineOperator(unittest.TestCase):
+    def setUp(self):
+        self.operator = BeamRunGoPipelineOperator(
+            task_id=TASK_ID,
+            go_file=GO_FILE,
+            default_pipeline_options=DEFAULT_OPTIONS_PYTHON,
+            pipeline_options=ADDITIONAL_OPTIONS,
+        )
+
+    def test_init(self):
+        """Test BeamRunGoPipelineOperator instance is properly initialized."""
+        self.assertEqual(self.operator.task_id, TASK_ID)
+        self.assertEqual(self.operator.go_file, GO_FILE)
+        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
+        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_PYTHON)
+        self.assertEqual(self.operator.pipeline_options, EXPECTED_ADDITIONAL_OPTIONS)
+
+    @mock.patch(
+        "tempfile.TemporaryDirectory",
+        return_value=MagicMock(__enter__=MagicMock(return_value='/tmp/apache-beam-go')),
+    )
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_direct_runner(self, gcs_hook, beam_hook_mock, _):
+        """Test BeamHook is created and the right args are passed to
+        start_go_workflow.
+        """
+        start_go_pipeline_method = beam_hook_mock.return_value.start_go_pipeline
+        gcs_provide_file_method = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        beam_hook_mock.assert_called_once_with(runner=DEFAULT_RUNNER)
+        expected_options = {
+            'project': 'test',
+            'staging_location': 'gs://test/staging',
+            'output': 'gs://test/output',
+            'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
+        }
+        gcs_provide_file_method.assert_called_once_with(object_url=GO_FILE, dir="/tmp/apache-beam-go")
+        start_go_pipeline_method.assert_called_once_with(
+            variables=expected_options,
+            go_file=gcs_provide_file_method.return_value.__enter__.return_value.name,
+            process_line_callback=None,
+            should_init_module=True,
+        )
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.google.go_module_utils.init_module')
+    def test_exec_source_on_local_path(self, init_module, beam_hook_mock):
+        """
+        Check that start_go_pipeline is called without initializing the Go module when source is locale.
+        """
+        local_go_file_path = '/tmp/file/path/example.go'
+        operator = BeamRunGoPipelineOperator(
+            task_id=TASK_ID,
+            go_file=local_go_file_path,
+        )
+        start_go_pipeline_method = beam_hook_mock.return_value.start_go_pipeline
+        operator.execute(None)
+        beam_hook_mock.assert_called_once_with(runner=DEFAULT_RUNNER)
+        init_module.assert_not_called()
+        start_go_pipeline_method.assert_called_once_with(
+            variables={'labels': {'airflow-version': TEST_VERSION}},
+            go_file=local_go_file_path,
+            process_line_callback=None,
+            should_init_module=False,
+        )
+
+    @mock.patch(
+        "tempfile.TemporaryDirectory",
+        return_value=MagicMock(__enter__=MagicMock(return_value='/tmp/apache-beam-go')),
+    )
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_dataflow_runner(self, gcs_hook, dataflow_hook_mock, beam_hook_mock, _):
+        """Test DataflowHook is created and the right args are passed to
+        start_go_dataflow.
+        """
+        dataflow_config = DataflowConfiguration()
+        self.operator.runner = "DataflowRunner"
+        self.operator.dataflow_config = dataflow_config
+        gcs_provide_file = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        job_name = dataflow_hook_mock.build_dataflow_job_name.return_value
+        dataflow_hook_mock.assert_called_once_with(
+            gcp_conn_id=dataflow_config.gcp_conn_id,
+            delegate_to=dataflow_config.delegate_to,
+            poll_sleep=dataflow_config.poll_sleep,
+            impersonation_chain=dataflow_config.impersonation_chain,
+            drain_pipeline=dataflow_config.drain_pipeline,
+            cancel_timeout=dataflow_config.cancel_timeout,
+            wait_until_finished=dataflow_config.wait_until_finished,
+        )
+        expected_options = {
+            'project': dataflow_hook_mock.return_value.project_id,
+            'job_name': job_name,
+            'staging_location': 'gs://test/staging',
+            'output': 'gs://test/output',
+            'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
+            'region': 'us-central1',
+        }
+        gcs_provide_file.assert_called_once_with(object_url=GO_FILE, dir='/tmp/apache-beam-go')
+        beam_hook_mock.return_value.start_go_pipeline.assert_called_once_with(
+            variables=expected_options,
+            go_file=gcs_provide_file.return_value.__enter__.return_value.name,
+            process_line_callback=mock.ANY,
+            should_init_module=True,
+        )
+        dataflow_hook_mock.return_value.wait_for_done.assert_called_once_with(
+            job_id=self.operator.dataflow_job_id,
+            job_name=job_name,
+            location='us-central1',
+            multiple_jobs=False,
+        )
+        dataflow_hook_mock.return_value.provide_authorized_gcloud.assert_called_once_with()
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    def test_on_kill_dataflow_runner(self, dataflow_hook_mock, _, __):
+        self.operator.runner = "DataflowRunner"
         dataflow_cancel_job = dataflow_hook_mock.return_value.cancel_job
         self.operator.execute(None)
         self.operator.dataflow_job_id = JOB_ID

--- a/tests/providers/apache/beam/operators/test_beam_system.py
+++ b/tests/providers/apache/beam/operators/test_beam_system.py
@@ -45,3 +45,9 @@ class BeamExampleDagsSystemTest(SystemTest):
 
     def test_run_example_dag_beam_java_flink_runner(self):
         self.run_dag('example_beam_native_java_flink_runner', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_go(self):
+        self.run_dag('example_beam_native_go', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_go_dataflow_async(self):
+        self.run_dag('example_beam_native_go_dataflow_async', BEAM_DAG_FOLDER)

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -705,7 +705,7 @@ class TestGCSHook(unittest.TestCase):
         download_filename_method.assert_called_once_with(test_file, timeout=60)
         mock_temp_file.assert_has_calls(
             [
-                mock.call(suffix='test_object'),
+                mock.call(suffix='test_object', dir=None),
                 mock.call().__enter__(),
                 mock.call().__enter__().flush(),
                 mock.call().__exit__(None, None, None),

--- a/tests/providers/google/test_go_module.py
+++ b/tests/providers/google/test_go_module.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+from unittest import mock
+
+from airflow.providers.google.go_module_utils import init_module, install_dependencies
+
+
+class TestGoModule(unittest.TestCase):
+    @mock.patch('airflow.providers.google.go_module_utils.execute_in_subprocess')
+    def test_should_init_go_module(self, mock_execute_in_subprocess):
+        init_module(go_module_name="example.com/main", go_module_path="/home/example/go")
+        mock_execute_in_subprocess.assert_called_once_with(
+            ['go', 'mod', 'init', 'example.com/main'], cwd='/home/example/go'
+        )
+
+    @mock.patch('airflow.providers.google.go_module_utils.execute_in_subprocess')
+    def test_should_install_module_dependencies(self, mock_execute_in_subprocess):
+        install_dependencies(go_module_path="/home/example/go")
+        mock_execute_in_subprocess.assert_called_once_with(['go', 'mod', 'tidy'], cwd='/home/example/go')

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -35,7 +35,7 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.utils import process_utils
-from airflow.utils.process_utils import check_if_pidfile_process_is_running, execute_in_subprocess, log
+from airflow.utils.process_utils import check_if_pidfile_process_is_running, execute_in_subprocess
 
 
 class TestReapProcessGroup(unittest.TestCase):
@@ -96,14 +96,22 @@ class TestReapProcessGroup(unittest.TestCase):
                 pass
 
 
-class TestExecuteInSubProcess(unittest.TestCase):
-    def test_should_print_all_messages1(self):
-        with self.assertLogs(log) as logs:
-            execute_in_subprocess(["bash", "-c", "echo CAT; echo KITTY;"])
-
-        msgs = [record.getMessage() for record in logs.records]
-
+class TestExecuteInSubProcess:
+    def test_should_print_all_messages1(self, caplog):
+        execute_in_subprocess(["bash", "-c", "echo CAT; echo KITTY;"])
+        msgs = [record.getMessage() for record in caplog.records]
         assert ["Executing cmd: bash -c 'echo CAT; echo KITTY;'", 'Output:', 'CAT', 'KITTY'] == msgs
+
+    def test_should_print_all_messages_from_cwd(self, caplog, tmp_path):
+        execute_in_subprocess(["bash", "-c", "echo CAT; pwd; echo KITTY;"], cwd=str(tmp_path))
+        msgs = [record.getMessage() for record in caplog.records]
+        assert [
+            "Executing cmd: bash -c 'echo CAT; pwd; echo KITTY;'",
+            'Output:',
+            'CAT',
+            str(tmp_path),
+            'KITTY',
+        ] == msgs
 
     def test_should_raise_exception(self):
         with pytest.raises(CalledProcessError):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/20283

In this PR:
- [x]  Upgrade the minimum package requirement to 2.33.0 for apache-beam (first stable for beam go sdk)
- [x]  Refactor `operators/beam.py` with an abstract `BeamBasePipelineOperator` class to factorize initialization and common code, also fixed mypy hook on ``BeamDataflowMixin``
- [x] Add `BeamRunGoPipelineOperator` and `BeamHook.start_go_pipeline` (+tests)
- [x]  Add `utils/go_module.py` to handle initialisation and dependency installation for a module. (+ tests)
- [x]  Slightly modified `process_util` + tests to be able to handle an extra optional parameter `cwd`. (This way we can move to the module directory to build it)
- [x]  Write docs
- [x]  Add dags examples, with system tests
- [ ]  I think we might want to install Go in the docker images. Go 1.16 minimum for beam 2.33

``` bash
wget https://dl.google.com/go/go1.16.4.linux-amd64.tar.gz
sudo tar -xvf go1.16.4.linux-amd64.tar.gz   
sudo mv go /usr/local 
# in bashrc
export GOROOT=/usr/local/go
export PATH=$GOPATH/bin:$GOROOT/bin:$PATH 
```