### PR TITLE
Fix errors thrown by some versions of Bash v4

### DIFF
--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -119,14 +119,19 @@ function run_all_test_types_in_parallel() {
     # Run all tests that should run in parallel (from test_types_to_run variable)
     run_test_types_in_parallel "${@}"
 
-    # if needed run remaining tests sequentially
-    for sequential_test in "${sequential_tests[@]}"; do
-        parallel::cleanup_runner
-        test_types_to_run="${sequential_test}"
-        run_test_types_in_parallel "${@}"
-    done
+    # Check if sequential_tests contains any values since accessing an empty (and only initted) array throws an
+    # error in some versions of Bash 4
+    if [[ ${sequential_tests[0]+"${sequential_tests[@]}"} ]]
+    then
+        # If needed run remaining tests sequentially
+        for sequential_test in "${sequential_tests[@]}"; do
+            parallel::cleanup_runner
+            test_types_to_run="${sequential_test}"
+            run_test_types_in_parallel "${@}"
+        done
+    fi
     set -e
-    # this will exit with error code in case some of the non-Quarantined tests failed
+    # This will exit with error code in case some of the non-Quarantined tests failed
     parallel::print_job_summary_and_return_status_code
 }
 


### PR DESCRIPTION
In some versions of Bash V4, accessing an array that's only been initted
but contains no values can throw an error (specifically if -u is set):
```
./scripts/ci/testing/ci_run_airflow_testing.sh: line 68: sequential_tests[@]: unbound variable
```

So wrap access in an if check first.
See more background and specific details about the bash alchemy here: https://stackoverflow.com/a/58261136/1055702

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
