### PR TITLE
Allow to except_skip None on BranchPythonOperator

### DIFF
--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -128,7 +128,7 @@ class SkipMixin(LoggingMixin):
                 session=session,
             )
 
-    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Optional[Union[str, Iterable[str]]]):
+    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Union[None, str, Iterable[str]]):
         """
         This method implements the logic for a branching operator; given a single
         task ID or list of task IDs to follow, this skips all other tasks
@@ -141,7 +141,7 @@ class SkipMixin(LoggingMixin):
         if isinstance(branch_task_ids, str):
             branch_task_ids = {branch_task_ids}
         elif branch_task_ids is None:
-            branch_task_ids = {}
+            branch_task_ids = ()
 
         branch_task_ids = set(branch_task_ids)
 

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -128,7 +128,7 @@ class SkipMixin(LoggingMixin):
                 session=session,
             )
 
-    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Union[str, Iterable[str]]):
+    def skip_all_except(self, ti: TaskInstance, branch_task_ids: Optional[Union[str, Iterable[str]]]):
         """
         This method implements the logic for a branching operator; given a single
         task ID or list of task IDs to follow, this skips all other tasks
@@ -140,6 +140,8 @@ class SkipMixin(LoggingMixin):
         self.log.info("Following branch %s", branch_task_ids)
         if isinstance(branch_task_ids, str):
             branch_task_ids = {branch_task_ids}
+        elif branch_task_ids is None:
+            branch_task_ids = {}
 
         branch_task_ids = set(branch_task_ids)
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -210,8 +210,10 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
             branches = {branch}
         elif isinstance(branch, list):
             branches = set(branch)
+        elif branch is None:
+            branches = set()
         else:
-            raise AirflowException("Branch callable must return either a task ID or a list of IDs")
+            raise AirflowException("Branch callable must return either None or a task ID or a list of IDs")
         valid_task_ids = set(context["dag"].task_ids)
         invalid_task_ids = branches - valid_task_ids
         if invalid_task_ids:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -213,7 +213,7 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
         elif branch is None:
             branches = set()
         else:
-            raise AirflowException("Branch callable must return either None or a task ID or a list of IDs")
+            raise AirflowException("Branch callable must return either None, a task ID, or a list of IDs")
         valid_task_ids = set(context["dag"].task_ids)
         invalid_task_ids = branches - valid_task_ids
         if invalid_task_ids:

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -314,7 +314,7 @@ The ``BranchPythonOperator`` can also be used with XComs allowing branching cont
 
 If you wish to implement your own operators with branching functionality, you can inherit from :class:`~airflow.operators.branch.BaseBranchOperator`, which behaves similarly to ``BranchPythonOperator`` but expects you to provide an implementation of the method ``choose_branch``.
 
-As with the callable for ``BranchPythonOperator``, this method should return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped::
+As with the callable for ``BranchPythonOperator``, this method can return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped. It can also return None to skip all downstream task::
 
     class MyBranchOperator(BaseBranchOperator):
         def choose_branch(self, context):
@@ -323,8 +323,10 @@ As with the callable for ``BranchPythonOperator``, this method should return the
             """
             if context['data_interval_start'].day == 1:
                 return ['daily_task_id', 'monthly_task_id']
-            else:
+            elif context['data_interval_start'].day == 2:
                 return 'daily_task_id'
+            else:
+                return None
 
 
 .. _concepts:latest-only:

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -271,7 +271,7 @@ Branching
 
 You can make use of branching in order to tell the DAG *not* to run all dependent tasks, but instead to pick and choose one or more paths to go down. This is where the branching Operators come in.
 
-The ``BranchPythonOperator`` is much like the PythonOperator except that it expects a ``python_callable`` that returns a task_id (or list of task_ids). The task_id returned is followed, and all of the other paths are skipped.
+The ``BranchPythonOperator`` is much like the PythonOperator except that it expects a ``python_callable`` that returns a task_id (or list of task_ids). The task_id returned is followed, and all of the other paths are skipped. It can also return None to skip all downstream task.
 
 The task_id returned by the Python function has to reference a task directly downstream from the BranchPythonOperator task.
 
@@ -290,8 +290,10 @@ The ``BranchPythonOperator`` can also be used with XComs allowing branching cont
         xcom_value = int(ti.xcom_pull(task_ids="start_task"))
         if xcom_value >= 5:
             return "continue_task"
-        else:
+        elif xcom_value >= 3:
             return "stop_task"
+        else:
+            return None
 
 
     start_op = BashOperator(
@@ -314,7 +316,7 @@ The ``BranchPythonOperator`` can also be used with XComs allowing branching cont
 
 If you wish to implement your own operators with branching functionality, you can inherit from :class:`~airflow.operators.branch.BaseBranchOperator`, which behaves similarly to ``BranchPythonOperator`` but expects you to provide an implementation of the method ``choose_branch``.
 
-As with the callable for ``BranchPythonOperator``, this method can return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped. It can also return None to skip all downstream task:
+As with the callable for ``BranchPythonOperator``, this method can return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped. It can also return None to skip all downstream task::
 
     class MyBranchOperator(BaseBranchOperator):
         def choose_branch(self, context):

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -314,7 +314,7 @@ The ``BranchPythonOperator`` can also be used with XComs allowing branching cont
 
 If you wish to implement your own operators with branching functionality, you can inherit from :class:`~airflow.operators.branch.BaseBranchOperator`, which behaves similarly to ``BranchPythonOperator`` but expects you to provide an implementation of the method ``choose_branch``.
 
-As with the callable for ``BranchPythonOperator``, this method can return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped. It can also return None to skip all downstream task::
+As with the callable for ``BranchPythonOperator``, this method can return the ID of a downstream task, or a list of task IDs, which will be run, and all others will be skipped. It can also return None to skip all downstream task:
 
     class MyBranchOperator(BaseBranchOperator):
         def choose_branch(self, context):

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -117,3 +117,51 @@ class TestSkipMixin:
 
         assert get_state(ti2) == State.NONE
         assert get_state(ti3) == State.SKIPPED
+
+    def test_skip_all_except_none(self, dag_maker):
+        with dag_maker(
+            'dag_test_skip_none_except',
+        ):
+            task1 = DummyOperator(task_id='task1')
+            task2 = DummyOperator(task_id='task2')
+            task3 = DummyOperator(task_id='task3')
+
+            task1 >> [task2, task3]
+        dag_maker.create_dagrun()
+
+        ti1 = TI(task1, execution_date=DEFAULT_DATE)
+        ti2 = TI(task2, execution_date=DEFAULT_DATE)
+        ti3 = TI(task3, execution_date=DEFAULT_DATE)
+
+        SkipMixin().skip_all_except(ti=ti1, branch_task_ids=None)
+
+        def get_state(ti):
+            ti.refresh_from_db()
+            return ti.state
+
+        assert get_state(ti2) == State.SKIPPED
+        assert get_state(ti3) == State.SKIPPED
+
+    def test_skip_all_except_empty(self, dag_maker):
+        with dag_maker(
+            'dag_test_skip_none_except',
+        ):
+            task1 = DummyOperator(task_id='task1')
+            task2 = DummyOperator(task_id='task2')
+            task3 = DummyOperator(task_id='task3')
+
+            task1 >> [task2, task3]
+        dag_maker.create_dagrun()
+
+        ti1 = TI(task1, execution_date=DEFAULT_DATE)
+        ti2 = TI(task2, execution_date=DEFAULT_DATE)
+        ti3 = TI(task3, execution_date=DEFAULT_DATE)
+
+        SkipMixin().skip_all_except(ti=ti1, branch_task_ids=[])
+
+        def get_state(ti):
+            ti.refresh_from_db()
+            return ti.state
+
+        assert get_state(ti2) == State.SKIPPED
+        assert get_state(ti3) == State.SKIPPED

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -125,13 +125,6 @@ class TestSkipMixin:
             ti.refresh_from_db()
             return ti.state
 
-        task_instances = {
-            "task2": ti2,
-            "task3": ti3
-        }
-        executed_states = {
-            task_id: get_state(task_instances[task_id])
-            for task_id in task_instances
-        }
+        executed_states = {"task2": get_state(ti2), "task3": get_state(ti3)}
 
         assert executed_states == expected_states

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -574,7 +574,7 @@ class TestBranchOperator(unittest.TestCase):
         self.dag.clear()
         with pytest.raises(AirflowException) as ctx:
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        assert 'Branch callable must return either None or a task ID or a list of IDs' == str(ctx.value)
+        assert 'Branch callable must return either None, a task ID, or a list of IDs' == str(ctx.value)
 
     def test_raise_exception_on_invalid_task_id(self):
         branch_op = BranchPythonOperator(

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -569,12 +569,12 @@ class TestBranchOperator(unittest.TestCase):
             else:
                 raise ValueError(f'Invalid task id {ti.task_id} found!')
 
-    def test_raise_exception_on_no_task_id_return(self):
-        branch_op = BranchPythonOperator(task_id='make_choice', dag=self.dag, python_callable=lambda: None)
+    def test_raise_exception_on_no_accepted_type_return(self):
+        branch_op = BranchPythonOperator(task_id='make_choice', dag=self.dag, python_callable=lambda: 5)
         self.dag.clear()
         with pytest.raises(AirflowException) as ctx:
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        assert 'Branch callable must return either a task ID or a list of IDs' == str(ctx.value)
+        assert 'Branch callable must return either None or a task ID or a list of IDs' == str(ctx.value)
 
     def test_raise_exception_on_invalid_task_id(self):
         branch_op = BranchPythonOperator(


### PR DESCRIPTION
Add a test on skip_all_except and also allow None and not only empty iterable object.

because currently this code
```python
def skip_things() -> str:
        if NOTHING:
            return None
        elif SOMETHING_WEIRD:
            return "task_2"
        else:
            return "task_3"

branch_task = BranchPythonOperator(
    task_id='branch_task',
    python_callable=skip_things)

task_2 = ...
task_3 = ...

branch_task >> [task_2, task_3 ]
```

fail with :

```log
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1165, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/usr/local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1283, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/usr/local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1313, in _execute_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.8/site-packages/airflow/operators/python.py", line 180, in execute
    self.skip_all_except(context['ti'], branch)
  File "/usr/local/lib/python3.8/site-packages/airflow/models/skipmixin.py", line 128, in skip_all_except
    branch_task_ids = set(branch_task_ids)
TypeError: 'NoneType' object is not iterable
```

Only an empty iterable is currently allow
```python
def skip_things() -> str:
        if NOTHING:
            return []
        elif SOMETHING_WEIRD:
            return "task_2"
        else:
            return "task_3"

branch_task = BranchPythonOperator(
    task_id='branch_task',
    python_callable=skip_things)

task_2 = ...
task_3 = ...

branch_task >> [task_2, task_3 ]
```