### PR TITLE
Add pre-commit that checks credentials are not persisted in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -684,6 +684,13 @@ repos:
         files: airflow/config_templates/config\.yml$
         require_serial: true
         additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+      - id: persist-credentials-disabled
+        name: Check that workflow files have persist-credentials disabled
+        entry: ./scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
+        language: python
+        pass_filenames: true
+        files: \.github/workflows/.*\.yml$
+        additional_dependencies: ['PyYAML', 'rich']
       - id: chart-schema-lint
         name: Lint chart/values.schema.json file
         entry: ./scripts/ci/pre_commit/pre_commit_chart_schema.py

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2202,14 +2202,14 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  fix-encoding-pragma flake8 flynt codespell forbid-tabs helm-lint identity
                  incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
                  lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
-                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
-                 pre-commit-hook-names pretty-format-json provide-create-sessions
-                 providers-changelogs providers-init-file providers-subpackages-init-file
-                 provider-yamls pydevd pydocstyle python-no-log-warn pyupgrade restrict-start_date
-                 rst-backticks setup-order setup-extra-packages shellcheck sort-in-the-wild
-                 sort-spelling-wordlist stylelint trailing-whitespace ui-lint update-breeze-file
-                 update-extras update-local-yml-file update-setup-cfg-file update-versions
-                 verify-db-migrations-documented version-sync www-lint yamllint yesqa
+                 no-providers-in-core-examples no-relative-imports persist-credentials-disabled
+                 pre-commit-descriptions pre-commit-hook-names pretty-format-json
+                 provide-create-sessions providers-changelogs providers-init-file
+                 providers-subpackages-init-file provider-yamls pydevd pydocstyle python-no-log-warn
+                 pyupgrade restrict-start_date rst-backticks setup-order setup-extra-packages
+                 shellcheck sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace
+                 ui-lint update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
+                 update-versions verify-db-migrations-documented version-sync www-lint yamllint yesqa
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -224,6 +224,8 @@ require Breeze Docker images to be installed locally.
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``mypy``                               Runs mypy                                                            *
 ------------------------------------ ---------------------------------------------------------------- ------------
+``persist-credentials-disabled``       Check that workflow files have persist-credentials disabled
+------------------------------------ ---------------------------------------------------------------- ------------
 ``pre-commit-descriptions``            Check if all pre-commits are described in docs
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``pre-commit-hook-names``              Check that hook names are not overly long

--- a/breeze-complete
+++ b/breeze-complete
@@ -123,6 +123,7 @@ mypy
 mypy-helm
 no-providers-in-core-examples
 no-relative-imports
+persist-credentials-disabled
 pre-commit-descriptions
 pre-commit-hook-names
 pretty-format-json

--- a/scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
+++ b/scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import sys
+from pathlib import Path
+
+import yaml
+from rich.console import Console
+
+if __name__ not in ("__main__", "__mp_main__"):
+    raise SystemExit(
+        "This file is intended to be executed as an executable program. You cannot use it as a module."
+        f"To run this script, run the ./{__file__} command [FILE] ..."
+    )
+
+
+console = Console(color_system="standard", width=200)
+
+
+def check_file(the_file: Path) -> int:
+    """Returns number of wrong checkout instructions in the workflow file"""
+    error_num = 0
+    res = yaml.safe_load(the_file.read_text())
+    console.print(f"Checking file [yellow]{the_file}[/]")
+    for job in res['jobs'].values():
+        for step in job['steps']:
+            uses = step.get('uses')
+            pretty_step = yaml.safe_dump(step, indent=2)
+            if uses is not None and uses.startswith('actions/checkout'):
+                with_clause = step.get('with')
+                if with_clause is None:
+                    console.print(f"\n[red]The `with` clause is missing in step:[/]\n\n{pretty_step}")
+                    error_num += 1
+                    continue
+                persist_credentials = with_clause.get("persist-credentials")
+                if persist_credentials is None:
+                    console.print(
+                        "\n[red]The `with` clause does not have persist-credentials in step:[/]"
+                        f"\n\n{pretty_step}"
+                    )
+                    error_num += 1
+                    continue
+                else:
+                    if persist_credentials:
+                        console.print(
+                            "\n[red]The `with` clause have persist-credentials=True in step:[/]"
+                            f"\n\n{pretty_step}"
+                        )
+                        error_num += 1
+                        continue
+    return error_num
+
+
+if __name__ == '__main__':
+    total_err_num = 0
+    for a_file in sys.argv[1:]:
+        total_err_num += check_file(Path(a_file))
+    if total_err_num:
+        console.print(
+            """
+[red]There are are some checkout instructions in github workflows that have no "persist_credentials"
+set to False.[/]
+
+For security reasons - make sure all of the checkout actions have persist_credentials set, similar to:
+
+  - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+    uses: actions/checkout@v2
+    with:
+      persist-credentials: false
+
+"""
+        )
+        sys.exit(1)


### PR DESCRIPTION
For security reason we should not persist credentials on checking
out code during GitHub actions. This pre-commit prevents this
from happening.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
