### PR TITLE
Use KubernetesHook to create api client in KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -19,6 +19,19 @@
 Changelog
 ---------
 
+main
+....
+
+Features
+~~~~~~~~
+
+KubernetesPodOperator now uses KubernetesHook
+`````````````````````````````````````````````
+
+Previously, KubernetesPodOperator relied on core Airflow configuration (namely setting for kubernetes executor) for certain settings used in client generation.  Now KubernetesPodOperator uses KubernetesHook, and the consideration of core k8s settings is officially deprecated.
+
+If you are using the Airflow configuration settings (e.g. as opposed to operator params) to configure the kubernetes client, then prior to the next major release you will need to add an Airflow connection and set your KPO processes to use that connection.
+
 4.0.2
 .....
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -30,7 +30,7 @@ KubernetesPodOperator now uses KubernetesHook
 
 Previously, KubernetesPodOperator relied on core Airflow configuration (namely setting for kubernetes executor) for certain settings used in client generation.  Now KubernetesPodOperator uses KubernetesHook, and the consideration of core k8s settings is officially deprecated.
 
-If you are using the Airflow configuration settings (e.g. as opposed to operator params) to configure the kubernetes client, then prior to the next major release you will need to add an Airflow connection and set your KPO processes to use that connection.
+If you are using the Airflow configuration settings (e.g. as opposed to operator params) to configure the kubernetes client, then prior to the next major release you will need to add an Airflow connection and set your KPO tasks to use that connection.
 
 4.0.2
 .....

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -205,7 +205,9 @@ class KubernetesHook(BaseHook):
         if disable_verify_ssl is None and self._deprecated_core_disable_verify_ssl is True:
             deprecation_warnings.append(('verify_ssl', False))
             disable_verify_ssl = self._deprecated_core_disable_verify_ssl
-        if in_cluster is None and self._deprecated_core_in_cluster is not None:
+        # by default, hook will try in_cluster first. so we only need to
+        # apply core airflow config and alert when False and in_cluster not otherwise set.
+        if in_cluster is None and self._deprecated_core_in_cluster is False:
             deprecation_warnings.append(('in_cluster', self._deprecated_core_in_cluster))
             in_cluster = self._deprecated_core_in_cluster
         if not cluster_context and self._deprecated_core_cluster_context:

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -66,6 +66,14 @@ class KubernetesHook(BaseHook):
 
     :param conn_id: The :ref:`kubernetes connection <howto/connection:kubernetes>`
         to Kubernetes cluster.
+    :param client_configuration: Optional dictionary of client configuration params.
+        Passed on to kubernetes client.
+    :param cluster_context: Optionally specify a context to use (e.g. if you have multiple
+        in your kubeconfig.
+    :param config_file: Path to kubeconfig file.
+    :param in_cluster: Set to ``True`` if running from within a kubernetes cluster.
+    :param disable_verify_ssl: Set to ``True`` if SSL verification should be disabled.
+    :param disable_tcp_keepalive: Set to ``True`` if you want to disable keepalive logic.
     """
 
     conn_name_attr = 'kubernetes_conn_id'

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -174,7 +174,7 @@ class KubernetesHook(BaseHook):
             f"\nApplying core Airflow settings from section [kubernetes] with the following keys:"
             f"{settings_list_str}\n"
             "In a future release, KubernetesPodOperator will no longer consider core\n"
-            "airflow settings; define an Airflow connection instead.",
+            "Airflow settings; define an Airflow connection instead.",
             DeprecationWarning,
         )
 

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -16,9 +16,12 @@
 # under the License.
 import sys
 import tempfile
-from typing import Any, Dict, Generator, Optional, Tuple, Union
+import warnings
+from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from kubernetes.config import ConfigException
+
+from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -91,6 +94,8 @@ class KubernetesHook(BaseHook):
             "extra__kubernetes__cluster_context": StringField(
                 lazy_gettext('Cluster context'), widget=BS3TextFieldWidget()
             ),
+            "extra__kubernetes__disable_verify_ssl": BooleanField(lazy_gettext('Disable SSL')),
+            "extra__kubernetes__disable_tcp_keepalive": BooleanField(lazy_gettext('Disable TCP keepalive')),
         }
 
     @staticmethod
@@ -108,6 +113,8 @@ class KubernetesHook(BaseHook):
         cluster_context: Optional[str] = None,
         config_file: Optional[str] = None,
         in_cluster: Optional[bool] = None,
+        disable_verify_ssl: Optional[bool] = None,
+        disable_tcp_keepalive: Optional[bool] = None,
     ) -> None:
         super().__init__()
         self.conn_id = conn_id
@@ -115,6 +122,16 @@ class KubernetesHook(BaseHook):
         self.cluster_context = cluster_context
         self.config_file = config_file
         self.in_cluster = in_cluster
+        self.disable_verify_ssl = disable_verify_ssl
+        self.disable_tcp_keepalive = disable_tcp_keepalive
+
+        # these params used for transition in KPO to K8s hook
+        # for a deprecation period we will continue to consider
+        self._deprecated_core_disable_tcp_keepalive = None
+        self._deprecated_core_disable_verify_ssl = None
+        self._deprecated_core_in_cluster = None
+        self._deprecated_core_cluster_context = None
+        self._deprecated_core_config_file = None
 
     @staticmethod
     def _coalesce_param(*params):
@@ -122,23 +139,50 @@ class KubernetesHook(BaseHook):
             if param is not None:
                 return param
 
-    def get_conn(self) -> Any:
-        """Returns kubernetes api session for use with requests"""
+    @cached_property
+    def conn_extras(self):
         if self.conn_id:
             connection = self.get_connection(self.conn_id)
             extras = connection.extra_dejson
         else:
             extras = {}
+        return extras
+
+    def _get_field(self, field_name):
+        if field_name.startswith('extra_'):
+            raise ValueError(
+                f"Got prefixed name {field_name}; please remove the 'extra__kubernetes__' prefix "
+                f"when using this method."
+            )
+        if field_name in self.conn_extras:
+            return self.conn_extras[field_name] or None
+        prefixed_name = f"extra__kubernetes__{field_name}"
+        return self.conn_extras.get(prefixed_name) or None
+
+    @staticmethod
+    def _deprecation_warning_core_param(deprecation_warnings):
+        settings_list_str = ''.join([f"\n\t{k}={v!r}" for k, v in deprecation_warnings])
+        warnings.warn(
+            f"Using core Airflow settings from section [kubernetes] with the following keys: "
+            f"{settings_list_str}"
+            "In a future release, KubernetesPodOperator will no longer consider core "
+            "airflow settings; define an Airflow connection instead."
+        )
+
+    def get_conn(self) -> Any:
+        """Returns kubernetes api session for use with requests"""
+
         in_cluster = self._coalesce_param(
-            self.in_cluster, extras.get("extra__kubernetes__in_cluster") or None
+            self.in_cluster, self.conn_extras.get("extra__kubernetes__in_cluster") or None
         )
         cluster_context = self._coalesce_param(
-            self.cluster_context, extras.get("extra__kubernetes__cluster_context") or None
+            self.cluster_context, self.conn_extras.get("extra__kubernetes__cluster_context") or None
         )
         kubeconfig_path = self._coalesce_param(
-            self.config_file, extras.get("extra__kubernetes__kube_config_path") or None
+            self.config_file, self.conn_extras.get("extra__kubernetes__kube_config_path") or None
         )
-        kubeconfig = extras.get("extra__kubernetes__kube_config") or None
+
+        kubeconfig = self.conn_extras.get("extra__kubernetes__kube_config") or None
         num_selected_configuration = len([o for o in [in_cluster, kubeconfig, kubeconfig_path] if o])
 
         if num_selected_configuration > 1:
@@ -147,6 +191,41 @@ class KubernetesHook(BaseHook):
                 "kube_config, in_cluster are mutually exclusive. "
                 "You can only use one option at a time."
             )
+
+        disable_verify_ssl = self._coalesce_param(
+            self.disable_verify_ssl, _get_bool(self._get_field("disable_verify_ssl"))
+        )
+        disable_tcp_keepalive = self._coalesce_param(
+            self.disable_tcp_keepalive, _get_bool(self._get_field("disable_tcp_keepalive"))
+        )
+
+        # BEGIN apply settings from core kubernetes configuration
+        # this section should be removed in next major release
+        deprecation_warnings: List[Tuple[str, Any]] = []
+        if disable_verify_ssl is None and self._deprecated_core_disable_verify_ssl is True:
+            deprecation_warnings.append(('verify_ssl', False))
+            disable_verify_ssl = self._deprecated_core_disable_verify_ssl
+        if in_cluster is None and self._deprecated_core_in_cluster is not None:
+            deprecation_warnings.append(('in_cluster', self._deprecated_core_in_cluster))
+            in_cluster = self._deprecated_core_in_cluster
+        if not cluster_context and self._deprecated_core_cluster_context:
+            deprecation_warnings.append(('cluster_context', self._deprecated_core_cluster_context))
+            cluster_context = self._deprecated_core_cluster_context
+        if not kubeconfig_path and self._deprecated_core_config_file:
+            deprecation_warnings.append(('config_file', self._deprecated_core_config_file))
+            kubeconfig_path = self._deprecated_core_config_file
+        if disable_tcp_keepalive is None and self._deprecated_core_disable_tcp_keepalive is True:
+            deprecation_warnings.append(('enable_tcp_keepalive', False))
+            disable_tcp_keepalive = True
+        if deprecation_warnings:
+            self._deprecation_warning_core_param(deprecation_warnings)
+        # END apply settings from core kubernetes configuration
+
+        if disable_verify_ssl is True:
+            _disable_verify_ssl()
+        if disable_tcp_keepalive is not True:
+            _enable_tcp_keepalive()
+
         if in_cluster:
             self.log.debug("loading kube_config from: in_cluster configuration")
             config.load_incluster_config()
@@ -316,3 +395,18 @@ class KubernetesHook(BaseHook):
             _preload_content=False,
             namespace=namespace if namespace else self.get_namespace(),
         )
+
+
+def _get_bool(val) -> Optional[bool]:
+    """
+    Converts val to bool if can be done with certainty.
+    If we cannot infer intention we return None.
+    """
+    if isinstance(val, bool):
+        return val
+    elif isinstance(val, str):
+        if val.strip().lower() == 'true':
+            return True
+        elif val.strip().lower() == 'false':
+            return False
+    return None

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -163,10 +163,11 @@ class KubernetesHook(BaseHook):
     def _deprecation_warning_core_param(deprecation_warnings):
         settings_list_str = ''.join([f"\n\t{k}={v!r}" for k, v in deprecation_warnings])
         warnings.warn(
-            f"Using core Airflow settings from section [kubernetes] with the following keys: "
-            f"{settings_list_str}"
-            "In a future release, KubernetesPodOperator will no longer consider core "
-            "airflow settings; define an Airflow connection instead."
+            f"\nApplying core Airflow settings from section [kubernetes] with the following keys:"
+            f"{settings_list_str}\n"
+            "In a future release, KubernetesPodOperator will no longer consider core\n"
+            "airflow settings; define an Airflow connection instead.",
+            DeprecationWarning,
         )
 
     def get_conn(self) -> Any:

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -127,11 +127,11 @@ class KubernetesHook(BaseHook):
 
         # these params used for transition in KPO to K8s hook
         # for a deprecation period we will continue to consider k8s settings from airflow.cfg
-        self._deprecated_core_disable_tcp_keepalive = None
-        self._deprecated_core_disable_verify_ssl = None
-        self._deprecated_core_in_cluster = None
-        self._deprecated_core_cluster_context = None
-        self._deprecated_core_config_file = None
+        self._deprecated_core_disable_tcp_keepalive: Optional[bool] = None
+        self._deprecated_core_disable_verify_ssl: Optional[bool] = None
+        self._deprecated_core_in_cluster: Optional[bool] = None
+        self._deprecated_core_cluster_context: Optional[str] = None
+        self._deprecated_core_config_file: Optional[str] = None
 
     @staticmethod
     def _coalesce_param(*params):

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -126,7 +126,7 @@ class KubernetesHook(BaseHook):
         self.disable_tcp_keepalive = disable_tcp_keepalive
 
         # these params used for transition in KPO to K8s hook
-        # for a deprecation period we will continue to consider
+        # for a deprecation period we will continue to consider k8s settings from airflow.cfg
         self._deprecated_core_disable_tcp_keepalive = None
         self._deprecated_core_disable_verify_ssl = None
         self._deprecated_core_in_cluster = None

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -587,15 +587,15 @@ class KubernetesPodOperator(BaseOperator):
         """
 
         # default for enable_tcp_keepalive is True; patch if False
-        if conf.getboolean('kubernetes', 'enable_tcp_keepalive', fallback=None) is False:
+        if conf.getboolean('kubernetes', 'enable_tcp_keepalive') is False:
             hook._deprecated_core_disable_tcp_keepalive = True
 
         # default verify_ssl is True; patch if False.
-        if conf.getboolean('kubernetes', 'verify_ssl', fallback=None) is False:
+        if conf.getboolean('kubernetes', 'verify_ssl') is False:
             hook._deprecated_core_disable_verify_ssl = True
 
         # default for in_cluster is True; patch if False and no KPO param.
-        conf_in_cluster = conf.getboolean('kubernetes', 'in_cluster', fallback=None)
+        conf_in_cluster = conf.getboolean('kubernetes', 'in_cluster')
         if self.in_cluster is None and conf_in_cluster is False:
             hook._deprecated_core_in_cluster = conf_in_cluster
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -143,7 +143,7 @@ class KubernetesPodOperator(BaseOperator):
     :param priority_class_name: priority class name for the launched Pod
     :param termination_grace_period: Termination grace period if task killed in UI,
         defaults to kubernetes default
-    :param: kubernetes_conn_id: To retrieve creds for your k8s cluster from an Airflow connection
+    :param: kubernetes_conn_id: To retrieve credentials for your k8s cluster from an Airflow connection
     """
 
     BASE_CONTAINER_NAME = 'base'

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -206,7 +206,6 @@ class KubernetesPodOperator(BaseOperator):
         pod_runtime_info_envs: Optional[List[k8s.V1EnvVar]] = None,
         termination_grace_period: Optional[int] = None,
         configmaps: Optional[List[str]] = None,
-        kubernetes_conn_id: Optional[str] = None,
         **kwargs,
     ) -> None:
         if kwargs.get('xcom_push') is not None:

--- a/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
@@ -58,12 +58,17 @@ Kube config (JSON format)
 Namespace
   Default Kubernetes namespace for the connection.
 
-When specifying the connection in environment variable you should specify
-it using URI syntax.
+Cluster context
+  When using a kube config, can specify which context to use.
 
-Note that all components of the URI should be URL-encoded.
+Disable verify SSL
+  Can optionally disable SSL certificate verification.  By default SSL is verified.
 
-For example:
+Disable TCP keepalive
+  TCP keepalive is a feature (enabled by default) that tries to keep long-running connections
+  alive. Set this parameter to True to disable this feature.
+
+Example storing connection in env var using URI format:
 
 .. code-block:: bash
 

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -127,7 +127,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
     def tearDown(self) -> None:
         hook = KubernetesHook(conn_id=None, in_cluster=False)
-        client = hook.get_conn()
+        client = hook.core_v1_client
         client.delete_collection_namespaced_pod(namespace="default")
         import time
 
@@ -1017,7 +1017,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
     @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion", new=MagicMock)
     def test_on_kill(self):
         hook = KubernetesHook(conn_id=None, in_cluster=False)
-        client = hook.get_conn()
+        client = hook.core_v1_client
         name = "test"
         namespace = "default"
         k = KubernetesPodOperator(
@@ -1045,7 +1045,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
     def test_reattach_failing_pod_once(self):
         hook = KubernetesHook(conn_id=None, in_cluster=False)
-        client = hook.get_conn()
+        client = hook.core_v1_client
         name = "test"
         namespace = "default"
 

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -696,6 +696,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         assert self.expected_pod == actual_pod
 
     def test_pod_template_file_system(self):
+        """Note: this test requires that you have a namespace ``mem-example`` in your cluster."""
         fixture = sys.path[0] + '/tests/kubernetes/basic_pod.yaml'
         k = KubernetesPodOperator(
             task_id="task" + self.get_current_task_name(),

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -126,7 +126,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         }
 
     def tearDown(self) -> None:
-        hook = KubernetesHook(in_cluster=False)
+        hook = KubernetesHook(conn_id=None, in_cluster=False)
         client = hook.get_conn()
         client.delete_collection_namespaced_pod(namespace="default")
         import time
@@ -1016,7 +1016,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
     @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion", new=MagicMock)
     def test_on_kill(self):
-        hook = KubernetesHook(in_cluster=False)
+        hook = KubernetesHook(conn_id=None, in_cluster=False)
         client = hook.get_conn()
         name = "test"
         namespace = "default"
@@ -1044,7 +1044,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             client.read_namespaced_pod(name=name, namespace=namespace)
 
     def test_reattach_failing_pod_once(self):
-        hook = KubernetesHook(in_cluster=False)
+        hook = KubernetesHook(conn_id=None, in_cluster=False)
         client = hook.get_conn()
         name = "test"
         namespace = "default"

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -33,15 +33,18 @@ from kubernetes.client.api_client import ApiClient
 from kubernetes.client.rest import ApiException
 
 from airflow.exceptions import AirflowException
-from airflow.kubernetes import kube_client
 from airflow.kubernetes.secret import Secret
 from airflow.models import DAG, XCOM_RETURN_KEY, DagRun, TaskInstance
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodManager
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 from airflow.version import version as airflow_version
+
+HOOK_CLASS = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesHook"
+POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
 
 
 def create_context(task):
@@ -123,7 +126,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         }
 
     def tearDown(self) -> None:
-        client = kube_client.get_kube_client(in_cluster=False)
+        hook = KubernetesHook(in_cluster=False)
+        client = hook.get_conn()
         client.delete_collection_namespaced_pod(namespace="default")
         import time
 
@@ -632,10 +636,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_envs_from_secrets(self, mock_client, await_pod_completion_mock, create_pod):
+    @mock.patch(f"{POD_MANAGER_CLASS}.create_pod")
+    @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
+    @mock.patch(HOOK_CLASS, new=MagicMock)
+    def test_envs_from_secrets(self, await_pod_completion_mock, create_pod):
+        # todo: This isn't really a system test
+
         # GIVEN
 
         secret_ref = 'secret_name'
@@ -873,11 +879,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.extract_xcom")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_pod_template_file(self, mock_client, await_pod_completion_mock, create_mock, extract_xcom_mock):
+    @mock.patch(f"{POD_MANAGER_CLASS}.extract_xcom")
+    @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
+    @mock.patch(f"{POD_MANAGER_CLASS}.create_pod", new=MagicMock)
+    @mock.patch(HOOK_CLASS, new=MagicMock)
+    def test_pod_template_file(self, await_pod_completion_mock, extract_xcom_mock):
+        # todo: This isn't really a system test
         extract_xcom_mock.return_value = '{}'
         path = sys.path[0] + '/tests/kubernetes/pod.yaml'
         k = KubernetesPodOperator(
@@ -959,11 +966,15 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         del actual_pod['metadata']['labels']['airflow_version']
         assert expected_dict == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_pod_priority_class_name(self, mock_client, await_pod_completion_mock, create_mock):
-        """Test ability to assign priorityClassName to pod"""
+    @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
+    @mock.patch(f"{POD_MANAGER_CLASS}.create_pod", new=MagicMock)
+    @mock.patch(HOOK_CLASS, new=MagicMock)
+    def test_pod_priority_class_name(self, await_pod_completion_mock):
+        """
+        Test ability to assign priorityClassName to pod
+
+        todo: This isn't really a system test
+        """
 
         priority_class_name = "medium-test"
         k = KubernetesPodOperator(
@@ -1003,10 +1014,10 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 do_xcom_push=False,
             )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
-    def test_on_kill(self, await_pod_completion_mock):
-
-        client = kube_client.get_kube_client(in_cluster=False)
+    @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion", new=MagicMock)
+    def test_on_kill(self):
+        hook = KubernetesHook(in_cluster=False)
+        client = hook.get_conn()
         name = "test"
         namespace = "default"
         k = KubernetesPodOperator(
@@ -1033,7 +1044,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             client.read_namespaced_pod(name=name, namespace=namespace)
 
     def test_reattach_failing_pod_once(self):
-        client = kube_client.get_kube_client(in_cluster=False)
+        hook = KubernetesHook(in_cluster=False)
+        client = hook.get_conn()
         name = "test"
         namespace = "default"
 
@@ -1057,9 +1069,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         context = create_context(k)
 
         # launch pod
-        with mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion"
-        ) as await_pod_completion_mock:
+        with mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion") as await_pod_completion_mock:
             pod_mock = MagicMock()
 
             pod_mock.status.phase = 'Succeeded'
@@ -1083,9 +1093,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
         # `create_pod` should not be called because there's a pod there it should find
         # should use the found pod and patch as "already_checked" (in failure block)
-        with mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod"
-        ) as create_mock:
+        with mock.patch(f"{POD_MANAGER_CLASS}.create_pod") as create_mock:
             with pytest.raises(AirflowException):
                 k.execute(context)
             pod = client.read_namespaced_pod(name=name, namespace=namespace)
@@ -1097,9 +1105,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
         # `create_pod` should be called because though there's still a pod to be found,
         # it will be `already_checked`
-        with mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod"
-        ) as create_mock:
+        with mock.patch(f"{POD_MANAGER_CLASS}.create_pod") as create_mock:
             with pytest.raises(AirflowException):
                 k.execute(context)
             create_mock.assert_called_once()

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -165,7 +165,7 @@ class TestKubernetesHook:
         """
         kubernetes_hook = KubernetesHook(conn_id=conn_id, disable_verify_ssl=disable_verify_ssl)
         api_conn = kubernetes_hook.get_conn()
-        assert mock_disable.called is disabled_called
+        assert mock_disable.called is disable_called
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -313,6 +313,59 @@ class TestKubernetesHook:
         assert isinstance(hook.api_client, kubernetes.client.ApiClient)
         assert isinstance(hook.get_conn(), kubernetes.client.ApiClient)
 
+    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._disable_verify_ssl")
+    def test_patch_core_settings_verify_ssl(self, mock_disable_verify_ssl):
+        hook = KubernetesHook()
+        hook.get_conn()
+        mock_disable_verify_ssl.assert_not_called()
+        mock_disable_verify_ssl.reset_mock()
+        hook._deprecated_core_disable_verify_ssl = True
+        hook.get_conn()
+        mock_disable_verify_ssl.assert_called()
+
+    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._enable_tcp_keepalive")
+    def test_patch_core_settings_tcp_keepalive(self, mock_enable_tcp_keepalive):
+        hook = KubernetesHook()
+        hook.get_conn()
+        mock_enable_tcp_keepalive.assert_called()
+        mock_enable_tcp_keepalive.reset_mock()
+        hook._deprecated_core_disable_tcp_keepalive = True
+        hook.get_conn()
+        mock_enable_tcp_keepalive.assert_not_called()
+
+    @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
+    @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
+    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    def test_patch_core_settings_in_cluster(self, mock_get_default_client, mock_in_cluster_loader):
+        hook = KubernetesHook(conn_id=None)
+        hook.get_conn()
+        mock_in_cluster_loader.assert_not_called()
+        mock_in_cluster_loader.reset_mock()
+        hook._deprecated_core_in_cluster = False
+        hook.get_conn()
+        mock_in_cluster_loader.assert_not_called()
+        mock_get_default_client.assert_called()
+
+    @pytest.mark.parametrize(
+        'key, key_val, attr, attr_val',
+        [
+            ('in_cluster', False, '_deprecated_core_in_cluster', False),
+            ('verify_ssl', False, '_deprecated_core_disable_verify_ssl', True),
+            ('cluster_context', 'hi', '_deprecated_core_cluster_context', 'hi'),
+            ('config_file', '/path/to/file.txt', '_deprecated_core_config_file', '/path/to/file.txt'),
+            ('enable_tcp_keepalive', False, '_deprecated_core_disable_tcp_keepalive', True),
+        ],
+    )
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
+    @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
+    @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
+    def test_core_settings_warnings(self, key, key_val, attr, attr_val):
+        hook = KubernetesHook(conn_id=None)
+        setattr(hook, attr, attr_val)
+        with pytest.warns(DeprecationWarning, match=rf'.*Airflow settings.*\n.*{key}={key_val!r}.*') as w:
+            hook.get_conn()
+
 
 class TestKubernetesHookIncorrectConfiguration:
     @pytest.mark.parametrize(

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -169,17 +169,17 @@ class TestKubernetesHook:
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(
-        'disable_tcp_keepalive, conn_id, should_disable',
+        'disable_tcp_keepalive, conn_id, expected',
         (
-            (True, None, True),
-            (None, None, False),
-            (False, None, False),
-            (None, 'disable_tcp_keepalive', True),
-            (True, 'disable_tcp_keepalive', True),
-            (False, 'disable_tcp_keepalive', False),
-            (None, 'disable_tcp_keepalive_empty', False),
-            (True, 'disable_tcp_keepalive_empty', True),
-            (False, 'disable_tcp_keepalive_empty', False),
+            (True, None, False),
+            (None, None, True),
+            (False, None, True),
+            (None, 'disable_tcp_keepalive', False),
+            (True, 'disable_tcp_keepalive', False),
+            (False, 'disable_tcp_keepalive', True),
+            (None, 'disable_tcp_keepalive_empty', True),
+            (True, 'disable_tcp_keepalive_empty', False),
+            (False, 'disable_tcp_keepalive_empty', True),
         ),
     )
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
@@ -189,7 +189,7 @@ class TestKubernetesHook:
         mock_enable,
         disable_tcp_keepalive,
         conn_id,
-        should_disable,
+        expected,
     ):
         """
         Verifies whether enable tcp keepalive is called depending on combination of hook
@@ -197,10 +197,7 @@ class TestKubernetesHook:
         """
         kubernetes_hook = KubernetesHook(conn_id=conn_id, disable_tcp_keepalive=disable_tcp_keepalive)
         api_conn = kubernetes_hook.get_conn()
-        if not should_disable:
-            assert mock_enable.called
-        else:
-            assert not mock_enable.called
+        assert mock_enable.called is expected
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -363,7 +363,7 @@ class TestKubernetesHook:
     def test_core_settings_warnings(self, key, key_val, attr, attr_val):
         hook = KubernetesHook(conn_id=None)
         setattr(hook, attr, attr_val)
-        with pytest.warns(DeprecationWarning, match=rf'.*Airflow settings.*\n.*{key}={key_val!r}.*') as w:
+        with pytest.warns(DeprecationWarning, match=rf'.*Airflow settings.*\n.*{key}={key_val!r}.*'):
             hook.get_conn()
 
 

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -165,10 +165,7 @@ class TestKubernetesHook:
         """
         kubernetes_hook = KubernetesHook(conn_id=conn_id, disable_verify_ssl=disable_verify_ssl)
         api_conn = kubernetes_hook.get_conn()
-        if disable_called:
-            assert mock_disable.called
-        else:
-            assert not mock_disable.called
+        assert mock_disable.called is disabled_called
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -34,6 +34,7 @@ from airflow.utils import db
 from tests.test_utils.db import clear_db_connections
 
 KUBE_CONFIG_PATH = os.getenv('KUBECONFIG', '~/.kube/config')
+HOOK_MODULE = "airflow.providers.cncf.kubernetes.hooks.kubernetes"
 
 
 class TestKubernetesHook:
@@ -80,7 +81,7 @@ class TestKubernetesHook:
     @patch("kubernetes.config.kube_config.KubeConfigLoader")
     @patch("kubernetes.config.kube_config.KubeConfigMerger")
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client")
     def test_in_cluster_connection(
         self,
         mock_get_default_client,
@@ -150,7 +151,7 @@ class TestKubernetesHook:
         ),
     )
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._disable_verify_ssl")
+    @patch(f"{HOOK_MODULE}._disable_verify_ssl")
     def test_disable_verify_ssl(
         self,
         mock_disable,
@@ -185,7 +186,7 @@ class TestKubernetesHook:
         ),
     )
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._enable_tcp_keepalive")
+    @patch(f"{HOOK_MODULE}._enable_tcp_keepalive")
     def test_disable_tcp_keepalive(
         self,
         mock_enable,
@@ -313,7 +314,8 @@ class TestKubernetesHook:
         assert isinstance(hook.api_client, kubernetes.client.ApiClient)
         assert isinstance(hook.get_conn(), kubernetes.client.ApiClient)
 
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._disable_verify_ssl")
+    @patch(f"{HOOK_MODULE}._disable_verify_ssl")
+    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client", new=MagicMock)
     def test_patch_core_settings_verify_ssl(self, mock_disable_verify_ssl):
         hook = KubernetesHook()
         hook.get_conn()
@@ -323,7 +325,8 @@ class TestKubernetesHook:
         hook.get_conn()
         mock_disable_verify_ssl.assert_called()
 
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes._enable_tcp_keepalive")
+    @patch(f"{HOOK_MODULE}._enable_tcp_keepalive")
+    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client", new=MagicMock)
     def test_patch_core_settings_tcp_keepalive(self, mock_enable_tcp_keepalive):
         hook = KubernetesHook()
         hook.get_conn()
@@ -336,7 +339,7 @@ class TestKubernetesHook:
     @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
     @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
-    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client")
     def test_patch_core_settings_in_cluster(self, mock_get_default_client, mock_in_cluster_loader):
         hook = KubernetesHook(conn_id=None)
         hook.get_conn()

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -84,10 +84,7 @@ class TestKubernetesPodOperator:
 
         yield
 
-        self.create_pod_patch.stop()
-        self.await_pod_patch.stop()
-        self.await_pod_completion_patch.stop()
-        self.hook_patch.stop()
+        mock.patch.stopall()
 
     def run_pod(self, operator: KubernetesPodOperator, map_index: int = -1) -> k8s.V1Pod:
         with self.dag_maker(dag_id='dag') as dag:


### PR DESCRIPTION
Reopened and ready for review.

TLDR: add support for k8s hook in KPO; use it always (even when no conn id); continue to consider the core k8s settings that KPO already takes into account but emit deprecation warning about them.

This one was pretty tricky.

Here are some notes:

KPO takes into account a few settings from core airflow cfg (e.g. verify ssl, tcp keepalive, context, config file, and in_cluster).  So if we're using the hook to generate the client, somehow the hook has to take these settings into account. But we don't want the hook to consider these settings in general.  

So we need to read the settings in KPO and somehow pass them to the hook.  We can't do it through init params, because that would interfere with migration to an airflow connection.  So what I did was establish some "private" attribtues that could be patched from KPO when the setting is something other than the default.  Then the hook will consider these patched params only when it's not using an airflow connection or hook params.

The other tricky part was we want to minimize the warnings.  So we need to try and warn only when the configuration taken from core settings actually ends up being used.  E.g. `[kubernetes] > in_cluster=True` is the default value so we only want to warn when it's been set to False, and only when it is actually considered (so that when the user adds an airflow connection, the warning will go away).

Lastly one thing to note (smaller thing), with two settings, when adding them to the hook, I changed the wording.  Core airflow setting `verify_ssl` is True by default.  When adding this to the hook, I add it as `disable_verify_ssl`.  And the reason for this is, `False` seems like a safer default value.  So the default would be `disable_verify_ssl=False`.  E.g. if you did `if extra.get('disable_verify_ssl'): disable` that is safe when the key is not there.  But if you do `if not extra.get('verify_ssl'): disable` well this will disable SSL when the value is not there.  To make this work you'd have to do `if extra.get('verify_ssl') is False`.  The other thing


