### PR TITLE
Test util `env_vars` to take arbitrary env vars

### DIFF
--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -67,7 +67,7 @@ TEMP_DAG_FILENAME = "temp_dag.py"
 @pytest.fixture(scope="class")
 def disable_load_example():
     with conf_vars({('core', 'load_examples'): 'false'}):
-        with env_vars({('core', 'load_examples'): 'false'}):
+        with env_vars({'AIRFLOW__CORE__LOAD_EXAMPLES': 'false'}):
             yield
 
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -84,7 +84,7 @@ TRY_NUMBER = 1
 @pytest.fixture(scope="class")
 def disable_load_example():
     with conf_vars({('core', 'load_examples'): 'false'}):
-        with env_vars({('core', 'load_examples'): 'false'}):
+        with env_vars({'AIRFLOW__CORE__LOAD_EXAMPLES': 'false'}):
             yield
 
 

--- a/tests/test_utils/config.py
+++ b/tests/test_utils/config.py
@@ -59,10 +59,16 @@ def conf_vars(overrides):
 
 @contextlib.contextmanager
 def env_vars(overrides):
+    """
+    Temporarily patches env vars, restoring env as it was after context exit.
+
+    Example:
+        with env_vars({'AIRFLOW_CONN_AWS_DEFAULT': 's3://@'}):
+            # now we have an aws default connection available
+    """
     orig_vars = {}
     new_vars = []
-    for (section, key), value in overrides.items():
-        env = conf._env_var_name(section, key)
+    for env, value in overrides.items():
         if env in os.environ:
             orig_vars[env] = os.environ.pop(env, '')
         else:


### PR DESCRIPTION
Currently it assumes that you will only use this for config settings (which you can already do with `conf_vars`).

We should allow any kind of env var so that for example it could be used to patch an airflow conn or any other env var (which is sort of what is advertised in the function name anyway).
