### PR TITLE
Log trigger status only if at least one is running

### DIFF
--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -245,9 +245,11 @@ class TriggerRunner(threading.Thread, LoggingMixin):
             await self.cleanup_finished_triggers()
             # Sleep for a bit
             await asyncio.sleep(1)
-            # Every minute, log status
+            # Every minute, log status if at least one trigger is running.
             if time.time() - last_status >= 60:
-                self.log.info("%i triggers currently running", len(self.triggers))
+                count = len(self.triggers)
+                if count > 0:
+                    self.log.info("%i triggers currently running", count)
                 last_status = time.time()
         # Wait for watchdog to complete
         await watchdog


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Previously, every minute a line would be logged such as:
```
{triggerer_job.py:251} INFO - 0 triggers currently running
```

Seems a little excessive.