### PR TITLE
StreamLogWriter: swap _buffer before _propagate_log()

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -117,15 +117,15 @@ class StreamLogWriter(IOBase):
         if not message.endswith("\n"):
             self._buffer += message
         else:
-            self._buffer += message
-            self._propagate_log(self._buffer.rstrip())
-            self._buffer = ''
+            self._buffer += message.rstrip()
+            self.flush()
 
     def flush(self):
         """Ensure all logging output has been flushed"""
-        if len(self._buffer) > 0:
-            self._propagate_log(self._buffer)
+        buf = self._buffer
+        if len(buf) > 0:
             self._buffer = ''
+            self._propagate_log(buf)
 
     def isatty(self):
         """


### PR DESCRIPTION
As initially discussed in #20500, if the user code adds a log handler to write to the standard out/err, there will be an infinite loop of logging messages.  The `StreamLogWriter._buffer` will be doubled in each iteration, and soon use up all the memory.

This change doesn't stop the infinite loop; it merely changes the growth of `StreamLogWriter._buffer` from exponential to linear, which will also lead to runtime error (stack overflow).  However, that is much easier to debug (see the infinite loop) than the out-of-memory error (no call stack).

For normal cases, this doesn't change the logging behavior.