### PR TITLE
Bugfix for cleanup-pods command

### DIFF
--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -94,7 +94,6 @@ def cleanup_pods(args):
     airflow_pod_labels = [
         'dag_id',
         'task_id',
-        'execution_date',
         'try_number',
         'airflow_version',
     ]

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -56,7 +56,7 @@ class TestGenerateDagYamlCommand(unittest.TestCase):
 
 class TestCleanUpPodsCommand(unittest.TestCase):
 
-    label_selector = ','.join(['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version'])
+    label_selector = ','.join(['dag_id', 'task_id', 'try_number', 'airflow_version'])
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When getting cleanup pods list, it requires to have `execution_date` label.
But from the [code](https://github.com/apache/airflow/blob/aa27d9f92ef261ce2bf2b0e1b3699c1ffd23307f/airflow/executors/kubernetes_executor.py#L319), it does not set `execution_date` label when trigger by scheduler.

So I remove `execution_date` label when get pod list.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
