### PR TITLE
Unpin ``argcomplete`` and ``colorlog``

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -81,14 +81,14 @@ setup_requires =
 #####################################################################################################
 install_requires =
     alembic>=1.5.1, <2.0
-    argcomplete>=1.10
+    argcomplete>=1.10, <3.0
     attrs>=20.0, <21.0
     blinker
     cached_property~=1.5;python_version<="3.7"
     cattrs~=1.1, !=1.7.*
     # Required by vendored-in connexion
     clickclick>=1.2
-    colorlog>=4.0.2
+    colorlog>=4.0.2, <7.0
     cron-descriptor>=1.2.24
     croniter>=0.3.17
     cryptography>=0.9.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,14 +81,14 @@ setup_requires =
 #####################################################################################################
 install_requires =
     alembic>=1.5.1, <2.0
-    argcomplete~=1.10
+    argcomplete>=1.10
     attrs>=20.0, <21.0
     blinker
     cached_property~=1.5;python_version<="3.7"
     cattrs~=1.1, !=1.7.*
     # Required by vendored-in connexion
     clickclick>=1.2
-    colorlog>=4.0.2, <6.0
+    colorlog>=4.0.2
     cron-descriptor>=1.2.24
     croniter>=0.3.17
     cryptography>=0.9.3


### PR DESCRIPTION
For Both of these libraries, the only breaking changes are dropping support for old Python version.

- https://github.com/kislyuk/argcomplete/blob/develop/Changes.rst
- https://github.com/borntyping/python-colorlog/releases

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
