### PR TITLE
Add optional features in providers.

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -98,6 +98,10 @@ class AirflowFailException(AirflowException):
     """Raise when the task should be failed without retrying."""
 
 
+class AirflowOptionalProviderFeatureException(AirflowException):
+    """Raise by providers when imports are missing for optional provider features."""
+
+
 class UnmappableXComTypePushed(AirflowException):
     """Raise when an unmappable type is pushed as a mapped downstream's dependency."""
 

--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -97,6 +97,14 @@ class BaseHook(LoggingMixin):
         """Returns connection for the hook."""
         raise NotImplementedError()
 
+    @classmethod
+    def get_connection_form_widgets(cls) -> Dict[str, Any]:
+        ...
+
+    @classmethod
+    def get_ui_field_behaviour(cls) -> Dict[str, Any]:
+        ...
+
 
 class DiscoverableHook(Protocol):
     """
@@ -159,7 +167,7 @@ class DiscoverableHook(Protocol):
         ...
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """
         Returns dictionary describing customizations to implement in javascript handling the
         connection form. Should be compliant with airflow/customized_form_field_behaviours.schema.json'

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -86,7 +86,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     hook_name = 'Spark'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'login', 'password'],

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -62,7 +62,7 @@ class AsanaHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ["port", "host", "login", "schema"],

--- a/airflow/providers/cloudant/hooks/cloudant.py
+++ b/airflow/providers/cloudant/hooks/cloudant.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Hook for Cloudant"""
-from typing import Dict
+from typing import Any, Dict
 
 from cloudant import cloudant
 
@@ -39,7 +39,7 @@ class CloudantHook(BaseHook):
     hook_name = 'Cloudant'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['port', 'extra'],

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -92,7 +92,7 @@ class KubernetesHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],

--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from docker import APIClient
 from docker.errors import APIError
@@ -39,7 +39,7 @@ class DockerHook(BaseHook, LoggingMixin):
     hook_name = 'Docker'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema'],

--- a/airflow/providers/google/cloud/hooks/compute_ssh.py
+++ b/airflow/providers/google/cloud/hooks/compute_ssh.py
@@ -90,7 +90,7 @@ class ComputeEngineSSHHook(SSHHook):
     hook_name = 'Google Cloud SSH'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         return {
             "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
             "relabeling": {},

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -197,7 +197,7 @@ class GoogleBaseHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],

--- a/airflow/providers/google/leveldb/hooks/leveldb.py
+++ b/airflow/providers/google/leveldb/hooks/leveldb.py
@@ -17,11 +17,24 @@
 """Hook for Level DB"""
 from typing import List, Optional
 
-import plyvel
-from plyvel import DB
+try:
+    import plyvel
+    from plyvel import DB
 
-from airflow.exceptions import AirflowException
-from airflow.hooks.base import BaseHook
+    from airflow.exceptions import AirflowException
+    from airflow.hooks.base import BaseHook
+
+except ImportError as e:
+    # Plyvel is an optional feature and if imports are missing, it should be silently ignored
+    # As of Airflow 2.3  and above the operator can throw OptionalProviderFeatureException
+    try:
+        from airflow.exceptions import AirflowOptionalProviderFeatureException
+    except ImportError:
+        # However, in order to keep backwards-compatibility with Airflow 2.1 and 2.2, if the
+        # 2.3 exception cannot be imported, the original ImportError should be raised.
+        # This try/except can be removed when the provider depends on Airflow >= 2.3.0
+        raise e from None
+    raise AirflowOptionalProviderFeatureException(e)
 
 DB_NOT_INITIALIZED_BEFORE = "The `get_conn` method should be called before!"
 

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -54,7 +54,7 @@ class JdbcHook(DbApiHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['port', 'schema', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -97,7 +97,7 @@ class AzureDataExplorerHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -57,7 +57,7 @@ class AzureBaseHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         import json
 

--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -56,7 +56,7 @@ class AzureBatchHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/container_registry.py
@@ -17,7 +17,7 @@
 # under the License.
 """Hook for Azure Container Registry"""
 
-from typing import Dict
+from typing import Any, Dict
 
 from azure.mgmt.containerinstance.models import ImageRegistryCredential
 
@@ -39,7 +39,7 @@ class AzureContainerRegistryHook(BaseHook):
     hook_name = 'Azure Container Registry'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -54,7 +54,7 @@ class AzureContainerVolumeHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', "extra"],

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -67,7 +67,7 @@ class AzureCosmosDBHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -144,7 +144,7 @@ class AzureDataFactoryHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -65,7 +65,7 @@ class AzureDataLakeHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -64,7 +64,7 @@ class AzureFileShareHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -81,7 +81,7 @@ class WasbHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port'],

--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -49,7 +49,7 @@ class PagerdutyHook(BaseHook):
     hook_name = "Pagerduty"
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['port', 'login', 'schema', 'host'],

--- a/airflow/providers/pagerduty/hooks/pagerduty_events.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty_events.py
@@ -41,7 +41,7 @@ class PagerdutyEventsHook(BaseHook):
     hook_name = "Pagerduty Events"
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['port', 'login', 'schema', 'host', 'extra'],

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -22,7 +22,7 @@ import logging
 import os
 import pathlib
 import time
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from qds_sdk.commands import (
     Command,
@@ -119,7 +119,7 @@ class QuboleHook(BaseHook):
     hook_name = 'Qubole'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['login', 'schema', 'port', 'extra'],

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -119,7 +119,7 @@ class SalesforceHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ["schema", "port", "extra", "host"],

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -19,7 +19,7 @@
 import datetime
 import stat
 import warnings
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import pysftp
 import tenacity
@@ -61,7 +61,7 @@ class SFTPHook(SSHHook):
     hook_name = 'SFTP'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         return {
             "hidden_fields": ['schema'],
             "relabeling": {

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -97,7 +97,7 @@ class SnowflakeHook(DbApiHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         import json
 

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -88,7 +88,7 @@ class SSHHook(BaseHook):
     hook_name = 'SSH'
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema'],

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -95,7 +95,7 @@ class YandexCloudBaseHook(BaseHook):
             return None
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],

--- a/docs/apache-airflow-providers/howto/create-update-providers.rst
+++ b/docs/apache-airflow-providers/howto/create-update-providers.rst
@@ -304,6 +304,53 @@ main Airflow documentation that involves some steps with the providers is also w
     ./breeze build-docs -- --package-filter apache-airflow-providers-<NEW_PROVIDER>
     ./breeze build-docs -- --package-filter apache-airflow
 
+Optional provider features
+--------------------------
+
+  .. note::
+
+    This feature is available in Airflow 2.3+.
+
+Some providers might provide optional features, which are only available when some packages or libraries
+are installed. Such features will typically result in ``ImportErrors`` however those import errors
+should be silently ignored rather than pollute the logs of Airflow with false warnings. False warnings
+are a very bad pattern, as they tend to turn into blind spots, so avoiding false warnings is encouraged.
+However until Airflow 2.3, Airflow had no mechanism to selectively ignore "known" ImportErrors. So
+Airflow 2.1 and 2.2 silently ignored all ImportErrors coming from providers with actually lead to
+ignoring even important import errors - without giving the clue to Airflow users that there is something
+missing in provider dependencies.
+
+In Airflow 2.3, new exception :class:`~airflow.exceptions.OptionalProviderFeatureException` has been
+introduced and Providers can use the exception to signal that the ImportError (or any other error) should
+be ignored by Airflow ProvidersManager. However this Exception is only available in Airflow 2.3 so if
+providers would like to remain compatible with Airflow 2.1 and 2.2, they should continue throwing
+the ImportError exception.
+
+Example code (from Plyvel Hook, part of the Google Provider) explains how such conditional error handling
+should be implemented to keep compatibility with Airflow 2.1 and 2.2
+
+  .. code-block:: python
+
+    try:
+        import plyvel
+        from plyvel import DB
+
+        from airflow.exceptions import AirflowException
+        from airflow.hooks.base import BaseHook
+
+    except ImportError as e:
+        # Plyvel is an optional feature and if imports are missing, it should be silently ignored
+        # As of Airflow 2.3  and above the operator can throw OptionalProviderFeatureException
+        try:
+            from airflow.exceptions import AirflowOptionalProviderFeatureException
+        except ImportError:
+            # However, in order to keep backwards-compatibility with Airflow 2.1 and 2.2, if the
+            # 2.3 exception cannot be imported, the original ImportError should be raised.
+            # This try/except can be removed when the provider depends on Airflow >= 2.3.0
+            raise e
+        raise AirflowOptionalProviderFeatureException(e)
+
+
 How-to Update a community provider
 ----------------------------------
 


### PR DESCRIPTION
Some features in providers can be optional, depending on the
presence of some libraries. Since Providers Manager tries
to import the right classes that are exposed via providers it
should not - in this case - log warning message for those
optional features. Previously, all ImportErrors were turned into
debug log but now we only turn them in debug log when creator
of the provider deliberately raised
an AirflowOptionalProviderFeatureException.

Instructions on how to raise such exception in the way to keep
backwards compatibility were updated in proider's documentation.

Fixes: #20709

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
