### PR TITLE
Fix MyPy issues in ``airflow/providers/amazon/aws/transfers``

### DIFF
--- a/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/gcs_to_s3.py
@@ -17,7 +17,7 @@
 # under the License.
 """This module contains Google Cloud Storage to S3 operator."""
 import warnings
-from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -182,7 +182,7 @@ class GCSToS3Operator(BaseOperator):
                 self.log.info("Saving file to %s", dest_key)
 
                 s3_hook.load_bytes(
-                    cast(bytes, file_bytes), key=dest_key, replace=self.replace, acl_policy=self.s3_acl_policy
+                    file_bytes, key=dest_key, replace=self.replace, acl_policy=self.s3_acl_policy
                 )
 
             self.log.info("All done, uploaded %d files to S3", len(files))


### PR DESCRIPTION
We were using ``cast`` redundantly.

Before:

```
root@de8d91a123ec:/opt/airflow# mypy --namespace-packages airflow/providers/amazon/aws/transfers
airflow/providers/amazon/aws/transfers/gcs_to_s3.py:185: error: Redundant cast to "bytes"
                        cast(bytes, file_bytes), key=dest_key, replace=self.replace, acl_policy=self.s3_acl_policy
                        ^
Found 1 error in 1 file (checked 18 source files)
```

After:
```
root@de8d91a123ec:/opt/airflow# mypy --namespace-packages airflow/providers/amazon/aws/transfers
Success: no issues found in 18 source files
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
