### PR TITLE
Remove unneeded FAB REST API endpoints

### DIFF
--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -44,6 +44,7 @@ from sqlalchemy.orm import Session
 
 from airflow import settings
 from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 
 # This module contains code imported from FlaskAppbuilder, so lets use _its_ logger name
 log = logging.getLogger("flask_appbuilder.base")
@@ -524,12 +525,7 @@ class AirflowAppBuilder:
         return baseview
 
     def add_api(self, baseview):
-        """
-            Add a BaseApi class or child to AppBuilder
-        :param baseview: A BaseApi type class
-        :return: The instantiated base view
-        """
-        return self.add_view_no_menu(baseview)
+        raise AirflowException("Airflow doesn't support the Flask AppBuilder REST API")
 
     def security_cleanup(self):
         """

--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -26,7 +26,6 @@ from typing import Dict, List, Union
 
 from flask import Blueprint, current_app, url_for
 from flask_appbuilder import BaseView, __version__
-from flask_appbuilder.api.manager import OpenApiManager
 from flask_appbuilder.babel.manager import BabelManager
 from flask_appbuilder.const import (
     LOGMSG_ERR_FAB_ADD_PERMISSION_MENU,
@@ -102,8 +101,6 @@ class AirflowAppBuilder:
     sm: BaseSecurityManager
     # Babel Manager Class
     bm = None
-    # OpenAPI Manager Class
-    openapi_manager = None
     # dict with addon name has key and intantiated class has value
     addon_managers = None
     # temporary list that hold addon_managers config key
@@ -210,7 +207,6 @@ class AirflowAppBuilder:
         self.session = session
         self.sm = self.security_manager_class(self)
         self.bm = BabelManager(self)
-        self.openapi_manager = OpenApiManager(self)
         self._add_global_static()
         self._add_global_filters()
         app.before_request(self.sm.before_request)
@@ -314,7 +310,6 @@ class AirflowAppBuilder:
         self.add_view_no_menu(UtilView())
         self.bm.register_views()
         self.sm.register_views()
-        self.openapi_manager.register_views()
 
     def _add_addon_views(self):
         """Register declared addons."""

--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -44,7 +44,6 @@ from sqlalchemy.orm import Session
 
 from airflow import settings
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
 
 # This module contains code imported from FlaskAppbuilder, so lets use _its_ logger name
 log = logging.getLogger("flask_appbuilder.base")
@@ -523,9 +522,6 @@ class AirflowAppBuilder:
         else:
             log.warning(LOGMSG_WAR_FAB_VIEW_EXISTS.format(baseview.__class__.__name__))
         return baseview
-
-    def add_api(self, baseview):
-        raise AirflowException("Airflow doesn't support the Flask AppBuilder REST API")
 
     def security_cleanup(self):
         """

--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -38,7 +38,7 @@ from flask_appbuilder.const import (
     LOGMSG_WAR_FAB_VIEW_EXISTS,
 )
 from flask_appbuilder.filters import TemplateFilters
-from flask_appbuilder.menu import Menu, MenuApiManager
+from flask_appbuilder.menu import Menu
 from flask_appbuilder.security.manager import BaseSecurityManager
 from flask_appbuilder.views import IndexView, UtilView
 from sqlalchemy.orm import Session
@@ -211,7 +211,6 @@ class AirflowAppBuilder:
         self.sm = self.security_manager_class(self)
         self.bm = BabelManager(self)
         self.openapi_manager = OpenApiManager(self)
-        self.menuapi_manager = MenuApiManager(self)
         self._add_global_static()
         self._add_global_filters()
         app.before_request(self.sm.before_request)
@@ -316,7 +315,6 @@ class AirflowAppBuilder:
         self.bm.register_views()
         self.sm.register_views()
         self.openapi_manager.register_views()
-        self.menuapi_manager.register_views()
 
     def _add_addon_views(self):
         """Register declared addons."""

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -41,7 +41,6 @@ from flask_appbuilder.const import (
     LOGMSG_WAR_SEC_NO_USER,
     LOGMSG_WAR_SEC_NOLDAP_OBJ,
 )
-from flask_appbuilder.security.api import SecurityApi
 from flask_appbuilder.security.registerviews import (
     RegisterUserDBView,
     RegisterUserOAuthView,
@@ -169,10 +168,6 @@ class BaseSecurityManager:
     """ Override if you want your own reset password view """
     userinfoeditview = UserInfoEditView
     """ Override if you want your own User information edit view """
-
-    # API
-    security_api = SecurityApi
-    """ Override if you want your own Security API login endpoint """
 
     rolemodelview = RoleModelView
     actionmodelview = PermissionModelView
@@ -654,8 +649,6 @@ class BaseSecurityManager:
     def register_views(self):
         if not self.appbuilder.app.config.get("FAB_ADD_SECURITY_VIEWS", True):
             return
-        # Security APIs
-        self.appbuilder.add_api(self.security_api)
 
         if self.auth_user_registration:
             if self.auth_type == AUTH_DB:


### PR DESCRIPTION
We don't need or want these default FAB REST API endpoints to be
exposed, so remove them.