### PR TITLE
OpenApiSpec - DAGRun - make dag_id in body not required

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2173,8 +2173,6 @@ components:
 
             The value of this field can be set only when creating the object. If you try to modify the
             field of an existing object, the request fails with an BAD_REQUEST error.
-      required:
-        - dag_id
 
     UpdateDagRunState:
       type: object


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: https://github.com/apache/airflow-client-go/issues/9


When generating a golang client for the spec and trying to create a DAGRun. it requires the dag_id property in the body which the server refuses. see above linked issue.


Results for how code gen changes would look after the schema change can be seen here: https://github.com/DrFaust92/airflow-client-go/pull/2/files