### PR TITLE
Remove `host` as an instance attr in `DatabricksHook`

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -312,11 +312,11 @@ class DatabricksHook(BaseHook):
         method, endpoint = endpoint_info
 
         if 'host' in self.databricks_conn.extra_dejson:
-            self.host = self._parse_host(self.databricks_conn.extra_dejson['host'])
+            host = self._parse_host(self.databricks_conn.extra_dejson['host'])
         else:
-            self.host = self._parse_host(self.databricks_conn.host)
+            host = self._parse_host(self.databricks_conn.host)
 
-        url = f'https://{self.host}/{endpoint}'
+        url = f'https://{host}/{endpoint}'
 
         aad_headers = self._get_aad_headers()
         headers = {**USER_AGENT_HEADER.copy(), **aad_headers}


### PR DESCRIPTION
As part of #20526, parsing logic of `host` was moved out of the `__init__()` method in `DatabricksHook`. With this change, `host` no longer needs to be an instance attribute of the hook.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
