### PR TITLE
Allow setting port in IMAP Connection

### DIFF
--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -71,7 +71,7 @@ class ImapHook(BaseHook):
         """
         if not self.mail_client:
             conn = self.get_connection(self.imap_conn_id)
-            self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port)
+            self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port or imaplib.IMAP4_SSL_PORT)
             self.mail_client.login(conn.login, conn.password)
 
         return self

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -71,7 +71,7 @@ class ImapHook(BaseHook):
         """
         if not self.mail_client:
             conn = self.get_connection(self.imap_conn_id)
-            self.mail_client = imaplib.IMAP4_SSL(conn.host)
+            self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port)
             self.mail_client.login(conn.login, conn.password)
 
         return self

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -60,4 +60,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:143'
+   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993'

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -46,7 +46,10 @@ Password
     Specify the password used for the IMAP client.
 
 Host
-    Specify the the IMAP host url.
+    Specify the IMAP host url.
+
+Port
+    Specify the IMAP port to connect to.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -57,4 +60,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com'
+   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:143'

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -63,7 +63,7 @@ class TestImapHook(unittest.TestCase):
                 conn_type='imap',
                 host='imap_server_address',
                 login='imap_user',
-                port=1143,
+                port=1993,
                 password='imap_password',
             )
         )
@@ -75,7 +75,7 @@ class TestImapHook(unittest.TestCase):
         with ImapHook():
             pass
 
-        mock_imaplib.IMAP4_SSL.assert_called_once_with('imap_server_address', 1143)
+        mock_imaplib.IMAP4_SSL.assert_called_once_with('imap_server_address', 1993)
         mock_conn.login.assert_called_once_with('imap_user', 'imap_password')
         assert mock_conn.logout.call_count == 1
 

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -63,6 +63,7 @@ class TestImapHook(unittest.TestCase):
                 conn_type='imap',
                 host='imap_server_address',
                 login='imap_user',
+                port=1143,
                 password='imap_password',
             )
         )
@@ -74,7 +75,7 @@ class TestImapHook(unittest.TestCase):
         with ImapHook():
             pass
 
-        mock_imaplib.IMAP4_SSL.assert_called_once_with('imap_server_address')
+        mock_imaplib.IMAP4_SSL.assert_called_once_with('imap_server_address', 1143)
         mock_conn.login.assert_called_once_with('imap_user', 'imap_password')
         assert mock_conn.logout.call_count == 1
 


### PR DESCRIPTION
This PR allows setting the port for a connection via imap. If not set it will use the default port.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
