### PR TITLE
Set dependencies in MappedOperator via XComArgs

### DIFF
--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -48,3 +48,4 @@ class DagAttributeTypes(str, Enum):
     TASK_GROUP = 'taskgroup'
     EDGE_INFO = 'edgeinfo'
     PARAM = 'param'
+    XCOM_REF = 'xcom_ref'

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -48,4 +48,4 @@ class DagAttributeTypes(str, Enum):
     TASK_GROUP = 'taskgroup'
     EDGE_INFO = 'edgeinfo'
     PARAM = 'param'
-    XCOM_REF = 'xcom_ref'
+    XCOM_REF = 'xcomref'

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -21,7 +21,7 @@ import enum
 import logging
 from dataclasses import dataclass
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, NamedTuple, Optional, Set, Type, Union
 
 import cattr
 import pendulum
@@ -36,6 +36,7 @@ from airflow.models.connection import Connection
 from airflow.models.dag import DAG, create_timetable
 from airflow.models.param import Param, ParamsDict
 from airflow.models.taskmixin import DAGNode
+from airflow.models.xcom_arg import XComArg
 from airflow.providers_manager import ProvidersManager
 from airflow.serialization.enums import DagAttributeTypes as DAT, Encoding
 from airflow.serialization.helpers import serialize_template_field
@@ -166,6 +167,18 @@ def _decode_timetable(var: Dict[str, Any]) -> Timetable:
     if timetable_class is None:
         raise _TimetableNotRegistered(importable_string)
     return timetable_class.deserialize(var[Encoding.VAR])
+
+
+class _XcomRef(NamedTuple):
+    """
+    Used to store info needed to create XComArg when deserializing MappedOperator.
+
+    We can't turn it in to a XComArg until we've loaded _all_ the tasks, so when deserializing an operator we
+    need to create _something_, and then post-process it in deserialize_dag
+    """
+
+    task_id: str
+    key: str
 
 
 class BaseSerialization:
@@ -331,6 +344,8 @@ class BaseSerialization:
             return SerializedTaskGroup.serialize_task_group(var)
         elif isinstance(var, Param):
             return cls._encode(cls._serialize_param(var), type_=DAT.PARAM)
+        elif isinstance(var, XComArg):
+            return cls._encode(cls._serialize_xcomarg(var), type_=DAT.XCOM_REF)
         else:
             log.debug('Cast type %s to str in serialization.', type(var))
             return str(var)
@@ -374,6 +389,8 @@ class BaseSerialization:
             return tuple(cls._deserialize(v) for v in var)
         elif type_ == DAT.PARAM:
             return cls._deserialize_param(var)
+        elif type_ == DAT.XCOM_REF:
+            return cls._deserialize_xcomref(var)
         else:
             raise TypeError(f'Invalid type {type_!s} in deserialization.')
 
@@ -475,6 +492,14 @@ class BaseSerialization:
                 op_params[k] = Param(v)
 
         return ParamsDict(op_params)
+
+    @classmethod
+    def _serialize_xcomarg(cls, arg: XComArg) -> dict:
+        return {"key": arg.key, "task_id": arg.operator.task_id}
+
+    @classmethod
+    def _deserialize_xcomref(cls, encoded: dict) -> _XcomRef:
+        return _XcomRef(key=encoded['key'], task_id=encoded['task_id'])
 
 
 class DependencyDetector:
@@ -687,6 +712,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = cls._deserialize_deps(v)
             elif k == "params":
                 v = cls._deserialize_params_dict(v)
+            elif k in ("mapped_kwargs", "partial_kwargs"):
+                v = {arg: cls._deserialize(value) for arg, value in v.items()}
             elif k in cls._decorated_fields or k not in op.get_serialized_fields():
                 v = cls._deserialize(v)
             # else use v as it is
@@ -969,6 +996,14 @@ class SerializedDAG(DAG, BaseSerialization):
 
             if serializable_task.subdag is not None:
                 setattr(serializable_task.subdag, 'parent_dag', dag)
+
+            if isinstance(task, MappedOperator):
+                for d in (task.mapped_kwargs, task.partial_kwargs):
+                    for k in d:
+                        if not isinstance(d[k], _XcomRef):
+                            continue
+
+                        d[k] = XComArg(operator=dag.get_task(d[k].task_id), key=d[k].key)
 
             for task_id in serializable_task.downstream_task_ids:
                 # Bypass set_upstream etc here - it does more than we want

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -999,11 +999,11 @@ class SerializedDAG(DAG, BaseSerialization):
 
             if isinstance(task, MappedOperator):
                 for d in (task.mapped_kwargs, task.partial_kwargs):
-                    for k in d:
-                        if not isinstance(d[k], _XcomRef):
+                    for k, v in d.items():
+                        if not isinstance(v, _XcomRef):
                             continue
 
-                        d[k] = XComArg(operator=dag.get_task(d[k].task_id), key=d[k].key)
+                        d[k] = XComArg(operator=dag.get_task(v.task_id), key=v.key)
 
             for task_id in serializable_task.downstream_task_ids:
                 # Bypass set_upstream etc here - it does more than we want

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -731,6 +731,21 @@ def test_map_unknown_arg_raises():
         BaseOperator(task_id='a').map(file=[1, 2, {'a': 'b'}])
 
 
+def test_map_xcom_arg():
+    """Test that dependencies are correct when mapping with an XComArg"""
+    from airflow.models.xcom_arg import XComArg
+
+    with DAG("test-dag", start_date=DEFAULT_DATE):
+        task1 = BaseOperator(task_id="op1")
+        xcomarg = XComArg(task1, "test_key")
+        mapped = MockOperator(task_id='task_2').map(arg2=xcomarg)
+        finish = MockOperator(task_id="finish")
+
+        mapped >> finish
+
+    assert task1.downstream_list == [mapped]
+
+
 def test_partial_on_instance() -> None:
     """`.partial` on an instance should fail -- it's only designed to be called on classes"""
     with pytest.raises(TypeError):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1628,7 +1628,7 @@ def test_mapped_operator_xcomarg_serde():
         '_task_module': 'tests.test_utils.mock_operators',
         '_task_type': 'MockOperator',
         'downstream_task_ids': [],
-        'mapped_kwargs': {'arg2': {'__type': 'xcom_ref', '__var': {'task_id': 'op1', 'key': 'test_key'}}},
+        'mapped_kwargs': {'arg2': {'__type': 'xcomref', '__var': {'task_id': 'op1', 'key': 'test_key'}}},
         'partial_kwargs': {},
         'task_id': 'task_2',
         'template_fields': ['arg1', 'arg2'],

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -37,7 +37,7 @@ from airflow.exceptions import SerializationError
 from airflow.hooks.base import BaseHook
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.models import DAG, Connection, DagBag
-from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+from airflow.models.baseoperator import BaseOperator, BaseOperatorLink, MappedOperator
 from airflow.models.param import Param, ParamsDict
 from airflow.models.xcom import XCom
 from airflow.operators.bash import BashOperator
@@ -52,7 +52,7 @@ from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.utils import timezone
 from airflow.utils.context import Context
 from airflow.utils.task_group import TaskGroup
-from tests.test_utils.mock_operators import CustomOperator, CustomOpLink, GoogleLink
+from tests.test_utils.mock_operators import CustomOperator, CustomOpLink, GoogleLink, MockOperator
 from tests.test_utils.timetables import CustomSerializationTimetable, cron_timetable, delta_timetable
 
 executor_config_pod = k8s.V1Pod(
@@ -1573,7 +1573,10 @@ def test_kubernetes_optional():
 
 
 def test_mapped_operator_serde():
-    real_op = BashOperator.partial(task_id='a').map(bash_command=[1, 2, {'a': 'b'}])
+    literal = [1, 2, {'a': 'b'}]
+    real_op = BashOperator.partial(task_id='a', executor_config={'dict': {'sub': 'value'}}).map(
+        bash_command=literal
+    )
 
     serialized = SerializedBaseOperator._serialize(real_op)
 
@@ -1590,14 +1593,58 @@ def test_mapped_operator_serde():
                 {"__type": "dict", "__var": {'a': 'b'}},
             ]
         },
-        'partial_kwargs': {},
+        'partial_kwargs': {
+            'executor_config': {
+                '__type': 'dict',
+                '__var': {
+                    'dict': {"__type": "dict", "__var": {'sub': 'value'}},
+                },
+            },
+        },
         'task_id': 'a',
         'template_fields': ['bash_command', 'env'],
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)
+    assert isinstance(op, MappedOperator)
 
     assert op.operator_class == "airflow.operators.bash.BashOperator"
+    assert op.mapped_kwargs['bash_command'] == literal
+    assert op.partial_kwargs['executor_config'] == {'dict': {'sub': 'value'}}
+
+
+def test_mapped_operator_xcomarg_serde():
+    from airflow.models.xcom_arg import XComArg
+
+    with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
+        task1 = BaseOperator(task_id="op1")
+        xcomarg = XComArg(task1, "test_key")
+        mapped = MockOperator(task_id='task_2').map(arg2=xcomarg)
+
+    serialized = SerializedBaseOperator._serialize(mapped)
+    assert serialized == {
+        '_is_dummy': False,
+        '_is_mapped': True,
+        '_task_module': 'tests.test_utils.mock_operators',
+        '_task_type': 'MockOperator',
+        'downstream_task_ids': [],
+        'mapped_kwargs': {'arg2': {'__type': 'xcom_ref', '__var': {'task_id': 'op1', 'key': 'test_key'}}},
+        'partial_kwargs': {},
+        'task_id': 'task_2',
+        'template_fields': ['arg1', 'arg2'],
+    }
+
+    op = SerializedBaseOperator.deserialize_operator(serialized)
+
+    arg = op.mapped_kwargs['arg2']
+    assert arg.task_id == 'op1'
+    assert arg.key == 'test_key'
+
+    serialized_dag: DAG = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
+
+    xcom_arg = serialized_dag.task_dict['task_2'].mapped_kwargs['arg2']
+    assert isinstance(xcom_arg, XComArg)
+    assert xcom_arg.operator is serialized_dag.task_dict['op1']
 
 
 def test_mapped_task_group_serde():


### PR DESCRIPTION
Set upstream dependencies when an XComArg is used in a MappedOperator, and (de)serialize them correctly.

We can only re-create XComArg at the DAG level as we need to get hold of the Operator (not just a task_id) so we need a two phase approach here: when deserializing operators we create them as a place-holder class (`_XcomRef`) and then "up a level" when deserializing the DAG we turn these back in to XComArg objects.

(And in so doing we needed to fix a bug or two in serializing MappedOperator that have a DAG -- it caused a recursion error.)

This PR could possibly be split in to two (one to set deps, a second to serialize them.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).