### PR TITLE
Have sshd send logs/output to stderr

### DIFF
--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -166,7 +166,8 @@ ln -s -f ~/.ssh/authorized_keys ~/.ssh/authorized_keys2
 chmod 600 ~/.ssh/*
 
 # SSH Service
-sudo service ssh restart >/dev/null 2>&1
+install -d /run/sshd
+/usr/sbin/sshd -e -D &
 
 # Sometimes the server is not quick enough to load the keys!
 while [[ $(ssh-keyscan -H localhost 2>/dev/null | wc -l) != "3" ]] ; do


### PR DESCRIPTION
We don't need to detatch or background it, as sshd does that by default


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).