### PR TITLE
(Re)fix Dangling rows moving with MySQL+Replication

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -860,8 +860,15 @@ def _move_dangling_data_to_new_table(
         cte_sql = stmt.ctes[cte]
 
         session.execute(f"WITH {cte_sql} SELECT source.* INTO {target_table_name} FROM source")
+    elif dialect_name == "mysql":
+        # MySQL when replcation is turned needs this split in to two queries, so just do it for all MySQL
+        # ERROR 1786 (HY000): Statement violates GTID consistency: CREATE TABLE ... SELECT.
+        session.execute(f"CREATE TABLE {target_table_name} LIKE {source_table.name}")
+        session.execute(
+            f"INSERT INTO {target_table_name} {source_query.selectable.compile(bind=session.get_bind())}"
+        )
     else:
-        # Postgres, MySQL and SQLite all support the same "create as select"
+        # Postgres and SQLite both support the same "CREATE TABLE a AS SELECT ..." syntax
         session.execute(
             f"CREATE TABLE {target_table_name} AS {source_query.selectable.compile(bind=session.get_bind())}"
         )

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -861,7 +861,7 @@ def _move_dangling_data_to_new_table(
 
         session.execute(f"WITH {cte_sql} SELECT source.* INTO {target_table_name} FROM source")
     elif dialect_name == "mysql":
-        # MySQL when replcation is turned needs this split in to two queries, so just do it for all MySQL
+        # MySQL with replication needs this split in to two queries, so just do it for all MySQL
         # ERROR 1786 (HY000): Statement violates GTID consistency: CREATE TABLE ... SELECT.
         session.execute(f"CREATE TABLE {target_table_name} LIKE {source_table.name}")
         session.execute(


### PR DESCRIPTION
Splitting this CREATE TABLE AS SELECT query into two queries (CREATE TABLE LIKE .. followed by INSERT INTO) because the former doesn't play nicely with MySQL when replication is enabled

This re-introduces the change from #19999 that I mistakenly removed in my refactor in #19808.

There aren't automatic tests for this as a) it's hard to set up, b) this code isn't touched very often anyway, and c) we don't have replicated MySQL in our tests either. So it's very unlikely this will happen again.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).