### PR TITLE
Fix the hyperlink between anchors in the contribution guideline

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,7 +198,7 @@ Step 2: Configure Your Environment
 ----------------------------------
 
 You can use either a local virtual env or a Docker-based env. The differences
-between the two are explained `here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments/>`__.
+between the two are explained `here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments>`__.
 
 
 The local env's instructions can be found in full in the `LOCAL_VIRTUALENV.rst`_ file.


### PR DESCRIPTION
The last slash in the link will invalidate the anchor.