### PR TITLE
Limit SQLAlchemy until MSSQL datetime bug is fixed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -131,7 +131,7 @@ install_requires =
     # SQL Alchemy 1.4.10 introduces a bug where for PyODBC driver UTCDateTime fields get wrongly converted
     # as string and fail to be converted back to datetime. It was supposed to be fixed in
     # https://github.com/sqlalchemy/sqlalchemy/issues/6366 (released in 1.4.12) but apparently our case
-    # is different. Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660  to track it
+    # is different. Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660 to track it
     sqlalchemy>=1.3.18,<1.4.10
     sqlalchemy_jsonfield~=1.0
     tabulate>=0.7.5, <0.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,7 +128,11 @@ install_requires =
     python-slugify~=5.0
     rich>=9.2.0
     setproctitle>=1.1.8, <2
-    sqlalchemy>=1.3.18
+    # SQL Alchemy 1.4.10 introduces a bug where for PyODBC driver UTCDateTime fields get wrongly converted
+    # as string and fail to be converted back to datetime. It was supposed to be fixed in
+    # https://github.com/sqlalchemy/sqlalchemy/issues/6366 (released in 1.4.12) but apparently our case
+    # is different. Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660  to track it
+    sqlalchemy>=1.3.18,<1.4.10
     sqlalchemy_jsonfield~=1.0
     tabulate>=0.7.5, <0.9
     tenacity>=6.2.0


### PR DESCRIPTION
SQL Alchemy 1.4.10 introduces a bug where for PyODBC driver UTCDateTime
fields get wrongly converted as string and fail to be converted back to
datetime. It was supposed to be fixed in
https://github.com/sqlalchemy/sqlalchemy/issues/6366 (released in
1.4.10) but apparently our case is different.

Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660 to track it

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
