### PR TITLE
Delete pods by default in KubernetesPodOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -18,13 +18,12 @@
 """This module contains Amazon EKS operators."""
 import warnings
 from time import sleep
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
 from airflow import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EksHook, FargateProfileStates
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
-from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -654,7 +653,7 @@ class EksPodOperator(KubernetesPodOperator):
         pod_username: Optional[str] = None,
         aws_conn_id: str = DEFAULT_CONN_ID,
         region: Optional[str] = None,
-        is_delete_operator_pod: Union[bool, ArgNotSet] = NOTSET,
+        is_delete_operator_pod: Optional[bool] = None,
         **kwargs,
     ) -> None:
         if pod_name is None:
@@ -666,7 +665,7 @@ class EksPodOperator(KubernetesPodOperator):
             )
             pod_name = DEFAULT_POD_NAME
 
-        if is_delete_operator_pod == NOTSET:
+        if is_delete_operator_pod is None:
             warnings.warn(
                 f"You have not set parameter `is_delete_operator_pod` in class {self.__class__.__name__}. "
                 "Currently the default for this parameter is `False` but in a future release the default "

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -669,8 +669,8 @@ class EksPodOperator(KubernetesPodOperator):
             warnings.warn(
                 f"You have not set parameter `is_delete_operator_pod` in class {self.__class__.__name__}. "
                 "Currently the default for this parameter is `False` but in a future release the default "
-                "will be changed to `True`. To ensure pods are not deleted in the future you will need to set "
-                "`is_delete_operator_pod=False` explicitly.",
+                "will be changed to `True`. To ensure pods are not deleted in the future you will need to "
+                "set `is_delete_operator_pod=False` explicitly.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -28,7 +28,7 @@ Breaking changes
 * ``Simplify KubernetesPodOperator (#19572)``
 * Class ``pod_launcher.PodLauncher`` renamed to ``pod_manager.PodManager``
 * :func:`airflow.settings.pod_mutation_hook` is no longer called in :meth:`~cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async``. For ``KubernetesPodOperator``, mutation now occurs in ``build_pod_request_obj``.
-
+* Parameter ``is_delete_operator_pod`` default is changed to ``True`` so that pods are deleted after task completion and not left to accumulate. In practice it seems more common to disable pod deletion only on a temporary basis for debugging purposes and therefore pod deletion is the more sensible default.
 
 .. warning:: Many methods in :class:`~.KubernetesPodOperator` and class:`~.PodManager` (formerly named ``PodLauncher``)
     have been renamed. If you have subclassed :class:`~.KubernetesPodOperator` you will need to update your subclass to

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -149,8 +149,8 @@ class KubernetesPodOperator(BaseOperator):
     :param service_account_name: Name of the service account
     :type service_account_name: str
     :param is_delete_operator_pod: What to do when the pod reaches its final
-        state, or the execution is interrupted.
-        If False (default): do nothing, If True: delete the pod
+        state, or the execution is interrupted. If True (default), delete the
+        pod; if False, leave the pod.
     :type is_delete_operator_pod: bool
     :param hostnetwork: If True enable host networking on the pod.
     :type hostnetwork: bool
@@ -226,7 +226,7 @@ class KubernetesPodOperator(BaseOperator):
         node_selector: Optional[dict] = None,
         image_pull_secrets: Optional[List[k8s.V1LocalObjectReference]] = None,
         service_account_name: Optional[str] = None,
-        is_delete_operator_pod: bool = False,
+        is_delete_operator_pod: bool = True,
         hostnetwork: bool = False,
         tolerations: Optional[List[k8s.V1Toleration]] = None,
         security_context: Optional[Dict] = None,

--- a/airflow/providers/google/cloud/example_dags/example_kubernetes_engine.py
+++ b/airflow/providers/google/cloud/example_dags/example_kubernetes_engine.py
@@ -63,6 +63,7 @@ with models.DAG(
         image="perl",
         name="test-pod",
         in_cluster=False,
+        is_delete_operator_pod=True,
     )
 
     # [START howto_operator_gke_start_pod_xcom]
@@ -77,6 +78,7 @@ with models.DAG(
         cmds=["sh", "-c", 'mkdir -p /airflow/xcom/;echo \'[1,2,3,4]\' > /airflow/xcom/return.json'],
         name="test-pod-xcom",
         in_cluster=False,
+        is_delete_operator_pod=True,
     )
     # [END howto_operator_gke_start_pod_xcom]
 

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -327,8 +327,8 @@ class GKEStartPodOperator(KubernetesPodOperator):
             warnings.warn(
                 f"You have not set parameter `is_delete_operator_pod` in class {self.__class__.__name__}. "
                 "Currently the default for this parameter is `False` but in a future release the default "
-                "will be changed to `True`. To ensure pods are not deleted in the future you will need to set "
-                "`is_delete_operator_pod=False` explicitly.",
+                "will be changed to `True`. To ensure pods are not deleted in the future you will need to "
+                "set `is_delete_operator_pod=False` explicitly.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -31,7 +31,6 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Kubernete
 from airflow.providers.google.cloud.hooks.kubernetes_engine import GKEHook
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.utils.process_utils import execute_in_subprocess, patch_environ
-from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -321,10 +320,10 @@ class GKEStartPodOperator(KubernetesPodOperator):
         gcp_conn_id: str = 'google_cloud_default',
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         regional: bool = False,
-        is_delete_operator_pod: Union[bool, ArgNotSet] = NOTSET,
+        is_delete_operator_pod: Optional[bool] = None,
         **kwargs,
     ) -> None:
-        if is_delete_operator_pod == NOTSET:
+        if is_delete_operator_pod is None:
             warnings.warn(
                 f"You have not set parameter `is_delete_operator_pod` in class {self.__class__.__name__}. "
                 "Currently the default for this parameter is `False` but in a future release the default "


### PR DESCRIPTION
We change the default for `is_delete_operator_pod` to `True`.  For subclasses `GKEStartPodOperator` and `EksPodOperator` we do not _yet_ change the default since we may not want to do a major release in those providers.  Instead we identify when the parameter is not set and emit a deprecation warning to notify users of the impending change.
