### PR TITLE
Remove unused "airflow_2" test marker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,7 +242,6 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "credential_file(name): mark tests that require credential file in CREDENTIALS_DIR"
     )
-    config.addinivalue_line("markers", "airflow_2: mark tests that works only on Airflow 2.0 / master")
 
 
 def skip_if_not_marked_with_integration(selected_integrations, item):
@@ -342,12 +341,6 @@ def skip_if_credential_file_missing(item):
             pytest.skip(f"The test requires credential file {credential_path}: {item}")
 
 
-def skip_if_airflow_2_test(item):
-    for _ in item.iter_markers(name="airflow_2"):
-        if os.environ.get("RUN_AIRFLOW_1_10") == "true":
-            pytest.skip("The test works only with Airflow 2.0 / main branch")
-
-
 def pytest_runtest_setup(item):
     selected_integrations_list = item.config.getoption("--integration")
     selected_systems_list = item.config.getoption("--system")
@@ -373,7 +366,6 @@ def pytest_runtest_setup(item):
     if not include_quarantined:
         skip_quarantined_test(item)
     skip_if_credential_file_missing(item)
-    skip_if_airflow_2_test(item)
 
 
 @pytest.fixture


### PR DESCRIPTION
This hasn't every really been used.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).