### PR TITLE
Improve documentation on ``Params``

### DIFF
--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -60,7 +60,7 @@ If there's already a dag param with that name, the task-level default will take 
 
 When a user manually triggers a dag, they can change the parameters that are provided to the dagrun.
 This can be disabled by setting ``core.dag_run_conf_overrides_params = False``, which will prevent the user from changing the params.
-If the user-supplied values don't pass validation, Airflow will show the user a warning it will not create the dagrun.
+If the user-supplied values don't pass validation, Airflow will show the user a warning instead of creating the dagrun.
 
 
 You can reference dag params via a templated task argument:

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -15,6 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
+.. _concepts:params:
+
 Params
 ======
 
@@ -26,7 +28,8 @@ If the user-supplied values don't pass validation, Airflow shows a warning inste
 Adding Params to a DAG
 ----------------------
 
-To add Params to a :class:`~airflow.models.dag.DAG`, initialize it with the ``params`` kwarg with a dictionary that maps Param names to a either a class:`~airflow.models.param.Param` or an object indicating the parameter's default value.
+To add Params to a :class:`~airflow.models.dag.DAG`, initialize it with the ``params`` kwarg.
+Use a dictionary that maps Param names to a either a :class:`~airflow.models.param.Param` or an object indicating the parameter's default value.
 
 .. code-block::
 
@@ -42,7 +45,7 @@ To add Params to a :class:`~airflow.models.dag.DAG`, initialize it with the ``pa
 Referencing Params in a Task
 ----------------------------
 
-Params are stored as ``params`` in the :doc:`template context <../templates/templates-ref>`.
+Params are stored as ``params`` in the :ref:`template context <templates-ref>`.
 So you can reference them in a template.
 
 .. code-block::

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -60,7 +60,6 @@ So you can reference them in a template.
         ),
     )
 
-By default, Jinja templates create strings, even though Params can be of different types.
 If you're using non-string Params, you might be interested in the ``render_template_as_native_obj`` DAG kwarg.
 
 .. code-block::
@@ -73,7 +72,8 @@ If you're using non-string Params, you might be interested in the ``render_templ
     ) as the_dag:
 
 
-If ``True``, the true Param type will be provided to your tasks.
+Even though Params can use a variety of types, the default behavior of templates is to provide your task with a string.
+You can change this by setting``render_template_as_native_obj=True`` while initializing the :class:`~airflow.models.dag.DAG`.
 
 .. code-block::
 
@@ -147,3 +147,9 @@ JSON Schema Validation
 .. note::
     As of now, for security reasons, one can not use Param objects derived out of custom classes. We are
     planning to have a registration system for custom Param classes, just like we've for Operator ExtraLinks.
+
+Disabling Runtime Param Modification
+------------------------------------
+
+The ability to update params while triggering a DAG depends on the flag ``core.dag_run_conf_overrides_params``.
+Setting this config to ``False`` will effectively turn your default params into constants.

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -93,7 +93,7 @@ Another way to access your param is via a task's ``context`` kwarg.
 .. code-block::
 
     def print_x(**context):
-        x = context["params"]["x"]
+        print(context["params"]["x"])
 
     PythonOperator(
         task_id="print_x",

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -20,7 +20,7 @@
 Params
 ======
 
-Params how Airflow provides runtime configuration to tasks.
+Params are how Airflow provides runtime configuration to tasks.
 When you trigger a DAG manually, you can modify its Params before the dagrun starts.
 If the user-supplied values don't pass validation, Airflow shows a warning instead of creating the dagrun.
 (For scheduled runs, the default values are used.)

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -25,7 +25,7 @@ To use them, initialize your DAG with a dictionary where the keys are strings wi
 Or, if you want a default value without any validation, you can use literals instead.
 
 .. code-block::
-   :caption a simple DAG with a parameter
+   :caption: a simple DAG with a parameter
         from airflow import DAG
         from airflow.models.param import Param
         from airflow.operators.python_operator import PythonOperator
@@ -49,7 +49,7 @@ Params can also be added to individual tasks.
 If there's already a dag param with that name, the task-level default will take precedence over the dag-level default.
 
 .. code-block::
-   :caption tasks can have parameters too
+   :caption: tasks can have parameters too
 
             # prints 10, or whatever the user provided at trigger time
             PythonOperator(
@@ -66,7 +66,7 @@ If the user-supplied values don't pass validation, Airflow will show the user a 
 You can reference dag params via a templated task argument:
 
 .. code-block::
-   :caption use a template
+   :caption: use a template
         from airflow import DAG
         from airflow.models.param import Param
         from airflow.operators.python import PythonOperator
@@ -114,7 +114,7 @@ It will allow you to preserve the type of the parameter, even if you manipulate 
 If templates aren't your style, you can access params in via the context.
 
 .. code-block::
-   :caption use the context kwarg
+   :caption: use the context kwarg
 
             # or you can reference them through the context
             def from_context(**context):

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -38,8 +38,10 @@ Use a dictionary that maps Param names to a either a :class:`~airflow.models.par
 
     with DAG(
         "the_dag",
-        params={"x": Param(5, type="integer", minimum=3),
-                "y": 6},
+        params={
+            "x": Param(5, type="integer", minimum=3),
+            "y": 6
+        },
     ) as the_dag:
 
 Referencing Params in a Task

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -21,7 +21,7 @@ Params
 Params are Airflow's way to provide runtime configuration to tasks when a DAG gets triggered manually.
 To use them, initialize your DAG with a dictionary where the keys are strings with each param's name, and the values are ``Param`` objects.
 
-``Param`` makes use of `json-schema <https://json-schema.org/>`, so one can use the full json-schema specifications mentioned at https://json-schema.org/draft/2020-12/json-schema-validation.html to define the construct of a ``Param`` objects.
+``Param`` makes use of ``json-schema <https://json-schema.org/>``, so one can use the full json-schema specifications mentioned at https://json-schema.org/draft/2020-12/json-schema-validation.html to define the construct of a ``Param`` objects.
 Or, if you want a default value without any validation, you can use literals instead.
 
 .. code-block::

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -60,20 +60,19 @@ So you can reference them in a template.
         ),
     )
 
-If you're using non-string Params, you might be interested in the ``render_template_as_native_obj`` DAG kwarg.
+Even though Params can use a variety of types, the default behavior of templates is to provide your task with a string.
+You can change this by setting ``render_template_as_native_obj=True`` while initializing the :class:`~airflow.models.dag.DAG`.
 
 .. code-block::
 
     with DAG(
         "the_dag",
-        params={"x": Param(5, type="integer", minimum=3),
-                "y": 6},
+        params={"x": Param(5, type="integer", minimum=3)},
         render_template_as_native_obj=True
     ) as the_dag:
 
 
-Even though Params can use a variety of types, the default behavior of templates is to provide your task with a string.
-You can change this by setting``render_template_as_native_obj=True`` while initializing the :class:`~airflow.models.dag.DAG`.
+This way, the Param's type is respected when its provided to your task.
 
 .. code-block::
 
@@ -82,7 +81,7 @@ You can change this by setting``render_template_as_native_obj=True`` while initi
     PythonOperator(
         task_id="template_type",
         op_args=[
-            "{{ params.int_param + 10 }}",
+            "{{ params.int_param }}",
         ],
         python_callable=(
             lambda x: print(type(x))

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -18,46 +18,115 @@
 Params
 ======
 
-Params are Airflow's concept of providing runtime configuration to tasks when a DAG gets triggered manually.
-Params are configured while defining the DAG & tasks, that can be altered while doing a manual trigger. The
-ability to update params while triggering a DAG depends on the flag ``core.dag_run_conf_overrides_params``,
-so if that flag is ``False``, params would behave like constants.
+Params are Airflow's way to provide runtime configuration to tasks when a DAG gets triggered manually.
+To use them, initialize your DAG with a dictionary where the keys are strings with each param's name, and the values are ``Param`` objects.
 
-To use them, one can use the ``Param`` class for complex trigger-time validations or simply use primitive types,
-which won't be doing any such validations.
+``Param`` makes use of `json-schema <https://json-schema.org/>`, so one can use the full json-schema specifications mentioned at https://json-schema.org/draft/2020-12/json-schema-validation.html to define the construct of a ``Param`` objects.
+Or, if you want a default value without any validation, you can use literals instead.
 
 .. code-block::
+   :caption a simple DAG with a parameter
+        from airflow import DAG
+        from airflow.models.param import Param
+        from airflow.operators.python_operator import PythonOperator
 
-    from airflow import DAG
-    from airflow.models.param import Param
+        with DAG(
+            "params",
+            params={"x": Param(5, type="integer", minimum=3),
+                    "y": 6},
+        ) as the_dag:
 
-    with DAG(
-        'my_dag',
-        params={
-            'int_param': Param(10, type='integer', minimum=0, maximum=20),  # a int param with default value
-            'str_param': Param(type='string', minLength=2, maxLength=4),    # a mandatory str param
-            'dummy_param': Param(type=['null', 'number', 'string'])         # a param which can be None as well
-            'old_param': 'old_way_of_passing',                              # i.e. no data or type validations
-            'simple_param': Param('im_just_like_old_param'),                # i.e. no data or type validations
-            'email_param': Param(
-                default='example@example.com',
-                type='string',
-                format='idn-email',
-                minLength=5,
-                maxLength=255,
-            ),
-        },
-    )
+            def print_x(**context):
+                print(context["params"]["x"])
 
-``Param`` make use of `json-schema <https://json-schema.org/>`__ to define the properties and doing the
-validation, so one can use the full json-schema specifications mentioned at
-https://json-schema.org/draft/2020-12/json-schema-validation.html to define the construct of a ``Param``
-objects.
+            # prints 5, or whatever the user provided at trigger time
+            PythonOperator(
+                task_id="print_x",
+                python_callable=print_it,
+            )
 
-Also, it worthwhile to note that if you have any DAG which uses a mandatory param value, i.e. a ``Param``
-object with no default value or ``null`` as an allowed type, that DAG schedule has to be ``None``. However,
-if such ``Param`` has been defined at task level, Airflow has no way to restrict that & the task would be
-failing at the execution time.
+Params can also be added to individual tasks.
+If there's already a dag param with that name, the task-level default will take precedence over the dag-level default.
+
+.. code-block::
+   :caption tasks can have parameters too
+
+            # prints 10, or whatever the user provided at trigger time
+            PythonOperator(
+                task_id="print_x",
+                params={"x": 10},
+                python_callable=print_it,
+            )
+
+When a user manually triggers a dag, they can change the parameters that are provided to the dagrun.
+This can be disabled by setting ``core.dag_run_conf_overrides_params = False``, which will prevent the user from changing the params.
+If the user-supplied values don't pass validation, Airflow will show the user a warning it will not create the dagrun.
+
+
+You can reference dag params via a templated task argument:
+
+.. code-block::
+   :caption use a template
+        from airflow import DAG
+        from airflow.models.param import Param
+        from airflow.operators.python import PythonOperator
+
+        with DAG(
+            "my_dag",
+            params={
+                # a int with a default value
+                "int_param": Param(10, type="integer", minimum=0, maximum=20),
+
+                # a required param which can be of multiple types
+                "dummy": Param(type=["null", "number", "string"]),
+
+                # a param which uses json-schema formatting
+                "email": Param(
+                    default="example@example.com",
+                    type="string",
+                    format="idn-email",
+                    minLength=5,
+                    maxLength=255,
+                ),
+            },
+
+            # instead of getting strings from templates, get objects
+            render_template_as_native_obj=True,
+
+        ) as my_dag:
+
+            PythonOperator(
+                task_id="from_template",
+                op_args=[
+                    "{{ params.int_param + 10 }}",
+                ],
+                python_callable=(
+                    lambda x: print(type(x), x)
+                    # '<class 'str'> 20' by default
+                    # '<class 'int'> 20' if render_template_as_native_obj=True
+                ),
+            )
+
+By default, Jinja templates create strings.
+So if you have parameters that aren't strings, and you want to use templated task arguments, you might be interested in the ``render_template_as_native_obj`` DAG kwarg.
+It will allow you to preserve the type of the parameter, even if you manipulate it in a template.
+
+If templates aren't your style, you can access params in via the context.
+
+.. code-block::
+   :caption use the context kwarg
+
+            # or you can reference them through the context
+            def from_context(**context):
+                int_param = context["params"]["int_param"]
+                print(type(int_param), int_param + 10)
+                # <class 'int'> 20
+
+            PythonOperator(
+                task_id="from_context",
+                python_callable=from_context,
+            )
+
 
 .. note::
     As of now, for security reasons, one can not use Param objects derived out of custom classes. We are

--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -114,7 +114,7 @@ You can also add Params to individual tasks.
     )
 
 If there's already a dag param with that name, the task-level default will take precedence over the dag-level default.
-Although a user supplies their own value when the DAG was triggered, that is always used.
+If a user supplies their own value when the DAG was triggered, Airflow ignores all defaults and uses the user's value.
 
 JSON Schema Validation
 ----------------------


### PR DESCRIPTION
I think that this doc could be improved by adding examples of how to reference the params in your dag.  (Also, the current example code causes this: https://github.com/apache/airflow/issues/20559.)

While trying to find the right place to work a few reference examples in, I ended up rewriting quite a lot of it.
Let me know if you think that this is an improvement.

I haven't yet figured out how to build this and view it locally, and I'd want to do that as a sanity check before merging it, but I figured get feedback on what I've written before I do that.