### PR TITLE
Ensure Tableau connection is active to access wait_for_state

### DIFF
--- a/airflow/providers/tableau/operators/tableau.py
+++ b/airflow/providers/tableau/operators/tableau.py
@@ -116,16 +116,16 @@ class TableauOperator(BaseOperator):
 
             response = method(resource_id)
 
-        job_id = response.id
+            job_id = response.id
 
-        if self.method == 'refresh':
-            if self.blocking_refresh:
-                if not tableau_hook.wait_for_state(
-                    job_id=job_id,
-                    check_interval=self.check_interval,
-                    target_state=TableauJobFinishCode.SUCCESS,
-                ):
-                    raise TableauJobFailedException(f'The Tableau Refresh {self.resource} Job failed!')
+            if self.method == 'refresh':
+                if self.blocking_refresh:
+                    if not tableau_hook.wait_for_state(
+                        job_id=job_id,
+                        check_interval=self.check_interval,
+                        target_state=TableauJobFinishCode.SUCCESS,
+                    ):
+                        raise TableauJobFailedException(f'The Tableau Refresh {self.resource} Job failed!')
 
         return job_id
 

--- a/tests/providers/tableau/operators/test_tableau.py
+++ b/tests/providers/tableau/operators/test_tableau.py
@@ -76,8 +76,26 @@ class TestTableauOperator(unittest.TestCase):
         """
         Test execute workbooks blocking
         """
+        mock_signed_in = [False]
+
+        def mock_hook_enter():
+            mock_signed_in[0] = True
+            return mock_tableau_hook
+
+        def mock_hook_exit(exc_type, exc_val, exc_tb):
+            mock_signed_in[0] = False
+
+        def mock_wait_for_state(job_id, target_state, check_interval):
+            if not mock_signed_in[0]:
+                raise Exception('Not signed in')
+
+            return True
+
+        mock_tableau_hook.return_value.__enter__ = Mock(side_effect=mock_hook_enter)
+        mock_tableau_hook.return_value.__exit__ = Mock(side_effect=mock_hook_exit)
+        mock_tableau_hook.wait_for_state = Mock(side_effect=mock_wait_for_state)
+
         mock_tableau_hook.get_all = Mock(return_value=self.mocked_workbooks)
-        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         mock_tableau_hook.server.jobs.get_by_id = Mock(
             return_value=Mock(finish_code=TableauJobFinishCode.SUCCESS.value)
         )
@@ -123,8 +141,26 @@ class TestTableauOperator(unittest.TestCase):
         """
         Test execute datasources blocking
         """
+        mock_signed_in = [False]
+
+        def mock_hook_enter():
+            mock_signed_in[0] = True
+            return mock_tableau_hook
+
+        def mock_hook_exit(exc_type, exc_val, exc_tb):
+            mock_signed_in[0] = False
+
+        def mock_wait_for_state(job_id, target_state, check_interval):
+            if not mock_signed_in[0]:
+                raise Exception('Not signed in')
+
+            return True
+
+        mock_tableau_hook.return_value.__enter__ = Mock(side_effect=mock_hook_enter)
+        mock_tableau_hook.return_value.__exit__ = Mock(side_effect=mock_hook_exit)
+        mock_tableau_hook.wait_for_state = Mock(side_effect=mock_wait_for_state)
+
         mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
-        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
         operator = TableauOperator(find='ds_2', resource='datasources', **self.kwargs)
 
         job_id = operator.execute(context={})


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #20432 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR should resolve issue #20432 which is caused by the `wait_for_state` call being executed outside of the `TableauHook` context after it has logged out of the Tableau server. This code moves the call into the context so that it is executed while still logged into the Tableau server.

closes: #20432 