### PR TITLE
Add a link to the DAG model in the Python API reference

### DIFF
--- a/docs/apache-airflow/python-api-ref.rst
+++ b/docs/apache-airflow/python-api-ref.rst
@@ -20,6 +20,12 @@
 Python API Reference
 ====================
 
+.. _pythonapi:dags:
+
+DAGs
+---------
+The DAG is Airflow's core model that represents a recurring workflow. Check out :class:`~airflow.models.dag.DAG` for details.
+
 .. _pythonapi:operators:
 
 Operators


### PR DESCRIPTION
The DAG model reference is hard to find. This makes it easier.