### PR TITLE
Emit "logs not found" message when ES logs appear to be missing

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -198,7 +198,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
                     (
                         '',
                         (
-                            f"*** Log {log_id} not found in elasticsearch. "
+                            f"*** Log {log_id} not found in Elasticsearch. "
                             "If your task started recently, please wait a moment and reload this page. "
                             "Otherwise, the logs for this task instance may have been removed."
                         ),

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -196,11 +196,12 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
                 metadata['end_of_log'] = True
                 message = (
                     f"*** Log {log_id} not found in elasticsearch. "
-                    f"If your task started recently, please wait a moment and reload this page. "
-                    f"Otherwise, the logs for this task instance may have been removed."
+                    "If your task started recently, please wait a moment and reload this page. "
+                    "Otherwise, the logs for this task instance may have been removed."
                 )
                 return [('', message)], metadata
-            elif (
+
+            if (
                 # Assume end of log after not receiving new log for N min,
                 cur_ts.diff(last_log_ts).in_minutes() >= 5
                 # if max_offset specified, respect it

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -194,12 +194,16 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             # assume logs do not exist
             if int(next_offset) == 0 and cur_ts.diff(last_log_ts).in_seconds() > 5:
                 metadata['end_of_log'] = True
-                message = (
-                    f"*** Log {log_id} not found in elasticsearch. "
-                    "If your task started recently, please wait a moment and reload this page. "
-                    "Otherwise, the logs for this task instance may have been removed."
-                )
-                return [('', message)], metadata
+                return [
+                    (
+                        '',
+                        (
+                            f"*** Log {log_id} not found in elasticsearch. "
+                            "If your task started recently, please wait a moment and reload this page. "
+                            "Otherwise, the logs for this task instance may have been removed."
+                        ),
+                    )
+                ], metadata
 
             if (
                 # Assume end of log after not receiving new log for N min,

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -194,17 +194,12 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             # assume logs do not exist
             if int(next_offset) == 0 and cur_ts.diff(last_log_ts).in_seconds() > 5:
                 metadata['end_of_log'] = True
-                return [
-                    (
-                        '',
-                        (
-                            f"*** Log {log_id} not found in Elasticsearch. "
-                            "If your task started recently, please wait a moment and reload this page. "
-                            "Otherwise, the logs for this task instance may have been removed."
-                        ),
-                    )
-                ], metadata
-
+                missing_log_message = (
+                    f"*** Log {log_id} not found in Elasticsearch. "
+                    "If your task started recently, please wait a moment and reload this page. "
+                    "Otherwise, the logs for this task instance may have been removed."
+                )
+                return [('', missing_log_message)], metadata
             if (
                 # Assume end of log after not receiving new log for N min,
                 cur_ts.diff(last_log_ts).in_minutes() >= 5

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -156,7 +156,7 @@ class TestElasticsearchTaskHandler:
         logs, metadatas = self.es_task_handler.read(ti, 1, {'offset': 0, 'last_log_timestamp': str(ts)})
 
         assert 1 == len(logs)
-        assert re.match(r'.*Log .* not found in elasticsearch.*', logs[0][0][1]) is not None
+        assert re.match(r'^\*\*\* Log .* not found in elasticsearch.*', logs[0][0][1]) is not None
         assert len(logs) == len(metadatas)
         assert len(logs[0]) == 1
         assert metadatas[0]['end_of_log'] is True

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -161,7 +161,7 @@ class TestElasticsearchTaskHandler:
             # we expect a log not found message when checking began more than 5 seconds ago
             assert len(logs[0]) == 1
             actual_message = logs[0][0][1]
-            expected_pattern = r'^\*\*\* Log .* not found in elasticsearch.*'
+            expected_pattern = r'^\*\*\* Log .* not found in Elasticsearch.*'
             assert re.match(expected_pattern, actual_message) is not None
             assert metadatas[0]['end_of_log'] is True
         else:


### PR DESCRIPTION
Current ES log handler will wait up to 5 minutes for logs to appear (or for _more_ logs to appear since last log message was emitted).  This produces undesirable behavior when the log message has been deleted from the elasticsearch cluster.  A user may wait a long time thinking that the logs are coming when they are not.

To resolve this, if no logs whatsoever have been retrieved after 5 seconds of trying, we give up and emit a "logs not  found" message.

If the task has only just started, this may be a "false negative", and we guide the user to refresh if they think that might be the case.
