### PR TITLE
Fix MyPy issues in ``airflow/jobs``

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -29,8 +29,8 @@ from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
-from airflow.models import DagRun
 from airflow.models.base import ID_LEN, Base
+from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.stats import Stats
 from airflow.utils import timezone


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891
**Before**:
```
root@57b2ac1779ad:/opt/airflow# mypy --namespace-packages airflow/jobs
airflow/jobs/base_job.py:32: error: Name "DagRun" already defined (by an import)
    from airflow.models import DagRun
    ^
airflow/jobs/base_job.py:85: error: Module has no attribute "creating_job_id"
            primaryjoin=id == foreign(DagRun.creating_job_id),
                                      ^
Found 2 errors in 1 file (checked 6 source files)
```

**Now**:
```
root@57b2ac1779ad:/opt/airflow# mypy --namespace-packages airflow/jobs
Success: no issues found in 6 source files
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
