### PR TITLE
Increase default livenessProbe timeout

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -67,6 +67,11 @@ Changes in webserver and flower ``NetworkPolicy`` default ports
 
 The defaults for ``webserver.networkPolicy.ingress.ports`` and ``flower.networkPolicy.ingress.ports`` moved away from using named ports to numerical ports to avoid issues with OpenShift.
 
+Increase default ``livenessProbe`` ``timeoutSeconds`` for scheduler and triggerer
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The default timeout for the scheduler and triggerer ``livenessProbe`` has been increased from 10 seconds to 20 seconds.
+
 Airflow Helm Chart 1.3.0
 ------------------------
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1485,7 +1485,7 @@
                         "timeoutSeconds": {
                             "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
                             "type": "integer",
-                            "default": 10
+                            "default": 20
                         },
                         "failureThreshold": {
                             "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
@@ -1781,7 +1781,7 @@
                         "timeoutSeconds": {
                             "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
                             "type": "integer",
-                            "default": 10
+                            "default": 20
                         },
                         "failureThreshold": {
                             "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -559,7 +559,7 @@ scheduler:
   # scheduler and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 10
-    timeoutSeconds: 10
+    timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
   # Airflow 2.0 allows users to run multiple schedulers,
@@ -901,7 +901,7 @@ triggerer:
   # triggerer and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 10
-    timeoutSeconds: 10
+    timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
 


### PR DESCRIPTION
This increases the default livenessProbe timeout to 20 seconds, giving
more leeway for less powerful or busier instances.

related: #20644, https://github.com/apache/airflow/pull/19003#issuecomment-957728373, https://github.com/apache/airflow/issues/19001#issuecomment-989186841