### PR TITLE
Quelch deprecation warning in tests

### DIFF
--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -147,7 +147,7 @@ def post_role() -> APIResponse:
     if not role:
         perms = [(item['action']['name'], item['resource']['name']) for item in data['permissions'] if item]
         _check_action_and_resource(security_manager, perms)
-        security_manager.init_role(role_name=data['name'], perms=perms)
+        security_manager.bulk_sync_roles([{"role": data["name"], "perms": perms}])
         return role_schema.dump(role)
     detail = f"Role with name {role.name!r} already exists; please update with the PATCH endpoint"
     raise AlreadyExists(detail=detail)

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -79,7 +79,7 @@ class DAGDetailSchema(DAGSchema):
     timezone = TimezoneField()
     catchup = fields.Boolean()
     orientation = fields.String()
-    concurrency = fields.Integer()  # TODO: Remove in Airflow 3.0
+    concurrency = fields.Method("get_concurrency")  # TODO: Remove in Airflow 3.0
     max_active_tasks = fields.Integer()
     start_date = fields.DateTime()
     dag_run_timeout = fields.Nested(TimeDeltaSchema, attribute="dagrun_timeout")
@@ -89,6 +89,10 @@ class DAGDetailSchema(DAGSchema):
     tags = fields.Method("get_tags", dump_only=True)  # type: ignore
     is_paused = fields.Method("get_is_paused", dump_only=True)
     is_active = fields.Method("get_is_active", dump_only=True)
+
+    @staticmethod
+    def get_concurrency(obj: DAG):
+        return obj.max_active_runs
 
     @staticmethod
     def get_tags(obj: DAG):

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -92,7 +92,7 @@ class DAGDetailSchema(DAGSchema):
 
     @staticmethod
     def get_concurrency(obj: DAG):
-        return obj.max_active_runs
+        return obj.max_active_tasks
 
     @staticmethod
     def get_tags(obj: DAG):

--- a/tests/api/auth/backend/test_basic_auth.py
+++ b/tests/api/auth/backend/test_basic_auth.py
@@ -19,7 +19,6 @@ from base64 import b64encode
 
 import pytest
 from flask_login import current_user
-from parameterized import parameterized
 
 from tests.test_utils.db import clear_db_pools
 
@@ -52,17 +51,18 @@ class TestBasicAuth:
 
         assert response.status_code == 200
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "token",
         [
-            ("basic",),
-            ("basic ",),
-            ("bearer",),
-            ("test:test",),
-            (b64encode(b"test:test").decode(),),
-            ("bearer ",),
-            ("basic: ",),
-            ("basic 123",),
-        ]
+            "basic",
+            "basic ",
+            "bearer",
+            "test:test",
+            b64encode(b"test:test").decode(),
+            "bearer ",
+            "basic: ",
+            "basic 123",
+        ],
     )
     def test_malformed_headers(self, token):
         with self.app.test_client() as test_client:
@@ -70,13 +70,14 @@ class TestBasicAuth:
             assert response.status_code == 401
             assert response.headers["WWW-Authenticate"] == "Basic"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "token",
         [
             ("basic " + b64encode(b"test").decode(),),
             ("basic " + b64encode(b"test:").decode(),),
             ("basic " + b64encode(b"test:123").decode(),),
             ("basic " + b64encode(b"test test").decode(),),
-        ]
+        ],
     )
     def test_invalid_auth_header(self, token):
         with self.app.test_client() as test_client:
@@ -84,6 +85,7 @@ class TestBasicAuth:
             assert response.status_code == 401
             assert response.headers["WWW-Authenticate"] == "Basic"
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_experimental_api(self):
         with self.app.test_client() as test_client:
             response = test_client.get("/api/experimental/pools", headers={"Authorization": "Basic"})

--- a/tests/api/common/experimental/test_pool.py
+++ b/tests/api/common/experimental/test_pool.py
@@ -18,7 +18,6 @@
 
 import random
 import string
-import unittest
 
 import pytest
 
@@ -30,12 +29,13 @@ from airflow.utils.session import create_session
 from tests.test_utils.db import clear_db_pools
 
 
-class TestPool(unittest.TestCase):
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+class TestPool:
 
     USER_POOL_COUNT = 2
     TOTAL_POOL_COUNT = USER_POOL_COUNT + 1  # including default_pool
 
-    def setUp(self):
+    def setup_method(self):
         clear_db_pools()
         self.pools = [Pool.get_default_pool()]
         for i in range(self.USER_POOL_COUNT):

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import eagerload
 from airflow import models
 from airflow.api.common.mark_tasks import (
     _create_dagruns,
+    _DagRunInfo,
     set_dag_run_state_to_failed,
     set_dag_run_state_to_running,
     set_dag_run_state_to_success,
@@ -70,20 +71,34 @@ class TestMarkTasks:
 
         clear_db_runs()
         drs = _create_dagruns(
-            self.dag1, self.execution_dates, state=State.RUNNING, run_type=DagRunType.SCHEDULED
+            self.dag1,
+            [_DagRunInfo(d, (d, d + timedelta(days=1))) for d in self.execution_dates],
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
         )
         for dr in drs:
             dr.dag = self.dag1
 
         drs = _create_dagruns(
-            self.dag2, [self.dag2.start_date], state=State.RUNNING, run_type=DagRunType.SCHEDULED
+            self.dag2,
+            [
+                _DagRunInfo(
+                    self.dag2.start_date,
+                    (self.dag2.start_date, self.dag2.start_date + timedelta(days=1)),
+                ),
+            ],
+            state=State.RUNNING,
+            run_type=DagRunType.SCHEDULED,
         )
 
         for dr in drs:
             dr.dag = self.dag2
 
         drs = _create_dagruns(
-            self.dag3, self.dag3_execution_dates, state=State.SUCCESS, run_type=DagRunType.MANUAL
+            self.dag3,
+            [_DagRunInfo(d, (d, d)) for d in self.dag3_execution_dates],
+            state=State.SUCCESS,
+            run_type=DagRunType.MANUAL,
         )
         for dr in drs:
             dr.dag = self.dag3


### PR DESCRIPTION
Re-submitting #20742 with conflicts removed. Most significantly, `mark_tasks` is modified to not use bare execution dates, but AIP-39 data intervals.