### PR TITLE
removed unnecessary paren in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -337,7 +337,7 @@ RUN if [[ -f /docker-context-files/requirements.txt ]]; then \
 FROM ${PYTHON_BASE_IMAGE} as main
 
 # Nolog bash flag is currently ignored - but you can replace it with other flags (for example
-# xtrace - to show commands executed)
+# xtrace - to show commands executed
 SHELL ["/bin/bash", "-o", "pipefail", "-o", "errexit", "-o", "nounset", "-o", "nolog", "-c"]
 
 ARG AIRFLOW_UID


### PR DESCRIPTION
**What I Changed**
While reading through the production Dockerfile I noticed what appears to be an arbitrary parenthesis. This may have been intended  to be  ` xtrace - (to show commands executed)` however I don think that looks good either, so I believe removing it makes the most sense. 
