### PR TITLE
Serialize mapped tasks and task groups

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1727,7 +1727,7 @@ class MappedOperator(DAGNode):
             return val.rsplit('.', 1)[-1]
         return val.__name__
 
-    operator_class: Type[BaseOperator] = attr.ib(repr=_operator_class_repr)
+    operator_class: Union[Type[BaseOperator], str] = attr.ib(repr=_operator_class_repr)
     task_type: str = attr.ib()
     task_id: str
     partial_kwargs: Dict[str, Any]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1706,8 +1706,8 @@ class MappedOperator(DAGNode):
     def __repr__(self) -> str:
         return (
             f'MappedOperator(task_type={self.task_type}, '
-            + f'task_id={self.task_id!r}, partial_kwargs={self.partial_kwargs!r}, '
-            + f'mapped_kwargs={self.mapped_kwargs!r}, dag={self.dag})'
+            f'task_id={self.task_id!r}, partial_kwargs={self.partial_kwargs!r}, '
+            f'mapped_kwargs={self.mapped_kwargs!r}, dag={self.dag})'
         )
 
     operator_class: Union[Type[BaseOperator], str]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1673,7 +1673,11 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         return False
 
 
-def _validate_kwarg_names_for_mapping(cls: Type[BaseOperator], func_name: str, value: Dict[str, Any]):
+def _validate_kwarg_names_for_mapping(
+    cls: Union[str, Type[BaseOperator]],
+    func_name: str,
+    value: Dict[str, Any],
+) -> None:
     if isinstance(cls, str):
         # Serialized version -- would have been validated at parse time
         return
@@ -1750,7 +1754,7 @@ class MappedOperator(DAGNode):
 
     deps: Iterable[BaseTIDep] = attr.ib()
     operator_extra_links: Iterable['BaseOperatorLink'] = ()
-    params: ParamsDict = None
+    params: Union[ParamsDict, dict] = attr.ib(factory=ParamsDict)
     template_fields: Iterable[str] = attr.ib()
 
     del _operator_class_repr

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -747,9 +747,8 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         self.doc_rst = doc_rst
         self.doc = doc
 
-        # Private attributes
-        self._upstream_task_ids: Set[str] = set()
-        self._downstream_task_ids: Set[str] = set()
+        self.upstream_task_ids: Set[str] = set()
+        self.downstream_task_ids: Set[str] = set()
 
         if dag:
             self.dag = dag
@@ -1261,16 +1260,6 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
                                 self.log.exception(e)
         self.prepare_template()
 
-    @property
-    def upstream_task_ids(self) -> Set[str]:
-        """@property: set of ids of tasks directly upstream"""
-        return self._upstream_task_ids
-
-    @property
-    def downstream_task_ids(self) -> Set[str]:
-        """@property: set of ids of tasks directly downstream"""
-        return self._downstream_task_ids
-
     @provide_session
     def clear(
         self,
@@ -1430,9 +1419,9 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         downstream.
         """
         if upstream:
-            return self._upstream_task_ids
+            return self.upstream_task_ids
         else:
-            return self._downstream_task_ids
+            return self.downstream_task_ids
 
     def get_direct_relatives(self, upstream: bool = False) -> Iterable["DAGNode"]:
         """
@@ -1578,7 +1567,7 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
                 - {
                     'inlets',
                     'outlets',
-                    '_upstream_task_ids',
+                    'upstream_task_ids',
                     'default_args',
                     'dag',
                     '_dag',

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -134,9 +134,11 @@ class BaseOperatorMeta(abc.ABCMeta):
             if param.name != 'self' and param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
         }
         non_optional_args = {
-            name for (name, param) in non_variadic_params.items() if param.default == param.empty
+            name
+            for name, param in non_variadic_params.items()
+            if param.default == param.empty
+            and name != "task_id"
         }
-        non_optional_args -= {'task_id'}
 
         class autostacklevel_warn:
             def __init__(self):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1720,9 +1720,9 @@ class MappedOperator(DAGNode):
 
     def __repr__(self) -> str:
         return (
-            'MappedOperator(operator_class={self._operator_class_repr(self.operator_class)}, '
-            + 'task_id={self.task_id!r}, partial_kwargs={self.partial_kwargs!r}, '
-            + 'mapped_kwargs={self.mapped_kwargs!r}, dag={self.dag})'
+            f'MappedOperator(operator_class={self._operator_class_repr(self.operator_class)}, '
+            + f'task_id={self.task_id!r}, partial_kwargs={self.partial_kwargs!r}, '
+            + f'mapped_kwargs={self.mapped_kwargs!r}, dag={self.dag})'
         )
 
     operator_class: Union[Type[BaseOperator], str]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -136,8 +136,7 @@ class BaseOperatorMeta(abc.ABCMeta):
         non_optional_args = {
             name
             for name, param in non_variadic_params.items()
-            if param.default == param.empty
-            and name != "task_id"
+            if param.default == param.empty and name != "task_id"
         }
 
         class autostacklevel_warn:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2102,8 +2102,8 @@ class DAG(LoggingMixin):
         for t in dag.tasks:
             # Removing upstream/downstream references to tasks that did not
             # make the cut
-            t._upstream_task_ids = t.upstream_task_ids.intersection(dag.task_dict.keys())
-            t._downstream_task_ids = t.downstream_task_ids.intersection(dag.task_dict.keys())
+            t.upstream_task_ids.intersection_update(dag.task_dict)
+            t.downstream_task_ids.intersection_update(dag.task_dict)
 
         if len(dag.tasks) < len(self.tasks):
             dag.partial = True

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -128,19 +128,11 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
 
     start_date: Optional[pendulum.DateTime]
     end_date: Optional[pendulum.DateTime]
+    upstream_task_ids: Set[str]
+    downstream_task_ids: Set[str]
 
     def has_dag(self) -> bool:
         return self.dag is not None
-
-    @property
-    @abstractmethod
-    def upstream_task_ids(self) -> Set[str]:
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def downstream_task_ids(self) -> Set[str]:
-        raise NotImplementedError()
 
     @property
     def log(self) -> "Logger":

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -196,7 +196,7 @@
           "items": { "type": "string" }
         },
         "subdag": { "$ref": "#/definitions/dag" },
-        "_downstream_task_ids": {
+        "downstream_task_ids": {
           "type": "array",
           "items": { "type": "string" }
         },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -211,7 +211,13 @@
         "doc_md":  { "type": "string" },
         "doc_json":  { "type": "string" },
         "doc_yaml":  { "type": "string" },
-        "doc_rst":  { "type": "string" }
+        "doc_rst":  { "type": "string" },
+        "mapped_kwargs": { "type": "object" },
+        "partial_kwargs": { "type": "object" }
+      },
+      "dependencies": {
+        "mapped_kwargs":[ "partial_kwargs"],
+        "partial_kwargs":[ "mapped_kwargs"]
       },
       "additionalProperties": true
     },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -212,12 +212,14 @@
         "doc_json":  { "type": "string" },
         "doc_yaml":  { "type": "string" },
         "doc_rst":  { "type": "string" },
+        "_is_mapped": { "const": true, "$comment": "only present when True" },
         "mapped_kwargs": { "type": "object" },
         "partial_kwargs": { "type": "object" }
       },
       "dependencies": {
-        "mapped_kwargs":[ "partial_kwargs"],
-        "partial_kwargs":[ "mapped_kwargs"]
+        "mapped_kwargs": ["partial_kwargs", "_is_mapped"],
+        "partial_kwargs": ["mapped_kwargs", "_is_mapped"],
+        "_is_mapped": ["mapped_kwargs", "partial_kwargs"]
       },
       "additionalProperties": true
     },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -608,11 +608,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         """Deserializes an operator from a JSON object."""
         op: Union[BaseOperator, MappedOperator]
         # Check if it's a mapped operator
-        if "mapped_kwargs" in encoded_op:
+        if encoded_op.get("_is_mapped", False):
             op = MappedOperator(
                 task_id=encoded_op['task_id'],
                 dag=None,
-                operator_class='.'.join(filter(None, (encoded_op['_task_module'], encoded_op['_task_type']))),
+                operator_class=f"{encoded_op['_task_module']}.{encoded_op['_task_type']}",
                 # These are all re-set later
                 partial_kwargs={},
                 mapped_kwargs={},

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -694,6 +694,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             setattr(op, k, v)
 
         for k in op.get_serialized_fields() - encoded_op.keys() - cls._CONSTRUCTOR_PARAMS.keys():
+            # TODO: refactor deserialization of BaseOperator and MappedOperaotr (split it out), then check could go away.
             if not hasattr(op, k):
                 setattr(op, k, None)
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -43,7 +43,7 @@ from airflow.settings import json
 from airflow.timetables.base import Timetable
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.module_loading import as_importable_string, import_string
-from airflow.utils.task_group import TaskGroup
+from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
 try:
     # isort: off
@@ -596,7 +596,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         return serialize_op
 
     @classmethod
-    def deserialize_operator(cls, encoded_op: Dict[str, Any]) -> BaseOperator:
+    def deserialize_operator(cls, encoded_op: Dict[str, Any]) -> Union[BaseOperator, MappedOperator]:
         """Deserializes an operator from a JSON object."""
         # Check if it's a mapped operator
         if "mapped_kwargs" in encoded_op:
@@ -1010,6 +1010,14 @@ class SerializedTaskGroup(TaskGroup, BaseSerialization):
             "upstream_task_ids": cls._serialize(sorted(task_group.upstream_task_ids)),
             "downstream_task_ids": cls._serialize(sorted(task_group.downstream_task_ids)),
         }
+
+        if isinstance(task_group, MappedTaskGroup):
+            if task_group.mapped_arg:
+                serialize_group['mapped_arg'] = cls._serialize(task_group.mapped_arg)
+            if task_group.mapped_kwargs:
+                serialize_group['mapped_arg'] = cls._serialize(task_group.mapped_kwargs)
+            if task_group.partial_kwargs:
+                serialize_group['mapped_arg'] = cls._serialize(task_group.partial_kwargs)
 
         return serialize_group
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -694,7 +694,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             setattr(op, k, v)
 
         for k in op.get_serialized_fields() - encoded_op.keys() - cls._CONSTRUCTOR_PARAMS.keys():
-            # TODO: refactor deserialization of BaseOperator and MappedOperaotr (split it out), then check could go away.
+            # TODO: refactor deserialization of BaseOperator and MappedOperaotr (split it out), then check
+            # could go away.
             if not hasattr(op, k):
                 setattr(op, k, None)
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -148,9 +148,8 @@ class TaskGroup(DAGNode):
         # so that we can optimize the number of edges when entire TaskGroups depend on each other.
         self.upstream_group_ids: Set[Optional[str]] = set()
         self.downstream_group_ids: Set[Optional[str]] = set()
-        # Since the parent class defines these as read-only properties, we can 't just do `self.x = ...`
-        self.__dict__['upstream_task_ids'] = set()
-        self.__dict__['downstream_task_ids'] = set()
+        self.upstream_task_ids = set()
+        self.downstream_task_ids = set()
 
     def _check_for_group_id_collisions(self, add_suffix_on_collision: bool):
         if self._group_id is None:
@@ -184,14 +183,6 @@ class TaskGroup(DAGNode):
     def is_root(self) -> bool:
         """Returns True if this TaskGroup is the root TaskGroup. Otherwise False"""
         return not self.group_id
-
-    @property
-    def upstream_task_ids(self) -> Set[str]:
-        return self.__dict__['upstream_task_ids']
-
-    @property
-    def downstream_task_ids(self) -> Set[str]:
-        return self.__dict__['downstream_task_ids']
 
     def __iter__(self):
         for child in self.children.values():

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -400,7 +400,7 @@ class TaskGroup(DAGNode):
             raise RuntimeError("Cannot map a TaskGroup before it has a group_id")
         if self._parent_group:
             self._parent_group._remove(self)
-        return MappedTaskGroup(group_id=self._group_id, mapped_arg=arg)
+        return MappedTaskGroup(group_id=self._group_id, dag=self.dag, mapped_arg=arg)
 
 
 class MappedTaskGroup(TaskGroup):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -102,7 +102,7 @@ serialized_simple_dag_ground_truth = {
                 "retry_delay": 300.0,
                 "max_retry_delay": 600.0,
                 "sla": 100.0,
-                "_downstream_task_ids": [],
+                "downstream_task_ids": [],
                 "_inlets": [],
                 "_is_dummy": False,
                 "_outlets": [],
@@ -132,7 +132,7 @@ serialized_simple_dag_ground_truth = {
                 "retry_delay": 300.0,
                 "max_retry_delay": 600.0,
                 "sla": 100.0,
-                "_downstream_task_ids": [],
+                "downstream_task_ids": [],
                 "_inlets": [],
                 "_is_dummy": False,
                 "_outlets": [],
@@ -1099,13 +1099,13 @@ class TestStringifiedDAGs:
         base_operator = BaseOperator(task_id="10")
         fields = {k: v for (k, v) in vars(base_operator).items() if k in BaseOperator.get_serialized_fields()}
         assert fields == {
-            '_downstream_task_ids': set(),
             '_inlets': [],
             '_log': base_operator.log,
             '_outlets': [],
             '_pre_execute_hook': None,
             '_post_execute_hook': None,
             'depends_on_past': False,
+            'downstream_task_ids': set(),
             'do_xcom_push': True,
             'doc': None,
             'doc_json': None,
@@ -1152,6 +1152,24 @@ class TestStringifiedDAGs:
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                          """
+
+    def test_operator_deserialize_old_names(self):
+        blob = {
+            "task_id": "custom_task",
+            "_downstream_task_ids": ['foo'],
+            "template_ext": [],
+            "template_fields": ['bash_command'],
+            "template_fields_renderers": {},
+            "_task_type": "CustomOperator",
+            "_task_module": "tests.test_utils.mock_operators",
+            "pool": "default_pool",
+            "ui_color": "#fff",
+            "ui_fgcolor": "#000",
+        }
+
+        SerializedDAG._json_schema.validate(blob, _schema=load_dag_schema_dict()['definitions']['operator'])
+        serialized_op = SerializedBaseOperator.deserialize_operator(blob)
+        assert serialized_op.downstream_task_ids == {'foo'}
 
     def test_task_group_serialization(self):
         """

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -41,7 +41,7 @@ def get_task_instance(session, dag_maker):
                 task_id='test_task', trigger_rule=trigger_rule, start_date=datetime(2015, 1, 1)
             )
             if upstream_task_ids:
-                task._upstream_task_ids.update(upstream_task_ids)
+                task.upstream_task_ids.update(upstream_task_ids)
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task


### PR DESCRIPTION
This is needed for the scheduler to be able to expand the task instances at runtime