### PR TITLE
Speedup liveness probe for scheduler and triggerer

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -157,6 +157,7 @@ spec:
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
             exec:
               command:
+              - CONNECTION_CHECK_MAX_COUNT=0
               - /entrypoint
               - python
               - -Wignore

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -160,6 +160,7 @@ spec:
             periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
             exec:
               command:
+              - CONNECTION_CHECK_MAX_COUNT=0
               - /entrypoint
               - python
               - -Wignore


### PR DESCRIPTION
Speedup liveness probe for scheduler and triggerer
Liveness probe is submitted through `/entrypoint` which by default runs `airflow db check`.
This can be slow.
We can disable by setting `CONNECTION_CHECK_MAX_COUNT=0`.
