### PR TITLE
Delay the creation of ssh proxy until `get_conn()`

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -17,6 +17,7 @@
 # under the License.
 """Hook for SSH connections."""
 import os
+import sys
 import warnings
 from base64 import decodebytes
 from io import StringIO
@@ -25,6 +26,11 @@ from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union
 import paramiko
 from paramiko.config import SSH_PORT
 from sshtunnel import SSHTunnelForwarder
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from cached_property import cached_property
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -123,12 +129,12 @@ class SSHHook(BaseHook):
         self.timeout = timeout
         self.conn_timeout = conn_timeout
         self.keepalive_interval = keepalive_interval
+        self.host_proxy_cmd = None
 
         # Default values, overridable from Connection
         self.compress = True
         self.no_host_key_check = True
         self.allow_host_key_change = False
-        self.host_proxy = None
         self.host_key = None
         self.look_for_keys = True
 
@@ -242,13 +248,18 @@ class SSHHook(BaseHook):
                 ssh_conf.parse(config_fd)
             host_info = ssh_conf.lookup(self.remote_host)
             if host_info and host_info.get('proxycommand'):
-                self.host_proxy = paramiko.ProxyCommand(host_info['proxycommand'])
+                self.host_proxy_cmd = host_info['proxycommand']
 
             if not (self.password or self.key_file):
                 if host_info and host_info.get('identityfile'):
                     self.key_file = host_info['identityfile'][0]
 
         self.port = self.port or SSH_PORT
+
+    @cached_property
+    def host_proxy(self) -> Optional[paramiko.ProxyCommand]:
+        cmd = self.host_proxy_cmd
+        return paramiko.ProxyCommand(cmd) if cmd else None
 
     def get_conn(self) -> paramiko.SSHClient:
         """


### PR DESCRIPTION
We recently upgraded from Airflow 1.9 to 2.2.2 (to be more precise, we are still in the process of upgrading, dealing with various issues related to the upgrade).  I like the change that the newly refactored SSHHook initializes most of the parameters in `__init__`, making customization easier.  However, there is one "heavy" operation related to SSH proxy which I wonder might be better off moving back to where it will be used.

I noticed that for every 30+ seconds (`min_file_process_interval=30`), during the run of DAGFileProcessor, a bunch of SSH processes would be launched.  This is because a `paramiko.ProxyCommand` is ran for any connection used in tasks, as long as that connection has a "ProxyCommand" in the `.ssh/config` file.  This seems too much (also heavy) to me.

I wonder if a change in the spirit of the attached pull request is acceptable or not?