### PR TITLE
changing execution_date to run_id

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -3079,7 +3079,7 @@ log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{
 log_processor_filename_template = {{{{ filename }}}}.log
 
 [elasticsearch]
-elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{run_id}}-{{try_number}}
 elasticsearch_end_of_log_mark = end_of_log
 ```
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1000,7 +1000,7 @@ api_rev = v3
 host =
 
 # Format of the log_id, which is used to query for a given tasks logs
-log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+log_id_template = {{dag_id}}-{{task_id}}-{{run_id}}-{{try_number}}
 
 # Used to mark the end of a log stream for a task
 end_of_log_mark = end_of_log

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -115,7 +115,7 @@ max_tis_per_query = 512
 
 [elasticsearch]
 host =
-log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+log_id_template = {{dag_id}}-{{task_id}}-{{run_id}}-{{try_number}}
 end_of_log_mark = end_of_log
 
 [elasticsearch_configs]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1395,7 +1395,7 @@ config:
     run_duration: 41460
   elasticsearch:
     json_format: 'True'
-    log_id_template: "{dag_id}_{task_id}_{execution_date}_{try_number}"
+    log_id_template: "{dag_id}_{task_id}_{run_id}_{try_number}"
   elasticsearch_configs:
     max_retries: 3
     timeout: 30

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -64,7 +64,7 @@ class TestElasticsearchTaskHandler:
     def setup(self):
         self.local_log_location = 'local/log/location'
         self.filename_template = '{try_number}.log'
-        self.log_id_template = '{dag_id}-{task_id}-{execution_date}-{try_number}'
+        self.log_id_template = '{dag_id}-{task_id}-{run_id}-{try_number}'
         self.end_of_log_mark = 'end_of_log\n'
         self.write_stdout = False
         self.json_format = False


### PR DESCRIPTION
related: [#19593](https://github.com/apache/airflow/pull/19593/files)

Align test of the configuration files to work with `run_id` (rather than `execution_date`)