### PR TITLE
Rename ``PodLauncher`` to ``PodManager``

### DIFF
--- a/airflow/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/kubernetes/pod_launcher_deprecated.py
@@ -39,7 +39,7 @@ from airflow.utils.state import State
 
 warnings.warn(
     """
-    Please use :mod: Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`
+    Please use :mod: Please use `airflow.providers.cncf.kubernetes.utils.pod_manager`
 
     To use this module install the provider package by installing this pip package:
 
@@ -62,7 +62,7 @@ class PodStatus:
 
 class PodLauncher(LoggingMixin):
     """Deprecated class for launching pods. please use
-    airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead
+    airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager instead
     """
 
     def __init__(
@@ -74,7 +74,7 @@ class PodLauncher(LoggingMixin):
     ):
         """
         Deprecated class for launching pods. please use
-        airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead
+        airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager instead
         Creates the launcher.
 
         :param kube_client: kubernetes client

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -26,10 +26,11 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 * ``Simplify KubernetesPodOperator (#19572)``
+* Class ``pod_launcher.PodLauncher`` renamed to ``pod_manager.PodManager``
 
-.. warning:: Many methods in :class:`~.KubernetesPodOperator` and class:`~.PodLauncher` have been renamed.
-    If you have subclassed :class:`~.KubernetesPodOperator` will need to update your subclass to reflect
-    the new structure. Additionally ``PodStatus`` enum has been renamed to ``PodPhase``.
+.. warning:: Many methods in :class:`~.KubernetesPodOperator` and class:`~.PodManager` (formerly named ``PodLauncher``)
+    have been renamed. If you have subclassed :class:`~.KubernetesPodOperator` you will need to update your subclass to
+    reflect the new structure. Additionally, class ``PodStatus`` enum has been renamed to ``PodPhase``.
 
 Notes on changes KubernetesPodOperator and PodLauncher
 ``````````````````````````````````````````````````````
@@ -51,7 +52,7 @@ into the top level of ``execute`` because it can be the same for "attached" pods
 
 :meth:`~.KubernetesPodOperator.get_or_create_pod` tries first to find an existing pod using labels
 specific to the task instance (see :meth:`~.KubernetesPodOperator.find_pod`).
-If one does not exist it :meth:`creates a pod <~.PodLauncher.create_pod>`.
+If one does not exist it :meth:`creates a pod <~.PodManager.create_pod>`.
 
 The "waiting" part of execution has three components.  The first step is to wait for the pod to leave the
 ``Pending`` phase (:meth:`~.KubernetesPodOperator.await_pod_start`). Next, if configured to do so,
@@ -59,7 +60,7 @@ the operator will :meth:`follow the base container logs <~.KubernetesPodOperator
 and forward these logs to the task logger until the ``base`` container is done. If not configured to harvest the
 logs, the operator will instead :meth:`poll for container completion until done <~.KubernetesPodOperator.await_container_completion>`;
 either way, we must await container completion before harvesting xcom. After (optionally) extracting the xcom
-value from the base container, we :meth:`await pod completion <~.PodLauncher.await_pod_completion>`.
+value from the base container, we :meth:`await pod completion <~.PodManager.await_pod_completion>`.
 
 Previously, depending on whether the pod was "reattached to" (e.g. after a worker failure) or
 created anew, the waiting logic may have occurred in either ``handle_pod_overlap`` or ``create_new_pod_for_operator``.
@@ -80,7 +81,7 @@ Details on method renames, refactors, and deletions
 
 In ``KubernetesPodOperator``:
 
-* Method ``create_pod_launcher`` is converted to cached property ``launcher``
+* Method ``create_pod_launcher`` is converted to cached property ``pod_manager``
 * Construction of k8s ``CoreV1Api`` client is now encapsulated within cached property ``client``
 * Logic to search for an existing pod (e.g. after an airflow worker failure) is moved out of ``execute`` and into method ``find_pod``.
 * Method ``handle_pod_overlap`` is removed. Previously it monitored a "found" pod until completion.  With this change the pod monitoring (and log following) is orchestrated directly from ``execute`` and it is the same  whether it's a "found" pod or a "new" pod. See methods ``await_pod_start``, ``follow_container_logs``, ``await_container_completion`` and ``await_pod_completion``.
@@ -90,7 +91,7 @@ In ``KubernetesPodOperator``:
 * Method ``_try_numbers_match`` is removed.
 * Method ``create_new_pod_for_operator`` is removed. Previously it would mutate the labels on ``self.pod``, launch the pod, monitor the pod to completion etc.  Now this logic is in part handled by ``get_or_create_pod``, where a new pod will be created if necessary. The monitoring etc is now orchestrated directly from ``execute``.  Again, see the calls to methods ``await_pod_start``, ``follow_container_logs``, ``await_container_completion`` and ``await_pod_completion``.
 
-In ``pod_launcher.py``, in class ``PodLauncher``:
+In class ``PodManager`` (formerly ``PodLauncher``):
 
 * Method ``start_pod`` is removed and split into two methods: ``create_pod`` and ``await_pod_start``.
 * Method ``monitor_pod`` is removed and split into methods ``follow_container_logs``, ``await_container_completion``, ``await_pod_completion``
@@ -99,7 +100,7 @@ In ``pod_launcher.py``, in class ``PodLauncher``:
 * Method ``read_pod_logs`` now takes kwarg ``container_name``
 
 
-Other changes in ``pod_launcher.py``:
+Other changes in ``pod_manager.py`` (formerly ``pod_launcher.py``):
 
 * Enum-like class ``PodStatus`` is renamed ``PodPhase``, and the values are no longer lower-cased.
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -30,7 +30,7 @@ Breaking changes
 
 .. warning:: Many methods in :class:`~.KubernetesPodOperator` and class:`~.PodManager` (formerly named ``PodLauncher``)
     have been renamed. If you have subclassed :class:`~.KubernetesPodOperator` you will need to update your subclass to
-    reflect the new structure. Additionally, class ``PodStatus`` enum has been renamed to ``PodPhase``.
+    reflect the new structure. Additionally, class ``PodStatus`` has been renamed to ``PodPhase``.
 
 Notes on changes KubernetesPodOperator and PodLauncher
 ``````````````````````````````````````````````````````

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from kubernetes.client import CoreV1Api, models as k8s
 
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLaunchFailedException, PodPhase
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLaunchFailedException, PodManager, PodPhase
 
 try:
     import airflow.utils.yaml as yaml
@@ -54,7 +54,7 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume_mount,
 )
 from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
-from airflow.providers.cncf.kubernetes.utils import pod_launcher, xcom_sidecar
+from airflow.providers.cncf.kubernetes.utils import xcom_sidecar
 from airflow.utils.helpers import validate_key
 from airflow.version import version as airflow_version
 
@@ -344,8 +344,8 @@ class KubernetesPodOperator(BaseOperator):
         return labels
 
     @cached_property
-    def launcher(self) -> pod_launcher.PodLauncher:
-        return pod_launcher.PodLauncher(kube_client=self.client)
+    def pod_manager(self) -> PodManager:
+        return PodManager(kube_client=self.client)
 
     @cached_property
     def client(self) -> CoreV1Api:
@@ -382,21 +382,21 @@ class KubernetesPodOperator(BaseOperator):
             if pod:
                 return pod
         self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod_request_obj.to_dict()))
-        self.launcher.create_pod(pod=pod_request_obj)
+        self.pod_manager.create_pod(pod=pod_request_obj)
         return pod_request_obj
 
     def await_pod_start(self, pod):
         try:
-            self.launcher.await_pod_start(pod=pod, startup_timeout=self.startup_timeout_seconds)
+            self.pod_manager.await_pod_start(pod=pod, startup_timeout=self.startup_timeout_seconds)
         except PodLaunchFailedException:
             if self.log_events_on_failure:
-                for event in self.launcher.read_pod_events(pod).items:
+                for event in self.pod_manager.read_pod_events(pod).items:
                     self.log.error("Pod Event: %s - %s", event.reason, event.message)
             raise
 
     def extract_xcom(self, pod):
         """Retrieves xcom value and kills xcom sidecar container"""
-        result = self.launcher.extract_xcom(pod)
+        result = self.pod_manager.extract_xcom(pod)
         self.log.info("xcom result: \n%s", result)
         return json.loads(result)
 
@@ -411,18 +411,18 @@ class KubernetesPodOperator(BaseOperator):
             self.await_pod_start(pod=self.pod)
 
             if self.get_logs:
-                self.launcher.follow_container_logs(
+                self.pod_manager.follow_container_logs(
                     pod=self.pod,
                     container_name=self.BASE_CONTAINER_NAME,
                 )
             else:
-                self.launcher.await_container_completion(
+                self.pod_manager.await_container_completion(
                     pod=self.pod, container_name=self.BASE_CONTAINER_NAME
                 )
 
             if self.do_xcom_push:
                 result = self.extract_xcom(pod=self.pod)
-            remote_pod = self.launcher.await_pod_completion(self.pod)
+            remote_pod = self.pod_manager.await_pod_completion(self.pod)
         finally:
             self.cleanup(
                 pod=self.pod or self.pod_request_obj,
@@ -439,7 +439,7 @@ class KubernetesPodOperator(BaseOperator):
         if pod_phase != PodPhase.SUCCEEDED:
             if self.log_events_on_failure:
                 with _suppress(Exception):
-                    for event in self.launcher.read_pod_events(pod).items:
+                    for event in self.pod_manager.read_pod_events(pod).items:
                         self.log.error("Pod Event: %s - %s", event.reason, event.message)
             if not self.is_delete_operator_pod:
                 with _suppress(Exception):
@@ -454,7 +454,7 @@ class KubernetesPodOperator(BaseOperator):
     def process_pod_deletion(self, pod):
         if self.is_delete_operator_pod:
             self.log.info("Deleting pod: %s", pod.metadata.name)
-            self.launcher.delete_pod(pod)
+            self.pod_manager.delete_pod(pod)
         else:
             self.log.info("skipping deleting pod: %s", pod.metadata.name)
 

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -81,7 +81,7 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
 
 class PodManager(LoggingMixin):
     """
-    Helper class for creating, monitoring and otherwise interacting with kubernetes pods
+    Helper class for creating, monitoring, and otherwise interacting with Kubernetes pods
     for use with the KubernetesPodOperator
     """
 

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -79,8 +79,11 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
     return container_status.state.running is not None
 
 
-class PodLauncher(LoggingMixin):
-    """Launches PODS"""
+class PodManager(LoggingMixin):
+    """
+    Helper class for creating, monitoring and otherwise interacting with kubernetes pods
+    for use with the KubernetesPodOperator
+    """
 
     def __init__(
         self,

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -184,8 +184,7 @@ def task_instance_mutation_hook(task_instance):
 def pod_mutation_hook(pod):
     """
     This setting allows altering ``kubernetes.client.models.V1Pod`` object
-    before they are passed to the Kubernetes client by the ``PodLauncher``
-    for scheduling.
+    before they are passed to the Kubernetes client for scheduling.
 
     To define a pod mutation hook, add a ``airflow_local_settings`` module
     to your PYTHONPATH that defines this ``pod_mutation_hook`` function.

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -36,7 +36,7 @@ from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
 from airflow.version import version as airflow_version
@@ -117,8 +117,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         client = kube_client.get_kube_client(in_cluster=False)
         client.delete_collection_namespaced_pod(namespace="default")
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_image_pull_secrets_correctly_set(self, mock_client, await_pod_completion_mock, create_mock):
         fake_pull_secrets = "fakeSecret"
@@ -266,7 +266,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         assert self.expected_pod == actual_pod
 
     def test_volume_mount(self):
-        with patch.object(PodLauncher, 'log') as mock_logger:
+        with patch.object(PodManager, 'log') as mock_logger:
             volume_mount = VolumeMount(
                 'test-volume', mount_path='/tmp/test_volume', sub_path=None, read_only=False
             )
@@ -451,8 +451,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_configmaps(self, mock_client, mock_monitor, mock_start):
         # GIVEN
@@ -480,8 +480,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmap))
         ]
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_secrets(self, mock_client, await_pod_completion_mock, create_mock):
         # GIVEN

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -23,18 +23,18 @@ from kubernetes.client.rest import ApiException
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from airflow.exceptions import AirflowException
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodPhase, container_is_running
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager, PodPhase, container_is_running
 
 
-class TestPodLauncher:
+class TestPodManager:
     def setup_method(self):
         self.mock_kube_client = mock.Mock()
-        self.pod_launcher = PodLauncher(kube_client=self.mock_kube_client)
+        self.pod_manager = PodManager(kube_client=self.mock_kube_client)
 
     def test_read_pod_logs_successfully_returns_logs(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.return_value = mock.sentinel.logs
-        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
+        logs = self.pod_manager.read_pod_logs(pod=mock.sentinel, container_name='base')
         assert mock.sentinel.logs == logs
 
     def test_read_pod_logs_retries_successfully(self):
@@ -43,7 +43,7 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
             mock.sentinel.logs,
         ]
-        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
+        logs = self.pod_manager.read_pod_logs(pod=mock.sentinel, container_name='base')
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -74,12 +74,12 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
         ]
         with pytest.raises(BaseHTTPError):
-            self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
+            self.pod_manager.read_pod_logs(pod=mock.sentinel, container_name='base')
 
     def test_read_pod_logs_successfully_with_tail_lines(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [mock.sentinel.logs]
-        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base', tail_lines=100)
+        logs = self.pod_manager.read_pod_logs(pod=mock.sentinel, container_name='base', tail_lines=100)
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -98,7 +98,7 @@ class TestPodLauncher:
     def test_read_pod_logs_successfully_with_since_seconds(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [mock.sentinel.logs]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel, 'base', since_seconds=2)
+        logs = self.pod_manager.read_pod_logs(mock.sentinel, 'base', since_seconds=2)
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -117,7 +117,7 @@ class TestPodLauncher:
     def test_read_pod_events_successfully_returns_events(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.list_namespaced_event.return_value = mock.sentinel.events
-        events = self.pod_launcher.read_pod_events(mock.sentinel)
+        events = self.pod_manager.read_pod_events(mock.sentinel)
         assert mock.sentinel.events == events
 
     def test_read_pod_events_retries_successfully(self):
@@ -126,7 +126,7 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
             mock.sentinel.events,
         ]
-        events = self.pod_launcher.read_pod_events(mock.sentinel)
+        events = self.pod_manager.read_pod_events(mock.sentinel)
         assert mock.sentinel.events == events
         self.mock_kube_client.list_namespaced_event.assert_has_calls(
             [
@@ -149,12 +149,12 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
         ]
         with pytest.raises(AirflowException):
-            self.pod_launcher.read_pod_events(mock.sentinel)
+            self.pod_manager.read_pod_events(mock.sentinel)
 
     def test_read_pod_returns_logs(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod.return_value = mock.sentinel.pod_info
-        pod_info = self.pod_launcher.read_pod(mock.sentinel)
+        pod_info = self.pod_manager.read_pod(mock.sentinel)
         assert mock.sentinel.pod_info == pod_info
 
     def test_read_pod_retries_successfully(self):
@@ -163,7 +163,7 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
             mock.sentinel.pod_info,
         ]
-        pod_info = self.pod_launcher.read_pod(mock.sentinel)
+        pod_info = self.pod_manager.read_pod(mock.sentinel)
         assert mock.sentinel.pod_info == pod_info
         self.mock_kube_client.read_namespaced_pod.assert_has_calls(
             [
@@ -186,7 +186,7 @@ class TestPodLauncher:
 
         self.mock_kube_client.read_namespaced_pod.side_effect = pod_state_gen()
         self.mock_kube_client.read_namespaced_pod_log.return_value = iter(())
-        self.pod_launcher.follow_container_logs(mock.sentinel, 'base')
+        self.pod_manager.follow_container_logs(mock.sentinel, 'base')
 
     def test_monitor_pod_logs_failures_non_fatal(self):
         mock.sentinel.metadata = mock.MagicMock()
@@ -209,7 +209,7 @@ class TestPodLauncher:
 
         self.mock_kube_client.read_namespaced_pod_log.side_effect = pod_log_gen()
 
-        self.pod_launcher.follow_container_logs(mock.sentinel, 'base')
+        self.pod_manager.follow_container_logs(mock.sentinel, 'base')
 
     def test_read_pod_retries_fails(self):
         mock.sentinel.metadata = mock.MagicMock()
@@ -219,38 +219,38 @@ class TestPodLauncher:
             BaseHTTPError('Boom'),
         ]
         with pytest.raises(AirflowException):
-            self.pod_launcher.read_pod(mock.sentinel)
+            self.pod_manager.read_pod(mock.sentinel)
 
     def test_parse_log_line(self):
         log_message = "This should return no timestamp"
-        timestamp, line = self.pod_launcher.parse_log_line(log_message)
+        timestamp, line = self.pod_manager.parse_log_line(log_message)
         assert timestamp is None
         assert line == log_message
 
         real_timestamp = "2020-10-08T14:16:17.793417674Z"
-        timestamp, line = self.pod_launcher.parse_log_line(" ".join([real_timestamp, log_message]))
+        timestamp, line = self.pod_manager.parse_log_line(" ".join([real_timestamp, log_message]))
         assert timestamp == pendulum.parse(real_timestamp)
         assert line == log_message
 
         with pytest.raises(Exception):
-            self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674ZInvalidmessage\n')
+            self.pod_manager.parse_log_line('2020-10-08T14:16:17.793417674ZInvalidmessage\n')
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
     def test_start_pod_retries_on_409_error(self, mock_run_pod_async):
         mock_run_pod_async.side_effect = [
             ApiException(status=409),
             mock.MagicMock(),
         ]
-        self.pod_launcher.create_pod(mock.sentinel)
+        self.pod_manager.create_pod(mock.sentinel)
         assert mock_run_pod_async.call_count == 2
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
     def test_start_pod_fails_on_other_exception(self, mock_run_pod_async):
         mock_run_pod_async.side_effect = [ApiException(status=504)]
         with pytest.raises(ApiException):
-            self.pod_launcher.create_pod(mock.sentinel)
+            self.pod_manager.create_pod(mock.sentinel)
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
     def test_start_pod_retries_three_times(self, mock_run_pod_async):
         mock_run_pod_async.side_effect = [
             ApiException(status=409),
@@ -259,7 +259,7 @@ class TestPodLauncher:
             ApiException(status=409),
         ]
         with pytest.raises(ApiException):
-            self.pod_launcher.create_pod(mock.sentinel)
+            self.pod_manager.create_pod(mock.sentinel)
 
         assert mock_run_pod_async.call_count == 3
 
@@ -270,7 +270,7 @@ class TestPodLauncher:
         expected_msg = "Check the pod events in kubernetes"
         mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
-            self.pod_launcher.await_pod_start(
+            self.pod_manager.await_pod_start(
                 pod=mock_pod,
                 startup_timeout=0,
             )
@@ -278,8 +278,8 @@ class TestPodLauncher:
     @mock.patch('airflow.providers.cncf.kubernetes.utils.pod_launcher.container_is_running')
     def test_container_is_running(self, container_is_running_mock):
         mock_pod = MagicMock()
-        self.pod_launcher.read_pod = mock.MagicMock(return_value=mock_pod)
-        self.pod_launcher.container_is_running(None, 'base')
+        self.pod_manager.read_pod = mock.MagicMock(return_value=mock_pod)
+        self.pod_manager.container_is_running(None, 'base')
         container_is_running_mock.assert_called_with(pod=mock_pod, container_name='base')
 
 

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -275,7 +275,7 @@ class TestPodManager:
                 startup_timeout=0,
             )
 
-    @mock.patch('airflow.providers.cncf.kubernetes.utils.pod_launcher.container_is_running')
+    @mock.patch('airflow.providers.cncf.kubernetes.utils.pod_manager.container_is_running')
     def test_container_is_running(self, container_is_running_mock):
         mock_pod = MagicMock()
         self.pod_manager.read_pod = mock.MagicMock(return_value=mock_pod)


### PR DESCRIPTION
The name PodLauncher may have been appropriate at one time. But currently the PodLauncher class is used for much more than "launching" pods.  It's a more comprehensive helper class for creating, monitoring, and otherwise interacting with pods. For this reason PodManager is a more representative name and since we're doing a major release we can take the opportunity to update the name.
