### PR TITLE
Clarify `sentry_on` value is not quoted with example

### DIFF
--- a/docs/apache-airflow/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/logging-monitoring/errors.rst
@@ -29,9 +29,9 @@ First you must install sentry requirement:
 
    pip install 'apache-airflow[sentry]'
 
-After that, you need to enable the integration by set ``sentry_on`` option in ``[sentry]`` section to ``'True'``.
+After that, you need to enable the integration by set ``sentry_on`` option in ``[sentry]`` section to ``True``.
 
-Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` in ``[sentry]`` section. Its template resembles the following: ``'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'``
+Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` in ``[sentry]`` section. Its template resembles the following: ``{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}``
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/logging-monitoring/errors.rst
@@ -29,13 +29,14 @@ First you must install sentry requirement:
 
    pip install 'apache-airflow[sentry]'
 
-After that, you need to enable the integration by set ``sentry_on`` option in ``[sentry]`` section to ``"True"``.
+After that, you need to enable the integration by set ``sentry_on`` option in ``[sentry]`` section to ``'True'``.
 
 Add your ``SENTRY_DSN`` to your configuration file e.g. ``airflow.cfg`` in ``[sentry]`` section. Its template resembles the following: ``'{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}'``
 
 .. code-block:: ini
 
     [sentry]
+    sentry_on = True
     sentry_dsn = http://foo@sentry.io/123
 
 .. note::


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Clarify the value for `sentry_on` is not quoted by providing an example.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
