### PR TITLE
Rename `OpsgenieAlertOperator` to `OpsgenieCreateAlertOperator`

### DIFF
--- a/airflow/contrib/operators/opsgenie_alert_operator.py
+++ b/airflow/contrib/operators/opsgenie_alert_operator.py
@@ -19,10 +19,26 @@
 
 import warnings
 
-from airflow.providers.opsgenie.operators.opsgenie import OpsgenieAlertOperator  # noqa
+from airflow.providers.opsgenie.operators.opsgenie import OpsgenieCreateAlertOperator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.opsgenie.operators.opsgenie`.",
+    "This module is deprecated. Please use :mod:`airflow.providers.opsgenie.operators.opsgenie`.",
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+class OpsgenieAlertOperator(OpsgenieCreateAlertOperator):
+    """
+    This class is deprecated.
+    Please use :class:`airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This class is deprecated. "
+            "Please use :class:`airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/contrib/operators/opsgenie_alert_operator.py
+++ b/airflow/contrib/operators/opsgenie_alert_operator.py
@@ -22,7 +22,7 @@ import warnings
 from airflow.providers.opsgenie.operators.opsgenie import OpsgenieCreateAlertOperator
 
 warnings.warn(
-    "This module is deprecated. Please use :mod:`airflow.providers.opsgenie.operators.opsgenie`.",
+    "This module is deprecated. Please use `airflow.providers.opsgenie.operators.opsgenie`.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/opsgenie/example_dags/example_opsgenie_alert.py
+++ b/airflow/providers/opsgenie/example_dags/example_opsgenie_alert.py
@@ -17,7 +17,10 @@
 from datetime import datetime
 
 from airflow import DAG
-from airflow.providers.opsgenie.operators.opsgenie import OpsgenieAlertOperator, OpsgenieCloseAlertOperator
+from airflow.providers.opsgenie.operators.opsgenie import (
+    OpsgenieCloseAlertOperator,
+    OpsgenieCreateAlertOperator,
+)
 
 with DAG(
     dag_id="opsgenie_alert_operator_dag",
@@ -26,9 +29,9 @@ with DAG(
     catchup=False,
 ) as dag:
 
-    # [START howto_opsgenie_alert_operator]
-    opsgenie_alert_operator = OpsgenieAlertOperator(task_id="opsgenie_task", message="Hello World!")
-    # [END howto_opsgenie_alert_operator]
+    # [START howto_opsgenie_create_alert_operator]
+    opsgenie_alert_operator = OpsgenieCreateAlertOperator(task_id="opsgenie_task", message="Hello World!")
+    # [END howto_opsgenie_create_alert_operator]
 
     # [START howto_opsgenie_close_alert_operator]
     opsgenie_close_alert_operator = OpsgenieCloseAlertOperator(

--- a/airflow/providers/opsgenie/operators/opsgenie.py
+++ b/airflow/providers/opsgenie/operators/opsgenie.py
@@ -22,7 +22,7 @@ from airflow.models import BaseOperator
 from airflow.providers.opsgenie.hooks.opsgenie import OpsgenieAlertHook
 
 
-class OpsgenieAlertOperator(BaseOperator):
+class OpsgenieCreateAlertOperator(BaseOperator):
     """
     This operator allows you to post alerts to Opsgenie.
     Accepts a connection that has an Opsgenie API key as the connection's password.
@@ -34,7 +34,7 @@ class OpsgenieAlertOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:OpsgenieAlertOperator`
+        :ref:`howto/operator:OpsgenieCreateAlertOperator`
 
     :param opsgenie_conn_id: The name of the Opsgenie connection to use
     :type opsgenie_conn_id: str

--- a/airflow/providers/opsgenie/operators/opsgenie_alert.py
+++ b/airflow/providers/opsgenie/operators/opsgenie_alert.py
@@ -19,10 +19,26 @@
 
 import warnings
 
-from airflow.providers.opsgenie.operators.opsgenie import OpsgenieAlertOperator  # noqa
+from airflow.providers.opsgenie.operators.opsgenie import OpsgenieCreateAlertOperator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.opsgenie.operators.opsgenie`.",
+    "This module is deprecated. Please use :mod:`airflow.providers.opsgenie.operators.opsgenie`.",
     DeprecationWarning,
     stacklevel=2,
 )
+
+
+class OpsgenieAlertOperator(OpsgenieCreateAlertOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use :class:`airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/opsgenie/operators/opsgenie_alert.py
+++ b/airflow/providers/opsgenie/operators/opsgenie_alert.py
@@ -22,7 +22,7 @@ import warnings
 from airflow.providers.opsgenie.operators.opsgenie import OpsgenieCreateAlertOperator
 
 warnings.warn(
-    "This module is deprecated. Please use :mod:`airflow.providers.opsgenie.operators.opsgenie`.",
+    "This module is deprecated. Please use `airflow.providers.opsgenie.operators.opsgenie`.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/docs/apache-airflow-providers-opsgenie/operators/index.rst
+++ b/docs/apache-airflow-providers-opsgenie/operators/index.rst
@@ -22,5 +22,6 @@ Opsgenie Operators
 
 .. toctree::
     :maxdepth: 1
+    :glob:
 
     opsgenie_alert

--- a/docs/apache-airflow-providers-opsgenie/operators/index.rst
+++ b/docs/apache-airflow-providers-opsgenie/operators/index.rst
@@ -22,6 +22,5 @@ Opsgenie Operators
 
 .. toctree::
     :maxdepth: 1
-    :glob:
 
     opsgenie_alert

--- a/docs/apache-airflow-providers-opsgenie/operators/opsgenie_alert.rst
+++ b/docs/apache-airflow-providers-opsgenie/operators/opsgenie_alert.rst
@@ -15,12 +15,12 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/operator:OpsgenieAlertOperator:
+.. _howto/operator:OpsgenieCreateAlertOperator:
 
-OpsgenieAlertOperator
-==========================
+OpsgenieCreateAlertOperator
+===========================
 
-Use the :class:`~airflow.providers.opsgenie.operators.opsgenie.OpsgenieAlertOperator` to send an alert to opsgenie.
+Use the :class:`~airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator` to send an alert to opsgenie.
 
 
 Using the Operator
@@ -29,8 +29,8 @@ Send an alert to Opsgenie with a specific message.
 
 .. exampleinclude:: /../../airflow/providers/opsgenie/example_dags/example_opsgenie_alert.py
     :language: python
-    :start-after: [START howto_opsgenie_alert_operator]
-    :end-before: [END howto_opsgenie_alert_operator]
+    :start-after: [START howto_opsgenie_create_alert_operator]
+    :end-before: [END howto_opsgenie_create_alert_operator]
 
 .. _howto/operator:OpsgenieCloseAlertOperator:
 

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1304,7 +1304,7 @@ OPERATORS = [
         'airflow.contrib.operators.jenkins_job_trigger_operator.JenkinsJobTriggerOperator',
     ),
     (
-        'airflow.providers.opsgenie.operators.opsgenie.OpsgenieAlertOperator',
+        'airflow.providers.opsgenie.operators.opsgenie.OpsgenieCreateAlertOperator',
         'airflow.contrib.operators.opsgenie_alert_operator.OpsgenieAlertOperator',
     ),
     (

--- a/tests/providers/opsgenie/operators/test_opsgenie.py
+++ b/tests/providers/opsgenie/operators/test_opsgenie.py
@@ -20,13 +20,16 @@
 import unittest
 
 from airflow.models.dag import DAG
-from airflow.providers.opsgenie.operators.opsgenie import OpsgenieAlertOperator, OpsgenieCloseAlertOperator
+from airflow.providers.opsgenie.operators.opsgenie import (
+    OpsgenieCloseAlertOperator,
+    OpsgenieCreateAlertOperator,
+)
 from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 
-class TestOpsgenieAlertOperator(unittest.TestCase):
+class TestOpsgenieCreateAlertOperator(unittest.TestCase):
     _config = {
         'message': 'An example alert message',
         'alias': 'Life is too short for no alias',
@@ -79,7 +82,7 @@ class TestOpsgenieAlertOperator(unittest.TestCase):
 
     def test_build_opsgenie_payload(self):
         # Given / When
-        operator = OpsgenieAlertOperator(task_id='opsgenie_alert_job', dag=self.dag, **self._config)
+        operator = OpsgenieCreateAlertOperator(task_id='opsgenie_alert_job', dag=self.dag, **self._config)
 
         payload = operator._build_opsgenie_payload()
 
@@ -88,7 +91,7 @@ class TestOpsgenieAlertOperator(unittest.TestCase):
 
     def test_properties(self):
         # Given / When
-        operator = OpsgenieAlertOperator(task_id='opsgenie_alert_job', dag=self.dag, **self._config)
+        operator = OpsgenieCreateAlertOperator(task_id='opsgenie_alert_job', dag=self.dag, **self._config)
 
         assert 'opsgenie_default' == operator.opsgenie_conn_id
         assert self._config['message'] == operator.message


### PR DESCRIPTION
After https://github.com/apache/airflow/pull/20488/ it doesn't make sense to have `OpsgenieAlertOperator` as it doesn't explain the action this operator does - there can be many different actions under the Alert API.
This PR renames `OpsgenieAlertOperator` to `OpsgenieCreateAlertOperator`

Note: there is no need to deprecate `OpsgenieAlertOperator` in `operators/opsgenie.py` since https://github.com/apache/airflow/pull/20454/ wasn't released yet.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
