### PR TITLE
Change default python version in docker image docs

### DIFF
--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -46,9 +46,9 @@ for all the supported Python versions.
 
 You can find the following images there (Assuming Airflow version |airflow-version|):
 
-* :subst-code:`apache/airflow:latest`              - the latest released Airflow image with default Python version (3.6 currently)
+* :subst-code:`apache/airflow:latest`              - the latest released Airflow image with default Python version (3.7 currently)
 * :subst-code:`apache/airflow:latest-pythonX.Y`    - the latest released Airflow image with specific Python version
-* :subst-code:`apache/airflow:|airflow-version|`           - the versioned Airflow image with default Python version (3.6 currently)
+* :subst-code:`apache/airflow:|airflow-version|`           - the versioned Airflow image with default Python version (3.7 currently)
 * :subst-code:`apache/airflow:|airflow-version|-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" images. They contain the most common set of extras, dependencies and providers that are


### PR DESCRIPTION
Added information that you get a 3.7 python version when using apache/airflow:latest or apache/airflow:2.2.2 images

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
