### PR TITLE
Fix task ID deduplication in @task_group

### DIFF
--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1096,6 +1096,32 @@ def test_decorator_unknown_args():
             ...
 
 
+def test_decorator_multiple_use_task():
+    from airflow.decorators import task
+
+    @dag("test-dag", start_date=DEFAULT_DATE)
+    def _test_dag():
+        @task
+        def t():
+            pass
+
+        @task_group_decorator
+        def tg():
+            for _ in range(3):
+                t()
+
+        t() >> tg() >> t()
+
+    test_dag = _test_dag()
+    assert test_dag.task_ids == [
+        "t",  # Start end.
+        "tg.t",
+        "tg.t__1",
+        "tg.t__2",
+        "t__1",  # End node.
+    ]
+
+
 def test_decorator_partial_unmapped():
     @task_group_decorator
     def tg():


### PR DESCRIPTION
When appending `__{n}` for task ID deduplication, we are currently using `dag.task_ids`, which prepends the surrounding task group ID. This means that we must also use the group-prefixed *current* task ID to detect duplication, not the raw, un-prefixed, task ID.

Fix #19902