### PR TITLE
Add downgrade to some FAB migrations

### DIFF
--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -313,7 +313,7 @@ def undo_remap_permissions():
     """Unapply Map Airflow permissions"""
     appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
     for old, new in mapping.items:
-        (new_resource_name, new_action_name) = new
+        (new_resource_name, new_action_name) = new[0]
         new_permission = appbuilder.sm.get_permission(new_action_name, new_resource_name)
         if not new_permission:
             continue

--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -309,6 +309,31 @@ def remap_permissions():
             appbuilder.sm.delete_action(old_action_name)
 
 
+def undo_remap_permissions():
+    """Unapply Map Airflow permissions"""
+    appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
+    for old, new in mapping.items:
+        (new_resource_name, new_action_name) = new
+        new_permission = appbuilder.sm.get_permission(new_action_name, new_resource_name)
+        if not new_permission:
+            continue
+        for old_resource_name, old_action_name in old:
+            old_permission = appbuilder.sm.create_permission(old_action_name, old_resource_name)
+            for role in appbuilder.sm.get_all_roles():
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(
+                    new_resource_name, new_action_name, [role.id]
+                ):
+                    appbuilder.sm.add_permission_to_role(role, old_permission)
+                    appbuilder.sm.remove_permission_from_role(role, new_permission)
+        appbuilder.sm.delete_permission(new_action_name, new_resource_name)
+
+        if not appbuilder.sm.get_action(new_action_name):
+            continue
+        resources = appbuilder.sm.get_all_resources()
+        if not any(appbuilder.sm.get_permission(new_action_name, resource.name) for resource in resources):
+            appbuilder.sm.delete_action(new_action_name)
+
+
 def upgrade():
     """Apply Resource based permissions."""
     log = logging.getLogger()
@@ -319,3 +344,7 @@ def upgrade():
 
 def downgrade():
     """Unapply Resource based permissions."""
+    log = logging.getLogger()
+    handlers = log.handlers[:]
+    undo_remap_permissions()
+    log.handlers = handlers

--- a/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
+++ b/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
@@ -56,7 +56,7 @@ def prefix_individual_dag_permissions(session):
 
 
 def remove_prefix_in_individual_dag_permissions(session):
-    dag_perms = ['can_dag_read', 'can_dag_edit']
+    dag_perms = ['can_read', 'can_edit']
     prefix = "DAG:"
     perms = (
         session.query(Permission)

--- a/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
+++ b/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
@@ -55,6 +55,22 @@ def prefix_individual_dag_permissions(session):
     session.commit()
 
 
+def remove_prefix_in_individual_dag_permissions(session):
+    dag_perms = ['can_dag_read', 'can_dag_edit']
+    prefix = "DAG:"
+    perms = (
+        session.query(Permission)
+        .join(Action)
+        .filter(Action.name.in_(dag_perms))
+        .join(Resource)
+        .filter(Resource.name.like(prefix + '%'))
+        .all()
+    )
+    for permission in perms:
+        permission.resource.name = permission.resource.name[len(prefix) :]
+    session.commit()
+
+
 def get_or_create_dag_resource(session):
     dag_resource = get_resource_query(session, permissions.RESOURCE_DAG).first()
     if dag_resource:
@@ -66,6 +82,19 @@ def get_or_create_dag_resource(session):
     session.commit()
 
     return dag_resource
+
+
+def get_or_create_all_dag_resource(session):
+    all_dag_resource = get_resource_query(session, 'all_dags').first()
+    if all_dag_resource:
+        return all_dag_resource
+
+    all_dag_resource = Resource()
+    all_dag_resource.name = 'all_dags'
+    session.add(all_dag_resource)
+    session.commit()
+
+    return all_dag_resource
 
 
 def get_or_create_action(session, action_name):
@@ -158,6 +187,43 @@ def migrate_to_new_dag_permissions(db):
     db.session.commit()
 
 
+def undo_migrate_to_new_dag_permissions(db):
+    # Remove prefix from individual dag perms
+    remove_prefix_in_individual_dag_permissions(db.session)
+
+    # Update existing permissions to use `can_dag_read` instead of `can_read`
+    can_read_action = get_action_query(db.session, 'can_read').first()
+    new_can_read_permissions = get_permission_with_action_query(db.session, can_read_action)
+    can_dag_read_action = get_or_create_action(db.session, 'can_dag_read')
+    update_permission_action(db.session, new_can_read_permissions, can_dag_read_action)
+
+    # Update existing permissions to use `can_dag_edit` instead of `can_edit`
+    can_edit_action = get_action_query(db.session, 'can_edit').first()
+    new_can_edit_permissions = get_permission_with_action_query(db.session, can_edit_action)
+    can_dag_edit_action = get_or_create_action(db.session, 'can_dag_edit')
+    update_permission_action(db.session, new_can_edit_permissions, can_dag_edit_action)
+
+    # Update existing permissions for `DAGs` resource to use `all_dags` resource.
+    dag_resource = get_resource_query(db.session, permissions.RESOURCE_DAG).first()
+    if dag_resource:
+        new_dag_permission = get_permission_with_resource_query(db.session, dag_resource)
+        old_all_dag_resource = get_or_create_all_dag_resource(db.session)
+        update_permission_resource(db.session, new_dag_permission, old_all_dag_resource)
+
+        # Delete the `DAG` resource
+        db.session.delete(dag_resource)
+
+    # Delete `can_read` action
+    if can_read_action:
+        db.session.delete(can_read_action)
+
+    # Delete `can_edit` action
+    if can_edit_action:
+        db.session.delete(can_edit_action)
+
+    db.session.commit()
+
+
 def upgrade():
     db = SQLA()
     db.session = settings.Session
@@ -167,4 +233,8 @@ def upgrade():
 
 
 def downgrade():
-    pass
+    db = SQLA()
+    db.session = settings.Session
+    undo_migrate_to_new_dag_permissions(db)
+    db.session.commit()
+    db.session.close()

--- a/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
+++ b/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
@@ -165,7 +165,7 @@ def undo_remap_permissions():
     """Unapply Map Airflow permissions"""
     appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
     for old, new in mapping.items():
-        (new_resource_name, new_action_name) = new
+        (new_resource_name, new_action_name) = new[0]
         new_permission = appbuilder.sm.get_permission(new_action_name, new_resource_name)
         if not new_permission:
             continue

--- a/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
+++ b/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
@@ -161,6 +161,31 @@ def remap_permissions():
             appbuilder.sm.delete_action(old_action_name)
 
 
+def undo_remap_permissions():
+    """Unapply Map Airflow permissions"""
+    appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
+    for old, new in mapping.items():
+        (new_resource_name, new_action_name) = new
+        new_permission = appbuilder.sm.get_permission(new_action_name, new_resource_name)
+        if not new_permission:
+            continue
+        for old_action_name, old_resource_name in old:
+            old_permission = appbuilder.sm.create_permission(old_action_name, old_resource_name)
+            for role in appbuilder.sm.get_all_roles():
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(
+                    new_resource_name, new_action_name, [role.id]
+                ):
+                    appbuilder.sm.add_permission_to_role(role, old_permission)
+                    appbuilder.sm.remove_permission_from_role(role, new_permission)
+        appbuilder.sm.delete_permission(new_action_name, new_resource_name)
+
+        if not appbuilder.sm.get_action(new_action_name):
+            continue
+        resources = appbuilder.sm.get_all_resources()
+        if not any(appbuilder.sm.get_permission(new_action_name, resource.name) for resource in resources):
+            appbuilder.sm.delete_action(new_action_name)
+
+
 def upgrade():
     """Apply Resource based permissions."""
     log = logging.getLogger()
@@ -171,3 +196,7 @@ def upgrade():
 
 def downgrade():
     """Unapply Resource based permissions."""
+    log = logging.getLogger()
+    handlers = log.handlers[:]
+    undo_remap_permissions()
+    log.handlers = handlers


### PR DESCRIPTION
There are some FAB migrations that don't have downgrades.
This PR fixes it


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
