### PR TITLE
Fix wrong use of $ref and nullable

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2434,6 +2434,11 @@ components:
         notification_sent:
           type: boolean
 
+    NullableSLAMiss:
+      oneOf:
+        - type: null
+        - $ref: '#/components/schemas/SLAMiss'
+
     TaskInstance:
       type: object
       properties:
@@ -2462,8 +2467,7 @@ components:
           type: number
           nullable: true
         state:
-          $ref: '#/components/schemas/TaskState'
-          nullable: true
+          $ref: '#/components/schemas/NullableTaskState'
         try_number:
           type: integer
         max_tries:
@@ -2494,8 +2498,7 @@ components:
         executor_config:
           type: string
         sla_miss:
-          $ref: '#/components/schemas/SLAMiss'
-          nullable: true
+          $ref: '#/components/schemas/NullableSLAMiss'
 
     TaskInstanceCollection:
       type: object
@@ -2657,8 +2660,7 @@ components:
 
                 *Changed in version 2.0.1*&#58; Field becomes nullable.
             dag_run_timeout:
-              nullable: true
-              $ref: '#/components/schemas/TimeDelta'
+              $ref: '#/components/schemas/NullableTimeDelta'
             doc_md:
               type: string
               readOnly: true
@@ -2748,11 +2750,9 @@ components:
           type: number
           readOnly: true
         execution_timeout:
-          $ref: '#/components/schemas/TimeDelta'
-          nullable: true
+          $ref: '#/components/schemas/NullableTimeDelta'
         retry_delay:
-          $ref: '#/components/schemas/TimeDelta'
-          nullable: true
+          $ref: '#/components/schemas/NullableTimeDelta'
         retry_exponential_backoff:
           type: boolean
           readOnly: true
@@ -3302,6 +3302,13 @@ components:
         seconds: {type: integer}
         microseconds: {type: integer}
 
+    NullableTimeDelta:
+      description: |
+        nullable timeDelta. marks a timeDelta object to be nullable.
+      oneOf:
+        - type: null
+        - $ref: '#/components/schemas/TimeDelta'
+
     RelativeDelta:
       description: Relative delta
       # TODO: Why we need these fields?
@@ -3441,6 +3448,11 @@ components:
         - deferred
         - sensing
         - removed
+
+    NullableTaskState:
+      oneOf:
+        - type: null
+        - $ref: '#/components/schemas/TaskState'
 
     DagState:
       description: |


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE
https://github.com/OpenAPITools/openapi-generator/issues/11352

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
### Composed schemas `$ref` and `nullable` are not supported. And inline composed schemas has bug using tooling.

> Per the openapi spec, properties adjacent to refs are ignored:
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
This object cannot be extended with additional properties and any properties added SHALL be ignored. except for summary and description.

```
dag_run_timeout:
              nullable: true
              $ref: '#/components/schemas/TimeDelta'
```

```
dag_run_timeout:
 oneOf:
  - type: null
  - $ref: '#/components/schemas/TimeDelta'
```

All the above definitions are not correct.

related:
https://github.com/OpenAPITools/openapi-generator/issues/11352
https://github.com/apache/airflow-client-python/issues/40