### PR TITLE
Explicitly set pytest asyncio mode to 'strict'

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,3 +34,4 @@ filterwarnings =
     error::pytest.PytestCollectionWarning
 markers =
     need_serialized_dag
+asyncio-mode = strict


### PR DESCRIPTION
Recently `pytest-asyncio` started to emit a ton of deprecation warnings on fixtures due to a preparetion to default behaviour migration.[^1] This sets the behaviour flag explicitly to silence them.

I chose `strict` (instead of `auto`, the other possibility) because, from what I can tell, we have only one async test right now, and it’s already explicitly marked as async. This means we don’t really need auto detection and can disable it for now (until we actually need it).

cc @andrewgodwin since you’d likely know if there are in fact more async tests I missed.

[^1]: https://github.com/pytest-dev/pytest-asyncio/tree/048a6edc56e7d2c4a5f1283b5d2dd93a1270bfce#modes