### PR TITLE
Fix task instances iteration in a pool to prevent blocking

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -339,16 +339,17 @@ class SchedulerJob(BaseJob):
                 continue
 
             pool_total = pools[pool]["total"]
-            if task_instance.pool_slots > pool_total:
-                self.log.warning(
-                    "Not executing %s. Requested pool slots (%s) are greater than "
-                    "total pool slots: '%s' for pool: %s.",
-                    task_instance,
-                    task_instance.pool_slots,
-                    pool_total,
-                    pool,
-                )
-                continue
+            for task_instance in task_instances:
+                if task_instance.pool_slots > pool_total:
+                    self.log.warning(
+                        "Not executing %s. Requested pool slots (%s) are greater than "
+                        "total pool slots: '%s' for pool: %s.",
+                        task_instance,
+                        task_instance.pool_slots,
+                        pool_total,
+                        pool,
+                    )
+                    task_instances.remove(task_instance)
 
             open_slots = pools[pool]["open"]
 


### PR DESCRIPTION
While investigating another issue, I found what appears to be a bug introduced in https://github.com/apache/airflow/pull/20178 in the `_executable_task_instances_to_queued` function of the scheduler job. 

Here is the affected piece of code:
https://github.com/apache/airflow/blob/c9023fad4287213e4d3d77f4c66799c762bff7ba/airflow/jobs/scheduler_job.py#L335-L351

So we're iterating through a list of `(pool_name: string, task_instances: List[TaskInstance])` pairs, but then checking the value of `task_instance.pool_slots`, which is not explicitly set anywhere.

This means that we actually end up using the value set implicitly by this loop earlier in the function:
https://github.com/apache/airflow/blob/c9023fad4287213e4d3d77f4c66799c762bff7ba/airflow/jobs/scheduler_job.py#L318-L319

This also means that we're comparing the pool capacity to the required slots from a task which may not even be assigned to that pool, which could have other affects. 

And because of the `continue`, if this task happens to require more slots than the specified pool can provide, then all of the scheduled tasks in all pools will be skipped over and none will be advanced to the `QUEUED` state. 

Anyways, I've refactored this check such that it checks every TI in `task_instances` individually and simply removes any non-executable TIs from the list of candidates tasks to be queued. I've updated the test accordingly. 


