### PR TITLE
Fix liveness probe speedup for scheduler and triggerer

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -162,26 +162,26 @@ spec:
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
             exec:
               command:
-              - CONNECTION_CHECK_MAX_COUNT=0
-              - /entrypoint
-              - python
-              - -Wignore
-              - -c
-              - |
-                import os
-                os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
-                os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
+                - sh
+                - -c
+                - exec
+                - |
+                  CONNECTION_CHECK_MAX_COUNT=0 /entrypoint python -Wignore -c "
+                  import os
+                  os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
+                  os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
 
-                from airflow.jobs.scheduler_job import SchedulerJob
-                from airflow.utils.db import create_session
-                from airflow.utils.net import get_hostname
-                import sys
+                  from airflow.jobs.scheduler_job import SchedulerJob
+                  from airflow.utils.db import create_session
+                  from airflow.utils.net import get_hostname
+                  import sys
 
-                with create_session() as session:
-                    job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(
-                        SchedulerJob.latest_heartbeat.desc()).limit(1).first()
+                  with create_session() as session:
+                      job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(
+                          SchedulerJob.latest_heartbeat.desc()).limit(1).first()
 
-                sys.exit(0 if job.is_alive() else 1)
+                  sys.exit(0 if job.is_alive() else 1)
+                  "
           {{- if and $local (not $elasticsearch) }}
           # Serve logs if we're in local mode and we don't have elasticsearch enabled.
           ports:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -174,14 +174,14 @@ spec:
                   os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
                   os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
 
-                  from airflow.jobs.scheduler_job import SchedulerJob
+                  from airflow.jobs.triggerer_job import TriggererJob
                   from airflow.utils.db import create_session
                   from airflow.utils.net import get_hostname
                   import sys
 
                   with create_session() as session:
-                      job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(
-                          SchedulerJob.latest_heartbeat.desc()).limit(1).first()
+                      job = session.query(TriggererJob).filter_by(hostname=get_hostname()).order_by(
+                          TriggererJob.latest_heartbeat.desc()).limit(1).first()
 
                   sys.exit(0 if job.is_alive() else 1)
                   "

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -165,26 +165,26 @@ spec:
             periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
             exec:
               command:
-              - CONNECTION_CHECK_MAX_COUNT=0
-              - /entrypoint
-              - python
-              - -Wignore
-              - -c
-              - |
-                import os
-                os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
-                os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
+                - sh
+                - -c
+                - exec
+                - |
+                  CONNECTION_CHECK_MAX_COUNT=0 /entrypoint python -Wignore -c "
+                  import os
+                  os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
+                  os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
 
-                from airflow.jobs.triggerer_job import TriggererJob
-                from airflow.utils.db import create_session
-                from airflow.utils.net import get_hostname
-                import sys
+                  from airflow.jobs.scheduler_job import SchedulerJob
+                  from airflow.utils.db import create_session
+                  from airflow.utils.net import get_hostname
+                  import sys
 
-                with create_session() as session:
-                    job = session.query(TriggererJob).filter_by(hostname=get_hostname()).order_by(
-                        TriggererJob.latest_heartbeat.desc()).limit(1).first()
+                  with create_session() as session:
+                      job = session.query(SchedulerJob).filter_by(hostname=get_hostname()).order_by(
+                          SchedulerJob.latest_heartbeat.desc()).limit(1).first()
 
-                sys.exit(0 if job.is_alive() else 1)
+                  sys.exit(0 if job.is_alive() else 1)
+                  "
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
PR https://github.com/apache/airflow/pull/20833 tried to speed up the liveness probe by setting variable CONNECTION_CHECK_MAX_COUNT=0 which disables a connectivity check in `/entrypoint` (which turns out to be slow).

Unfortunately the approach taken doesn't work; we have to use `sh -c exec` instead.
