### PR TITLE
Remove un-needed deps/version requirements

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -260,10 +260,9 @@ ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
 # Those are additional constraints that are needed for some extras but we do not want to
 # force them on the main Airflow package. Those limitations are:
 # * certifi<2021.0.0: required by snowflake provider
-# * lazy-object-proxy<1.5.0: required by astroid
 # * dill<0.3.3 required by apache-beam
 # * google-ads<14.0.1 required to prevent updating google-python-api>=2.0.0
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="lazy-object-proxy<1.5.0 dill<0.3.3 certifi<2021.0.0 google-ads<14.0.1"
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 certifi<2021.0.0 google-ads<14.0.1"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
     UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,14 +92,8 @@ install_requires =
     cryptography>=0.9.3
     deprecated>=1.2.13
     dill>=0.2.2, <0.4
-    # Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for some docutils markup
-    # change:
-    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1112
-    # This limitation can be removed after this issue is closed:
-    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-    docutils<0.17
     flask>=1.1.0, <2.0
-    flask-appbuilder>=3.3.4, <4.0.0
+    flask-appbuilder~=3.4, <4.0.0
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15
@@ -108,7 +102,6 @@ install_requires =
     httpx
     importlib_metadata>=1.7;python_version<"3.9"
     importlib_resources~=5.2;python_version<"3.9"
-    iso8601>=0.1.12
     # Logging is broken with itsdangerous > 2
     itsdangerous>=1.1.0, <2.0
     # Jinja2 3.1 will remove the 'autoescape' and 'with' extensions, which would
@@ -118,7 +111,7 @@ install_requires =
     jsonschema~=3.0
     lazy-object-proxy
     lockfile>=0.12.2
-    markdown>=2.5.2, <4.0
+    markdown~=3.0
     markupsafe>=1.1.1
     marshmallow-oneofschema>=2.0.1
     packaging>=14.0
@@ -127,18 +120,12 @@ install_requires =
     pluggy~=1.0
     psutil>=4.2.0, <6.0.0
     pygments>=2.0.1, <3.0
-    pyjwt<3
     # python daemon crashes with 'socket operation on non-socket' for python 3.8+ in version < 2.2.4
     # https://pagure.io/python-daemon/issue/34
     python-daemon>=2.2.4
     python-dateutil>=2.3, <3
     python-nvd3~=0.15.0
-    python-slugify>=3.0.0,<5.0
-    # Required for flask-openID which comes with flask-appbuilder in case of poetry installation
-    # earlier versions of the dependency are installed but they do not work for Python 3
-    # (pip installs the right version).
-    # More info: https://github.com/apache/airflow/issues/13149#issuecomment-748705193
-    python3-openid~=3.2
+    python-slugify~=5.0
     rich>=9.2.0
     setproctitle>=1.1.8, <2
     sqlalchemy>=1.3.18
@@ -149,8 +136,6 @@ install_requires =
     typing-extensions>=3.7.4;python_version<"3.8"
     unicodecsv>=0.14.1
     werkzeug~=1.0, >=1.0.1
-    # SQLA still imports the compat
-    wtforms<3.0.0
 
 [options.packages.find]
 include =


### PR DESCRIPTION
This is in an aim to reduce the search space pip will hve to look at
when backtracking

- iso8601 hasn't been in use since 2017(!)
- pyjwt has been fixed upstream (flask-jwt-extended, via FAB), so we
  don't need to require it ourselfs # Please enter the commit message
  for your changes.
- wtforms and python3-openid issues have been fixed in FAB 3.4.0, so lets just update to that
  version

When looking at another dep backtrack issue I noticed a couple of restrictions that we are placing that we don't need (and one dep we install that just isn't need at all)

I don't know if this will help or hurt backtracking problems, but removing deps/pins we don't need feels like a good thing overall.

I haven't tested these changes (just tested that it installed without build errors.)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
