### PR TITLE
Alleviate import warning for `EmrClusterLink` in deprecated AWS module

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
+++ b/airflow/providers/amazon/aws/operators/emr_create_job_flow.py
@@ -20,10 +20,12 @@
 
 import warnings
 
-from airflow.providers.amazon.aws.operators.emr import EmrCreateJobFlowOperator  # noqa
+from airflow.providers.amazon.aws.operators.emr import EmrClusterLink, EmrCreateJobFlowOperator
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.emr`.",
     DeprecationWarning,
     stacklevel=2,
 )
+
+__all__ = ["EmrClusterLink", "EmrCreateJobFlowOperator"]


### PR DESCRIPTION
In `main` with Breeze, the webserver logs emit a providers-manager warning for an import of `EmrClusterLink`:
```
WARNING - Exception when importing 'airflow.providers.amazon.aws.operators.emr_create_job_flow.EmrClusterLink' from 'apache-airflow-providers-amazon' package
Traceback (most recent call last):
 File "/opt/airflow/airflow/utils/module_loading.py", line 35, in import_string
   return getattr(module, class_name)
AttributeError: module 'airflow.providers.amazon.aws.operators.emr_create_job_flow' has no attribute 'EmrClusterLink'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
 File "/opt/airflow/airflow/providers_manager.py", line 156, in _sanity_check
   imported_class = import_string(class_name)
 File "/opt/airflow/airflow/utils/module_loading.py", line 37, in import_string
   raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute/class')
ImportError: Module "airflow.providers.amazon.aws.operators.emr_create_job_flow" does not define a "EmrClusterLink" attribute/class
```

This PR adds the `EmrClusterLink` to the now-deprecated module to suppress this warning.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
