### PR TITLE
Update stat_name_handler documentation

### DIFF
--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -50,7 +50,7 @@ the metrics that start with the elements of the list:
     statsd_allow_list = scheduler,executor,dagrun
 
 If you want to redirect metrics to different name, you can configure ``stat_name_handler`` option
-in ``[scheduler]`` section.  It should point to a function that validates the StatsD stat name, applies changes
+in ``[metrics]`` section.  It should point to a function that validates the StatsD stat name, applies changes
 to the stat name if necessary, and returns the transformed stat name. The function may looks as follow:
 
 .. code-block:: python


### PR DESCRIPTION
Previously stat_name_handler was under the scheduler section of the
configuration but it was moved to the metrics section since 2.0.0. This
MR is a very small fix to the documentation reflecting this change.