### PR TITLE
Clarify ElasticsearchTaskHandler docstring

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -49,12 +49,12 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
     into local files. Additional software setup is required
     to index the logs into Elasticsearch, such as using
     Filebeat and Logstash.
-    To efficiently query and sort Elasticsearch results, we assume each
+    To efficiently query and sort Elasticsearch results, this handler assumes each
     log message has a field `log_id` consists of ti primary keys:
     `log_id = {dag_id}-{task_id}-{execution_date}-{try_number}`
     Log messages with specific log_id are sorted based on `offset`,
     which is a unique integer indicates log message's order.
-    Timestamp here are unreliable because multiple log messages
+    Timestamps here are unreliable because multiple log messages
     might have the same timestamp.
     """
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -44,10 +44,10 @@ EsLogMsgType = List[Tuple[str, str]]
 class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMixin):
     """
     ElasticsearchTaskHandler is a python log handler that
-    reads logs from Elasticsearch. Note logs are not directly
-    indexed into Elasticsearch. Instead, it flushes logs
+    reads logs from Elasticsearch. Note that Airflow does not handle the indexing
+    of logs into Elasticsearch. Instead, Airflow flushes logs
     into local files. Additional software setup is required
-    to index the log into Elasticsearch, such as using
+    to index the logs into Elasticsearch, such as using
     Filebeat and Logstash.
     To efficiently query and sort Elasticsearch results, we assume each
     log message has a field `log_id` consists of ti primary keys:


### PR DESCRIPTION
Previously it said 'logs are not indexed into ES' but what it meant was '_airflow_ does not index the logs for you'.
