### PR TITLE
Add ADR describing reasoning why we build images and security of it

### DIFF
--- a/dev/breeze/doc/adr/0004-using-docker-images-as-test-environment.md
+++ b/dev/breeze/doc/adr/0004-using-docker-images-as-test-environment.md
@@ -1,0 +1,140 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [4. Using Docker images as test environment](#4-using-docker-images-as-test-environment)
+  - [Status](#status)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# 4. Using Docker images as test environment
+
+Date: 2021-12-19
+
+## Status
+
+Draft
+
+Also see [5. Preventing using contributed code when building images](0005-preventing-using-contributed-code-when-building-images.md)
+
+## Context
+
+Airflow is not only an application but also a complex "ecosystem" that integrates with multiple external
+services. It is split into multiple packages (main `apache-airflow` package and more than 70 provider
+packages). Each of those packages brings its own set of dependencies and when you count all the transitive
+dependencies they bring, it totals to more than 550 dependencies.
+
+This number of dependencies is huge, and it makes it very difficult to keep the dependencies in
+sync for all the developers that are contributing to Airflow. Airflow developers are coming with
+different background and experiences. They also use various development environments - Linux,
+Intel-based MacOS, WSL2 on Windows, soon also Windows, soon ARM-based MacOS. A lot of the dependencies
+of Airflow are data-science related and optimized using "C" libraries (numpy, pandas and others) which
+makes it extremely painful to set up and keep the virtual environments updated when you want to run
+tests for all the components of Airflow. Another dependencies of Airflow (mysql, postgres and others)
+also require "system-level" dependencies to be installed, not only Python dependencies (for example
+mysql integration requires mysql client system libraries to be installed). Those dependencies that have
+system dependencies change over time (for example when we added MsSQL support) so the environment needs
+to include also evolution of those.
+
+The usual, simple approach where each developer keeps their own virtualenv updated in this case does not
+scale for Airflow. There are literally more than 10 dependencies updated every day for airflow and keeping
+up with all those dependencies is next to impossible - for both casual users and seasoned committers.
+Relying on the set of dependencies each developer in the past led often to "works for me" syndrome - where
+tests executed worked fine for one developer but failed on CI and for other developers and only deep
+investigation could reveal that single - seemingly unrelated - dependency had different version for one
+of the developers.
+
+Also, some tools that we use (for example mypy) require all dependencies to be installed and present
+in precisely the same versions in order to produce repeatable results because they rely
+on information present in the libraries (mypy relies on type hinting present in the libraries).
+That means that if - for example - we want to have consistent `mypy` errors seen by different developers,
+they should have the same versions of all dependencies and libraries that are used in CI. In the past it
+has been a major source of confusion and problems when the errors reported in CI were not locally
+reproducible (because again - seemingly unrelated dependency was installed in a different version)
+
+Observations of this problem led to conclusion that we need a common development environment that will be
+the common source of truth for the "current" set of dependencies in "main". This development environment
+should have the following characteristics:
+
+* It should be fully cross-platform, including an easy way to install and update dependencies without
+  complex additional prerequisites and "dealing" with platform-specific issues.
+* It should support multiple Python versions out of the box
+* It should support running all the tests we have in Airflow - unit, integration, system tests
+* It should be automatically used by the CI system of ours so that errors in CI can be reproduced locally
+* Each developer should be able to easily synchronize the environment with the one that is used in CI
+* Each developer should be able to contribute to the environment by adding new/changing dependencies
+* Other developers should be able to easily get the updated environment after changes from other developers
+  are merged.
+* The environment should be cacheable for the CI speed purpose. Installing 500 dependencies takes a lot of
+  time - and there should be an easy way to incrementally add new dependencies to the environment
+  as PRs are adding dependencies. It should take minimum time to update the environment with minimum time
+  needed for different cases:
+  * when only sources change, rebuild should not be needed at all
+  * when Python dependencies change, rebuilds should be incremental only without rebuilding all dependencies
+  * only when node modules changes, the node modules and javascript `transpilation` (which takes quite
+    some time) should be performed.
+  * some dependencies only when some new, system requirements change, the environment might be rebuilt
+    from scratch.
+* The environment should also provide a way to test Airflow with the latest security fixes installed. Airflow,
+  due to its hundreds of dependencies is very prone to "supply chain" attacks, therefore it is crucial that
+  all the dependencies that are possible to upgrade, are upgraded as soon as possible, and they are used in
+  CI and local development to make sure, that Airflow continues to work with the newest versions of the
+  dependencies possibly containing security fixes.
+
+## Decision
+
+We decided to use Docker Images to provide such a development environment. Docker images are perfectly
+suited for the job:
+
+* they are fully cross-platform (including support for multiple architectures)
+* they are easily shareable (docker push/pull)
+* we have a registry (`ghcr.io`) in GitHub where we can keep the images for both CI and development
+* they are cacheable, providing the right layering of the images
+* they provide a mechanism to not only synchronize Python dependencies but also System dependencies
+* they provide an easy mechanism to query and inspect the images
+* the concept of the CI environment might also be extended to provide similar Production Image (but with
+  slightly different characteristics
+* they can be easily built and used in CI including caching support
+* management and automated synchronisation of the environment can be easily done using simple, external
+  scripts that will check the "freshness" of the images and propose corrective actions (pulling or
+  rebuilding the image) for the user whenever they are needed (all that in cross-platform way)
+* we can use specific base image (Debian Buster with Long Term Support) and rely on security fixes provided
+  by Debian for system dependencies.
+
+The only alternative considered is a plain virtualenv managed individually by each user. The problem with
+that in case of Airflow is a number of dependencies to manage and extremely weak cross-platform support
+that virtualenv provide in case of many Airflow dependencies. The Virtualenv environment is good for many
+local development needs, however in order to reliably recreate the same development environment that is
+on CI and in order to run all the tests, virtualenv in conjunction with many C-level and system
+dependencies is to "brittle" to make it "stable" and "repeatable" environment.
+
+## Consequences
+
+As a consequence of choosing Docker image as common development environment, the Airflow development
+ecosystem gets fast, robust and seamless way to make sure that all the developers of Airflow have
+consistent environment with the latest security fixes applied, one that allows to reproduce CI failures
+and make sure that they are fixed without actually pushing them to CI. It avoids "works for me syndrome"
+and enables similar development/test experience for various developers (from casual to seasoned ones) using
+different platforms for development.

--- a/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
+++ b/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
@@ -72,7 +72,7 @@ This requires those prerequisites:
 
 GitHub Actions provide some features that we can use for that purpose:
 
-* there isa "pull request target" workflow that uses only the code present in the protected "main" version
+* there is a "pull request target" workflow that uses only the code present in the protected "main" version
   of the code even if the code is modified in the PR. That code also has access to secrets stored in
   Airflow repository (for example in our case secret used to push documentation to S3 Bucket). Those
   secrets should not be made available to user code coming from PR.

--- a/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
+++ b/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
@@ -1,0 +1,160 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [5. Preventing using contributed code when building images](#5-preventing-using-contributed-code-when-building-images)
+  - [Status](#status)
+  - [Context](#context)
+  - [Decision](#decision)
+  - [Consequences](#consequences)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# 5. Preventing using contributed code when building images
+
+Date: 2021-12-19
+
+## Status
+
+Draft
+
+Builds on [4. Using Docker images as test environment](0004-using-docker-images-as-test-environment.md)
+
+## Context
+
+As described in [4. Using Docker images as test environment](0004-using-docker-images-as-test-environment.md),
+Airflow CI system uses CI Docker image as consistent test execution environment. This environment provides
+cacheability and rebuild capabilities that allow the image to be rebuilt quickly, incrementally based on
+previous version of the images - whenever any of the source code, Python dependencies, System dependencies
+are changed (in optimal way depending on the change). However, even with optimalizations, rebuilding
+the image might take quite some time (when only sources change ~ 1 minute, but when system dependencies
+change ~ 10 minutes). In certain cases we run (for the same Python version) 20 jobs that require the same
+image as the environment, which in extreme cases would mean 20x10 = 200 build minutes on CI to
+just rebuild the same image.
+
+Therefore, there is a need to use the process that will allow to build the images once and share it with
+all the test jobs that need it. Another advantage of having such image is that since the image is stored
+in the registry with "commit" tag which allows to easily reproduce the environment used in particular
+build on CI. This is a nice side effect of such setup, one that can be useful in case a user does not want
+to lose time on checking out and rebuilding the environment locally for a build that comes from their own,
+or another developer's PR.
+
+This requires those prerequisites:
+
+  * the images need to be built in a workflow that has "write" access to store the images after they are
+    built, so that the images can then be "pulled" by the test jobs rather than rebuilt
+
+  * the process to build the images need to be secured from malicious users that would like to inject a
+    code in the build process to make bad use of the "write" access - for example to push the code
+    to the repository or to inject malicious code to "common" artifacts used by the jobs
+
+  * however, in order to build the images that reflect the PR of the user, they should be able to modify some
+    code that is usually used to build airflow packages (`setup.py`, airflow sources, scripts).
+
+GitHub Actions provide some features that we can use for that purpose:
+
+* there isa "pull request target" workflow that uses only the code present in the protected "main" version
+  of the code even if the code is modified in the PR. That code also has access to secrets stored in
+  Airflow repository (for example in our case secret used to push documentation to S3 Bucket). Those
+  secrets should not be made available to user code coming from PR.
+
+* this "pull request target" workflow can have granular "write" permissions assigned, so that each job
+  can be granted access to certain resources only
+
+* however, they are ways (using some GitHub Actions) to inject more permissions - for example
+  when "checkout" is performed by default using GitHub Actions checkout command by default the checked-out
+  repository has "write" access and any of the further steps in the job can "push" using this repository
+  (see https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+status#GitHubActionsstatus-Security)
+  for details.
+
+* when using 3rd-party actions, you need to "pin" the actions to specific COMMIT SHA versions because
+  there is a risk, a 3rd-party might inject a code to your workflow by releasing and tagging new version
+  of their actions: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
+
+* some code that should be executed "inside" of the images when building should be possible to come from the
+  PR - for example code that is used inside the docker image to install mysql or postgres should be possible
+  to be changed in the PR - as long as we make sure the code is executed inside the Docker image or Docker
+  build process.
+
+Those protections are gradually strengthened (up until recently there was no granular access rights possible)
+however we decided to add certain rules of the "build" code that is executed in our GitHub "Build Images"
+"pull request target" to make sure
+
+## Decision
+
+The decision of our use of GitHub images is to utilise "Pull Request Workflow" to build the shared image,
+but to make sure that the following rules are in-place:
+
+1) We always use `persist-credentials: false` in all GitHub Action checkouts, to prevent unauthorized pushes
+   to our repository
+
+```yaml
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_COMMIT_SHA }}
+          persist-credentials: false
+          fetch-depth: 2
+```
+
+2) we use submodules (in .github/actions) where we keep actions that we are using (except of the standard
+   GitHub managed actions). Submodules provide few features such as - automated linking to specific commit
+   SHA (not tag) and integration with Pull Request Review process when someone creates a PR to upgrade the
+   action, which makes it ideal to securely and seamlessly keep the action updated if needed.
+
+3) No user code coming from the PR can be executed directly in the "Build image" workflow. For example, the
+   build scripts should not import `setup.py` or execute bash scripts coming from other places than:
+   * scripts/ci
+   * dev/
+   All the other sources are taken from the PR, but those two folders, during the "Build image" workflow
+   are overwritten by the `main` version of the scripts. This means that it is safe to execute those
+   scripts in the "Build Image" workflow.
+
+4) All the other code coming from the PR can only be executed inside the docker container started by the
+   `scripts/ci` or `dev` scripts. The docker containers should not have any volumes mounted from
+   the host that will enable them to read or modify values, environment variables that are present in the
+   Host CI environment.
+
+5) The "docker build" commands automatically execute Dockerfile commands inside such a container, so there
+   is no risk that sensitive information from the host will be passed to them.
+
+6) In case any information is needed from the "sources" of Airflow (such as name of the current branch or
+   version of airflow) it should be extracted by parsing of the incoming scripts but not executing them. Under
+   any circumstances any of the scripts coming from the outside of `scripts/ci` and `dev` should be
+   executed on the host during the image building process.
+
+Unfortunately, this setup means that any changes in `scripts/ci` and `dev` that are needed in
+the `Build Workflow` cannot be effective until they are merged. So if you have a change in one of those
+that should affect the build workflow, it has to be tested by pushing the `main` branch into your own
+repository fork in order to make it "eligible for running".
+
+## Consequences
+
+As a consequence of that decision, we should have optimized build of images which can be reused during
+multiple CI jobs of the same PR build. This should decrease the waiting time for the result of the CI
+tests as well as decrease the amount of build time needed to run the CI tests.
+
+Thanks to combination of features available in GitHub, the builds are secured against potentially injected
+code by users contributing PRs, that could get uncontrolled write access to Airflow repository.
+
+The negative consequence of this is that the build process becomes much more complex
+(see [CI](../../../../CI.rst) for complete description) and that some cases (like modifying build behaviour
+require additional process of testing by pushing the changes as `main` branch to a fork of Apache Airflow)


### PR DESCRIPTION
The ADRs document the decision why Docker imaages are used as common
environment for CI and development environment, and also why building
images should be done in a secure way.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
