### PR TITLE
Modernize DAG-related URL routes and rename "tree" to "grid"

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -21,7 +21,7 @@ import gzip
 import logging
 from io import BytesIO as IO
 from itertools import chain
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, TypeVar, cast
 
 import pendulum
 from flask import after_this_request, g, request
@@ -49,10 +49,11 @@ def action_logging(f: T) -> T:
                 user = g.user.username
 
             fields_skip_logging = {'csrf_token', '_csrf_token'}
-            log_fields = {k: v for k, v in chain(
-                request.values.items(), 
-                request.view_args.items()                                
-                ) if k not in fields_skip_logging}
+            log_fields = {
+                k: v
+                for k, v in chain(request.values.items(), request.view_args.items())
+                if k not in fields_skip_logging
+            }
 
             log = Log(
                 event=f.__name__,

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -34,6 +34,15 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
+def _get_dag_id() -> str:
+    dag_id = request.args.get('dag_id') 
+    if dag_id:
+        return dag_id
+    path_parts = request.path.split('/')
+    if len(path_parts) >= 3 and path_parts[1] == 'dags':
+        return path_parts[2]
+
+
 def action_logging(f: T) -> T:
     """Decorator to log user actions"""
 
@@ -48,13 +57,18 @@ def action_logging(f: T) -> T:
                 user = g.user.username
 
             fields_skip_logging = {'csrf_token', '_csrf_token'}
+            log_fields = {k: v for k, v in request.values.items() if k not in fields_skip_logging}
+            dag_id = _get_dag_id()
+            if dag_id:
+                log_fields['dag_id'] = dag_id
+
             log = Log(
                 event=f.__name__,
                 task_instance=None,
                 owner=user,
-                extra=str([(k, v) for k, v in request.values.items() if k not in fields_skip_logging]),
-                task_id=request.values.get('task_id'),
-                dag_id=request.values.get('dag_id'),
+                extra=str([(k, log_fields[k]) for k in log_fields]),
+                task_id=log_fields.get('task_id'),
+                dag_id=log_fields.get('dag_id'),
             )
 
             if 'execution_date' in request.values:

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -110,33 +110,33 @@
     <div class="row">
       <div class="col-md-10">
         <ul class="nav nav-pills">
-          <li><a href="{{ url_for('Airflow.dag_grid', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.grid', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">grid_on</span>
             Grid
           </a></li>
-          <li><a href="{{ url_for('Airflow.dag_graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">account_tree</span>
             Graph</a></li>
-          <li><a href="{{ url_for('Airflow.dag_calendar', dag_id=dag.dag_id) }}">
+          <li><a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}">
             <span class="material-icons" aria-hidden="true">event</span>
             Calendar
           </a></li>
-          <li><a href="{{ url_for('Airflow.dag_duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">hourglass_bottom</span>
             Task Duration</a></li>
-          <li><a href="{{ url_for('Airflow.dag_tries', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.tries', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">repeat</span>
             Task Tries</a></li>
-          <li><a href="{{ url_for('Airflow.dag_landing_times', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.landing_times', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">flight_land</span>
             Landing Times</a></li>
-          <li><a href="{{ url_for('Airflow.dag_gantt', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.gantt', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">vertical_distribute</span>
             Gantt</a></li>
           <li><a href="{{ url_for('Airflow.dag_details', dag_id=dag.dag_id) }}">
             <span class="material-icons" aria-hidden="true">details</span>
             Details</a></li>
-          <li><a href="{{ url_for('Airflow.dag_code', dag_id=dag.dag_id, root=root) }}">
+          <li><a href="{{ url_for('Airflow.code', dag_id=dag.dag_id, root=root) }}">
             <span class="material-icons" aria-hidden="true">code</span>
             Code</a></li>
         </ul>
@@ -182,7 +182,7 @@
         </div>
         <div class="modal-body">
           <div id="div_btn_subdag">
-            <a id="btn_subdag" class="btn btn-primary" data-base-url="{{ url_for('Airflow.' + dag.default_view) }}">
+            <a id="btn_subdag" class="btn btn-primary" data-base-url="{{ url_for('Airflow.legacy_' + dag.default_view) }}">
               Zoom into Sub DAG
             </a>
             <hr>
@@ -402,7 +402,7 @@
               </form>
             </span>
             <span class="col-md-4 text-right">
-              <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph') }}" role="button">
+              <a id="btn_dag_graph_view" class="btn" data-base-url="{{ url_for('Airflow.graph', dag_id=dag.dag_id) }}" role="button">
                 <span class="material-icons" aria-hidden="true">account_tree</span>
                 Graph
               </a>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -110,33 +110,33 @@
     <div class="row">
       <div class="col-md-10">
         <ul class="nav nav-pills">
-          <li><a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
-            <span class="material-icons" aria-hidden="true">nature</span>
-            Tree
+          <li><a href="{{ url_for('Airflow.dag_grid', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
+            <span class="material-icons" aria-hidden="true">grid_on</span>
+            Grid
           </a></li>
-          <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.dag_graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">account_tree</span>
             Graph</a></li>
-          <li><a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}">
+          <li><a href="{{ url_for('Airflow.dag_calendar', dag_id=dag.dag_id) }}">
             <span class="material-icons" aria-hidden="true">event</span>
             Calendar
           </a></li>
-          <li><a href="{{ url_for('Airflow.duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.dag_duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">hourglass_bottom</span>
             Task Duration</a></li>
-          <li><a href="{{ url_for('Airflow.tries', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.dag_tries', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">repeat</span>
             Task Tries</a></li>
-          <li><a href="{{ url_for('Airflow.landing_times', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.dag_landing_times', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">flight_land</span>
             Landing Times</a></li>
-          <li><a href="{{ url_for('Airflow.gantt', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
+          <li><a href="{{ url_for('Airflow.dag_gantt', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">vertical_distribute</span>
             Gantt</a></li>
           <li><a href="{{ url_for('Airflow.dag_details', dag_id=dag.dag_id) }}">
             <span class="material-icons" aria-hidden="true">details</span>
             Details</a></li>
-          <li><a href="{{ url_for('Airflow.code', dag_id=dag.dag_id, root=root) }}">
+          <li><a href="{{ url_for('Airflow.dag_code', dag_id=dag.dag_id, root=root) }}">
             <span class="material-icons" aria-hidden="true">code</span>
             Code</a></li>
         </ul>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -31,7 +31,7 @@
   <meta name="paused_url" content="{{ url_for('Airflow.paused') }}">
   <meta name="status_filter" content="{{ status_filter }}">
   <meta name="autocomplete_url" content="{{ url_for('AutocompleteView.autocomplete') }}">
-  <meta name="graph_url" content="{{ url_for('Airflow.graph') }}">
+  <meta name="graph_url" content="{{ url_for('Airflow.legacy_graph') }}">
   <meta name="dag_run_url" content="{{ url_for('DagRunModelView.list') }}">
   <meta name="task_instance_url" content="{{ url_for('TaskInstanceModelView.list') }}">
   <meta name="blocked_url" content="{{ url_for('Airflow.blocked') }}">
@@ -39,7 +39,7 @@
   <meta name="last_dag_runs_url" content="{{ url_for('Airflow.last_dagruns') }}">
   <meta name="dag_stats_url" content="{{ url_for('Airflow.dag_stats') }}">
   <meta name="task_stats_url" content="{{ url_for('Airflow.task_stats') }}">
-  <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
+  <meta name="tree_url" content="{{ url_for('Airflow.legacy_tree') }}">
 {% endblock %}
 
 {% block head_css %}
@@ -293,9 +293,9 @@
                           <span class="material-icons" aria-hidden="true">account_tree</span>
                           Graph
                         </a>
-                        <a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}" class="dags-table-more__link">
-                          <span class="material-icons" aria-hidden="true">nature</span>
-                          Tree
+                        <a href="{{ url_for('Airflow.grid', dag_id=dag.dag_id, num_runs=num_runs) }}" class="dags-table-more__link">
+                          <span class="material-icons" aria-hidden="true">grid_on</span>
+                          Grid
                         </a>
                       </div>
                       <span class="dags-table-more__toggle"><span class="material-icons">more_horiz</span></span>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -39,7 +39,7 @@
   <meta name="last_dag_runs_url" content="{{ url_for('Airflow.last_dagruns') }}">
   <meta name="dag_stats_url" content="{{ url_for('Airflow.dag_stats') }}">
   <meta name="task_stats_url" content="{{ url_for('Airflow.task_stats') }}">
-  <meta name="tree_url" content="{{ url_for('Airflow.legacy_tree') }}">
+  <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
 {% endblock %}
 
 {% block head_css %}

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -356,8 +356,10 @@ def dag_link(attr):
     """Generates a URL to the Graph view for a Dag."""
     dag_id = attr.get('dag_id')
     execution_date = attr.get('execution_date')
+    if not dag_id:
+        return Markup('None')
     url = url_for('Airflow.graph', dag_id=dag_id, execution_date=execution_date)
-    return Markup('<a href="{}">{}</a>').format(url, dag_id) if dag_id else Markup('None')
+    return Markup('<a href="{}">{}</a>').format(url, dag_id)
 
 
 def dag_run_link(attr):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1054,15 +1054,24 @@ class Airflow(AirflowBaseView):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE),
         ]
     )
+    def code(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_code', **request.args))
+
+    @expose('/dags/<string:dag_id>/code')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE),
+        ]
+    )
     @provide_session
-    def code(self, session=None):
+    def dag_code(self, dag_id, session=None):
         """Dag Code."""
         all_errors = ""
         dag_orm = None
-        dag_id = None
 
         try:
-            dag_id = request.args.get('dag_id')
             dag_orm = DagModel.get_dagmodel(dag_id, session=session)
             code = DagCode.get_code_by_fileloc(dag_orm.fileloc)
             html_code = Markup(highlight(code, lexers.PythonLexer(), HtmlFormatter(linenos=True)))
@@ -1095,10 +1104,20 @@ class Airflow(AirflowBaseView):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         ]
     )
+    def dag_details_redirect(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_details', **request.args))
+
+    @expose('/dags/<string:dag_id>/details')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+        ]
+    )
     @provide_session
-    def dag_details(self, session=None):
+    def dag_details(self, dag_id, session=None):
         """Get Dag details."""
-        dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
 
@@ -2301,6 +2320,20 @@ class Airflow(AirflowBaseView):
             State.SUCCESS,
         )
 
+    @expose('/dags/<string:dag_id>')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+        ]
+    )
+    @gzipped
+    @action_logging
+    def dag(self, dag_id):
+        """Redirect to default DAG view."""
+        return redirect(url_for('Airflow.dag_grid', dag_id=dag_id, **request.args))
+
     @expose('/tree')
     @auth.has_access(
         [
@@ -2311,10 +2344,23 @@ class Airflow(AirflowBaseView):
     )
     @gzipped
     @action_logging
+    def tree(self):
+        """Redirect to the replacement - grid view."""
+        return redirect(url_for('Airflow.dag_grid', **request.args))
+
+    @expose('/dags/<string:dag_id>/grid')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+        ]
+    )
+    @gzipped
+    @action_logging
     @provide_session
-    def tree(self, session=None):
-        """Get Dag as tree."""
-        dag_id = request.args.get('dag_id')
+    def dag_grid(self, dag_id, session=None):
+        """Get Dag as tree (grid)."""
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         if not dag:
@@ -2399,8 +2445,21 @@ class Airflow(AirflowBaseView):
     )
     @gzipped
     @action_logging
+    def calendar(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_calendar', **request.args))
+
+    @expose('/dags/<string:dag_id>/calendar')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+        ]
+    )
+    @gzipped
+    @action_logging
     @provide_session
-    def calendar(self, session=None):
+    def dag_calendar(self, dag_id, session=None):
         """Get DAG runs as calendar"""
 
         def _convert_to_date(session, column):
@@ -2410,7 +2469,6 @@ class Airflow(AirflowBaseView):
             else:
                 return func.date(column)
 
-        dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         if not dag:
@@ -2476,10 +2534,23 @@ class Airflow(AirflowBaseView):
     )
     @gzipped
     @action_logging
+    def graph(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_graph', **request.args))
+
+    @expose('/dags/<string:dag_id>/graph')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+        ]
+    )
+    @gzipped
+    @action_logging
     @provide_session
-    def graph(self, session=None):
+    def dag_graph(self, dag_id, session=None):
         """Get DAG as Graph."""
-        dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         if not dag:
@@ -2569,11 +2640,22 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
+    def duration(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_duration', **request.args))
+
+    @expose('/dags/<string:dag_id>/duration')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+        ]
+    )
+    @action_logging
     @provide_session
-    def duration(self, session=None):
+    def dag_duration(self, dag_id, session=None):
         """Get Dag as duration graph."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
-        dag_id = request.args.get('dag_id')
         dag_model = DagModel.get_dagmodel(dag_id)
 
         dag: Optional[DAG] = current_app.dag_bag.get_dag(dag_id)
@@ -2711,11 +2793,22 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
+    def tries(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_tries', **request.args))
+
+    @expose('/dags/<string:dag_id>/tries')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+        ]
+    )
+    @action_logging
     @provide_session
-    def tries(self, session=None):
+    def dag_tries(self, dag_id, session=None):
         """Shows all tries."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
-        dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         base_date = request.args.get('base_date')
@@ -2788,11 +2881,22 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
+    def landing_times(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_landing_times', **request.args))
+
+    @expose('/dags/<string:dag_id>/landing_times')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+        ]
+    )
+    @action_logging
     @provide_session
-    def landing_times(self, session=None):
+    def dag_landing_times(self, dag_id, session=None):
         """Shows landing times."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
-        dag_id = request.args.get('dag_id')
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         base_date = request.args.get('base_date')
@@ -2893,10 +2997,21 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
+    def gantt(self):
+        """Redirect from url param."""
+        return redirect(url_for('Airflow.dag_gantt', **request.args))
+
+    @expose('/dags/<string:dag_id>/gantt')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+        ]
+    )
+    @action_logging
     @provide_session
-    def gantt(self, session=None):
+    def dag_gantt(self, dag_id, session=None):
         """Show GANTT chart."""
-        dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1054,9 +1054,9 @@ class Airflow(AirflowBaseView):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE),
         ]
     )
-    def code(self):
+    def legacy_code(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_code', **request.args))
+        return redirect(url_for('Airflow.code', **request.args))
 
     @expose('/dags/<string:dag_id>/code')
     @auth.has_access(
@@ -1066,7 +1066,7 @@ class Airflow(AirflowBaseView):
         ]
     )
     @provide_session
-    def dag_code(self, dag_id, session=None):
+    def code(self, dag_id, session=None):
         """Dag Code."""
         all_errors = ""
         dag_orm = None
@@ -1104,7 +1104,7 @@ class Airflow(AirflowBaseView):
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         ]
     )
-    def dag_details_redirect(self):
+    def legacy_dag_details(self):
         """Redirect from url param."""
         return redirect(url_for('Airflow.dag_details', **request.args))
 
@@ -2332,7 +2332,21 @@ class Airflow(AirflowBaseView):
     @action_logging
     def dag(self, dag_id):
         """Redirect to default DAG view."""
-        return redirect(url_for('Airflow.dag_grid', dag_id=dag_id, **request.args))
+        return redirect(url_for('Airflow.grid', dag_id=dag_id, **request.args))
+
+    @expose('/legacy_tree')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+        ]
+    )
+    @gzipped
+    @action_logging
+    def legacy_tree(self):
+        """Redirect to the replacement - grid view."""
+        return redirect(url_for('Airflow.grid', **request.args))
 
     @expose('/tree')
     @auth.has_access(
@@ -2345,8 +2359,8 @@ class Airflow(AirflowBaseView):
     @gzipped
     @action_logging
     def tree(self):
-        """Redirect to the replacement - grid view."""
-        return redirect(url_for('Airflow.dag_grid', **request.args))
+        """Redirect to the replacement - grid view. Kept for backwards compatibility."""
+        return redirect(url_for('Airflow.grid', **request.args))
 
     @expose('/dags/<string:dag_id>/grid')
     @auth.has_access(
@@ -2359,8 +2373,8 @@ class Airflow(AirflowBaseView):
     @gzipped
     @action_logging
     @provide_session
-    def dag_grid(self, dag_id, session=None):
-        """Get Dag as tree (grid)."""
+    def grid(self, dag_id, session=None):
+        """Get Dag's grid view."""
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
         if not dag:
@@ -2445,9 +2459,9 @@ class Airflow(AirflowBaseView):
     )
     @gzipped
     @action_logging
-    def calendar(self):
+    def legacy_calendar(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_calendar', **request.args))
+        return redirect(url_for('Airflow.calendar', **request.args))
 
     @expose('/dags/<string:dag_id>/calendar')
     @auth.has_access(
@@ -2459,7 +2473,7 @@ class Airflow(AirflowBaseView):
     @gzipped
     @action_logging
     @provide_session
-    def dag_calendar(self, dag_id, session=None):
+    def calendar(self, dag_id, session=None):
         """Get DAG runs as calendar"""
 
         def _convert_to_date(session, column):
@@ -2534,9 +2548,9 @@ class Airflow(AirflowBaseView):
     )
     @gzipped
     @action_logging
-    def graph(self):
+    def legacy_graph(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_graph', **request.args))
+        return redirect(url_for('Airflow.graph', **request.args))
 
     @expose('/dags/<string:dag_id>/graph')
     @auth.has_access(
@@ -2549,7 +2563,7 @@ class Airflow(AirflowBaseView):
     @gzipped
     @action_logging
     @provide_session
-    def dag_graph(self, dag_id, session=None):
+    def graph(self, dag_id, session=None):
         """Get DAG as Graph."""
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)
@@ -2640,9 +2654,9 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
-    def duration(self):
+    def legacy_duration(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_duration', **request.args))
+        return redirect(url_for('Airflow.duration', **request.args))
 
     @expose('/dags/<string:dag_id>/duration')
     @auth.has_access(
@@ -2653,7 +2667,7 @@ class Airflow(AirflowBaseView):
     )
     @action_logging
     @provide_session
-    def dag_duration(self, dag_id, session=None):
+    def duration(self, dag_id, session=None):
         """Get Dag as duration graph."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag_model = DagModel.get_dagmodel(dag_id)
@@ -2793,9 +2807,9 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
-    def tries(self):
+    def legacy_tries(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_tries', **request.args))
+        return redirect(url_for('Airflow.tries', **request.args))
 
     @expose('/dags/<string:dag_id>/tries')
     @auth.has_access(
@@ -2806,7 +2820,7 @@ class Airflow(AirflowBaseView):
     )
     @action_logging
     @provide_session
-    def dag_tries(self, dag_id, session=None):
+    def tries(self, dag_id, session=None):
         """Shows all tries."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag = current_app.dag_bag.get_dag(dag_id)
@@ -2881,9 +2895,9 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
-    def landing_times(self):
+    def legacy_landing_times(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_landing_times', **request.args))
+        return redirect(url_for('Airflow.landing_times', **request.args))
 
     @expose('/dags/<string:dag_id>/landing_times')
     @auth.has_access(
@@ -2894,7 +2908,7 @@ class Airflow(AirflowBaseView):
     )
     @action_logging
     @provide_session
-    def dag_landing_times(self, dag_id, session=None):
+    def landing_times(self, dag_id, session=None):
         """Shows landing times."""
         default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
@@ -2997,9 +3011,9 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
-    def gantt(self):
+    def legacy_gantt(self):
         """Redirect from url param."""
-        return redirect(url_for('Airflow.dag_gantt', **request.args))
+        return redirect(url_for('Airflow.gantt', **request.args))
 
     @expose('/dags/<string:dag_id>/gantt')
     @auth.has_access(
@@ -3010,7 +3024,7 @@ class Airflow(AirflowBaseView):
     )
     @action_logging
     @provide_session
-    def dag_gantt(self, dag_id, session=None):
+    def gantt(self, dag_id, session=None):
         """Show GANTT chart."""
         dag = current_app.dag_bag.get_dag(dag_id)
         dag_model = DagModel.get_dagmodel(dag_id)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2899,7 +2899,7 @@ class Airflow(AirflowBaseView):
         """Redirect from url param."""
         return redirect(url_for('Airflow.landing_times', **request.args))
 
-    @expose('/dags/<string:dag_id>/landing_times')
+    @expose('/dags/<string:dag_id>/landing-times')
     @auth.has_access(
         [
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -115,7 +115,7 @@ def _check_last_log(session, dag_id, event, execution_date):
 
 def test_action_logging_get(session, admin_client):
     url = (
-        f'graph?dag_id=example_bash_operator&'
+        f'dags/example_bash_operator/graph?'
         f'execution_date={urllib.parse.quote_plus(str(EXAMPLE_DAG_DEFAULT_DATE))}'
     )
     resp = admin_client.get(url, follow_redirects=True)
@@ -127,6 +127,24 @@ def test_action_logging_get(session, admin_client):
         session,
         dag_id="example_bash_operator",
         event="graph",
+        execution_date=EXAMPLE_DAG_DEFAULT_DATE,
+    )
+
+
+def test_action_logging_get_legacy_view(session, admin_client):
+    url = (
+        f'graph?dag_id=example_bash_operator&'
+        f'execution_date={urllib.parse.quote_plus(str(EXAMPLE_DAG_DEFAULT_DATE))}'
+    )
+    resp = admin_client.get(url, follow_redirects=True)
+    check_content_in_response('runme_1', resp)
+
+    # In mysql backend, this commit() is needed to write down the logs
+    session.commit()
+    _check_last_log(
+        session,
+        dag_id="example_bash_operator",
+        event="legacy_graph",
         execution_date=EXAMPLE_DAG_DEFAULT_DATE,
     )
 

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -217,7 +217,7 @@ def client_ti_without_dag_edit(app):
             id='landing-times-url-param',
         ),
         pytest.param(
-            'dags/example_bash_operator/landing_times?days=30',
+            'dags/example_bash_operator/landing-times?days=30',
             ['example_bash_operator'],
             id='landing-times',
         ),

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -339,7 +339,7 @@ def test_tree_trigger_origin_tree_view(app, admin_client):
 
     url = 'tree?dag_id=test_tree_view'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_tree_view', 'origin': '/tree?dag_id=test_tree_view'}
+    params = {'dag_id': 'test_tree_view', 'origin': '/dags/test_tree_view/grid'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 
@@ -353,9 +353,9 @@ def test_graph_trigger_origin_graph_view(app, admin_client):
         state=State.RUNNING,
     )
 
-    url = 'graph?dag_id=test_tree_view'
+    url = '/dags/test_tree_view/graph'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_tree_view', 'origin': '/graph?dag_id=test_tree_view'}
+    params = {'dag_id': 'test_tree_view', 'origin': '/dags/test_tree_view/graph'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 
@@ -369,9 +369,9 @@ def test_dag_details_trigger_origin_dag_details_view(app, admin_client):
         state=State.RUNNING,
     )
 
-    url = 'dag_details?dag_id=test_graph_view'
+    url = '/dags/test_graph_view/details'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_graph_view', 'origin': '/dag_details?dag_id=test_graph_view'}
+    params = {'dag_id': 'test_graph_view', 'origin': '/dags/test_graph_view/details'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -139,15 +139,25 @@ def client_ti_without_dag_edit(app):
         pytest.param(
             'dag_details?dag_id=example_bash_operator',
             ['DAG Details'],
-            id="dag-details",
+            id="dag-details-url-param",
         ),
         pytest.param(
             'dag_details?dag_id=example_subdag_operator.section-1',
+            ['DAG Details'],
+            id="dag-details-subdag-url-param",
+        ),
+        pytest.param(
+            'dags/example_subdag_operator.section-1/details',
             ['DAG Details'],
             id="dag-details-subdag",
         ),
         pytest.param(
             'graph?dag_id=example_bash_operator',
+            ['runme_1'],
+            id='graph-url-param',
+        ),
+        pytest.param(
+            'dags/example_bash_operator/graph',
             ['runme_1'],
             id='graph',
         ),
@@ -157,32 +167,67 @@ def client_ti_without_dag_edit(app):
             id='tree',
         ),
         pytest.param(
+            'dags/example_bash_operator/grid',
+            ['runme_1'],
+            id='grid',
+        ),
+        pytest.param(
             'tree?dag_id=example_subdag_operator.section-1',
             ['section-1-task-1'],
-            id="tree-subdag",
+            id="tree-subdag-url-param",
+        ),
+        pytest.param(
+            'dags/example_subdag_operator.section-1/grid',
+            ['section-1-task-1'],
+            id="grid-subdag",
         ),
         pytest.param(
             'duration?days=30&dag_id=example_bash_operator',
+            ['example_bash_operator'],
+            id='duration-url-param',
+        ),
+        pytest.param(
+            'dags/example_bash_operator/duration?days=30',
             ['example_bash_operator'],
             id='duration',
         ),
         pytest.param(
             'duration?days=30&dag_id=missing_dag',
             ['seems to be missing'],
+            id='duration-missing-url-param',
+        ),
+        pytest.param(
+            'dags/missing_dag/duration?days=30',
+            ['seems to be missing'],
             id='duration-missing',
         ),
         pytest.param(
             'tries?days=30&dag_id=example_bash_operator',
+            ['example_bash_operator'],
+            id='tries-url-param',
+        ),
+        pytest.param(
+            'dags/example_bash_operator/tries?days=30',
             ['example_bash_operator'],
             id='tries',
         ),
         pytest.param(
             'landing_times?days=30&dag_id=example_bash_operator',
             ['example_bash_operator'],
+            id='landing-times-url-param',
+        ),
+        pytest.param(
+            'dags/example_bash_operator/landing_times?days=30',
+            ['example_bash_operator'],
             id='landing-times',
         ),
         pytest.param(
             'gantt?dag_id=example_bash_operator',
+            ['example_bash_operator'],
+            id="gantt-url-param",
+        ),
+        pytest.param(
+            'dags/example_bash_operator/gantt',
             ['example_bash_operator'],
             id="gantt",
         ),
@@ -196,20 +241,40 @@ def client_ti_without_dag_edit(app):
         pytest.param(
             "graph?dag_id=example_bash_operator",
             ["example_bash_operator"],
+            id="existing-dagbag-graph-url-param",
+        ),
+        pytest.param(
+            "dags/example_bash_operator/graph",
+            ["example_bash_operator"],
             id="existing-dagbag-graph",
         ),
         pytest.param(
             "tree?dag_id=example_bash_operator",
             ["example_bash_operator"],
-            id="existing-dagbag-tree",
+            id="existing-dagbag-tree-url-param",
+        ),
+        pytest.param(
+            "dags/example_bash_operator/grid",
+            ["example_bash_operator"],
+            id="existing-dagbag-grid",
         ),
         pytest.param(
             "calendar?dag_id=example_bash_operator",
+            ["example_bash_operator"],
+            id="existing-dagbag-calendar-url-param",
+        ),
+        pytest.param(
+            "dags/example_bash_operator/calendar",
             ["example_bash_operator"],
             id="existing-dagbag-calendar",
         ),
         pytest.param(
             "dag_details?dag_id=example_bash_operator",
+            ["example_bash_operator"],
+            id="existing-dagbag-dag-details-url-param",
+        ),
+        pytest.param(
+            "dags/example_bash_operator/details",
             ["example_bash_operator"],
             id="existing-dagbag-dag-details",
         ),
@@ -348,7 +413,7 @@ def test_code_from_db(admin_client):
     dag = DagBag(include_examples=True).get_dag("example_bash_operator")
     DagCode(dag.fileloc, DagCode._get_code_from_file(dag.fileloc)).sync_to_db()
     url = 'code?dag_id=example_bash_operator'
-    resp = admin_client.get(url)
+    resp = admin_client.get(url, follow_redirects=True)
     check_content_not_in_response('Failed to load DAG file Code', resp)
     check_content_in_response('example_bash_operator', resp)
 
@@ -358,7 +423,7 @@ def test_code_from_db_all_example_dags(admin_client):
     for dag in dagbag.dags.values():
         DagCode(dag.fileloc, DagCode._get_code_from_file(dag.fileloc)).sync_to_db()
     url = 'code?dag_id=example_bash_operator'
-    resp = admin_client.get(url)
+    resp = admin_client.get(url, follow_redirects=True)
     check_content_not_in_response('Failed to load DAG file Code', resp)
     check_content_in_response('example_bash_operator', resp)
 


### PR DESCRIPTION
related: #19944

- Rename "tree" view to "grid" view
- Update URL routes and add redirects from old path:
  - `/tree` -> `/dags/<dag_id>/grid`
  - `/graph` -> `/dags/<dag_id>/graph`
  - `/landing_times` -> `/dags/<dag_id>/landing_times`
  - `/duration` -> `/dags/<dag_id>/duration`
  - `/tries` -> `/dags/<dag_id>/tries`
  - `/calendar` -> `/dags/<dag_id>/calendar`
  - `/gantt` -> `/dags/<dag_id>/gantt`
  - `/code` -> `/dags/<dag_id>/code`
  - `/dag_details` -> `/dags/<dag_id>/details`
- New redirect - `/dags/<dag_id>` -> `/dags/<dag_id>/grid`

Once a new single DAG page is ready, the subroutes can be dropped and transformed into redirects to single `/dags/<dag_id>` page (with proper query params).  As alternative, only single view could've been renamed (`/tree` -> `/dags/<dag_id>`), but I thought that it would be better to keep routes self-consistent mid-flight (in case if single-page view won't make it into 2.3.0).

DAGs page before: ![Screenshot 2022-01-06 at 14-14-22 tutorial - Tree - Airflow](https://user-images.githubusercontent.com/2447492/148435122-46b69c57-de31-425d-ad63-87ae398375c4.png)
DAGs page after: ![Screenshot 2022-01-06 at 14-02-14 tutorial - Tree - Airflow](https://user-images.githubusercontent.com/2447492/148435142-f534aeb0-ab7f-4a43-ae54-823233aca5ce.png)


---