### PR TITLE
Fix `insecure_mode` parameter formatting in Snowflake conn doc

### DIFF
--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -59,13 +59,10 @@ Extra (optional)
     * ``region``: Warehouse region.
     * ``warehouse``: Snowflake warehouse name.
     * ``role``: Snowflake role.
-    * ``authenticator``: To connect using OAuth set this parameter ``oath``
+    * ``authenticator``: To connect using OAuth set this parameter ``oath``.
     * ``private_key_file``: Specify the path to the private key file.
-    * ``session_parameters``: Specify `session level parameters
-      <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_
-    * ``insecure_mode``: Turn off OCSP certificate checks
-        For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community
-        <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`__.
+    * ``session_parameters``: Specify `session level parameters <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_.
+    * ``insecure_mode``: Turn off OCSP certificate checks. For details, see: `How To: Turn Off OCSP Checking in Snowflake Client Drivers - Snowflake Community <https://community.snowflake.com/s/article/How-to-turn-off-OCSP-checking-in-Snowflake-client-drivers>`_.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.


### PR DESCRIPTION
Addresses the below formatting issue in the Snowflake connection doc:
![image](https://user-images.githubusercontent.com/48934154/152039160-6b3a9c93-2e71-4e92-b56b-61c868d0f491.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
