### PR TITLE
Correctly specify overloads for TaskFlow API for type-hinting

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -58,6 +58,10 @@ class TaskDecoratorFactory:
             such as transmission a large amount of XCom to TaskAPI.
         :type show_return_value_in_logs: bool
         """
+    # [START mixin_for_typing]
+    @overload
+    def python(self, python_callable: F) -> F: ...
+    # [END mixin_for_typing]
     @overload
     def __call__(
         self,
@@ -86,6 +90,8 @@ class TaskDecoratorFactory:
             such as transmission a large amount of XCom to TaskAPI.
         :type show_return_value_in_logs: bool
         """
+    @overload
+    def __call__(self, python_callable: F) -> F: ...
     @overload
     def virtualenv(
         self,
@@ -133,6 +139,8 @@ class TaskDecoratorFactory:
             such as transmission a large amount of XCom to TaskAPI.
         :type show_return_value_in_logs: bool
         """
+    @overload
+    def virtualenv(self, python_callable: F) -> F: ...
     # [START decorator_signature]
     @overload
     def docker(
@@ -263,15 +271,5 @@ class TaskDecoratorFactory:
         :type cap_add: list[str]
         """
         # [END decorator_signature]
-    # [START mixin_for_typing]
-    @overload
-    def __call__(self, python_callable: F) -> F: ...
-    @overload
-    def python(self, python_callable: F) -> F: ...
-    @overload
-    def virtualenv(self, python_callable: F) -> F: ...
-    @overload
-    def docker(self, python_callable: F) -> F: ...
-    # [END mixin_for_typing]
 
 task = TaskDecoratorFactory()

--- a/docs/apache-airflow/howto/create-custom-decorator.rst
+++ b/docs/apache-airflow/howto/create-custom-decorator.rst
@@ -105,7 +105,7 @@ automatically provided by default. All other arguments should be copied directly
 and we recommend adding a comment to explain what arguments are filled automatically by FooDecoratedOperator
 and thus not included.
 
-You should also add an overload that takes a single calable immediately after the "real" definition so mypy can recognize the function as
+You should also add an overload that takes a single callable immediately after the "real" definition so mypy can recognize the function as
 a decorator:
 
 .. exampleinclude:: ../../../airflow/decorators/__init__.pyi

--- a/docs/apache-airflow/howto/create-custom-decorator.rst
+++ b/docs/apache-airflow/howto/create-custom-decorator.rst
@@ -105,7 +105,7 @@ automatically provided by default. All other arguments should be copied directly
 and we recommend adding a comment to explain what arguments are filled automatically by FooDecoratedOperator
 and thus not included.
 
-You should also add an overload at the end of the class similar to this so mypy can recognize the function as
+You should also add an overload that takes a single calable immediately after the "real" definition so mypy can recognize the function as
 a decorator:
 
 .. exampleinclude:: ../../../airflow/decorators/__init__.pyi


### PR DESCRIPTION
The position of `@overload` matters -- at least to MyPy, and all
function overloads have to be next to each other.

I also removed the overload for `@task.docker`, as that one _requires_
at least an image to be passed, so isn't valid with no parameters

Closes #20929
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).