### PR TITLE
Add a note about broken DAG dependency graph

### DIFF
--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -713,7 +713,7 @@ Additional difficulty is that one DAG could wait for or trigger several runs of 
 with different data intervals. The **Dag Dependencies** view
 ``Menu -> Browse -> DAG Dependencies`` helps visualize dependencies between DAGs. The dependencies
 are calculated by the scheduler during DAG serialization and the webserver uses them to build
-the dependency graph. Note that if a DAG depdens on another DAG which does not exist (for example a deleted DAG),
+the dependency graph. Note that if a DAG depends on another DAG which does not exist (for example a deleted DAG),
 the webserver will fail to render the dependency graph.
 
 The dependency detector is configurable, so you can implement your own logic different than the defaults in

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -713,7 +713,8 @@ Additional difficulty is that one DAG could wait for or trigger several runs of 
 with different data intervals. The **Dag Dependencies** view
 ``Menu -> Browse -> DAG Dependencies`` helps visualize dependencies between DAGs. The dependencies
 are calculated by the scheduler during DAG serialization and the webserver uses them to build
-the dependency graph.
+the dependency graph. Note that if a DAG depdens on another DAG which does not exist (for example a deleted DAG),
+the webserver will fail to render the dependency graph.
 
 The dependency detector is configurable, so you can implement your own logic different than the defaults in
 :class:`~airflow.serialization.serialized_objects.DependencyDetector`


### PR DESCRIPTION
Airflow webserver fails to render dependency graph is a dependency DAG is missing.
The issue and cause was described  in https://github.com/apache/airflow/issues/21059.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: [Dag dependency view is not rendering for Postgres backed Airflow](https://github.com/apache/airflow/issues/21059)

