### PR TITLE
Fix handling of Oracle bindvars in stored procedure call when parameters are not provided

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -309,6 +309,9 @@ class OracleHook(DbApiHook):
         sql = f"BEGIN {identifier}({args}); END;"
 
         def handler(cursor):
+            if cursor.bindvars is None:
+                return
+
             if isinstance(cursor.bindvars, list):
                 return [v.getvalue() for v in cursor.bindvars]
 

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -292,6 +292,18 @@ class TestOracleHook(unittest.TestCase):
         with pytest.raises(ValueError):
             self.db_hook.bulk_insert_rows('table', rows)
 
+    def test_callproc_none(self):
+        parameters = None
+
+        class bindvar(int):
+            def getvalue(self):
+                return self
+
+        self.cur.bindvars = None
+        result = self.db_hook.callproc('proc', True, parameters)
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END;')]
+        assert result == parameters
+
     def test_callproc_dict(self):
         parameters = {"a": 1, "b": 2, "c": 3}
 


### PR DESCRIPTION
This fixes a bug in the new `callproc` method where an exception will be raised when no parameters are provided – as in `None`.
