### PR TITLE
Fix flaky dask executor test

### DIFF
--- a/tests/executors/.gitignore
+++ b/tests/executors/.gitignore
@@ -1,0 +1,1 @@
+/dask-worker-space/*.lock

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -46,7 +46,7 @@ FAIL_COMMAND = ['airflow', 'tasks', 'run', 'false']
 
 
 class TestBaseDask(unittest.TestCase):
-    def assert_tasks_on_executor(self, executor):
+    def assert_tasks_on_executor(self, executor, timeout_executor=120):
 
         # start the executor
         executor.start()
@@ -58,7 +58,7 @@ class TestBaseDask(unittest.TestCase):
         fail_future = next(k for k, v in executor.futures.items() if v == 'fail')
 
         # wait for the futures to execute, with a timeout
-        timeout = timezone.utcnow() + timedelta(seconds=30)
+        timeout = timezone.utcnow() + timedelta(seconds=timeout_executor)
         while not (success_future.done() and fail_future.done()):
             if timezone.utcnow() > timeout:
                 raise ValueError(
@@ -82,7 +82,7 @@ class TestDaskExecutor(TestBaseDask):
 
     def test_dask_executor_functions(self):
         executor = DaskExecutor(cluster_address=self.cluster.scheduler_address)
-        self.assert_tasks_on_executor(executor)
+        self.assert_tasks_on_executor(executor, timeout_executor=120)
 
     def test_backfill_integration(self):
         """
@@ -127,7 +127,7 @@ class TestDaskExecutorTLS(TestBaseDask):
 
             executor = DaskExecutor(cluster_address=cluster['address'])
 
-            self.assert_tasks_on_executor(executor)
+            self.assert_tasks_on_executor(executor, timeout_executor=120)
 
             executor.end()
             # close the executor, the cluster context manager expects all listeners


### PR DESCRIPTION
The dask_executor test was failing occasionally on busy systems
and seems that it was caused by being throttled by other tests.

The 30 seconds timeout in the test seems to be too short. Changed
it to 120 seconds by default (it's just a timeout so it does
not really impact speed of execution of the tests but it gives
the test extra time to complete in case it is throttled.

Timeout was added to assert method so that we can control it
individually in different tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
