### PR TITLE
Add explicit image push to cache preparation

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -294,7 +294,7 @@ function build_images::check_if_buildx_plugin_available() {
     buildx_version=$(docker buildx version 2>/dev/null || true)
     if [[ ${buildx_version} != "" ]]; then
         if [[ ${PREPARE_BUILDX_CACHE} == "true" ]]; then
-            BUILD_COMMAND+=("buildx" "build" "--builder" "airflow_cache" "--progress=tty" "--push")
+            BUILD_COMMAND+=("buildx" "build" "--builder" "airflow_cache" "--progress=tty")
             docker_v buildx inspect airflow_cache || docker_v buildx create --name airflow_cache
         else
             BUILD_COMMAND+=("buildx" "build" "--builder" "default" "--progress=tty")
@@ -509,6 +509,10 @@ function build_images::build_ci_image() {
         -t "${AIRFLOW_CI_IMAGE}" \
         --target "main" \
         . -f Dockerfile.ci
+    if [[ ${PREPARE_BUILDX_CACHE} == "true" ]]; then
+        # Push the image as "latest" so that it can be used in Breeze
+        docker_v push "${AIRFLOW_CI_IMAGE}"
+    fi
     set -u
     if [[ -n "${IMAGE_TAG=}" ]]; then
         echo "Tagging additionally image ${AIRFLOW_CI_IMAGE} with ${IMAGE_TAG}"
@@ -658,6 +662,10 @@ function build_images::build_prod_images() {
         -t "${AIRFLOW_PROD_IMAGE}" \
         --target "main" \
         . -f Dockerfile
+    if [[ ${PREPARE_BUILDX_CACHE} == "true" ]]; then
+        # Push the image as "latest" so that it can be used in Breeze
+        docker_v push "${AIRFLOW_PROD_IMAGE}"
+    fi
     set -u
     if [[ -n "${IMAGE_TAG=}" ]]; then
         echo "Tagging additionally image ${AIRFLOW_PROD_IMAGE} with ${IMAGE_TAG}"


### PR DESCRIPTION
When BUILDKIT cache is prepared, you cannot (yet) at the same time
to "load" the image to local docker engine and "push" it to the
registry. You need to push it separately.

This change adds separate "push" step when buildx cache is prepared.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
