### PR TITLE
Revert "Obtain lock for update when scheduling tis (#20894)"

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -916,37 +916,34 @@ class DagRun(Base, LoggingMixin):
         count = 0
 
         if schedulable_ti_ids:
-
-            count += with_row_locks(
-                session.query(TI).filter(
+            count += (
+                session.query(TI)
+                .filter(
                     TI.dag_id == self.dag_id,
                     TI.run_id == self.run_id,
                     TI.task_id.in_(schedulable_ti_ids),
-                ),
-                of=TI,
-                session=session,
-                **skip_locked(session=session),
-            ).update({TI.state: State.SCHEDULED}, synchronize_session=False)
+                )
+                .update({TI.state: State.SCHEDULED}, synchronize_session=False)
+            )
 
         # Tasks using DummyOperator should not be executed, mark them as success
         if dummy_ti_ids:
-            count += with_row_locks(
-                session.query(TI).filter(
+            count += (
+                session.query(TI)
+                .filter(
                     TI.dag_id == self.dag_id,
                     TI.run_id == self.run_id,
                     TI.task_id.in_(dummy_ti_ids),
-                ),
-                of=TI,
-                session=session,
-                **skip_locked(session=session),
-            ).update(
-                {
-                    TI.state: State.SUCCESS,
-                    TI.start_date: timezone.utcnow(),
-                    TI.end_date: timezone.utcnow(),
-                    TI.duration: 0,
-                },
-                synchronize_session=False,
+                )
+                .update(
+                    {
+                        TI.state: State.SUCCESS,
+                        TI.start_date: timezone.utcnow(),
+                        TI.end_date: timezone.utcnow(),
+                        TI.duration: 0,
+                    },
+                    synchronize_session=False,
+                )
             )
 
         return count


### PR DESCRIPTION
This reverts commit 0e4a057cd8f704a51376d9694c0114eb2ced64ef.

The change was not really effective. It did not change the
behaviour of the UPDATE query. The "with_row_lock" clause
adds "FOR UPDATE" clause to SELECT queries but it is
silently ignored by SQLAlchemy for UPDATE queries because
UPDATE queries obtain row locks automatically.

As the result, this change did not change Airflow Behaviour
but added "noise" around the query.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
