### PR TITLE
Fix: pin pymongo < 4.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -392,7 +392,7 @@ ldap = [
 leveldb = ['plyvel']
 mongo = [
     'dnspython>=1.13.0,<3.0.0',
-    'pymongo>=3.6.0',
+    'pymongo>=3.6.0,<4.0.0',
 ]
 mssql = [
     'pymssql~=2.1,>=2.1.5',

--- a/setup.py
+++ b/setup.py
@@ -392,6 +392,7 @@ ldap = [
 leveldb = ['plyvel']
 mongo = [
     'dnspython>=1.13.0,<3.0.0',
+    # pymongo 4.0.0 removes connection option `ssl_cert_reqs` which is used in providers-mongo/2.2.0
     'pymongo>=3.6.0,<4.0.0',
 ]
 mssql = [


### PR DESCRIPTION
Connection option `ssl_cert_reqs` is removed in pymongo 4.0.0

closes: #20155 


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
