### PR TITLE
Switch to new MySQL public key

### DIFF
--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -44,7 +44,7 @@ install_mysql_client() {
         exit 1
     fi
 
-    local key="A4A9406876FCBD3C456770C88C718D3B5072E1F5"
+    local key="467B942D3A79BD29"
     readonly key
 
     GNUPGHOME="$(mktemp -d)"


### PR DESCRIPTION
MySQL changed key used to sign their apt packages. This caused
docker building failing for prod images as MySQL could not be
installed.

New Public Key is used instead.

Fixes: #20911

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
