### PR TITLE
Update test connection functionality to use custom form fields

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -190,29 +190,6 @@ $(document).ready(() => {
   }
 
   /**
-   * Produces JSON stringified data from a html form data
-   *
-   * @param {string} selector Jquery from selector string.
-   * @returns {string} Form data as a JSON string
-   */
-  function getSerializedFormData(selector) {
-    const outObj = {};
-    const inArray = $(selector).serializeArray();
-
-    $.each(inArray, function () {
-      if (this.name === 'conn_id') {
-        outObj.connection_id = this.value;
-      } else if (this.value !== '' && this.name === 'port') {
-        outObj[this.name] = Number(this.value);
-      } else if (this.value !== '' && this.name !== 'csrf_token' && !this.name.match('extra__')) {
-        outObj[this.name] = this.value;
-      }
-    });
-
-    return JSON.stringify(outObj);
-  }
-
-  /**
    * Displays the Flask style alert on UI via JS
    *
    * @param {boolean} status - true for success, false for error
@@ -232,6 +209,70 @@ $(document).ready(() => {
 
       $('.container .row').prepend(alertBox).show();
     }
+  }
+
+  /**
+   * Produces JSON stringified data from a html form data
+   *
+   * @param {string} selector Jquery from selector string.
+   * @returns {string} Form data as a JSON string
+   */
+  function getSerializedFormData(selector) {
+    const outObj = {};
+    const extrasObj = {};
+    const inArray = $(selector).serializeArray();
+
+    /*
+    Form data fields are processed in the below order:
+        - csrf_token
+        - conn_id
+        - conn_type
+        - description
+        - host
+        - schema
+        - login
+        - password
+        - port
+        - extra
+        - All other custom form fields (i.e. fields that are named ``extra__...``) in
+          alphabetical order
+    */
+    $.each(inArray, function () {
+      if (this.name === 'conn_id') {
+        outObj.connection_id = this.value;
+      } else if (this.value !== '' && this.name === 'port') {
+        outObj[this.name] = Number(this.value);
+      } else if (this.value !== '' && this.name !== 'csrf_token') {
+        // Check if there are values in the classic Extra form field. These values come in
+        // stringified and need to be converted to a JSON object in case there are custom form
+        // field values that also need to be included in the ``extra`` object for the output
+        // payload.
+        if (this.name === 'extra') {
+          let extra;
+          try {
+            extra = JSON.parse(this.value);
+          } catch (e) {
+            if (e instanceof SyntaxError) {
+              displayAlert(false, 'Extra field value is not valid JSON.');
+            }
+            throw e;
+          }
+
+          Object.entries(extra).forEach(([key, val]) => {
+            extrasObj[key] = val;
+          });
+        // Check if field is a custom form field.
+        } else if (this.name.startsWith('extra__')) {
+          extrasObj[this.name] = this.value;
+        } else {
+          outObj[this.name] = this.value;
+        }
+      }
+    });
+
+    // Stringify all extras for the AJAX call payload.
+    outObj.extra = JSON.stringify(extrasObj);
+    return JSON.stringify(outObj);
   }
 
   // Bind click event to Test Connection button & perform an AJAX call via REST API


### PR DESCRIPTION
Closes: #21188

Currently the test connection functionality in the UI doesn't account for custom form fields. This PR intends to include custom form fields as part of the testing mechanism.

| Before | After |
| -------- | ------- |
| ![image](https://user-images.githubusercontent.com/48934154/152560015-90986c3e-e3a4-4191-a749-f59e4e6e9c1e.png) | ![image](https://user-images.githubusercontent.com/48934154/152560749-6a0da10f-b83e-491c-b9d1-90d9f6eba99f.png) |

When testing, if the `Extra` field is not a valid JSON, an error message is displayed to the user to help provide some direction. (The simple JSON parsing check doesn't _definitively_ assess whether the value is valid JSON but the edge cases like `true`, `{false}`, `1`, etc. would be effectively useless for the connection anyway. Thinking providing some feedback to users was valuable here especially for syntax errors of manually entering a JSON object.)

![image](https://user-images.githubusercontent.com/48934154/152569773-16084760-cf98-4e60-b679-b0370439c303.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
