### PR TITLE
Fix JSON formatting in cassandra example

### DIFF
--- a/docs/apache-airflow-providers-apache-cassandra/connections/cassandra.rst
+++ b/docs/apache-airflow-providers-apache-cassandra/connections/cassandra.rst
@@ -64,11 +64,11 @@ Examples for the **Extra** field
 
 If SSL is enabled in Cassandra, pass in a dict in the extra field as kwargs for ``ssl.wrap_socket()``. For example:
 
-.. code-block:: JSON
+.. code-block:: json
 
     {
-      "ssl_options" : {
-        "ca_certs" : "PATH/TO/CA_CERTS"
+      "ssl_options": {
+        "ca_certs": "PATH/TO/CA_CERTS"
       }
     }
 
@@ -78,7 +78,7 @@ Default load balancing policy is ``RoundRobinPolicy``. Following are a few sampl
 
 DCAwareRoundRobinPolicy:
 
-.. code-block:: JSON
+.. code-block:: json
 
     {
       "load_balancing_policy": "DCAwareRoundRobinPolicy",
@@ -90,7 +90,7 @@ DCAwareRoundRobinPolicy:
 
 WhiteListRoundRobinPolicy:
 
-.. code-block:: JSON
+.. code-block:: json
 
     {
       "load_balancing_policy": "WhiteListRoundRobinPolicy",
@@ -101,7 +101,7 @@ WhiteListRoundRobinPolicy:
 
 TokenAwarePolicy:
 
-.. code-block:: JSON
+.. code-block:: json
 
     {
       "load_balancing_policy": "TokenAwarePolicy",


### PR DESCRIPTION
New Sphinx highlighter does not like spaces in json after ':' and it
fails main builds because of that.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
