### PR TITLE
Docs: Changed macros to correct classes and modules

### DIFF
--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -166,9 +166,9 @@ Variable                            Description
 ``macros.datetime``                 The standard lib's :class:`datetime.datetime`
 ``macros.timedelta``                The standard lib's :class:`datetime.timedelta`
 ``macros.dateutil``                 A reference to the ``dateutil`` package
-``macros.time``                     The standard lib's :class:`datetime.time`
+``macros.time``                     The standard lib's :mod:`time`
 ``macros.uuid``                     The standard lib's :mod:`uuid`
-``macros.random``                   The standard lib's :mod:`random`
+``macros.random``                   The standard lib's :class:`random.random`
 =================================   ==============================================
 
 Some airflow specific macros are also defined:


### PR DESCRIPTION
closes: #20545 
Fixed docs for time and random macros as the reference to what they were was incorrect.
