### PR TITLE
Fxing MyPy issues for airflow/dag_processing/processor.py

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -70,6 +70,7 @@ from airflow.models.dagcode import DagCode
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.param import DagParam, ParamsDict
+from airflow.models.slamiss import SlaMiss
 from airflow.models.taskinstance import Context, TaskInstance, TaskInstanceKey, clear_task_instances
 from airflow.security import permissions
 from airflow.stats import Stats
@@ -344,7 +345,9 @@ class DAG(LoggingMixin):
         max_active_tasks: int = conf.getint('core', 'max_active_tasks_per_dag'),
         max_active_runs: int = conf.getint('core', 'max_active_runs_per_dag'),
         dagrun_timeout: Optional[timedelta] = None,
-        sla_miss_callback: Optional[Callable[["DAG", str, str, List[str], List[TaskInstance]], None]] = None,
+        sla_miss_callback: Optional[
+            Callable[["DAG", str, str, List[SlaMiss], List[TaskInstance]], None]
+        ] = None,
         default_view: str = conf.get('webserver', 'dag_default_view').lower(),
         orientation: str = conf.get('webserver', 'dag_orientation'),
         catchup: bool = conf.getboolean('scheduler', 'catchup_by_default'),

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1564,7 +1564,7 @@ class TaskInstance(Base, LoggingMixin):
         except Exception:
             self.log.exception("Failed when executing execute callback")
 
-    def _run_finished_callback(self, error: Optional[Union[str, Exception]] = None) -> None:
+    def _run_finished_callback(self, error: Optional[Union[str, BaseException]] = None) -> None:
         """
         Call callback defined for finished state change.
 
@@ -1764,7 +1764,7 @@ class TaskInstance(Base, LoggingMixin):
     @provide_session
     def handle_failure_with_callback(
         self,
-        error: Union[str, Exception],
+        error: Optional[Union[str, BaseException]] = None,
         test_mode: Optional[bool] = None,
         force_fail: bool = False,
         session=NEW_SESSION,


### PR DESCRIPTION
Part of: https://github.com/apache/airflow/issues/19891

Fixed following issues:
- Ignoring StreamLogWriter as redirect_stdout input as it cant acknowledge type compatibility
- Fetching dags from dag bag directly as opposed to `get` method as it's mandatory value rather than Optional
- Correcting type for a function input for SlaMiss-es
- Use consistency in callback signatures

 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
