### PR TITLE
Remove duplicate typing definition in CLI cheat-sheet command

### DIFF
--- a/airflow/cli/commands/cheat_sheet_command.py
+++ b/airflow/cli/commands/cheat_sheet_command.py
@@ -35,8 +35,6 @@ def display_commands_index():
         commands: Iterable[Union[GroupCommand, ActionCommand]],
         help_msg: Optional[str] = None,
     ):
-        actions: List[ActionCommand]
-        groups: List[GroupCommand]
         actions: List[ActionCommand] = []
         groups: List[GroupCommand] = []
         for command in commands:


### PR DESCRIPTION
Related: #19891

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
