### PR TITLE
Fix opening "Task Instance Details" page in web UI unintentionally resets TaskInstance.max_tries

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -474,6 +474,7 @@ class TaskInstance(Base, LoggingMixin):
         self.run_id = run_id
 
         self.try_number = 0
+        self.max_tries = self.task.retries
         self.unixname = getuser()
         if state:
             self.state = state
@@ -806,7 +807,8 @@ class TaskInstance(Base, LoggingMixin):
         self.pool_slots = task.pool_slots
         self.priority_weight = task.priority_weight_total
         self.run_as_user = task.run_as_user
-        self.max_tries = task.retries
+        # Do not set max_tries from task.retries here because max_tries is a cumulative
+        # value that needs to be stored in the db.
         self.executor_config = task.executor_config
         self.operator = task.task_type
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -807,7 +807,7 @@ class TaskInstance(Base, LoggingMixin):
         self.pool_slots = task.pool_slots
         self.priority_weight = task.priority_weight_total
         self.run_as_user = task.run_as_user
-        # Do not set max_tries from task.retries here because max_tries is a cumulative
+        # Do not set max_tries to task.retries here because max_tries is a cumulative
         # value that needs to be stored in the db.
         self.executor_config = task.executor_config
         self.operator = task.task_type

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2160,6 +2160,12 @@ def test_refresh_from_task(pool_override):
     assert ti.executor_config == task.executor_config
     assert ti.operator == DummyOperator.__name__
 
+    # Test that refresh_from_task does not reset ti.max_tries
+    expected_max_tries = task.retries + 10
+    ti.max_tries = expected_max_tries
+    ti.refresh_from_task(task)
+    assert ti.max_tries == expected_max_tries
+
 
 class TestRunRawTaskQueriesCount:
     """


### PR DESCRIPTION
closes: #21017

---
Do not change `max_tries` in `refresh_from_tasks()`. This is to prevent the web UI from accidentally resetting the value of `max_tries` to the initial value and causing tasks in "reschedule" mode to raise `AirflowSensorTimeout` prematurely.

Note that this PR only addresses the symptom reported in #21017. A more comprehensive fix should be to stop auto-committing the session in `views.py` in functions that are not supposed to modify the database. That can be done separately if someone is interested.