### PR TITLE
Snowflake Provider: Improve tests for Snowflake Hook

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -315,9 +315,10 @@ class SnowflakeHook(DbApiHook):
                         self.log.info("Statement execution info - %s", row)
                         execution_info.append(row)
 
+                    query_id = cur.sfqid
                     self.log.info("Rows affected: %s", cur.rowcount)
-                    self.log.info("Snowflake query id: %s", cur.sfqid)
-                    self.query_ids.append(cur.sfqid)
+                    self.log.info("Snowflake query id: %s", query_id)
+                    self.query_ids.append(query_id)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.


### PR DESCRIPTION
This PR improves `test_run_storing_query_ids_extra` test for Snowflake Hook.

- Redundant testing of `Snowflake.get_conn` (This is already tested in `test_get_conn_should_call_connect`)
- The expected values were derived from input, so you can't easily fail the test ! I have passed expected results and input separately
- We were passing duplicate values in `query_ids`. I have fixed that by changing the code to only access `cur.sfqid` once in a variable and reuse that variable for logging and returning.

Co-authored-by: bharanidharan14 <94612827+bharanidharan14@users.noreply.github.com>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
