### PR TITLE
Unpin ``cattrs``

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,7 +85,7 @@ install_requires =
     attrs>=20.0, <21.0
     blinker
     cached_property~=1.5;python_version<="3.7"
-    cattrs~=1.1
+    cattrs~=1.1, !=1.7.*
     # Required by vendored-in connexion
     clickclick>=1.2
     colorlog>=4.0.2, <6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,8 +85,7 @@ install_requires =
     attrs>=20.0, <21.0
     blinker
     cached_property~=1.5;python_version<="3.7"
-    # cattrs >= 1.7.0 break lineage - see https://github.com/apache/airflow/issues/16172
-    cattrs~=1.1, <1.7.0
+    cattrs~=1.1
     # Required by vendored-in connexion
     clickclick>=1.2
     colorlog>=4.0.2, <6.0


### PR DESCRIPTION
This was pinned because of issue mentioned in https://github.com/apache/airflow/issues/16172 . However this was fixed in 1.8.0 of cattrs by https://github.com/python-attrs/cattrs/issues/151

Changelog entry - https://cattrs.readthedocs.io/en/latest/history.html#id9

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
