### PR TITLE
Add constraint to ensure task map length >= 0

### DIFF
--- a/airflow/migrations/versions/e655c0453f75_add_taskmap_and_map_id_on_taskinstance.py
+++ b/airflow/migrations/versions/e655c0453f75_add_taskmap_and_map_id_on_taskinstance.py
@@ -24,7 +24,7 @@ Create Date: 2021-12-13 22:59:41.052584
 """
 
 from alembic import op
-from sqlalchemy import Column, ForeignKeyConstraint, Integer, text
+from sqlalchemy import CheckConstraint, Column, ForeignKeyConstraint, Integer, text
 
 from airflow.models.base import StringID
 from airflow.utils.sqlalchemy import ExtendedJSON
@@ -75,6 +75,7 @@ def upgrade():
         Column("map_index", Integer, primary_key=True),
         Column("length", Integer, nullable=False),
         Column("keys", ExtendedJSON, nullable=True),
+        CheckConstraint("length >= 0", name="task_map_length_not_negative"),
         ForeignKeyConstraint(
             ["dag_id", "task_id", "run_id", "map_index"],
             [

--- a/airflow/models/taskmap.py
+++ b/airflow/models/taskmap.py
@@ -22,7 +22,7 @@ import collections.abc
 import enum
 from typing import TYPE_CHECKING, Any, Collection, List, Optional
 
-from sqlalchemy import Column, ForeignKeyConstraint, Integer, String
+from sqlalchemy import CheckConstraint, Column, ForeignKeyConstraint, Integer, String
 
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.utils.sqlalchemy import ExtendedJSON
@@ -61,6 +61,7 @@ class TaskMap(Base):
     keys = Column(ExtendedJSON, nullable=True)
 
     __table_args__ = (
+        CheckConstraint(length >= 0, name="task_map_length_not_negative"),
         ForeignKeyConstraint(
             [dag_id, task_id, run_id, map_index],
             [


### PR DESCRIPTION
This value is obtained from `len()`. Adding this at the db level to simplify later logic.