### PR TITLE
Fixed PostgresToGCSOperator fail on empty resultset for use_server_side_cursor=True

### DIFF
--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -41,22 +41,27 @@ class _PostgresServerSideCursorDecorator:
 
     def __init__(self, cursor):
         self.cursor = cursor
+        self.rows = []
         self.initialized = False
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        self.initialized = True
-        return next(self.cursor)
+        if self.rows:
+            return self.rows.pop()
+        else:
+            self.initialized = True
+            return next(self.cursor)
 
     @property
     def description(self):
-        """Fetch a row to initialize cursor's `description` attribute when server side cursor is used."""
+        """Fetch first row to initialize cursor description when using server side cursor."""
         if not self.initialized:
+            element = self.cursor.fetchone()
+            if element is not None:
+                self.rows.append(element)
             self.initialized = True
-            self.cursor.fetchone()
-            self.cursor.scroll(0, mode='absolute')
         return self.cursor.description
 
 

--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -41,26 +41,22 @@ class _PostgresServerSideCursorDecorator:
 
     def __init__(self, cursor):
         self.cursor = cursor
-        self.rows = []
         self.initialized = False
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        if self.rows:
-            return self.rows.pop()
-        else:
-            self.initialized = True
-            return next(self.cursor)
+        self.initialized = True
+        return next(self.cursor)
 
     @property
     def description(self):
-        """Fetch first row to initialize cursor description when using server side cursor."""
+        """Fetch a row to initialize cursor's `description` attribute when server side cursor is used."""
         if not self.initialized:
-            element = self.cursor.fetchone()
-            self.rows.append(element)
             self.initialized = True
+            self.cursor.fetchone()
+            self.cursor.scroll(0, mode='absolute')
         return self.cursor.description
 
 


### PR DESCRIPTION
Attribute `description` of simple psycopg2 cursor is available after `.execute()` method.  
But for the named cursor (server-side cursor) any `.fetch*` method call is needed.

In case of an empty result set like `.execute("SELECT 1 LIMIT 0")`:
- for the simple cursor, there are initialized `.description` and an empty iterator
- for the server-side cursor, there are not initialized `.description`and an empty original iterator.
But also we have `self.rows=[None]`, as a result of `fetchone()` on an empty iterator of the server-side cursor. 
This `None` makes `_PostgresServerSideCursorDecorator` non-empty iterator.

~~I decided to remove `rows` attribute because it could consist of a maximum of one row, and also psycopg2 server-side cursor have `.scroll()` method and it is safe to call `.scroll()` on empty resultset even without `.fetchone()`~~

closes #20007
