### PR TITLE
Fix BigQuery system test

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
@@ -193,7 +193,7 @@ with models.DAG(
         task_id="update_table",
         dataset_id=DATASET_NAME,
         table_id="test_table",
-        fields=["emp_name", "salary"],
+        fields=["friendlyName", "description"],
         table_resource={
             "friendlyName": "Updated Table",
             "description": "Updated Table",

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1079,6 +1079,10 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             self.table_resource = None
         else:
             self.table_resource = table_resource
+            self.bucket = ""
+            self.source_objects = []
+            self.schema_object = None
+            self.destination_project_dataset_table = ""
 
         if table_resource and kwargs_passed:
             raise ValueError("You provided both `table_resource` and exclusive keywords arguments.")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In our BigQuery system test we have a wrong configuration for `BigQueryUpdateTableOperator`. For this operator in `fields` parameter we should type parameters from `table_resource` which we want to update in current table and in `table_resource` you should point a new value for these parameters.

For `BigQueryCreateExternalTableOperator` we have problem with `template_fields`. Parameters from `template_fields` should be assign to `self.*`. Some of them under the if-clause and in some cases are not assigned.

Co-authored-by: Wojciech Januszek [januszek@google.com](mailto:januszek@google.com)
Co-authored-by: Lukasz Wyszomirski [wyszomirski@google.com](mailto:wyszomirski@google.com)
Co-authored-by: Maksim Yermakou [maksimy@google.com](mailto:maksimy@google.com)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
