### PR TITLE
Fixed MyPy errors for Azure provider:

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
@@ -25,7 +25,7 @@ NAME = 'myfileshare'
 DIRECTORY = "mydirectory"
 
 
-@task
+@task()
 def create_fileshare():
     """Create a fileshare with directory"""
     hook = AzureFileShareHook()
@@ -36,7 +36,7 @@ def create_fileshare():
         raise Exception
 
 
-@task
+@task()
 def delete_fileshare():
     """Delete a fileshare"""
     hook = AzureFileShareHook()

--- a/airflow/providers/microsoft/azure/example_dags/example_sftp_to_wasb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_sftp_to_wasb.py
@@ -34,7 +34,7 @@ FILE_COMPLETE_PATH = os.path.join(LOCAL_FILE_PATH, SAMPLE_FILENAME)
 SFTP_FILE_COMPLETE_PATH = os.path.join(SFTP_SRC_PATH, SAMPLE_FILENAME)
 
 
-@task
+@task()
 def delete_sftp_file():
     """Delete a file at SFTP SERVER"""
     SFTPHook().delete_file(SFTP_FILE_COMPLETE_PATH)


### PR DESCRIPTION
Part of #19891

Example errors fixed:

```
airflow/providers/microsoft/azure/example_dags/example_fileshare.py:28:
error: Too many positional arguments for "__call__" of
"TaskDecoratorFactory"  [misc] @task
     ^
airflow/providers/microsoft/azure/example_dags/example_fileshare.py:28:
error: Argument 1 to "__call__" of "TaskDecoratorFactory" has
incompatible type "Callable[[], Any]"; expected "Optional[bool]"
[arg-type] @task
     ^
airflow/providers/microsoft/azure/example_dags/example_fileshare.py:39:
error: Too many positional arguments for "__call__" of
"TaskDecoratorFactory"  [misc]
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
