### PR TITLE
Logs in to Github Registry when preparing cache

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -474,6 +474,8 @@ function build_images::build_ci_image() {
         exit 1
     fi
     if [[ ${PREPARE_BUILDX_CACHE} == "true" ]]; then
+        # we need to login to docker registry so that we can push cache there
+        build_images::login_to_docker_registry
         docker_ci_cache_directive+=(
             "--cache-to=type=registry,ref=${AIRFLOW_CI_IMAGE}:cache"
             "--load"
@@ -628,6 +630,8 @@ function build_images::build_prod_images() {
         exit 1
     fi
     if [[ ${PREPARE_BUILDX_CACHE} == "true" ]]; then
+        # we need to login to docker registry so that we can push cache there
+        build_images::login_to_docker_registry
         # Cache for prod image contains also build stage for buildx when mode=max specified!
         docker_cache_prod_directive+=(
             "--cache-to=type=registry,ref=${AIRFLOW_PROD_IMAGE}:cache,mode=max"


### PR DESCRIPTION
Whe we are preparing cache on CI, we should login to the
GitHub registry (using GITHUB_TOKEN) in order for --cache-to
to be able to push images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
