### PR TITLE
Update boto3 to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ alibaba = [
     'oss2>=2.14.0',
 ]
 amazon = [
-    'boto3>=1.15.0,<1.19.0',
+    'boto3>=1.15.0,<2.0.0',
     'watchtower~=2.0.1',
     'jsonpath_ng>=1.5.3',
     'redshift_connector~=2.0.888',


### PR DESCRIPTION
boto3's latest release is `1.20.48`, but is currently constrained to be `<1.19.0`. 

There was no reason given for pinning to `<1.19.0` in https://github.com/apache/airflow/pull/18389, and that PR was just bumping the pinning from `<1.18.0` to `<1.19.0`. 

Most other packages that are preemptively constrained to be less than a certain release are pinned to be less than a _major_ release. This PR updates boto3 to follow that convention.

The `<1.19.0` constraint is in conflict with `awswrangler`'s latest release. https://github.com/awslabs/aws-data-wrangler/blob/e8cba42922626b6dfe4ea50c0e1498a3be9def79/pyproject.toml#L31

A discussion of another Airflow user encountering this issue, and @potiuk 's recommendation to try this PR, is here: https://github.com/apache/airflow/discussions/20340

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
