### PR TITLE
Fix tests for mssql after SQLA 1.4 upgrade

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -215,6 +215,9 @@ class ExternalTaskSensor(BaseSensorOperator):
         """
         TI = TaskInstance
         DR = DagRun
+        if not dttm_filter:
+            return 0
+
         if self.external_task_ids:
             count = (
                 session.query(func.count())  # .count() is inefficient


### PR DESCRIPTION
The way SQLA 1.4 constructed the query then `exeuction_date.in_([])`
changed, and as a result it started failing.

But we don't even need to ask the database in this case, as we know it
won't return any rows.

The error was this

```
tests/sensors/test_external_task_sensor.py::test_external_task_marker_clear_activate: sqlalchemy.exc.DataError: (pyodbc.DataError) ('22018', '[22018] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Operand type clash: datetime2 is incompatible with int (206) (SQLExecDirectW)')
[SQL: SELECT count(*) AS count_1 
FROM task_instance 
WHERE task_instance.dag_id = ? AND task_instance.task_id IN (?) AND task_instance.state IN (?) AND (EXISTS (SELECT 1 
FROM dag_run 
WHERE dag_run.dag_id = task_instance.dag_id AND dag_run.run_id = task_instance.run_id AND dag_run.execution_date IN (SELECT 1 WHERE 1!=1)))]
[parameters: ('parent_dag_0', 'task_0', <TaskInstanceState.SUCCESS: 'success'>)]
(Background on this error at: http://sqlalche.me/e/14/9h9h)
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).