### PR TITLE
Add max_map_size to limit XCom task mapping size

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -453,10 +453,10 @@
       type: string
       example: ~
       default: "128"
-    - name: max_map_size
+    - name: max_map_length
       description: |
-        The maximum list/dict size an XCom can push to trigger task mapping. If the pushed list/dict
-        size exceeds this value, the task pushing the XCom will be failed automatically to prevent the
+        The maximum list/dict length an XCom can push to trigger task mapping. If the pushed list/dict has a
+        length exceeding this value, the task pushing the XCom will be failed automatically to prevent the
         mapped tasks from clogging the scheduler.
       version_added: 2.3.0
       type: integer

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -461,7 +461,7 @@
       version_added: 2.3.0
       type: integer
       example: ~
-      default: "128"
+      default: "1024"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -453,6 +453,15 @@
       type: string
       example: ~
       default: "128"
+    - name: max_map_size
+      description: |
+        The maximum list/dict size an XCom can push to trigger task mapping. If the pushed list/dict
+        size exceeds this value, the task pushing the XCom will be failed automatically to prevent the
+        mapped tasks from clogging the scheduler.
+      version_added: 2.3.0
+      type: integer
+      example: ~
+      default: "128"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -259,10 +259,10 @@ sensitive_var_conn_names =
 # change the number of slots using Webserver, API or the CLI
 default_pool_task_slot_count = 128
 
-# The maximum list/dict size an XCom can push to trigger task mapping. If the pushed list/dict
-# size exceeds this value, the task pushing the XCom will be failed automatically to prevent the
+# The maximum list/dict length an XCom can push to trigger task mapping. If the pushed list/dict has a
+# length exceeding this value, the task pushing the XCom will be failed automatically to prevent the
 # mapped tasks from clogging the scheduler.
-max_map_size = 1024
+max_map_length = 1024
 
 [logging]
 # The folder where airflow should store its log files.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -259,6 +259,11 @@ sensitive_var_conn_names =
 # change the number of slots using Webserver, API or the CLI
 default_pool_task_slot_count = 128
 
+# The maximum list/dict size an XCom can push to trigger task mapping. If the pushed list/dict
+# size exceeds this value, the task pushing the XCom will be failed automatically to prevent the
+# mapped tasks from clogging the scheduler.
+max_map_size = 128
+
 [logging]
 # The folder where airflow should store its log files.
 # This path must be absolute.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -262,7 +262,7 @@ default_pool_task_slot_count = 128
 # The maximum list/dict size an XCom can push to trigger task mapping. If the pushed list/dict
 # size exceeds this value, the task pushing the XCom will be failed automatically to prevent the
 # mapped tasks from clogging the scheduler.
-max_map_size = 128
+max_map_size = 1024
 
 [logging]
 # The folder where airflow should store its log files.

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -109,16 +109,16 @@ class UnmappableXComTypePushed(AirflowException):
         return f"unmappable return type {type(self.value).__qualname__!r}"
 
 
-class UnmappableXComSizePushed(AirflowException):
-    """Raise when the pushed value is to large to map as a downstream's dependency."""
+class UnmappableXComLengthPushed(AirflowException):
+    """Raise when the pushed value is too large to map as a downstream's dependency."""
 
-    def __init__(self, value: Sized, max_size: int) -> None:
+    def __init__(self, value: Sized, max_length: int) -> None:
         super().__init__(value)
         self.value = value
-        self.max_size = max_size
+        self.max_length = max_length
 
     def __str__(self) -> str:
-        return f"unmappable return value size: {len(self.value)} > {self.max_size}"
+        return f"unmappable return value length: {len(self.value)} > {self.max_length}"
 
 
 class AirflowDagCycleException(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -105,8 +105,19 @@ class UnmappableXComPushed(AirflowException):
         super().__init__(value)
         self.value = value
 
+
+class UnmappableXComTypePushed(UnmappableXComPushed):
+    """Raise when an unmappable type is pushed."""
+
     def __str__(self) -> str:
         return f"unmappable return type {type(self.value).__qualname__!r}"
+
+
+class UnmappableXComSizePushed(UnmappableXComPushed):
+    """Raise when the pushed value is to large to map."""
+
+    def __str__(self) -> str:
+        return f"unmappable return value size: {len(self.value)}"
 
 
 class AirflowDagCycleException(AirflowException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -21,7 +21,7 @@
 """Exceptions used by Airflow"""
 import datetime
 import warnings
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional, Sized
 
 from airflow.api_connexion.exceptions import NotFound as ApiConnexionNotFound
 from airflow.utils.code_utils import prepare_code_snippet
@@ -98,26 +98,27 @@ class AirflowFailException(AirflowException):
     """Raise when the task should be failed without retrying."""
 
 
-class UnmappableXComPushed(AirflowException):
-    """Raise when an unmappable value is pushed as a mapped downstream's dependency."""
+class UnmappableXComTypePushed(AirflowException):
+    """Raise when an unmappable type is pushed as a mapped downstream's dependency."""
 
     def __init__(self, value: Any) -> None:
         super().__init__(value)
         self.value = value
 
-
-class UnmappableXComTypePushed(UnmappableXComPushed):
-    """Raise when an unmappable type is pushed."""
-
     def __str__(self) -> str:
         return f"unmappable return type {type(self.value).__qualname__!r}"
 
 
-class UnmappableXComSizePushed(UnmappableXComPushed):
-    """Raise when the pushed value is to large to map."""
+class UnmappableXComSizePushed(AirflowException):
+    """Raise when the pushed value is to large to map as a downstream's dependency."""
+
+    def __init__(self, value: Sized, max_size: int) -> None:
+        super().__init__(value)
+        self.value = value
+        self.max_size = max_size
 
     def __str__(self) -> str:
-        return f"unmappable return value size: {len(self.value)}"
+        return f"unmappable return value size: {len(self.value)} > {self.max_size}"
 
 
 class AirflowDagCycleException(AirflowException):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2105,12 +2105,10 @@ class TaskInstance(Base, LoggingMixin):
         if not self.task.has_mapped_dependants():
             return
         if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
-            self.log.info("Failing %s for unmappable XCom push %r", self.key, type(value).__qualname__)
             raise UnmappableXComTypePushed(value)
         max_map_size = conf.getint("core", "max_map_size", fallback=1024)
         if len(value) > max_map_size:
-            self.log.info("Failing %s for oversize XCom push (%d > %d)", self.key, len(value), max_map_size)
-            raise UnmappableXComSizePushed(value)
+            raise UnmappableXComSizePushed(value, max_map_size)
         session.merge(TaskMap.from_task_instance_xcom(self, value))
 
     @provide_session

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -84,7 +84,7 @@ from airflow.exceptions import (
     DagRunNotFound,
     TaskDeferralError,
     TaskDeferred,
-    UnmappableXComSizePushed,
+    UnmappableXComLengthPushed,
     UnmappableXComTypePushed,
 )
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
@@ -2106,9 +2106,9 @@ class TaskInstance(Base, LoggingMixin):
             return
         if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
             raise UnmappableXComTypePushed(value)
-        max_map_size = conf.getint("core", "max_map_size", fallback=1024)
-        if len(value) > max_map_size:
-            raise UnmappableXComSizePushed(value, max_map_size)
+        max_map_length = conf.getint("core", "max_map_length", fallback=1024)
+        if len(value) > max_map_length:
+            raise UnmappableXComLengthPushed(value, max_map_length)
         session.merge(TaskMap.from_task_instance_xcom(self, value))
 
     @provide_session

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2107,7 +2107,7 @@ class TaskInstance(Base, LoggingMixin):
         if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
             self.log.info("Failing %s for unmappable XCom push %r", self.key, type(value).__qualname__)
             raise UnmappableXComTypePushed(value)
-        max_map_size = conf.getint("core", "max_map_size", fallback=128)
+        max_map_size = conf.getint("core", "max_map_size", fallback=1024)
         if len(value) > max_map_size:
             self.log.info("Failing %s for oversize XCom push (%d > %d)", self.key, len(value), max_map_size)
             raise UnmappableXComSizePushed(value)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -37,7 +37,7 @@ from airflow.exceptions import (
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
-    UnmappableXComSizePushed,
+    UnmappableXComLengthPushed,
     UnmappableXComTypePushed,
 )
 from airflow.models import (
@@ -2292,8 +2292,8 @@ class TestTaskInstanceRecordTaskMapXComPush:
         assert ti.state == TaskInstanceState.FAILED
         assert str(ctx.value) == "unmappable return type 'str'"
 
-    @conf_vars({("core", "max_map_size"): "1"})
-    def test_error_if_unmappable_size(self, dag_maker):
+    @conf_vars({("core", "max_map_length"): "1"})
+    def test_error_if_unmappable_length(self, dag_maker):
         """If an unmappable return value is used to map, fail the task that pushed the XCom."""
         with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
 
@@ -2308,12 +2308,12 @@ class TestTaskInstanceRecordTaskMapXComPush:
             pull_something.map(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
-        with pytest.raises(UnmappableXComSizePushed) as ctx:
+        with pytest.raises(UnmappableXComLengthPushed) as ctx:
             ti.run()
 
         assert dag_maker.session.query(TaskMap).count() == 0
         assert ti.state == TaskInstanceState.FAILED
-        assert str(ctx.value) == "unmappable return value size: 2 > 1"
+        assert str(ctx.value) == "unmappable return value length: 2 > 1"
 
     @pytest.mark.parametrize(
         "xcom_value, expected_length, expected_keys",

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -37,7 +37,8 @@ from airflow.exceptions import (
     AirflowRescheduleException,
     AirflowSensorTimeout,
     AirflowSkipException,
-    UnmappableXComPushed,
+    UnmappableXComSizePushed,
+    UnmappableXComTypePushed,
 )
 from airflow.models import (
     DAG,
@@ -2284,7 +2285,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             pull_something.map(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
-        with pytest.raises(UnmappableXComPushed) as ctx:
+        with pytest.raises(UnmappableXComTypePushed) as ctx:
             ti.run()
 
         assert dag_maker.session.query(TaskMap).count() == 0
@@ -2307,12 +2308,12 @@ class TestTaskInstanceRecordTaskMapXComPush:
             pull_something.map(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
-        with pytest.raises(UnmappableXComPushed) as ctx:
+        with pytest.raises(UnmappableXComSizePushed) as ctx:
             ti.run()
 
         assert dag_maker.session.query(TaskMap).count() == 0
         assert ti.state == TaskInstanceState.FAILED
-        assert str(ctx.value) == "unmappable return value size: 2"
+        assert str(ctx.value) == "unmappable return value size: 2 > 1"
 
     @pytest.mark.parametrize(
         "xcom_value, expected_length, expected_keys",


### PR DESCRIPTION
The default value (128) is arbitrary.