### PR TITLE
Remove unnecessary python 3.6 conditionals

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -104,9 +104,3 @@ if STATICA_HACK:  # pragma: no cover
     from airflow.models.dag import DAG
     from airflow.models.xcom_arg import XComArg
     from airflow.exceptions import AirflowException
-
-
-if not PY37:
-    from pep562 import Pep562
-
-    Pep562(__name__)

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -28,7 +28,7 @@ from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Union
 
 import lazy_object_proxy
 
-from airflow import PY37, settings
+from airflow import settings
 from airflow.cli.commands.legacy_commands import check_legacy_command
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -97,9 +97,6 @@ class DefaultHelpParser(argparse.ArgumentParser):
                     "To do it, run: pip install 'apache-airflow[cncf.kubernetes]'"
                 )
                 raise ArgumentError(action, message)
-        if action.dest == 'subcommand' and value == 'triggerer':
-            if not PY37:
-                raise ArgumentError(action, 'triggerer subcommand only works with Python 3.7+')
 
         if action.choices is not None and value not in action.choices:
             check_legacy_command(action, value)

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1291,10 +1291,3 @@ WEBSERVER_CONFIG = ''  # Set by initialize_config
 conf = initialize_config()
 secrets_backend_list = initialize_secrets_backends()
 conf.validate()
-
-
-PY37 = sys.version_info >= (3, 7)
-if not PY37:
-    from pep562 import Pep562
-
-    Pep562(__name__)

--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 import logging
-import sys
 import warnings
 from logging.config import dictConfig
 
@@ -103,22 +102,3 @@ def validate_logging_config(logging_config):
                 f"Configured task_log_reader {task_log_reader!r} was not a handler of "
                 f"the 'airflow.task' logger."
             )
-
-
-if sys.version_info < (3, 7):
-    # Python 3.7 added this via https://bugs.python.org/issue30520 -- but Python 3.6 doesn't have this
-    # support.
-    import copyreg
-
-    def _reduce_Logger(logger):
-        if logging.getLogger(logger.name) is not logger:
-            import pickle
-
-            raise pickle.PicklingError('logger cannot be pickled')
-        return logging.getLogger, (logger.name,)
-
-    def _reduce_RootLogger(logger):
-        return logging.getLogger, ()
-
-    copyreg.pickle(logging.Logger, _reduce_Logger)
-    copyreg.pickle(logging.RootLogger, _reduce_RootLogger)

--- a/airflow/migrations/db_types.py
+++ b/airflow/migrations/db_types.py
@@ -16,8 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import sys
-
 import sqlalchemy as sa
 from alembic import context
 from lazy_object_proxy import Proxy
@@ -100,9 +98,3 @@ def __getattr__(name):
         return Proxy(lazy_load)
 
     raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
-if sys.version_info < (3, 7):
-    from pep562 import Pep562
-
-    Pep562(__name__)

--- a/airflow/utils/yaml.py
+++ b/airflow/utils/yaml.py
@@ -26,7 +26,6 @@ This module delegates all other properties to the yaml module, so it can be used
 
 And then be used directly in place of the normal python module.
 """
-import sys
 from typing import TYPE_CHECKING, Any, BinaryIO, TextIO, Union, cast
 
 if TYPE_CHECKING:
@@ -68,9 +67,3 @@ def __getattr__(name):
         getattr(yaml, "CFullLoader", yaml.FullLoader)
 
     return getattr(yaml, name)
-
-
-if sys.version_info < (3, 7):
-    from pep562 import Pep562
-
-    Pep562(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,7 +143,6 @@ install_requires =
     marshmallow-oneofschema>=2.0.1
     packaging>=14.0
     pendulum>=2.0
-    pep562>=1.0;python_version<"3.7"
     pluggy>=1.0
     psutil>=4.2.0
     pygments>=2.0.1

--- a/tests/cli/commands/test_triggerer_command.py
+++ b/tests/cli/commands/test_triggerer_command.py
@@ -18,9 +18,6 @@
 import unittest
 from unittest import mock
 
-import pytest
-
-from airflow import PY37
 from airflow.cli import cli_parser
 from airflow.cli.commands import triggerer_command
 
@@ -34,7 +31,6 @@ class TestTriggererCommand(unittest.TestCase):
     def setUpClass(cls):
         cls.parser = cli_parser.get_parser()
 
-    @pytest.mark.skipif(not PY37, reason="triggerer subcommand only works with Python 3.7+")
     @mock.patch("airflow.cli.commands.triggerer_command.TriggererJob")
     def test_capacity_argument(
         self,

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -18,7 +18,6 @@
 
 import asyncio
 import datetime
-import sys
 import time
 from threading import Thread
 
@@ -73,7 +72,6 @@ def session():
         yield session
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_is_alive():
     """Checks the heartbeat logic"""
     # Current time
@@ -94,7 +92,6 @@ def test_is_alive():
     assert not triggerer_job.is_alive(), "Completed jobs even with recent heartbeat should not be alive"
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_is_needed(session):
     """Checks the triggerer-is-needed logic"""
     # No triggers, no need
@@ -109,7 +106,6 @@ def test_is_needed(session):
     assert triggerer_job.is_needed() is True
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_capacity_decode():
     """
     Tests that TriggererJob correctly sets capacity to a valid value passed in as a CLI arg,
@@ -136,7 +132,6 @@ def test_capacity_decode():
             TriggererJob(capacity=input_str)
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_lifecycle(session):
     """
     Checks that the triggerer will correctly see a new Trigger in the database
@@ -183,7 +178,6 @@ def test_trigger_lifecycle(session):
         job.runner.stop = True
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_create_race_condition_18392(session, tmp_path):
     """
     This verifies the resolution of race condition documented in github issue #18392.
@@ -289,7 +283,6 @@ def test_trigger_create_race_condition_18392(session, tmp_path):
     assert len(instances) == 1
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_from_dead_triggerer(session):
     """
     Checks that the triggerer will correctly claim a Trigger that is assigned to a
@@ -309,7 +302,6 @@ def test_trigger_from_dead_triggerer(session):
     assert [x for x, y in job.runner.to_create] == [1]
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_from_expired_triggerer(session):
     """
     Checks that the triggerer will correctly claim a Trigger that is assigned to a
@@ -336,7 +328,6 @@ def test_trigger_from_expired_triggerer(session):
     assert [x for x, y in job.runner.to_create] == [1]
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_firing(session):
     """
     Checks that when a trigger fires, it correctly makes it into the
@@ -368,7 +359,6 @@ def test_trigger_firing(session):
         job.runner.stop = True
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_failing(session):
     """
     Checks that when a trigger fails, it correctly makes it into the
@@ -404,7 +394,6 @@ def test_trigger_failing(session):
         job.runner.stop = True
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_trigger_cleanup(session):
     """
     Checks that the triggerer will correctly clean up triggers that do not
@@ -424,7 +413,6 @@ def test_trigger_cleanup(session):
     assert session.query(Trigger).count() == 0
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_invalid_trigger(session, dag_maker):
     """
     Checks that the triggerer will correctly fail task instances that depend on

--- a/tests/triggers/test_temporal.py
+++ b/tests/triggers/test_temporal.py
@@ -17,7 +17,6 @@
 
 import asyncio
 import datetime
-import sys
 
 import pendulum
 import pytest
@@ -62,7 +61,6 @@ def test_timedelta_trigger_serialization():
     assert -2 < (kwargs["moment"] - expected_moment).total_seconds() < 2
 
 
-@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No async on 3.6")
 @pytest.mark.asyncio
 async def test_datetime_trigger_timing():
     """


### PR DESCRIPTION
Since Python 3.7 is now the lowest supported version, we no longer need
to have conditionals to support 3.6.