### PR TITLE
Display better error message when importing providers has errors 

### DIFF
--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -345,36 +345,6 @@ function filename_to_python_module() {
     echo "${no_init//\//.}"
 }
 
-function import_all_provider_classes() {
-    group_start "Import all Airflow classes"
-    # We have to move to a directory where "airflow" is
-    unset PYTHONPATH
-    # We need to make sure we are not in the airflow checkout, otherwise it will automatically be added to the
-    # import path
-    cd /
-
-    declare -a IMPORT_CLASS_PARAMETERS
-
-    PROVIDER_PATHS=$(
-        python3 <<EOF 2>/dev/null
-import airflow.providers;
-path=airflow.providers.__path__
-for p in path._path:
-    print(p)
-EOF
-    )
-    export PROVIDER_PATHS
-
-    echo "Searching for providers packages in:"
-    echo "${PROVIDER_PATHS}"
-
-    while read -r provider_path; do
-        IMPORT_CLASS_PARAMETERS+=("--path" "${provider_path}")
-    done < <(echo "${PROVIDER_PATHS}")
-
-    python3 /opt/airflow/dev/import_all_classes.py "${IMPORT_CLASS_PARAMETERS[@]}"
-    group_end
-}
 
 function in_container_set_colors() {
     COLOR_BLUE=$'\e[34m'

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -238,6 +238,44 @@ function ver() {
   printf "%04d%04d%04d%.0s" ${1//[.-]/ }
 }
 
+function import_all_provider_classes() {
+    group_start "Import all Airflow classes"
+    # We have to move to a directory where "airflow" is
+    unset PYTHONPATH
+    # We need to make sure we are not in the airflow checkout, otherwise it will automatically be added to the
+    # import path
+    pushd /
+
+    declare -a IMPORT_CLASS_PARAMETERS
+
+    PROVIDER_PATHS=$(
+        python3 <<EOF 2>/dev/null
+import airflow.providers;
+path=airflow.providers.__path__
+for p in path._path:
+    print(p)
+EOF
+    )
+    export PROVIDER_PATHS
+
+    echo "Searching for providers packages in:"
+    echo "${PROVIDER_PATHS}"
+
+    while read -r provider_path; do
+        IMPORT_CLASS_PARAMETERS+=("--path" "${provider_path}")
+    done < <(echo "${PROVIDER_PATHS}")
+
+    if python3 /opt/airflow/dev/import_all_classes.py "${IMPORT_CLASS_PARAMETERS[@]}"; then
+        popd
+        group_end
+    else
+        popd
+        group_end
+        return 1
+    fi
+}
+
+
 setup_provider_packages
 verify_parameters
 install_airflow_as_specified
@@ -248,7 +286,44 @@ if [[ ${SKIP_TWINE_CHECK=""} != "true" ]]; then
     twine_check_provider_packages
 fi
 install_provider_packages
-import_all_provider_classes
+set +e
+
+import_error_file="/tmp/import_errors.txt"
+
+if import_all_provider_classes 2>"${import_error_file}"; then
+    echo "${COLOR_GREEN}All classes imported properly${COLOR_RESET}"
+else
+    echo "${COLOR_RED}There were errors when importing Providers!${COLOR_RESET}"
+    if [[ ${USE_AIRFLOW_VERSION} =~ [0-9\.]* ]]; then
+        echo "${COLOR_RED}This test is run to check Provider's compatibility with Airflow ${USE_AIRFLOW_VERSION}${COLOR_RESET}"
+        echo "${COLOR_RED}So this error might mean that your providers are not Airflow ${USE_AIRFLOW_VERSION} compatible${COLOR_RESET}"
+
+        if grep "airflow.utils.context" <"${import_error_file}" >/dev/null 2>&1; then
+            echo
+            echo "${COLOR_YELLOW}You are using Context class which is only available in Airflow 2.3${COLOR_RESET}"
+            echo
+            echo """
+You should use this construct to use the Context class in your operator:
+
+${COLOR_BLUE}from typing import TYPE_CHECKING${COLOR_RESET}
+
+${COLOR_BLUE}if TYPE_CHECKING:${COLOR_RESET}
+${COLOR_BLUE}    from airflow.utils.context import Context${COLOR_RESET}
+
+${COLOR_BLUE}def execute(self, context: 'Context'):${COLOR_RESET}
+
+${COLOR_YELLOW}You can also have other imports that are missing in Airflow ${USE_AIRFLOW_VERSION} so look at the details below!${COLOR_RESET}
+
+"""
+        fi
+    fi
+    echo
+    echo "${COLOR_YELLOW}Detailed errors:${COLOR_RESET}"
+    echo
+    cat /"${import_error_file}"
+    echo
+    exit 1
+fi
 
 discover_all_provider_packages
 discover_all_hooks

--- a/scripts/in_container/run_prepare_provider_documentation.sh
+++ b/scripts/in_container/run_prepare_provider_documentation.sh
@@ -18,12 +18,6 @@
 # shellcheck source=scripts/in_container/_in_container_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
 
-function import_all_provider_classes() {
-    group_start "Importing all classes"
-    python3 "${AIRFLOW_SOURCES}/dev/import_all_classes.py" --path "airflow/providers"
-    group_end
-}
-
 function verify_provider_packages_named_properly() {
     python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
         verify-provider-classes
@@ -142,7 +136,6 @@ function run_prepare_documentation() {
     fi
 }
 
-
 setup_provider_packages
 
 cd "${AIRFLOW_SOURCES}" || exit 1
@@ -150,7 +143,11 @@ cd "${AIRFLOW_SOURCES}" || exit 1
 export PYTHONPATH="${AIRFLOW_SOURCES}"
 
 install_supported_pip_version
-import_all_provider_classes
+
+group_start "Importing all classes"
+python3 "${AIRFLOW_SOURCES}/dev/import_all_classes.py" --path "airflow/providers"
+group_end
+
 verify_provider_packages_named_properly
 
 OPTIONAL_RELEASE_VERSION_ARGUMENT=()


### PR DESCRIPTION
When there are import errors in providers we printed errors
in a folded group which lead to poor discovery of those errors.
Also with recent changes to Airflow main for upcoming 2.3 version
some errors might become more common when developing providers.
Specifically the way how to import Context in order to satisfy
MyPy and keep Airflow 2.1 compatibility is not obvious.

This change introduces helpful guideline to users adding new
providers:

* moving errors outside of the folded group with imports
* adding comment explaining what the errors are about
* adding message about backwards compatibility in case
  errors happen during 2.1.0 backwards-compatibility check
* adding explanation and suggest a fix in the common Context
  impport error

Just last commit matters!

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
