### PR TITLE
Bump PyJWT from `<2` to `<3`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,7 @@ install_requires =
     psutil>=4.2.0, <6.0.0
     pygments>=2.0.1, <3.0
     # Required for flask-jwt-extended and msal
-    pyjwt<2
+    pyjwt<3
     # python daemon crashes with 'socket operation on non-socket' for python 3.8+ in version < 2.2.4
     # https://pagure.io/python-daemon/issue/34
     python-daemon>=2.2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,7 +134,6 @@ install_requires =
     pep562~=1.0;python_version<"3.7"
     psutil>=4.2.0, <6.0.0
     pygments>=2.0.1, <3.0
-    # Required for flask-jwt-extended and msal
     pyjwt<3
     # python daemon crashes with 'socket operation on non-socket' for python 3.8+ in version < 2.2.4
     # https://pagure.io/python-daemon/issue/34


### PR DESCRIPTION
Both [flask-jwt-extended] and [msal] now support PyJWT `<3`.

[flask-jwt-extended]:
  https://github.com/vimalloc/flask-jwt-extended/blob/2c7ae9e81de030f67fb3577be7a74f2a6b7ef5a2/setup.py#L31
[msal]:
  https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/8bdb1ef8a3ee2ba3da0c50090683c555d7020198/setup.py#L76