### PR TITLE
fix: cloudwatch logs fetch logic

### DIFF
--- a/airflow/providers/amazon/aws/hooks/logs.py
+++ b/airflow/providers/amazon/aws/hooks/logs.py
@@ -71,9 +71,7 @@ class AwsLogsHook(AwsBaseHook):
                  |   'ingestionTime' (int): The time in milliseconds the event was ingested.
         """
         next_token = None
-
-        event_count = 1
-        while event_count > 0:
+        while True:
             if next_token is not None:
                 token_arg: Optional[Dict[str, str]] = {'nextToken': next_token}
             else:
@@ -99,7 +97,7 @@ class AwsLogsHook(AwsBaseHook):
 
             yield from events
 
-            if 'nextForwardToken' in response:
+            if next_token != response['nextForwardToken']:
                 next_token = response['nextForwardToken']
             else:
                 return


### PR DESCRIPTION
Cloudwatch `get_log_events` can return empty results even though there are more log events available in the stream. In my recent interaction with the AWS team, it was pointed out that the correct way to check for end of stream is that if the value of `nextForwardToken` is same in subsequent calls 

https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html