### PR TITLE
fix(standalone): remove hardcoded webserver-port

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -72,7 +72,7 @@ class StandaloneCommand:
         self.subcommands["webserver"] = SubCommand(
             self,
             name="webserver",
-            command=["webserver", "--port", "8080"],
+            command=["webserver"],
             env=env,
         )
         self.subcommands["triggerer"] = SubCommand(

--- a/docs/apache-airflow/start/local.rst
+++ b/docs/apache-airflow/start/local.rst
@@ -62,7 +62,7 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and create the "airflow.cfg" file with defaults that will get you going fast.
-You can override defaults using `environment variables <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html>`.
+You can override defaults using environment variables, see :doc:`/configurations-ref`.
 You can inspect the file either in ``$AIRFLOW_HOME/airflow.cfg``, or through the UI in
 the ``Admin->Configuration`` menu. The PID file for the webserver will be stored
 in ``$AIRFLOW_HOME/airflow-webserver.pid`` or in ``/run/airflow/webserver.pid``

--- a/docs/apache-airflow/start/local.rst
+++ b/docs/apache-airflow/start/local.rst
@@ -62,6 +62,7 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and create the "airflow.cfg" file with defaults that will get you going fast.
+You can override defaults using `environment variables <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html>`.
 You can inspect the file either in ``$AIRFLOW_HOME/airflow.cfg``, or through the UI in
 the ``Admin->Configuration`` menu. The PID file for the webserver will be stored
 in ``$AIRFLOW_HOME/airflow-webserver.pid`` or in ``/run/airflow/webserver.pid``


### PR DESCRIPTION
Port 8080 is the default port for webserver (https://airflow.apache.org/docs/apache-airflow/stable/cli-and-env-variables-ref.html?highlight=webserver#webserver). By setting it here again explicitly, we forbid users to override it using AIRFLOW__WEBSERVER__WEB_SERVER_PORT. Removing it IMO is not a breaking change, since it will still default to 8080.

I tested locally if it still spins up the web server at port 8080. It did.

TODO:

- [x] add to docs how to override port
