### PR TITLE
Ignore standalone_admin_password.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ airflow/www/static/dist
 
 /logs/
 airflow-webserver.pid
+standalone_admin_password.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
The `airflow standalone` command generates a `standalone_admin_password.txt` file with a random password. You don't want this in version control.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
