### PR TITLE
Add encoding parameter to `GCSToLocalFilesystemOperator` to fix #20901

### DIFF
--- a/tests/providers/google/cloud/transfers/test_gcs_to_local.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_local.py
@@ -34,7 +34,10 @@ MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
 TEST_OBJECT = "dir1/test-object"
 LOCAL_FILE_PATH = "/home/airflow/gcp/test-object"
 XCOM_KEY = "some_xkom_key"
-FILE_CONTENT = "some file content"
+FILE_CONTENT_STR = "some file content"
+FILE_CONTENT_BYTES_UTF8 = b"some file content"
+FILE_CONTENT_BYTES_UTF16 = b'\xff\xfes\x00o\x00m\x00e\x00 \x00f\x00i\x00l\x00e\x00 \x00c\x00o\x00n\x00t\x00e\x00n\x00' \
+                           b't\x00'
 
 
 class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
@@ -61,7 +64,7 @@ class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
             store_to_xcom_key=XCOM_KEY,
         )
         context = {"ti": MagicMock()}
-        mock_hook.return_value.download.return_value = FILE_CONTENT
+        mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF8
         mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE - 1
 
         operator.execute(context=context)
@@ -71,7 +74,7 @@ class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
         mock_hook.return_value.download.assert_called_once_with(
             bucket_name=TEST_BUCKET, object_name=TEST_OBJECT
         )
-        context["ti"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT)
+        context["ti"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)
 
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_local.GCSHook")
     def test_size_gt_max_xcom_size(self, mock_hook):
@@ -82,8 +85,30 @@ class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
             store_to_xcom_key=XCOM_KEY,
         )
         context = {"ti": MagicMock()}
-        mock_hook.return_value.download.return_value = FILE_CONTENT
+        mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF8
         mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE + 1
 
         with pytest.raises(AirflowException, match="file is too large"):
             operator.execute(context=context)
+
+    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_local.GCSHook")
+    def test_xcom_encoding(self, mock_hook):
+        operator = GCSToLocalFilesystemOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            object_name=TEST_OBJECT,
+            store_to_xcom_key=XCOM_KEY,
+            file_encoding='utf-16'
+        )
+        context = {"ti": MagicMock()}
+        mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF16
+        mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE - 1
+
+        operator.execute(context=context)
+        mock_hook.return_value.get_size.assert_called_once_with(
+            bucket_name=TEST_BUCKET, object_name=TEST_OBJECT
+        )
+        mock_hook.return_value.download.assert_called_once_with(
+            bucket_name=TEST_BUCKET, object_name=TEST_OBJECT
+        )
+        context["ti"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)

--- a/tests/providers/google/cloud/transfers/test_gcs_to_local.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_local.py
@@ -36,8 +36,9 @@ LOCAL_FILE_PATH = "/home/airflow/gcp/test-object"
 XCOM_KEY = "some_xkom_key"
 FILE_CONTENT_STR = "some file content"
 FILE_CONTENT_BYTES_UTF8 = b"some file content"
-FILE_CONTENT_BYTES_UTF16 = b'\xff\xfes\x00o\x00m\x00e\x00 \x00f\x00i\x00l\x00e\x00 \x00c\x00o\x00n\x00t\x00e\x00n\x00' \
-                           b't\x00'
+FILE_CONTENT_BYTES_UTF16 = (
+    b'\xff\xfes\x00o\x00m\x00e\x00 \x00f\x00i\x00l\x00e\x00 \x00c\x00o\x00n\x00t\x00e\x00n\x00t\x00'
+)
 
 
 class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
@@ -98,7 +99,7 @@ class TestGoogleCloudStorageDownloadOperator(unittest.TestCase):
             bucket=TEST_BUCKET,
             object_name=TEST_OBJECT,
             store_to_xcom_key=XCOM_KEY,
-            file_encoding='utf-16'
+            file_encoding='utf-16',
         )
         context = {"ti": MagicMock()}
         mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF16


### PR DESCRIPTION
Adds encoding parameter to `GCSToLocalFilesystemOperator` that is used to decode `file_bytes` into a serializable string for XCom

Closes #20901