### PR TITLE
Fix `oauth_whitelists` in BaseSecurityManager

### DIFF
--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -107,7 +107,7 @@ class BaseSecurityManager:
     """ Flask-OAuth """
     oauth_remotes: Dict[str, Any]
     """ OAuth email whitelists """
-    oauth_whitelists: Dict[str, List]
+    oauth_whitelists: Dict[str, List] = {}
     """ Initialized (remote_app) providers dict {'provider_name', OBJ } """
 
     @staticmethod


### PR DESCRIPTION
Recent typing changes in `BaseSecurityManager` broke oauth integrations. This fixes it by initializing `oauth_whitelists` as an empty dict, like it is in FAB.

Without a whitelist:
```
  File "/Users/jedc/Envs/af/lib/python3.7/site-packages/flask_appbuilder/security/views.py", line 674, in oauth_authorized
    if provider in self.appbuilder.sm.oauth_whitelists:
AttributeError: 'AirflowSecurityManager' object has no attribute 'oauth_whitelists'
```

With a whitelist:
```
  File "/Users/jedc/github/airflow/airflow/www/fab_security/manager.py", line 238, in __init__               
    self.oauth_whitelists[provider_name] = _provider["whitelist"]                              
AttributeError: 'AirflowSecurityManager' object has no attribute 'oauth_whitelists'
```