### PR TITLE
Simplest event note POC

### DIFF
--- a/airflow/migrations/versions/3b2ef693bc2e_added_task_notes.py
+++ b/airflow/migrations/versions/3b2ef693bc2e_added_task_notes.py
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Added task notes
+
+Revision ID: 3b2ef693bc2e
+Revises: 786e3737b18f
+Create Date: 2021-12-18 15:10:03.346251
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+from airflow.models.base import COLLATION_ARGS
+
+revision = '3b2ef693bc2e'
+down_revision = '786e3737b18f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply Added event notes table"""
+    op.create_table(
+        'event_note',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+        sa.Column('execution_date', sa.DateTime(), nullable=False),
+        sa.Column("event", sa.String(length=30), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), nullable=False),
+        sa.Column('owner', sa.String(length=50), nullable=True),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade():
+    """Unapply Add task notes"""
+    op.drop_table('event_note')

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -37,3 +37,4 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
+from airflow.models.event_note import EventNote

--- a/airflow/models/event_note.py
+++ b/airflow/models/event_note.py
@@ -1,0 +1,48 @@
+import logging
+from sqlalchemy import Column, Integer, String, Text
+from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
+from airflow.utils import timezone
+from airflow.utils.sqlalchemy import UtcDateTime
+
+log = logging.getLogger(__name__)
+
+
+class EventNote(Base):
+    """Model that stores a note for an event"""
+
+    __tablename__ = "event_note"
+
+    id = Column(Integer, primary_key=True)
+
+    dag_id = Column(String(ID_LEN, **COLLATION_ARGS))
+    task_id = Column(String(ID_LEN), nullable=True)
+    execution_date = Column(UtcDateTime, nullable=True)
+    timestamp = Column(UtcDateTime, nullable=True)
+    event = Column(String(30), nullable=True)
+    owner = Column(String(30), nullable=True)
+    note = Column(Text)
+
+    def __repr__(self):
+        return str(self.__key())
+
+    def __init__(self, event, note,  task_instance=None, owner=None,  **kwargs):
+        self.note = note
+        self.event = event
+        self.timestamp = timezone.utcnow()
+        task_owner = None
+
+        if task_instance:
+            self.dag_id = task_instance.dag_id
+            self.task_id = task_instance.task_id
+            self.execution_date = task_instance.execution_date
+            task_owner = task_instance.task.owner
+
+        if 'task_id' in kwargs:
+            self.task_id = kwargs['task_id']
+        if 'dag_id' in kwargs:
+            self.dag_id = kwargs['dag_id']
+        if 'execution_date' in kwargs:
+            if kwargs['execution_date']:
+                self.execution_date = kwargs['execution_date']
+
+        self.owner = owner or task_owner

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -52,7 +52,7 @@ RESOURCE_USER_STATS_CHART = "User Stats Chart"
 RESOURCE_VARIABLE = "Variables"
 RESOURCE_WEBSITE = "Website"
 RESOURCE_XCOM = "XComs"
-
+RESOURCE_EVENT_NOTE = "Event notes"
 
 # Action Constants
 ACTION_CAN_CREATE = "can_create"

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -51,6 +51,7 @@ from airflow.models import (  # noqa: F401
     TaskReschedule,
     Variable,
     XCom,
+    EventNote
 )
 
 # We need to add this model manually to get reset working well

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -106,6 +106,9 @@ def init_appbuilder_views(app):
         views.XComModelView, permissions.RESOURCE_XCOM, category=permissions.RESOURCE_ADMIN_MENU
     )
     appbuilder.add_view(
+        views.EventNoteView, permissions.RESOURCE_EVENT_NOTE, category=permissions.RESOURCE_BROWSE_MENU
+    )
+    appbuilder.add_view(
         views.DagDependenciesView,
         permissions.RESOURCE_DAG_DEPENDENCIES,
         category=permissions.RESOURCE_BROWSE_MENU,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -82,6 +82,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_EVENT_NOTE),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_BROWSE_MENU),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DAG_DEPENDENCIES),
@@ -93,6 +94,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_PLUGIN),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_SLA_MISS),
         (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_TASK_INSTANCE),
+        (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_EVENT_NOTE),
     ]
     # [END security_viewer_perms]
 
@@ -106,6 +108,9 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG_RUN),
+        (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_EVENT_NOTE),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_EVENT_NOTE),
+        (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_EVENT_NOTE),
     ]
     # [END security_user_perms]
 
@@ -132,6 +137,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_XCOM),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_EVENT_NOTE)
     ]
     # [END security_op_perms]
 

--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -38,6 +38,10 @@
     {% for name,val in request.values.items() if name != "csrf_token" %}
       <input type="hidden" name="{{ name }}" value="{{ val }}">
     {% endfor %}
+    <div class="form-group">
+      <label for="note">(Optional) Addd a note</label>
+      <textarea class="form-control" name="note" id="text"></textarea>
+    </div>
     <button type="submit" class="btn btn-primary">OK</button>
     <button type="button" class="btn" onclick="window.history.back(); return false">Cancel</button>
   </form>


### PR DESCRIPTION
Hello airflow community! 
I have seen that lately the topic "manual notes" has been mentioned by various users (#19011, #20122 etc), and they were all referred back to my original issue #16790 (and PRs #16953 and #17181). 

Unfortunately, the work in those PRs is far from being great and the lack of time (and feedback from the community) drove me away from that work. (Moreover the code was deleted from my fork and it was hard to reach)

I am just sharing again my original idea here with this stripped down version of the previous implementations, hopefully this sparkles a discussion and/or a real implementation among the interested people (such as @euccas and @Acehaidrey)

My very original idea in #19011 was to introduce a concept of "task note" for a task instance loosely based on the concept of Xcom (in retrospective it did not make much sense 😄 ). 

In #17181, I tried to generalize the idea by having a generic "even note" that works something like this: 
- I tried to select some events (user actions) which could be interesting to be noted (mostly any "confirm operation" and trigger) and there I added a field in the post request with the "note" name. 
- The model of an Event note is composed by `dag_id`, `task_id`, `execution_date` `owner` `timestamp` which means that an event should be related to a specific task_id of a specific dag of a specific execution_date (Which is kind of a limitation). (Actually in #17181 i also support trigger_run event note which are not related to a task id leaving the field empty)
- Instead of changing of the relative APIs to handle the extra field, I created a decorated (loosely inspired by the action_logging operator) that if the request contains the `note` field it creates an entry in the even_notes table using as event name the name of the API (again inspired by the action_logging). 
This is also great, imho, because you can extend any API adding the support for note taking without changing it (and if you want to improve/change the note part, you also need to modify it in one place) 


This being the simplest POC possible does have unanswered questions such as:
- What does "event" mean? Which kind of activities/event should be notables? EG: Pausing a dag should be notable?
- Should an event always be linked to a dag or/and task id (It is in this current implementation), if yes, how do you handle the "mark recursively success/failures" ?
- How do users access notes? Here we are using the browser view but in #17181 there was an idea of having a dag view notes and a task instance note view as well.
- Probably many others 😄 

My feeling is that there should probably be an higher level of abstraction for handling this feature properly and this is mostly a borderline wrong implementation, but without the vision of the core contributors it's complicated to implement a feature that spans different domains (frontend/backend/database/user expectations)


I really hope this sparkles a discussion in the community on how to develop this feature in the best possible way 😄 

