### PR TITLE
Rename amazon EMR hook name

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -39,7 +39,7 @@ class EmrHook(AwsBaseHook):
     conn_name_attr = 'emr_conn_id'
     default_conn_name = 'emr_default'
     conn_type = 'emr'
-    hook_name = 'Elastic MapReduce'
+    hook_name = 'Amazon Elastic MapReduce'
 
     def __init__(self, emr_conn_id: Optional[str] = default_conn_name, *args, **kwargs) -> None:
         self.emr_conn_id = emr_conn_id


### PR DESCRIPTION
Renamed emr hook from Elastic MapReduce to Amazon Elastic MapReduce

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fixes for request at https://github.com/apache/airflow/issues/20746 to make the hook naming consistent with other AWS hooks
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
