### PR TITLE
Fix building documentation for PSRP

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -52,6 +52,7 @@ Invitation link: https://s.apache.org/airflow-slack\
 
 ERRORS_ELIGIBLE_TO_REBUILD = [
     'failed to reach any of the inventories with the following issues',
+    'toctree contains reference to nonexisting document',
     'undefined label:',
     'unknown document:',
     'Error loading airflow.providers',


### PR DESCRIPTION
The PSRP docs building fails in main/PR after merging #19806
because the docusmentation needs to be rebuilt one more time
because of sequence of building the documentation. In main and
new PRs the "apache-airflow" documentation is not build
before misrosoft psrp is built, and the psrp docs uses
reference to the airlfow "concept" documentation and the
link is not existing yet in the inventory for apache-airflow.
This results in a race condition where PSRP documentation fails
with `toctree contains reference to nonexisting document`

The error has not been included in the list of errors that
are "eligible for rebuild" and the race condition was triggered.

This change adds the error to errors "eligible for rebuild" and
makes PSRP documentation build succeed on retry.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
