### PR TITLE
Chart: Update git-sync to v3.4.0

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   initContainers:
     - name: git-sync
-      image: "k8s.gcr.io/git-sync/git-sync:v3.3.0"
+      image: "k8s.gcr.io/git-sync/git-sync:v3.4.0"
       env:
         - name: GIT_SYNC_BRANCH
           value: "v2-2-stable"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -646,7 +646,7 @@
                         "tag": {
                             "description": "The gitSync image tag.",
                             "type": "string",
-                            "default": "v3.3.0"
+                            "default": "v3.4.0"
                         },
                         "pullPolicy": {
                             "description": "The gitSync image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -90,7 +90,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: k8s.gcr.io/git-sync/git-sync
-    tag: v3.3.0
+    tag: v3.4.0
     pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.


### PR DESCRIPTION
The PR updates git-sync container version from v3.3.0 to v3.4.0 which addresses a few vulnerabilities from base image.