### PR TITLE
Fix import check for nested providers.

### DIFF
--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -346,7 +346,7 @@ function filename_to_python_module() {
 }
 
 function import_all_provider_classes() {
-    group_start "Import all Airflow classes"
+    group_start "Import all Provider classes"
     # We have to move to a directory where "airflow" is
     unset PYTHONPATH
     # We need to make sure we are not in the airflow checkout, otherwise it will automatically be added to the
@@ -358,9 +358,13 @@ function import_all_provider_classes() {
     PROVIDER_PATHS=$(
         python3 <<EOF 2>/dev/null
 import airflow.providers;
+from pathlib import Path
 path=airflow.providers.__path__
 for p in path._path:
     print(p)
+    for subdir in Path(p).iterdir():
+        if subdir.is_dir() and not (subdir / "provider.yaml").exists():
+            print(subdir)
 EOF
     )
     export PROVIDER_PATHS


### PR DESCRIPTION
We have a check that chekcs that our providers are importable
for Airlfow 2.1, hoewever some providers (nested ones) were missing
from the check. This PR checks one level deeper in providers to see
if there are some nested imports as well.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
