### PR TITLE
added an enum param example

### DIFF
--- a/docs/apache-airflow/concepts/params.rst
+++ b/docs/apache-airflow/concepts/params.rst
@@ -134,6 +134,9 @@ JSON Schema Validation
             # a required param which can be of multiple types
             "dummy": Param(type=["null", "number", "string"]),
 
+            # an enum param, must be one of three values
+            "enum_param": Param("foo", enum=["foo", "bar", 42]),
+
             # a param which uses json-schema formatting
             "email": Param(
                 default="example@example.com",


### PR DESCRIPTION
More examples makes it easier to compare our docs with the json-schema docs and figure out how they work together.
I ended up doing something similar to this in my code and figured I'd contribute an example.