### PR TITLE
Bug fix in AWS glue operator related to num_of_dpus #19787

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -66,7 +66,7 @@ class GlueJobOperator(BaseOperator):
         concurrent_run_limit: Optional[int] = None,
         script_args: Optional[dict] = None,
         retry_limit: int = 0,
-        num_of_dpus: int = 6,
+        num_of_dpus: Optional[int] = None,
         aws_conn_id: str = 'aws_default',
         region_name: Optional[str] = None,
         s3_bucket: Optional[str] = None,

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -103,7 +103,7 @@ class TestGlueJobHook(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
+            msg="ValueError should be raised for specifying the num_of_dpus and worker type together.",
         ):
             GlueJobHook(
                 job_name='aws_test_glue_job',

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -103,7 +103,7 @@ class TestGlueJobHook(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="ValueError should be raised for specifying the num_of_dpus and worker type together.",
+            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
         ):
             GlueJobHook(
                 job_name='aws_test_glue_job',


### PR DESCRIPTION
This pull request is to fix an inconsistency and bug found during testing in #21348. This is an additional fix to the issue solved in #19787.

This pull request is in accordance with https://github.com/apache/airflow/issues/21348#issuecomment-1030723900
In the `AWSGlueJobOperator` (file path: `airflow/providers/amazon/aws/operators/glue.py`), I have changed the default value of `num_of_dpus` from `6` to `None`. 

Without this fix, it becomes inconsistent with the logic changed in the [airflow/providers/amazon/aws/hooks/glue.py](https://github.com/apache/airflow/pull/19787/files#diff-039a9f654ab15c81177e8747d7dd210768a6c3dcb5404be66f4e3c3a7b732c6a). In the `AWSGlueJobOperator` script, if the user does not want to specify the `num_of_dpus`, then also the `__init__` function is default initializing it to `6` (which gives the error below). Currently, to get around it, the user has to specify `num_of_dpus=None` to run without error. This fix solves this issue.

```
File "/Users/opt/anaconda3/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1511, in _execute_task result = execute_callable(context=context)
File "/Users/opt/anaconda3/lib/python3.7/site-packages/airflow/providers/amazon/aws/operators/glue.py", line 123, in execute create_job_kwargs=self.create_job_kwargs, 
File "/Users/opt/anaconda3/lib/python3.7/site-packages/airflow/providers/amazon/aws/hooks/glue.py", line 74, in __init__ raise ValueError("Cannot specify num_of_dpus with custom WorkerType") 
ValueError: Cannot specify num_of_dpus with custom WorkerType [2022-02-05, 16:57:41 UTC] {local_task_job.py:154}
INFO - Task exited with return code 1
```