### PR TITLE
Mask secrets in stdout for `airflow tasks test ...` CLI command (#17476)

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -52,6 +52,7 @@ from airflow.utils.cli import (
 )
 from airflow.utils.dates import timezone
 from airflow.utils.log.logging_mixin import StreamLogWriter
+from airflow.utils.log.secrets_masker import StdoutRedactContext
 from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 
@@ -505,10 +506,11 @@ def task_test(args, dag=None):
     ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
 
     try:
-        if args.dry_run:
-            ti.dry_run()
-        else:
-            ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
+        with StdoutRedactContext():
+            if args.dry_run:
+                ti.dry_run()
+            else:
+                ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
     except Exception:
         if args.post_mortem:
             debugger = _guess_debugger()


### PR DESCRIPTION
The problem with `airflow tasks test ...` is that any `stdout` that comes from a task inside an operator or other callable does not go through a logger.  It runs in the main process.  This results in secrets that are printed to `stdout` to not be masked according to the `airflow.task` logger.

I wanted a way to capture and filter stdout without having to route everything through a secondary logger.  I decided a context manager that filters `stdout` would be the best way to go about this.  The context manager redacts all secrets according to the filters on the `airflow.task` logger.

Closes #17476 
