### PR TITLE
Update md5 information about image after waiting

### DIFF
--- a/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
@@ -38,4 +38,6 @@ if [[ ${VERIFY_IMAGE=} != "false" ]]; then
     verify_image::verify_ci_image "${image_name_with_tag}"
 fi
 
+md5sum::update_all_md5_with_group
+
 docker_v tag  "${image_name_with_tag}" "${AIRFLOW_CI_IMAGE}"


### PR DESCRIPTION
When "wait_for_image" was called, the information that the image
was built (including the information about md5 hashes of important
files) had not been stored locally. It was only stored when
image was pulled by "prepare_image". Constraints job uses
wait for image, because it runs in parallel for all python versions.

With recent changes, the flag that image had never been built,
automatically generates image build - unnecessarily, because the
image is already pulled by "wait_for_image".

It made almost no difference for "regular builds" because the image
is rebuilt from cache (which is now very quick) but in case of
PRs that change setup.py it caused image rebuild. Additionally if
this iamge has conflicting requirement, it would cause build failure.

The change simply registers the fact that image is "ok" so that
no attempt to rebuild image happens when constraints are generated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
