### PR TITLE
Remove check for tuple in test_security

### DIFF
--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -742,9 +742,7 @@ def test_get_all_permissions(security_manager):
 
     assert isinstance(perms, set)
     for perm in perms:
-        assert isinstance(perm, tuple)
         assert len(perm) == 2
-
     assert ('can_read', 'Connections') in perms
 
 


### PR DESCRIPTION
SQLAlchemy 1.4 does not produce iterator of "real" Tuples,
it returns iterator of Rows. Rows are not Tuples so instance
check will fail for them, however for all practical purpose
they behave as Tuples (even comparing them with Tuples of the
same content produce an equality). They also behave like dict,
but this is a different story.

The test started to fail in SQLAlchemy 1.4 because it contained
assert for the returned set entry to be Tuple, but it also contained
the actual check for length and whether the expected Tuple is in
the set, so assert for instance is pretty redundant.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
