### PR TITLE
Add "use_ssl" option to IMAP connection

### DIFF
--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -71,10 +71,11 @@ class ImapHook(BaseHook):
         """
         if not self.mail_client:
             conn = self.get_connection(self.imap_conn_id)
-            if conn.port:
-                self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port)
-            else:
-                self.mail_client = imaplib.IMAP4_SSL(conn.host)
+
+            if conn.extra_dejson.get('use_ssl', True):
+                self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port or imaplib.IMAP4_SSL_PORT)
+            else: # fallback to standard imap connection
+                self.mail_client = imaplib.IMAP4(conn.host, conn.port or imaplib.IMAP4_PORT)
             self.mail_client.login(conn.login, conn.password)
 
         return self

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -24,7 +24,7 @@ import email
 import imaplib
 import os
 import re
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -51,7 +51,7 @@ class ImapHook(BaseHook):
     def __init__(self, imap_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.imap_conn_id = imap_conn_id
-        self.mail_client: Optional[imaplib.IMAP4_SSL] = None
+        self.mail_client: Optional[Union[imaplib.IMAP4_SSL, imaplib.IMAP4]] = None
 
     def __enter__(self) -> 'ImapHook':
         return self.get_conn()
@@ -74,7 +74,7 @@ class ImapHook(BaseHook):
 
             if conn.extra_dejson.get('use_ssl', True):
                 self.mail_client = imaplib.IMAP4_SSL(conn.host, conn.port or imaplib.IMAP4_SSL_PORT)
-            else: # fallback to standard imap connection
+            else:  # fallback to standard imap connection
                 self.mail_client = imaplib.IMAP4(conn.host, conn.port or imaplib.IMAP4_PORT)
             self.mail_client.login(conn.login, conn.password)
 

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -51,10 +51,10 @@ Host
 Port
     Specify the IMAP port to connect to.
 
-Extras (optional)
-    Specify the extra parameters (as json dictionary) 
+Extra (optional)
+    Specify the extra parameters (as json dictionary)
 
-    * ``use_ssl``: If set to False, then a non-ssl connection is being used. Default is True.
+    * ``use_ssl``: If set to false, then a non-ssl connection is being used. Default is true.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -65,4 +65,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993?use_ssl=false'
+   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993?use_ssl=true'

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -49,12 +49,12 @@ Host
     Specify the IMAP host url.
 
 Port
-    Specify the IMAP port to connect to.
+    Specify the IMAP port to connect to. The default depends on the whether you use ssl or not.
 
 Extra (optional)
     Specify the extra parameters (as json dictionary)
 
-    * ``use_ssl``: If set to false, then a non-ssl connection is being used. Default is true.
+    * ``use_ssl``: If set to false, then a non-ssl connection is being used. Default is true. Also note that changing the ssl option also influences the default port being used.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -66,3 +66,11 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993?use_ssl=true'
+
+Another example for connecting via a non-SSL connection.
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_IMAP_NONSSL='imap://username:password@myimap.com:143?use_ssl=false'
+
+Note that you can set the port regardless of whether you choose to use ssl or not. The above examples show default ports for SSL and Non-SSL connections.

--- a/docs/apache-airflow-providers-imap/connections/imap.rst
+++ b/docs/apache-airflow-providers-imap/connections/imap.rst
@@ -51,6 +51,11 @@ Host
 Port
     Specify the IMAP port to connect to.
 
+Extras (optional)
+    Specify the extra parameters (as json dictionary) 
+
+    * ``use_ssl``: If set to False, then a non-ssl connection is being used. Default is True.
+
 When specifying the connection in environment variable you should specify
 it using URI syntax.
 
@@ -60,4 +65,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993'
+   export AIRFLOW_CONN_IMAP_DEFAULT='imap://username:password@myimap.com:993?use_ssl=false'

--- a/tests/providers/imap/hooks/test_imap.py
+++ b/tests/providers/imap/hooks/test_imap.py
@@ -63,8 +63,19 @@ class TestImapHook(unittest.TestCase):
                 conn_type='imap',
                 host='imap_server_address',
                 login='imap_user',
-                port=1993,
                 password='imap_password',
+                port=1993,
+                extra='{"use_ssl":"true"}',
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id='imap_nonssl',
+                conn_type='imap',
+                host='imap_server_address',
+                login='imap_user',
+                password='imap_password',
+                port=1143,
             )
         )
 
@@ -76,6 +87,17 @@ class TestImapHook(unittest.TestCase):
             pass
 
         mock_imaplib.IMAP4_SSL.assert_called_once_with('imap_server_address', 1993)
+        mock_conn.login.assert_called_once_with('imap_user', 'imap_password')
+        assert mock_conn.logout.call_count == 1
+
+    @patch(imaplib_string)
+    def test_connect_and_disconnect_via_nonssl(self, mock_imaplib):
+        mock_conn = _create_fake_imap(mock_imaplib)
+
+        with ImapHook(imap_conn_id='imap_nonssl'):
+            pass
+
+        mock_imaplib.IMAP4.assert_called_once_with('imap_server_address', 1143)
         mock_conn.login.assert_called_once_with('imap_user', 'imap_password')
         assert mock_conn.logout.call_count == 1
 


### PR DESCRIPTION
The default imap connection uses ssl by default. To turn it off, you can now set "use_ssl=False" in the extra connection args.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
