### PR TITLE
Fix airflow dag trigger cli

### DIFF
--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -20,6 +20,8 @@ import json
 from datetime import datetime
 from typing import List, Optional, Union
 
+import pendulum
+
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.utils import timezone
@@ -88,6 +90,9 @@ def _trigger_dag(
             conf=run_conf,
             external_trigger=True,
             dag_hash=dag_bag.dags_hash.get(dag_id),
+            data_interval=_dag.timetable.infer_manual_data_interval(
+                run_after=pendulum.instance(execution_date)
+            ),
         )
         dag_runs.append(dag_run)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The "airflow dag trigger" reports a harmless yet annoying warning message "Calling DAG.create_dagrun() without an explicit data interval is deprecated". The issue can be fixed by setting the `create_dagrun`  function argument `data_interval` to the same value as is calculated by the function.

closes: https://github.com/apache/airflow/issues/20579
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
