### PR TITLE
Check free space python version for Breeze2

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -230,7 +230,7 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Push CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
@@ -309,7 +309,7 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
         # Pull images built in the previous step

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -227,7 +227,8 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
@@ -305,7 +306,8 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -223,8 +223,13 @@ jobs:
         run: |
           rm -rf "scripts/ci"
           mv "main-airflow/scripts/ci" "scripts"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Push CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
@@ -296,8 +301,13 @@ jobs:
         run: |
           rm -rf "scripts/ci"
           mv "main-airflow/scripts/ci" "scripts"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
         # Pull images built in the previous step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,9 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable .../../dev/breeze/
-      - run: python -m pytest .../../dev/breeze/ -n auto --color=yes
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
+      - run: python -m pytest ./dev/breeze/ -n auto --color=yes
 
   tests-ui:
     timeout-minutes: 10
@@ -327,19 +328,17 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-          cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
-      - name: "Free space"
-        run: freespace
-        if: |
-          needs.build-info.outputs.waitForImage == 'true'
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
+          cache: 'pip'
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
+      - name: "Free space"
+        run: freespace
+        if: |
+          needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
         uses: actions/cache@v2
         with:
@@ -360,19 +359,17 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-          cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
-      - name: "Free space"
-        run: freespace
-        if: |
-          needs.build-info.outputs.waitForImage == 'true'
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
+          cache: 'pip'
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
+      - name: "Free space"
+        run: freespace
+        if: |
+          needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
         uses: actions/cache@v2
         with:
@@ -402,12 +399,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
-        if: needs.build-info.outputs.waitForImage == 'true'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+        if: needs.build-info.outputs.waitForImage == 'true'      
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
         if: |
@@ -452,11 +447,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -567,9 +560,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           submodules: recursive
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -624,11 +618,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -678,11 +670,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -732,11 +722,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -797,11 +785,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -861,11 +847,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -924,11 +908,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*        
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -985,11 +967,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -1043,6 +1023,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+          cache: 'pip'
+          cache-dependency-path: ./dev/breeze/setup*
       - name: "Set issue id for main"
         if: github.ref == 'refs/heads/main'
         run: |
@@ -1055,11 +1037,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: github.ref == 'refs/heads/v1-10-test'
         run: |
           echo "ISSUE_ID=10128" >> $GITHUB_ENV
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-          cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -1153,12 +1131,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-        if: needs.build-info.outputs.waitForImage == 'true'
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+        if: needs.build-info.outputs.waitForImage == 'true'
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
         if: |
@@ -1219,11 +1195,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Get all PROD images"
@@ -1281,11 +1255,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Get all PROD images"
@@ -1354,11 +1326,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: >
@@ -1454,11 +1424,9 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
           cache: 'pip'
-      - run: python -m pip install --editable ../../dev/breeze/
+          cache-dependency-path: ./dev/breeze/setup*
+      - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -367,7 +367,7 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -404,7 +404,7 @@ jobs:
         if: needs.build-info.outputs.waitForImage == 'true'
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -451,7 +451,7 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Get Python version"
@@ -565,7 +565,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Fetch inventory versions"
@@ -622,7 +622,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider documentation"
@@ -674,7 +674,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider packages: sdist"
@@ -726,7 +726,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: Helm"
@@ -789,7 +789,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -851,7 +851,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -912,7 +912,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -971,7 +971,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -1039,7 +1039,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           echo "ISSUE_ID=10128" >> $GITHUB_ENV
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: Quarantined"
@@ -1136,7 +1136,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: needs.build-info.outputs.waitForImage == 'true'
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -1199,7 +1199,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
         env:
@@ -1259,7 +1259,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
         env:
@@ -1330,7 +1330,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: >
           Wait for CI images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
@@ -1428,7 +1428,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
-        run: freespace
+        run: airflow-freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:latest"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare PROD image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,10 +242,6 @@ jobs:
     name: Breeze2 tests
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info]
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./dev/breeze
     steps:
       - uses: actions/checkout@v2
         with:
@@ -254,8 +250,8 @@ jobs:
         with:
           python-version: '3.7'
           cache: 'pip'
-      - run: pip install -e .
-      - run: python3 -m pytest -n auto --color=yes
+      - run: python -m pip install --editable .../../dev/breeze/
+      - run: python -m pytest .../../dev/breeze/ -n auto --color=yes
 
   tests-ui:
     timeout-minutes: 10
@@ -331,8 +327,13 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Setup python"
@@ -359,8 +360,13 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Setup python"
@@ -397,8 +403,13 @@ jobs:
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
         if: needs.build-info.outputs.waitForImage == 'true'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -441,8 +452,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Get Python version"
@@ -549,8 +565,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           persist-credentials: false
           submodules: recursive
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Fetch inventory versions"
@@ -603,8 +624,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider documentation"
@@ -652,8 +678,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider packages: sdist"
@@ -701,8 +732,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: Helm"
@@ -761,8 +797,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -820,8 +861,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -878,8 +924,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -934,8 +985,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -999,8 +1055,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: github.ref == 'refs/heads/v1-10-test'
         run: |
           echo "ISSUE_ID=10128" >> $GITHUB_ENV
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: Quarantined"
@@ -1093,8 +1154,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
         if: needs.build-info.outputs.waitForImage == 'true'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
         if: |
           needs.build-info.outputs.waitForImage == 'true'
       - name: "Cache virtualenv environmnent"
@@ -1153,8 +1219,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
         env:
@@ -1210,8 +1281,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
         env:
@@ -1278,8 +1354,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: >
           Wait for CI images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
@@ -1373,8 +1454,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+          cache: 'pip'
+      - run: python -m pip install --editable ../../dev/breeze/
       - name: "Free space"
-        run: ./scripts/ci/tools/free_space.sh
+        run: freespace
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:latest"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare PROD image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,7 @@ jobs:
           python-version: ${{needs.build-info.outputs.defaultPythonVersion}}
           cache: 'pip'
           cache-dependency-path: ./dev/breeze/setup*
-        if: needs.build-info.outputs.waitForImage == 'true'      
+        if: needs.build-info.outputs.waitForImage == 'true'
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace
@@ -909,7 +909,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
           cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*        
+          cache-dependency-path: ./dev/breeze/setup*
       - run: python -m pip install --editable ./dev/breeze/
       - name: "Free space"
         run: freespace

--- a/dev/breeze/setup.cfg
+++ b/dev/breeze/setup.cfg
@@ -65,7 +65,7 @@ where=src
 [options.entry_points]
 console_scripts=
     Breeze2=airflow_breeze.breeze:main
-    freespace=airflow_ci.freespace:main
+    airflow-freespace=airflow_ci.freespace:main
 
 [bdist_wheel]
 python-tag=py3

--- a/dev/breeze/setup.cfg
+++ b/dev/breeze/setup.cfg
@@ -65,6 +65,7 @@ where=src
 [options.entry_points]
 console_scripts=
     Breeze2=airflow_breeze.breeze:main
+    freespace=airflow_ci.freespace:main
 
 [bdist_wheel]
 python-tag=py3

--- a/dev/breeze/src/airflow_ci/__init__.py
+++ b/dev/breeze/src/airflow_ci/__init__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,22 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# shellcheck source=scripts/ci/libraries/_script_init.sh
-. "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
-
-echo "${COLOR_BLUE}Disable swap${COLOR_RESET}"
-sudo swapoff -a
-sudo rm -f /swapfile
-
-echo "${COLOR_BLUE}Cleaning apt${COLOR_RESET}"
-sudo apt clean || true
-
-echo "${COLOR_BLUE}Pruning docker${COLOR_RESET}"
-docker_v system prune --all --force --volumes
-
-echo "${COLOR_BLUE}Free disk space  ${COLOR_RESET}"
-df -h
-
-# always logout from the docker registry - this is necessary as we can have an expired token from
-# previous job!.
-docker_v logout "ghcr.io"

--- a/dev/breeze/src/airflow_ci/freespace.py
+++ b/dev/breeze/src/airflow_ci/freespace.py
@@ -48,7 +48,7 @@ option_dry_run = click.option(
 def main(verbose, dry_run):
     run_command(["sudo", "swapoff", "-a"], verbose, dry_run)
     run_command(["sudo", "rm", "-f", "/swapfile"], verbose, dry_run)
-    run_command(["sudo", "apt", "clean", "||", "true"], verbose, dry_run)
+    run_command(["sudo", "apt-get", "clean"], verbose, dry_run, check=False)
     run_command(["docker", "system", "prune", "--all", "--force", "--volumes"], verbose, dry_run)
     run_command(["df", "-h"], verbose, dry_run)
     run_command(["docker", "logout", "ghcr.io"], verbose, dry_run)

--- a/dev/breeze/src/airflow_ci/freespace.py
+++ b/dev/breeze/src/airflow_ci/freespace.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""freespace.py for clean environment before start CI"""
+
+import shlex
+import subprocess
+from typing import List
+
+import click
+from rich.console import Console
+
+console = Console(force_terminal=True, color_system="standard", width=180)
+
+option_verbose = click.option(
+    "--verbose",
+    envvar='VERBOSE',
+    is_flag=True,
+    help="Print verbose information about free space steps",
+)
+
+option_dry_run = click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Just prints commands without executing them",
+)
+
+
+@click.command()
+@option_verbose
+@option_dry_run
+def main(verbose, dry_run):
+    run_command(["sudo", "swapoff", "-a"], verbose, dry_run)
+    run_command(["sudo", "rm", "-f", "/swapfile"], verbose, dry_run)
+    run_command(["sudo", "apt", "clean", "||", "true"], verbose, dry_run)
+    run_command(["docker", "system", "prune", "--all", "--force", "--volumes"], verbose, dry_run)
+    run_command(["df", "-h"], verbose, dry_run)
+    run_command(["docker", "logout", "ghcr.io"], verbose, dry_run)
+
+
+def run_command(cmd: List[str], verbose, dry_run, *, check: bool = True, **kwargs):
+    if verbose:
+        console.print(f"\n[green]$ {' '.join(shlex.quote(c) for c in cmd)}[/]\n")
+    if dry_run:
+        return
+    try:
+        subprocess.run(cmd, check=check, **kwargs)
+    except subprocess.CalledProcessError as ex:
+        print("========================= OUTPUT start ============================")
+        print(ex.stderr)
+        print(ex.stdout)
+        print("========================= OUTPUT end ============================")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Regarding this task: https://github.com/apache/airflow/issues/19969
@potiuk realized that **freespace** was doing nothing that printing commands in the console, It was not releasing any space. 

In the way how click was working it was necessary to choose an option to execute **freespace** but, it is not necessary, since we can run just `freespace` on the terminal and start releasing space. Taking as a reference: 
Group Invocation Without Command
https://click.palletsprojects.com/en/5.x/commands/#group-invocation-without-command 
