### PR TITLE
Split out confusing path combination logic to separate method

### DIFF
--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -113,10 +113,7 @@ class HttpHook(BaseHook):
 
         session = self.get_conn(headers)
 
-        if self.base_url and not self.base_url.endswith('/') and endpoint and not endpoint.startswith('/'):
-            url = self.base_url + '/' + endpoint
-        else:
-            url = (self.base_url or '') + (endpoint or '')
+        url = self.url_from_endpoint(endpoint)
 
         if self.method == 'GET':
             # GET uses params
@@ -214,6 +211,12 @@ class HttpHook(BaseHook):
         self._retry_obj = tenacity.Retrying(**_retry_args)
 
         return self._retry_obj(self.run, *args, **kwargs)
+
+    def url_from_endpoint(self, endpoint: str) -> str:
+        """Combine base url with endpoint"""
+        if self.base_url and not self.base_url.endswith('/') and endpoint and not endpoint.startswith('/'):
+            return self.base_url + '/' + endpoint
+        return (self.base_url or '') + (endpoint or '')
 
     def test_connection(self):
         """Test HTTP Connection"""

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -212,7 +212,7 @@ class HttpHook(BaseHook):
 
         return self._retry_obj(self.run, *args, **kwargs)
 
-    def url_from_endpoint(self, endpoint: str) -> str:
+    def url_from_endpoint(self, endpoint: Optional[str]) -> str:
         """Combine base url with endpoint"""
         if self.base_url and not self.base_url.endswith('/') and endpoint and not endpoint.startswith('/'):
             return self.base_url + '/' + endpoint


### PR DESCRIPTION
An additional justification for this minor refactoring is that a subclass might be run custom authentication/authorization logic and reuse this functionality outside of the `run` method.