### PR TITLE
removed query_id instance variable from snowflake

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -144,7 +144,6 @@ class SnowflakeHook(DbApiHook):
         self.schema = kwargs.pop("schema", None)
         self.authenticator = kwargs.pop("authenticator", None)
         self.session_parameters = kwargs.pop("session_parameters", None)
-        self.query_ids: List[str] = []
 
     def _get_conn_params(self) -> Dict[str, Optional[str]]:
         """
@@ -281,7 +280,7 @@ class SnowflakeHook(DbApiHook):
         :param handler: The result handler which is called with the result of each statement.
         :type handler: callable
         """
-        self.query_ids = []
+        query_ids = []
 
         with closing(self.get_conn()) as conn:
             self.set_autocommit(conn, autocommit)
@@ -310,14 +309,14 @@ class SnowflakeHook(DbApiHook):
 
                     self.log.info("Rows affected: %s", cur.rowcount)
                     self.log.info("Snowflake query id: %s", cur.sfqid)
-                    self.query_ids.append(cur.sfqid)
+                    query_ids.append(cur.sfqid)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.
             if not self.get_autocommit(conn):
                 conn.commit()
 
-        return execution_info
+        return execution_info, query_ids
 
     def test_connection(self):
         """Test the Snowflake connection by running a simple query."""

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -356,11 +356,12 @@ class TestPytestSnowflakeHook:
             conn.cursor.return_value = cur
             type(cur).sfqid = mock.PropertyMock(side_effect=query_ids)
             mock_params = {"mock_param": "mock_param"}
-            hook.run(sql, parameters=mock_params)
-
+            _,queries = hook.run(sql, parameters=mock_params)
+        
             sql_list = sql if isinstance(sql, list) else re.findall(".*?[;]", sql)
-            cur.execute.assert_has_calls([mock.call(query, mock_params) for query in sql_list])
-            assert hook.query_ids == query_ids[::2]
+            cur.execute.assert_has_calls([
+                mock.call(query, mock_params) for query in sql_list]) 
+            assert queries == query_ids[::2]
             cur.close.assert_called()
 
     @mock.patch('airflow.providers.snowflake.hooks.snowflake.SnowflakeHook.run')


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #20398 

Removed query_id instance variable from snowflake , does not store query_ids

---

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
