### PR TITLE
Add `--map-index` parameter to task CLI commands

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -414,16 +414,16 @@ ARG_VAR_EXPORT = Arg(("file",), help="Export all variables to JSON file")
 ARG_PRINCIPAL = Arg(("principal",), help="kerberos principal", nargs='?')
 ARG_KEYTAB = Arg(("-k", "--keytab"), help="keytab", nargs='?', default=conf.get('kerberos', 'keytab'))
 # run
-# TODO(aoen): "force" is a poor choice of name here since it implies it overrides
-# all dependencies (not just past success), e.g. the ignore_depends_on_past
-# dependency. This flag should be deprecated and renamed to 'ignore_ti_state' and
-# the "ignore_all_dependencies" command should be called the"force" command
-# instead.
 ARG_INTERACTIVE = Arg(
     ('-N', '--interactive'),
     help='Do not capture standard output and error streams (useful for interactive debugging)',
     action='store_true',
 )
+# TODO(aoen): "force" is a poor choice of name here since it implies it overrides
+# all dependencies (not just past success), e.g. the ignore_depends_on_past
+# dependency. This flag should be deprecated and renamed to 'ignore_ti_state' and
+# the "ignore_all_dependencies" command should be called the"force" command
+# instead.
 ARG_FORCE = Arg(
     ("-f", "--force"),
     help="Ignore previous task instance state, rerun regardless if task already succeeded/failed",
@@ -457,6 +457,8 @@ ARG_PICKLE = Arg(("-p", "--pickle"), help="Serialized pickle object of the entir
 ARG_ERROR_FILE = Arg(("--error-file",), help="File to store task failure error")
 ARG_JOB_ID = Arg(("-j", "--job-id"), help=argparse.SUPPRESS)
 ARG_CFG_PATH = Arg(("--cfg-path",), help="Path to config file to use instead of airflow.cfg")
+ARG_MAP_INDEX = Arg(('--map-index',), type=int, default=-1, help="Mapped task index")
+
 ARG_MIGRATION_TIMEOUT = Arg(
     ("-t", "--migration-wait-timeout"),
     help="timeout to wait for db to migrate ",
@@ -1085,7 +1087,14 @@ TASKS_COMMANDS = (
         name='state',
         help="Get the status of a task instance",
         func=lazy_load_command('airflow.cli.commands.task_command.task_state'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(
+            ARG_DAG_ID,
+            ARG_TASK_ID,
+            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_SUBDIR,
+            ARG_VERBOSE,
+            ARG_MAP_INDEX,
+        ),
     ),
     ActionCommand(
         name='failed-deps',
@@ -1096,13 +1105,20 @@ TASKS_COMMANDS = (
             "and then run by an executor."
         ),
         func=lazy_load_command('airflow.cli.commands.task_command.task_failed_deps'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_MAP_INDEX),
     ),
     ActionCommand(
         name='render',
         help="Render a task instance's template(s)",
         func=lazy_load_command('airflow.cli.commands.task_command.task_render'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(
+            ARG_DAG_ID,
+            ARG_TASK_ID,
+            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_SUBDIR,
+            ARG_VERBOSE,
+            ARG_MAP_INDEX,
+        ),
     ),
     ActionCommand(
         name='run',
@@ -1128,6 +1144,7 @@ TASKS_COMMANDS = (
             ARG_INTERACTIVE,
             ARG_ERROR_FILE,
             ARG_SHUT_DOWN_LOGGING,
+            ARG_MAP_INDEX,
         ),
     ),
     ActionCommand(
@@ -1147,6 +1164,7 @@ TASKS_COMMANDS = (
             ARG_TASK_PARAMS,
             ARG_POST_MORTEM,
             ARG_ENV_VARS,
+            ARG_MAP_INDEX,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -124,7 +124,7 @@ def _get_ti(
         session=session,
     )
 
-    ti_or_none = dag_run.get_task_instance(task.task_id)
+    ti_or_none = dag_run.get_task_instance(task.task_id, map_index=map_index, session=session)
     if ti_or_none is None:
         if not create_if_necessary:
             raise TaskInstanceNotFound(

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -106,11 +106,17 @@ def _get_dag_run(
 def _get_ti(
     task: BaseOperator,
     exec_date_or_run_id: str,
+    map_index: int,
     *,
     create_if_necessary: bool = False,
     session: Session = NEW_SESSION,
 ) -> TaskInstance:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way"""
+    if task.is_mapped:
+        if map_index == -1:
+            raise RuntimeError("No map_index passed to mapped task")
+    elif map_index != -1:
+        raise RuntimeError("map_index passed to non-mapped task")
     dag_run = _get_dag_run(
         dag=task.dag,
         exec_date_or_run_id=exec_date_or_run_id,
@@ -122,10 +128,11 @@ def _get_ti(
     if ti_or_none is None:
         if not create_if_necessary:
             raise TaskInstanceNotFound(
-                f"TaskInstance for {task.dag.dag_id}, {task.task_id} with "
+                f"TaskInstance for {task.dag.dag_id}, {task.task_id}, map={map_index} with "
                 f"run_id or execution_date of {exec_date_or_run_id!r} not found"
             )
-        ti = TaskInstance(task, run_id=dag_run.run_id)
+        # TODO: Validate map_index is in range?
+        ti = TaskInstance(task, run_id=dag_run.run_id, map_index=map_index)
         ti.dag_run = dag_run
     else:
         ti = ti_or_none
@@ -325,7 +332,7 @@ def task_run(args, dag=None):
         # Use DAG from parameter
         pass
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id, args.map_index)
     ti.init_run_context(raw=args.raw)
 
     hostname = get_hostname()
@@ -353,7 +360,7 @@ def task_failed_deps(args):
     """
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id, args.map_index)
 
     dep_context = DepContext(deps=SCHEDULER_QUEUED_DEPS)
     failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
@@ -376,7 +383,7 @@ def task_state(args):
     """
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id, args.map_index)
     print(ti.current_state())
 
 
@@ -495,7 +502,7 @@ def task_test(args, dag=None):
     if task.params:
         task.params.validate()
 
-    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necessary=True)
+    ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
 
     try:
         if args.dry_run:
@@ -521,7 +528,7 @@ def task_render(args):
     """Renders and displays templated fields for a given task"""
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necessary=True)
+    ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1589,6 +1589,10 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         return False
 
     @property
+    def is_mapped(self) -> bool:
+        return False
+
+    @property
     def inherits_from_dummy_operator(self):
         """Used to determine if an Operator is inherited from DummyOperator"""
         # This looks like `isinstance(self, DummyOperator) would work, but this also
@@ -1853,6 +1857,10 @@ class MappedOperator(DAGNode):
         """Used to determine if an Operator is inherited from DummyOperator"""
         return self._is_dummy
 
+    @property
+    def is_mapped(self) -> bool:
+        return True
+
     # The _serialized_fields are lazily loaded when get_serialized_fields() method is called
     __serialized_fields: ClassVar[Optional[FrozenSet[str]]] = None
 
@@ -1866,6 +1874,7 @@ class MappedOperator(DAGNode):
                     'dag',
                     'deps',
                     'inherits_from_dummy_operator',
+                    'is_mapped',
                     'operator_extra_links',
                     'upstream_task_ids',
                     'task_type',

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -441,7 +441,11 @@ class DagRun(Base, LoggingMixin):
 
     @provide_session
     def get_task_instance(
-        self, task_id: str, map_index: int = -1, session: Session = NEW_SESSION
+        self,
+        task_id: str,
+        session: Session = NEW_SESSION,
+        *,
+        map_index: int = -1,
     ) -> Optional[TI]:
         """
         Returns the task instance specified by task_id for this dag run

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -440,7 +440,9 @@ class DagRun(Base, LoggingMixin):
         return tis.all()
 
     @provide_session
-    def get_task_instance(self, task_id: str, session: Session = NEW_SESSION) -> Optional[TI]:
+    def get_task_instance(
+        self, task_id: str, map_index: int = -1, session: Session = NEW_SESSION
+    ) -> Optional[TI]:
         """
         Returns the task instance specified by task_id for this dag run
 
@@ -451,7 +453,7 @@ class DagRun(Base, LoggingMixin):
         """
         return (
             session.query(TI)
-            .filter(TI.dag_id == self.dag_id, TI.run_id == self.run_id, TI.task_id == task_id)
+            .filter_by(dag_id=self.dag_id, run_id=self.run_id, task_id=task_id, map_index=map_index)
             .one_or_none()
         )
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -603,6 +603,7 @@ class TaskInstance(Base, LoggingMixin):
             job_id=job_id,
             pool=pool,
             cfg_path=cfg_path,
+            map_index=self.map_index,
         )
 
     @staticmethod
@@ -622,6 +623,7 @@ class TaskInstance(Base, LoggingMixin):
         job_id: Optional[str] = None,
         pool: Optional[str] = None,
         cfg_path: Optional[str] = None,
+        map_index: int = -1,
     ) -> List[str]:
         """
         Generates the shell command required to execute this task instance.
@@ -688,6 +690,8 @@ class TaskInstance(Base, LoggingMixin):
             cmd.extend(["--subdir", file_path])
         if cfg_path:
             cmd.extend(["--cfg-path", cfg_path])
+        if map_index != -1:
+            cmd.extend(['--map-index', str(map_index)])
         return cmd
 
     @property

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1933,9 +1933,11 @@ class TestTaskInstance:
             task_id,
             'run_1',
             '--mark-success',
+            '--map-index',
+            '0',
         ]
         generate_command = TI.generate_command(
-            dag_id=dag_id, task_id=task_id, run_id='run_1', mark_success=True
+            dag_id=dag_id, task_id=task_id, run_id='run_1', mark_success=True, map_index=0
         )
         assert assert_command == generate_command
 


### PR DESCRIPTION
A nice small change -- pass down the map_index from the TI on the scheduler to the executor so that (when we have expanded them) mapped tasks will be able to find the right TaskInstance.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
