### PR TITLE
Fix incorrect arguments in airflow-license

### DIFF
--- a/dev/airflow-license
+++ b/dev/airflow-license
@@ -55,7 +55,7 @@ def parse_license_file(project_name):
     path = f"../licenses/LICENSE-{name}.txt"
     if os.path.exists(path):
         data = " ".join(line.strip() for line in open(path)).lower()
-        data = data.translate(None, string.punctuation)
+        data = data.translate(string.punctuation)
         for k in _licenses:
             matches = 0
             for v in _licenses[k]:


### PR DESCRIPTION
The function `str.translate()` in `dev/airflow-license` should only be given one argument, otherwise it raises `TypeError: translate() takes exactly one argument (2 given)`.