### PR TITLE
Fix documentation errors in apache-airflow/lineage.rst

### DIFF
--- a/docs/apache-airflow/lineage.rst
+++ b/docs/apache-airflow/lineage.rst
@@ -96,7 +96,7 @@ has outlets defined (e.g. by using ``add_outlets(..)`` or has out of the box sup
 Lineage Backend
 ---------------
 
-It's possible to push the lineage metrics to a custom backend by providing an instance of a LinageBackend in the config:
+It's possible to push the lineage metrics to a custom backend by providing an instance of a LineageBackend in the config:
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/lineage.rst
+++ b/docs/apache-airflow/lineage.rst
@@ -71,7 +71,7 @@ for the downstream task.
 
 .. note:: Operators can add inlets and outlets automatically if the operator supports it.
 
-In the example DAG task ``run_this`` (task_id=``run_me_first``) is a BashOperator that takes 3 inlets: ``CAT1``, ``CAT2``, ``CAT3``, that are
+In the example DAG task ``run_this`` (``task_id=run_me_first``) is a BashOperator that takes 3 inlets: ``CAT1``, ``CAT2``, ``CAT3``, that are
 generated from a list. Note that ``data_interval_start`` is a templated field and will be rendered when the task is running.
 
 .. note:: Behind the scenes Airflow prepares the lineage metadata as part of the ``pre_execute`` method of a task. When the task

--- a/docs/apache-airflow/lineage.rst
+++ b/docs/apache-airflow/lineage.rst
@@ -110,7 +110,7 @@ The backend should inherit from ``airflow.lineage.LineageBackend``.
   from airflow.lineage.backend import LineageBackend
 
 
-  class ExampleBackend(LineageBackend):
+  class CustomBackend(LineageBackend):
       def send_lineage(self, operator, inlets=None, outlets=None, context=None):
           ...
           # Send the info to some external service


### PR DESCRIPTION
Noticed two errors in the [Lineage documentation page](https://airflow.apache.org/docs/apache-airflow/stable/lineage.html):

- Inline code highlight "task_id=\`\`run_me_first\`\`" doesn't work due to a missing whitespace.
- Sample name of custom lineage backend, `ExampleBackend` , is different from the one configured above - `CustomBackend`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
