### PR TITLE
Fix Vault default conn name

### DIFF
--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -112,7 +112,7 @@ class VaultHook(BaseHook):
     """
 
     conn_name_attr = 'vault_conn_id'
-    default_conn_name = 'imap_default'
+    default_conn_name = 'vault_default'
     conn_type = 'vault'
     hook_name = 'Hashicorp Vault'
 


### PR DESCRIPTION
HashiCorp Vault connection uses `imap_default` as default connection name, which seems to be a copy/paste error.