### PR TITLE
Add limit to openapi-schema-validator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ license_files =
    licenses/LICENSE-moment.txt
    licenses/LICENSE-normalize.txt
 # End of licences generated automatically
-   licenses/LICENSES-ui.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
@@ -125,6 +124,10 @@ install_requires =
     markdown>=2.5.2, <4.0
     markupsafe>=1.1.1
     marshmallow-oneofschema>=2.0.1
+    # Open-API schema validator 0.2.0 breaks openapi-spec-validator in vendored-in connexion
+    # We should review and remove those limits when we bump (or get-rid of) connexion
+    # See https://github.com/apache/airflow/issues/20862
+    openapi-schema-validator<0.2.0
     # Required by vendored-in connexion
     openapi-spec-validator>=0.2.4
     packaging>=14.0


### PR DESCRIPTION
The openapi-schema-validator 0.2.0 breaks vendored-in
connexion and until we decide what to do with connexion we should
limit it.

Fixes: #20862

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
