### PR TITLE
Chart: fix extra containers docs and remove krb excess if

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -277,15 +277,13 @@ spec:
 {{- if .Values.workers.extraVolumes }}
 {{ toYaml .Values.workers.extraVolumes | indent 8 }}
 {{- end }}
-        {{- if .Values.kerberos.enabled }}
-        - name: kerberos-keytab
-          secret:
-            secretName: {{ include "kerberos_keytab_secret" . | quote }}
-        {{- end }}
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
         {{- if .Values.kerberos.enabled }}
+        - name: kerberos-keytab
+          secret:
+            secretName: {{ include "kerberos_keytab_secret" . | quote }}
         - name: kerberos-ccache
           emptyDir: {}
         {{- end }}

--- a/docs/helm-chart/using-additional-containers.rst
+++ b/docs/helm-chart/using-additional-containers.rst
@@ -22,7 +22,7 @@ Sidecar Containers
 ------------------
 
 If you want to deploy your own sidecar container, you can add it through the ``extraContainers`` parameter.
-You can define different containers for the scheduler, webserver and worker pods.
+You can define different containers for the scheduler, webserver, worker, triggerer, flower and Airflow k8s job pods.
 
 For example, sidecars that sync DAGs from object storage.
 
@@ -49,7 +49,7 @@ Init Containers
 ---------------
 
 You can also deploy extra init containers through the ``extraInitContainers`` parameter.
-You can define different containers for the scheduler, webserver and worker pods.
+You can define different containers for the scheduler, webserver, worker and triggerer pods.
 
 For example, an init container that just says hello:
 

--- a/docs/helm-chart/using-additional-containers.rst
+++ b/docs/helm-chart/using-additional-containers.rst
@@ -22,7 +22,7 @@ Sidecar Containers
 ------------------
 
 If you want to deploy your own sidecar container, you can add it through the ``extraContainers`` parameter.
-You can define different containers for the scheduler, webserver, worker, triggerer, flower and Airflow k8s job pods.
+You can define different containers for the scheduler, webserver, worker, triggerer, flower, create user Job and migrate database Job Pods.
 
 For example, sidecars that sync DAGs from object storage.
 


### PR DESCRIPTION
Two minor changes for the chart:

* Update documentation about extra containers
* Put worker kerberos volumes into a single `if` block for better readability

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
