### PR TITLE
Add extra sync when adding executable flag to installation scripts

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -96,9 +96,17 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Only copy mysql/mssql installation scripts for now - so that changing the other
-# scripts which are needed much later will not invalidate the docker layer here
+# scripts which are needed much later will not invalidate the docker layer here.
 COPY scripts/docker/install_mysql.sh scripts/docker/install_mssql.sh /scripts/docker/
-RUN /scripts/docker/install_mysql.sh dev && /scripts/docker/install_mssql.sh \
+# We run chmod +x to fix permission issue in Azure DevOps when running the scripts
+# However when AUFS Docker backend is used, this might cause "text file busy" error
+# when script is executed right after it's executable flag has been changed, so
+# we run additional sync afterwards. See https://github.com/moby/moby/issues/13594
+RUN chmod a+x /scripts/docker/install_mysql.sh /scripts/docker/install_mssql.sh \
+    && sync  \
+    && /scripts/docker/install_mysql.sh prod  \
+    && /scripts/docker/install_mysql.sh dev  \
+    && /scripts/docker/install_mssql.sh \
     && adduser --gecos "First Last,RoomNumber,WorkPhone,HomePhone" --disabled-password \
               --quiet "airflow" --home "/home/airflow" \
     && echo -e "airflow\nairflow" | passwd airflow 2>&1 \


### PR DESCRIPTION
Seems that when AUFS is a backing storage for Docker, changing
the script to executable and executing it right after during the
build phase might cause an error: 'text file busy'

https://github.com/moby/moby/issues/13594

Workaround for that is to add extra `sync` command after changing
the executable flag to make sure that the filesystem change has
propageted to the underlying AUFS storage.

This PR adds the sync and also makes sure that both CI And PROD
image use same formatting, executable bits and `&&` between
commands rather than `;`. The `&&` is better to separate the
commands because it will not continue with execution steps in the
same bash command after previous command fails. This caused
confusion as to what is the reason for docker build failure.

The problem was raised in the #20971 discussion.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
