### PR TITLE
 lazy load operation of attribute 'dag_model'

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -404,6 +404,7 @@ class TaskInstance(Base, LoggingMixin):
         uselist=False,
         innerjoin=True,
         viewonly=True,
+        lazy='joined'
     )
 
     trigger = relationship(


### PR DESCRIPTION
 is not bound to a Session; lazy load operation of attribute 'dag_model' #20534

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
