### PR TITLE
Make native environment Airflow-flavoured like sandbox

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -50,7 +50,6 @@ from typing import (
 import jinja2
 import pendulum
 from dateutil.relativedelta import relativedelta
-from jinja2.nativetypes import NativeEnvironment
 from pendulum.tz.timezone import Timezone
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, func, or_
 from sqlalchemy.orm import backref, joinedload, relationship
@@ -1287,7 +1286,7 @@ class DAG(LoggingMixin):
         if self.jinja_environment_kwargs:
             jinja_env_options.update(self.jinja_environment_kwargs)
         if self.render_template_as_native_obj:
-            env_class: Any = NativeEnvironment
+            env_class = airflow.templates.NativeEnvironment
         else:
             env_class = airflow.templates.SandboxedEnvironment
         env: jinja2.Environment = env_class(**jinja_env_options)

--- a/airflow/templates.py
+++ b/airflow/templates.py
@@ -16,12 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import jinja2.nativetypes
 import jinja2.sandbox
 
 
-class SandboxedEnvironment(jinja2.sandbox.SandboxedEnvironment):
-    """SandboxedEnvironment for Airflow task templates."""
-
+class _AirflowEnvironmentMixin:
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -35,6 +34,14 @@ class SandboxedEnvironment(jinja2.sandbox.SandboxedEnvironment):
         ``_``) whilst still blocking internal or truly private attributes (``__`` prefixed ones).
         """
         return not jinja2.sandbox.is_internal_attribute(obj, attr)
+
+
+class NativeEnvironment(_AirflowEnvironmentMixin, jinja2.nativetypes.NativeEnvironment):
+    """NativeEnvironment for Airflow task templates."""
+
+
+class SandboxedEnvironment(_AirflowEnvironmentMixin, jinja2.sandbox.SandboxedEnvironment):
+    """SandboxedEnvironment for Airflow task templates."""
 
 
 def ds_filter(value):


### PR DESCRIPTION
When `render_template_as_native_obj` is used, the template environment is instantiated from `NativeEnvironment` instead of `SandboxedEnvironment`.

However, unlike the latter, the native environment does not have Airflow-specific filters such as `ds_nodash` – and it also does not private access to private attributes.

This pull request adds a common base class that sets up a similar environment in both cases.