### PR TITLE
Remove redundant ``dataclass`` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,6 @@ install_requires =
     cron-descriptor>=1.2.24
     croniter>=0.3.17
     cryptography>=0.9.3
-    dataclasses;python_version<"3.7"
     deprecated>=1.2.13
     dill>=0.2.2, <0.4
     # Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for some docutils markup
@@ -130,7 +129,6 @@ install_requires =
     openapi-spec-validator>=0.2.4
     packaging>=14.0
     pendulum~=2.0
-    pep562~=1.0;python_version<"3.7"
     pluggy~=1.0
     psutil>=4.2.0, <6.0.0
     pygments>=2.0.1, <3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,6 +129,7 @@ install_requires =
     openapi-spec-validator>=0.2.4
     packaging>=14.0
     pendulum~=2.0
+    pep562~=1.0;python_version<"3.7"
     pluggy~=1.0
     psutil>=4.2.0, <6.0.0
     pygments>=2.0.1, <3.0


### PR DESCRIPTION
We had to install `dataclasses` because it was not available in Python <3.7

This is no longer required as `main` is Python 3.7 only. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
