### PR TITLE
Generate version documentation from single source of truth

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -357,6 +357,13 @@ repos:
         files: ^Dockerfile$
         pass_filenames: false
         additional_dependencies: ['rich']
+      - id: update-supported-versions
+        name: Updates supported versions in documentation
+        entry: ./scripts/ci/pre_commit/supported_versions.py
+        language: python
+        files: ^scripts/ci/pre_commit/supported_versions.py$|^README.md$|^docs/apache-airflow/supported-versions.rst$
+        pass_filenames: false
+        additional_dependencies: ['tabulate']
       - id: update-version
         name: Update version to the latest version in the documentation
         entry: ./scripts/ci/pre_commit/pre_commit_update_versions.py

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2209,8 +2209,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  pyupgrade restrict-start_date rst-backticks setup-order setup-extra-packages
                  shellcheck sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace
                  ui-lint update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 update-versions vendor-k8s-json-schema verify-db-migrations-documented version-sync
-                 www-lint yamllint yesqa
+                 update-supported-versions update-versions vendor-k8s-json-schema
+                 verify-db-migrations-documented version-sync www-lint yamllint yesqa
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/README.md
+++ b/README.md
@@ -261,13 +261,18 @@ packages:
 
 Apache Airflow version life cycle:
 
-| Version | Current Patch/Minor | State     | First Release | Limited Support | EOL/Terminated |
-|---------|---------------------|-----------|---------------|-----------------|----------------|
-| 2       | 2.2.3               | Supported | Dec 17, 2020  | TBD             | TBD            |
-| 1.10    | 1.10.15             | EOL       | Aug 27, 2018  | Dec 17, 2020    | June 17, 2021  |
-| 1.9     | 1.9.0               | EOL       | Jan 03, 2018  | Aug 27, 2018    | Aug 27, 2018   |
-| 1.8     | 1.8.2               | EOL       | Mar 19, 2017  | Jan 03, 2018    | Jan 03, 2018   |
-| 1.7     | 1.7.1.2             | EOL       | Mar 28, 2016  | Mar 19, 2017    | Mar 19, 2017   |
+<!-- This table is automatically updated by pre-commit scripts/ci/pre-commit/supported_versions.py -->
+<!-- Beginning of auto-generated table -->
+
+| Version   | Current Patch/Minor   | State     | First Release   | Limited Support   | EOL/Terminated   |
+|-----------|-----------------------|-----------|-----------------|-------------------|------------------|
+| 2         | 2.2.3                 | Supported | Dec 17, 2020    | TBD               | TBD              |
+| 1.10      | 1.10.15               | EOL       | Aug 27, 2018    | Dec 17, 2020      | June 17, 2021    |
+| 1.9       | 1.9.0                 | EOL       | Jan 03, 2018    | Aug 27, 2018      | Aug 27, 2018     |
+| 1.8       | 1.8.2                 | EOL       | Mar 19, 2017    | Jan 03, 2018      | Jan 03, 2018     |
+| 1.7       | 1.7.1.2               | EOL       | Mar 28, 2016    | Mar 19, 2017      | Mar 19, 2017     |
+
+<!-- End of auto-generated table -->
 
 Limited support versions will be supported with security and critical bug fix only.
 EOL versions will not get any fixes nor support.

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -278,6 +278,8 @@ require Breeze Docker images to be installed locally.
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``update-setup-cfg-file``              Update setup.cfg file with all licenses
 ------------------------------------ ---------------------------------------------------------------- ------------
+``update-supported-versions``          Updates supported versions in documentation
+------------------------------------ ---------------------------------------------------------------- ------------
 ``update-versions``                    Updates latest versions in the documentation
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``vendor-k8s-json-schema``             Vendor k8s schema definitions in the helm chart schema file

--- a/breeze-complete
+++ b/breeze-complete
@@ -151,6 +151,7 @@ update-breeze-file
 update-extras
 update-local-yml-file
 update-setup-cfg-file
+update-supported-versions
 update-versions
 vendor-k8s-json-schema
 verify-db-migrations-documented

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -957,6 +957,7 @@ EOF
 
 This includes:
 
+- Modify `./scripts/ci/pre-commit/supported_versions.py` and let pre-commit do the job
 - Sync `CHANGELOG.txt`, `UPDATING.md` and `README.md` changes
 - Updating issue templates in `.github/ISSUE_TEMPLATE/` with the new version
 

--- a/docs/apache-airflow/installation/supported-versions.rst
+++ b/docs/apache-airflow/installation/supported-versions.rst
@@ -23,19 +23,21 @@ Version Life Cycle
 
 Apache Airflow version life cycle:
 
-+---------+-----------------+---------------+-----------------+----------------+
-| Version | State           | First Release | Limited Support | EOL/Terminated |
-+---------+-----------------+---------------+-----------------+----------------+
-| 2       | Supported       | Dec 17, 2020  | TBD             | TBD            |
-+---------+-----------------+---------------+-----------------+----------------+
-| 1.10    | EOL             | Aug 27, 2018  | Dec 17, 2020    | June 2021      |
-+---------+-----------------+---------------+-----------------+----------------+
-| 1.9     | EOL             | Jan 03, 2018  | Aug 27, 2018    | Aug 2018       |
-+---------+-----------------+---------------+-----------------+----------------+
-| 1.8     | EOL             | Mar 19, 2017  | Jan 03, 2018    | Jan 2018       |
-+---------+-----------------+---------------+-----------------+----------------+
-| 1.7     | EOL             | Mar 28, 2016  | Mar 19, 2017    | Mar 2017       |
-+---------+-----------------+---------------+-----------------+----------------+
+ .. This table is automatically updated by pre-commit scripts/ci/pre-commit/supported_versions.py
+ .. Beginning of auto-generated table
+
+=========  =====================  =========  ===============  =================  ================
+Version    Current Patch/Minor    State      First Release    Limited Support    EOL/Terminated
+=========  =====================  =========  ===============  =================  ================
+2          2.2.3                  Supported  Dec 17, 2020     TBD                TBD
+1.10       1.10.15                EOL        Aug 27, 2018     Dec 17, 2020       June 17, 2021
+1.9        1.9.0                  EOL        Jan 03, 2018     Aug 27, 2018       Aug 27, 2018
+1.8        1.8.2                  EOL        Mar 19, 2017     Jan 03, 2018       Jan 03, 2018
+1.7        1.7.1.2                EOL        Mar 28, 2016     Mar 19, 2017       Mar 19, 2017
+=========  =====================  =========  ===============  =================  ================
+
+ .. End of auto-generated table
+
 
 Limited support versions will be supported with security and critical bug fix only.
 EOL versions will not get any fixes nor support.

--- a/scripts/ci/pre_commit/supported_versions.py
+++ b/scripts/ci/pre_commit/supported_versions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from pathlib import Path
+
+from tabulate import tabulate
+
+AIRFLOW_SOURCES = Path(__file__).resolve().parent.parent.parent.parent
+
+
+HEADERS = ("Version", "Current Patch/Minor", "State", "First Release", "Limited Support", "EOL/Terminated")
+
+SUPPORTED_VERSIONS = (
+    ("2", "2.2.3", "Supported", "Dec 17, 2020", "TBD", "TBD"),
+    ("1.10", "1.10.15", "EOL", "Aug 27, 2018", "Dec 17, 2020", "June 17, 2021"),
+    ("1.9", "1.9.0", "EOL", "Jan 03, 2018", "Aug 27, 2018", "Aug 27, 2018"),
+    ("1.8", "1.8.2", "EOL", "Mar 19, 2017", "Jan 03, 2018", "Jan 03, 2018"),
+    ("1.7", "1.7.1.2", "EOL", "Mar 28, 2016", "Mar 19, 2017", "Mar 19, 2017"),
+)
+
+
+def replace_text_between(file: Path, start: str, end: str, replacement_text: str):
+    original_text = file.read_text()
+    leading_text = original_text.split(start)[0]
+    trailing_text = original_text.split(end)[1]
+    file.write_text(leading_text + start + replacement_text + end + trailing_text)
+
+
+if __name__ == '__main__':
+    replace_text_between(
+        file=AIRFLOW_SOURCES / "README.md",
+        start="<!-- Beginning of auto-generated table -->\n",
+        end="<!-- End of auto-generated table -->\n",
+        replacement_text="\n"
+        + tabulate(
+            SUPPORTED_VERSIONS, tablefmt="github", headers=HEADERS, stralign="left", disable_numparse=True
+        )
+        + "\n\n",
+    )
+    replace_text_between(
+        file=AIRFLOW_SOURCES / "docs" / "apache-airflow" / "installation" / "supported-versions.rst",
+        start=" .. Beginning of auto-generated table\n",
+        end=" .. End of auto-generated table\n",
+        replacement_text="\n"
+        + tabulate(
+            SUPPORTED_VERSIONS, tablefmt="rst", headers=HEADERS, stralign="left", disable_numparse=True
+        )
+        + "\n\n",
+    )


### PR DESCRIPTION
We used to maintain supported versions separately in the docs
and it led to discrepancies. Now we have single source of truth which
is used to generate it automatically with pre-commits

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
