### PR TITLE
Rename params to cloudformation_parameter in CloudFormation operators.

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -19,6 +19,20 @@
 Changelog
 ---------
 
+3.0.0
+.....
+
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+The CloudFormationCreateStackOperator and CloudFormationDeleteStackOperator
+used ``params`` as one of the constructor arguments, however this name clashes with params
+argument ``params`` field which is processed differently in Airflow 2.2.
+The ``params`` parameter has been renamed to ``cloudformation_parameters`` to make it non-ambiguous.
+
+Any usage of CloudFormationCreateStackOperator and CloudFormationDeleteStackOperator where
+``params`` were passed, should be changed to use ``cloudformation_parameters`` instead.
+
 2.6.0
 .....
 

--- a/airflow/providers/amazon/aws/hooks/cloud_formation.py
+++ b/airflow/providers/amazon/aws/hooks/cloud_formation.py
@@ -53,32 +53,32 @@ class CloudFormationHook(AwsBaseHook):
             else:
                 raise e
 
-    def create_stack(self, stack_name: str, params: dict) -> None:
+    def create_stack(self, stack_name: str, cloudformation_parameters: dict) -> None:
         """
         Create stack in CloudFormation.
 
         :param stack_name: stack_name.
         :type stack_name: str
-        :param params: parameters to be passed to CloudFormation.
-        :type params: dict
+        :param cloudformation_parameters: parameters to be passed to CloudFormation.
+        :type cloudformation_parameters: dict
         """
-        if 'StackName' not in params:
-            params['StackName'] = stack_name
-        self.get_conn().create_stack(**params)
+        if 'StackName' not in cloudformation_parameters:
+            cloudformation_parameters['StackName'] = stack_name
+        self.get_conn().create_stack(**cloudformation_parameters)
 
-    def delete_stack(self, stack_name: str, params: Optional[dict] = None) -> None:
+    def delete_stack(self, stack_name: str, cloudformation_parameters: Optional[dict] = None) -> None:
         """
         Delete stack in CloudFormation.
 
         :param stack_name: stack_name.
         :type stack_name: str
-        :param params: parameters to be passed to CloudFormation (optional).
-        :type params: dict
+        :param cloudformation_parameters: parameters to be passed to CloudFormation (optional).
+        :type cloudformation_parameters: dict
         """
-        params = params or {}
-        if 'StackName' not in params:
-            params['StackName'] = stack_name
-        self.get_conn().delete_stack(**params)
+        cloudformation_parameters = cloudformation_parameters or {}
+        if 'StackName' not in cloudformation_parameters:
+            cloudformation_parameters['StackName'] = stack_name
+        self.get_conn().delete_stack(**cloudformation_parameters)
 
 
 class AWSCloudFormationHook(CloudFormationHook):

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -31,11 +31,11 @@ class CloudFormationCreateStackOperator(BaseOperator):
 
     :param stack_name: stack name (templated)
     :type stack_name: str
-    :param params: parameters to be passed to CloudFormation.
+    :param cloudformation_parameters: parameters to be passed to CloudFormation.
 
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.create_stack
-    :type params: dict
+    :type cloudformation_parameters: dict
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
     """
@@ -44,17 +44,19 @@ class CloudFormationCreateStackOperator(BaseOperator):
     template_ext: Sequence[str] = ()
     ui_color = '#6b9659'
 
-    def __init__(self, *, stack_name: str, params: dict, aws_conn_id: str = 'aws_default', **kwargs):
+    def __init__(
+        self, *, stack_name: str, cloudformation_parameters: dict, aws_conn_id: str = 'aws_default', **kwargs
+    ):
         super().__init__(**kwargs)
         self.stack_name = stack_name
-        self.params = params
+        self.cloudformation_parameters = cloudformation_parameters
         self.aws_conn_id = aws_conn_id
 
     def execute(self, context: 'Context'):
-        self.log.info('Parameters: %s', self.params)
+        self.log.info('CloudFormation parameters: %s', self.cloudformation_parameters)
 
         cloudformation_hook = CloudFormationHook(aws_conn_id=self.aws_conn_id)
-        cloudformation_hook.create_stack(self.stack_name, self.params)
+        cloudformation_hook.create_stack(self.stack_name, self.cloudformation_parameters)
 
 
 class CloudFormationDeleteStackOperator(BaseOperator):
@@ -63,11 +65,11 @@ class CloudFormationDeleteStackOperator(BaseOperator):
 
     :param stack_name: stack name (templated)
     :type stack_name: str
-    :param params: parameters to be passed to CloudFormation.
+    :param cloudformation_parameters: parameters to be passed to CloudFormation.
 
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack
-    :type params: dict
+    :type cloudformation_parameters: dict
     :param aws_conn_id: aws connection to uses
     :type aws_conn_id: str
     """
@@ -78,15 +80,20 @@ class CloudFormationDeleteStackOperator(BaseOperator):
     ui_fgcolor = '#FFF'
 
     def __init__(
-        self, *, stack_name: str, params: Optional[dict] = None, aws_conn_id: str = 'aws_default', **kwargs
+        self,
+        *,
+        stack_name: str,
+        cloudformation_parameters: Optional[dict] = None,
+        aws_conn_id: str = 'aws_default',
+        **kwargs,
     ):
         super().__init__(**kwargs)
-        self.params = params or {}
+        self.cloudformation_parameters = cloudformation_parameters or {}
         self.stack_name = stack_name
         self.aws_conn_id = aws_conn_id
 
     def execute(self, context: 'Context'):
-        self.log.info('Parameters: %s', self.params)
+        self.log.info('CloudFormation Parameters: %s', self.cloudformation_parameters)
 
         cloudformation_hook = CloudFormationHook(aws_conn_id=self.aws_conn_id)
-        cloudformation_hook.delete_stack(self.stack_name, self.params)
+        cloudformation_hook.delete_stack(self.stack_name, self.cloudformation_parameters)

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -22,6 +22,7 @@ description: |
     Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 versions:
+  - 3.0.0
   - 2.6.0
   - 2.5.0
   - 2.4.0

--- a/tests/providers/amazon/aws/hooks/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/hooks/test_cloud_formation.py
@@ -57,7 +57,7 @@ class TestCloudFormationHook(unittest.TestCase):
 
         self.hook.create_stack(
             stack_name=stack_name,
-            params={
+            cloudformation_parameters={
                 'TimeoutInMinutes': timeout,
                 'TemplateBody': template_body,
                 'Parameters': [{'ParameterKey': "VPCCidr", 'ParameterValue': '10.0.0.0/16'}],

--- a/tests/providers/amazon/aws/operators/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/operators/test_cloud_formation.py
@@ -50,7 +50,7 @@ class TestCloudFormationCreateStackOperator(unittest.TestCase):
         operator = CloudFormationCreateStackOperator(
             task_id='test_task',
             stack_name=stack_name,
-            params={'TimeoutInMinutes': timeout, 'TemplateBody': template_body},
+            cloudformation_parameters={'TimeoutInMinutes': timeout, 'TemplateBody': template_body},
             dag=DAG('test_dag_id', default_args=self.args),
         )
 


### PR DESCRIPTION
The CloudFormationCreateStackOperator and
CloudFormationDeleteStackOperator used ``params`` as one of the
constructor arguments, however this name clashes with params argument
``params`` field which is processed differently in Airflow 2.2.  The
``params`` parameter has been renamed to ``cloudformation_parameters``
to make it non-ambiguous.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
