### PR TITLE
Rewrite decorated task mapping

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1870,9 +1870,9 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
 
         return ret
 
-    def create_unmapped_operator(self, dag: "DAG", kwargs: Dict[str, Any]) -> BaseOperator:
+    def create_unmapped_operator(self, dag: "DAG") -> BaseOperator:
         assert not isinstance(self.operator_class, str)
-        return self.operator_class(dag=dag, task_id=self.task_id, **kwargs)
+        return self.operator_class(dag=dag, task_id=self.task_id, **self.partial_kwargs, **self.mapped_kwargs)
 
     def unmap(self) -> BaseOperator:
         """Get the "normal" Operator after applying the current mapping"""
@@ -1880,7 +1880,7 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
         if not dag:
             raise RuntimeError("Cannot unmap a task unless it has a DAG")
         dag._remove_task(self.task_id)
-        return self.create_unmapped_operator(dag, {**self.partial_kwargs, **self.mapped_kwargs})
+        return self.create_unmapped_operator(dag)
 
 
 # TODO: Deprecate for Airflow 3.0

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -82,7 +82,6 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 
 if TYPE_CHECKING:
-    from airflow.decorators.base import _TaskDecorator
     from airflow.models.dag import DAG
     from airflow.utils.task_group import TaskGroup
 
@@ -243,7 +242,7 @@ class BaseOperatorMeta(abc.ABCMeta):
         return new_cls
 
     # The class level partial function. This is what handles the actual mapping
-    def partial(cls, *, task_id: str, dag: Optional["DAG"] = None, **kwargs):
+    def partial(cls, *, task_id: str, dag: Optional["DAG"] = None, **kwargs) -> "MappedOperator":
         operator_class = cast("Type[BaseOperator]", cls)
         # Validate that the args we passed are known -- at call/DAG parse time, not run time!
         _validate_kwarg_names_for_mapping(operator_class, "partial", kwargs)
@@ -1632,7 +1631,7 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
             dag._remove_task(operator.task_id)
 
         operator_init_kwargs: dict = operator._BaseOperator__init_kwargs  # type: ignore
-        return MappedOperator(
+        return cls(
             operator_class=type(operator),
             task_id=operator.task_id,
             task_group=task_group,
@@ -1647,37 +1646,6 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
             max_active_tis_per_dag=operator.max_active_tis_per_dag,
             deps=cls._deps(operator.deps),
         )
-
-    @classmethod
-    def from_decorator(
-        cls,
-        *,
-        decorator: "_TaskDecorator",
-        dag: Optional["DAG"],
-        task_group: Optional["TaskGroup"],
-        task_id: str,
-        mapped_kwargs: Dict[str, Any],
-    ) -> "MappedOperator":
-        """Create a mapped operator from a task decorator.
-
-        Different from ``from_operator``, this DOES NOT validate ``mapped_kwargs``.
-        The task decorator calling this should be responsible for validation.
-        """
-        from airflow.models.xcom_arg import XComArg
-
-        operator = MappedOperator(
-            operator_class=decorator.operator_class,
-            partial_kwargs=decorator.kwargs,
-            mapped_kwargs={},
-            task_id=task_id,
-            dag=dag,
-            task_group=task_group,
-            deps=cls._deps(decorator.operator_class.deps),
-        )
-        operator.mapped_kwargs.update(mapped_kwargs)
-        for arg in mapped_kwargs.values():
-            XComArg.apply_upstream_relationship(operator, arg)
-        return operator
 
     @classmethod
     def _deps(cls, deps: Iterable[BaseTIDep]):
@@ -1902,22 +1870,17 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
 
         return ret
 
+    def create_unmapped_operator(self, dag: "DAG", kwargs: Dict[str, Any]) -> BaseOperator:
+        assert not isinstance(self.operator_class, str)
+        return self.operator_class(dag=dag, task_id=self.task_id, **kwargs)
+
     def unmap(self) -> BaseOperator:
         """Get the "normal" Operator after applying the current mapping"""
-        assert not isinstance(self.operator_class, str)
-
         dag = self.get_dag()
         if not dag:
-            raise RuntimeError("Cannot unmapp a task unless it has a dag")
-
-        args = {
-            **self.partial_kwargs,
-            **self.mapped_kwargs,
-        }
+            raise RuntimeError("Cannot unmap a task unless it has a DAG")
         dag._remove_task(self.task_id)
-        task = self.operator_class(task_id=self.task_id, dag=self.dag, **args)
-
-        return task
+        return self.create_unmapped_operator(dag, {**self.partial_kwargs, **self.mapped_kwargs})
 
 
 # TODO: Deprecate for Airflow 3.0

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1717,7 +1717,7 @@ class MappedOperator(Operator, LoggingMixin, DAGNode):
     @classmethod
     def get_serialized_fields(cls):
         if cls.__serialized_fields is None:
-            fields_dict = attr.fields_dict(cls)
+            fields_dict = attr.fields_dict(MappedOperator)
             cls.__serialized_fields = frozenset(
                 fields_dict.keys()
                 - {

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1713,7 +1713,7 @@ class TaskInstance(Base, LoggingMixin):
         test_mode: Optional[bool] = None,
         force_fail: bool = False,
         error_file: Optional[str] = None,
-        session=NEW_SESSION,
+        session: Session = NEW_SESSION,
     ) -> None:
         """Handle Failure for the TaskInstance"""
         if test_mode is None:

--- a/tests/dags/test_mapped_taskflow.py
+++ b/tests/dags/test_mapped_taskflow.py
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow import DAG
+from airflow.utils.dates import days_ago
+
+with DAG(dag_id='test_mapped_taskflow', start_date=days_ago(2)) as dag:
+
+    @dag.task
+    def make_list():
+        return [1, 2, {'a': 'b'}]
+
+    @dag.task
+    def consumer(value):
+        print(repr(value))
+
+    consumer.map(value=make_list())

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -17,7 +17,7 @@
 # under the License.
 import sys
 from collections import namedtuple
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Dict  # noqa: F401  # This is used by annotation tests.
 from typing import Tuple
 
@@ -548,3 +548,20 @@ def test_partial_mapped_decorator() -> None:
     }
 
     assert doubled.operator is not trippled.operator
+
+
+def test_mapped_decorator_unmap_merge_op_kwargs():
+    with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
+
+        @task_decorator
+        def task1():
+            ...
+
+        @task_decorator
+        def task2(arg1, arg2):
+            ...
+
+        task2.partial(arg1=1).map(arg2=task1())
+
+    unmapped = dag.get_task("task2").unmap()
+    assert set(unmapped.op_kwargs) == {"arg1", "arg2"}

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -532,20 +532,10 @@ def test_partial_mapped_decorator() -> None:
     assert isinstance(doubled, XComArg)
     assert isinstance(doubled.operator, MappedOperator)
     assert doubled.operator.mapped_kwargs == {"op_args": [], "op_kwargs": {"number": literal}}
-    assert doubled.operator.partial_kwargs == {
-        "python_callable": product.function,
-        "multiple_outputs": False,
-        "op_args": [],
-        "op_kwargs": {"multiple": 2},
-    }
+    assert doubled.operator.partial_kwargs == {"op_args": [], "op_kwargs": {"multiple": 2}}
 
     assert isinstance(trippled.operator, MappedOperator)  # For type-checking on partial_kwargs.
-    assert trippled.operator.partial_kwargs == {
-        "python_callable": product.function,
-        "multiple_outputs": False,
-        "op_args": [],
-        "op_kwargs": {"multiple": 3},
-    }
+    assert trippled.operator.partial_kwargs == {"op_args": [], "op_kwargs": {"multiple": 3}}
 
     assert doubled.operator is not trippled.operator
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1519,13 +1519,14 @@ class TestBackfillJob:
         job.run()
         assert executor.job_id is not None
 
-    def test_mapped_dag(self):
+    @pytest.mark.parametrize("dag_id", ["test_mapped_classic", "test_mapped_taskflow"])
+    def test_mapped_dag(self, dag_id):
         """End-to-end test of a simple mapped dag"""
         # Use SequentialExecutor for more predictable test behaviour
         from airflow.executors.sequential_executor import SequentialExecutor
 
-        self.dagbag.process_file(str(TEST_DAGS_FOLDER / 'test_mapped_classic.py'))
-        dag = self.dagbag.get_dag('test_mapped_classic')
+        self.dagbag.process_file(str(TEST_DAGS_FOLDER / f'{dag_id}.py'))
+        dag = self.dagbag.get_dag(dag_id)
 
         # This needs a real executor to run, so that the `make_list` task can write out the TaskMap
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -47,7 +47,13 @@ from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.types import DagRunType
 from tests.models import TEST_DAGS_FOLDER
-from tests.test_utils.db import clear_db_dags, clear_db_pools, clear_db_runs, set_default_pool_slots
+from tests.test_utils.db import (
+    clear_db_dags,
+    clear_db_pools,
+    clear_db_runs,
+    clear_db_xcom,
+    set_default_pool_slots,
+)
 from tests.test_utils.mock_executor import MockExecutor
 from tests.test_utils.timetables import cron_timetable
 
@@ -66,6 +72,7 @@ class TestBackfillJob:
     def clean_db():
         clear_db_dags()
         clear_db_runs()
+        clear_db_xcom()
         clear_db_pools()
 
     @pytest.fixture(autouse=True)
@@ -1512,7 +1519,7 @@ class TestBackfillJob:
         job.run()
         assert executor.job_id is not None
 
-    def test_mapped_dag(self, dag_maker):
+    def test_mapped_dag(self):
         """End-to-end test of a simple mapped dag"""
         # Use SequentialExecutor for more predictable test behaviour
         from airflow.executors.sequential_executor import SequentialExecutor

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1654,6 +1654,59 @@ def test_mapped_operator_xcomarg_serde():
     assert xcom_arg.operator is serialized_dag.task_dict['op1']
 
 
+def test_mapped_decorator_serde():
+    from airflow.decorators import task
+    from airflow.models.xcom_arg import XComArg
+    from airflow.serialization.serialized_objects import _XComRef
+
+    with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
+        op1 = BaseOperator(task_id="op1")
+        xcomarg = XComArg(op1, "my_key")
+
+        @task(retry_delay=30)
+        def x(arg1, arg2, arg3, arg4):
+            print(arg1, arg2, arg3, arg4)
+
+        x.partial("foo", arg3=[1, 2, {"a": "b"}]).map({"a": 1, "b": 2}, arg4=xcomarg)
+
+    original = dag.get_task("x")
+
+    serialized = SerializedBaseOperator._serialize(original)
+    assert serialized == {
+        '_is_dummy': False,
+        '_is_mapped': True,
+        '_task_module': 'airflow.decorators.python',
+        '_task_type': '_PythonDecoratedOperator',
+        'downstream_task_ids': [],
+        'partial_kwargs': {
+            'op_args': ["foo"],
+            'op_kwargs': {'arg3': [1, 2, {"__type": "dict", "__var": {'a': 'b'}}]},
+            'retry_delay': 30,
+        },
+        'mapped_kwargs': {
+            'op_args': [{"__type": "dict", "__var": {'a': 1, 'b': 2}}],
+            'op_kwargs': {'arg4': {'__type': 'xcomref', '__var': {'task_id': 'op1', 'key': 'my_key'}}},
+        },
+        'task_id': 'x',
+        'template_ext': [],
+        'template_fields': ['op_args', 'op_kwargs'],
+    }
+
+    deserialized = SerializedBaseOperator.deserialize_operator(serialized)
+    assert isinstance(deserialized, MappedOperator)
+    assert deserialized.deps is MappedOperator.DEFAULT_DEPS
+
+    assert deserialized.mapped_kwargs == {
+        "op_args": [{"a": 1, "b": 2}],
+        "op_kwargs": {"arg4": _XComRef("op1", "my_key")},
+    }
+    assert deserialized.partial_kwargs == {
+        "retry_delay": 30,
+        "op_args": ["foo"],
+        "op_kwargs": {"arg3": [1, 2, {"a": "b"}]},
+    }
+
+
 def test_mapped_task_group_serde():
     execution_date = datetime(2020, 1, 1)
 


### PR DESCRIPTION
~~Need to get #21210 merged first and rebase this.~~ Done

This rewrites how `map()` is implemented on `_TaskDecorator`. The previous implementation incorrectly assumed mapping a task decorator works like mapping a traditional operator, but in fact they have entirely different semantics.

When mapping a traditional operator, `FooOperator.map(my_arg=[1, 2, 3])`, the argument on _`FooOperator`_ is mapped. But when mapping a task decorator, `my_task.map(my_val=[1, 2, 3])`, it’s the argument on _the function wrapped by the task object_ being mapped. Therefore, mapped (and also partial-ed) values for `my_val` should go into the `DecoratedOperator`’s `op_kwargs` (and `op_args`) arguments instead.

An end-to-end test is provided to validate the simplest case of this. Also fixed a test where the end-to-end test becomes broken after running a DAG (because I need to run a second DAG!)