### PR TITLE
Add back legacy .piprc customization for pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,6 +212,9 @@ USER airflow
 RUN if [[ -f /docker-context-files/pip.conf ]]; then \
         mkdir -p ${AIRFLOW_USER_HOME_DIR}/.config/pip; \
         cp /docker-context-files/pip.conf "${AIRFLOW_USER_HOME_DIR}/.config/pip/pip.conf"; \
+    fi; \
+    if [[ -f /docker-context-files/.piprc ]]; then \
+        cp /docker-context-files/.piprc "${AIRFLOW_USER_HOME_DIR}/.piprc"; \
     fi
 
 ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION} \

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -537,12 +537,20 @@ described below but here is an example of rather complex command to customize th
 based on example in `this comment <https://github.com/apache/airflow/issues/8605#issuecomment-690065621>`_:
 
 In case you need to use your custom PyPI package indexes, you can also customize PYPI sources used during
-image build by adding a ``docker-context-files``/``pip.conf`` file when building the image.
+image build by adding a ``docker-context-files/pip.conf`` file when building the image.
 This ``pip.conf`` will not be committed to the repository (it is added to ``.gitignore``) and it will not be
 present in the final production image. It is added and used only in the build segment of the image.
 Therefore this ``pip.conf`` file can safely contain list of package indexes you want to use,
 usernames and passwords used for authentication. More details about ``pip.conf`` file can be found in the
 `pip configuration <https://pip.pypa.io/en/stable/topics/configuration/>`_.
+
+If you used the ``.piprc`` before (some older versions of ``pip`` used it for customization), you can put it
+in the ``docker-context-files/.piprc`` file and it will be automatically copied to ``HOME`` directory
+of the ``airflow`` user.
+
+Note, that those customizations are only available in the ``build`` segment of the Airflow image and they
+are not present in the ``final`` image. If you wish to extend the final image and add custom ``.piprc`` and
+``pip.conf``, you should add them in your own Dockerfile used to extend the Airflow image.
 
 Such customizations are independent of the way how airflow is installed.
 


### PR DESCRIPTION
This change brings back backwards compatibility to using .piprc
to customize Airflow Image. Some older vrsions of pip used .piprc
(even though documentation about is difficult to find now) and we
used to support this option. With #20445, we changed to use
(fully documented) ``pip.conf`` option, however if someone used
.piprc before to customize their image, this change would break it.

The PR brings back also the .piprc option to the image (even if
it is not really clear whether current and future versions of pip
will support it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
