### PR TITLE
Bump croniter from `<1.1` to `<1.2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ install_requires =
     clickclick>=1.2
     colorlog>=4.0.2, <6.0
     cron-descriptor>=1.2.24
-    croniter>=0.3.17, <1.1
+    croniter>=0.3.17, <1.2
     cryptography>=0.9.3
     dataclasses;python_version<"3.7"
     deprecated>=1.2.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,7 +94,7 @@ install_requires =
     clickclick>=1.2
     colorlog>=4.0.2, <6.0
     cron-descriptor>=1.2.24
-    croniter>=0.3.17, <1.2
+    croniter>=0.3.17
     cryptography>=0.9.3
     dataclasses;python_version<"3.7"
     deprecated>=1.2.13


### PR DESCRIPTION
This minor release makes cron validation stricter. https://pypi.org/project/croniter/1.1.0/#id1

> Enforce validation for month=1. Before this release we used to support month=0 and it was silently glided to month=1 to support having both day in month in 4th field when it came to have 6fields cron forms (second repeat). It will now raises a CroniterBadDateError. See https://github.com/kiorky/croniter/issues/6 [kiorky]