### PR TITLE
Return to the same place when triggering a DAG

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -153,11 +153,11 @@
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                   <input type="hidden" name="unpause" value="True">
-                  <input type="hidden" name="origin" value="{{ request.full_path }}">
+                  <input type="hidden" name="origin" value="{{ url_for(request.endpoint, dag_id=dag.dag_id) }}">
                   <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                 </form>
               </li>
-              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=request.full_path) }}">Trigger DAG w/ config</a></li>
+              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for(request.endpoint, dag_id=dag.dag_id)) }}">Trigger DAG w/ config</a></li>
             </ul>
           </div>
           <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}" title="Delete&nbsp;DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_delete }}"

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -153,11 +153,11 @@
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                   <input type="hidden" name="unpause" value="True">
-                  <input type="hidden" name="origin" value="{{ url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id) }}">
+                  <input type="hidden" name="origin" value="{{ request.full_path }}">
                   <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                 </form>
               </li>
-              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id)) }}">Trigger DAG w/ config</a></li>
+              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=request.full_path) }}">Trigger DAG w/ config</a></li>
             </ul>
           </div>
           <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}" title="Delete&nbsp;DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_delete }}"

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -263,7 +263,7 @@ def test_rendered_k8s_without_k8s(admin_client):
     assert 404 == resp.status_code
 
 
-def test_tree_trigger_origin_tree(app, admin_client):
+def test_tree_trigger_origin_tree_view(app, admin_client):
     app.dag_bag.get_dag('test_tree_view').create_dagrun(
         run_type=DagRunType.SCHEDULED,
         execution_date=DEFAULT_DATE,
@@ -279,7 +279,7 @@ def test_tree_trigger_origin_tree(app, admin_client):
     check_content_in_response(href, resp)
 
 
-def test_dag_details_trigger_origin_dag_details_view(app, admin_client):
+def test_graph_trigger_origin_graph_view(app, admin_client):
     app.dag_bag.get_dag('test_tree_view').create_dagrun(
         run_type=DagRunType.SCHEDULED,
         execution_date=DEFAULT_DATE,
@@ -288,9 +288,9 @@ def test_dag_details_trigger_origin_dag_details_view(app, admin_client):
         state=State.RUNNING,
     )
 
-    url = 'dag_details?dag_id=test_tree_view'
+    url = 'graph?dag_id=test_tree_view'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_tree_view', 'origin': '/dag_details?dag_id=test_tree_view'}
+    params = {'dag_id': 'test_tree_view', 'origin': '/graph?dag_id=test_tree_view'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -263,7 +263,23 @@ def test_rendered_k8s_without_k8s(admin_client):
     assert 404 == resp.status_code
 
 
-def test_dag_details_trigger_origin_tree_view(app, admin_client):
+def test_tree_trigger_origin_tree(app, admin_client):
+    app.dag_bag.get_dag('test_tree_view').create_dagrun(
+        run_type=DagRunType.SCHEDULED,
+        execution_date=DEFAULT_DATE,
+        data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+        start_date=timezone.utcnow(),
+        state=State.RUNNING,
+    )
+
+    url = 'tree?dag_id=test_tree_view'
+    resp = admin_client.get(url, follow_redirects=True)
+    params = {'dag_id': 'test_tree_view', 'origin': '/tree?dag_id=test_tree_view'}
+    href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
+    check_content_in_response(href, resp)
+
+
+def test_dag_details_trigger_origin_dag_details_view(app, admin_client):
     app.dag_bag.get_dag('test_tree_view').create_dagrun(
         run_type=DagRunType.SCHEDULED,
         execution_date=DEFAULT_DATE,
@@ -274,12 +290,12 @@ def test_dag_details_trigger_origin_tree_view(app, admin_client):
 
     url = 'dag_details?dag_id=test_tree_view'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_tree_view', 'origin': '/tree?dag_id=test_tree_view'}
+    params = {'dag_id': 'test_tree_view', 'origin': '/dag_details?dag_id=test_tree_view'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 
 
-def test_dag_details_trigger_origin_graph_view(app, admin_client):
+def test_dag_details_trigger_origin_dag_details_view(app, admin_client):
     app.dag_bag.get_dag('test_graph_view').create_dagrun(
         run_type=DagRunType.SCHEDULED,
         execution_date=DEFAULT_DATE,
@@ -290,7 +306,7 @@ def test_dag_details_trigger_origin_graph_view(app, admin_client):
 
     url = 'dag_details?dag_id=test_graph_view'
     resp = admin_client.get(url, follow_redirects=True)
-    params = {'dag_id': 'test_graph_view', 'origin': '/graph?dag_id=test_graph_view'}
+    params = {'dag_id': 'test_graph_view', 'origin': '/dag_details?dag_id=test_graph_view'}
     href = f"/trigger?{html.escape(urllib.parse.urlencode(params))}"
     check_content_in_response(href, resp)
 


### PR DESCRIPTION
Rather than always going to the DAG's default view, return to the same view as you were on.

closes: #20197
