### PR TITLE
[WIP] SparkKubernetesOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -213,6 +213,32 @@ class KubernetesHook(BaseHook):
         except client.rest.ApiException as e:
             raise AirflowException(f"Exception when calling -> create_custom_object: {e}\n")
 
+    def delete_custom_object(
+        self, group: str, version: str, plural: str, body: Union[str, dict], namespace: Optional[str] = None
+    ):
+        """
+        Delete custom resource definition object in Kubernetes
+
+        :param group: api group
+        :param version: api version
+        :param plural: api plural
+        :param body: crd object definition
+        :param namespace: kubernetes namespace
+        """
+        api = client.CustomObjectsApi(self.api_client)
+        if namespace is None:
+            namespace = self.get_namespace()
+        if isinstance(body, str):
+            body = _load_body_to_dict(body)
+        try:
+            response = api.delete_namespaced_custom_object(
+                group=group, version=version, namespace=namespace, plural=plural, body=body
+            )
+            self.log.debug("Response: %s", response)
+            return response
+        except client.rest.ApiException as e:
+            raise AirflowException(f"Exception when calling -> create_custom_object: {e}\n")
+
     def get_custom_object(
         self, group: str, version: str, plural: str, name: str, namespace: Optional[str] = None
     ):

--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -73,3 +73,14 @@ class SparkKubernetesOperator(BaseOperator):
             namespace=self.namespace,
         )
         return response
+
+    def on_kill(self) -> None:
+        self.log.info("Deleting sparkApplication")
+        hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
+        hook.delete_custom_object(
+            group=self.api_group,
+            version=self.api_version,
+            plural="sparkapplications",
+            body=self.application_file,
+            namespace=self.namespace,
+        )

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -180,6 +180,31 @@ class TestKubernetesHook:
 
     @patch("kubernetes.config.kube_config.KubeConfigLoader")
     @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch(
+        "airflow.providers.cncf.kubernetes.hooks.kubernetes.client."
+        "CustomObjectsApi.delete_namespaced_custom_object"
+    )
+    def test_delete_custom_object(
+        self, mock_delete_custom_object, mock_kube_config_merger, mock_kube_config_loader
+    ):
+        kubernetes_hook = KubernetesHook(conn_id='default_kube_config')
+        kubernetes_hook.delete_custom_object(
+            group="test-group",
+            version="test-version",
+            plural="test-plural",
+            body="test-body",
+            namespace="test-namespace",
+        )
+        mock_delete_custom_object.assert_called_once_with(
+            group="test-group",
+            version="test-version",
+            plural="test-plural",
+            body="test-body",
+            namespace="test-namespace",
+        )
+
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
     @patch("kubernetes.config.kube_config.KUBE_CONFIG_DEFAULT_LOCATION", "/mock/config")
     def test_default_kube_config_connection(self, mock_kube_config_merger, mock_kube_config_loader):
         kubernetes_hook = KubernetesHook(conn_id='default_kube_config')


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
related: #21325

There are two issues on `SparkKubernetesOperator`  listed here:
1. based on this [question](https://stackoverflow.com/questions/70902485/airflow-sparkkubernetesoperator-logging) on stackoverflow, the operator does not watch the whole process of the job unlike other operator/transformations that monitors the job and change status of the task based on that.
2. It needs to write `on_kill` method on the operator in order to kill spark driver and executors in case of receiving `SIGTERM` signal. 