### PR TITLE
Fix static checks for isort failing in stub files

### DIFF
--- a/airflow/providers/apache/cassandra/sensors/record.pyi
+++ b/airflow/providers/apache/cassandra/sensors/record.pyi
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 

--- a/airflow/providers/apache/cassandra/sensors/table.pyi
+++ b/airflow/providers/apache/cassandra/sensors/table.pyi
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional, Any
+from typing import Any, Optional
 
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 


### PR DESCRIPTION
The change to add pre-commit on isort-ing .pyi files crossed with
merge of already approved and not isorted files.

Part of #19891

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
