### PR TITLE
Add `wait_for_termination` option for Databricks Operators

### DIFF
--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -277,6 +277,57 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
 
         db_mock.cancel_run.assert_called_once_with(RUN_ID)
 
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_wait_for_termination(self, db_mock_class):
+        run = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        assert op.wait_for_termination
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce(
+            {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': TASK_ID}
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+        )
+
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_no_wait_for_termination(self, db_mock_class):
+        run = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, wait_for_termination=False, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+
+        assert not op.wait_for_termination
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce(
+            {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': TASK_ID}
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+        )
+
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_not_called()
+
 
 class TestDatabricksRunNowOperator(unittest.TestCase):
     def test_init_with_named_parameters(self):
@@ -439,3 +490,58 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
 
         op.on_kill()
         db_mock.cancel_run.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_wait_for_termination(self, db_mock_class):
+        run = {'notebook_params': NOTEBOOK_PARAMS, 'notebook_task': NOTEBOOK_TASK, 'jar_params': JAR_PARAMS}
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        assert op.wait_for_termination
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce(
+            {
+                'notebook_params': NOTEBOOK_PARAMS,
+                'notebook_task': NOTEBOOK_TASK,
+                'jar_params': JAR_PARAMS,
+                'job_id': JOB_ID,
+            }
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+        )
+
+        db_mock.run_now.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_no_wait_for_termination(self, db_mock_class):
+        run = {'notebook_params': NOTEBOOK_PARAMS, 'notebook_task': NOTEBOOK_TASK, 'jar_params': JAR_PARAMS}
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, wait_for_termination=False, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = 1
+
+        assert not op.wait_for_termination
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce(
+            {
+                'notebook_params': NOTEBOOK_PARAMS,
+                'notebook_task': NOTEBOOK_TASK,
+                'jar_params': JAR_PARAMS,
+                'job_id': JOB_ID,
+            }
+        )
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+        )
+
+        db_mock.run_now.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_not_called()


### PR DESCRIPTION
The PR intends to close the issue #10921 by adding an input argument and a property named `wait_for_termination` for the Databricks operator classes. The default behaviour doesn't change, the operators will wait for termination.