### PR TITLE
Clarify variable names and use cleaner set diff syntax

### DIFF
--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -382,8 +382,8 @@ class TriggerRunner(threading.Thread, LoggingMixin):
         # handling.
         current_trigger_ids = set(self.triggers.keys())
         # Work out the two difference sets
-        new_trigger_ids = requested_trigger_ids.difference(current_trigger_ids)
-        old_trigger_ids = current_trigger_ids.difference(requested_trigger_ids)
+        new_trigger_ids = requested_trigger_ids - current_trigger_ids
+        remove_trigger_ids = current_trigger_ids - requested_trigger_ids
         # Bulk-fetch new trigger records
         new_triggers = Trigger.bulk_fetch(new_trigger_ids)
         # Add in new triggers
@@ -400,9 +400,9 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                 self.failed_triggers.append(new_id)
                 continue
             self.to_create.append((new_id, trigger_class(**new_triggers[new_id].kwargs)))
-        # Remove old triggers
-        for old_id in old_trigger_ids:
-            self.to_delete.append(old_id)
+        # Remove unneeded triggers
+        for remove_id in remove_trigger_ids:
+            self.to_delete.append(remove_id)
 
     def get_trigger_by_classpath(self, classpath: str) -> Type[BaseTrigger]:
         """


### PR DESCRIPTION
The word 'old' could suggest 'triggers we already have' i.e. 'current triggers' as compared with the 'requested' triggers, or with  'triggers we need to create' a.k.a. new triggers.  However, here its usage is actually 'triggers we need to remove'.  So, updating the variable to use the word 'remove' instead of 'old' is clearer.

Additionally I take the opportunity to use the `-` operator in place of calling method `difference` -- I think this results in much better readability.
