### PR TITLE
Add ArtifactHUB annotations for docs and screenshots

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -41,3 +41,24 @@ maintainers:
   - email: dev@airflow.apache.org
     name: Apache Airflow PMC
 type: application
+annotations:
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://airflow.apache.org/docs/helm-chart/1.4.0/
+  artifacthub.io/screenshots: |
+    - title: DAGs View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/dags.png
+    - title: Tree View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/tree.png
+    - title: Calendar View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/calendar.png
+    - title: Variable View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/variable_hidden1.png
+    - title: Gantt Chart
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/gantt.png
+    - title: Task Duration
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/duration.png
+    - title: Code View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/code.png
+    - title: Task Instance Context Menu
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/context.png

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -968,6 +968,8 @@ will use the latest released version. You'll need to update `chart/values.yaml`,
 
 Also add a note to `UPDATING.rst` that the default version of Airflow has changed.
 
+In `chart/Chart.yaml`, make sure the screenshot annotations are still all valid URLs.
+
 ## Update airflow/config_templates/config.yml file
 
 File `airflow/config_templates/config.yml` contains documentation on all configuration options available in Airflow. The `version_added` fields must be updated when a new Airflow version is released.


### PR DESCRIPTION
This will provide a link out to our docs and screenshots in the
ArtifactHUB UI. For example:

![Screen Shot 2021-12-29 at 1 41 43 PM](https://user-images.githubusercontent.com/66968678/147701783-610bbab3-fca8-43f3-b7a5-1a554d1957a9.png)

![Screen Shot 2021-12-29 at 1 40 33 PM](https://user-images.githubusercontent.com/66968678/147701725-02e99c09-de98-4d76-823b-4bb2666e87a2.png)
![Screen Shot 2021-12-29 at 1 39 58 PM](https://user-images.githubusercontent.com/66968678/147701736-c9bca41c-efbf-4279-8fb1-68688ec78844.png)


