### PR TITLE
Docs: Note that `remote_log_conn_id` is only used for reading logs, not writing them

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -471,7 +471,7 @@
     - name: remote_log_conn_id
       description: |
         Users must supply an Airflow connection id that provides access to the storage
-        location.
+        location. Note: This is only used for reading logs, not writing logs
       version_added: 2.0.0
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -268,7 +268,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 remote_logging = False
 
 # Users must supply an Airflow connection id that provides access to the storage
-# location.
+# location. Note: This is only used for reading logs, not writing logs
 remote_log_conn_id =
 
 # Path to Google Credential JSON file. If omitted, authorization based on `the Application Default


### PR DESCRIPTION
related: #20408
