### PR TITLE
helm: add type to extra secrets param

### DIFF
--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -36,6 +36,9 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
+{{- if $secretContent.type }}
+type: {{ $secretContent.type }}
+{{- end }}
 {{- if $secretContent.data }}
 data:
   {{- with $secretContent.data }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -814,6 +814,10 @@
                 "minProperties": 1,
                 "additionalProperties": false,
                 "properties": {
+                    "type": {
+                        "description": "Type **as string** of secret E.G. Opaque, kubernetes.io/dockerconfigjson, etc.",
+                        "type": "string"
+                    },
                     "data": {
                         "description": "Content **as string** for the 'data' item of the secret (can be templated)",
                         "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -264,6 +264,7 @@ extraSecrets: {}
 # eg:
 # extraSecrets:
 #   '{{ .Release.Name }}-airflow-connections':
+#     type: 'Opaque'
 #     data: |
 #       AIRFLOW_CONN_GCP: 'base64_encoded_gcp_conn_string'
 #       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'


### PR DESCRIPTION
Description: allows users to specify the type of secret they are adding when adding extra secrets. Previously we were just defaulting to Opaque.