### PR TITLE
Chart: Fix extra secrets/configmaps labels

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -29,13 +29,13 @@ metadata:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}
+{{- with $Global.Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
-{{- with $Global.Values.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
 {{- if $configMapContent.data }}
 data:
   {{- with $configMapContent.data }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -29,13 +29,13 @@ metadata:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}
+{{- with $Global.Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
-{{- with $Global.Values.labels }}
-{{ toYaml . | indent 4 }}
-{{- end }}
 {{- if $secretContent.data }}
 data:
   {{- with $secretContent.data }}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently the labels (when set) end up in annotations of extra secrets/configmaps, this PR fixes it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
