### PR TITLE
Fixing MyPy issues inside tests providers google cloud hooks

### DIFF
--- a/airflow/providers/google/cloud/hooks/datacatalog.py
+++ b/airflow/providers/google/cloud/hooks/datacatalog.py
@@ -637,7 +637,7 @@ class CloudDataCatalogHook(GoogleBaseHook):
         location: str,
         entry_group: str,
         project_id: str,
-        read_mask: Optional[Union[FieldMask, Dict]] = None,
+        read_mask: Optional[FieldMask] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Sequence[Tuple[str, str]] = (),

--- a/airflow/providers/google/cloud/hooks/datacatalog.py
+++ b/airflow/providers/google/cloud/hooks/datacatalog.py
@@ -637,7 +637,7 @@ class CloudDataCatalogHook(GoogleBaseHook):
         location: str,
         entry_group: str,
         project_id: str,
-        read_mask: Optional[FieldMask] = None,
+        read_mask: Optional[Union[FieldMask, Dict]] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Sequence[Tuple[str, str]] = (),

--- a/tests/providers/google/cloud/hooks/test_datacatalog.py
+++ b/tests/providers/google/cloud/hooks/test_datacatalog.py
@@ -23,6 +23,7 @@ from unittest import TestCase, mock
 import pytest
 from google.api_core.retry import Retry
 from google.cloud.datacatalog import CreateTagRequest, CreateTagTemplateRequest, Entry, Tag, TagTemplate
+from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow import AirflowException
 from airflow.providers.google.cloud.hooks.datacatalog import CloudDataCatalogHook
@@ -47,7 +48,7 @@ TEST_TAG_TEMPLATE: Dict = {"name": TEST_TAG_TEMPLATE_ID}
 TEST_TAG_TEMPLATE_FIELD_ID: str = "test-tag-template-field-id"
 TEST_TAG_TEMPLATE_FIELD: Dict = {}
 TEST_FORCE: bool = False
-TEST_READ_MASK: Dict = {"fields": ["name"]}
+TEST_READ_MASK: FieldMask = FieldMask(paths=["name"])
 TEST_RESOURCE: str = "test-resource"
 TEST_PAGE_SIZE: int = 50
 TEST_LINKED_RESOURCE: str = "test-linked-resource"

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -19,6 +19,7 @@
 import unittest
 from typing import Any, Dict
 from unittest import mock
+from unittest.mock import MagicMock
 
 from google.cloud.tasks_v2.types import Queue, Task
 
@@ -33,6 +34,15 @@ QUEUE_ID = "test-queue"
 FULL_QUEUE_PATH = "projects/test-project/locations/asia-east2/queues/test-queue"
 TASK_NAME = "test-task"
 FULL_TASK_PATH = "projects/test-project/locations/asia-east2/queues/test-queue/tasks/test-task"
+
+
+def mock_patch_return_object(attribute: str, return_value: Any) -> object:
+    class Obj:
+        pass
+
+    obj = Obj()
+    obj.__setattr__(attribute, MagicMock(return_value=return_value))
+    return obj
 
 
 class TestCloudTasksHook(unittest.TestCase):
@@ -59,7 +69,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.create_queue.return_value": API_RESPONSE},  # type: ignore
+        return_value=mock_patch_return_object('create_queue', API_RESPONSE),
     )
     def test_create_queue(self, get_conn):
         result = self.hook.create_queue(
@@ -80,7 +90,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.update_queue.return_value": API_RESPONSE},  # type: ignore
+        return_value=mock_patch_return_object('update_queue', API_RESPONSE),
     )
     def test_update_queue(self, get_conn):
         result = self.hook.update_queue(
@@ -101,7 +111,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.get_queue.return_value": API_RESPONSE},  # type: ignore
+        return_value=mock_patch_return_object('get_queue', API_RESPONSE),
     )
     def test_get_queue(self, get_conn):
         result = self.hook.get_queue(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -114,7 +124,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.list_queues.return_value": [Queue(name=FULL_QUEUE_PATH)]},  # type: ignore
+        return_value=mock_patch_return_object('list_queues', [Queue(name=FULL_QUEUE_PATH)]),
     )
     def test_list_queues(self, get_conn):
         result = self.hook.list_queues(location=LOCATION, project_id=PROJECT_ID)
@@ -130,7 +140,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.delete_queue.return_value": None},  # type: ignore
+        return_value=mock_patch_return_object('delete_queue', None),
     )
     def test_delete_queue(self, get_conn):
         result = self.hook.delete_queue(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -143,7 +153,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.purge_queue.return_value": Queue(name=FULL_QUEUE_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('purge_queue', Queue(name=FULL_QUEUE_PATH)),
     )
     def test_purge_queue(self, get_conn):
         result = self.hook.purge_queue(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -156,7 +166,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.pause_queue.return_value": Queue(name=FULL_QUEUE_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('pause_queue', Queue(name=FULL_QUEUE_PATH)),
     )
     def test_pause_queue(self, get_conn):
         result = self.hook.pause_queue(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -169,7 +179,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.resume_queue.return_value": Queue(name=FULL_QUEUE_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('resume_queue', Queue(name=FULL_QUEUE_PATH)),
     )
     def test_resume_queue(self, get_conn):
         result = self.hook.resume_queue(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -182,7 +192,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.create_task.return_value": Task(name=FULL_TASK_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('create_task', Task(name=FULL_TASK_PATH)),
     )
     def test_create_task(self, get_conn):
         result = self.hook.create_task(
@@ -204,7 +214,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.get_task.return_value": Task(name=FULL_TASK_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('get_task', Task(name=FULL_TASK_PATH)),
     )
     def test_get_task(self, get_conn):
         result = self.hook.get_task(
@@ -225,7 +235,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.list_tasks.return_value": [Task(name=FULL_TASK_PATH)]},  # type: ignore
+        return_value=mock_patch_return_object('list_tasks', [Task(name=FULL_TASK_PATH)]),
     )
     def test_list_tasks(self, get_conn):
         result = self.hook.list_tasks(location=LOCATION, queue_name=QUEUE_ID, project_id=PROJECT_ID)
@@ -241,7 +251,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.delete_task.return_value": None},  # type: ignore
+        return_value=mock_patch_return_object('delete_task', None),
     )
     def test_delete_task(self, get_conn):
         result = self.hook.delete_task(
@@ -259,7 +269,7 @@ class TestCloudTasksHook(unittest.TestCase):
 
     @mock.patch(
         "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.get_conn",
-        **{"return_value.run_task.return_value": Task(name=FULL_TASK_PATH)},  # type: ignore
+        return_value=mock_patch_return_object('run_task', Task(name=FULL_TASK_PATH)),
     )
     def test_run_task(self, get_conn):
         result = self.hook.run_task(

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -19,7 +19,6 @@
 import unittest
 from typing import Any, Dict
 from unittest import mock
-from unittest.mock import MagicMock
 
 from google.cloud.tasks_v2.types import Queue, Task
 
@@ -41,7 +40,7 @@ def mock_patch_return_object(attribute: str, return_value: Any) -> object:
         pass
 
     obj = Obj()
-    obj.__setattr__(attribute, MagicMock(return_value=return_value))
+    obj.__setattr__(attribute, mock.MagicMock(return_value=return_value))
     return obj
 
 


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891

- Fixes dictionary expansion by replacing with a factory function
- Using FieldMask explicitly instead of `dict` replacement

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
