### PR TITLE
Improvements for `SnowflakeHook.get_sqlalchemy_engine` 

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -223,14 +223,13 @@ class SnowflakeHook(DbApiHook):
         return self._conn_params_to_sqlalchemy_uri(conn_params)
 
     def _conn_params_to_sqlalchemy_uri(self, conn_params: Dict) -> str:
-        uri = URL(
+        return URL(
             **{
                 k: v
                 for k, v in conn_params.items()
                 if v and k not in ['session_parameters', 'insecure_mode', 'private_key']
             }
         )
-        return uri.format(**conn_params)
 
     def get_conn(self) -> SnowflakeConnection:
         """Returns a snowflake.connection object"""

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -224,7 +224,11 @@ class SnowflakeHook(DbApiHook):
 
     def _conn_params_to_sqlalchemy_uri(self, conn_params: Dict) -> str:
         uri = URL(
-            **{k: v for k, v in conn_params.items() if v and k not in ['session_parameters', 'insecure_mode']}
+            **{
+                k: v
+                for k, v in conn_params.items()
+                if v and k not in ['session_parameters', 'insecure_mode', 'private_key']
+            }
         )
         return uri.format(**conn_params)
 
@@ -246,9 +250,10 @@ class SnowflakeHook(DbApiHook):
         if 'insecure_mode' in conn_params:
             engine_kwargs.setdefault('connect_args', dict())
             engine_kwargs['connect_args']['insecure_mode'] = True
-        if conn_params.get('session_parameters'):
-            engine_kwargs.setdefault('connect_args', dict())
-            engine_kwargs['connect_args']['session_parameters'] = conn_params['session_parameters']
+        for key in ['session_parameters', 'private_key']:
+            if conn_params.get(key):
+                engine_kwargs.setdefault('connect_args', dict())
+                engine_kwargs['connect_args'][key] = conn_params[key]
         return create_engine(self._conn_params_to_sqlalchemy_uri(conn_params), **engine_kwargs)
 
     def set_autocommit(self, conn, autocommit: Any) -> None:

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -222,10 +222,17 @@ class SnowflakeHook(DbApiHook):
         return self._conn_params_to_sqlalchemy_uri(conn_params)
 
     def _conn_params_to_sqlalchemy_uri(self, conn_params: Dict) -> str:
-        uri = (
-            'snowflake://{user}:{password}@{account}.{region}/{database}/{schema}'
+        if conn_params['region'] == '':
+            del conn_params['region']
+            uri = (
+            'snowflake://{user}:{password}@{account}/{database}/{schema}'
             '?warehouse={warehouse}&role={role}&authenticator={authenticator}'
-        )
+            )
+        else:    
+            uri = (
+                'snowflake://{user}:{password}@{account}.{region}/{database}/{schema}'
+                '?warehouse={warehouse}&role={role}&authenticator={authenticator}'
+            )
         return uri.format(**conn_params)
 
     def get_conn(self) -> SnowflakeConnection:

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -79,7 +79,7 @@ class TestPytestSnowflakeHook:
                 BASE_CONNECTION_KWARGS,
                 (
                     'snowflake://user:pw@airflow.af_region/db/public?'
-                    'warehouse=af_wh&role=af_role&authenticator=snowflake'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
                 ),
                 {
                     'account': 'airflow',
@@ -98,19 +98,17 @@ class TestPytestSnowflakeHook:
             (
                 {
                     **BASE_CONNECTION_KWARGS,
-                    **{
-                        'extra': {
-                            'extra__snowflake__database': 'db',
-                            'extra__snowflake__account': 'airflow',
-                            'extra__snowflake__warehouse': 'af_wh',
-                            'extra__snowflake__region': 'af_region',
-                            'extra__snowflake__role': 'af_role',
-                        },
+                    'extra': {
+                        'extra__snowflake__database': 'db',
+                        'extra__snowflake__account': 'airflow',
+                        'extra__snowflake__warehouse': 'af_wh',
+                        'extra__snowflake__region': 'af_region',
+                        'extra__snowflake__role': 'af_role',
                     },
                 },
                 (
                     'snowflake://user:pw@airflow.af_region/db/public?'
-                    'warehouse=af_wh&role=af_role&authenticator=snowflake'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
                 ),
                 {
                     'account': 'airflow',
@@ -129,20 +127,18 @@ class TestPytestSnowflakeHook:
             (
                 {
                     **BASE_CONNECTION_KWARGS,
-                    **{
-                        'extra': {
-                            'extra__snowflake__database': 'db',
-                            'extra__snowflake__account': 'airflow',
-                            'extra__snowflake__warehouse': 'af_wh',
-                            'extra__snowflake__region': 'af_region',
-                            'extra__snowflake__role': 'af_role',
-                            'extra__snowflake__insecure_mode': 'True',
-                        },
+                    'extra': {
+                        'extra__snowflake__database': 'db',
+                        'extra__snowflake__account': 'airflow',
+                        'extra__snowflake__warehouse': 'af_wh',
+                        'extra__snowflake__region': 'af_region',
+                        'extra__snowflake__role': 'af_role',
+                        'extra__snowflake__insecure_mode': 'True',
                     },
                 },
                 (
                     'snowflake://user:pw@airflow.af_region/db/public?'
-                    'warehouse=af_wh&role=af_role&authenticator=snowflake'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
                 ),
                 {
                     'account': 'airflow',
@@ -162,20 +158,18 @@ class TestPytestSnowflakeHook:
             (
                 {
                     **BASE_CONNECTION_KWARGS,
-                    **{
-                        'extra': {
-                            'extra__snowflake__database': 'db',
-                            'extra__snowflake__account': 'airflow',
-                            'extra__snowflake__warehouse': 'af_wh',
-                            'extra__snowflake__region': 'af_region',
-                            'extra__snowflake__role': 'af_role',
-                            'extra__snowflake__insecure_mode': 'False',
-                        }
+                    'extra': {
+                        'extra__snowflake__database': 'db',
+                        'extra__snowflake__account': 'airflow',
+                        'extra__snowflake__warehouse': 'af_wh',
+                        'extra__snowflake__region': 'af_region',
+                        'extra__snowflake__role': 'af_role',
+                        'extra__snowflake__insecure_mode': 'False',
                     },
                 },
                 (
                     'snowflake://user:pw@airflow.af_region/db/public?'
-                    'warehouse=af_wh&role=af_role&authenticator=snowflake'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
                 ),
                 {
                     'account': 'airflow',
@@ -183,6 +177,55 @@ class TestPytestSnowflakeHook:
                     'authenticator': 'snowflake',
                     'database': 'db',
                     'password': 'pw',
+                    'region': 'af_region',
+                    'role': 'af_role',
+                    'schema': 'public',
+                    'session_parameters': None,
+                    'user': 'user',
+                    'warehouse': 'af_wh',
+                },
+            ),
+            (
+                {
+                    **BASE_CONNECTION_KWARGS,
+                    'extra': {
+                        **BASE_CONNECTION_KWARGS['extra'],
+                        'region': '',
+                    },
+                },
+                (
+                    'snowflake://user:pw@airflow/db/public?'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
+                ),
+                {
+                    'account': 'airflow',
+                    'application': 'AIRFLOW',
+                    'authenticator': 'snowflake',
+                    'database': 'db',
+                    'password': 'pw',
+                    'region': '',
+                    'role': 'af_role',
+                    'schema': 'public',
+                    'session_parameters': None,
+                    'user': 'user',
+                    'warehouse': 'af_wh',
+                },
+            ),
+            (
+                {
+                    **BASE_CONNECTION_KWARGS,
+                    'password': ';/?:@&=+$, ',
+                },
+                (
+                    'snowflake://user:;%2F?%3A%40&=+$, @airflow.af_region/db/public?'
+                    'application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
+                ),
+                {
+                    'account': 'airflow',
+                    'application': 'AIRFLOW',
+                    'authenticator': 'snowflake',
+                    'database': 'db',
+                    'password': ';/?:@&=+$, ',
                     'region': 'af_region',
                     'role': 'af_role',
                     'schema': 'public',
@@ -282,7 +325,7 @@ class TestPytestSnowflakeHook:
             conn = hook.get_sqlalchemy_engine()
             mock_create_engine.assert_called_once_with(
                 'snowflake://user:pw@airflow.af_region/db/public'
-                '?warehouse=af_wh&role=af_role&authenticator=snowflake'
+                '?application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh'
             )
             assert mock_create_engine.return_value == conn
 
@@ -299,7 +342,7 @@ class TestPytestSnowflakeHook:
             conn = hook.get_sqlalchemy_engine()
             mock_create_engine.assert_called_once_with(
                 'snowflake://user:pw@airflow.af_region/db/public'
-                '?warehouse=af_wh&role=af_role&authenticator=snowflake',
+                '?application=AIRFLOW&authenticator=snowflake&role=af_role&warehouse=af_wh',
                 connect_args={'insecure_mode': True},
             )
             assert mock_create_engine.return_value == conn
@@ -334,7 +377,7 @@ class TestPytestSnowflakeHook:
             } == hook._get_conn_params()
             assert (
                 "snowflake://user:pw@TEST_ACCOUNT.TEST_REGION/TEST_DATABASE/TEST_SCHEMA"
-                "?warehouse=TEST_WAREHOUSE&role=TEST_ROLE&authenticator=TEST_AUTH"
+                "?application=AIRFLOW&authenticator=TEST_AUTH&role=TEST_ROLE&warehouse=TEST_WAREHOUSE"
             ) == hook.get_uri()
 
     @pytest.mark.parametrize(
@@ -388,38 +431,3 @@ class TestPytestSnowflakeHook:
             assert status is False
             assert msg == 'Connection Errors'
             mock_run.assert_called_once_with(sql='select 1')
-
-    @mock.patch('airflow.providers.snowflake.hooks.snowflake.SnowflakeHook.run')
-    def test_connection_without_region(self, mock_run):
-        connection_kwargs = deepcopy(BASE_CONNECTION_KWARGS)
-        connection_kwargs['extra']['region'] = ''
-        with unittest.mock.patch.dict(
-            'os.environ', AIRFLOW_CONN_TEST_CONN=Connection(**connection_kwargs).get_uri()
-        ):
-            hook = SnowflakeHook(
-                snowflake_conn_id='test_conn',
-                account="TEST_ACCOUNT",
-                warehouse="TEST_WAREHOUSE",
-                database="TEST_DATABASE",
-                role="TEST_ROLE",
-                region="",
-                schema="TEST_SCHEMA",
-                authenticator='TEST_AUTH',
-                session_parameters={"AA": "AAA"},
-            )
-            assert {
-                'account': 'TEST_ACCOUNT',
-                'application': 'AIRFLOW',
-                'authenticator': 'TEST_AUTH',
-                'database': 'TEST_DATABASE',
-                'password': 'pw',
-                'role': 'TEST_ROLE',
-                'schema': 'TEST_SCHEMA',
-                'region': '',
-                'session_parameters': {'AA': 'AAA'},
-                'user': 'user',
-                'warehouse': 'TEST_WAREHOUSE',
-            } == hook._get_conn_params()
-            assert ("snowflake://user:pw@TEST_ACCOUNT/TEST_DATABASE/TEST_SCHEMA"
-                "?warehouse=TEST_WAREHOUSE&role=TEST_ROLE&authenticator=TEST_AUTH"
-            ) == hook.get_uri()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #20032 
related: #20032 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Closes: #20032 

When using the Snowflake provider connector for Airflow, if a region is specified in the connection URI, the connection succeeds. If a region is not specified, the Snowflake instance will take US-West-2 as the default instance, however, the URI is malformed and results in an erroneous connection. This fix forms the URI depending on whether the user specifies the region name or not.

For example, when a region is specified, the URI looks like:

```
'snowflake://{user}:{password}@{account}.{region}/{database}/{schema}'
'?warehouse={warehouse}&role={role}&authenticator={authenticator}'

```
If a region is not specified, the URI looks like:

```
'snowflake://{user}:{password}@{account}/{database}/{schema}'
'?warehouse={warehouse}&role={role}&authenticator={authenticator}'
```
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
