### PR TITLE
Switch from zdesk to zenpy in ZendeskHook

### DIFF
--- a/airflow/hooks/zendesk_hook.py
+++ b/airflow/hooks/zendesk_hook.py
@@ -19,7 +19,7 @@
 
 import warnings
 
-from airflow.providers.zendesk.hooks.zendesk import Zendesk, ZendeskError, ZendeskHook  # noqa
+from airflow.providers.zendesk.hooks.zendesk import ZendeskHook  # noqa
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.zendesk.hooks.zendesk`.",

--- a/airflow/providers/zendesk/CHANGELOG.rst
+++ b/airflow/providers/zendesk/CHANGELOG.rst
@@ -19,6 +19,19 @@
 Changelog
 ---------
 
+2.0.2
+.....
+
+Misc
+~~~
+``ZendeskHook`` moved from using ``zdesk`` to ``zenpy`` package.
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+Changed the return type of ``ZendeskHook.get_conn`` to return a ``zenpy.Zenpy`` object instead of a ``zdesk.Zendesk`` object.
+Changed the return type of ``ZendeskHook.call`` to return a ``zenpy.lib.api_objects.BaseObject`` instead of a dictionary.
+``Zendesk`` and ``ZendeskError`` classes are removed from ``airflow.hooks.zendesk_hook`` imports.
+
 2.0.1
 .....
 

--- a/airflow/providers/zendesk/CHANGELOG.rst
+++ b/airflow/providers/zendesk/CHANGELOG.rst
@@ -19,7 +19,7 @@
 Changelog
 ---------
 
-2.0.2
+3.0.0
 .....
 
 Misc
@@ -29,7 +29,7 @@ Misc
 Breaking changes
 ~~~~~~~~~~~~~~~~
 Changed the return type of ``ZendeskHook.get_conn`` to return a ``zenpy.Zenpy`` object instead of a ``zdesk.Zendesk`` object.
-Changed the return type of ``ZendeskHook.call`` to return a ``zenpy.lib.api_objects.BaseObject`` instead of a dictionary.
+Deleted the ``ZendeskHook.call``, alternatively you can use the ``ZendeskHook.get`` method to make custom get calls to Zendesk API.
 ``Zendesk`` and ``ZendeskError`` classes are removed from ``airflow.hooks.zendesk_hook`` imports.
 
 2.0.1

--- a/airflow/providers/zendesk/example_dags/__init__.py
+++ b/airflow/providers/zendesk/example_dags/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/zendesk/example_dags/example_zendesk_custom_get.py
+++ b/airflow/providers/zendesk/example_dags/example_zendesk_custom_get.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from typing import Dict, List
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
+
+
+def zendesk_custom_get_request() -> List[Dict]:
+    hook = ZendeskHook()
+    response = hook.get(
+        url="https://yourdomain.zendesk.com/api/v2/organizations.json",
+    )
+    return [org.to_dict() for org in response]
+
+
+with DAG(
+    dag_id="zendesk_custom_get_dag",
+    schedule_interval=None,
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
+    fetch_organizations = PythonOperator(
+        task_id="trigger_zendesk_hook",
+        python_callable=zendesk_custom_get_request,
+    )

--- a/airflow/providers/zendesk/hooks/zendesk.py
+++ b/airflow/providers/zendesk/hooks/zendesk.py
@@ -44,8 +44,6 @@ class ZendeskHook(BaseHook):
         zenpy_client, url = self._init_conn()
         self.zenpy_client = zenpy_client
         self.__url = url
-        # Keep reference to the _get method to allow arbitrary endpoint call for
-        # backwards compatibility. (alternative to old ZendeskHook.call method)
         self.get = self.zenpy_client.users._get
 
     def _init_conn(self) -> Tuple[Zenpy, str]:

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Zendesk <https://www.zendesk.com/>`__
 
 versions:
+  - 3.0.0
   - 2.0.1
   - 2.0.0
   - 1.0.1

--- a/docs/apache-airflow-providers-zendesk/index.rst
+++ b/docs/apache-airflow-providers-zendesk/index.rst
@@ -27,6 +27,7 @@ Content
     :caption: References
 
     Python API <_api/airflow/providers/zendesk/index>
+    Example DAGs <https://github.com/apache/airflow/tree/main/airflow/providers/zendesk/example_dags>
     PyPI Repository <https://pypi.org/project/apache-airflow-providers-zendesk/>
     Installing from sources <installing-providers-from-sources>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -583,7 +583,7 @@ autodoc_mock_imports = [
     'tenacity',
     'vertica_python',
     'winrm',
-    'zdesk',
+    'zenpy',
 ]
 
 # The default options for autodoc directives. They are applied to all autodoc directives automatically.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -34,6 +34,7 @@ BackfillJobTest
 Backfills
 Banco
 BaseClient
+BaseObject
 BaseOperator
 BaseView
 BaseXCom
@@ -420,6 +421,7 @@ Yandex
 Yieldr
 Zego
 Zendesk
+Zenpy
 Zsh
 Zymergen
 abc
@@ -1502,5 +1504,6 @@ youtrack
 youtube
 zA
 zendesk
+zenpy
 zope
 zsh

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -203,6 +203,7 @@ Jira
 JobComplete
 JobExists
 JobRunning
+JobStatus
 JobTrigger
 Json
 Jupyter
@@ -329,6 +330,7 @@ SSHTunnelForwarder
 SaaS
 Sagemaker
 Sasl
+SearchResultGenerator
 SecretManagerClient
 Seedlist
 Sendgrid
@@ -383,6 +385,7 @@ Terraform
 TextToSpeechClient
 Tez
 Thinknear
+TicketAudit
 ToC
 Tooltip
 Tunables

--- a/setup.py
+++ b/setup.py
@@ -525,7 +525,7 @@ yandex = [
     'yandexcloud>=0.122.0',
 ]
 zendesk = [
-    'zdesk',
+    'zenpy>=2.0.24',
 ]
 # End dependencies group
 

--- a/tests/providers/zendesk/hooks/test_zendesk.py
+++ b/tests/providers/zendesk/hooks/test_zendesk.py
@@ -16,103 +16,88 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-import unittest
 from unittest import mock
 
 import pytest
-from zdesk import RateLimitError
 
+from airflow.models import Connection
 from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
+from airflow.utils import db
 
 
-class TestZendeskHook(unittest.TestCase):
-    @mock.patch("airflow.providers.zendesk.hooks.zendesk.time")
-    def test_sleeps_for_correct_interval(self, mocked_time):
-        sleep_time = 10
-        # To break out of the otherwise infinite tries
-        mocked_time.sleep = mock.Mock(side_effect=ValueError, return_value=3)
-        conn_mock = mock.Mock()
-        mock_response = mock.Mock()
-        mock_response.headers.get.return_value = sleep_time
-        conn_mock.call = mock.Mock(
-            side_effect=RateLimitError(msg="some message", code="some code", response=mock_response)
+class TestZendeskHook:
+    conn_id = 'zendesk_conn_id_test'
+
+    @pytest.fixture(autouse=True)
+    def init_connection(self):
+        db.merge_conn(
+            Connection(
+                conn_id=self.conn_id,
+                conn_type='zendesk',
+                host='yoursubdomain.zendesk.com',
+                login='user@gmail.com',
+                password='eb243592-faa2-4ba2-a551q-1afdf565c889',
+            )
         )
 
-        zendesk_hook = ZendeskHook("conn_id")
-        zendesk_hook.get_conn = mock.Mock(return_value=conn_mock)
+    def test_hook_init_and_get_conn(self):
+        hook = ZendeskHook(zendesk_conn_id=self.conn_id)
+        zenpy_client = hook.get_conn()
+        # Verify config of zenpy APIs
+        assert zenpy_client.users.subdomain == 'yoursubdomain'
+        assert zenpy_client.users.domain == 'zendesk.com'
+        assert zenpy_client.users.session.auth == ('user@gmail.com', 'eb243592-faa2-4ba2-a551q-1afdf565c889')
+        assert not zenpy_client.cache.disabled
+        assert hook._ZendeskHook__url == 'https://yoursubdomain.zendesk.com'
 
-        with pytest.raises(ValueError):
-            zendesk_hook.call("some_path", get_all_pages=False)
-            mocked_time.sleep.assert_called_once_with(sleep_time)
-
-    @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
-    def test_returns_single_page_if_get_all_pages_false(self, _):
-        zendesk_hook = ZendeskHook("conn_id")
-        mock_connection = mock.Mock()
-        mock_connection.host = "some_host"
-        zendesk_hook.get_connection = mock.Mock(return_value=mock_connection)
-        zendesk_hook.get_conn()
-
-        mock_conn = mock.Mock()
-        mock_call = mock.Mock(return_value={'next_page': 'https://some_host/something', 'path': []})
-        mock_conn.call = mock_call
-        zendesk_hook.get_conn = mock.Mock(return_value=mock_conn)
-        zendesk_hook.call("path", get_all_pages=False)
-        mock_call.assert_called_once_with("path", {})
-
-    @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
-    def test_returns_multiple_pages_if_get_all_pages_true(self, _):
-        zendesk_hook = ZendeskHook("conn_id")
-        mock_connection = mock.Mock()
-        mock_connection.host = "some_host"
-        zendesk_hook.get_connection = mock.Mock(return_value=mock_connection)
-        zendesk_hook.get_conn()
-
-        mock_conn = mock.Mock()
-        mock_call = mock.Mock(return_value={'next_page': 'https://some_host/something', 'path': []})
-        mock_conn.call = mock_call
-        zendesk_hook.get_conn = mock.Mock(return_value=mock_conn)
-        zendesk_hook.call("path", get_all_pages=True)
-        assert mock_call.call_count == 2
-
-    @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
-    def test_zdesk_is_inited_correctly(self, mock_zendesk):
-        conn_mock = mock.Mock()
-        conn_mock.host = "conn_host"
-        conn_mock.login = "conn_login"
-        conn_mock.password = "conn_pass"
-
-        zendesk_hook = ZendeskHook("conn_id")
-        zendesk_hook.get_connection = mock.Mock(return_value=conn_mock)
-        zendesk_hook.get_conn()
-        mock_zendesk.assert_called_once_with(
-            zdesk_url='https://conn_host',
-            zdesk_email='conn_login',
-            zdesk_password='conn_pass',
-            zdesk_token=True,
-        )
-
-    @mock.patch("airflow.providers.zendesk.hooks.zendesk.Zendesk")
-    def test_zdesk_sideloading_works_correctly(self, mock_zendesk):
-        zendesk_hook = ZendeskHook("conn_id")
-        mock_connection = mock.Mock()
-        mock_connection.host = "some_host"
-        zendesk_hook.get_connection = mock.Mock(return_value=mock_connection)
-        zendesk_hook.get_conn()
-
-        mock_conn = mock.Mock()
-        mock_call = mock.Mock(
-            return_value={
-                'next_page': 'https://some_host/something',
-                'tickets': [],
-                'users': [],
-                'groups': [],
-            }
-        )
-        mock_conn.call = mock_call
-        zendesk_hook.get_conn = mock.Mock(return_value=mock_conn)
-        results = zendesk_hook.call(
-            ".../tickets.json", query={"include": "users,groups"}, get_all_pages=False, side_loading=True
-        )
-        assert results == {'groups': [], 'users': [], 'tickets': []}
+    @pytest.mark.parametrize(
+        "call_params,expected_params",
+        [
+            (
+                {
+                    "path": 'api/v2/users/1/tickets.json',
+                    "query": {'query_param1': 'value1', "query_param2": "value2"},
+                },
+                {
+                    "url": "https://yoursubdomain.zendesk.com/api/v2/users/1/tickets" ".json",
+                    "params": {'query_param1': 'value1', "query_param2": "value2"},
+                },
+            ),
+            (
+                {
+                    "path": 'api/v2/users/1/tickets.json',
+                    "query": {'query_param1': 'value1', "query_param2": "value2"},
+                    "extra_param1": 'extra_value1',
+                    "extra_param2": 'extra_value2',
+                },
+                {
+                    "url": "https://yoursubdomain.zendesk.com/api/v2/users/1/tickets" ".json",
+                    "params": {'query_param1': 'value1', "query_param2": "value2"},
+                    "extra_param1": 'extra_value1',
+                    "extra_param2": 'extra_value2',
+                },
+            ),
+            (
+                {
+                    "path": '/api/v2/users/1/tickets.json',
+                    "query": {'query_param1': 'value1', "query_param2": "value2"},
+                },
+                {
+                    "url": "https://yoursubdomain.zendesk.com/api/v2/users/1/tickets" ".json",
+                    "params": {'query_param1': 'value1', "query_param2": "value2"},
+                },
+            ),
+            (
+                {
+                    "path": '/api/v2/users/1/tickets.json',
+                },
+                {"url": "https://yoursubdomain.zendesk.com/api/v2/users/1/tickets" ".json", "params": None},
+            ),
+        ],
+    )
+    def test_hook_custom_get_request(self, call_params, expected_params):
+        hook = ZendeskHook(zendesk_conn_id=self.conn_id)
+        mock_get = mock.Mock()
+        hook._get = mock_get
+        hook.call(**call_params)
+        mock_get.assert_called_once_with(**expected_params)


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/8937

This pull request changes `ZendeskHook` to use `zenpy` package instead of `zdesk`.

I tried to introduce as little breaking changes as possible. We keep the ability to make 'custom' get request via the `call` method.
 
Starting from here we can then add specific methods for each resource using dedicated zenpy APIs. (accessible trough zenpy's client e.g: users, tickets, organizations etc.). But I think this goes beyond the scope of this PR.

Let me know what you think.

> Note: Zenpy is now taking care of the rate limiting for us