### PR TITLE
Refactor operator links to not create ad hoc TaskInstances

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -220,7 +220,7 @@ class BaseXCom(Base, LoggingMixin):
     @classmethod
     def get_one(
         cls,
-        execution_date: pendulum.DateTime,
+        execution_date: datetime.datetime,
         key: Optional[str] = None,
         task_id: Optional[str] = None,
         dag_id: Optional[str] = None,
@@ -233,7 +233,7 @@ class BaseXCom(Base, LoggingMixin):
     @provide_session
     def get_one(
         cls,
-        execution_date: Optional[pendulum.DateTime] = None,
+        execution_date: Optional[datetime.datetime] = None,
         key: Optional[str] = None,
         task_id: Optional[Union[str, Iterable[str]]] = None,
         dag_id: Optional[Union[str, Iterable[str]]] = None,
@@ -314,7 +314,7 @@ class BaseXCom(Base, LoggingMixin):
     @classmethod
     def get_many(
         cls,
-        execution_date: pendulum.DateTime,
+        execution_date: datetime.datetime,
         key: Optional[str] = None,
         task_ids: Union[str, Iterable[str], None] = None,
         dag_ids: Union[str, Iterable[str], None] = None,
@@ -328,7 +328,7 @@ class BaseXCom(Base, LoggingMixin):
     @provide_session
     def get_many(
         cls,
-        execution_date: Optional[pendulum.DateTime] = None,
+        execution_date: Optional[datetime.datetime] = None,
         key: Optional[str] = None,
         task_ids: Optional[Union[str, Iterable[str]]] = None,
         dag_ids: Optional[Union[str, Iterable[str]]] = None,

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from uuid import uuid4
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator, BaseOperatorLink, TaskInstance
+from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.amazon.aws.hooks.emr import EmrHook
 
 if TYPE_CHECKING:
@@ -238,8 +238,9 @@ class EmrClusterLink(BaseOperatorLink):
         :param dttm: datetime
         :return: url link
         """
-        ti = TaskInstance(task=operator, execution_date=dttm)
-        flow_id = ti.xcom_pull(task_ids=operator.task_id)
+        flow_id = XCom.get_one(
+            key="return_value", dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm
+        )
         return (
             f'https://console.aws.amazon.com/elasticmapreduce/home#cluster-details:{flow_id}'
             if flow_id

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -36,8 +36,7 @@ from google.protobuf.duration_pb2 import Duration
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.taskinstance import TaskInstance
+from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook, DataProcJobBuilder
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.utils import timezone
@@ -59,8 +58,9 @@ class DataprocJobLink(BaseOperatorLink):
     name = "Dataproc Job"
 
     def get_link(self, operator, dttm):
-        ti = TaskInstance(task=operator, execution_date=dttm)
-        job_conf = ti.xcom_pull(task_ids=operator.task_id, key="job_conf")
+        job_conf = XCom.get_one(
+            key="job_conf", dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm
+        )
         return (
             DATAPROC_JOB_LOG_LINK.format(
                 job_id=job_conf["job_id"],
@@ -78,8 +78,9 @@ class DataprocClusterLink(BaseOperatorLink):
     name = "Dataproc Cluster"
 
     def get_link(self, operator, dttm):
-        ti = TaskInstance(task=operator, execution_date=dttm)
-        cluster_conf = ti.xcom_pull(task_ids=operator.task_id, key="cluster_conf")
+        cluster_conf = XCom.get_one(
+            key="cluster_conf", dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm
+        )
         return (
             DATAPROC_CLUSTER_LINK.format(
                 cluster_name=cluster_conf["cluster_name"],

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -22,8 +22,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.taskinstance import TaskInstance
+from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.google.cloud.hooks.mlengine import MLEngineHook
 
 if TYPE_CHECKING:
@@ -980,8 +979,9 @@ class AIPlatformConsoleLink(BaseOperatorLink):
     name = "AI Platform Console"
 
     def get_link(self, operator, dttm):
-        task_instance = TaskInstance(task=operator, execution_date=dttm)
-        gcp_metadata_dict = task_instance.xcom_pull(task_ids=operator.task_id, key="gcp_metadata")
+        gcp_metadata_dict = XCom.get_one(
+            key="gcp_metadata", dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm
+        )
         if not gcp_metadata_dict:
             return ''
         job_id = gcp_metadata_dict['job_id']

--- a/airflow/providers/qubole/operators/qubole.py
+++ b/airflow/providers/qubole/operators/qubole.py
@@ -21,8 +21,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from airflow.hooks.base import BaseHook
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.taskinstance import TaskInstance
+from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.qubole.hooks.qubole import (
     COMMAND_ARGS,
     HYPHEN_ARGS,
@@ -48,7 +47,6 @@ class QDSLink(BaseOperatorLink):
         :param dttm: datetime
         :return: url link
         """
-        ti = TaskInstance(task=operator, execution_date=dttm)
         conn = BaseHook.get_connection(
             getattr(operator, "qubole_conn_id", None)
             or operator.kwargs['qubole_conn_id']  # type: ignore[attr-defined]
@@ -57,7 +55,9 @@ class QDSLink(BaseOperatorLink):
             host = re.sub(r'api$', 'v2/analyze?command_id=', conn.host)
         else:
             host = 'https://api.qubole.com/v2/analyze?command_id='
-        qds_command_id = ti.xcom_pull(task_ids=operator.task_id, key='qbol_cmd_id')
+        qds_command_id = XCom.get_one(
+            key='qbol_cmd_id', dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm
+        )
         url = host + str(qds_command_id) if qds_command_id else ''
         return url
 


### PR DESCRIPTION
Given that there is now a foreign key constraint between `TaskInstance` and `DagRun`, ideally ad hoc `TaskInstance` objects shouldn't be created within operator links. See [this comment](https://github.com/apache/airflow/pull/21192#discussion_r795007832).

Almost all of the existing operator links can be refactored to using `XCom.get_one()` to pull the necessary `XCom` to generate the URL needed.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
