### PR TITLE
Fix empty excludes in selective checks

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -125,8 +125,10 @@ function output_all_basic_variables() {
     initialization::ga_output default-helm-version "${HELM_VERSION}"
 
     if [[ ${FULL_TESTS_NEEDED_LABEL} == "true" ]]; then
-        initialization::ga_output mysql-exclude '[{ "python-version": "3.7" }, { "python-version": "3.9" }]'
-        initialization::ga_output sqlite-exclude '[{ "python-version": "3.7" }, { "python-version": "3.8" }]'
+        initialization::ga_output postgres-exclude '[{ "python-version": "3.7" }]'
+        initialization::ga_output mssql-exclude '[{ "python-version": "3.8" }]'
+        initialization::ga_output mysql-exclude '[]'
+        initialization::ga_output sqlite-exclude '[{ "python-version": "3.9" }]'
     else
         initialization::ga_output postgres-exclude '[]'
         initialization::ga_output mysql-exclude '[]'


### PR DESCRIPTION
After removing Python 3.6, some of the excludes have been
empty - which caused error when evaluating combinations to run
im main or when FULL_TESTS were needed.

This PR brings sane excludes

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
