### PR TITLE
Update metric name in documentation

### DIFF
--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -101,13 +101,13 @@ Name                                        Description
                                             section (needed to send tasks to the executor) and found it locked by
                                             another process.
 ``sla_email_notification_failure``          Number of failed SLA miss email notification attempts
-``ti.start.<dagid>.<taskid>``               Number of started task in a given dag. Similar to <job_name>_start but for task
-``ti.finish.<dagid>.<taskid>.<state>``      Number of completed task in a given dag. Similar to <job_name>_end but for task
+``ti.start.<dag_id>.<task_id>``               Number of started task in a given dag. Similar to <job_name>_start but for task
+``ti.finish.<dag_id>.<task_id>.<state>``      Number of completed task in a given dag. Similar to <job_name>_end but for task
 ``dag.callback_exceptions``                 Number of exceptions raised from DAG callbacks. When this happens, it
                                             means DAG callback is not working.
 ``celery.task_timeout_error``               Number of ``AirflowTaskTimeout`` errors raised when publishing Task to Celery Broker.
-``task_removed_from_dag.<dagid>``           Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
-``task_restored_to_dag.<dagid>``            Number of tasks restored for a given dag (i.e. task instance which was
+``task_removed_from_dag.<dag_id>``           Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
+``task_restored_to_dag.<dag_id>``            Number of tasks restored for a given dag (i.e. task instance which was
                                             previously in REMOVED state in the DB is added to DAG file)
 ``task_instance_created-<operator_name>``   Number of tasks instances created for a given Operator
 ``triggers.blocked_main_thread``            Number of triggers that blocked the main thread (likely due to not being

--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -101,13 +101,13 @@ Name                                        Description
                                             section (needed to send tasks to the executor) and found it locked by
                                             another process.
 ``sla_email_notification_failure``          Number of failed SLA miss email notification attempts
-``ti.start.<dag_id>.<task_id>``               Number of started task in a given dag. Similar to <job_name>_start but for task
-``ti.finish.<dag_id>.<task_id>.<state>``      Number of completed task in a given dag. Similar to <job_name>_end but for task
+``ti.start.<dag_id>.<task_id>``             Number of started task in a given dag. Similar to <job_name>_start but for task
+``ti.finish.<dag_id>.<task_id>.<state>``    Number of completed task in a given dag. Similar to <job_name>_end but for task
 ``dag.callback_exceptions``                 Number of exceptions raised from DAG callbacks. When this happens, it
                                             means DAG callback is not working.
 ``celery.task_timeout_error``               Number of ``AirflowTaskTimeout`` errors raised when publishing Task to Celery Broker.
-``task_removed_from_dag.<dag_id>``           Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
-``task_restored_to_dag.<dag_id>``            Number of tasks restored for a given dag (i.e. task instance which was
+``task_removed_from_dag.<dag_id>``          Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
+``task_restored_to_dag.<dag_id>``           Number of tasks restored for a given dag (i.e. task instance which was
                                             previously in REMOVED state in the DB is added to DAG file)
 ``task_instance_created-<operator_name>``   Number of tasks instances created for a given Operator
 ``triggers.blocked_main_thread``            Number of triggers that blocked the main thread (likely due to not being


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In documentation, some metric name are `<dagid>`, `<taskid>`.

So I update them `<dag_id>` and `<task_id>`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
