### PR TITLE
fix deprecation messages for SFTPHook

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -121,7 +121,7 @@ class SFTPHook(SSHHook):
                     warnings.warn(
                         'Extra option `ignore_hostkey_verification` is deprecated.'
                         'Please use `no_host_key_check` instead.'
-                        'This option will be removed in future release',
+                        'This option will be removed in a future release.',
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -102,7 +102,7 @@ class SFTPHook(SSHHook):
                 extra_options = conn.extra_dejson
 
                 # For backward compatibility
-                # TODO: remove in next major provider release
+                # TODO: remove in the next major provider release.
 
                 if 'private_key_pass' in extra_options:
                     warnings.warn(

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -102,14 +102,14 @@ class SFTPHook(SSHHook):
                 extra_options = conn.extra_dejson
 
                 # For backward compatibility
-                # TODO: remove in Airflow 2.1
+                # TODO: remove in next major provider release
 
                 if 'private_key_pass' in extra_options:
                     warnings.warn(
                         'Extra option `private_key_pass` is deprecated.'
                         'Please use `private_key_passphrase` instead.'
                         '`private_key_passphrase` will precede if both options are specified.'
-                        'The old option `private_key_pass` will be removed in Airflow 2.1',
+                        'The old option `private_key_pass` will be removed in future release',
                         DeprecationWarning,
                         stacklevel=2,
                     )
@@ -121,7 +121,7 @@ class SFTPHook(SSHHook):
                     warnings.warn(
                         'Extra option `ignore_hostkey_verification` is deprecated.'
                         'Please use `no_host_key_check` instead.'
-                        'This option will be removed in Airflow 2.1',
+                        'This option will be removed in future release',
                         DeprecationWarning,
                         stacklevel=2,
                     )

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -109,7 +109,7 @@ class SFTPHook(SSHHook):
                         'Extra option `private_key_pass` is deprecated.'
                         'Please use `private_key_passphrase` instead.'
                         '`private_key_passphrase` will precede if both options are specified.'
-                        'The old option `private_key_pass` will be removed in future release',
+                        'The old option `private_key_pass` will be removed in a future release.',
                         DeprecationWarning,
                         stacklevel=2,
                     )


### PR DESCRIPTION
deprecation warning of some functions in SFTPHook isn't accurate. Fixing the message

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
