### PR TITLE
Use local definitions for k8s schema validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -665,6 +665,12 @@ repos:
         files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
         require_serial: true
         additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+      - id: vendor-k8s-json-schema
+        name: Vendor k8s definitions into values.schema.json
+        entry: ./scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
+        language: python
+        files: ^chart/values\.schema\.json$
+        additional_dependencies: ['requests==2.25.0']
       - id: json-schema
         name: Lint chart/values.yaml file with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2209,7 +2209,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  pyupgrade restrict-start_date rst-backticks setup-order setup-extra-packages
                  shellcheck sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace
                  ui-lint update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 update-versions verify-db-migrations-documented version-sync www-lint yamllint yesqa
+                 update-versions vendor-k8s-json-schema verify-db-migrations-documented version-sync
+                 www-lint yamllint yesqa
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -280,6 +280,8 @@ require Breeze Docker images to be installed locally.
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``update-versions``                    Updates latest versions in the documentation
 ------------------------------------ ---------------------------------------------------------------- ------------
+``vendor-k8s-json-schema``             Vendor k8s schema definitions in the helm chart schema file
+------------------------------------ ---------------------------------------------------------------- ------------
 ``verify-db-migrations-documented``    Verify DB Migrations have been documented
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``www-lint``                           Static checks of js in airflow/www/static/js/ folder

--- a/breeze-complete
+++ b/breeze-complete
@@ -152,6 +152,7 @@ update-extras
 update-local-yml-file
 update-setup-cfg-file
 update-versions
+vendor-k8s-json-schema
 verify-db-migrations-documented
 version-sync
 www-lint

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -79,7 +79,7 @@
         "securityContext": {
             "description": "Pod security context definition. The values in this parameter will be used when `securityContext` is not defined for specific Pods",
             "type": "object",
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+            "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
             "default": {},
             "x-docsSection": "Kubernetes",
             "examples": [
@@ -104,7 +104,7 @@
             "type": "object",
             "default": {},
             "x-docsSection": "Kubernetes",
-            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+            "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
         },
         "tolerations": {
             "description": "Specify Tolerations for all pods.",
@@ -113,7 +113,7 @@
             "x-docsSection": "Kubernetes",
             "items": {
                 "type": "object",
-                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
             }
         },
         "labels": {
@@ -1275,7 +1275,7 @@
                                     }
                                 }
                             ],
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         }
                     }
                 },
@@ -1295,7 +1295,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "terminationGracePeriodSeconds": {
                     "description": "Grace period for tasks to finish after SIGTERM is sent from Kubernetes.",
@@ -1312,13 +1312,13 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraInitContainers": {
                     "description": "Add additional init containers into workers.",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     },
                     "type": "array",
                     "default": []
@@ -1328,7 +1328,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -1336,7 +1336,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "nodeSelector": {
@@ -1351,7 +1351,7 @@
                     "description": "Specify scheduling constraints for worker pods.",
                     "type": "object",
                     "default": "See values.yaml",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for worker pods.",
@@ -1359,13 +1359,13 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "hostAliases": {
                     "description": "Specify HostAliases for workers.",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/hostalias-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
                     },
                     "type": "array",
                     "default": [],
@@ -1443,14 +1443,14 @@
                                     }
                                 }
                             ],
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         }
                     }
                 },
                 "securityContext": {
                     "description": "Security context for the worker pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -1609,7 +1609,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "safeToEvict": {
                     "description": "This setting tells Kubernetes that its ok to evict when it wants to scale a node down.",
@@ -1621,7 +1621,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraInitContainers": {
@@ -1629,7 +1629,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -1637,7 +1637,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -1645,7 +1645,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "nodeSelector": {
@@ -1660,7 +1660,7 @@
                     "description": "Specify scheduling constraints for scheduler pods.",
                     "type": "object",
                     "default": "See values.yaml",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for scheduler pods.",
@@ -1668,7 +1668,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "podAnnotations": {
@@ -1734,14 +1734,14 @@
                                     }
                                 }
                             ],
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         }
                     }
                 },
                 "securityContext": {
                     "description": "Security context for the scheduler pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -1828,7 +1828,7 @@
                         "null",
                         "object"
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/deploymentstrategy-apps-v1.json",
+                    "$ref": "#/definitions/io.k8s.api.apps.v1.DeploymentStrategy",
                     "default": {
                         "rollingUpdate": {
                             "maxSurge": "100%",
@@ -1879,7 +1879,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "safeToEvict": {
                     "description": "This setting tells Kubernetes that its ok to evict when it wants to scale a node down.",
@@ -1891,7 +1891,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraInitContainers": {
@@ -1899,7 +1899,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -1907,7 +1907,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -1915,7 +1915,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "nodeSelector": {
@@ -1930,7 +1930,7 @@
                     "description": "Specify scheduling constraints for triggerer pods.",
                     "type": "object",
                     "default": "See values.yaml",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for triggerer pods.",
@@ -1938,7 +1938,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "terminationGracePeriodSeconds": {
@@ -1957,7 +1957,7 @@
                 "securityContext": {
                     "description": "Security context for the triggerer pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -2024,7 +2024,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -2032,7 +2032,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -2040,7 +2040,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "nodeSelector": {
@@ -2055,7 +2055,7 @@
                     "description": "Specify scheduling constraints for the create user job pod.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for the create user job pod.",
@@ -2063,13 +2063,13 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "securityContext": {
                     "description": "Security context for the create user job pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -2082,7 +2082,7 @@
                 "resources": {
                     "description": "Resources for the create user job pod",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "default": {},
                     "examples": [
                         {
@@ -2156,7 +2156,7 @@
                 "resources": {
                     "description": "Resources for the migrate database job pod",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "default": {},
                     "examples": [
                         {
@@ -2176,7 +2176,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -2184,7 +2184,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -2192,7 +2192,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "nodeSelector": {
@@ -2207,7 +2207,7 @@
                     "description": "Specify scheduling constraints for the migrate database job pod.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for the migrate database job pod.",
@@ -2215,13 +2215,13 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "securityContext": {
                     "description": "Security context for the migrate database job pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -2374,7 +2374,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                     },
                     "default": []
                 },
@@ -2393,14 +2393,14 @@
                                     "type": "array",
                                     "default": [],
                                     "items": {
-                                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                                     }
                                 },
                                 "ports": {
                                     "description": "Ports for webserver NetworkPolicy ingress (if `from` is set).",
                                     "type": "array",
                                     "items": {
-                                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicyport-networking-v1.json"
+                                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
                                     },
                                     "default": [
                                         {
@@ -2420,7 +2420,7 @@
                 "securityContext": {
                     "description": "Security context for the webserver job pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -2446,7 +2446,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "defaultUser": {
                     "description": "Optional default Airflow user information",
@@ -2496,7 +2496,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraInitContainers": {
@@ -2504,7 +2504,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -2512,7 +2512,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -2520,7 +2520,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "webserverConfig": {
@@ -2632,7 +2632,7 @@
                     "description": "Specify scheduling constraints for webserver pods.",
                     "type": "object",
                     "default": "See values.yaml",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for webserver pods.",
@@ -2640,7 +2640,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "podAnnotations": {
@@ -2695,7 +2695,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                     },
                     "default": []
                 },
@@ -2714,14 +2714,14 @@
                                     "type": "array",
                                     "default": [],
                                     "items": {
-                                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                                     }
                                 },
                                 "ports": {
                                     "description": "Ports for flower NetworkPolicy ingress (if `from` is set).",
                                     "type": "array",
                                     "items": {
-                                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicyport-networking-v1.json"
+                                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPort"
                                     },
                                     "default": [
                                         {
@@ -2754,7 +2754,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "secretName": {
                     "description": "A secret containing the user and password pair.",
@@ -2892,7 +2892,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
                     }
                 },
                 "extraVolumes": {
@@ -2900,7 +2900,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "nodeSelector": {
@@ -2915,7 +2915,7 @@
                     "description": "Specify scheduling constraints for Flower pods.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for Flower pods.",
@@ -2923,7 +2923,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "podAnnotations": {
@@ -2937,7 +2937,7 @@
                 "securityContext": {
                     "description": "Security context for the flower pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -2965,7 +2965,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                     },
                     "default": []
                 },
@@ -2985,7 +2985,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "service": {
                     "description": "StatsD Service configuration.",
@@ -3046,7 +3046,7 @@
                     "description": "Specify scheduling constraints for StatsD pods.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for StatsD pods.",
@@ -3054,7 +3054,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "extraMappings": {
@@ -3065,7 +3065,7 @@
                 "securityContext": {
                     "description": "Security context for the statsd pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -3121,7 +3121,7 @@
                     "type": "array",
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicypeer-networking-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.networking.v1.NetworkPolicyPeer"
                     },
                     "default": []
                 },
@@ -3188,7 +3188,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "service": {
                     "description": "PgBouncer Service configuration.",
@@ -3297,7 +3297,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Volume"
                     }
                 },
                 "extraVolumeMounts": {
@@ -3305,7 +3305,7 @@
                     "type": "array",
                     "default": [],
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                     }
                 },
                 "serviceAccount": {
@@ -3347,7 +3347,7 @@
                     "description": "Specify scheduling constraints for PgBouncer pods.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for PgBouncer pods.",
@@ -3355,7 +3355,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "uid": {
@@ -3385,7 +3385,7 @@
                                     }
                                 }
                             ],
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         },
                         "sslmode": {
                             "description": "SSL mode for ``metricsExporterSidecar``",
@@ -3459,7 +3459,7 @@
                             }
                         }
                     ],
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                 },
                 "passwordSecretName": {
                     "description": "Redis password secret.",
@@ -3494,7 +3494,7 @@
                     "description": "Specify scheduling constraints for Redis pods.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for Redis pods.",
@@ -3502,7 +3502,7 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "serviceAccount": {
@@ -3712,7 +3712,7 @@
             "x-docsSection": "Kubernetes",
             "default": [],
             "items": {
-                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/limitrangeitem-v1.json"
+                "$ref": "#/definitions/io.k8s.api.core.v1.LimitRangeItem"
             }
         },
         "cleanup": {
@@ -3769,7 +3769,7 @@
                     "description": "Specify scheduling constraints for cleanup pods.",
                     "type": "object",
                     "default": {},
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/affinity-v1.json"
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Affinity"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for cleanup pods.",
@@ -3777,13 +3777,13 @@
                     "default": [],
                     "items": {
                         "type": "object",
-                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
                 "resources": {
                     "description": "Resources for or cleanup pods",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
                     "default": {},
                     "examples": [
                         {
@@ -3829,7 +3829,7 @@
                 "securityContext": {
                     "description": "Security context for the cleanup job pod. If not set, the values from `securityContext` will be used.",
                     "type": "object",
-                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},
                     "examples": [
                         {
@@ -4000,7 +4000,7 @@
                         "securityContext": {
                             "description": "Security context for the gitSync container. If not set, the values from `securityContext` will be used.",
                             "type": "object",
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.SecurityContext",
+                            "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
                             "default": {},
                             "examples": [
                                 {
@@ -4019,7 +4019,7 @@
                             "type": "array",
                             "default": [],
                             "items": {
-                                "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                                "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
                             }
                         },
                         "credentialsSecret": {
@@ -4093,7 +4093,7 @@
                                     }
                                 }
                             ],
-                            "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                            "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements"
                         }
                     }
                 }
@@ -4139,6 +4139,2639 @@
                     }
                 }
             }
+        }
+    },
+    "definitions": {
+        "io.k8s.api.apps.v1.DeploymentStrategy": {
+            "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+            "properties": {
+                "rollingUpdate": {
+                    "$ref": "#/definitions/io.k8s.api.apps.v1.RollingUpdateDeployment",
+                    "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+                },
+                "type": {
+                    "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.apps.v1.RollingUpdateDeployment": {
+            "description": "Spec to control the desired behavior of rolling update.",
+            "properties": {
+                "maxSurge": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+                    "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods."
+                },
+                "maxUnavailable": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+                    "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old ReplicaSet can be scaled down further, followed by scaling up the new ReplicaSet, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
+            "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                },
+                "partition": {
+                    "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "readOnly": {
+                    "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "boolean"
+                },
+                "volumeID": {
+                    "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "volumeID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Affinity": {
+            "description": "Affinity is a group of affinity scheduling rules.",
+            "properties": {
+                "nodeAffinity": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.NodeAffinity",
+                    "description": "Describes node affinity scheduling rules for the pod."
+                },
+                "podAffinity": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinity",
+                    "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s))."
+                },
+                "podAntiAffinity": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodAntiAffinity",
+                    "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s))."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.AzureDiskVolumeSource": {
+            "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+            "properties": {
+                "cachingMode": {
+                    "description": "Host Caching mode: None, Read Only, Read Write.",
+                    "type": "string"
+                },
+                "diskName": {
+                    "description": "The Name of the data disk in the blob storage",
+                    "type": "string"
+                },
+                "diskURI": {
+                    "description": "The URI the data disk in the blob storage",
+                    "type": "string"
+                },
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "diskName",
+                "diskURI"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.AzureFileVolumeSource": {
+            "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+            "properties": {
+                "readOnly": {
+                    "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "secretName": {
+                    "description": "the name of secret that contains Azure Storage Account Name and Key",
+                    "type": "string"
+                },
+                "shareName": {
+                    "description": "Share Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "secretName",
+                "shareName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.CSIVolumeSource": {
+            "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+            "properties": {
+                "driver": {
+                    "description": "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                    "type": "string"
+                },
+                "fsType": {
+                    "description": "Filesystem type to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                    "type": "string"
+                },
+                "nodePublishSecretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed."
+                },
+                "readOnly": {
+                    "description": "Specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                    "type": "boolean"
+                },
+                "volumeAttributes": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                    "type": "object"
+                }
+            },
+            "required": [
+                "driver"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Capabilities": {
+            "description": "Adds and removes POSIX capabilities from running containers.",
+            "properties": {
+                "add": {
+                    "description": "Added capabilities",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "drop": {
+                    "description": "Removed capabilities",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.CephFSVolumeSource": {
+            "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "monitors": {
+                    "description": "Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "path": {
+                    "description": "Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "boolean"
+                },
+                "secretFile": {
+                    "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it"
+                },
+                "user": {
+                    "description": "Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "monitors"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.CinderVolumeSource": {
+            "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "Optional: points to a secret object containing parameters used to connect to OpenStack."
+                },
+                "volumeID": {
+                    "description": "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "volumeID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ConfigMapEnvSource": {
+            "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the ConfigMap must be defined",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ConfigMapKeySelector": {
+            "description": "Selects a key from a ConfigMap.",
+            "properties": {
+                "key": {
+                    "description": "The key to select.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the ConfigMap or its key must be defined",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "key"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ConfigMapProjection": {
+            "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+            "properties": {
+                "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ConfigMapVolumeSource": {
+            "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "defaultMode": {
+                    "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the ConfigMap or its keys must be defined",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Container": {
+            "description": "A single application container that you want to run within a pod.",
+            "properties": {
+                "args": {
+                    "description": "Arguments to the entrypoint. The docker image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "command": {
+                    "description": "Entrypoint array. Not executed within a shell. The docker image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "env": {
+                    "description": "List of environment variables to set in the container. Cannot be updated.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.EnvVar"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "name",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "envFrom": {
+                    "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.EnvFromSource"
+                    },
+                    "type": "array"
+                },
+                "image": {
+                    "description": "Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                    "type": "string"
+                },
+                "imagePullPolicy": {
+                    "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                    "type": "string"
+                },
+                "lifecycle": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Lifecycle",
+                    "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated."
+                },
+                "livenessProbe": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+                    "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                },
+                "name": {
+                    "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                    "type": "string"
+                },
+                "ports": {
+                    "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.ContainerPort"
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "containerPort",
+                        "protocol"
+                    ],
+                    "x-kubernetes-list-type": "map",
+                    "x-kubernetes-patch-merge-key": "containerPort",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "readinessProbe": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+                    "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                },
+                "resources": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                },
+                "securityContext": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext",
+                    "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/"
+                },
+                "startupProbe": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Probe",
+                    "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes"
+                },
+                "stdin": {
+                    "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                    "type": "boolean"
+                },
+                "stdinOnce": {
+                    "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                    "type": "boolean"
+                },
+                "terminationMessagePath": {
+                    "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                    "type": "string"
+                },
+                "terminationMessagePolicy": {
+                    "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                    "type": "string"
+                },
+                "tty": {
+                    "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                    "type": "boolean"
+                },
+                "volumeDevices": {
+                    "description": "volumeDevices is the list of block devices to be used by the container.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeDevice"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "devicePath",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "volumeMounts": {
+                    "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeMount"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "mountPath",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "workingDir": {
+                    "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ContainerPort": {
+            "description": "ContainerPort represents a network port in a single container.",
+            "properties": {
+                "containerPort": {
+                    "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "hostIP": {
+                    "description": "What host IP to bind the external port to.",
+                    "type": "string"
+                },
+                "hostPort": {
+                    "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                    "type": "string"
+                },
+                "protocol": {
+                    "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "containerPort"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.DownwardAPIProjection": {
+            "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+            "properties": {
+                "items": {
+                    "description": "Items is a list of DownwardAPIVolume file",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
+            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+            "properties": {
+                "fieldRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+                    "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+                },
+                "mode": {
+                    "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "path": {
+                    "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                    "type": "string"
+                },
+                "resourceFieldRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
+            "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "defaultMode": {
+                    "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "Items is a list of downward API volume file",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.EmptyDirVolumeSource": {
+            "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "medium": {
+                    "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "string"
+                },
+                "sizeLimit": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+                    "description": "Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.EnvFromSource": {
+            "description": "EnvFromSource represents the source of a set of ConfigMaps",
+            "properties": {
+                "configMapRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapEnvSource",
+                    "description": "The ConfigMap to select from"
+                },
+                "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SecretEnvSource",
+                    "description": "The Secret to select from"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.EnvVar": {
+            "description": "EnvVar represents an environment variable present in a Container.",
+            "properties": {
+                "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                    "type": "string"
+                },
+                "valueFrom": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.EnvVarSource",
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty."
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.EnvVarSource": {
+            "description": "EnvVarSource represents a source for the value of an EnvVar.",
+            "properties": {
+                "configMapKeyRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapKeySelector",
+                    "description": "Selects a key of a ConfigMap."
+                },
+                "fieldRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector",
+                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs."
+                },
+                "resourceFieldRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector",
+                    "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported."
+                },
+                "secretKeyRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SecretKeySelector",
+                    "description": "Selects a key of a secret in the pod's namespace"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.EphemeralVolumeSource": {
+            "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
+            "properties": {
+                "volumeClaimTemplate": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimTemplate",
+                    "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.\n\nRequired, must not be nil."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ExecAction": {
+            "description": "ExecAction describes a \"run in container\" action.",
+            "properties": {
+                "command": {
+                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.FCVolumeSource": {
+            "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "lun": {
+                    "description": "Optional: FC target lun number",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "readOnly": {
+                    "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "targetWWNs": {
+                    "description": "Optional: FC target worldwide names (WWNs)",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "wwids": {
+                    "description": "Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.FlexVolumeSource": {
+            "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+            "properties": {
+                "driver": {
+                    "description": "Driver is the name of the driver to use for this volume.",
+                    "type": "string"
+                },
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                    "type": "string"
+                },
+                "options": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Optional: Extra command options if any.",
+                    "type": "object"
+                },
+                "readOnly": {
+                    "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts."
+                }
+            },
+            "required": [
+                "driver"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.FlockerVolumeSource": {
+            "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "datasetName": {
+                    "description": "Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                    "type": "string"
+                },
+                "datasetUUID": {
+                    "description": "UUID of the dataset. This is unique identifier of a Flocker dataset",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
+            "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                },
+                "partition": {
+                    "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "pdName": {
+                    "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "pdName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.GitRepoVolumeSource": {
+            "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+            "properties": {
+                "directory": {
+                    "description": "Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                    "type": "string"
+                },
+                "repository": {
+                    "description": "Repository URL",
+                    "type": "string"
+                },
+                "revision": {
+                    "description": "Commit hash for the specified revision.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "repository"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.GlusterfsVolumeSource": {
+            "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "endpoints": {
+                    "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                },
+                "path": {
+                    "description": "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "endpoints",
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.HTTPGetAction": {
+            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+            "properties": {
+                "host": {
+                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                    "type": "string"
+                },
+                "httpHeaders": {
+                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.HTTPHeader"
+                    },
+                    "type": "array"
+                },
+                "path": {
+                    "description": "Path to access on the HTTP server.",
+                    "type": "string"
+                },
+                "port": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+                    "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+                },
+                "scheme": {
+                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.HTTPHeader": {
+            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+            "properties": {
+                "name": {
+                    "description": "The header field name",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "The header field value",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Handler": {
+            "description": "Handler defines a specific action that should be taken",
+            "properties": {
+                "exec": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+                    "description": "One and only one of the following should be specified. Exec specifies the action to take."
+                },
+                "httpGet": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+                    "description": "HTTPGet specifies the http request to perform."
+                },
+                "tcpSocket": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.HostAlias": {
+            "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+            "properties": {
+                "hostnames": {
+                    "description": "Hostnames for the above IP address.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "ip": {
+                    "description": "IP address of the host file entry.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.HostPathVolumeSource": {
+            "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "path": {
+                    "description": "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ISCSIVolumeSource": {
+            "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "chapAuthDiscovery": {
+                    "description": "whether support iSCSI Discovery CHAP authentication",
+                    "type": "boolean"
+                },
+                "chapAuthSession": {
+                    "description": "whether support iSCSI Session CHAP authentication",
+                    "type": "boolean"
+                },
+                "fsType": {
+                    "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                    "type": "string"
+                },
+                "initiatorName": {
+                    "description": "Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                    "type": "string"
+                },
+                "iqn": {
+                    "description": "Target iSCSI Qualified Name.",
+                    "type": "string"
+                },
+                "iscsiInterface": {
+                    "description": "iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                    "type": "string"
+                },
+                "lun": {
+                    "description": "iSCSI Target Lun number.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "portals": {
+                    "description": "iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "CHAP Secret for iSCSI target and initiator authentication"
+                },
+                "targetPortal": {
+                    "description": "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "targetPortal",
+                "iqn",
+                "lun"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.KeyToPath": {
+            "description": "Maps a string key to a path within a volume.",
+            "properties": {
+                "key": {
+                    "description": "The key to project.",
+                    "type": "string"
+                },
+                "mode": {
+                    "description": "Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "path": {
+                    "description": "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "key",
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Lifecycle": {
+            "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+            "properties": {
+                "postStart": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Handler",
+                    "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+                },
+                "preStop": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Handler",
+                    "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod's termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.LimitRangeItem": {
+            "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
+            "properties": {
+                "default": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
+                    "type": "object"
+                },
+                "defaultRequest": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
+                    "type": "object"
+                },
+                "max": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "Max usage constraints on this kind by resource name.",
+                    "type": "object"
+                },
+                "maxLimitRequestRatio": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
+                    "type": "object"
+                },
+                "min": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "Min usage constraints on this kind by resource name.",
+                    "type": "object"
+                },
+                "type": {
+                    "description": "Type of resource that this limit applies to.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.LocalObjectReference": {
+            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.NFSVolumeSource": {
+            "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "path": {
+                    "description": "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "boolean"
+                },
+                "server": {
+                    "description": "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "server",
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.NodeAffinity": {
+            "description": "Node affinity is a group of node affinity scheduling rules.",
+            "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.PreferredSchedulingTerm"
+                    },
+                    "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelector",
+                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.NodeSelector": {
+            "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+            "properties": {
+                "nodeSelectorTerms": {
+                    "description": "Required. A list of node selector terms. The terms are ORed.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "nodeSelectorTerms"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.NodeSelectorRequirement": {
+            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+            "properties": {
+                "key": {
+                    "description": "The label key that the selector applies to.",
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "key",
+                "operator"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.NodeSelectorTerm": {
+            "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+            "properties": {
+                "matchExpressions": {
+                    "description": "A list of node selector requirements by node's labels.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+                    },
+                    "type": "array"
+                },
+                "matchFields": {
+                    "description": "A list of node selector requirements by node's fields.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorRequirement"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ObjectFieldSelector": {
+            "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+            "properties": {
+                "apiVersion": {
+                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                    "type": "string"
+                },
+                "fieldPath": {
+                    "description": "Path of the field to select in the specified API version.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "fieldPath"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
+            "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+            "properties": {
+                "accessModes": {
+                    "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "dataSource": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
+                    "description": "This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field."
+                },
+                "dataSourceRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.TypedLocalObjectReference",
+                    "description": "Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While DataSource ignores disallowed values (dropping them), DataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n(Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled."
+                },
+                "resources": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "description": "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources"
+                },
+                "selector": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                    "description": "A label query over volumes to consider for binding."
+                },
+                "storageClassName": {
+                    "description": "Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                    "type": "string"
+                },
+                "volumeMode": {
+                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                    "type": "string"
+                },
+                "volumeName": {
+                    "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PersistentVolumeClaimTemplate": {
+            "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
+            "properties": {
+                "metadata": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
+                    "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation."
+                },
+                "spec": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimSpec",
+                    "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here."
+                }
+            },
+            "required": [
+                "spec"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
+            "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+            "properties": {
+                "claimName": {
+                    "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Will force the ReadOnly setting in VolumeMounts. Default false.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "claimName"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
+            "description": "Represents a Photon Controller persistent disk resource.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "pdID": {
+                    "description": "ID that identifies Photon Controller persistent disk",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "pdID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PodAffinity": {
+            "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+            "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+                    },
+                    "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PodAffinityTerm": {
+            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+            "properties": {
+                "labelSelector": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                    "description": "A label query over a set of resources, in this case pods."
+                },
+                "namespaceSelector": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                    "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled."
+                },
+                "namespaces": {
+                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\"",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "topologyKey": {
+                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "topologyKey"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PodAntiAffinity": {
+            "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+            "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                    "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.WeightedPodAffinityTerm"
+                    },
+                    "type": "array"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PodSecurityContext": {
+            "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+            "properties": {
+                "fsGroup": {
+                    "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "fsGroupChangePolicy": {
+                    "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.",
+                    "type": "string"
+                },
+                "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "seLinuxOptions": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+                    "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+                },
+                "seccompProfile": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+                    "description": "The seccomp options to use by the containers in this pod."
+                },
+                "supplementalGroups": {
+                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+                    "items": {
+                        "format": "int64",
+                        "type": "integer"
+                    },
+                    "type": "array"
+                },
+                "sysctls": {
+                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+                    },
+                    "type": "array"
+                },
+                "windowsOptions": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+                    "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PortworxVolumeSource": {
+            "description": "PortworxVolumeSource represents a Portworx volume resource.",
+            "properties": {
+                "fsType": {
+                    "description": "FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "volumeID": {
+                    "description": "VolumeID uniquely identifies a Portworx volume",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "volumeID"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.PreferredSchedulingTerm": {
+            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+            "properties": {
+                "preference": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.NodeSelectorTerm",
+                    "description": "A node selector term, associated with the corresponding weight."
+                },
+                "weight": {
+                    "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                    "format": "int32",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "weight",
+                "preference"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Probe": {
+            "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+            "properties": {
+                "exec": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ExecAction",
+                    "description": "One and only one of the following should be specified. Exec specifies the action to take."
+                },
+                "failureThreshold": {
+                    "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "httpGet": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.HTTPGetAction",
+                    "description": "HTTPGet specifies the http request to perform."
+                },
+                "initialDelaySeconds": {
+                    "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "periodSeconds": {
+                    "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "successThreshold": {
+                    "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "tcpSocket": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.TCPSocketAction",
+                    "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported"
+                },
+                "terminationGracePeriodSeconds": {
+                    "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "timeoutSeconds": {
+                    "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                    "format": "int32",
+                    "type": "integer"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ProjectedVolumeSource": {
+            "description": "Represents a projected volume source",
+            "properties": {
+                "defaultMode": {
+                    "description": "Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "sources": {
+                    "description": "list of volume projections",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.VolumeProjection"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.QuobyteVolumeSource": {
+            "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+            "properties": {
+                "group": {
+                    "description": "Group to map volume access to Default is no group",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                    "type": "boolean"
+                },
+                "registry": {
+                    "description": "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                    "type": "string"
+                },
+                "tenant": {
+                    "description": "Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                    "type": "string"
+                },
+                "user": {
+                    "description": "User to map volume access to Defaults to serivceaccount user",
+                    "type": "string"
+                },
+                "volume": {
+                    "description": "Volume is a string that references an already created Quobyte volume by name.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "registry",
+                "volume"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.RBDVolumeSource": {
+            "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                    "type": "string"
+                },
+                "image": {
+                    "description": "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                },
+                "keyring": {
+                    "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                },
+                "monitors": {
+                    "description": "A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "pool": {
+                    "description": "The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it"
+                },
+                "user": {
+                    "description": "The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "monitors",
+                "image"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ResourceFieldSelector": {
+            "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+            "properties": {
+                "containerName": {
+                    "description": "Container name: required for volumes, optional for env vars",
+                    "type": "string"
+                },
+                "divisor": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity",
+                    "description": "Specifies the output format of the exposed resources, defaults to \"1\""
+                },
+                "resource": {
+                    "description": "Required: resource to select",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "resource"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ResourceRequirements": {
+            "description": "ResourceRequirements describes the compute resource requirements.",
+            "properties": {
+                "limits": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                },
+                "requests": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
+                    },
+                    "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SELinuxOptions": {
+            "description": "SELinuxOptions are the labels to be applied to the container",
+            "properties": {
+                "level": {
+                    "description": "Level is SELinux level label that applies to the container.",
+                    "type": "string"
+                },
+                "role": {
+                    "description": "Role is a SELinux role label that applies to the container.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "Type is a SELinux type label that applies to the container.",
+                    "type": "string"
+                },
+                "user": {
+                    "description": "User is a SELinux user label that applies to the container.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ScaleIOVolumeSource": {
+            "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                    "type": "string"
+                },
+                "gateway": {
+                    "description": "The host address of the ScaleIO API Gateway.",
+                    "type": "string"
+                },
+                "protectionDomain": {
+                    "description": "The name of the ScaleIO Protection Domain for the configured storage.",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail."
+                },
+                "sslEnabled": {
+                    "description": "Flag to enable/disable SSL communication with Gateway, default false",
+                    "type": "boolean"
+                },
+                "storageMode": {
+                    "description": "Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                    "type": "string"
+                },
+                "storagePool": {
+                    "description": "The ScaleIO Storage Pool associated with the protection domain.",
+                    "type": "string"
+                },
+                "system": {
+                    "description": "The name of the storage system as configured in ScaleIO.",
+                    "type": "string"
+                },
+                "volumeName": {
+                    "description": "The name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "gateway",
+                "system",
+                "secretRef"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SeccompProfile": {
+            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+            "properties": {
+                "localhostProfile": {
+                    "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is \"Localhost\".",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "type"
+            ],
+            "type": "object",
+            "x-kubernetes-unions": [
+                {
+                    "discriminator": "type",
+                    "fields-to-discriminateBy": {
+                        "localhostProfile": "LocalhostProfile"
+                    }
+                }
+            ],
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SecretEnvSource": {
+            "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+            "properties": {
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the Secret must be defined",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SecretKeySelector": {
+            "description": "SecretKeySelector selects a key of a Secret.",
+            "properties": {
+                "key": {
+                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the Secret or its key must be defined",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "key"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SecretProjection": {
+            "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+            "properties": {
+                "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "optional": {
+                    "description": "Specify whether the Secret or its key must be defined",
+                    "type": "boolean"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SecretVolumeSource": {
+            "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+            "properties": {
+                "defaultMode": {
+                    "description": "Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "items": {
+                    "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.KeyToPath"
+                    },
+                    "type": "array"
+                },
+                "optional": {
+                    "description": "Specify whether the Secret or its keys must be defined",
+                    "type": "boolean"
+                },
+                "secretName": {
+                    "description": "Name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.SecurityContext": {
+            "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+                    "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
+                },
+                "privileged": {
+                    "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+                    "type": "boolean"
+                },
+                "procMount": {
+                    "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+                    "type": "string"
+                },
+                "readOnlyRootFilesystem": {
+                    "description": "Whether this container has a read-only root filesystem. Default is false.",
+                    "type": "boolean"
+                },
+                "runAsGroup": {
+                    "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "runAsNonRoot": {
+                    "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "boolean"
+                },
+                "runAsUser": {
+                    "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "seLinuxOptions": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+                    "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+                },
+                "seccompProfile": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SeccompProfile",
+                    "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options."
+                },
+                "windowsOptions": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+                    "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
+            "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+            "properties": {
+                "audience": {
+                    "description": "Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                    "type": "string"
+                },
+                "expirationSeconds": {
+                    "description": "ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "path": {
+                    "description": "Path is the path relative to the mount point of the file to project the token into.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.StorageOSVolumeSource": {
+            "description": "Represents a StorageOS persistent volume resource.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                    "type": "boolean"
+                },
+                "secretRef": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.LocalObjectReference",
+                    "description": "SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted."
+                },
+                "volumeName": {
+                    "description": "VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                    "type": "string"
+                },
+                "volumeNamespace": {
+                    "description": "VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Sysctl": {
+            "description": "Sysctl defines a kernel parameter to be set",
+            "properties": {
+                "name": {
+                    "description": "Name of a property to set",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Value of a property to set",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "value"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.TCPSocketAction": {
+            "description": "TCPSocketAction describes an action based on opening a socket",
+            "properties": {
+                "host": {
+                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                    "type": "string"
+                },
+                "port": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+                    "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+                }
+            },
+            "required": [
+                "port"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Toleration": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+            "properties": {
+                "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                },
+                "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                },
+                "operator": {
+                    "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                    "type": "string"
+                },
+                "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "value": {
+                    "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.TypedLocalObjectReference": {
+            "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+            "properties": {
+                "apiGroup": {
+                    "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                    "type": "string"
+                },
+                "kind": {
+                    "description": "Kind is the type of resource being referenced",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name is the name of resource being referenced",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "kind",
+                "name"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.Volume": {
+            "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+            "properties": {
+                "awsElasticBlockStore": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource",
+                    "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore"
+                },
+                "azureDisk": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.AzureDiskVolumeSource",
+                    "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod."
+                },
+                "azureFile": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.AzureFileVolumeSource",
+                    "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod."
+                },
+                "cephfs": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.CephFSVolumeSource",
+                    "description": "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime"
+                },
+                "cinder": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.CinderVolumeSource",
+                    "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md"
+                },
+                "configMap": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapVolumeSource",
+                    "description": "ConfigMap represents a configMap that should populate this volume"
+                },
+                "csi": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.CSIVolumeSource",
+                    "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature)."
+                },
+                "downwardAPI": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeSource",
+                    "description": "DownwardAPI represents downward API about the pod that should populate this volume"
+                },
+                "emptyDir": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.EmptyDirVolumeSource",
+                    "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir"
+                },
+                "ephemeral": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.EphemeralVolumeSource",
+                    "description": "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.\n\nUse this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.\n\nA pod can use both types of ephemeral volumes and persistent volumes at the same time.\n\nThis is a beta feature and only available when the GenericEphemeralVolume feature gate is enabled."
+                },
+                "fc": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.FCVolumeSource",
+                    "description": "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod."
+                },
+                "flexVolume": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.FlexVolumeSource",
+                    "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin."
+                },
+                "flocker": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.FlockerVolumeSource",
+                    "description": "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running"
+                },
+                "gcePersistentDisk": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.GCEPersistentDiskVolumeSource",
+                    "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk"
+                },
+                "gitRepo": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.GitRepoVolumeSource",
+                    "description": "GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container."
+                },
+                "glusterfs": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.GlusterfsVolumeSource",
+                    "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md"
+                },
+                "hostPath": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.HostPathVolumeSource",
+                    "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath"
+                },
+                "iscsi": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ISCSIVolumeSource",
+                    "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md"
+                },
+                "name": {
+                    "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                },
+                "nfs": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.NFSVolumeSource",
+                    "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs"
+                },
+                "persistentVolumeClaim": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource",
+                    "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims"
+                },
+                "photonPersistentDisk": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource",
+                    "description": "PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine"
+                },
+                "portworxVolume": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PortworxVolumeSource",
+                    "description": "PortworxVolume represents a portworx volume attached and mounted on kubelets host machine"
+                },
+                "projected": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ProjectedVolumeSource",
+                    "description": "Items for all in one resources secrets, configmaps, and downward API"
+                },
+                "quobyte": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.QuobyteVolumeSource",
+                    "description": "Quobyte represents a Quobyte mount on the host that shares a pod's lifetime"
+                },
+                "rbd": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.RBDVolumeSource",
+                    "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md"
+                },
+                "scaleIO": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ScaleIOVolumeSource",
+                    "description": "ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes."
+                },
+                "secret": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SecretVolumeSource",
+                    "description": "Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                },
+                "storageos": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.StorageOSVolumeSource",
+                    "description": "StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes."
+                },
+                "vsphereVolume": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource",
+                    "description": "VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.VolumeDevice": {
+            "description": "volumeDevice describes a mapping of a raw block device within a container.",
+            "properties": {
+                "devicePath": {
+                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "devicePath"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.VolumeMount": {
+            "description": "VolumeMount describes a mounting of a Volume within a container.",
+            "properties": {
+                "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                    "type": "string"
+                },
+                "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                },
+                "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                    "type": "boolean"
+                },
+                "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                    "type": "string"
+                },
+                "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "mountPath"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.VolumeProjection": {
+            "description": "Projection that may be projected along with other supported volume types",
+            "properties": {
+                "configMap": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ConfigMapProjection",
+                    "description": "information about the configMap data to project"
+                },
+                "downwardAPI": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIProjection",
+                    "description": "information about the downwardAPI data to project"
+                },
+                "secret": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.SecretProjection",
+                    "description": "information about the secret data to project"
+                },
+                "serviceAccountToken": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.ServiceAccountTokenProjection",
+                    "description": "information about the serviceAccountToken data to project"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
+            "description": "Represents a vSphere volume resource.",
+            "properties": {
+                "fsType": {
+                    "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                    "type": "string"
+                },
+                "storagePolicyID": {
+                    "description": "Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                    "type": "string"
+                },
+                "storagePolicyName": {
+                    "description": "Storage Policy Based Management (SPBM) profile name.",
+                    "type": "string"
+                },
+                "volumePath": {
+                    "description": "Path that identifies vSphere volume vmdk",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "volumePath"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
+            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+            "properties": {
+                "podAffinityTerm": {
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodAffinityTerm",
+                    "description": "Required. A pod affinity term, associated with the corresponding weight."
+                },
+                "weight": {
+                    "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                    "format": "int32",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "weight",
+                "podAffinityTerm"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+            "properties": {
+                "gmsaCredentialSpec": {
+                    "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                    "type": "string"
+                },
+                "gmsaCredentialSpecName": {
+                    "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                    "type": "string"
+                },
+                "hostProcess": {
+                    "description": "HostProcess determines if a container should be run as a 'Host Process' container. This field is alpha-level and will only be honored by components that enable the WindowsHostProcessContainers feature flag. Setting this field without the feature flag will result in errors when validating the Pod. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).  In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                    "type": "boolean"
+                },
+                "runAsUserName": {
+                    "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.networking.v1.IPBlock": {
+            "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\",\"2001:db9::/64\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+            "properties": {
+                "cidr": {
+                    "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\"",
+                    "type": "string"
+                },
+                "except": {
+                    "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" or \"2001:db9::/64\" Except values will be rejected if they are outside the CIDR range",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cidr"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.networking.v1.NetworkPolicyPeer": {
+            "description": "NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed",
+            "properties": {
+                "ipBlock": {
+                    "$ref": "#/definitions/io.k8s.api.networking.v1.IPBlock",
+                    "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be."
+                },
+                "namespaceSelector": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                    "description": "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces.\n\nIf PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                },
+                "podSelector": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector",
+                    "description": "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods.\n\nIf NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.api.networking.v1.NetworkPolicyPort": {
+            "description": "NetworkPolicyPort describes a port to allow traffic on",
+            "properties": {
+                "endPort": {
+                    "description": "If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port. This feature is in Beta state and is enabled by default. It can be disabled using the Feature Gate \"NetworkPolicyEndPort\".",
+                    "format": "int32",
+                    "type": "integer"
+                },
+                "port": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.util.intstr.IntOrString",
+                    "description": "The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
+                },
+                "protocol": {
+                    "description": "The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.api.resource.Quantity": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1": {
+            "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+            "type": "object"
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
+            "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+            "properties": {
+                "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement"
+                    },
+                    "type": "array"
+                },
+                "matchLabels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object"
+                }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
+            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+            "properties": {
+                "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string",
+                    "x-kubernetes-patch-merge-key": "key",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                },
+                "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "key",
+                "operator"
+            ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "properties": {
+                "apiVersion": {
+                    "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                    "type": "string"
+                },
+                "fieldsType": {
+                    "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                    "type": "string"
+                },
+                "fieldsV1": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1",
+                    "description": "FieldsV1 holds the first JSON version format as described in the \"FieldsV1\" type."
+                },
+                "manager": {
+                    "description": "Manager is an identifier of the workflow managing these fields.",
+                    "type": "string"
+                },
+                "operation": {
+                    "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                    "type": "string"
+                },
+                "subresource": {
+                    "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                    "type": "string"
+                },
+                "time": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+                    "description": "Time is timestamp of when these fields were set. It should always be empty if Operation is 'Apply'"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
+            "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+            "properties": {
+                "annotations": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+                    "type": "object"
+                },
+                "clusterName": {
+                    "description": "The name of the cluster which the object belongs to. This is used to distinguish resources with same name and namespace in different clusters. This field is not set anywhere right now and apiserver is going to ignore it if set in create or update request.",
+                    "type": "string"
+                },
+                "creationTimestamp": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+                    "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+                },
+                "deletionGracePeriodSeconds": {
+                    "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "deletionTimestamp": {
+                    "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
+                    "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
+                },
+                "finalizers": {
+                    "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "generateName": {
+                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                    "type": "string"
+                },
+                "generation": {
+                    "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                    "format": "int64",
+                    "type": "integer"
+                },
+                "labels": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+                    "type": "object"
+                },
+                "managedFields": {
+                    "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ManagedFieldsEntry"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "namespace": {
+                    "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces",
+                    "type": "string"
+                },
+                "ownerReferences": {
+                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
+                    },
+                    "type": "array",
+                    "x-kubernetes-patch-merge-key": "uid",
+                    "x-kubernetes-patch-strategy": "merge"
+                },
+                "resourceVersion": {
+                    "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                },
+                "selfLink": {
+                    "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.\n\nDEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "properties": {
+                "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                },
+                "blockOwnerDeletion": {
+                    "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                    "type": "boolean"
+                },
+                "controller": {
+                    "description": "If true, this reference points to the managing controller.",
+                    "type": "boolean"
+                },
+                "kind": {
+                    "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+                    "type": "string"
+                },
+                "uid": {
+                    "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "apiVersion",
+                "kind",
+                "name",
+                "uid"
+            ],
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+        },
+        "io.k8s.apimachinery.pkg.apis.meta.v1.Time": {
+            "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+            "format": "date-time",
+            "type": "string"
+        },
+        "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
         }
     }
 }

--- a/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
@@ -18,6 +18,7 @@
 # under the License.
 
 import json
+from typing import Iterator
 
 import requests
 
@@ -31,26 +32,24 @@ VALUES_SCHEMA_FILE = "chart/values.schema.json"
 with open(VALUES_SCHEMA_FILE) as f:
     schema = json.load(f)
 
-refs = set()
 
-
-def find_refs(props: dict):
+def find_refs(props: dict) -> Iterator[str]:
     for value in props.values():
         if "$ref" in value:
-            refs.add(value["$ref"])
+            yield value["$ref"]
 
         if "items" in value:
             if "$ref" in value["items"]:
-                refs.add(value["items"]["$ref"])
+                yield value["items"]["$ref"]
 
         if "properties" in value:
-            find_refs(value["properties"])
+            yield from find_refs(value["properties"])
 
 
 def get_remote_schema(url: str) -> dict:
     req = requests.get(url)
     req.raise_for_status()
-    return json.loads(req.text)
+    return req.json()
 
 
 # Create 'definitions' if it doesn't exist or reset it
@@ -60,23 +59,23 @@ schema["definitions"] = {}
 defs = get_remote_schema(K8S_DEFINITIONS)
 
 # first find refs in our schema
-find_refs(schema["properties"])
+refs = set(find_refs(schema["properties"]))
 
 # now we look for refs in refs
 i = 0
 while True:
-    starting_refs = refs.copy()
+    starting_refs = refs
     for ref in refs:
         ref_id = ref.split('/')[-1]
         schema["definitions"][ref_id] = defs["definitions"][ref_id]
-    find_refs(schema["definitions"])
+    refs = set(find_refs(schema["definitions"]))
     if refs == starting_refs:
         break
 
     # Make sure we don't have a runaway loop
     i += 1
     if i > 15:
-        raise Exception("Wasn't able to find all nested references in 15 cycles")
+        raise SystemExit("Wasn't able to find all nested references in 15 cycles")
 
 # and finally, sort them all!
 schema["definitions"] = dict(sorted(schema["definitions"].items()))

--- a/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
@@ -52,8 +52,8 @@ def get_remote_schema(url: str) -> dict:
     return req.json()
 
 
-# Create 'definitions' if it doesn't exist or reset it
-schema["definitions"] = {}
+# Create 'definitions' if it doesn't exist or reset the io.k8s defs
+schema["definitions"] = {k: v for k, v in schema.get("definitions", {}).items() if not k.startswith("io.k8s")}
 
 # Get the k8s defs
 defs = get_remote_schema(K8S_DEFINITIONS)

--- a/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+
+import requests
+
+K8S_DEFINITIONS = (
+    "https://raw.githubusercontent.com/yannh/kubernetes-json-schema"
+    "/master/v1.22.0-standalone-strict/_definitions.json"
+)
+VALUES_SCHEMA_FILE = "chart/values.schema.json"
+
+
+with open(VALUES_SCHEMA_FILE) as f:
+    schema = json.load(f)
+
+refs = set()
+
+
+def find_refs(props: dict):
+    for value in props.values():
+        if "$ref" in value:
+            refs.add(value["$ref"])
+
+        if "items" in value:
+            if "$ref" in value["items"]:
+                refs.add(value["items"]["$ref"])
+
+        if "properties" in value:
+            find_refs(value["properties"])
+
+
+def get_remote_schema(url: str) -> dict:
+    req = requests.get(url)
+    req.raise_for_status()
+    return json.loads(req.text)
+
+
+# Create 'definitions' if it doesn't exist or reset it
+schema["definitions"] = {}
+
+# Get the k8s defs
+defs = get_remote_schema(K8S_DEFINITIONS)
+
+# first find refs in our schema
+find_refs(schema["properties"])
+
+# now we look for refs in refs
+i = 0
+while True:
+    starting_refs = refs.copy()
+    for ref in refs:
+        ref_id = ref.split('/')[-1]
+        schema["definitions"][ref_id] = defs["definitions"][ref_id]
+    find_refs(schema["definitions"])
+    if refs == starting_refs:
+        break
+
+    # Make sure we don't have a runaway loop
+    i += 1
+    if i > 15:
+        raise Exception("Wasn't able to find all nested references in 15 cycles")
+
+# and finally, sort them all!
+schema["definitions"] = dict(sorted(schema["definitions"].items()))
+
+# Then write out our schema
+with open(VALUES_SCHEMA_FILE, 'w') as f:
+    json.dump(schema, f, indent=4)
+    f.write('\n')  # with a newline!


### PR DESCRIPTION
Instead of using remote schemas to validate helm chart values, we will
vendor in the definitions locally so the chart can be used without
using outbound connections.

There is a precommit hook that will ensure only the definitions we use
are included in our schema file, as there are quite a few of them all
together otherwise.

closes: #20539