### PR TITLE
Chart: Add custom labels for ingresses/PVCs

### DIFF
--- a/chart/templates/dags-persistent-volume-claim.yaml
+++ b/chart/templates/dags-persistent-volume-claim.yaml
@@ -26,6 +26,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes: [{{ .Values.dags.persistence.accessMode | quote }}]
   resources:

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -35,6 +35,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.flower.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/templates/logs-persistent-volume-claim.yaml
+++ b/chart/templates/logs-persistent-volume-claim.yaml
@@ -26,6 +26,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes: ["ReadWriteMany"]
   resources:

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -34,6 +34,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.web.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -143,8 +143,11 @@ class TestBaseChartTest(unittest.TestCase):
                 "executor": "CeleryExecutor",
                 "pgbouncer": {"enabled": True},
                 "redis": {"enabled": True},
+                "ingress": {"enabled": True},
                 "networkPolicies": {"enabled": True},
                 "cleanup": {"enabled": True},
+                "logs": {"persistence": {"enabled": True}},
+                "dags": {"persistence": {"enabled": True}},
                 "postgresql": {"enabled": False},  # We won't check the objects created by the postgres chart
             },
         )
@@ -167,6 +170,7 @@ class TestBaseChartTest(unittest.TestCase):
             (f"{release_name}-airflow-statsd", "ServiceAccount", "statsd"),
             (f"{release_name}-airflow-webserver", "ServiceAccount", "webserver"),
             (f"{release_name}-airflow-worker", "ServiceAccount", "worker"),
+            (f"{release_name}-airflow-triggerer", "ServiceAccount", "triggerer"),
             (f"{release_name}-broker-url", "Secret", "redis"),
             (f"{release_name}-cleanup", "CronJob", "airflow-cleanup-pods"),
             (f"{release_name}-cleanup-role", "Role", None),
@@ -176,6 +180,7 @@ class TestBaseChartTest(unittest.TestCase):
             (f"{release_name}-flower", "Deployment", "flower"),
             (f"{release_name}-flower", "Service", "flower"),
             (f"{release_name}-flower-policy", "NetworkPolicy", "airflow-flower-policy"),
+            (f"{release_name}-flower-ingress", "Ingress", "flower-ingress"),
             (f"{release_name}-pgbouncer", "Deployment", "pgbouncer"),
             (f"{release_name}-pgbouncer", "Service", "pgbouncer"),
             (f"{release_name}-pgbouncer-config", "Secret", "pgbouncer"),
@@ -199,9 +204,13 @@ class TestBaseChartTest(unittest.TestCase):
             (f"{release_name}-webserver-secret-key", "Secret", "webserver"),
             (f"{release_name}-webserver", "Service", "webserver"),
             (f"{release_name}-webserver-policy", "NetworkPolicy", "airflow-webserver-policy"),
+            (f"{release_name}-airflow-ingress", "Ingress", "airflow-ingress"),
             (f"{release_name}-worker", "Service", "worker"),
             (f"{release_name}-worker", "StatefulSet", "worker"),
             (f"{release_name}-worker-policy", "NetworkPolicy", "airflow-worker-policy"),
+            (f"{release_name}-triggerer", "Deployment", "triggerer"),
+            (f"{release_name}-logs", "PersistentVolumeClaim", "logs-pvc"),
+            (f"{release_name}-dags", "PersistentVolumeClaim", "dags-pvc"),
         ]
         for k8s_object_name, kind, component in kind_names_tuples:
             expected_labels = {


### PR DESCRIPTION
Fix custom labels not being set for PVCs and ingresses created by the chart

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
