### PR TITLE
Fixing MyPy issues inside tests providers google cloud operators

### DIFF
--- a/tests/providers/google/cloud/operators/test_datacatalog.py
+++ b/tests/providers/google/cloud/operators/test_datacatalog.py
@@ -21,6 +21,7 @@ from unittest import TestCase, mock
 from google.api_core.exceptions import AlreadyExists
 from google.api_core.retry import Retry
 from google.cloud.datacatalog_v1beta1.types import Entry, EntryGroup, Tag, TagTemplate, TagTemplateField
+from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,
@@ -45,6 +46,7 @@ from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogUpdateTagTemplateFieldOperator,
     CloudDataCatalogUpdateTagTemplateOperator,
 )
+from airflow.utils.context import Context
 
 TEST_PROJECT_ID: str = "example_id"
 TEST_LOCATION: str = "en-west-3"
@@ -60,7 +62,7 @@ TEST_TAG_TEMPLATE_ID: str = "test-tag-template-id"
 TEST_TAG_TEMPLATE_FIELD_ID: str = "test-tag-template-field-id"
 TEST_TAG_TEMPLATE_NAME: str = "test-tag-template-field-name"
 TEST_FORCE: bool = False
-TEST_READ_MASK: Dict = {"fields": ["name"]}
+TEST_READ_MASK: FieldMask = FieldMask(paths=["name"])
 TEST_RESOURCE: str = "test-resource"
 TEST_OPTIONS_: Dict = {}
 TEST_PAGE_SIZE: int = 50
@@ -128,7 +130,7 @@ class TestCloudDataCatalogCreateEntryOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
@@ -168,7 +170,7 @@ class TestCloudDataCatalogCreateEntryOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
@@ -215,7 +217,7 @@ class TestCloudDataCatalogCreateEntryGroupOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
@@ -254,7 +256,7 @@ class TestCloudDataCatalogCreateTagOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
@@ -293,7 +295,7 @@ class TestCloudDataCatalogCreateTagTemplateOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
@@ -331,7 +333,7 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator(TestCase):
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
         ti = mock.MagicMock()
-        result = task.execute(context={"task_instance": ti})
+        result = task.execute(context=Context(task_instance=ti))
         mock_hook.assert_called_once_with(
             gcp_conn_id=TEST_GCP_CONN_ID,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,

--- a/tests/providers/google/cloud/operators/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/operators/test_dataproc_metastore.py
@@ -18,6 +18,7 @@
 from unittest import TestCase, mock
 
 from google.api_core.retry import Retry
+from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.providers.google.cloud.operators.dataproc_metastore import (
     DataprocMetastoreCreateBackupOperator,
@@ -63,7 +64,7 @@ TEST_SERVICE_TO_UPDATE = {
         "second_key": "second_value",
     }
 }
-TEST_UPDATE_MASK: dict = {"paths": ["labels"]}
+TEST_UPDATE_MASK: FieldMask = FieldMask(paths=["labels"])
 TEST_DESTINATION_GCS_FOLDER: str = "gs://bucket_name/path_inside_bucket"
 
 


### PR DESCRIPTION
Part of #19891

This fixes MyPy warnings by using actual classes where they are expected instead of superficial `dict` replacements.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
