### PR TITLE
Only validate Params when DAG is triggered

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -167,6 +167,10 @@ class SerializationError(AirflowException):
     """A problem occurred when trying to serialize a DAG."""
 
 
+class ParamValidationError(AirflowException):
+    """Raise when DAG params is invalid"""
+
+
 class TaskNotFound(AirflowNotFoundException):
     """Raise when a Task is not available in the system."""
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2388,11 +2388,6 @@ class DAG(LoggingMixin):
             else:
                 data_interval = self.infer_automated_data_interval(logical_date)
 
-        # create a copy of params before validating
-        copied_params = copy.deepcopy(self.params)
-        copied_params.update(conf or {})
-        copied_params.validate()
-
         run = DagRun(
             dag_id=self.dag_id,
             run_id=run_id,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2388,6 +2388,11 @@ class DAG(LoggingMixin):
             else:
                 data_interval = self.infer_automated_data_interval(logical_date)
 
+        # create a copy of params before validating
+        copied_params = copy.deepcopy(self.params)
+        copied_params.update(conf or {})
+        copied_params.validate()
+
         run = DagRun(
             dag_id=self.dag_id,
             run_id=run_id,

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -402,7 +402,6 @@ class DagBag(LoggingMixin):
                 dag.timetable.validate()
                 # create a copy of params before validating
                 copied_params = copy.deepcopy(dag.params)
-                copied_params.update(conf or {})
                 copied_params.validate()
                 self.bag_dag(dag=dag, root_dag=dag)
                 found_dags.append(dag)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import copy
 import hashlib
 import importlib
 import importlib.machinery
@@ -400,9 +399,8 @@ class DagBag(LoggingMixin):
             dag.fileloc = mod.__file__
             try:
                 dag.timetable.validate()
-                # create a copy of params before validating
-                copied_params = copy.deepcopy(dag.params)
-                copied_params.validate()
+                # validate dag params
+                dag.params.validate()
                 self.bag_dag(dag=dag, root_dag=dag)
                 found_dags.append(dag)
                 found_dags += dag.subdags

--- a/tests/dags/test_invalid_param.py
+++ b/tests/dags/test_invalid_param.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+from airflow.operators.python import PythonOperator
+
+with DAG(
+    "test_invalid_param",
+    start_date=datetime(2021, 1, 1),
+    schedule_interval="@once",
+    params={
+        # a mandatory str param
+        "str_param": Param(type="string", minLength=2, maxLength=4),
+    },
+) as the_dag:
+
+    def print_these(*params):
+        for param in params:
+            print(param)
+
+    PythonOperator(
+        task_id="ref_params",
+        python_callable=print_these,
+        op_args=[
+            "{{ params.str_param }}",
+        ],
+    )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2362,6 +2362,7 @@ class TestSchedulerJob:
             'test_invalid_cron.py',
             'test_zip_invalid_cron.zip',
             'test_ignore_this.py',
+            'test_invalid_param.py',
         }
         for root, _, files in os.walk(TEST_DAG_FOLDER):
             for file_name in files:

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -42,7 +42,7 @@ from sqlalchemy import inspect
 from airflow import models, settings
 from airflow.configuration import conf
 from airflow.decorators import task as task_decorator
-from airflow.exceptions import AirflowException, DuplicateTaskIdFound
+from airflow.exceptions import AirflowException, DuplicateTaskIdFound, ParamValidationError
 from airflow.models import DAG, DagModel, DagRun, DagTag, TaskFail, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import dag as dag_decorator
@@ -1861,7 +1861,7 @@ class TestDag(unittest.TestCase):
 
     def test_validate_params_on_trigger_dag(self):
         dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
-        with pytest.raises(TypeError, match="No value passed and Param has no default value"):
+        with pytest.raises(ParamValidationError, match="No value passed and Param has no default value"):
             dag.create_dagrun(
                 run_id="test_dagrun_missing_param",
                 state=State.RUNNING,
@@ -1869,7 +1869,9 @@ class TestDag(unittest.TestCase):
             )
 
         dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
-        with pytest.raises(ValueError, match="Invalid input for param param1: None is not of type 'string'"):
+        with pytest.raises(
+            ParamValidationError, match="Invalid input for param param1: None is not of type 'string'"
+        ):
             dag.create_dagrun(
                 run_id="test_dagrun_missing_param",
                 state=State.RUNNING,

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1859,32 +1859,6 @@ class TestDag(unittest.TestCase):
             dag.access_control = outdated_permissions
         assert dag.access_control == updated_permissions
 
-    def test_validate_params_on_trigger_dag(self):
-        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
-        with pytest.raises(TypeError, match="No value passed and Param has no default value"):
-            dag.create_dagrun(
-                run_id="test_dagrun_missing_param",
-                state=State.RUNNING,
-                execution_date=TEST_DATE,
-            )
-
-        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
-        with pytest.raises(ValueError, match="Invalid input for param param1: None is not of type 'string'"):
-            dag.create_dagrun(
-                run_id="test_dagrun_missing_param",
-                state=State.RUNNING,
-                execution_date=TEST_DATE,
-                conf={"param1": None},
-            )
-
-        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
-        dag.create_dagrun(
-            run_id="test_dagrun_missing_param",
-            state=State.RUNNING,
-            execution_date=TEST_DATE,
-            conf={"param1": "hello"},
-        )
-
 
 class TestDagModel:
     def test_dags_needing_dagruns_not_too_early(self):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1859,6 +1859,32 @@ class TestDag(unittest.TestCase):
             dag.access_control = outdated_permissions
         assert dag.access_control == updated_permissions
 
+    def test_validate_params_on_trigger_dag(self):
+        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
+        with pytest.raises(TypeError, match="No value passed and Param has no default value"):
+            dag.create_dagrun(
+                run_id="test_dagrun_missing_param",
+                state=State.RUNNING,
+                execution_date=TEST_DATE,
+            )
+
+        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
+        with pytest.raises(ValueError, match="Invalid input for param param1: None is not of type 'string'"):
+            dag.create_dagrun(
+                run_id="test_dagrun_missing_param",
+                state=State.RUNNING,
+                execution_date=TEST_DATE,
+                conf={"param1": None},
+            )
+
+        dag = models.DAG('dummy-dag', schedule_interval=None, params={'param1': Param(type="string")})
+        dag.create_dagrun(
+            run_id="test_dagrun_missing_param",
+            state=State.RUNNING,
+            execution_date=TEST_DATE,
+            conf={"param1": "hello"},
+        )
+
 
 class TestDagModel:
     def test_dags_needing_dagruns_not_too_early(self):

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -222,6 +222,19 @@ class TestDagBag:
         assert len(dagbag.import_errors) == len(invalid_dag_files)
         assert len(dagbag.dags) == 0
 
+    def test_process_file_invalid_param_check(self):
+        """
+        test if an invalid param in the dag param can be identified
+        """
+        invalid_dag_files = ["test_invalid_param.py"]
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+
+        assert len(dagbag.import_errors) == 0
+        for file in invalid_dag_files:
+            dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, file))
+        assert len(dagbag.import_errors) == len(invalid_dag_files)
+        assert len(dagbag.dags) == 0
+
     @patch.object(DagModel, 'get_current')
     def test_get_dag_without_refresh(self, mock_dagmodel):
         """

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -20,6 +20,7 @@ import unittest
 import pytest
 
 from airflow.decorators import task
+from airflow.exceptions import ParamValidationError
 from airflow.models.param import Param, ParamsDict
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
@@ -36,7 +37,7 @@ class TestParam(unittest.TestCase):
 
     def test_null_param(self):
         p = Param()
-        with pytest.raises(TypeError, match='No value passed and Param has no default value'):
+        with pytest.raises(ParamValidationError, match='No value passed and Param has no default value'):
             p.resolve()
         assert p.resolve(None) is None
 
@@ -48,7 +49,7 @@ class TestParam(unittest.TestCase):
         p = Param(None, type='null')
         assert p.resolve() is None
         assert p.resolve(None) is None
-        with pytest.raises(ValueError):
+        with pytest.raises(ParamValidationError):
             p.resolve('test')
 
     def test_string_param(self):
@@ -62,9 +63,9 @@ class TestParam(unittest.TestCase):
         assert p.resolve() == '10.0.0.0'
 
         p = Param(type='string')
-        with pytest.raises(ValueError):
+        with pytest.raises(ParamValidationError):
             p.resolve(None)
-        with pytest.raises(TypeError, match='No value passed and Param has no default value'):
+        with pytest.raises(ParamValidationError, match='No value passed and Param has no default value'):
             p.resolve()
 
     def test_int_param(self):
@@ -74,7 +75,7 @@ class TestParam(unittest.TestCase):
         p = Param(type='integer', minimum=0, maximum=10)
         assert p.resolve(value=5) == 5
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ParamValidationError):
             p.resolve(value=20)
 
     def test_number_param(self):
@@ -84,7 +85,7 @@ class TestParam(unittest.TestCase):
         p = Param(1.0, type='number')
         assert p.resolve() == 1.0
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ParamValidationError):
             p = Param('42', type='number')
             p.resolve()
 
@@ -125,7 +126,7 @@ class TestParam(unittest.TestCase):
         p = S3Param("s3://my_bucket/my_path")
         assert p.resolve() == "s3://my_bucket/my_path"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ParamValidationError):
             p = S3Param("file://not_valid/s3_path")
             p.resolve()
 
@@ -175,7 +176,7 @@ class TestParamsDict:
         pd3.validate()
 
         # Update the ParamsDict
-        with pytest.raises(ValueError, match=r'Invalid input for param key: 1 is not'):
+        with pytest.raises(ParamValidationError, match=r'Invalid input for param key: 1 is not'):
             pd3['key'] = 1
 
         # Should not raise an error as suppress_exception is True
@@ -188,7 +189,7 @@ class TestParamsDict:
         pd.update({'key': 'a'})
         internal_value = pd.get_param('key')
         assert isinstance(internal_value, Param)
-        with pytest.raises(ValueError, match=r'Invalid input for param key: 1 is not'):
+        with pytest.raises(ParamValidationError, match=r'Invalid input for param key: 1 is not'):
             pd.update({'key': 1})
 
 

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -86,6 +86,7 @@ class TestParam(unittest.TestCase):
 
         with pytest.raises(ValueError):
             p = Param('42', type='number')
+            p.resolve()
 
     def test_list_param(self):
         p = Param([1, 2], type='array')
@@ -126,6 +127,7 @@ class TestParam(unittest.TestCase):
 
         with pytest.raises(ValueError):
             p = S3Param("file://not_valid/s3_path")
+            p.resolve()
 
     def test_value_saved(self):
         p = Param("hello", type="string")
@@ -270,4 +272,5 @@ class TestDagParamRuntime:
 
     def test_param_non_json_serializable(self):
         with pytest.warns(DeprecationWarning, match='The use of non-json-serializable params is deprecated'):
-            Param(default={0, 1, 2})
+            p = Param(default={0, 1, 2})
+            p.resolve()


### PR DESCRIPTION
The current validation that happens when viewing the dag is raising
errors and preventing users from viewing the DAG. This PR moves validation
to the resolve method which runs validation when a dag is triggered with params

Closes: https://github.com/apache/airflow/issues/20559
Closes: https://github.com/apache/airflow/issues/20442

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
