### PR TITLE
Make container creation configurable when uploading files via WasbHook

### DIFF
--- a/airflow/providers/microsoft/azure/transfers/local_to_wasb.py
+++ b/airflow/providers/microsoft/azure/transfers/local_to_wasb.py
@@ -33,6 +33,8 @@ class LocalFilesystemToWasbOperator(BaseOperator):
     :param container_name: Name of the container. (templated)
     :param blob_name: Name of the blob. (templated)
     :param wasb_conn_id: Reference to the wasb connection.
+    :param create_container: Attempt to create the target container prior to uploading the blob. This is
+        useful if the target container may not exist yet. Defaults to False.
     :param load_options: Optional keyword arguments that
         `WasbHook.load_file()` takes.
     """
@@ -46,6 +48,7 @@ class LocalFilesystemToWasbOperator(BaseOperator):
         container_name: str,
         blob_name: str,
         wasb_conn_id: str = 'wasb_default',
+        create_container: bool = False,
         load_options: Optional[dict] = None,
         **kwargs,
     ) -> None:
@@ -56,6 +59,7 @@ class LocalFilesystemToWasbOperator(BaseOperator):
         self.container_name = container_name
         self.blob_name = blob_name
         self.wasb_conn_id = wasb_conn_id
+        self.create_container = create_container
         self.load_options = load_options
 
     def execute(self, context: "Context") -> None:
@@ -67,4 +71,10 @@ class LocalFilesystemToWasbOperator(BaseOperator):
             self.container_name,
             self.blob_name,
         )
-        hook.load_file(self.file_path, self.container_name, self.blob_name, **self.load_options)
+        hook.load_file(
+            file_path=self.file_path,
+            container_name=self.container_name,
+            blob_name=self.blob_name,
+            create_container=self.create_container,
+            **self.load_options,
+        )

--- a/tests/providers/microsoft/azure/transfers/test_local_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_wasb.py
@@ -18,14 +18,15 @@
 #
 
 import datetime
-import unittest
 from unittest import mock
+
+import pytest
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.transfers.local_to_wasb import LocalFilesystemToWasbOperator
 
 
-class TestLocalFilesystemToWasbOperator(unittest.TestCase):
+class TestLocalFilesystemToWasbOperator:
 
     _config = {
         'file_path': 'file',
@@ -35,7 +36,7 @@ class TestLocalFilesystemToWasbOperator(unittest.TestCase):
         'retries': 3,
     }
 
-    def setUp(self):
+    def setup(self):
         args = {'owner': 'airflow', 'start_date': datetime.datetime(2017, 1, 1)}
         self.dag = DAG('test_dag_id', default_args=args)
 
@@ -53,11 +54,18 @@ class TestLocalFilesystemToWasbOperator(unittest.TestCase):
         )
         assert operator.load_options == {'timeout': 2}
 
+    @pytest.mark.parametrize(argnames="create_container", argvalues=[True, False])
     @mock.patch('airflow.providers.microsoft.azure.transfers.local_to_wasb.WasbHook', autospec=True)
-    def test_execute(self, mock_hook):
+    def test_execute(self, mock_hook, create_container):
         mock_instance = mock_hook.return_value
         operator = LocalFilesystemToWasbOperator(
-            task_id='wasb_sensor', dag=self.dag, load_options={'timeout': 2}, **self._config
+            task_id='wasb_sensor',
+            dag=self.dag,
+            create_container=create_container,
+            load_options={'timeout': 2},
+            **self._config,
         )
         operator.execute(None)
-        mock_instance.load_file.assert_called_once_with('file', 'container', 'blob', timeout=2)
+        mock_instance.load_file.assert_called_once_with(
+            'file', 'container', 'blob', create_container, timeout=2
+        )


### PR DESCRIPTION
Closes: #19409

Current behavior within the `WasbHook` is to always attempt to create a container when uploading files to Azure Blob Storage. This allows users to not necessarily have to use an existing container to upload files but one can be created as part of the upload process. ~Unfortunately, if users authenticate via a Signed Access Signature (SAS) only certain signatures allow for container creation.~ Unfortunately not every configured connection will have permissions to create containers. In these scenarios, uploads to Azure Blob Storage can fail.

~This PR adds a check if a configured SAS permits container creation. If this operation is not permitted, then the container creation is not attempted. The default container-creation behavior is still intact.~
This PR adds the target container creation to be configurable if needed. (I also converted the unit tests I touched to `pytest` as well as a "bonus").

>Note: The PR does set the default behavior now to _not_ attempt container creation. I do not think a majority of users take advantage of this functionality now but it is configurable to turn it on if needed. If anyone feels that the default should be to attempt container creation for any backwards compat fears, I'm happy to update the default. Kind of a gray area here I suppose whether this should have been the approach in the first place + impact to users.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
