### PR TITLE
Remove Python 2 from our images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,9 +341,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# As of August 2021, Debian buster-slim does not include Python2 by default and we need it
-# as we still support running Python2 via PythonVirtualenvOperator
-# TODO: Remove python2 when we stop supporting it
 ARG RUNTIME_APT_DEPS="\
        apt-transport-https \
        apt-utils \
@@ -365,7 +362,6 @@ ARG RUNTIME_APT_DEPS="\
        netcat \
        openssh-client \
        postgresql-client \
-       python2 \
        rsync \
        sasl2-bin \
        sqlite3 \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -90,7 +90,6 @@ RUN mkdir -pv /usr/share/man/man1 \
            locales  \
            netcat \
            nodejs \
-           python2 \
            rsync \
            sasl2-bin \
            sudo \
@@ -123,7 +122,6 @@ ARG RUNTIME_APT_DEPS="\
       krb5-user \
       ldap-utils \
       less \
-      libpython2.7-stdlib \
       lsb-release \
       net-tools \
       openssh-client \

--- a/tests/decorators/test_python_virtualenv.py
+++ b/tests/decorators/test_python_virtualenv.py
@@ -139,27 +139,6 @@ class TestPythonVirtualenvDecorator(TestPythonBase):
         with pytest.raises(CalledProcessError):
             ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-    def test_python_2(self):
-        @task.virtualenv(python_version=2, requirements=['dill'])
-        def f():
-            {}.iteritems()
-
-        with self.dag:
-            ret = f()
-
-        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-    def test_python_2_7(self):
-        @task.virtualenv(python_version='2.7', requirements=['dill'])
-        def f():
-            {}.iteritems()
-            return True
-
-        with self.dag:
-            ret = f()
-
-        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
     def test_python_3(self):
         @task.virtualenv(python_version=3, use_dill=False, requirements=['dill'])
         def f():
@@ -171,26 +150,6 @@ class TestPythonVirtualenvDecorator(TestPythonBase):
             except AttributeError:
                 return
             raise Exception
-
-        with self.dag:
-            ret = f()
-
-        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-    @staticmethod
-    def _invert_python_major_version():
-        if sys.version_info[0] == 2:
-            return 3
-        else:
-            return 2
-
-    def test_string_args(self):
-        @task.virtualenv(python_version=self._invert_python_major_version(), string_args=[1, 2, 1])
-        def f():
-            global virtualenv_string_args
-            print(virtualenv_string_args)
-            if virtualenv_string_args[0] != virtualenv_string_args[2]:
-                raise Exception
 
         with self.dag:
             ret = f()

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -817,19 +817,6 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         with pytest.raises(CalledProcessError):
             self._run_as_operator(f)
 
-    def test_python_2(self):
-        def f():
-            {}.iteritems()
-
-        self._run_as_operator(f, python_version=2, requirements=['dill'])
-
-    def test_python_2_7(self):
-        def f():
-            {}.iteritems()
-            return True
-
-        self._run_as_operator(f, python_version='2.7', requirements=['dill'])
-
     def test_python_3(self):
         def f():
             import sys
@@ -842,25 +829,6 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             raise Exception
 
         self._run_as_operator(f, python_version=3, use_dill=False, requirements=['dill'])
-
-    @staticmethod
-    def _invert_python_major_version():
-        if sys.version_info[0] == 2:
-            return 3
-        else:
-            return 2
-
-    def test_wrong_python_version_with_op_args(self):
-        def f():
-            pass
-
-        version = self._invert_python_major_version()
-
-        with pytest.raises(AirflowException):
-            self._run_as_operator(f, python_version=version, op_args=[1])
-
-        with pytest.raises(AirflowException):
-            self._run_as_operator(f, python_version=version, op_kwargs={"arg": 1})
 
     def test_without_dill(self):
         def f(a):
@@ -875,7 +843,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             if virtualenv_string_args[0] != virtualenv_string_args[2]:
                 raise Exception
 
-        self._run_as_operator(f, python_version=self._invert_python_major_version(), string_args=[1, 2, 1])
+        self._run_as_operator(f, string_args=[1, 2, 1])
 
     def test_with_args(self):
         def f(a, b, c=False, d=False):


### PR DESCRIPTION
As discussed and lazy consensus achieved, we remove Python 2
from Airflow Reference images. This is the last remnant of
end-of-life Python2 which we only support by means of
using PythonVirtualenv operator.

Removal of Python 2 binaries from the image does not mean that
Python 2 will not work, but we are not going to test it from now
on.

Separated out from #20238 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
