### PR TITLE
fix ECSOperator deprecation

### DIFF
--- a/airflow/contrib/operators/ecs_operator.py
+++ b/airflow/contrib/operators/ecs_operator.py
@@ -19,7 +19,7 @@
 
 import warnings
 
-from airflow.providers.amazon.aws.operators.ecs import ECSOperator, ECSProtocol as NewECSProtocol  # noqa
+from airflow.providers.amazon.aws.operators.ecs import EcsOperator, EcsProtocol
 from airflow.typing_compat import Protocol, runtime_checkable
 
 warnings.warn(
@@ -29,16 +29,32 @@ warnings.warn(
 )
 
 
+class ECSOperator(EcsOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.providers.amazon.aws.operators.ecs.EcsOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.providers.amazon.aws.operators.ecs.EcsOperator`.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
 @runtime_checkable
-class ECSProtocol(NewECSProtocol, Protocol):
-    """This class is deprecated. Please use `airflow.providers.amazon.aws.operators.ecs.ECSProtocol`."""
+class ECSProtocol(EcsProtocol, Protocol):
+    """This class is deprecated. Please use `airflow.providers.amazon.aws.operators.ecs.EcsProtocol`."""
 
     # A Protocol cannot be instantiated
 
     def __new__(cls, *args, **kwargs):
         warnings.warn(
             """This class is deprecated.
-            Please use `airflow.providers.amazon.aws.operators.ecs.ECSProtocol`.""",
+            Please use `airflow.providers.amazon.aws.operators.ecs.EcsProtocol`.""",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -545,7 +545,7 @@ class ECSTaskLogFetcher(EcsTaskLogFetcher):
         super().__init__(*args, **kwargs)
 
 
-class ECSProtocol(EcsProtocol):
+class ECSProtocol(EcsProtocol, Protocol):
     """
     This class is deprecated.
     Please use :class:`airflow.providers.amazon.aws.operators.ecs.EcsProtocol`.

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1064,7 +1064,7 @@ OPERATORS = [
         'airflow.contrib.operators.wasb_delete_blob_operator.WasbDeleteBlobOperator',
     ),
     (
-        'airflow.providers.amazon.aws.operators.ecs.ECSOperator',
+        'airflow.providers.amazon.aws.operators.ecs.EcsOperator',
         'airflow.contrib.operators.ecs_operator.ECSOperator',
     ),
     (


### PR DESCRIPTION
related: https://github.com/apache/airflow/pull/20332

fix test failures:
```
  E               TypeError: Protocols can only inherit from other protocols, got <class 'airflow.providers.amazon.aws.operators.ecs.ECSProtocol'>
  
  /usr/local/lib/python3.7/site-packages/typing_extensions.py:1584: TypeError
  _ TestMovingCoreToContrib.test_warning_on_import_256_airflow_providers_amazon_aws_operators_ecs_ECSOperator _

```

and add correct deprecation

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
