### PR TITLE
Temporary limit Pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,10 @@ def write_version(filename: str = os.path.join(*[my_dir, "airflow", "git_version
         file.write(text)
 
 
-pandas_requirement = 'pandas>=0.17.1, <2.0'
+# We limit Pandas to <1.4 because Pandas 1.4 requires SQLAlchemy 1.4 which
+# We should remove the limits as soon as Flask App Builder releases version 3.4.4
+# Release candidate is there: https://pypi.org/project/Flask-AppBuilder/3.4.4rc1/
+pandas_requirement = 'pandas>=0.17.1, <1.4'
 
 # 'Start dependencies group' and 'Start dependencies group' are mark for ./scripts/ci/check_order_setup.py
 # If you change this mark you should also change ./scripts/ci/check_order_setup.py


### PR DESCRIPTION
This is likely only for couple of days to avoid test failures
in `main`. When the 3.4.4 version of Flask Builder gets
released we should be able to relax the limit as it will allow
us to migrate to sqlalchemy 1.4

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
