### PR TITLE
UI page title to allow for Markup

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1306,7 +1306,7 @@
     - name: instance_name_markup
       description: |
         Whether the custom page title for the DAGs overview page contains any Markup language
-      version_added: 2.3.1
+      version_added: 2.3.0
       type: boolean
       example: ~
       default: "False"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1303,6 +1303,13 @@
       type: string
       example: ~
       default:
+    - name: instance_name_markup
+      description: |
+        Whether the custom page title for the DAGs overview page contains any Markup language
+      version_added: 2.3.1
+      type: boolean
+      example: ~
+      default: "False"
     - name: auto_refresh_interval
       description: |
         How frequently, in seconds, the DAG data will auto-refresh in graph or tree view

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1303,7 +1303,7 @@
       type: string
       example: ~
       default:
-    - name: instance_name_markup
+    - name: instance_name_has_markup
       description: |
         Whether the custom page title for the DAGs overview page contains any Markup language
       version_added: 2.3.0

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -656,7 +656,7 @@ session_lifetime_minutes = 43200
 # instance_name =
 
 # Whether the custom page title for the DAGs overview page contains any Markup language
-instance_name_markup = False
+instance_name_has_markup = False
 
 # How frequently, in seconds, the DAG data will auto-refresh in graph or tree view
 # when auto-refresh is turned on

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -655,6 +655,9 @@ session_lifetime_minutes = 43200
 # Sets a custom page title for the DAGs overview page and site title for all pages
 # instance_name =
 
+# Whether the custom page title for the DAGs overview page contains any Markup language
+instance_name_markup = False
+
 # How frequently, in seconds, the DAG data will auto-refresh in graph or tree view
 # when auto-refresh is turned on
 auto_refresh_interval = 3

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -770,6 +770,7 @@ class Airflow(AirflowBaseView):
         state_color_mapping["null"] = state_color_mapping.pop(None)
 
         page_title = conf.get(section="webserver", key="instance_name", fallback="DAGs")
+        page_title_markup = conf.getboolean(section="webserver", key="instance_name_markup", fallback=False)
 
         dashboard_alerts = [
             fm for fm in settings.DASHBOARD_UIALERTS if fm.should_show(current_app.appbuilder.sm)
@@ -815,7 +816,7 @@ class Airflow(AirflowBaseView):
             migration_moved_data_alerts=sorted(set(_iter_parsed_moved_data_table_names())),
             current_page=current_page,
             search_query=arg_search_query if arg_search_query else '',
-            page_title=page_title,
+            page_title=Markup(page_title) if page_title_markup else page_title,
             page_size=dags_per_page,
             num_of_pages=num_of_pages,
             num_dag_from=min(start + 1, num_of_all_dags),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -770,7 +770,9 @@ class Airflow(AirflowBaseView):
         state_color_mapping["null"] = state_color_mapping.pop(None)
 
         page_title = conf.get(section="webserver", key="instance_name", fallback="DAGs")
-        page_title_markup = conf.getboolean(section="webserver", key="instance_name_markup", fallback=False)
+        page_title_has_markup = conf.getboolean(
+            section="webserver", key="instance_name_has_markup", fallback=False
+        )
 
         dashboard_alerts = [
             fm for fm in settings.DASHBOARD_UIALERTS if fm.should_show(current_app.appbuilder.sm)
@@ -816,7 +818,7 @@ class Airflow(AirflowBaseView):
             migration_moved_data_alerts=sorted(set(_iter_parsed_moved_data_table_names())),
             current_page=current_page,
             search_query=arg_search_query if arg_search_query else '',
-            page_title=Markup(page_title) if page_title_markup else page_title,
+            page_title=Markup(page_title) if page_title_has_markup else page_title,
             page_size=dags_per_page,
             num_of_pages=num_of_pages,
             num_dag_from=min(start + 1, num_of_all_dags),

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -121,7 +121,7 @@ After
 
 .. note::
 
-    From version 2.2.4 you can include markup in ``instance_name`` variable for further customization. To enable, set ``instance_name_markup`` under the ``[webserver]`` section inside ``airflow.cfg`` to ``True``.
+    From version 2.3.0 you can include markup in ``instance_name`` variable for further customization. To enable, set ``instance_name_markup`` under the ``[webserver]`` section inside ``airflow.cfg`` to ``True``.
 
 
 Add custom alert messages on the dashboard

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -121,7 +121,7 @@ After
 
 .. note::
 
-    From version 2.3.0 you can include markup in ``instance_name`` variable for further customization. To enable, set ``instance_name_markup`` under the ``[webserver]`` section inside ``airflow.cfg`` to ``True``.
+    From version 2.3.0 you can include markup in ``instance_name`` variable for further customization. To enable, set ``instance_name_has_markup`` under the ``[webserver]`` section inside ``airflow.cfg`` to ``True``.
 
 
 Add custom alert messages on the dashboard

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -84,7 +84,9 @@ Customizing DAG UI Header and Airflow Page Titles
 Airflow now allows you to customize the DAG home page header and page title. This will help
 distinguish between various installations of Airflow or simply amend the page text.
 
-Note: the custom title will be applied to both the page header and the page title.
+.. note::
+
+    The custom title will be applied to both the page header and the page title.
 
 To make this change, simply:
 
@@ -116,6 +118,10 @@ After
 """""
 
 .. image:: ../img/change-site-title/example_instance_name_configuration.png
+
+.. note::
+
+    From version 2.2.4 you can include markup in ``instance_name`` variable for further customization. To enable, set ``instance_name_markup`` under the ``[webserver]`` section inside ``airflow.cfg`` to ``True``.
 
 
 Add custom alert messages on the dashboard

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -395,7 +395,7 @@ def test_page_instance_name_xss_prevention(admin_client):
 @conf_vars(
     {
         ("webserver", "instance_name"): "<b>Bold Site Title Test</b>",
-        ("webserver", "instance_name_markup"): "True",
+        ("webserver", "instance_name_has_markup"): "True",
     }
 )
 def test_page_instance_name_with_markup(admin_client):

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -390,3 +390,14 @@ def test_page_instance_name_xss_prevention(admin_client):
         escaped_xss_string = "&lt;script&gt;alert(&#39;Give me your credit card number&#39;)&lt;/script&gt;"
         check_content_in_response(escaped_xss_string, resp)
         check_content_not_in_response(xss_string, resp)
+
+
+@conf_vars(
+    {
+        ("webserver", "instance_name"): "<b>Bold Site Title Test</b>",
+        ("webserver", "instance_name_markup"): "True",
+    }
+)
+def test_page_instance_name_with_markup(admin_client):
+    resp = admin_client.get('home', follow_redirects=True)
+    check_content_in_response('<b>Bold Site Title Test</b>', resp)


### PR DESCRIPTION
Set `instance_name_has_markup = True` in `airflow.cfg` to render `instance_name` with Markup.

Closes #20877.