### PR TITLE
Fix flaky sensor test

### DIFF
--- a/tests/sensors/test_python.py
+++ b/tests/sensors/test_python.py
@@ -103,7 +103,7 @@ class TestPythonSensor(TestPythonBase):
         task = PythonSensor(
             task_id='python_sensor',
             timeout=0.01,
-            poke_interval=0.3,
+            poke_interval=0.01,
             # a Mock instance cannot be used as a callable function or test fails with a
             # TypeError: Object of type Mock is not JSON serializable
             python_callable=build_recording_function(recorded_calls),
@@ -126,7 +126,9 @@ class TestPythonSensor(TestPythonBase):
             task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
         # 2 calls: first: at start, second: before timeout
-        assert 2 == len(recorded_calls)
+        # But sometimes 1 is also OK if the system is "busy" - we anyhow only check the first one which
+        # will always be there
+        assert len(recorded_calls) >= 1
         self._assert_calls_equal(
             recorded_calls[0],
             Call(


### PR DESCRIPTION
The test on a busy system could be flaky - the second call
could have not fired.

But this is perfectly ok as we only check the first call which will
always happen.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
