### PR TITLE
Chart: Use 2.2.3 as default Airflow version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 1.4.0-dev
-appVersion: 2.2.2
+appVersion: 2.2.3
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -38,10 +38,10 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 Airflow Helm Chart 1.4.0 (dev)
 ------------------------------
 
-Default Airflow image is updated to ``2.2.2``
+Default Airflow image is updated to ``2.2.3``
 """""""""""""""""""""""""""""""""""""""""""""
 
-The default Airflow image that is used with the Chart is now ``2.2.2``, previously it was ``2.2.1``.
+The default Airflow image that is used with the Chart is now ``2.2.3``, previously it was ``2.2.1``.
 
 ``ingress.web.hosts`` and ``ingress.flower.hosts`` parameters data type has changed and ``ingress.web.tls`` and ``ingress.flower.tls`` have moved
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -67,13 +67,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.2.2",
+            "default": "2.2.3",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.2.2",
+            "default": "2.2.3",
             "x-docsSection": "Common"
         },
         "securityContext": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,10 +46,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.2.2"
+defaultAirflowTag: "2.2.3"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.2.2"
+airflowVersion: "2.2.3"
 
 # Images
 images:


### PR DESCRIPTION
Now that 2.2.3 has been released, use it as the default for the Helm chart.