### PR TITLE
[SQSSensor] Add opt-in to disable auto-delete messages

### DIFF
--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -54,8 +54,10 @@ class SqsSensor(BaseSensorOperator):
     :param message_filtering_config: Additional configuration to pass to the message filter.
         For example with JSONPath filtering you can pass a JSONPath expression string here,
         such as `'foo[*].baz'`. Messages with a Body which does not match are ignored.
-    :param delete_message_on_reception: If set to False, the messages are not going to be deleted
-    from the queue. By default, the messages are deleted from the queue as soon as being consumed.
+    :param delete_message_on_reception: Default to `True`, the messages are deleted from the queue
+        as soon as being consumed. Otherwise, the messages remain in the queue after consumption and
+        should be deleted manually.
+
     """
 
     template_fields: Sequence[str] = ('sqs_queue', 'max_messages', 'message_filtering_config')

--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -54,6 +54,8 @@ class SqsSensor(BaseSensorOperator):
     :param message_filtering_config: Additional configuration to pass to the message filter.
         For example with JSONPath filtering you can pass a JSONPath expression string here,
         such as `'foo[*].baz'`. Messages with a Body which does not match are ignored.
+    :param delete_message_on_reception: If set to False, the messages are not going to be deleted
+    from the queue. By default, the messages are deleted from the queue as soon as being consumed.
     """
 
     template_fields: Sequence[str] = ('sqs_queue', 'max_messages', 'message_filtering_config')
@@ -69,6 +71,7 @@ class SqsSensor(BaseSensorOperator):
         message_filtering: Optional[Literal["literal", "jsonpath"]] = None,
         message_filtering_match_values: Any = None,
         message_filtering_config: Any = None,
+        delete_message_on_reception: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -79,6 +82,8 @@ class SqsSensor(BaseSensorOperator):
         self.visibility_timeout = visibility_timeout
 
         self.message_filtering = message_filtering
+
+        self.delete_message_on_reception = delete_message_on_reception
 
         if message_filtering_match_values is not None:
             if not isinstance(message_filtering_match_values, set):
@@ -128,6 +133,10 @@ class SqsSensor(BaseSensorOperator):
             messages = self.filter_messages(messages)
             num_messages = len(messages)
             self.log.info("There are %d messages left after filtering", num_messages)
+
+        if not self.delete_message_on_reception:
+            context['ti'].xcom_push(key='messages', value=messages)
+            return True
 
         if not num_messages:
             return False


### PR DESCRIPTION
## What

Add opt-in in `SQSSensor` to disable the behavior of automatically delete messages on consumption. This option is opt-in. By default it is set to `False`, which means the original feature is preserved.

- If `delete_message_on_reception` is `True` (default): SQS messages are deleted automatically from the queue upon consumption.
- If `delete_message_on_reception` is `False`. The user takes care of message deletion manually.

## Why

In many cases, the `SQSSensor` itselft is not the part of the code base that actually processes the messages. It serves as a short of polling to get messages out for further processing.

If the actually code/Aiflow task that processes the messages failed, the message should be put back in the queue for further processing. This is the very basic idea of SQS Polling provided by Amazon.

Reference to SQS with AWS Lambda function, [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html) states :

```
When your function *successfully* processes a batch, Lambda deletes its messages from the queue.
```

In many case, the `SQSSensor` polls the message and distributes the workload to different task, in a very similar way to AWS Lambda polling.

![SQSPolling](https://user-images.githubusercontent.com/6369285/151395485-f277165b-7ec2-42ca-880f-6cd74879c1d6.png)


Thus, there should be option to disable to default behavior, which is to delete the message upon reception.

