### PR TITLE
AwsAthenaOperator: do not generate client_request_token if not provided

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -19,7 +19,6 @@
 import sys
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
-from uuid import uuid4
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -88,7 +87,7 @@ class AthenaOperator(BaseOperator):
         self.database = database
         self.output_location = output_location
         self.aws_conn_id = aws_conn_id
-        self.client_request_token = client_request_token or str(uuid4())
+        self.client_request_token = client_request_token
         self.workgroup = workgroup
         self.query_execution_context = query_execution_context or {}
         self.result_configuration = result_configuration or {}


### PR DESCRIPTION
This PR aims to remove an unnecessary logic in `AwsAthenaOperator` (and in certain use cases, it may cause confusion)

## What this PR does
For `AwsAthenaOperator`, if `client_request_token` is not provided, we should do nothing here, rather than generating a UUID explicitly for it.

## Why do we need this change
- According to AWS doc (link provided below), boto3 will autopopulate `ClientRequestToken` if it's not provided. So it's not necessary to generate it explicitly here
- The current logic means a UUID will be generated when the DAG is being parsed into a DAG object. When we check this DAG object, we will see a "random" `client_request_token`. This may not be desired (for example in the product my team is running, this is causing issue).

## Reference
Relevant AWS Doc link: https://boto3.amazonaws.com/v1/documentation/api/1.18.0/reference/services/athena.html?highlight=start_query_execution#Athena.Client.start_query_execution