### PR TITLE
Add roles to create_user test

### DIFF
--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -326,6 +326,7 @@ def test_create_user(app, admin_client, non_exist_username):
             'last_name': 'fake_last_name',
             'username': non_exist_username,
             'email': 'fake_email@email.com',
+            'roles': [1],
             'password': 'test',
             'conf_password': 'test',
         },


### PR DESCRIPTION
Flask App Builder 3.4.3 made role and conf_password obligatory
when creating user:
https://github.com/dpgaspar/Flask-AppBuilder/pull/1758

Our test for user creation did not have the role set (though the
UI used it and the cient also allows to set it).

This change adds the `roles` in our tests to enable upgrade
to FAB 3.4.3 for the CI (currently tests in main fail because of
the test failure)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
