### PR TITLE
SSHOperator.execute() returns str regardless of enable_xcom_pickling

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -462,7 +462,7 @@ class BaseXCom(Base, LoggingMixin):
         return query.delete()
 
     @staticmethod
-    def serialize_value(value: Any):
+    def serialize_value(value: Any) -> bytes:
         """Serialize Xcom value to str or pickled object"""
         if conf.getboolean('core', 'enable_xcom_pickling'):
             return pickle.dumps(value)

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -17,7 +17,6 @@
 # under the License.
 
 import warnings
-from base64 import b64encode
 from select import select
 from typing import Optional, Tuple, Union
 
@@ -205,8 +204,7 @@ class SSHOperator(BaseOperator):
         self.raise_for_status(exit_status, agg_stderr)
         return agg_stdout
 
-    def execute(self, context=None) -> Union[bytes, str]:
-        result: Union[bytes, str]
+    def execute(self, context=None) -> str:
         if self.command is None:
             raise AirflowException("SSH operator error: SSH command not specified. Aborting.")
 
@@ -218,10 +216,7 @@ class SSHOperator(BaseOperator):
                 result = self.run_ssh_client_command(ssh_client, self.command)
         except Exception as e:
             raise AirflowException(f"SSH operator error: {str(e)}")
-        enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
-        if not enable_pickling:
-            result = b64encode(result).decode('utf-8')
-        return result
+        return result.decode('utf-8')
 
     def tunnel(self) -> None:
         """Get ssh tunnel"""

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -18,11 +18,10 @@
 
 import warnings
 from select import select
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from paramiko.client import SSHClient
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -117,7 +117,7 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         )
         assert check_file_task is not None
         result = check_file_task.execute(None)
-        assert result.strip() == test_remote_file_content.encode('utf-8')
+        assert result.strip() == test_remote_file_content
 
         # Clean up after finishing with test
         conn.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-from base64 import b64encode
 from unittest import mock
 
 import pytest
@@ -97,7 +96,7 @@ class TestSFTPOperator:
         tis["check_file_task"].run()
 
         pulled = tis["check_file_task"].xcom_pull(task_ids="check_file_task", key='return_value')
-        assert pulled.strip() == test_local_file_content
+        assert pulled.strip() == test_local_file_content.decode('utf-8')
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_file_transfer_no_intermediate_dir_error_put(self, create_task_instance_of_operator):
@@ -158,7 +157,7 @@ class TestSFTPOperator:
         tis["test_check_file"].run()
 
         pulled = tis["test_check_file"].xcom_pull(task_ids='test_check_file', key='return_value')
-        assert pulled.strip() == test_local_file_content
+        assert pulled.strip() == test_local_file_content.decode('utf-8')
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'False'})
     def test_json_file_transfer_put(self, dag_maker):
@@ -191,7 +190,7 @@ class TestSFTPOperator:
         tis["check_file_task"].run()
 
         pulled = tis["check_file_task"].xcom_pull(task_ids="check_file_task", key='return_value')
-        assert pulled.strip() == b64encode(test_local_file_content).decode('utf-8')
+        assert pulled.strip() == test_local_file_content.decode('utf-8')
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_pickle_file_transfer_get(self, dag_maker):

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -17,7 +17,6 @@
 # under the License.
 
 import unittest.mock
-from base64 import b64encode
 
 import pytest
 
@@ -93,7 +92,7 @@ class TestSSHOperator:
         )
         ti.run()
         assert ti.duration is not None
-        assert ti.xcom_pull(task_ids='test', key='return_value') == b64encode(b'airflow').decode('utf-8')
+        assert ti.xcom_pull(task_ids='test', key='return_value') == 'airflow'
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_pickle_command_execution(self, create_task_instance_of_operator):
@@ -107,7 +106,7 @@ class TestSSHOperator:
         )
         ti.run()
         assert ti.duration is not None
-        assert ti.xcom_pull(task_ids='test', key='return_value') == b'airflow'
+        assert ti.xcom_pull(task_ids='test', key='return_value') == 'airflow'
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_command_execution_with_env(self, create_task_instance_of_operator):
@@ -122,7 +121,7 @@ class TestSSHOperator:
         )
         ti.run()
         assert ti.duration is not None
-        assert ti.xcom_pull(task_ids='test', key='return_value') == b'airflow'
+        assert ti.xcom_pull(task_ids='test', key='return_value') == 'airflow'
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_no_output_command(self, create_task_instance_of_operator):
@@ -136,7 +135,7 @@ class TestSSHOperator:
         )
         ti.run()
         assert ti.duration is not None
-        assert ti.xcom_pull(task_ids='test', key='return_value') == b''
+        assert ti.xcom_pull(task_ids='test', key='return_value') == ''
 
     @unittest.mock.patch('os.environ', {'AIRFLOW_CONN_' + TEST_CONN_ID.upper(): "ssh://test_id@localhost"})
     def test_arg_checking(self):


### PR DESCRIPTION
Currently the return value from `SSHOperator.execute()` depends on whether `enable_xcom_pickling` is True or False.
* If `enable_xcom_pickling=True`, a `bytes` object is returned.
* otherwise, an `str` object with uuencode is returned.

Later the return value may be stored in XCom and retrieved by other tasks.

This confuses the "consumer" of its XCom messages.  They have to also check `enable_xcom_pickling` to know if the result should first be uudecoded.  Even worse, they have to know it is generated by an "SSHOperator" because other operators do not do that.

Should we change the behavior to always returning a `str`, without uuencode, as the attached pull request suggests?  Is that a sensible thing to do?

Thanks!