### PR TITLE
Trino init added to recieve a connection Issue 20965

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -58,9 +58,14 @@ class TrinoHook(DbApiHook):
     conn_type = 'trino'
     hook_name = 'Trino'
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.schema = kwargs.pop("schema", None)
+        self.connection = kwargs.pop("connection", None)
+
     def get_conn(self) -> Connection:
         """Returns a connection object"""
-        db = self.get_connection(self.trino_conn_id)  # type: ignore[attr-defined]
+        db = self.connection or self.get_connection(self.trino_conn_id)  # type: ignore[attr-defined]
         extra = db.extra_dejson
         auth = None
         if db.password and extra.get('auth') == 'kerberos':


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #20965
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The Trino hook requires a username and password to use the hook. If i were to try to use a connection without it, it would error out asking for basic authentication or a trino user. If i add a username and password to a connection. The connection becomes encrypted and is added to secrets then i won't be able to discover it unless i go through the basehook.

conn = BaseHook.get_connection(kwargs['my_conn_id'])

There are flaws in both systems that causes the inconsistency with the TrinoHook when using Basic Authentication. This will allow a connection from secrets to be passed to TrinoHook but will not fix the problem with TrinoHook Basic Authentication. Basic Authentication will not work with a Http connection and Airflow does not allow you to send a https connection without using a uri.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
