### PR TITLE
taskinstance: set task on sqlalchemy taskinstance object

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1251,7 +1251,7 @@ class TaskInstance(Base, LoggingMixin):
         self.external_executor_id = external_executor_id
         self.end_date = None
         if not test_mode:
-            session.merge(self)
+            session.merge(self).task = task
         session.commit()
 
         # Closing all pooled connections to prevent


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/20443 we added TaskListener API. It's contract promises to pass TaskInstance object to listener plugin. However, what happens is not 100% true - the object being passed is one that maps to current SQLAlchemy session.

`check_and_change_state_before_execution` operates on detached TaskInstance object, then merges it to current session. Since there is no attached object in the SQLAlchemy identity map, SQLAlchemy creates it, and it's this object that's being passed to the SQLAlchemy event listeners.

The problem with that is that when creating new SQLAlchemy object, SQLAlchemy takes care about setting only database-mapped fields. The ones that are purely on the python side, like `task` aren't being set on the new object.

This PR manually sets `task` on the new SQLAlchemy object, so that `on_task_instance_running` receives proper TaskInstance with `task` field set.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
