### PR TITLE
Return slack api call response in slack_hook

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -19,6 +19,7 @@
 from typing import Any, Optional
 
 from slack_sdk import WebClient
+from slack_sdk.web.slack_response import SlackResponse
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
@@ -78,7 +79,7 @@ class SlackHook(BaseHook):
 
         raise AirflowException('Cannot get token: No valid Slack token nor slack_conn_id supplied.')
 
-    def call(self, api_method: str, **kwargs) -> None:
+    def call(self, api_method: str, **kwargs) -> SlackResponse:
         """
         Calls Slack WebClient `WebClient.api_call` with given arguments.
 
@@ -89,5 +90,8 @@ class SlackHook(BaseHook):
             form-encoding will take place. Optional.
         :param params: The URL parameters to append to the URL. Optional.
         :param json: JSON for the body to attach to the request. Optional.
+        :return: The server's response to an HTTP request. Data from the response can be
+            accessed like a dict.  If the response included 'next_cursor' it can be
+            iterated on to execute subsequent requests.
         """
-        self.client.api_call(api_method, **kwargs)
+        return self.client.api_call(api_method, **kwargs)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -333,6 +333,7 @@ Seedlist
 Sendgrid
 SerializedDAG
 SlackHook
+SlackResponse
 SnowflakeHook
 Spark
 SparkPi

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -122,11 +122,14 @@ class TestSlackHook(unittest.TestCase):
         with pytest.raises(SlackApiError):
             slack_hook.call(test_method, data=test_api_params)
 
-    @mock.patch('airflow.providers.slack.hooks.slack.WebClient.api_call', autospec=True)
     @mock.patch('airflow.providers.slack.hooks.slack.WebClient')
-    def test_api_call(self, mock_slack_client, mock_slack_api_call):
+    def test_api_call(self, slack_client_class_mock):
+        slack_client_mock = mock.Mock()
+        slack_client_class_mock.return_value = slack_client_mock
+        slack_client_mock.api_call.return_value = {'ok': True}
+
         slack_hook = SlackHook(token='test_token')
         test_api_json = {'channel': 'test_channel'}
 
         slack_hook.call("chat.postMessage", json=test_api_json)
-        mock_slack_api_call.assert_called_once_with(mock_slack_client, "chat.postMessage", json=test_api_json)
+        slack_client_mock.api_call.assert_called_with("chat.postMessage", json=test_api_json)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There are some useful information returned from the slack api call, like `thread_ts` https://api.slack.com/methods/chat.postMessage#arg_thread_ts
so returning the response obj to the caller.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
