### PR TITLE
Enable asynchronous job submission in BigQuery Insert Job

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1516,7 +1516,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param project_id: Google Cloud Project where the job is running
         :param location: location the job is running
         :param is_async: specify whether to insert job in asynchronous mode
-        :type is_async: bool
         """
         location = location or self.location
         job_id = job_id or self._custom_job_id(configuration)

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1498,7 +1498,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         job_id: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
-        is_async: Optional[bool] = False,
+        is_async: bool = False,
     ) -> BigQueryJob:
         """
         Executes a BigQuery job. Waits for the job to complete and returns job id.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1498,7 +1498,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         job_id: Optional[str] = None,
         project_id: Optional[str] = None,
         location: Optional[str] = None,
-        is_async: bool = False,
+        nowait: bool = False,
     ) -> BigQueryJob:
         """
         Executes a BigQuery job. Waits for the job to complete and returns job id.
@@ -1515,7 +1515,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             characters. If not provided then uuid will be generated.
         :param project_id: Google Cloud Project where the job is running
         :param location: location the job is running
-        :param is_async: specify whether to insert job in asynchronous mode
+        :param nowait: specify whether to insert job without waiting for the result
         """
         location = location or self.location
         job_id = job_id or self._custom_job_id(configuration)
@@ -1543,8 +1543,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             raise AirflowException(f"Unknown job type. Supported types: {supported_jobs.keys()}")
         job = job.from_api_repr(job_data, client)
         self.log.info("Inserting job %s", job.job_id)
-        if is_async:
-            # In async mode,initiate the job without waiting for the result.
+        if nowait:
+            # Initiate the job and don't wait for it to complete.
             job._begin()
         else:
             # Start the job and wait for it to complete and get the result.

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -177,6 +177,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
                 r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]"
             ),
         ):
+
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -191,6 +192,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             match="schema_update_options is only allowed if"
             " write_disposition is 'WRITE_APPEND' or 'WRITE_TRUNCATE'.",
         ):
+
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -2006,6 +2008,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
 class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_labels(self, mock_insert):
+
         labels = {'label1': 'test1', 'label2': 'test2'}
         self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
@@ -2019,6 +2022,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_description(self, mock_insert):
+
         description = "Test Description"
         self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
@@ -2032,6 +2036,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
     def test_create_external_table_labels(self, mock_create):
+
         labels = {'label1': 'test1', 'label2': 'test2'}
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',
@@ -2045,6 +2050,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
     def test_create_external_table_description(self, mock_create):
+
         description = "Test Description"
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -177,7 +177,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
                 r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]"
             ),
         ):
-
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -192,7 +191,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             match="schema_update_options is only allowed if"
             " write_disposition is 'WRITE_APPEND' or 'WRITE_TRUNCATE'.",
         ):
-
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -945,6 +943,35 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             "and extra__google_cloud_platform__keyfile_dict",
         ):
             self.hook.get_sqlalchemy_engine()
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.QueryJob")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
+    def test_insert_job_with_async(self, mock_client, mock_query_job):
+        job_conf = {
+            "query": {
+                "query": "SELECT * FROM test",
+                "useLegacySql": "False",
+            }
+        }
+        mock_query_job._JOB_TYPE = "query"
+
+        self.hook.insert_job(
+            configuration=job_conf, job_id=JOB_ID, project_id=PROJECT_ID, location=LOCATION, is_async=True
+        )
+
+        mock_client.assert_called_once_with(
+            project_id=PROJECT_ID,
+            location=LOCATION,
+        )
+
+        mock_query_job.from_api_repr.assert_called_once_with(
+            {
+                'configuration': job_conf,
+                'jobReference': {'jobId': JOB_ID, 'projectId': PROJECT_ID, 'location': LOCATION},
+            },
+            mock_client.return_value,
+        )
+        mock_query_job.from_api_repr.return_value._begin.assert_called_once()
 
 
 class TestBigQueryTableSplitter(unittest.TestCase):
@@ -2018,7 +2045,6 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
     def test_create_external_table_description(self, mock_create):
-
         description = "Test Description"
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -898,10 +898,10 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         _, kwargs = mock_insert.call_args
         assert kwargs["configuration"]['labels'] == {'label1': 'test1', 'label2': 'test2'}
 
-    @pytest.mark.parametrize('is_async', [True, False])
+    @pytest.mark.parametrize('nowait', [True, False])
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.QueryJob")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
-    def test_insert_job(self, mock_client, mock_query_job, is_async):
+    def test_insert_job(self, mock_client, mock_query_job, nowait):
         job_conf = {
             "query": {
                 "query": "SELECT * FROM test",
@@ -911,7 +911,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         mock_query_job._JOB_TYPE = "query"
 
         self.hook.insert_job(
-            configuration=job_conf, job_id=JOB_ID, project_id=PROJECT_ID, location=LOCATION, is_async=is_async
+            configuration=job_conf, job_id=JOB_ID, project_id=PROJECT_ID, location=LOCATION, nowait=nowait
         )
 
         mock_client.assert_called_once_with(
@@ -926,7 +926,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             },
             mock_client.return_value,
         )
-        if is_async:
+        if nowait:
             mock_query_job.from_api_repr.return_value._begin.assert_called_once()
             mock_query_job.from_api_repr.return_value.result.assert_not_called()
         else:

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -946,35 +946,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         ):
             self.hook.get_sqlalchemy_engine()
 
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.QueryJob")
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client")
-    def test_insert_job_with_async(self, mock_client, mock_query_job):
-        job_conf = {
-            "query": {
-                "query": "SELECT * FROM test",
-                "useLegacySql": "False",
-            }
-        }
-        mock_query_job._JOB_TYPE = "query"
-
-        self.hook.insert_job(
-            configuration=job_conf, job_id=JOB_ID, project_id=PROJECT_ID, location=LOCATION, is_async=True
-        )
-
-        mock_client.assert_called_once_with(
-            project_id=PROJECT_ID,
-            location=LOCATION,
-        )
-
-        mock_query_job.from_api_repr.assert_called_once_with(
-            {
-                'configuration': job_conf,
-                'jobReference': {'jobId': JOB_ID, 'projectId': PROJECT_ID, 'location': LOCATION},
-            },
-            mock_client.return_value,
-        )
-        mock_query_job.from_api_repr.return_value._begin.assert_called_once()
-
 
 class TestBigQueryTableSplitter(unittest.TestCase):
     def test_internal_need_default_project(self):

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -177,6 +177,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
                 r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]"
             ),
         ):
+
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -191,6 +192,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             match="schema_update_options is only allowed if"
             " write_disposition is 'WRITE_APPEND' or 'WRITE_TRUNCATE'.",
         ):
+
             self.hook.run_load(
                 "test.test",
                 "test_schema.json",
@@ -2003,6 +2005,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
 class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_labels(self, mock_insert):
+
         labels = {'label1': 'test1', 'label2': 'test2'}
         self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
@@ -2016,6 +2019,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_description(self, mock_insert):
+
         description = "Test Description"
         self.hook.run_load(
             destination_project_dataset_table='my_dataset.my_table',
@@ -2029,6 +2033,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
     def test_create_external_table_labels(self, mock_create):
+
         labels = {'label1': 'test1', 'label2': 'test2'}
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',
@@ -2042,6 +2047,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
     def test_create_external_table_description(self, mock_create):
+
         description = "Test Description"
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',


### PR DESCRIPTION
- Add nowait flag to the insert_job method
- When nowait is True, the execution won't wait till the job results are available.
- By default, the job execution will wait till job results are available.

cc @dstandish @kaxil 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
