### PR TITLE
Add a button to set all tasks to skipped

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1325,7 +1325,7 @@ class Airflow(AirflowBaseView):
                 return jsonify(message=message, metadata=metadata)
 
             metadata['download_logs'] = True
-            attachment_filename = task_log_reader.render_log_filename(ti, try_number)
+            attachment_filename = task_log_reader.render_log_filename(ti, try_number, session=session)
             log_stream = task_log_reader.read_log_stream(ti, try_number, metadata)
             return Response(
                 response=log_stream,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4103,12 +4103,6 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         """Set state to running."""
         return self._set_dag_runs_to_active_state(drs, State.RUNNING)
 
-    @action('set_skipped', "Set state to 'skipped'", '', single=False)
-    @action_has_dag_edit_access
-    def action_set_skipped(self, drs: List[DagRun]):
-        """Set state to skipped."""
-        return self._set_dag_runs_to_active_state(drs, State.SKIPPED)
-
     @provide_session
     def _set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
         """This routine only supports Running and Queued state."""
@@ -4544,9 +4538,11 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_skipped', "Set state to 'skipped'", '', single=False)
     @action_has_dag_edit_access
-    def action_set_skipped(self, drs: List[DagRun]):
+    def action_set_skipped(self, tis):
         """Set state to skipped."""
-        return self._set_dag_runs_to_active_state(drs, State.SKIPPED)
+        self.set_task_instance_state(tis, State.SKIPPED)
+        self.update_redirect()
+        return redirect(self.get_redirect())
 
 
 class AutocompleteView(AirflowBaseView):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -118,7 +118,7 @@ from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils.log import secrets_masker
 from airflow.utils.log.log_reader import TaskLogReader
 from airflow.utils.session import create_session, provide_session
-from airflow.utils.state import State
+from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.strings import to_boolean
 from airflow.utils.timezone import td_format
 from airflow.version import version

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4539,7 +4539,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     @action_has_dag_edit_access
     def action_set_skipped(self, tis):
         """Set state to skipped."""
-        self.set_task_instance_state(tis, State.SKIPPED)
+        self.set_task_instance_state(tis, TaskInstanceState.SKIPPED)
         self.update_redirect()
         return redirect(self.get_redirect())
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4003,7 +4003,6 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'action_set_running': 'edit',
         'action_set_failed': 'edit',
         'action_set_success': 'edit',
-        'action_set_skipped': 'edit',
     }
     base_permissions = [
         permissions.ACTION_CAN_READ,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1325,7 +1325,7 @@ class Airflow(AirflowBaseView):
                 return jsonify(message=message, metadata=metadata)
 
             metadata['download_logs'] = True
-            attachment_filename = task_log_reader.render_log_filename(ti, try_number, session=session)
+            attachment_filename = task_log_reader.render_log_filename(ti, try_number)
             log_stream = task_log_reader.read_log_stream(ti, try_number, metadata)
             return Response(
                 response=log_stream,
@@ -4003,6 +4003,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'action_set_running': 'edit',
         'action_set_failed': 'edit',
         'action_set_success': 'edit',
+        'action_set_skipped': 'edit',
     }
     base_permissions = [
         permissions.ACTION_CAN_READ,
@@ -4101,6 +4102,12 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     def action_set_running(self, drs: List[DagRun]):
         """Set state to running."""
         return self._set_dag_runs_to_active_state(drs, State.RUNNING)
+
+    @action('set_skipped', "Set state to 'skipped'", '', single=False)
+    @action_has_dag_edit_access
+    def action_set_skipped(self, drs: List[DagRun]):
+        """Set state to skipped."""
+        return self._set_dag_runs_to_active_state(drs, State.SKIPPED)
 
     @provide_session
     def _set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
@@ -4350,6 +4357,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         'action_set_failed': 'edit',
         'action_set_success': 'edit',
         'action_set_retry': 'edit',
+        'action_set_skipped': 'edit',
     }
     base_permissions = [
         permissions.ACTION_CAN_CREATE,
@@ -4533,6 +4541,12 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         self.set_task_instance_state(tis, State.UP_FOR_RETRY)
         self.update_redirect()
         return redirect(self.get_redirect())
+
+    @action('set_skipped', "Set state to 'skipped'", '', single=False)
+    @action_has_dag_edit_access
+    def action_set_skipped(self, drs: List[DagRun]):
+        """Set state to skipped."""
+        return self._set_dag_runs_to_active_state(drs, State.SKIPPED)
 
 
 class AutocompleteView(AirflowBaseView):

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -667,8 +667,9 @@ def test_task_instance_clear_failure(admin_client):
         ("set_failed", State.FAILED),
         ("set_success", State.SUCCESS),
         ("set_retry", State.UP_FOR_RETRY),
+        ("set_skipped", State.SKIPPED),
     ],
-    ids=["running", "failed", "success", "retry"],
+    ids=["running", "failed", "success", "retry", "skipped"],
 )
 def test_task_instance_set_state(session, admin_client, action, expected_state):
     task_id = "runme_0"
@@ -695,6 +696,7 @@ def test_task_instance_set_state(session, admin_client, action, expected_state):
         "set_failed",
         "set_success",
         "set_retry",
+        "set_skipped",
     ],
 )
 def test_task_instance_set_state_failure(admin_client, action):
@@ -710,8 +712,8 @@ def test_task_instance_set_state_failure(admin_client, action):
 
 @pytest.mark.parametrize(
     "action",
-    ["clear", "set_success", "set_failed", "set_running"],
-    ids=["clear", "success", "failed", "running"],
+    ["clear", "set_success", "set_failed", "set_running", "set_skipped"],
+    ids=["clear", "success", "failed", "running", "skipped"],
 )
 def test_set_task_instance_action_permission_denied(session, client_ti_without_dag_edit, action):
     task_id = "runme_0"


### PR DESCRIPTION
This change is a request from a user of our platform - which uses Airflow.

When there is an issue with the scheduler, the tasks/dags are not running. Instead of setting all the missed task runs to failure or success, etc.. they want a way to set them to skipped. Signifying that they were not run so failed nor success does not identify the state of the task correctly. 

This small change adds the button to the tasks page in the dag, set_action_skipped.