### PR TITLE
Fix MyPy issues in ``airflow/macros``

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -19,11 +19,14 @@ import time  # noqa
 import uuid  # noqa
 from datetime import datetime, timedelta
 from random import random  # noqa
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import dateutil  # noqa
 
 from airflow.macros import hive  # noqa
+
+if TYPE_CHECKING:
+    from pendulum import DateTime
 
 
 def ds_add(ds: str, days: int) -> str:
@@ -66,7 +69,7 @@ def ds_format(ds: str, input_format: str, output_format: str) -> str:
     return datetime.strptime(str(ds), input_format).strftime(output_format)
 
 
-def datetime_diff_for_humans(dt: Any, since: Optional[datetime] = None) -> str:
+def datetime_diff_for_humans(dt: Any, since: Optional[DateTime] = None) -> str:
     """
     Return a human-readable/approximate difference between two datetimes, or
     one and now.
@@ -75,7 +78,7 @@ def datetime_diff_for_humans(dt: Any, since: Optional[datetime] = None) -> str:
     :type dt: datetime.datetime
     :param since: When to display the date from. If ``None`` then the diff is
         between ``dt`` and now.
-    :type since: None or datetime.datetime
+    :type since: None or DateTime
     :rtype: str
     """
     import pendulum

--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -19,14 +19,12 @@ import time  # noqa
 import uuid  # noqa
 from datetime import datetime, timedelta
 from random import random  # noqa
-from typing import TYPE_CHECKING, Any, Optional
+from typing import Any, Optional
 
 import dateutil  # noqa
+from pendulum import DateTime
 
 from airflow.macros import hive  # noqa
-
-if TYPE_CHECKING:
-    from pendulum import DateTime
 
 
 def ds_add(ds: str, days: int) -> str:


### PR DESCRIPTION
Part of #19891

**Before**:
```
root@57b2ac1779ad:/opt/airflow# mypy --namespace-packages airflow/macros
airflow/macros/__init__.py:83: error: Argument 1 to "diff_for_humans" of "DateTime" has incompatible type "Optional[datetime]"; expected "Optional[DateTime]"
        return pendulum.instance(dt).diff_for_humans(since)
                                                     ^
Found 1 error in 1 file (checked 2 source files)
```

**After**:
```
root@57b2ac1779ad:/opt/airflow# mypy --namespace-packages airflow/macros
Success: no issues found in 2 source files
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
