### PR TITLE
Fix elasticsearch secret default port 80 to 9200.

### DIFF
--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -33,6 +33,6 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.elasticsearch.connection }}
-  connection: {{ urlJoin (dict "scheme" (default "http" .scheme) "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery)) "host" (printf "%s:%s" .host ((default 80 .port) | toString) ) ) | b64enc | quote }}
+  connection: {{ urlJoin (dict "scheme" (default "http" .scheme) "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery)) "host" (printf "%s:%s" .host ((default 9200 .port) | toString) ) ) | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -95,7 +95,7 @@ class ElasticsearchSecretTest(unittest.TestCase):
 
         assert (
             "http://username%21%40%23$%25%25%5E&%2A%28%29:password%21%40%23$%25%25%5E&%2A%28%29@"
-            "elastichostname:80" == connection
+            "elastichostname:9200" == connection
         )
 
     def test_should_generate_secret_with_specified_port(self):
@@ -131,4 +131,4 @@ class ElasticsearchSecretTest(unittest.TestCase):
             }
         )
 
-        assert f"{scheme}://username:password@elastichostname:80" == connection
+        assert f"{scheme}://username:password@elastichostname:9200" == connection


### PR DESCRIPTION
Elasticsearch uses rather 9200 than 80 as default.