### PR TITLE
Change logging level details of connection info in `get_connection()`

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -66,18 +66,18 @@ class BaseHook(LoggingMixin):
         from airflow.models.connection import Connection
 
         conn = Connection.get_connection_from_secrets(conn_id)
-        if conn.host:
-            log.info(
-                "Using connection to: id: %s. Host: %s, Port: %s, Schema: %s, Login: %s, Password: %s, "
-                "extra: %s",
-                conn.conn_id,
-                conn.host,
-                conn.port,
-                conn.schema,
-                conn.login,
-                redact(conn.password),
-                redact(conn.extra_dejson),
-            )
+        log.info("Using connection ID '%s' for task execution.", conn.conn_id)
+        log.debug(
+            "Connection details for '%s':: Host: %s, Port: %s, Schema: %s, Login: %s, Password: %s, "
+            "Extra: %s",
+            conn.conn_id,
+            conn.host,
+            conn.port,
+            conn.schema,
+            conn.login,
+            redact(conn.password),
+            redact(conn.extra_dejson),
+        )
         return conn
 
     @classmethod

--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -749,7 +749,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
         sensor.poke(None)
         mock_log_call.assert_called_once_with("spark-pi-2020-02-24-1-driver", namespace="default")
-        log_info_call = info_log_call.mock_calls[1]
+        log_info_call = info_log_call.mock_calls[2]
         log_value = log_info_call[1][0]
         assert log_value == TEST_POD_LOG_RESULT
 


### PR DESCRIPTION
Related: #19883

Currently task logs can contain all of connection details depending on how the associated connection to the task is configured (i.e. if `host` is a provided connection attr). These details are logged at the INFO level but seem more appropriate for debugging.

This PR intends to clean up this connection logging a little. The INFO level logging will contain only the connection ID that is used while the details of the connection are changed to the DEBUG level (and still masked). Additionally the connection ID info is logged regardless of the provided connection attrs (i.e. removing the `host` check). Lastly this change also has a small added benefit of not accidentally or unknowingly exposing connection info that users do not want in their logs _first_ rather than the details be exposed and then having to setup configuration to mask them later (assuming the exposure is noticed at all).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
