### PR TITLE
Fix cancelling of Pull Request builds when image build fails

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -337,7 +337,7 @@ jobs:
           fi
 
           for cancel_url in $(
-              gh api "/repos/$GITHUB_REPOSITORY/actions/runs?${event_filter}branch=${branch}" \
+              gh api "/repos/$GITHUB_REPOSITORY/actions/runs?${event_filter}branch=${branch}" | \
                   jq -r '
                     .workflow_runs[] |
                     select(.head_sha == $ENV.GITHUB_REGISTRY_PUSH_IMAGE_TAG and .status != "completed") |


### PR DESCRIPTION
When image build fails, the pull request that triggered it should
be cancelled. The #15944 introduced rewrite of the GitHub actions
code but by mistake it also introduced a failure in cancelling
the PR workflow by missing pipeline to jq.

In most cases it did not matter, but it cause "wait for images"
in PRs to run far longer than they should be.

This PR restores cancelling feature.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
