### PR TITLE
Properly style code blocks in links

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -312,7 +312,8 @@ textarea {
   font-size: inherit;
   line-height: inherit;
 }
-a {
+a,
+a code {
   color: #365f84;
   text-decoration: none;
 }


### PR DESCRIPTION
Closes: #20873

Allow code blocked nested in links to retain the link text coloring.

Before:
![Screen Shot 2022-01-18 at 1 56 12 PM](https://user-images.githubusercontent.com/66968678/150017340-9221ab30-77d7-4126-ad53-24bbb1bf1dd0.png)

After:
![Screen Shot 2022-01-18 at 1 52 04 PM](https://user-images.githubusercontent.com/66968678/150017346-909fb83b-4bda-4f09-bedc-a7d9569dbaaa.png)

