### PR TITLE
Update documents(`CONTRIBUTORS_QUICK_START.rst`, `TESTING.rst`) related to dag_run_state.

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -549,13 +549,10 @@ Setting up Debug
 - Add a ``__main__`` block at the end of your DAG file to make it runnable. It will run a ``back_fill`` job:
 
   .. code-block:: python
-
-    from airflow.utils.state import State
-
     ...
 
     if __name__ == "__main__":
-        dag.clear(dag_run_state=State.NONE)
+        dag.clear()
         dag.run()
 
 - Add ``AIRFLOW__CORE__EXECUTOR=DebugExecutor`` to Environment variable of Run Configuration.
@@ -1362,13 +1359,10 @@ Setting up Debug
 - Add a ``__main__`` block at the end of your DAG file to make it runnable. It will run a ``back_fill`` job:
 
   .. code-block:: python
-
-    from airflow.utils.state import State
-
     ...
 
     if __name__ == "__main__":
-        dag.clear(dag_run_state=State.NONE)
+        dag.clear()
         dag.run()
 
 - Add ``"AIRFLOW__CORE__EXECUTOR": "DebugExecutor"`` to the ``"env"`` field of Debug configuration.

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -1308,9 +1308,7 @@ It will run a backfill job:
 .. code-block:: python
 
   if __name__ == "__main__":
-      from airflow.utils.state import State
-
-      dag.clear(dag_run_state=State.NONE)
+      dag.clear()
       dag.run()
 
 


### PR DESCRIPTION
As the argument type of `dag_run_state` of `dag.clear()` is `DagRunState`, it is a PR to reflect this in the document.
see https://github.com/apache/airflow/issues/21058