### PR TITLE
Add custom pip.conf to docker-context-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,10 +199,6 @@ ENV PATH=${PATH}:/opt/mssql-tools/bin
 
 COPY docker-context-files /docker-context-files
 
-RUN if [[ -f /docker-context-files/.pypirc ]]; then \
-        cp /docker-context-files/.pypirc /root/.pypirc; \
-    fi
-
 RUN if [[ -f /docker-context-files/pip.conf ]]; then \
         mkdir -p /root/.config/pip; \
         cp /docker-context-files/pip.conf /root/.config/pip/pip.conf; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,6 +203,11 @@ RUN if [[ -f /docker-context-files/.pypirc ]]; then \
         cp /docker-context-files/.pypirc /root/.pypirc; \
     fi
 
+RUN if [[ -f /docker-context-files/pip.conf ]]; then \
+        mkdir -p /root/.config/pip; \
+        cp /docker-context-files/pip.conf /root/.config/pip/pip.conf; \
+    fi
+
 ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES} \
     INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES} \
     AIRFLOW_VERSION=${AIRFLOW_VERSION} \

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -522,12 +522,12 @@ described below but here is an example of rather complex command to customize th
 based on example in `this comment <https://github.com/apache/airflow/issues/8605#issuecomment-690065621>`_:
 
 In case you need to use your custom PyPI package indexes, you can also customize PYPI sources used during
-image build by adding a ``docker-context-files``/``.pypirc`` file when building the image.
-This ``.pypirc`` will not be committed to the repository (it is added to ``.gitignore``) and it will not be
+image build by adding a ``docker-context-files``/``pip.conf`` file when building the image.
+This ``pip.conf`` will not be committed to the repository (it is added to ``.gitignore``) and it will not be
 present in the final production image. It is added and used only in the build segment of the image.
-Therefore this ``.pypirc`` file can safely contain list of package indexes you want to use,
-usernames and passwords used for authentication. More details about ``.pypirc`` file can be found in the
-`pypirc specification <https://packaging.python.org/specifications/pypirc/>`_.
+Therefore this ``pip.conf`` file can safely contain list of package indexes you want to use,
+usernames and passwords used for authentication. More details about ``pip.conf`` file can be found in the
+`pip configuration <https://pip.pypa.io/en/stable/topics/configuration/>`_.
 
 Such customizations are independent of the way how airflow is installed.
 


### PR DESCRIPTION

In case e.g. of custom repository or trusted-host configuration need, a custom [`pip.conf`](https://pip.pypa.io/en/stable/topics/configuration/#location) has to be passed to the build system.  Using the current `docker-context-files` is one way to solve the problem as it was done for `.pypirc`