### PR TITLE
Add color to pytest tests on CI

### DIFF
--- a/scripts/ci/images/ci_run_docker_tests.py
+++ b/scripts/ci/images/ci_run_docker_tests.py
@@ -87,10 +87,7 @@ def main():
     if not extra_pytest_args:
         raise SystemExit("You must select the tests to run.")
 
-    pytest_args = (
-        "-n",
-        "auto",
-    )
+    pytest_args = ("-n", "auto", "--color=yes")
 
     run_verbose([str(python_bin), "-m", "pytest", *pytest_args, *extra_pytest_args])
 


### PR DESCRIPTION
While GitHub CI supports coloured output, the programs cannot
detect it properly because the output is redirected. Similarly
as in all other cases we force the color output.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
