### PR TITLE
Fix import path for `SageMakerHook` in `airflow/contrib/sensors/sagemaker_training`

### DIFF
--- a/airflow/contrib/sensors/sagemaker_training_sensor.py
+++ b/airflow/contrib/sensors/sagemaker_training_sensor.py
@@ -15,17 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use :mod:`airflow.providers.amazon.aws.sensors.sagemaker_training`."""
+"""This module is deprecated. Please use :mod:`airflow.providers.amazon.aws.sensors.sagemaker`."""
 
 import warnings
 
-from airflow.providers.amazon.aws.sensors.sagemaker_training import (  # noqa
-    SageMakerHook,
-    SageMakerTrainingSensor,
-)
+from airflow.providers.amazon.aws.sensors.sagemaker import SageMakerHook, SageMakerTrainingSensor  # noqa
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.sagemaker_training`.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.sagemaker`.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/microsoft/azure/sensors/wasb.pyi
+++ b/airflow/providers/microsoft/azure/sensors/wasb.pyi
@@ -24,7 +24,6 @@
 
 from typing import Optional
 
-from airflow.providers.sensors.wasb import WasbPrefixSensor
 from airflow.sensors.base import BaseSensorOperator
 
 class WasbBlobSensor(BaseSensorOperator):
@@ -42,7 +41,3 @@ class WasbBlobSensor(BaseSensorOperator):
         check_options: Optional[dict] = None,
         **kwargs,
     ) -> None: ...
-
-# Adding this public module override to suppress Mypy errors stating
-# "airflow.providers.microsoft.azure.sensors.wasb has no attribute 'WasbPrefixSensor'".
-__all__ = ["WasbBlobSensor", "WasbPrefixSensor"]

--- a/airflow/providers/microsoft/azure/sensors/wasb.pyi
+++ b/airflow/providers/microsoft/azure/sensors/wasb.pyi
@@ -24,6 +24,7 @@
 
 from typing import Optional
 
+from airflow.providers.sensors.wasb import WasbPrefixSensor
 from airflow.sensors.base import BaseSensorOperator
 
 class WasbBlobSensor(BaseSensorOperator):
@@ -41,3 +42,7 @@ class WasbBlobSensor(BaseSensorOperator):
         check_options: Optional[dict] = None,
         **kwargs,
     ) -> None: ...
+
+# Adding this public module override to suppress Mypy errors stating
+# "airflow.providers.microsoft.azure.sensors.wasb has no attribute 'WasbPrefixSensor'".
+__all__ = ["WasbBlobSensor", "WasbPrefixSensor"]


### PR DESCRIPTION
Related: #19891 

Error being fixed:
```
airflow/contrib/sensors/sagemaker_training_sensor.py:22: error: Module "airflow.providers.amazon.aws.sensors.sagemaker_training" has no attribute "SageMakerHook"
    from airflow.providers.amazon.aws.sensors.sagemaker_training import (  # noqa
    ^
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
