### PR TITLE
Fix backfill job crash when use DebugExecutor

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -296,7 +296,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         """
         self.log.info('Kubernetes job is %s', str(next_job).replace("\n", " "))
         key, command, kube_executor_config, pod_template_file = next_job
-        dag_id, task_id, run_id, try_number = key
+        dag_id, task_id, run_id, try_number, map_index = key
 
         if command[0:3] != ["airflow", "tasks", "run"]:
             raise ValueError('The command must start with ["airflow", "tasks", "run"].')

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1509,7 +1509,7 @@ class DAG(LoggingMixin):
                 visited_external_tis = set()
 
             for ti in query.filter(TI.operator == ExternalTaskMarker.__name__):
-                ti_key = ti.key.primary
+                ti_key = ti.key
                 if ti_key in visited_external_tis:
                     continue
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2255,7 +2255,7 @@ def test_set_task_instance_state(run_id, execution_date, session, dag_maker):
     # dagrun should be set to QUEUED
     assert dagrun.get_state() == State.QUEUED
 
-    assert {t.key for t in altered} == {('test_set_task_instance_state', 'task_1', dagrun.run_id, 1)}
+    assert {t.key for t in altered} == {('test_set_task_instance_state', 'task_1', dagrun.run_id, -1)}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils/mock_executor.py
+++ b/tests/test_utils/mock_executor.py
@@ -39,7 +39,7 @@ class MockExecutor(BaseExecutor):
         self.sorted_tasks = []
 
         # If multiprocessing runs in spawn mode,
-        # arguments are to be pickled but lambda is not picclable.
+        # arguments are to be pickled but lambda is not picklable.
         # So we should pass self.success instead of lambda.
         self.mock_task_results = defaultdict(self.success)
 


### PR DESCRIPTION
whichever use DebugExecutor or default executor in BackfillJob
the function _update_couters always raise KeyError at one of them,
so I think TaskInstanceKey should match TaskInstance's primary keys
and unrelated with try_number when as a dict key.

related: #13712
