### PR TITLE
Fixing MyPy issue inside providers IMAP hooks

### DIFF
--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -24,7 +24,7 @@ import email
 import imaplib
 import os
 import re
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Type, Union
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -78,6 +78,7 @@ class ImapHook(BaseHook):
         return self
 
     def _build_client(self, conn: Connection) -> Union[imaplib.IMAP4_SSL, imaplib.IMAP4]:
+        IMAP: Union[Type[imaplib.IMAP4_SSL], Type[imaplib.IMAP4]]
         if conn.extra_dejson.get('use_ssl', True):
             IMAP = imaplib.IMAP4_SSL
         else:


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891

Defining type for IMAP variable so MyPy can understand the intention

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
