### PR TITLE
Fixed tests failing on unittest.skipIf

### DIFF
--- a/tests/always/test_deprecations.py
+++ b/tests/always/test_deprecations.py
@@ -49,7 +49,7 @@ class TestDeprecations:
         py_38 = sys.version_info >= (3, 8)
         if py_38:
             if "mssql" in path_a or "mssql" in path_b:
-                raise self.skipTest("Mssql package not available when Python >= 3.8.")
+                raise pytest.skip("Mssql package not available when Python >= 3.8.")
 
     @staticmethod
     def get_class_from_path(path_to_class, parent=False):

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -85,7 +85,7 @@ def revoke_permissions():
 
 def check_original_docker_image():
     if not os.path.isfile('/.dockerenv') or os.environ.get('PYTHON_BASE_IMAGE') is None:
-        raise unittest.SkipTest(
+        raise pytest.skip(
             """Adding/removing a user as part of a test is very bad for host os
 (especially if the user already existed to begin with on the OS), therefore we check if we run inside a
 the official docker container and only allow to run the test there. This is done by checking /.dockerenv
@@ -99,13 +99,13 @@ def create_user():
         subprocess.check_output(['sudo', 'useradd', '-m', TEST_USER, '-g', str(os.getegid())])
     except OSError as e:
         if e.errno == errno.ENOENT:
-            raise unittest.SkipTest(
+            raise pytest.skip(
                 "The 'useradd' command did not exist so unable to test "
                 "impersonation; Skipping Test. These tests can only be run on a "
                 "linux host that supports 'useradd'."
             )
         else:
-            raise unittest.SkipTest(
+            raise pytest.skip(
                 "The 'useradd' command exited non-zero; Skipping tests. Does the "
                 "current user have permission to run 'useradd' without a password "
                 "prompt (check sudoers file)?"

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -118,7 +118,7 @@ class TestAirflowTaskDecorator(TestPythonBase):
     @parameterized.expand([["dict"], ["dict[str, int]"], ["Dict"], ["Dict[str, int]"]])
     def test_infer_multiple_outputs_using_dict_typing(self, test_return_annotation):
         if sys.version_info < (3, 9) and test_return_annotation == "dict[str, int]":
-            self.skipTest("dict[...] not a supported typing prior to Python 3.9")
+            raise pytest.skip("dict[...] not a supported typing prior to Python 3.9")
 
             @task_decorator
             def identity_dict(x: int, y: int) -> eval(test_return_annotation):

--- a/tests/providers/apache/hdfs/hooks/test_hdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_hdfs.py
@@ -20,6 +20,8 @@ import json
 import unittest
 from unittest import mock
 
+import pytest
+
 from airflow.models import Connection
 from airflow.providers.apache.hdfs.hooks.hdfs import HDFSHook
 
@@ -29,9 +31,7 @@ try:
     snakebite_loaded = True
 except ImportError:
     snakebite_loaded = False
-
-if not snakebite_loaded:
-    raise unittest.SkipTest("Skipping test because HDFSHook is not installed")
+    pytestmark = pytest.mark.skip("Skipping test because HDFSHook is not installed")
 
 
 class TestHDFSHook(unittest.TestCase):
@@ -82,6 +82,8 @@ class TestHDFSHook(unittest.TestCase):
 
     @mock.patch('airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook.get_connections')
     def test_get_ha_client(self, mock_get_connections):
+        if not snakebite_loaded:
+            raise pytest.skip("Skipping test because HDFSHook is not installed")
         conn_1 = Connection(conn_id='hdfs_default', conn_type='hdfs', host='localhost', port=8020)
         conn_2 = Connection(conn_id='hdfs_default', conn_type='hdfs', host='localhost2', port=8020)
         mock_get_connections.return_value = [conn_1, conn_2]

--- a/tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py
+++ b/tests/providers/google/cloud/utils/test_mlengine_prediction_summary.py
@@ -27,7 +27,7 @@ try:
     from airflow.providers.google.cloud.utils import mlengine_prediction_summary
 except ImportError as e:
     if 'apache_beam' in str(e):
-        raise unittest.SkipTest(f"package apache_beam not present. Skipping all tests in {__name__}")
+        pytestmark = pytest.mark.skip(f"package apache_beam not present. Skipping all tests in {__name__}")
 
 
 class TestJsonCode(unittest.TestCase):

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -440,7 +440,7 @@ class TestMySql(unittest.TestCase):
             elif priv == ("",):
                 hook.bulk_dump("INFORMATION_SCHEMA.TABLES", f"TABLES_{client}_{uuid.uuid1()}")
             else:
-                self.skipTest("Skip test_mysql_hook_test_bulk_load since file output is not permitted")
+                raise pytest.skip("Skip test_mysql_hook_test_bulk_load since file output is not permitted")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
The change #21003 broke TestDeprecation class tests by removing
TestCase and leaving self.skipTest.

This change replaces self.skipTest with pytest.skipTest everywhere.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
