### PR TITLE
Move tests out of test core that are duplicated/should live elsewhere

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -16,32 +16,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
-import signal
-from datetime import timedelta
+from datetime import datetime, timedelta
 from time import sleep
-from unittest.mock import MagicMock
 
 import pytest
 
 from airflow import settings
-from airflow.exceptions import AirflowException, AirflowTaskTimeout
-from airflow.hooks.base import BaseHook
-from airflow.models import DagBag, TaskFail, TaskInstance
+from airflow.exceptions import AirflowTaskTimeout
+from airflow.models import TaskFail, TaskInstance
 from airflow.operators.bash import BashOperator
-from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
-from airflow.utils.dates import days_ago
-from airflow.utils.state import State
-from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_task_fail
 
-DEV_NULL = '/dev/null'
 DEFAULT_DATE = datetime(2015, 1, 1)
-TEST_DAG_ID = 'unit_tests'
 
 
 class TestCore:
@@ -51,159 +40,14 @@ class TestCore:
         clear_db_dags()
         clear_db_runs()
 
-    default_scheduler_args = {"num_runs": 1}
-
-    def setup_method(self):
-        self.clean_db()
-        self.dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True, read_dags_from_db=False)
-        self.dag_bash = self.dagbag.dags['example_bash_operator']
-        self.runme_0 = self.dag_bash.get_task('runme_0')
-        self.run_after_loop = self.dag_bash.get_task('run_after_loop')
-        self.run_this_last = self.dag_bash.get_task('run_this_last')
-
     def teardown_method(self):
         self.clean_db()
-
-    def test_check_operators(self, dag_maker):
-
-        conn_id = "sqlite_default"
-
-        captain_hook = BaseHook.get_hook(conn_id=conn_id)  # quite funny :D
-        captain_hook.run("CREATE TABLE operator_test_table (a, b)")
-        captain_hook.run("insert into operator_test_table values (1,2)")
-        with dag_maker(TEST_DAG_ID) as dag:
-            op = CheckOperator(
-                task_id='check', sql="select count(*) from operator_test_table", conn_id=conn_id
-            )
-        dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-        op = ValueCheckOperator(
-            task_id='value_check',
-            pass_value=95,
-            tolerance=0.1,
-            conn_id=conn_id,
-            sql="SELECT 100",
-            dag=dag,
-        )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-        captain_hook.run("drop table operator_test_table")
-
-    def test_clear_api(self, session):
-        task = self.dag_bash.tasks[0]
-
-        dr = self.dag_bash.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            execution_date=days_ago(1),
-            session=session,
-        )
-        task.clear(start_date=dr.execution_date, end_date=dr.execution_date, upstream=True, downstream=True)
-        ti = dr.get_task_instance(task.task_id, session=session)
-        ti.task = task
-        ti.are_dependents_done()
-
-    def test_illegal_args(self, dag_maker):
-        """
-        Tests that Operators reject illegal arguments
-        """
-        msg = 'Invalid arguments were passed to BashOperator (task_id: test_illegal_args).'
-        with conf_vars({('operators', 'allow_illegal_arguments'): 'True'}):
-            with pytest.warns(PendingDeprecationWarning) as warnings:
-                with dag_maker():
-                    BashOperator(
-                        task_id='test_illegal_args',
-                        bash_command='echo success',
-                        illegal_argument_1234='hello?',
-                    )
-                dag_maker.create_dagrun()
-                assert any(msg in str(w) for w in warnings)
-
-    def test_illegal_args_forbidden(self, dag_maker):
-        """
-        Tests that operators raise exceptions on illegal arguments when
-        illegal arguments are not allowed.
-        """
-        with pytest.raises(AirflowException) as ctx:
-            with dag_maker():
-                BashOperator(
-                    task_id='test_illegal_args',
-                    bash_command='echo success',
-                    illegal_argument_1234='hello?',
-                )
-            dag_maker.create_dagrun()
-        assert 'Invalid arguments were passed to BashOperator (task_id: test_illegal_args).' in str(ctx.value)
-
-    def test_bash_operator(self, dag_maker):
-        with dag_maker():
-            op = BashOperator(task_id='test_bash_operator', bash_command="echo success")
-        dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_bash_operator_multi_byte_output(self, dag_maker):
-        with dag_maker():
-            op = BashOperator(
-                task_id='test_multi_byte_bash_operator',
-                bash_command="echo \u2600",
-                output_encoding='utf-8',
-            )
-        dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_bash_operator_kill(self, dag_maker):
-        import psutil
-
-        sleep_time = "100%d" % os.getpid()
-        with dag_maker():
-            op = BashOperator(
-                task_id='test_bash_operator_kill',
-                execution_timeout=timedelta(seconds=1),
-                bash_command=f"/bin/bash -c 'sleep {sleep_time}'",
-            )
-        dag_maker.create_dagrun()
-        with pytest.raises(AirflowTaskTimeout):
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        sleep(2)
-        pid = -1
-        for proc in psutil.process_iter():
-            if proc.cmdline() == ['sleep', sleep_time]:
-                pid = proc.pid
-        if pid != -1:
-            os.kill(pid, signal.SIGTERM)
-            self.fail("BashOperator's subprocess still running after stopping on timeout!")
-
-    def test_on_failure_callback(self, dag_maker):
-        mock_failure_callback = MagicMock()
-
-        with dag_maker():
-            op = BashOperator(
-                task_id='check_on_failure_callback',
-                bash_command="exit 1",
-                on_failure_callback=mock_failure_callback,
-            )
-        dag_maker.create_dagrun()
-        with pytest.raises(AirflowException):
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        mock_failure_callback.assert_called_once()
 
     def test_dryrun(self, dag_maker):
         with dag_maker():
             op = BashOperator(task_id='test_dryrun', bash_command="echo success")
         dag_maker.create_dagrun()
         op.dry_run()
-
-    def test_sqlite(self, dag_maker):
-        import airflow.providers.sqlite.operators.sqlite
-
-        with dag_maker():
-            op = airflow.providers.sqlite.operators.sqlite.SqliteOperator(
-                task_id='time_sqlite',
-                sql="CREATE TABLE IF NOT EXISTS unitest (dummy VARCHAR(20))",
-            )
-        dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
     def test_timeout(self, dag_maker):
         with dag_maker():
@@ -215,72 +59,6 @@ class TestCore:
         dag_maker.create_dagrun()
         with pytest.raises(AirflowTaskTimeout):
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_python_op(self, dag_maker):
-        def test_py_op(templates_dict, ds):
-            if not templates_dict['ds'] == ds:
-                raise Exception("failure")
-
-        with dag_maker():
-            op = PythonOperator(
-                task_id='test_py_op', python_callable=test_py_op, templates_dict={'ds': "{{ ds }}"}
-            )
-        dag_maker.create_dagrun(run_type=DagRunType.MANUAL)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-    def test_task_get_template(self, session):
-        dr = self.dag_bash.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            data_interval=(DEFAULT_DATE, DEFAULT_DATE + timedelta(days=1)),
-            session=session,
-        )
-        ti = TaskInstance(task=self.runme_0, run_id=dr.run_id)
-        ti.dag = self.dag_bash
-        ti.run(ignore_ti_state=True)
-        context = ti.get_template_context()
-
-        # DEFAULT DATE is 2015-01-01
-        assert context['ds'] == '2015-01-01'
-        assert context['ds_nodash'] == '20150101'
-
-        assert context['ts'] == '2015-01-01T00:00:00+00:00'
-        assert context['ts_nodash'] == '20150101T000000'
-        assert context['ts_nodash_with_tz'] == '20150101T000000+0000'
-
-        assert context['data_interval_start'].isoformat() == '2015-01-01T00:00:00+00:00'
-        assert context['data_interval_end'].isoformat() == '2015-01-02T00:00:00+00:00'
-
-        # Test deprecated fields.
-        expected_deprecated_fields = [
-            ("next_ds", "2015-01-02"),
-            ("next_ds_nodash", "20150102"),
-            ("prev_ds", "2014-12-31"),
-            ("prev_ds_nodash", "20141231"),
-            ("yesterday_ds", "2014-12-31"),
-            ("yesterday_ds_nodash", "20141231"),
-            ("tomorrow_ds", "2015-01-02"),
-            ("tomorrow_ds_nodash", "20150102"),
-        ]
-        for key, expected_value in expected_deprecated_fields:
-            message_beginning = (
-                f"Accessing {key!r} from the template is deprecated and "
-                f"will be removed in a future version."
-            )
-            with pytest.deprecated_call() as recorder:
-                value = str(context[key])  # Simulate template evaluation to trigger warning.
-            assert value == expected_value
-
-            recorded_message = [str(m.message) for m in recorder]
-            assert len(recorded_message) == 1
-            assert recorded_message[0].startswith(message_beginning)
-
-    def test_bad_trigger_rule(self, dag_maker):
-        with pytest.raises(AirflowException):
-            with dag_maker():
-                DummyOperator(task_id='test_bad_trigger', trigger_rule="non_existent")
-            dag_maker.create_dagrun()
 
     def test_task_fail_duration(self, dag_maker):
         """If a task fails, the duration should be recorded in TaskFail"""

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from time import sleep
 
 import pytest
@@ -27,6 +27,7 @@ from airflow.models import TaskFail, TaskInstance
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
+from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_task_fail
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1643,7 +1643,7 @@ class TestTaskInstance:
         assert len(recorded_message) == 1
         assert recorded_message[0].startswith(message_beginning)
 
-    def test_templte_with_custom_timetable_deprecated_context(self, create_task_instance):
+    def test_template_with_custom_timetable_deprecated_context(self, create_task_instance):
         ti = create_task_instance(
             start_date=DEFAULT_DATE,
             timetable=AfterWorkdayTimetable(),

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1616,7 +1616,34 @@ class TestTaskInstance:
         with pytest.raises(KeyError):
             ti.task.render_template('{{ var.json.get("missing_variable") }}', context)
 
-    def test_tempalte_with_custom_timetable_deprecated_context(self, create_task_instance):
+    @pytest.mark.parametrize(
+        ("field", "expected"),
+        [
+            ("next_ds", "2016-01-01"),
+            ("next_ds_nodash", "20160101"),
+            ("prev_ds", "2015-12-31"),
+            ("prev_ds_nodash", "20151231"),
+            ("yesterday_ds", "2015-12-31"),
+            ("yesterday_ds_nodash", "20151231"),
+            ("tomorrow_ds", "2016-01-02"),
+            ("tomorrow_ds_nodash", "20160102"),
+        ],
+    )
+    def test_deprecated_context(self, field, expected, create_task_instance):
+        ti = create_task_instance(execution_date=DEFAULT_DATE)
+        context = ti.get_template_context()
+        with pytest.deprecated_call() as recorder:
+            assert context[field] == expected
+        message_beginning = (
+            f"Accessing {field!r} from the template is deprecated and "
+            f"will be removed in a future version."
+        )
+
+        recorded_message = [str(m.message) for m in recorder]
+        assert len(recorded_message) == 1
+        assert recorded_message[0].startswith(message_beginning)
+
+    def test_templte_with_custom_timetable_deprecated_context(self, create_task_instance):
         ti = create_task_instance(
             start_date=DEFAULT_DATE,
             timetable=AfterWorkdayTimetable(),


### PR DESCRIPTION
- Testing BashOperator lives in tests.operators.test_bash
- CheckOperator and ValueCheckOperator already tested in
  tests.operators.test.sql (using the non-deprecated names)
- on_failure_callback already tested in test_local_task_job
- SqliteOperator already tested in the sqlite provider
- PythonOperator already extensively tested in
  tests.operators.test_python
- trigger_rule tested in test_baseoperator
- Testing the task context was partially covvered already.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
