### PR TITLE
Align Black and blacken-docs config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,6 +154,13 @@ repos:
     hooks:
       - id: blacken-docs
         alias: black
+        args:
+          - --line-length=110
+          - --target-version=py36
+          - --target-version=py37
+          - --target-version=py38
+          - --target-version=py39
+          - --skip-string-normalization
         additional_dependencies: [black==21.12b0]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -2933,9 +2933,7 @@ def wait_for_transfer_job(self, job):
 New signature:
 
 ```python
-def wait_for_transfer_job(
-    self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS,)
-):
+def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS,)):
     ...
 ```
 

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -71,16 +71,12 @@ class BatchWaitersHook(BatchClientHook):
         # and the details of the config on that waiter can be further modified without any
         # accidental impact on the generation of new waiters from the defined waiter_model, e.g.
         waiters.get_waiter("JobExists").config.delay  # -> 5
-        waiter = waiters.get_waiter(
-            "JobExists"
-        )  # -> botocore.waiter.Batch.Waiter.JobExists object
+        waiter = waiters.get_waiter("JobExists")  # -> botocore.waiter.Batch.Waiter.JobExists object
         waiter.config.delay = 10
         waiters.get_waiter("JobExists").config.delay  # -> 5 as defined by waiter_model
 
         # To use a specific waiter, update the config and call the `wait()` method for jobId, e.g.
-        waiter = waiters.get_waiter(
-            "JobExists"
-        )  # -> botocore.waiter.Batch.Waiter.JobExists object
+        waiter = waiters.get_waiter("JobExists")  # -> botocore.waiter.Batch.Waiter.JobExists object
         waiter.config.delay = random.uniform(1, 10)  # seconds
         waiter.config.max_attempts = 10
         waiter.wait(jobs=[jobId])

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -539,7 +539,7 @@ now the snake_case convention is used.
     set_acl_permission = GCSBucketCreateAclEntryOperator(
         task_id="gcs-set-acl-permission",
         bucket=BUCKET_NAME,
-        entity="user-{{ task_instance.xcom_pull('get-instance')['persistenceIamIdentity']" ".split(':', 2)[1] }}",
+        entity="user-{{ task_instance.xcom_pull('get-instance')['persistenceIamIdentity'].split(':', 2)[1] }}",
         role="OWNER",
     )
 

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -539,8 +539,7 @@ now the snake_case convention is used.
     set_acl_permission = GCSBucketCreateAclEntryOperator(
         task_id="gcs-set-acl-permission",
         bucket=BUCKET_NAME,
-        entity="user-{{ task_instance.xcom_pull('get-instance')['persistenceIamIdentity']"
-        ".split(':', 2)[1] }}",
+        entity="user-{{ task_instance.xcom_pull('get-instance')['persistenceIamIdentity']" ".split(':', 2)[1] }}",
         role="OWNER",
     )
 

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -72,12 +72,7 @@ class OracleHook(DbApiHook):
 
         .. code-block:: python
 
-           {
-               "dsn": (
-                   "(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)"
-                   "(HOST=host)(PORT=1521))(CONNECT_DATA=(SID=sid)))"
-               )
-           }
+           {"dsn": ("(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=host)(PORT=1521))(CONNECT_DATA=(SID=sid)))")}
 
         see more param detail in
         `cx_Oracle.connect <https://cx-oracle.readthedocs.io/en/latest/module.html#cx_Oracle.connect>`_

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -249,17 +249,13 @@ Example
         def federated(self):
             return "federation" in self.extra_config
 
-        def _create_basic_session(
-            self, session_kwargs: Dict[str, Any]
-        ) -> boto3.session.Session:
+        def _create_basic_session(self, session_kwargs: Dict[str, Any]) -> boto3.session.Session:
             if self.federated:
                 return self._create_federated_session(session_kwargs)
             else:
                 return super()._create_basic_session(session_kwargs)
 
-        def _create_federated_session(
-            self, session_kwargs: Dict[str, Any]
-        ) -> boto3.session.Session:
+        def _create_federated_session(self, session_kwargs: Dict[str, Any]) -> boto3.session.Session:
             username = self.extra_config["federation"]["username"]
             region_name = self._get_region_name()
             self.log.debug(

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -283,15 +283,9 @@ It's easier to grab the concept with an example. Let's say that we have the foll
         start_date=datetime(2021, 1, 1),
         catchup=False,
     ) as dag:
-        failing_task = BashOperator(
-            task_id="failing_task", bash_command="exit 1", retries=0
-        )
-        passing_task = BashOperator(
-            task_id="passing_task", bash_command="echo passing_task"
-        )
-        teardown = BashOperator(
-            task_id="teardown", bash_command="echo teardown", trigger_rule="all_done"
-        )
+        failing_task = BashOperator(task_id="failing_task", bash_command="exit 1", retries=0)
+        passing_task = BashOperator(task_id="passing_task", bash_command="echo passing_task")
+        teardown = BashOperator(task_id="teardown", bash_command="echo teardown", trigger_rule="all_done")
 
         failing_task >> passing_task >> teardown
         list(dag.tasks) >> watcher()

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -409,9 +409,7 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
         )
 
         run_this_first = DummyOperator(task_id="run_this_first", dag=dag)
-        branching = BranchPythonOperator(
-            task_id="branching", dag=dag, python_callable=lambda: "branch_a"
-        )
+        branching = BranchPythonOperator(task_id="branching", dag=dag, python_callable=lambda: "branch_a")
 
         branch_a = DummyOperator(task_id="branch_a", dag=dag)
         follow_branch_a = DummyOperator(task_id="follow_branch_a", dag=dag)

--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -172,12 +172,8 @@ Here is an example of a task with both features:
         tags=["example3"],
     ) as dag:
         executor_config_template = {
-            "pod_template_file": os.path.join(
-                AIRFLOW_HOME, "pod_templates/basic_template.yaml"
-            ),
-            "pod_override": k8s.V1Pod(
-                metadata=k8s.V1ObjectMeta(labels={"release": "stable"})
-            ),
+            "pod_template_file": os.path.join(AIRFLOW_HOME, "pod_templates/basic_template.yaml"),
+            "pod_override": k8s.V1Pod(metadata=k8s.V1ObjectMeta(labels={"release": "stable"})),
         }
 
         @task(executor_config=executor_config_template)

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -325,9 +325,7 @@ You can verify a URI is parsed correctly like so:
 
     >>> from airflow.models.connection import Connection
 
-    >>> c = Connection(
-    ...     uri="my-conn-type://my-login:my-password@my-host:5432/my-schema?param1=val1&param2=val2"
-    ... )
+    >>> c = Connection(uri="my-conn-type://my-login:my-password@my-host:5432/my-schema?param1=val1&param2=val2")
     >>> print(c.login)
     my-login
     >>> print(c.password)
@@ -349,18 +347,14 @@ For example if your password has a ``/``, this fails:
 
 .. code-block:: pycon
 
-    >>> c = Connection(
-    ...     uri="my-conn-type://my-login:my-pa/ssword@my-host:5432/my-schema?param1=val1&param2=val2"
-    ... )
+    >>> c = Connection(uri="my-conn-type://my-login:my-pa/ssword@my-host:5432/my-schema?param1=val1&param2=val2")
     ValueError: invalid literal for int() with base 10: 'my-pa'
 
 To fix this, you can encode with :func:`~urllib.parse.quote_plus`:
 
 .. code-block:: pycon
 
-    >>> c = Connection(
-    ...     uri="my-conn-type://my-login:my-pa%2Fssword@my-host:5432/my-schema?param1=val1&param2=val2"
-    ... )
+    >>> c = Connection(uri="my-conn-type://my-login:my-pa%2Fssword@my-host:5432/my-schema?param1=val1&param2=val2")
     >>> print(c.password)
     my-pa/ssword
 

--- a/docs/apache-airflow/howto/custom-operator.rst
+++ b/docs/apache-airflow/howto/custom-operator.rst
@@ -169,9 +169,7 @@ You can use the template as follows:
 .. code-block:: python
 
         with dag:
-            hello_task = HelloOperator(
-                task_id="task_id_1", dag=dag, name="{{ task_instance.task_id }}"
-            )
+            hello_task = HelloOperator(task_id="task_id_1", dag=dag, name="{{ task_instance.task_id }}")
 
 In this example, Jinja looks for the ``name`` parameter and substitutes ``{{ task_instance.task_id }}`` with
 ``task_id_1``.

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -166,8 +166,6 @@ information, see `String Formatting in the MarkupSafe docs <https://markupsafe.p
     .. code-block:: python
 
       DASHBOARD_UIALERTS = [
-          UIAlert(
-              'Visit <a href="https://airflow.apache.org">airflow.apache.org</a>', html=True
-          ),
+          UIAlert('Visit <a href="https://airflow.apache.org">airflow.apache.org</a>', html=True),
           UIAlert(Markup("Welcome <em>%s</em>") % ("John & Jane Doe",)),
       ]

--- a/docs/apache-airflow/howto/define_extra_link.rst
+++ b/docs/apache-airflow/howto/define_extra_link.rst
@@ -93,12 +93,10 @@ tasks using :class:`~airflow.providers.amazon.aws.transfers.gcs_to_s3.GCSToS3Ope
       operators = [GCSToS3Operator]
 
       def get_link(self, operator, *, ti_key):
-          return (
-              "https://s3.amazonaws.com/airflow-logs/{dag_id}/{task_id}/{run_id}".format(
-                  dag_id=operator.dag_id,
-                  task_id=operator.task_id,
-                  run_id=ti_key.run_id,
-              )
+          return "https://s3.amazonaws.com/airflow-logs/{dag_id}/{task_id}/{run_id}".format(
+              dag_id=operator.dag_id,
+              task_id=operator.task_id,
+              run_id=ti_key.run_id,
           )
 
 

--- a/docs/apache-airflow/lineage.rst
+++ b/docs/apache-airflow/lineage.rst
@@ -50,9 +50,7 @@ works.
     )
 
     f_final = File(url="/tmp/final")
-    run_this_last = DummyOperator(
-        task_id="run_this_last", dag=dag, inlets=AUTO, outlets=f_final
-    )
+    run_this_last = DummyOperator(task_id="run_this_last", dag=dag, inlets=AUTO, outlets=f_final)
 
     f_in = File(url="/tmp/whole_directory/")
     outlets = []
@@ -60,9 +58,7 @@ works.
         f_out = File(url="/tmp/{}/{{{{ data_interval_start }}}}".format(file))
         outlets.append(f_out)
 
-    run_this = BashOperator(
-        task_id="run_me_first", bash_command="echo 1", dag=dag, inlets=f_in, outlets=outlets
-    )
+    run_this = BashOperator(task_id="run_me_first", bash_command="echo 1", dag=dag, inlets=f_in, outlets=outlets)
     run_this.set_downstream(run_this_last)
 
 Inlets can be a (list of) upstream task ids or statically defined as an attr annotated object

--- a/docs/apache-airflow/plugins.rst
+++ b/docs/apache-airflow/plugins.rst
@@ -312,9 +312,7 @@ will automatically load the registered plugins from the entrypoint list.
     setup(
         name="my-package",
         # ...
-        entry_points={
-            "airflow.plugins": ["my_plugin = my_package.my_plugin:MyAirflowPlugin"]
-        },
+        entry_points={"airflow.plugins": ["my_plugin = my_package.my_plugin:MyAirflowPlugin"]},
     )
 
 Automatic reloading webserver

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -157,9 +157,7 @@ Here is an example of what you might have in your webserver_config.py:
 
     AUTH_TYPE = AUTH_OAUTH
     AUTH_ROLES_SYNC_AT_LOGIN = True  # Checks roles on every login
-    AUTH_USER_REGISTRATION = (
-        True  # allow users who are not already in the FAB DB to register
-    )
+    AUTH_USER_REGISTRATION = True  # allow users who are not already in the FAB DB to register
     # Make sure to replace this with the path to your security manager class
     FAB_SECURITY_MANAGER_CLASS = "your_module.your_security_manager_class"
     AUTH_ROLES_MAPPING = {
@@ -226,9 +224,7 @@ webserver_config.py itself if you wish.
         # In this example, the oauth provider == 'github'.
         # If you ever want to support other providers, see how it is done here:
         # https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/manager.py#L550
-        def get_oauth_user_info(
-            self, provider: str, resp: Any
-        ) -> Dict[str, Union[str, List[str]]]:
+        def get_oauth_user_info(self, provider: str, resp: Any) -> Dict[str, Union[str, List[str]]]:
 
             # Creates the user info payload from Github.
             # The user previously allowed your app to act on their behalf,
@@ -241,9 +237,7 @@ webserver_config.py itself if you wish.
             team_data = remote_app.get("user/teams")
             teams = team_parser(team_data.json())
             roles = map_roles(teams)
-            log.debug(
-                f"User info from Github: {user_data}\n" f"Team info from Github: {teams}"
-            )
+            log.debug(f"User info from Github: {user_data}\n" f"Team info from Github: {teams}")
             return {"username": "github_" + user_data.get("login"), "role_keys": roles}
 
 

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -180,9 +180,7 @@ Whereas previously a user would import each individual class to build the pod as
 
     volume_config = {"persistentVolumeClaim": {"claimName": "test-volume"}}
     volume = Volume(name="test-volume", configs=volume_config)
-    volume_mount = VolumeMount(
-        "test-volume", mount_path="/root/mount_file", sub_path=None, read_only=True
-    )
+    volume_mount = VolumeMount("test-volume", mount_path="/root/mount_file", sub_path=None, read_only=True)
 
     port = Port("http", 80)
     secret_file = Secret("volume", "/etc/sql_conn", "airflow-secrets", "sql_alchemy_conn")
@@ -222,9 +220,7 @@ Now the user can use the ``kubernetes.client.models`` class as a single point of
 
     volume = k8s.V1Volume(
         name="test-volume",
-        persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
-            claim_name="test-volume"
-        ),
+        persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="test-volume"),
     )
 
     port = k8s.V1ContainerPort(name="http", container_port=80)
@@ -600,9 +596,7 @@ Before:
 
     from airflow.kubernetes.volume_mount import VolumeMount
 
-    volume_mount = VolumeMount(
-        "test-volume", mount_path="/root/mount_file", sub_path=None, read_only=True
-    )
+    volume_mount = VolumeMount("test-volume", mount_path="/root/mount_file", sub_path=None, read_only=True)
     k = KubernetesPodOperator(
         namespace="default",
         image="ubuntu:16.04",
@@ -658,9 +652,7 @@ After:
 
     volume = k8s.V1Volume(
         name="test-volume",
-        persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
-            claim_name="test-volume"
-        ),
+        persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(claim_name="test-volume"),
     )
     k = KubernetesPodOperator(
         namespace="default",
@@ -735,9 +727,7 @@ After:
     env_vars = [
         k8s.V1EnvVar(
             name="ENV3",
-            value_from=k8s.V1EnvVarSource(
-                field_ref=k8s.V1ObjectFieldSelector(field_path="status.podIP")
-            ),
+            value_from=k8s.V1EnvVarSource(field_ref=k8s.V1ObjectFieldSelector(field_path="status.podIP")),
         )
     ]
 
@@ -775,9 +765,7 @@ After:
     from kubernetes.client import models as k8s
 
     configmap = "test-configmap"
-    env_from = [
-        k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmap))
-    ]
+    env_from = [k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmap))]
 
     k = KubernetesPodOperator(
         namespace="default",
@@ -1147,9 +1135,7 @@ non-RBAC UI (``flask-admin`` based UI), update it to use ``flask_appbuilder_view
 
     v = TestView(category="Test Plugin", name="Test View")
 
-    ml = MenuLink(
-        category="Test Plugin", name="Test Menu Link", url="https://airflow.apache.org/"
-    )
+    ml = MenuLink(category="Test Plugin", name="Test Menu Link", url="https://airflow.apache.org/")
 
 
     class AirflowTestPlugin(AirflowPlugin):

--- a/tests/dags_corrupted/README.md
+++ b/tests/dags_corrupted/README.md
@@ -25,9 +25,7 @@ Python interpreter from loading this file.
 To access a DAG in this folder, use the following code inside a unit test.
 
 ```python
-TEST_DAG_FOLDER = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "dags_corrupted"
-)
+TEST_DAG_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "dags_corrupted")
 
 dagbag = DagBag(dag_folder=TEST_DAG_FOLDER)
 dag = dagbag.get_dag(dag_id)

--- a/tests/test_utils/perf/perf_kit/__init__.py
+++ b/tests/test_utils/perf/perf_kit/__init__.py
@@ -75,10 +75,7 @@ Suppose we have the following fragment of the file with tests.
 
     def test_bulk_write_to_db(self):
         clear_db_dags()
-        dags = [
-            DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"])
-            for i in range(0, 4)
-        ]
+        dags = [DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"]) for i in range(0, 4)]
 
         with assert_queries_count(3):
             DAG.bulk_write_to_db(dags)
@@ -101,10 +98,7 @@ queries in it.
     @trace_queries
     def test_bulk_write_to_db(self):
         clear_db_dags()
-        dags = [
-            DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"])
-            for i in range(0, 4)
-        ]
+        dags = [DAG(f"dag-bulk-sync-{i}", start_date=DEFAULT_DATE, tags=["test-dag"]) for i in range(0, 4)]
 
         with assert_queries_count(3):
             DAG.bulk_write_to_db(dags)


### PR DESCRIPTION
I suggest keeping the Black and blacken-docs configs aligned. For example, currently Black is running with 110 char line length while blacken-docs is using the default 88 char line length. Unfortunately, blacken-docs does not support a config file, so have to set flags separately. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
