### PR TITLE
Fix MyPy errors in Apache Providers

### DIFF
--- a/airflow/providers/apache/cassandra/sensors/record.py
+++ b/airflow/providers/apache/cassandra/sensors/record.py
@@ -20,10 +20,13 @@ This module contains sensor that check the existence
 of a record in a Cassandra cluster.
 """
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class CassandraRecordSensor(BaseSensorOperator):
@@ -58,8 +61,8 @@ class CassandraRecordSensor(BaseSensorOperator):
     def __init__(
         self,
         *,
-        table: str,
         keys: Dict[str, str],
+        table: str,
         cassandra_conn_id: str = CassandraHook.default_conn_name,
         **kwargs: Any,
     ) -> None:
@@ -68,7 +71,7 @@ class CassandraRecordSensor(BaseSensorOperator):
         self.table = table
         self.keys = keys
 
-    def poke(self, context: Dict[str, str]) -> bool:
+    def poke(self, context: "Context") -> bool:
         self.log.info('Sensor check existence of record: %s', self.keys)
         hook = CassandraHook(self.cassandra_conn_id)
         return hook.record_exists(self.table, self.keys)

--- a/airflow/providers/apache/cassandra/sensors/record.pyi
+++ b/airflow/providers/apache/cassandra/sensors/record.pyi
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Optional, Dict, Any
+
+from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
+
+class CassandraRecordSensor:
+    def __init__(
+        self,
+        *,
+        keys: Optional[Dict[str, str]] = None,
+        table: Optional[str] = None,
+        cassandra_conn_id: str = CassandraHook.default_conn_name,
+        **kwargs: Any,
+    ) -> None: ...

--- a/airflow/providers/apache/cassandra/sensors/table.py
+++ b/airflow/providers/apache/cassandra/sensors/table.py
@@ -21,10 +21,13 @@ This module contains sensor that check the existence
 of a table in a Cassandra cluster.
 """
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class CassandraTableSensor(BaseSensorOperator):
@@ -54,13 +57,17 @@ class CassandraTableSensor(BaseSensorOperator):
     template_fields = ('table',)
 
     def __init__(
-        self, *, table: str, cassandra_conn_id: str = CassandraHook.default_conn_name, **kwargs: Any
+        self,
+        *,
+        table: str,
+        cassandra_conn_id: str = CassandraHook.default_conn_name,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.cassandra_conn_id = cassandra_conn_id
         self.table = table
 
-    def poke(self, context: Dict[Any, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         self.log.info('Sensor check existence of table: %s', self.table)
         hook = CassandraHook(self.cassandra_conn_id)
         return hook.table_exists(self.table)

--- a/airflow/providers/apache/cassandra/sensors/table.pyi
+++ b/airflow/providers/apache/cassandra/sensors/table.pyi
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Optional, Any
+
+from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
+
+class CassandraTableSensor:
+    def __init__(
+        self,
+        *,
+        table: Optional[str] = None,
+        cassandra_conn_id: str = CassandraHook.default_conn_name,
+        **kwargs: Any,
+    ) -> None: ...

--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -16,10 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.apache.druid.hooks.druid import DruidHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class DruidOperator(BaseOperator):
@@ -57,7 +60,7 @@ class DruidOperator(BaseOperator):
         self.timeout = timeout
         self.max_ingestion_time = max_ingestion_time
 
-    def execute(self, context: Dict[Any, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         hook = DruidHook(
             druid_ingest_conn_id=self.conn_id,
             timeout=self.timeout,

--- a/airflow/providers/apache/druid/transfers/hive_to_druid.py
+++ b/airflow/providers/apache/druid/transfers/hive_to_druid.py
@@ -18,11 +18,14 @@
 
 """This module contains operator to move data from Hive to Druid."""
 
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.apache.druid.hooks.druid import DruidHook
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook, HiveMetastoreHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 LOAD_CHECK_INTERVAL = 5
 DEFAULT_TARGET_PARTITION_SIZE = 5000000
@@ -116,7 +119,7 @@ class HiveToDruidOperator(BaseOperator):
         self.hive_tblproperties = hive_tblproperties or {}
         self.job_properties = job_properties
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
         self.log.info("Extracting data from Hive")
         hive_table = 'druid.' + context['task_instance_key_str'].replace('.', '_')

--- a/airflow/providers/apache/hdfs/sensors/hdfs.py
+++ b/airflow/providers/apache/hdfs/sensors/hdfs.py
@@ -18,11 +18,14 @@
 import logging
 import re
 import sys
-from typing import Any, Dict, List, Optional, Pattern, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Pattern, Type
 
 from airflow import settings
 from airflow.providers.apache.hdfs.hooks.hdfs import HDFSHook
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +118,7 @@ class HdfsSensor(BaseSensorOperator):
             log.debug('HdfsSensor.poke: after ext filter result is %s', result)
         return result
 
-    def poke(self, context: Dict[Any, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         """Get a snakebite client connection and check for file."""
         sb_client = self.hook(self.hdfs_conn_id).get_conn()
         self.log.info('Poking for file %s', self.filepath)
@@ -149,7 +152,7 @@ class HdfsRegexSensor(HdfsSensor):
         super().__init__(*args, **kwargs)
         self.regex = regex
 
-    def poke(self, context: Dict[Any, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         """
         Poke matching files in a directory with self.regex
 
@@ -182,7 +185,7 @@ class HdfsFolderSensor(HdfsSensor):
         super().__init__(*args, **kwargs)
         self.be_empty = be_empty
 
-    def poke(self, context: Dict[str, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         """
         Poke for a non empty directory
 

--- a/airflow/providers/apache/hdfs/sensors/web_hdfs.py
+++ b/airflow/providers/apache/hdfs/sensors/web_hdfs.py
@@ -15,9 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class WebHdfsSensor(BaseSensorOperator):
@@ -30,7 +33,7 @@ class WebHdfsSensor(BaseSensorOperator):
         self.filepath = filepath
         self.webhdfs_conn_id = webhdfs_conn_id
 
-    def poke(self, context: Dict[Any, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         from airflow.providers.apache.hdfs.hooks.webhdfs import WebHDFSHook
 
         hook = WebHDFSHook(self.webhdfs_conn_id)

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -17,13 +17,16 @@
 # under the License.
 import os
 import re
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from airflow.configuration import conf
 from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
 from airflow.utils import operator_helpers
 from airflow.utils.operator_helpers import context_to_airflow_vars
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class HiveOperator(BaseOperator):
@@ -133,7 +136,7 @@ class HiveOperator(BaseOperator):
         if self.script_begin_tag and self.script_begin_tag in self.hql:
             self.hql = "\n".join(self.hql.split(self.script_begin_tag)[1:])
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         self.log.info('Executing: %s', self.hql)
         self.hook = self.get_hook()
 

--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -18,13 +18,16 @@
 import json
 import warnings
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.presto.hooks.presto import PrestoHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class HiveStatsCollectionOperator(BaseOperator):
@@ -116,7 +119,7 @@ class HiveStatsCollectionOperator(BaseOperator):
 
         return exp
 
-    def execute(self, context: Optional[Dict[str, Any]] = None) -> None:
+    def execute(self, context: "Context") -> None:
         metastore = HiveMetastoreHook(metastore_conn_id=self.metastore_conn_id)
         table = metastore.get_table(table_name=self.table)
         field_types = {col.name: col.type for col in table.sd.cols}

--- a/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -15,10 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from airflow.providers.apache.hive.hooks.hive import HiveMetastoreHook
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class HivePartitionSensor(BaseSensorOperator):
@@ -67,7 +70,7 @@ class HivePartitionSensor(BaseSensorOperator):
         self.partition = partition
         self.schema = schema
 
-    def poke(self, context: Dict[str, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         if '.' in self.table:
             self.schema, self.table = self.table.split('.')
         self.log.info('Poking for table %s.%s, partition %s', self.schema, self.table, self.partition)

--- a/airflow/providers/apache/hive/sensors/metastore_partition.py
+++ b/airflow/providers/apache/hive/sensors/metastore_partition.py
@@ -15,9 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from airflow.sensors.sql import SqlSensor
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class MetastorePartitionSensor(SqlSensor):
@@ -67,7 +70,7 @@ class MetastorePartitionSensor(SqlSensor):
         # constructor below and apply_defaults will no longer throw an exception.
         super().__init__(**kwargs)
 
-    def poke(self, context: Dict[str, Any]) -> Any:
+    def poke(self, context: "Context") -> Any:
         if self.first_poke:
             self.first_poke = False
             if '.' in self.table:

--- a/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -15,9 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, List, Tuple
 
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class NamedHivePartitionSensor(BaseSensorOperator):
@@ -92,7 +95,7 @@ class NamedHivePartitionSensor(BaseSensorOperator):
         self.log.info('Poking for %s.%s/%s', schema, table, partition)
         return self.hook.check_for_named_partition(schema, table, partition)
 
-    def poke(self, context: Dict[str, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
 
         number_of_partitions = len(self.partition_names)
         poke_index_start = self.next_index_to_poke

--- a/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -20,7 +20,7 @@
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import pymssql
 import unicodecsv as csv
@@ -28,6 +28,9 @@ import unicodecsv as csv
 from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class MsSqlToHiveOperator(BaseOperator):
@@ -109,7 +112,7 @@ class MsSqlToHiveOperator(BaseOperator):
         }
         return map_dict.get(mssql_type, 'STRING')
 
-    def execute(self, context: Dict[str, str]):
+    def execute(self, context: "Context"):
         mssql = MsSqlHook(mssql_conn_id=self.mssql_conn_id)
         self.log.info("Dumping Microsoft SQL Server query results to local file")
         with mssql.get_conn() as conn:

--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -20,7 +20,7 @@
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 
 import MySQLdb
 import unicodecsv as csv
@@ -28,6 +28,9 @@ import unicodecsv as csv
 from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class MySqlToHiveOperator(BaseOperator):
@@ -133,7 +136,7 @@ class MySqlToHiveOperator(BaseOperator):
         }
         return type_map.get(mysql_type, 'STRING')
 
-    def execute(self, context: Dict[str, str]):
+    def execute(self, context: "Context"):
         hive = HiveCliHook(hive_cli_conn_id=self.hive_cli_conn_id)
         mysql = MySqlHook(mysql_conn_id=self.mysql_conn_id)
 

--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -17,11 +17,14 @@
 
 """This module contains the Apache Livy operator."""
 from time import sleep
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.livy.hooks.livy import BatchState, LivyHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class LivyOperator(BaseOperator):
@@ -144,7 +147,7 @@ class LivyOperator(BaseOperator):
             )
         return self._livy_hook
 
-    def execute(self, context: Dict[Any, Any]) -> Any:
+    def execute(self, context: "Context") -> Any:
         self._batch_id = self.get_hook().post_batch(**self.spark_params)
 
         if self._polling_interval > 0:

--- a/airflow/providers/apache/livy/sensors/livy.py
+++ b/airflow/providers/apache/livy/sensors/livy.py
@@ -16,10 +16,13 @@
 # under the License.
 
 """This module contains the Apache Livy sensor."""
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from airflow.providers.apache.livy.hooks.livy import LivyHook
 from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class LivySensor(BaseSensorOperator):
@@ -61,7 +64,7 @@ class LivySensor(BaseSensorOperator):
             self._livy_hook = LivyHook(livy_conn_id=self._livy_conn_id, extra_options=self._extra_options)
         return self._livy_hook
 
-    def poke(self, context: Dict[Any, Any]) -> bool:
+    def poke(self, context: "Context") -> bool:
         batch_id = self.batch_id
 
         status = self.get_hook().get_batch_state(batch_id)

--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -90,10 +90,8 @@ class SparkSqlHook(BaseHook):
             conn = self.get_connection(conn_id)
         except AirflowNotFoundException:
             conn = None
-            options: Dict = {}
-        else:
-            if conn:
-                options = conn.extra_dejson
+        if conn:
+            options = conn.extra_dejson
 
         # Set arguments to values set in Connection if not explicitly provided.
         if master is None:

--- a/airflow/providers/apache/spark/operators/spark_jdbc.py
+++ b/airflow/providers/apache/spark/operators/spark_jdbc.py
@@ -16,10 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from airflow.providers.apache.spark.hooks.spark_jdbc import SparkJDBCHook
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class SparkJDBCOperator(SparkSubmitOperator):
@@ -181,7 +184,7 @@ class SparkJDBCOperator(SparkSubmitOperator):
         self._create_table_column_types = create_table_column_types
         self._hook: Optional[SparkJDBCHook] = None
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         """Call the SparkSubmitHook to run the provided spark job"""
         if self._hook is None:
             self._hook = self._get_hook()

--- a/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/airflow/providers/apache/spark/operators/spark_sql.py
@@ -16,10 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.apache.spark.hooks.spark_sql import SparkSqlHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class SparkSqlOperator(BaseOperator):
@@ -97,7 +100,7 @@ class SparkSqlOperator(BaseOperator):
         self._yarn_queue = yarn_queue
         self._hook: Optional[SparkSqlHook] = None
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         """Call the SparkSqlHook to run the provided sql query"""
         if self._hook is None:
             self._hook = self._get_hook()

--- a/airflow/providers/apache/spark/operators/spark_submit.py
+++ b/airflow/providers/apache/spark/operators/spark_submit.py
@@ -16,11 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from airflow.models import BaseOperator
 from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
 from airflow.settings import WEB_COLORS
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class SparkSubmitOperator(BaseOperator):
@@ -172,7 +175,7 @@ class SparkSubmitOperator(BaseOperator):
         self._hook: Optional[SparkSubmitHook] = None
         self._conn_id = conn_id
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         """Call the SparkSubmitHook to run the provided spark job"""
         if self._hook is None:
             self._hook = self._get_hook()

--- a/airflow/providers/apache/sqoop/operators/sqoop.py
+++ b/airflow/providers/apache/sqoop/operators/sqoop.py
@@ -19,11 +19,14 @@
 """This module contains a sqoop 1 operator"""
 import os
 import signal
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.sqoop.hooks.sqoop import SqoopHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class SqoopOperator(BaseOperator):
@@ -183,7 +186,7 @@ class SqoopOperator(BaseOperator):
         self.hook: Optional[SqoopHook] = None
         self.schema = schema
 
-    def execute(self, context: Dict[str, Any]) -> None:
+    def execute(self, context: "Context") -> None:
         """Execute sqoop job"""
         if self.hook is None:
             self.hook = self._get_hook()


### PR DESCRIPTION
Part of #19891

The .py additions are to handle "default_args" passed in
examples. Currently some of the obligatory parameters are
(correctly) passed as default_args. We have no good
mechanism yet to handle it properly for MyPy (it would
require to add a custom MyPy plugin to handle it)

We have no better way to handle it for now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
