### PR TITLE
Avoid unintentional data loss when deleting DAGs

### DIFF
--- a/airflow/api/common/delete_dag.py
+++ b/airflow/api/common/delete_dag.py
@@ -54,7 +54,7 @@ def delete_dag(dag_id: str, keep_records_in_log: bool = True, session=None) -> i
     if dag is None:
         raise DagNotFound(f"Dag id {dag_id} not found")
 
-    # deleting a DAG should also all of its subdags
+    # deleting a DAG should also delete all of its subdags
     dags_to_delete_query = session.query(DagModel.dag_id).filter(
         or_(
             DagModel.dag_id == dag_id,


### PR DESCRIPTION
We encountered some data loss today due to a user deleting a DAG from the UI called `project.load`, which then deleted all of the history from other DAGs called `project.load.bigquery` and `project.load.trino`, which also caused them to run unexpectedly due to the resetting of run history.

Note - we don't use SubDAGs, we're just using `.` in the DAG ID as a separator for a hierarchical naming system.

As it turns out, deleting a DAG `my_dag` will delete all of the metadata for any DAG which starts with `my_dag.`, as it is assumed that the latter are subdags of the former:

```python
            cond = or_(model.dag_id == dag_id, model.dag_id.like(dag_id + ".%"))
            count += session.query(model).filter(cond).delete(synchronize_session='fetch')
```

This isn't always the case. 

Anyways, this PR changes the delete_dag function so that it only deletes the intended DAG and DAGs starting with `<dag_id>.` _which are also SubDAGs_. I think that there may still be some other edge cases where DAGs can be unintentionally deleted, but this patches the most apparent case. 

This can all be cleaned up even more once the deprecation of SubDAGs is complete (Airflow 3?)
