### PR TITLE
Fix passing the gzip compression parameter on sftp_to_gcs

### DIFF
--- a/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sftp_to_gcs.py
@@ -168,6 +168,7 @@ class SFTPToGCSOperator(BaseOperator):
                 object_name=destination_object,
                 filename=tmp.name,
                 mime_type=self.mime_type,
+                gzip=self.gzip,
             )
 
         if self.move_object:


### PR DESCRIPTION
This small Pull Request fixes the gzip compression handling on `SFTPToGCSOperator` described at #20552.

The parameter is now passed to the GCS Hook `upload()` call.
