### PR TITLE
<doc>(docker-compose): add a config for M1 developer to build image

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -30,6 +30,7 @@ services:
 
   mysql:
     image: mysql:${MYSQL_VERSION}
+    # platform: linux/amd64  # uncomment this line if you're using mac M1
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_ROOT_HOST=%


### PR DESCRIPTION
Why: I was setting up breeze on my M1 mac and bumped into this issue

Tested by: add the platform flag and then `./breeze --python 3.8 --backend mysql` works fine

Links: https://github.com/apache/airflow/blob/main/CONTRIBUTORS_QUICK_START.rst#setting-up-breeze-1