### PR TITLE
Fix ECSProtocol compat shim inheritance

### DIFF
--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -19,26 +19,12 @@
 
 import warnings
 
-from airflow.providers.amazon.aws.operators.ecs import ECSOperator, ECSProtocol as NewECSProtocol  # noqa
-from airflow.typing_compat import Protocol, runtime_checkable
+from airflow.providers.amazon.aws.operators.ecs import ECSOperator, ECSProtocol
+
+__all__ = ["ECSOperator", "ECSProtocol"]
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.ecs`.",
     DeprecationWarning,
     stacklevel=2,
 )
-
-
-@runtime_checkable
-class ECSProtocol(NewECSProtocol, Protocol):
-    """This class is deprecated. Please use `airflow.providers.amazon.aws.operators.ecs.ECSProtocol`."""
-
-    # A Protocol cannot be instantiated
-
-    def __new__(cls, *args, **kwargs):
-        warnings.warn(
-            """This class is deprecated.
-            Please use `airflow.providers.amazon.aws.operators.ecs.ECSProtocol`.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )


### PR DESCRIPTION
Tests are failing:

```
TypeError: Protocols can only inherit from other protocols, got <class 'airflow.providers.amazon.aws.operators.ecs.ECSProtocol'>
```

This is due to the compatibility shim for `ECSProtocol` is incorrectly double-inheriting `Protocol`. Since #20332 already made both `ECSProtocol` a deprecated class (in favour of `EcsProtocol`), we don’t actually need that subclass now.