### PR TITLE
Add Roles from Azure OAUTH Response in internal Security Manager

### DIFF
--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -593,6 +593,7 @@ class BaseSecurityManager:
                 "last_name": me.get("family_name", ""),
                 "id": me["oid"],
                 "username": me["oid"],
+                "role_keys": me.get("roles", []),
             }
         # for OpenShift
         if provider == "openshift":


### PR DESCRIPTION
Currently, whenever the webserver is configured to utilise Azure AD as a oauth provider, it does not map the AD roles to Airflow roles correctly, instead it will set them to be the default defined for the instance. This is because of a discrepancy between the original code that previously existed before the Airflow <> FAB migration here: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/manager.py#L625 .

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
