### PR TITLE
Grant pod log reader to triggerer serviceaccount

### DIFF
--- a/chart/templates/rbac/pod-log-reader-role.yaml
+++ b/chart/templates/rbac/pod-log-reader-role.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Pod Reader Role
 #################################
-{{- if and .Values.rbac.create .Values.webserver.allowPodLogReading }}
+{{- if and .Values.rbac.create (or .Values.webserver.allowPodLogReading .Values.triggerer.enabled) }}
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRole
 {{- else }}

--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Pod Reader Role Binding
 #################################
-{{- if and .Values.rbac.create .Values.webserver.allowPodLogReading }}
+{{- if and .Values.rbac.create (or .Values.webserver.allowPodLogReading .Values.triggerer.enabled) }}
 {{- if .Values.multiNamespaceMode }}
 kind: ClusterRoleBinding
 {{- else }}
@@ -47,7 +47,14 @@ roleRef:
 {{- end }}
   name: {{ .Release.Name }}-pod-log-reader-role
 subjects:
+{{- if .Values.webserver.allowPodLogReading }}
   - kind: ServiceAccount
     name: {{ include "webserver.serviceAccountName" . }}
     namespace: "{{ .Release.Namespace }}"
+{{- end }}
+{{- if .Values.triggerer.enabled }}
+  - kind: ServiceAccount
+    name: {{ include "triggerer.serviceAccountName" . }}
+    namespace: "{{ .Release.Namespace }}"
+{{- end }}
 {{- end }}

--- a/chart/tests/test_rbac_pod_log_reader.py
+++ b/chart/tests/test_rbac_pod_log_reader.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import jmespath
+import pytest
+
+from tests.helm_template_generator import render_chart
+
+
+class TestPodReader:
+    @pytest.mark.parametrize(
+        'triggerer, webserver, expected',
+        [
+            (True, True, ['RELEASE-NAME-airflow-webserver', 'RELEASE-NAME-airflow-triggerer']),
+            (True, False, ['RELEASE-NAME-airflow-triggerer']),
+            (False, True, ['RELEASE-NAME-airflow-webserver']),
+            (False, False, []),
+        ],
+    )
+    def test_pod_log_reader_rolebinding(self, triggerer, webserver, expected):
+        docs = render_chart(
+            values={
+                "triggerer": {"enabled": triggerer},
+                "webserver": {"allowPodLogReading": webserver},
+            },
+            show_only=["templates/rbac/pod-log-reader-rolebinding.yaml"],
+        )
+        actual = jmespath.search("subjects[*].name", docs[0]) if docs else []
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        'triggerer, webserver, expected',
+        [
+            (True, True, 'RELEASE-NAME-pod-log-reader-role'),
+            (True, False, 'RELEASE-NAME-pod-log-reader-role'),
+            (False, True, 'RELEASE-NAME-pod-log-reader-role'),
+            (False, False, None),
+        ],
+    )
+    def test_pod_log_reader_role(self, triggerer, webserver, expected):
+        docs = render_chart(
+            values={
+                "triggerer": {"enabled": triggerer},
+                "webserver": {"allowPodLogReading": webserver},
+            },
+            show_only=["templates/rbac/pod-log-reader-role.yaml"],
+        )
+        actual = jmespath.search("metadata.name", docs[0]) if docs else None
+        assert actual == expected


### PR DESCRIPTION
In order to monitor a pod from a trigger (e.g. for use with a deferring k8s pod operator), we need some read permissions on the triggerer service account.
