### PR TITLE
Add Context stub to Airflow packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,3 +37,4 @@ include airflow/provider_info.schema.json
 include airflow/customized_form_field_behaviours.schema.json
 include airflow/serialization/schema.json
 include airflow/utils/python_virtualenv_script.jinja2
+include airflow/utils/context.pyi

--- a/setup.cfg
+++ b/setup.cfg
@@ -177,6 +177,8 @@ airflow=
 
 airflow.api_connexion.openapi=*.yaml
 airflow.serialization=*.json
+airflow.utils=
+    context.pyi
 
 [options.entry_points]
 console_scripts=


### PR DESCRIPTION
We agreed that context.pyi is useful to be included in the
airflow package as it will help our users with autocomplete and
verification of the custom operators.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
