### PR TITLE
Remove a few stray `:type`s in docs

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -99,7 +99,6 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
     :param processor_timeout: How long to wait before timing out a DAG file processor
     :param dag_ids: if specified, only schedule tasks with these DAG IDs
     :param pickle_dags: whether to pickle DAGs.
-    :type: pickle_dags: bool
     :param async_mode: Whether to start agent in async mode
     """
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1412,7 +1412,6 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         Make an XCom available for tasks to pull.
 
         :param context: Execution Context Dictionary
-        :type: Any
         :param key: A key for the XCom
         :param value: A value for the XCom. The value is pickled and stored
             in the database.
@@ -1443,7 +1442,6 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         whenever no matches are found.
 
         :param context: Execution Context Dictionary
-        :type: Any
         :param key: A key for the XCom. If provided, only XComs with matching
             keys will be returned. The default key is 'return_value', also
             available as a constant XCOM_RETURN_KEY. This key is automatically

--- a/airflow/models/sensorinstance.py
+++ b/airflow/models/sensorinstance.py
@@ -96,7 +96,6 @@ class SensorInstance(Base):
         context used for a sensor and set the sensor_instance table state to sensing.
 
         :param ti: The task instance for the sensor to be registered.
-        :type: ti:
         :param poke_context: Context used for sensor poke function.
         :param execution_context: Context used for execute sensor such as timeout
             setting and email configuration.

--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -105,9 +105,7 @@ class OSSHook(BaseHook):
         Parses the OSS Url into a bucket name and key.
 
         :param ossurl: The OSS Url to parse.
-        :rtype ossurl: str
         :return: the parsed bucket name and key
-        :rtype: tuple of str
         """
         parsed_url = urlparse(ossurl)
 

--- a/airflow/providers/amazon/aws/operators/cloud_formation.py
+++ b/airflow/providers/amazon/aws/operators/cloud_formation.py
@@ -65,7 +65,6 @@ class CloudFormationDeleteStackOperator(BaseOperator):
 
         .. seealso::
             https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudformation.html#CloudFormation.Client.delete_stack
-    :type cloudformation_parameters: dict
     :param aws_conn_id: aws connection to uses
     """
 

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -108,9 +108,7 @@ def gen_job_name(job_name: str) -> str:
     Suffix — current timestamp
 
     :param job_name:
-    :rtype job_name: str
     :return: job_name with suffix
-    :rtype: str
     """
     uniq = int(time.time())
     return f"{job_name}_{uniq}"

--- a/tests/providers/amazon/aws/utils/eks_test_utils.py
+++ b/tests/providers/amazon/aws/utils/eks_test_utils.py
@@ -153,7 +153,6 @@ def region_matches_partition(region: str, partition: str) -> bool:
     Returns True if the provided region and partition are a valid pair.
 
     :param region: AWS region code to test.
-    :type: region: str
     :param partition: AWS partition code to test.
     :return: Returns True if the provided region and partition are a valid pair.
     :rtype: bool


### PR DESCRIPTION
I also noticed a couple of `:rtype` that should have been `:type` so I've removed those too.

Sadly we can't remove `:rtype` en-mass yet as Sphinx doesn't pick up the return type from type hints.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).