### PR TITLE
Remove up-to-date checks for Python

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -252,4 +252,3 @@ checkUpToDate:
     - airflow/migrations/*
     - airflow/migrations/**/*
     - airflow/alembic.ini
-    - airflow/**/*.py


### PR DESCRIPTION
The up-to-date check for Python run for ~week so all the PRs
raised in the last week will need to be rebased to account for
MyPy changes. Hopefully there will be no more PRs from before,
that have not been rebased (we had one serious MyPy problem for
the #20077 change that was approved before the up-to-date checker
was enabled in #21016

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
