### PR TITLE
Fix DAG date range bug

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -570,7 +570,9 @@ class DAG(LoggingMixin):
         message = "`DAG.date_range()` is deprecated."
         if num is not None:
             warnings.warn(message, category=DeprecationWarning, stacklevel=2)
-            return utils_date_range(start_date=start_date, num=num, delta=self.normalized_schedule_interval)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                return utils_date_range(start_date=start_date, num=num, delta=self.normalized_schedule_interval)
         message += " Please use `DAG.iter_dagrun_infos_between(..., align=False)` instead."
         warnings.warn(message, category=DeprecationWarning, stacklevel=2)
         if end_date is None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -572,7 +572,9 @@ class DAG(LoggingMixin):
             warnings.warn(message, category=DeprecationWarning, stacklevel=2)
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                return utils_date_range(start_date=start_date, num=num, delta=self.normalized_schedule_interval)
+                return utils_date_range(
+                    start_date=start_date, num=num, delta=self.normalized_schedule_interval
+                )
         message += " Please use `DAG.iter_dagrun_infos_between(..., align=False)` instead."
         warnings.warn(message, category=DeprecationWarning, stacklevel=2)
         if end_date is None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -570,7 +570,7 @@ class DAG(LoggingMixin):
         message = "`DAG.date_range()` is deprecated."
         if num is not None:
             warnings.warn(message, category=DeprecationWarning, stacklevel=2)
-            return utils_date_range(start_date=start_date, num=num)
+            return utils_date_range(start_date=start_date, num=num, delta=self.normalized_schedule_interval)
         message += " Please use `DAG.iter_dagrun_infos_between(..., align=False)` instead."
         warnings.warn(message, category=DeprecationWarning, stacklevel=2)
         if end_date is None:

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1884,6 +1884,19 @@ class TestDag(unittest.TestCase):
             conf={"param1": "hello"},
         )
 
+    def test_return_date_range_with_num_method(self):
+        start_date = TEST_DATE
+        delta = timedelta(days=1)
+
+        dag = models.DAG('dummy-dag', schedule_interval=delta)
+        dag_dates = dag.date_range(start_date=start_date, num=3)
+
+        assert dag_dates == [
+            start_date,
+            start_date + delta,
+            start_date + 2 * delta,
+        ]
+
 
 class TestDagModel:
     def test_dags_needing_dagruns_not_too_early(self):


### PR DESCRIPTION
Recently function `date_range` in the DAG class has been changed in a way that made this function useless when using the `num` parameter instead of `end_date`.

Currently, when using this function with `num` parameter, the following code is executed:
https://github.com/apache/airflow/blob/f62e690efeb80863855282d33d3e047d01af2db0/airflow/models/dag.py#L564-L573

Util function `utils_date_range` (which is actually named `date_range`, but is renamed during import) takes these arguments:
https://github.com/apache/airflow/blob/f62e690efeb80863855282d33d3e047d01af2db0/airflow/utils/dates.py#L38-L43

`delta` argument is theoretically optional, but the first two lines make the function useless without this argument.
https://github.com/apache/airflow/blob/f62e690efeb80863855282d33d3e047d01af2db0/airflow/utils/dates.py#L82-L83

Therefore, the current implementation of `date_range` in DAG class always returns an empty list when using `num` argument. This fix provides `delta` of  `self.normalized_schedule_interval` to make it properly work, which is a way that this function worked before changes (so more or less I'm only reverting a change made in [this commit](https://github.com/apache/airflow/commit/5034414208f85a8be61fe51d6a3091936fe402ba)). I also added a unit test that makes sure this doesn't happen again in the future.

I know this function is deprecated, but it's still a small bug that IMO should be fixed.
