### PR TITLE
Fixing MyPy issue inside tests providers microsoft wasb systems

### DIFF
--- a/tests/providers/microsoft/azure/transfers/test_local_to_wasb_system.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_wasb_system.py
@@ -19,7 +19,9 @@ import os
 
 import pytest
 
-from airflow.providers.microsoft.azure.example_dags.example_local_to_wasb import PATH_TO_UPLOAD_FILE
+from airflow.providers.microsoft.azure.example_dags.example_local_to_wasb import (  # type: ignore
+    PATH_TO_UPLOAD_FILE,
+)
 from tests.test_utils.azure_system_helpers import (
     AZURE_DAG_FOLDER,
     AzureSystemTest,


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891

MyPy complains here with `[attr-defined]` error for PATH_TO_UPLOAD_FILE although that exists in the destination. 
It looks like "ignorance" `type: ignore[call-arg]` inside `example_local_to_wasb.py` causes MyPy not to follow the path and to not find that variable and causes this error. I know that ignore (`type: ignore[call-arg]`) has been put in-place for reason hence ignoring this import here. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
