### PR TITLE
Clarify docstring for `build_pod_request_obj`

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -491,9 +491,9 @@ class KubernetesPodOperator(BaseOperator):
 
     def build_pod_request_obj(self, context=None):
         """
-        Creates a V1Pod based on user parameters. Note that a `pod` or `pod_template_file`
-        will supersede all other values.
+        Returns V1Pod object based on pod template file, full pod spec, and other operator parameters.
 
+        Full pod spec overrides pod template, and operator params take highest precedence.
         """
         self.log.debug("Creating pod for KubernetesPodOperator task %s", self.task_id)
         if self.pod_template_file:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -493,7 +493,8 @@ class KubernetesPodOperator(BaseOperator):
         """
         Returns V1Pod object based on pod template file, full pod spec, and other operator parameters.
 
-        Full pod spec overrides pod template, and operator params take highest precedence.
+        The V1Pod attributes are derived (in order of precedence) from operator params, full pod spec, pod
+        template file.
         """
         self.log.debug("Creating pod for KubernetesPodOperator task %s", self.task_id)
         if self.pod_template_file:


### PR DESCRIPTION
It's unclear what was referred to by `pod` because there isn't a `pod` parameter. I attempt to replace with clearer (and accurate) information.
