### PR TITLE
Truncate stack trace to DAG user code for exceptions raised during execution

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -28,7 +28,8 @@ class AirflowException(Exception):
     """
     Base class for all Airflow's errors.
 
-    Each custom exception should be derived from this class.
+    An uncaught exception deriving from this class will not have its stacktrace
+    printed to the task log if raised during execution.
     """
 
     status_code = 500

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -28,8 +28,7 @@ class AirflowException(Exception):
     """
     Base class for all Airflow's errors.
 
-    An uncaught exception deriving from this class will not have its stacktrace
-    printed to the task log if raised during execution.
+    Each custom exception should be derived from this class.
     """
 
     status_code = 500

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1415,7 +1415,13 @@ class TaskInstance(Base, LoggingMixin):
         """Prepare Task for Execution"""
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
+        parent_pid = os.getpid()
+
         def signal_handler(signum, frame):
+            pid = os.getpid()
+            if pid != parent_pid:
+                os._exit(1)
+                return
             self.log.error("Received SIGTERM. Terminating subprocesses.")
             self.task.on_kill()
             raise AirflowException("Task received SIGTERM signal")

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -129,7 +129,7 @@ if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
 
-_EXECUTION_FRAME_MAPPING: "WeakKeyDictionary[BaseOperator, FrameType]" = WeakKeyDictionary()
+_EXECUTION_FRAME_MAPPING: "WeakKeyDictionary[Operator, FrameType]" = WeakKeyDictionary()
 
 
 @contextlib.contextmanager

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1419,6 +1419,11 @@ class TaskInstance(Base, LoggingMixin):
 
         def signal_handler(signum, frame):
             pid = os.getpid()
+
+            # If a task forks during execution (from DAG code) for whatever
+            # reason, we want to make sure that we react to the signal only in
+            # the process that we've spawned ourselves (referred to here as the
+            # parent process).
             if pid != parent_pid:
                 os._exit(1)
                 return

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -84,24 +84,19 @@ class StandardTaskRunner(BaseTaskRunner):
                 proc_title += " {0.job_id}"
             setproctitle(proc_title.format(args))
 
-            pid = os.getpid()
             try:
                 args.func(args, dag=self.dag)
                 return_code = 0
             except Exception as exc:
                 return_code = 1
 
-                # In some cases, the DAG function might spawn a new process which
-                # means we'll return here multiple times. Make sure we're only logging
-                # an error once.
-                if os.getpid() == pid:
-                    self.log.error(
-                        "Failed to execute job %s for task %s (%s; %r)",
-                        job_id,
-                        self._task_instance.task_id,
-                        exc,
-                        os.getpid(),
-                    )
+                self.log.error(
+                    "Failed to execute job %s for task %s (%s; %r)",
+                    job_id,
+                    self._task_instance.task_id,
+                    exc,
+                    os.getpid(),
+                )
             finally:
                 # Explicitly flush any pending exception to Sentry if enabled
                 Sentry.flush()

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -73,11 +73,14 @@ class StandardTaskRunner(BaseTaskRunner):
             # [1:] - remove "airflow" from the start of the command
             args = parser.parse_args(self._command[1:])
 
+            # We prefer the job_id passed on the command-line because at this time, the
+            # task instance may not have been updated.
+            job_id = getattr(args, "job_id", self._task_instance.job_id)
             self.log.info('Running: %s', self._command)
-            self.log.info('Job %s: Subtask %s', self._task_instance.job_id, self._task_instance.task_id)
+            self.log.info('Job %s: Subtask %s', job_id, self._task_instance.task_id)
 
             proc_title = "airflow task runner: {0.dag_id} {0.task_id} {0.execution_date_or_run_id}"
-            if hasattr(args, "job_id"):
+            if job_id is not None:
                 proc_title += " {0.job_id}"
             setproctitle(proc_title.format(args))
 
@@ -94,7 +97,7 @@ class StandardTaskRunner(BaseTaskRunner):
                 if os.getpid() == pid:
                     self.log.error(
                         "Failed to execute job %s for task %s (%s; %r)",
-                        self._task_instance.job_id,
+                        job_id,
                         self._task_instance.task_id,
                         exc,
                         os.getpid(),

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -22,6 +22,7 @@ import signal
 import sys
 import urllib
 from tempfile import NamedTemporaryFile
+from traceback import format_exception
 from typing import List, Optional, Union, cast
 from unittest import mock
 from unittest.mock import call, mock_open, patch
@@ -1877,7 +1878,8 @@ class TestTaskInstance:
         assert log.error.call_args[0] == ("Task failed with exception",)
         exc_info = log.error.call_args[1]["exc_info"]
         filename = exc_info[2].tb_frame.f_code.co_filename
-        assert sys.modules[PythonOperator.__module__].__file__ == filename
+        formatted_exc = format_exception(*exc_info)
+        assert sys.modules[PythonOperator.__module__].__file__ == filename, "".join(formatted_exc)
 
     def _env_var_check_callback(self):
         assert 'test_echo_env_variables' == os.environ['AIRFLOW_CTX_DAG_ID']

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -247,7 +247,7 @@ class TestStandardTaskRunner:
         ti.refresh_from_db()
         assert re.findall(r'ERROR - Failed to execute job (\S+) for task (\S+)', logged) == [
             (str(ti.job_id), ti.task_id)
-        ]
+        ], logged
 
         logging.info("Waiting for the on kill killed file to appear")
         with timeout(seconds=4):

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -205,12 +205,12 @@ class TestStandardTaskRunner:
         with create_session() as session, NamedTemporaryFile("w", delete=False) as f:
             dag.create_dagrun(
                 run_id="test",
+                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
                 state=State.RUNNING,
-                execution_date=DEFAULT_DATE,
                 start_date=DEFAULT_DATE,
                 session=session,
             )
-            ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
+            ti = TaskInstance(task=task, run_id="test")
             job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
             session.commit()
 


### PR DESCRIPTION
This fixes an issue where task errors would be logged twice.

In addition, the stack trace has been truncated such that only DAG code is included. That is, the Airflow task runner portion of the stack trace is now excluded.

There were some discussions previously on doing away with the stack trace for `AirflowException` altogether, but it was established that in most cases, a stack trace is required to establish the source of the error.