### PR TITLE
Fix the incorrect scheduling time for the first run of dag

### DIFF
--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -232,7 +232,7 @@ class CronDataIntervalTimetable(_DataIntervalTimetable):
             raise AssertionError("next schedule shouldn't be earlier")
         if earliest is None:
             return new_start
-        return max(new_start, earliest)
+        return max(new_start, self._align(earliest))
 
     def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
         # Get the last complete period before run_after, e.g. if a DAG run is


### PR DESCRIPTION

When catchup_by_default is set to false and the start_date in the dag is the previous day, the first dispatch time of this dag is incorrect



dag setting 

    schedule_interval='30 21 * * *',
    start_date=dates.days_ago(1),

![2022-01-21_18-31](https://user-images.githubusercontent.com/55907021/150512219-b78b98cd-69b6-415d-ac5d-986b6916956e.png)

---
error
![2022-01-21_17-27](https://user-images.githubusercontent.com/55907021/150510749-fa133559-91bb-495c-8834-d46f302be5af.png)

Correct
![2022-01-21_17-30](https://user-images.githubusercontent.com/55907021/150511023-85fcdb50-3687-4d3e-be9c-285713128519.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
