### PR TITLE
Fix precedence of affinity, nodeSelector, and tolerations

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -50,6 +50,18 @@ The default Airflow image that is used with the Chart is now ``2.2.3``, previous
 
 The old parameter names will continue to work, however support for them will be removed in a future release so please update your values file.
 
+Fixed precedence of ``nodeSelector``, ``affinity`` and ``tolerations`` params
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``nodeSelector``, ``affinity`` and ``tolerations`` params precedence has been fixed on all components. Now component-specific params
+(e.g. ``webserver.affinity``) takes precedence over the global param (e.g. ``affinity``).
+
+Default ``KubernetesExecutor`` worker affinity removed
+""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Previously a default affinity was added to ``KubernetesExecutor`` workers to spread the workers out across nodes. This default affinity is no
+longer set as, in general, there is no reason to spread task-specific workers across nodes.
+
 Changes in webserver and flower ``NetworkPolicy`` default ports
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -60,7 +60,7 @@ Default ``KubernetesExecutor`` worker affinity removed
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Previously a default affinity was added to ``KubernetesExecutor`` workers to spread the workers out across nodes. This default affinity is no
-longer set as, in general, there is no reason to spread task-specific workers across nodes.
+longer set because, in general, there is no reason to spread task-specific workers across nodes.
 
 Changes in webserver and flower ``NetworkPolicy`` default ports
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-{{- $nodeSelector := or .Values.nodeSelector .Values.workers.nodeSelector }}
-{{- $affinity := or .Values.affinity .Values.workers.affinity }}
-{{- $tolerations := or .Values.tolerations .Values.workers.tolerations }}
+{{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.workers.affinity .Values.affinity }}
+{{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
 {{- $securityContext := include "airflowSecurityContext" (list . .Values.workers) }}
 apiVersion: v1
 kind: Pod

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -98,12 +98,12 @@ spec:
 {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    component: scheduler
-                topologyKey: "kubernetes.io/hostname"
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 100
 {{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -93,9 +93,9 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
-{{ if $affinity }}
+{{- if $affinity }}
 {{ toYaml $affinity | indent 8 }}
-{{ else }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -104,7 +104,7 @@ spec:
                   matchLabels:
                     component: scheduler
                 topologyKey: "kubernetes.io/hostname"
-{{ end }}
+{{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
       restartPolicy: Always

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -93,7 +93,18 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
+{{ if $affinity }}
 {{ toYaml $affinity | indent 8 }}
+{{ else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    component: scheduler
+                topologyKey: "kubernetes.io/hostname"
+{{ end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
       restartPolicy: Always

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -76,9 +76,9 @@ spec:
       nodeSelector:
         {{- toYaml $nodeSelector | nindent 8 }}
       affinity:
-      {{ if $affinity }}
+      {{- if $affinity }}
         {{- toYaml $affinity | nindent 8 }}
-      {{ else }}
+      {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -87,7 +87,7 @@ spec:
                   matchLabels:
                     component: triggerer
                 topologyKey: "kubernetes.io/hostname"
-      {{ end }}
+      {{- end }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.triggerer.terminationGracePeriodSeconds }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -81,12 +81,12 @@ spec:
       {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    component: triggerer
-                topologyKey: "kubernetes.io/hostname"
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: triggerer
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       {{- end }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -20,9 +20,9 @@
 #################################
 {{- if semverCompare ">=2.2.0" .Values.airflowVersion }}
 {{- if .Values.triggerer.enabled }}
-{{- $nodeSelector := or .Values.nodeSelector .Values.triggerer.nodeSelector }}
-{{- $affinity := or .Values.affinity .Values.triggerer.affinity }}
-{{- $tolerations := or .Values.tolerations .Values.triggerer.tolerations }}
+{{- $nodeSelector := or .Values.triggerer.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.triggerer.affinity .Values.affinity }}
+{{- $tolerations := or .Values.triggerer.tolerations .Values.tolerations }}
 {{- $securityContext := include "airflowSecurityContext" (list . .Values.triggerer) }}
 kind: Deployment
 apiVersion: apps/v1
@@ -76,7 +76,18 @@ spec:
       nodeSelector:
         {{- toYaml $nodeSelector | nindent 8 }}
       affinity:
+      {{ if $affinity }}
         {{- toYaml $affinity | nindent 8 }}
+      {{ else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    component: triggerer
+                topologyKey: "kubernetes.io/hostname"
+      {{ end }}
       tolerations:
         {{- toYaml $tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.triggerer.terminationGracePeriodSeconds }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -95,12 +95,12 @@ spec:
 {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    component: webserver
-                topologyKey: "kubernetes.io/hostname"
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: webserver
+              topologyKey: kubernetes.io/hostname
+            weight: 100
 {{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -90,7 +90,18 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
+{{ if $affinity }}
 {{ toYaml $affinity | indent 8 }}
+{{ else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    component: webserver
+                topologyKey: "kubernetes.io/hostname"
+{{ end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
       restartPolicy: Always

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -90,9 +90,9 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
-{{ if $affinity }}
+{{- if $affinity }}
 {{ toYaml $affinity | indent 8 }}
-{{ else }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -101,7 +101,7 @@ spec:
                   matchLabels:
                     component: webserver
                 topologyKey: "kubernetes.io/hostname"
-{{ end }}
+{{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
       restartPolicy: Always

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -86,9 +86,9 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
-{{ if $affinity }}
+{{- if $affinity }}
 {{ toYaml $affinity | indent 8 }}
-{{ else }}
+{{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: 100
@@ -97,7 +97,7 @@ spec:
                   matchLabels:
                     component: worker
                 topologyKey: "kubernetes.io/hostname"
-{{ end }}
+{{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
 {{- if .Values.workers.hostAliases }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -91,12 +91,12 @@ spec:
 {{- else }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    component: worker
-                topologyKey: "kubernetes.io/hostname"
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  component: worker
+              topologyKey: kubernetes.io/hostname
+            weight: 100
 {{- end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -20,9 +20,9 @@
 #################################
 {{- $persistence := .Values.workers.persistence.enabled }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-{{- $nodeSelector := or .Values.nodeSelector .Values.workers.nodeSelector }}
-{{- $affinity := or .Values.affinity .Values.workers.affinity }}
-{{- $tolerations := or .Values.tolerations .Values.workers.tolerations }}
+{{- $nodeSelector := or .Values.workers.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.workers.affinity .Values.affinity }}
+{{- $tolerations := or .Values.workers.tolerations .Values.tolerations }}
 {{- $securityContext := include "airflowSecurityContext" (list . .Values.workers) }}
 kind: {{ if $persistence }}StatefulSet{{ else }}Deployment{{ end }}
 apiVersion: apps/v1
@@ -86,7 +86,18 @@ spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}
       affinity:
+{{ if $affinity }}
 {{ toYaml $affinity | indent 8 }}
+{{ else }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    component: worker
+                topologyKey: "kubernetes.io/hostname"
+{{ end }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
 {{- if .Values.workers.hostAliases }}

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -147,22 +147,23 @@ class SchedulerTest(unittest.TestCase):
 
     def test_affinity_tolerations_and_node_selector_precedence(self):
         """When given both global and scheduler affinity etc, scheduler affinity etc is used"""
+        expected_affinity = {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {"key": "foo", "operator": "In", "values": ["true"]},
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
         docs = render_chart(
             values={
                 "scheduler": {
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": [
-                                            {"key": "foo", "operator": "In", "values": ["true"]},
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
+                    "affinity": expected_affinity,
                     "tolerations": [
                         {"key": "dynamic-pods", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
                     ],
@@ -170,15 +171,16 @@ class SchedulerTest(unittest.TestCase):
                 },
                 "affinity": {
                     "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "weight": 1,
+                                "preference": {
                                     "matchExpressions": [
                                         {"key": "not-me", "operator": "In", "values": ["true"]},
                                     ]
-                                }
-                            ]
-                        }
+                                },
+                            }
+                        ]
                     }
                 },
                 "tolerations": [
@@ -189,22 +191,14 @@ class SchedulerTest(unittest.TestCase):
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
 
-        assert "foo" == jmespath.search(
-            "spec.template.spec.affinity.nodeAffinity."
-            "requiredDuringSchedulingIgnoredDuringExecution."
-            "nodeSelectorTerms[0]."
-            "matchExpressions[0]."
-            "key",
-            docs[0],
-        )
+        assert expected_affinity == jmespath.search("spec.template.spec.affinity", docs[0])
         assert "ssd" == jmespath.search(
             "spec.template.spec.nodeSelector.type",
             docs[0],
         )
-        assert "dynamic-pods" == jmespath.search(
-            "spec.template.spec.tolerations[0].key",
-            docs[0],
-        )
+        tolerations = jmespath.search("spec.template.spec.tolerations", docs[0])
+        assert 1 == len(tolerations)
+        assert "dynamic-pods" == tolerations[0]["key"]
 
     def test_should_create_default_affinity(self):
         docs = render_chart(show_only=["templates/scheduler/scheduler-deployment.yaml"])

--- a/chart/tests/test_triggerer.py
+++ b/chart/tests/test_triggerer.py
@@ -145,6 +145,67 @@ class TriggererTest(unittest.TestCase):
             docs[0],
         )
 
+    def test_affinity_tolerations_and_node_selector_precedence(self):
+        """When given both global and triggerer affinity etc, triggerer affinity etc is used"""
+        docs = render_chart(
+            values={
+                "triggerer": {
+                    "affinity": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {"key": "foo", "operator": "In", "values": ["true"]},
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tolerations": [
+                        {"key": "dynamic-pods", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
+                    ],
+                    "nodeSelector": {"type": "ssd"},
+                },
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchExpressions": [
+                                        {"key": "not-me", "operator": "In", "values": ["true"]},
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tolerations": [
+                    {"key": "not-me", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
+                ],
+                "nodeSelector": {"type": "not-me"},
+            },
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert "foo" == jmespath.search(
+            "spec.template.spec.affinity.nodeAffinity."
+            "requiredDuringSchedulingIgnoredDuringExecution."
+            "nodeSelectorTerms[0]."
+            "matchExpressions[0]."
+            "key",
+            docs[0],
+        )
+        assert "ssd" == jmespath.search(
+            "spec.template.spec.nodeSelector.type",
+            docs[0],
+        )
+        assert "dynamic-pods" == jmespath.search(
+            "spec.template.spec.tolerations[0].key",
+            docs[0],
+        )
+
     def test_should_create_default_affinity(self):
         docs = render_chart(show_only=["templates/scheduler/scheduler-deployment.yaml"])
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -518,12 +518,12 @@ workers:
   # default worker affinity is:
   #  podAntiAffinity:
   #    preferredDuringSchedulingIgnoredDuringExecution:
-  #      - weight: 100
-  #        podAffinityTerm:
-  #          labelSelector:
-  #            matchLabels:
-  #              component: worker
-  #          topologyKey: "kubernetes.io/hostname"
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: worker
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
   tolerations: []
   # hostAliases to use in worker pods.
   # See:
@@ -630,12 +630,12 @@ scheduler:
   # default scheduler affinity is:
   #  podAntiAffinity:
   #    preferredDuringSchedulingIgnoredDuringExecution:
-  #      - weight: 100
-  #        podAffinityTerm:
-  #          labelSelector:
-  #            matchLabels:
-  #              component: scheduler
-  #          topologyKey: "kubernetes.io/hostname"
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: scheduler
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
   tolerations: []
 
   podAnnotations: {}
@@ -870,12 +870,12 @@ webserver:
   # default webserver affinity is:
   #  podAntiAffinity:
   #    preferredDuringSchedulingIgnoredDuringExecution:
-  #      - weight: 100
-  #        podAffinityTerm:
-  #          labelSelector:
-  #            matchLabels:
-  #              component: webserver
-  #          topologyKey: "kubernetes.io/hostname"
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: webserver
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
   tolerations: []
 
   podAnnotations: {}
@@ -952,12 +952,12 @@ triggerer:
   # default triggerer affinity is:
   #  podAntiAffinity:
   #    preferredDuringSchedulingIgnoredDuringExecution:
-  #      - weight: 100
-  #        podAffinityTerm:
-  #          labelSelector:
-  #            matchLabels:
-  #              component: triggerer
-  #          topologyKey: "kubernetes.io/hostname"
+  #    - podAffinityTerm:
+  #        labelSelector:
+  #          matchLabels:
+  #            component: triggerer
+  #        topologyKey: kubernetes.io/hostname
+  #      weight: 100
   tolerations: []
 
   podAnnotations: {}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -514,15 +514,16 @@ workers:
 
   # Select certain nodes for airflow worker pods.
   nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                component: worker
-            topologyKey: "kubernetes.io/hostname"
+  affinity: {}
+  # default worker affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 100
+  #        podAffinityTerm:
+  #          labelSelector:
+  #            matchLabels:
+  #              component: worker
+  #          topologyKey: "kubernetes.io/hostname"
   tolerations: []
   # hostAliases to use in worker pods.
   # See:
@@ -625,15 +626,16 @@ scheduler:
 
   # Select certain nodes for airflow scheduler pods.
   nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                component: scheduler
-            topologyKey: "kubernetes.io/hostname"
+  affinity: {}
+  # default scheduler affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 100
+  #        podAffinityTerm:
+  #          labelSelector:
+  #            matchLabels:
+  #              component: scheduler
+  #          topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
   podAnnotations: {}
@@ -864,15 +866,16 @@ webserver:
 
   # Select certain nodes for airflow webserver pods.
   nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                component: webserver
-            topologyKey: "kubernetes.io/hostname"
+  affinity: {}
+  # default webserver affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 100
+  #        podAffinityTerm:
+  #          labelSelector:
+  #            matchLabels:
+  #              component: webserver
+  #          topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
   podAnnotations: {}
@@ -945,15 +948,16 @@ triggerer:
 
   # Select certain nodes for airflow triggerer pods.
   nodeSelector: {}
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchLabels:
-                component: triggerer
-            topologyKey: "kubernetes.io/hostname"
+  affinity: {}
+  # default triggerer affinity is:
+  #  podAntiAffinity:
+  #    preferredDuringSchedulingIgnoredDuringExecution:
+  #      - weight: 100
+  #        podAffinityTerm:
+  #          labelSelector:
+  #            matchLabels:
+  #              component: triggerer
+  #          topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
   podAnnotations: {}

--- a/docs/helm-chart/customizing-workers.rst
+++ b/docs/helm-chart/customizing-workers.rst
@@ -32,6 +32,9 @@ For example, to set resources on workers:
 
 See :ref:`workers parameters <parameters:workers>` for a complete list.
 
+One notable exception for ``KuberntesExecutor`` is the default anti-affinity applied to ``CeleryExecutor`` workers to spread them across nodes
+is not applied to ``KubernetesExecutor`` workers, as there is no reason to spread out per-task workers.
+
 Custom ``pod_template_file``
 ----------------------------
 


### PR DESCRIPTION
Move the default affinity for components out of the component-level override, so we can have proper precedence of component-level, global, and default for each component.

Closes: #20538