### PR TITLE
Fix `_get_prev` in `CronDataIntervalTimetable`

### DIFF
--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional, Union
 from cron_descriptor import CasingTypeEnum, ExpressionDescriptor, FormatException, MissingFieldException
 from croniter import CroniterBadCronError, CroniterBadDateError, croniter
 from dateutil.relativedelta import relativedelta
-from pendulum import DateTime
+from pendulum import DateTime, instance as pendulum_datetime
 from pendulum.tz.timezone import Timezone
 
 from airflow.compat.functools import cached_property
@@ -195,6 +195,9 @@ class CronDataIntervalTimetable(_DataIntervalTimetable):
         naive = make_naive(current, self._timezone)
         cron = croniter(self._expression, start_time=naive)
         scheduled = cron.get_prev(datetime.datetime)
+        # cron.get_prev return a python datetime and therefore `scheduled`
+        # need to be converted to a pendulum datetime when returned
+        scheduled = pendulum_datetime(scheduled)
         if not self._should_fix_dst:
             return convert_to_utc(make_aware(scheduled, self._timezone))
         delta = naive - scheduled


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #20925 
Fix a bug with `get_prev` which was returning python datetime object
where pendulum.datetime was to be expected
