### PR TITLE
Fix trigger dag redirect from task instance log view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1377,7 +1377,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
-        dttm = timezone.parse(execution_date)
+        dttm = timezone.parse(execution_date) if execution_date else None
         form = DateTimeForm(data={'execution_date': dttm})
         dag_model = DagModel.get_dagmodel(dag_id)
 


### PR DESCRIPTION
When triggering a dag run from log view, we are redirected back to log view and
execution_date is not populated.  This produces an error.

To resolve this we should not attempt to parse execution_date when it's empty.
