### PR TITLE
Removes Python 3.6 support

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1271,7 +1271,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           Uses different version of Airflow when building PROD image.
@@ -1474,7 +1474,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   -I, --production-image
           Use production image for entering the environment and builds (not for tests).
@@ -1541,7 +1541,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   -v, --verbose
           Show verbose information about executed docker, kind, kubectl, helm commands. Useful for
@@ -1632,7 +1632,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
 
   ####################################################################################################
@@ -1827,7 +1827,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   -b, --backend BACKEND
           Backend to use for tests - it determines which database is used.
@@ -1896,7 +1896,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   -F, --force-build-images
           Forces building of the local docker images. The images are rebuilt
@@ -2305,7 +2305,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9 3.6
+                 3.7 3.8 3.9
 
   ****************************************************************************************************
    Choose backend to run for Airflow

--- a/CI.rst
+++ b/CI.rst
@@ -662,7 +662,7 @@ have to be percent-encoded when you access them via UI (/ = %2F)
 +--------------+----------------------------------------------------------+----------------------------------------------------------+
 
 * <BRANCH> might be either "main" or "v2-*-test"
-* <X.Y> - Python version (Major + Minor).Should be one of ["3.6", "3.7", "3.8", "3.9"].
+* <X.Y> - Python version (Major + Minor).Should be one of ["3.7", "3.8", "3.9"].
 * <COMMIT_SHA> - full-length SHA of commit either from the tip of the branch (for pushes/schedule) or
   commit from the tip of the branch used for the PR.
 

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -603,7 +603,7 @@ which checks if the image has been released and will pull it and rebuild it if n
     export FORCE_ANSWER_TO_QUESTIONS="true"
     export CI="true"
 
-    for python_version in "3.6" "3.7" "3.8"
+    for python_version in "3.7" "3.8" "3.9"
     do
             ./breeze build-image --python ${python_version} --build-cache-local \
                     --check-if-python-base-image-updated --verbose

--- a/breeze-complete
+++ b/breeze-complete
@@ -23,7 +23,7 @@
 # by the BATS tests automatically during pre-commit and CI
 # Those cannot be made read-only as the breeze-complete must be re-sourceable
 
-_breeze_allowed_python_major_minor_versions="3.7 3.8 3.9 3.6"
+_breeze_allowed_python_major_minor_versions="3.7 3.8 3.9"
 _breeze_allowed_backends="sqlite mysql postgres mssql"
 _breeze_allowed_integrations="cassandra kerberos mongo openldap pinot rabbitmq redis statsd trino all"
 _breeze_allowed_generate_constraints_modes="source-providers pypi-providers no-providers"

--- a/dev/REFRESHING_CI_CACHE.md
+++ b/dev/REFRESHING_CI_CACHE.md
@@ -48,7 +48,7 @@ manual refresh might be needed.
 # Manually generating constraint files
 
 ```bash
-export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING="3.7 3.8 3.9 3.6"
+export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING="3.7 3.8 3.9"
 for python_version in $(echo "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING}")
 do
   ./breeze build-image --upgrade-to-newer-dependencies --python ${python_version} --build-cache-local
@@ -90,5 +90,5 @@ If you have fast network and powerful computer, you can refresh the images in pa
 or with gnu parallel:
 
 ```bash
-parallel -j 4 --linebuffer --tagstring '{}' ./dev/refresh_images.sh ::: 3.7 3.8 3.9 3.6
+parallel -j 4 --linebuffer --tagstring '{}' ./dev/refresh_images.sh ::: 3.7 3.8 3.9
 ```

--- a/dev/prepare_prod_docker_images.sh
+++ b/dev/prepare_prod_docker_images.sh
@@ -20,7 +20,7 @@ export AIRFLOW_SOURCES_DIR
 
 set -e
 
-CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=("3.7" "3.8" "3.9" "3.6")
+CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=("3.7" "3.8" "3.9")
 
 usage() {
     local cmdname

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -52,7 +52,7 @@ from rich.syntax import Syntax
 
 from airflow.utils.yaml import safe_load
 
-ALL_PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
+ALL_PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
 
 INITIAL_CHANGELOG_CONTENT = """
 

--- a/dev/retag_docker_images.py
+++ b/dev/retag_docker_images.py
@@ -31,7 +31,7 @@ from typing import List
 
 import click
 
-PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
+PYTHON_VERSIONS = ["3.7", "3.8", "3.9"]
 
 GHCR_IO_PREFIX = "ghcr.io"
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -107,11 +107,11 @@ function initialization::initialize_base_variables() {
     export PRODUCTION_IMAGE="false"
 
     # All supported major/minor versions of python in all versions of Airflow
-    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.6" "3.7" "3.8" "3.9")
+    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9")
     export ALL_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported major/minor versions of python
-    CURRENT_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9" "3.6")
+    CURRENT_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9")
     export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported versions of Postgres

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -125,9 +125,7 @@ function output_all_basic_variables() {
     initialization::ga_output default-helm-version "${HELM_VERSION}"
 
     if [[ ${FULL_TESTS_NEEDED_LABEL} == "true" ]]; then
-        initialization::ga_output postgres-exclude '[{ "python-version": "3.6" }]'
         initialization::ga_output mysql-exclude '[{ "python-version": "3.7" }, { "python-version": "3.9" }]'
-        initialization::ga_output mssql-exclude '[{ "python-version": "3.6" }, { "python-version": "3.8" }]'
         initialization::ga_output sqlite-exclude '[{ "python-version": "3.7" }, { "python-version": "3.8" }]'
     else
         initialization::ga_output postgres-exclude '[]'

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ classifiers =
     Intended Audience :: Developers
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -70,7 +69,7 @@ project_urls =
 [options]
 zip_safe = False
 include_package_data = True
-python_requires = ~=3.6
+python_requires = ~=3.7
 packages = find:
 setup_requires =
     gitpython
@@ -86,10 +85,8 @@ install_requires =
     attrs>=20.0, <21.0
     blinker
     cached_property~=1.5;python_version<="3.7"
-    # cattrs >= 1.1.0 dropped support for Python 3.6
-    cattrs>=1.0, <1.1.0;python_version<="3.6"
     # cattrs >= 1.7.0 break lineage - see https://github.com/apache/airflow/issues/16172
-    cattrs~=1.1, <1.7.0;python_version>"3.6"
+    cattrs~=1.1, <1.7.0
     # Required by vendored-in connexion
     clickclick>=1.2
     colorlog>=4.0.2, <6.0

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,7 @@ cloudant = [
 ]
 dask = [
     'cloudpickle>=1.4.1, <1.5.0',
-    'dask>=2.9.0, <2021.6.1;python_version>="3.7"',  # dask 2021.6.1 does not work with `distributed`
+    'dask>=2.9.0, <2021.6.1',  # dask 2021.6.1 does not work with `distributed`
     'distributed>=2.11.1, <2.20',
 ]
 databricks = [

--- a/setup.py
+++ b/setup.py
@@ -238,7 +238,6 @@ cloudant = [
 ]
 dask = [
     'cloudpickle>=1.4.1, <1.5.0',
-    'dask<2021.3.1;python_version<"3.7"',  # dask stopped supporting python 3.6 in 2021.3.1 version
     'dask>=2.9.0, <2021.6.1;python_version>="3.7"',  # dask 2021.6.1 does not work with `distributed`
     'distributed>=2.11.1, <2.20',
 ]
@@ -872,7 +871,7 @@ EXTRAS_REQUIREMENTS["devel_ci"] = devel_ci
 
 def sort_extras_requirements() -> Dict[str, List[str]]:
     """
-    For Python 3.6+ the dictionary order remains when keys() are retrieved.
+    The dictionary order remains when keys() are retrieved.
     Sort both: extras and list of dependencies to make it easier to analyse problems
     external packages will be first, then if providers are added they are added at the end of the lists.
     """

--- a/tests/bats/breeze/test_breeze_complete.bats
+++ b/tests/bats/breeze/test_breeze_complete.bats
@@ -25,7 +25,7 @@
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
   breeze_complete::get_known_values_breeze "-p"
-  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9 3.6"
+  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9"
 }
 
 @test "Test get_known_values long" {
@@ -34,7 +34,7 @@
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
   breeze_complete::get_known_values_breeze "--python"
-  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9 3.6"
+  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9"
 }
 
 @test "Test wrong get_known_values" {
@@ -125,7 +125,7 @@
   COMP_WORDS=("--python" "")
   breeze_complete::_comp_breeze
 
-  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9 3.6"
+  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9"
 }
 
 @test "Test autocomplete --python with prefix" {
@@ -136,7 +136,7 @@
   COMP_WORDS=("--python" "3")
   breeze_complete::_comp_breeze
 
-  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9 3.6"
+  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9"
 }
 
 @test "Test autocomplete build-" {


### PR DESCRIPTION
Python 3.6 End of Life was on December 23, 2021

Airflow supports Python versions up to the moment they reach
end of life as documented in:

https://github.com/apache/airflow/blob/main/README.md#support-for-python-and-kubernetes-versions

RIP Python 3.6

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
