### PR TITLE
Fix dates.days_ago to respect localized timezone configuration.

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -257,7 +257,8 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
     Get a datetime object representing `n` days ago. By default the time is
     set to midnight.
     """
-    today = timezone.utcnow().replace(hour=hour, minute=minute, second=second, microsecond=microsecond)
+    today = datetime.utcnow()
+    today = timezone.make_aware(today).replace(hour=hour, minute=minute, second=second, microsecond=microsecond)
     return today - timedelta(days=n)
 
 

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -257,8 +257,7 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
     Get a datetime object representing `n` days ago. By default the time is
     set to midnight.
     """
-    today = datetime.utcnow()
-    today = timezone.make_aware(today).replace(
+    today = datetime.now(timezone.TIMEZONE).replace(
         hour=hour, minute=minute, second=second, microsecond=microsecond
     )
     return today - timedelta(days=n)

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -258,7 +258,9 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
     set to midnight.
     """
     today = datetime.utcnow()
-    today = timezone.make_aware(today).replace(hour=hour, minute=minute, second=second, microsecond=microsecond)
+    today = timezone.make_aware(today).replace(
+        hour=hour, minute=minute, second=second, microsecond=microsecond
+    )
     return today - timedelta(days=n)
 
 

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -17,7 +17,7 @@
 # under the License.
 
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from typing import Dict, List, Optional, Union
 
 from croniter import croniter
@@ -257,10 +257,10 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0):
     Get a datetime object representing `n` days ago. By default the time is
     set to midnight.
     """
-    today = datetime.now(timezone.TIMEZONE).replace(
-        hour=hour, minute=minute, second=second, microsecond=microsecond
+    return datetime.combine(
+        datetime.now(timezone.TIMEZONE) - timedelta(days=n),
+        time(hour, minute, second, microsecond, tzinfo=timezone.TIMEZONE),
     )
-    return today - timedelta(days=n)
 
 
 def parse_execution_date(execution_date_str):

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -29,8 +29,10 @@ from airflow.utils import dates, timezone
 
 class TestDates(unittest.TestCase):
     def test_days_ago(self):
+        from airflow.settings import TIMEZONE
+
         today = pendulum.today()
-        today_midnight = pendulum.instance(datetime.fromordinal(today.date().toordinal()))
+        today_midnight = pendulum.instance(datetime.fromordinal(today.date().toordinal()), tz=TIMEZONE)
 
         assert dates.days_ago(0) == today_midnight
         assert dates.days_ago(100) == today_midnight + timedelta(days=-100)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
related: #17720 
closes: #17720 

There was problem that days_ago only uses utc time. 
If dag is set start_date with days_ago, then dag is scheduled in utc time.

After fixing this, the dags using days_ago are scheduled in local time.

For example, the dag below in timezone `Asia/Seoul`

```python
from airflow import DAG
from airflow.operators.dummy import DummyOperator

from airflow.utils.dates import days_ago

with DAG(
    dag_id = "test_days_ago_dag",
    start_date=days_ago(7),
    schedule_interval="0 2 * * *"
) as dag:
    dumb = DummyOperator(task_id="test_dummy", dag=dag)
```

is scheduled like below.


![airflow_schedule](https://user-images.githubusercontent.com/26663842/147425512-1f655ca4-ee22-45e2-bb3e-9e7bbc2b4971.png)


