### PR TITLE
Change download_video parameter to resourceName

### DIFF
--- a/airflow/providers/google/marketing_platform/hooks/display_video.py
+++ b/airflow/providers/google/marketing_platform/hooks/display_video.py
@@ -221,5 +221,5 @@ class GoogleDisplayVideo360Hook(GoogleBaseHook):
         :param resource_name: of the media that is being downloaded.
         :type resource_name: str
         """
-        request = self.get_conn_to_display_video().media().download_media(resource_name=resource_name)
+        request = self.get_conn_to_display_video().media().download_media(resourceName=resource_name)
         return request

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -645,6 +645,10 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
         self.log.info("Creating operation for SDF download task...")
         operation = hook.create_sdf_download_operation(body_request=self.body_request)
 
+        name = operation["name"]
+        self.xcom_push(context, key="name", value=name)
+        self.log.info("Created SDF operation with name: %s", name)
+
         return operation
 
 
@@ -736,7 +740,8 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
         operation = hook.get_sdf_download_operation(operation_name=self.operation_name)
 
         self.log.info("Creating file for upload...")
-        media = hook.download_media(resource_name=operation)
+        resource_name = operation["response"]["resourceName"]
+        media = hook.download_media(resource_name=resource_name)
 
         self.log.info("Sending file to the Google Cloud Storage...")
         with tempfile.NamedTemporaryFile() as temp_file:

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -737,11 +737,10 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
         )
 
         self.log.info("Retrieving operation...")
-        operation = hook.get_sdf_download_operation(operation_name=self.operation_name)
+        operation_state = hook.get_sdf_download_operation(operation_name=self.operation_name)
 
         self.log.info("Creating file for upload...")
-        resource_name = operation["response"]["resourceName"]
-        media = hook.download_media(resource_name=resource_name)
+        media = hook.download_media(resource_name=operation_state)
 
         self.log.info("Sending file to the Google Cloud Storage...")
         with tempfile.NamedTemporaryFile() as temp_file:

--- a/tests/providers/google/marketing_platform/hooks/test_display_video.py
+++ b/tests/providers/google/marketing_platform/hooks/test_display_video.py
@@ -367,5 +367,5 @@ class TestGoogleDisplayVideo360Hook(TestCase):
 
         self.hook.download_media(resource_name=resource_name)
         get_conn_to_display_video.return_value.media.return_value.download_media.assert_called_once_with(
-            resource_name=resource_name
+            resourceName=resource_name
         )

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -355,6 +355,7 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
     def test_execute(self, mock_temp, gcs_mock_hook, mock_hook):
         operation_name = "operation_name"
         operation = {"key": "value"}
+        operation = {"response": {"resourceName": "test_name"}}
         gzip = False
 
         # mock_hook.return_value.create_sdf_download_operation.return_value = response_name
@@ -415,13 +416,21 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
 
 class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator(TestCase):
     @mock.patch(
+        "airflow.providers.google.marketing_platform.operators."
+        "display_video.GoogleDisplayVideo360CreateSDFDownloadTaskOperator.xcom_push"
+    )
+    @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
     )
-    def test_execute(self, mock_hook):
+    def test_execute(self, mock_hook, xcom_mock):
         body_request = {
             "version": "1",
             "id": "id",
             "filter": {"id": []},
+        }
+        test_name = 'test_task'
+        mock_hook.return_value.create_sdf_download_operation.return_value = {
+            "name": test_name
         }
 
         op = GoogleDisplayVideo360CreateSDFDownloadTaskOperator(
@@ -443,3 +452,4 @@ class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator(TestCase):
         mock_hook.return_value.create_sdf_download_operation.assert_called_once_with(
             body_request=body_request
         )
+        xcom_mock.assert_called_once_with(None, key="name", value=test_name)

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -429,9 +429,7 @@ class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator(TestCase):
             "filter": {"id": []},
         }
         test_name = 'test_task'
-        mock_hook.return_value.create_sdf_download_operation.return_value = {
-            "name": test_name
-        }
+        mock_hook.return_value.create_sdf_download_operation.return_value = {"name": test_name}
 
         op = GoogleDisplayVideo360CreateSDFDownloadTaskOperator(
             body_request=body_request,


### PR DESCRIPTION
The GoogleDisplayVideo360Hook.download_media hook tries to download media using the 
"resource_name" argument. Changed parameter name in internal `download_media` call to 
the "resourceName" according the API spec. Also changed parameter name in tests. 

closes: #14077
related: #14077