### PR TITLE
Compare taskgroup and subdag

### DIFF
--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -489,12 +489,6 @@ If you want to see a more advanced use of TaskGroup, you can look at the ``examp
     To disable the prefixing, pass ``prefix_group_id=False`` when creating the TaskGroup, but note that you will now be responsible for ensuring every single task and group has a unique ID of its own.
 
 
-While TaskGroups and SubDAGs are both used to create repeating patterns, depending on your use case, one may be better
-than the other. The SubDagOperator launches a DAG as a separate entity from the original graph. This design pattern
-offers flexibility to create SubDAGs with different schedulers and executors at the cost of greater complexity and
-maintenance burden. TaskGroups creates a UI grouping concept on the same original DAG which simplifies logic and
-maintenance for less flexibility.
-
 .. _concepts:edge-labels:
 
 Edge Labels
@@ -616,7 +610,36 @@ See ``airflow/example_dags`` for a demonstration.
 Note that :doc:`pools` are *not honored* by :class:`~airflow.operators.subdag.SubDagOperator`, and so
 resources could be consumed by SubdagOperators beyond any limits you may have set.
 
-For a comparision of SubDAGs and TaskGroup, see the :ref:`TaskGroup <concepts:taskgroup>` section.
+
+TaskGroups vs SubDAGs
+----------------------
+
+SubDAGs, while serving a similar purpose as TaskGroups, introduces both performance and functional issues due to its implementation.
+
+* The SubDagOperator starts a BackfillJob, which ignores existing parallelism configurations potentially oversubscribing the worker environment.
+* SubDAGs have their own DAG attributes. When the SubDAG DAG attributes are inconsistent with its parent DAG, unexpected behavior can occur.
+* Unable to see the "full" DAG in one view as SubDAGs exists as a full fledged DAG.
+* SubDAGs introduces all sorts of edge cases and caveats. This can disrupt user experience and expectation.
+
+TaskGroups, on the other hand, is a better option given that it is purely a UI grouping concept. All tasks within the TaskGroup still behave as any other tasks outside of the TaskGroup.
+
+You can see the core differences between these two constructs.
+
++--------------------------------------------------------+--------------------------------------------------------+
+| TaskGroup                                              | SubDAG                                                 |
++========================================================+========================================================+
+| Repeating patterns as part of the same DAG             |  Repeating patterns as a separate DAG                  |
++--------------------------------------------------------+--------------------------------------------------------+
+| One set of views and statistics for the DAG            |  Separate set of views and statistics between parent   |
+|                                                        |  and child DAGs                                        |
++--------------------------------------------------------+--------------------------------------------------------+
+| One set of DAG configuration                           |  Several sets of DAG configurations                    |
++--------------------------------------------------------+--------------------------------------------------------+
+| Honours parallelism configurations through existing    |  Does not honour parallelism configurations due to     |
+| SchedulerJob                                           |  newly spawned BackfillJob                             |
++--------------------------------------------------------+--------------------------------------------------------+
+| Simple construct declaration with context manager      |  Complex DAG factory with naming restrictions          |
++--------------------------------------------------------+--------------------------------------------------------+
 
 
 Packaging DAGs

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -582,14 +582,12 @@ Note that SubDAG operators should contain a factory method that returns a DAG ob
     :start-after: [START subdag]
     :end-before: [END subdag]
 
-
 This SubDAG can then be referenced in your main DAG file:
 
 .. exampleinclude:: /../../airflow/example_dags/example_subdag_operator.py
     :language: python
     :start-after: [START example_subdag_operator]
     :end-before: [END example_subdag_operator]
-
 
 You can zoom into a :class:`~airflow.operators.subdag.SubDagOperator` from the graph view of the main DAG to show the tasks contained within the SubDAG:
 
@@ -607,8 +605,11 @@ Some other tips when using SubDAGs:
 
 See ``airflow/example_dags`` for a demonstration.
 
-Note that :doc:`pools` are *not honored* by :class:`~airflow.operators.subdag.SubDagOperator`, and so
-resources could be consumed by SubdagOperators beyond any limits you may have set.
+
+.. note::
+
+    Parallelism is *not honored* by :class:`~airflow.operators.subdag.SubDagOperator`, and so resources could be consumed by SubdagOperators beyond any limits you may have set.
+
 
 
 TaskGroups vs SubDAGs
@@ -640,6 +641,11 @@ You can see the core differences between these two constructs.
 +--------------------------------------------------------+--------------------------------------------------------+
 | Simple construct declaration with context manager      |  Complex DAG factory with naming restrictions          |
 +--------------------------------------------------------+--------------------------------------------------------+
+
+.. note::
+
+    SubDAG is deprecated hence TaskGroup is always the preferred choice.
+
 
 
 Packaging DAGs

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -635,7 +635,7 @@ You can see the core differences between these two constructs.
 +--------------------------------------------------------+--------------------------------------------------------+
 | One set of DAG configuration                           |  Several sets of DAG configurations                    |
 +--------------------------------------------------------+--------------------------------------------------------+
-| Honours parallelism configurations through existing    |  Does not honour parallelism configurations due to     |
+| Honors parallelism configurations through existing    |  Does not honor parallelism configurations due to       |
 | SchedulerJob                                           |  newly spawned BackfillJob                             |
 +--------------------------------------------------------+--------------------------------------------------------+
 | Simple construct declaration with context manager      |  Complex DAG factory with naming restrictions          |

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -489,6 +489,12 @@ If you want to see a more advanced use of TaskGroup, you can look at the ``examp
     To disable the prefixing, pass ``prefix_group_id=False`` when creating the TaskGroup, but note that you will now be responsible for ensuring every single task and group has a unique ID of its own.
 
 
+While TaskGroups and SubDAGs are both used to create repeating patterns, depending on your use case, one may be better
+than the other. The SubDagOperator launches a DAG as a separate entity from the original graph. This design pattern
+offers flexibility to create SubDAGs with different schedulers and executors at the cost of greater complexity and
+maintenance burden. TaskGroups creates a UI grouping concept on the same original DAG which simplifies logic and
+maintenance for less flexibility.
+
 .. _concepts:edge-labels:
 
 Edge Labels
@@ -582,12 +588,14 @@ Note that SubDAG operators should contain a factory method that returns a DAG ob
     :start-after: [START subdag]
     :end-before: [END subdag]
 
+
 This SubDAG can then be referenced in your main DAG file:
 
 .. exampleinclude:: /../../airflow/example_dags/example_subdag_operator.py
     :language: python
     :start-after: [START example_subdag_operator]
     :end-before: [END example_subdag_operator]
+
 
 You can zoom into a :class:`~airflow.operators.subdag.SubDagOperator` from the graph view of the main DAG to show the tasks contained within the SubDAG:
 
@@ -607,6 +615,8 @@ See ``airflow/example_dags`` for a demonstration.
 
 Note that :doc:`pools` are *not honored* by :class:`~airflow.operators.subdag.SubDagOperator`, and so
 resources could be consumed by SubdagOperators beyond any limits you may have set.
+
+For a comparision of SubDAGs and TaskGroup, see the :ref:`TaskGroup <concepts:taskgroup>` section.
 
 
 Packaging DAGs

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -635,7 +635,7 @@ You can see the core differences between these two constructs.
 +--------------------------------------------------------+--------------------------------------------------------+
 | One set of DAG configuration                           |  Several sets of DAG configurations                    |
 +--------------------------------------------------------+--------------------------------------------------------+
-| Honors parallelism configurations through existing    |  Does not honor parallelism configurations due to       |
+| Honors parallelism configurations through existing     |  Does not honor parallelism configurations due to      |
 | SchedulerJob                                           |  newly spawned BackfillJob                             |
 +--------------------------------------------------------+--------------------------------------------------------+
 | Simple construct declaration with context manager      |  Complex DAG factory with naming restrictions          |


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #12298
related: #12741

Pullling from the following resources:
* [TaskGroup AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-34+TaskGroup%3A+A+UI+task+grouping+concept+as+an+alternative+to+SubDagOperator)
* [Astronomer Guide on SubDAGs](https://www.astronomer.io/guides/subdags)
* Previous attempt (#12741) of resolving the issue 

I wrote a section to compare TaskGroup and SubDAGs with a tone that favours TaskGroups.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
