### PR TITLE
Improve handling of string type and non-attribute `template_fields`

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -748,6 +748,16 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
                 ]
             )
 
+        if isinstance(self.template_fields, str):
+            warnings.warn(
+                f"The `template_fields` value for {self.task_type} is a string "
+                "but should be a list or tuple of string. Wrapping it in a list for execution. "
+                f"Please update {self.task_type} accordingly.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.template_fields = [self.template_fields]
+
     def __eq__(self, other):
         if type(self) is type(other):
             # Use getattr() instead of __dict__ as __dict__ doesn't return
@@ -1054,7 +1064,14 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         seen_oids: Set,
     ) -> None:
         for attr_name in template_fields:
-            content = getattr(parent, attr_name)
+            try:
+                content = getattr(parent, attr_name)
+            except AttributeError:
+                raise AttributeError(
+                    f"{attr_name!r} is configured as a template field "
+                    f"but {parent.task_type} does not have this attribute."
+                )
+
             if content:
                 rendered_content = self.render_template(content, context, jinja_env, seen_oids)
                 setattr(parent, attr_name, rendered_content)
@@ -1260,7 +1277,14 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         """Performs dry run for the operator - just render template fields."""
         self.log.info('Dry run')
         for field in self.template_fields:
-            content = getattr(self, field)
+            try:
+                content = getattr(self, field)
+            except AttributeError:
+                raise AttributeError(
+                    f"{field!r} is configured as a template field "
+                    f"but {self.task_type} does not have this attribute."
+                )
+
             if content and isinstance(content, str):
                 self.log.info('Rendering template for %s', field)
                 self.log.info(content)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -284,10 +284,34 @@ class TestBaseOperator:
         """Test render_template when a nested template field is missing."""
         task = BaseOperator(task_id="op1")
 
-        with pytest.raises(AttributeError) as ctx:
-            task.render_template(ClassWithCustomAttributes(template_fields=["missing_field"]), {})
+        error_message = (
+            "'missing_field' is configured as a template field but ClassWithCustomAttributes does not have "
+            "this attribute."
+        )
+        with pytest.raises(AttributeError, match=error_message):
+            task.render_template(
+                ClassWithCustomAttributes(
+                    template_fields=["missing_field"], task_type="ClassWithCustomAttributes"
+                ),
+                {},
+            )
 
-        assert "'ClassWithCustomAttributes' object has no attribute 'missing_field'" == str(ctx.value)
+    def test_string_template_field_attr_is_converted_to_list(self):
+        """Verify template_fields attribute is converted to a list if declared as a string."""
+
+        class StringTemplateFieldsOperator(BaseOperator):
+            template_fields = "a_string"
+
+        warning_message = (
+            "The `template_fields` value for StringTemplateFieldsOperator is a string but should be a "
+            "list or tuple of string. Wrapping it in a list for execution. Please update "
+            "StringTemplateFieldsOperator accordingly."
+        )
+        with pytest.warns(UserWarning, match=warning_message) as warnings:
+            task = StringTemplateFieldsOperator(task_id="op1")
+
+            assert len(warnings) == 1
+            assert isinstance(task.template_fields, list)
 
     def test_jinja_invalid_expression_is_just_propagated(self):
         """Test render_template propagates Jinja invalid expression errors."""


### PR DESCRIPTION
Related: #19047, #19052
Closes: #12876

This PR intends to improve both the handling of `template_fields` values declared as strings (most typically seen as `template_fields = ("some_field")` as well as the error message for declaring `template_fields` that are not attributes of the operator.  In the first case, a warning is logged and the `template_fields` is "automagically" converted to a list for the task execution. For the second case, the error message is updated from the default `AttributeError` to something more specific to what is happening when attempting to render any template fields.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
