### PR TITLE
Optionally raise an error if source file does not exist in GCSToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -318,13 +318,12 @@ class GCSToGCSOperator(BaseOperator):
                 self._copy_single_object(
                     hook=hook, source_object=prefix, destination_object=self.destination_object
                 )
-            else:
+            elif self.source_object_required:
                 msg = (
                     f'{prefix} does not exist in bucket {self.source_bucket}'
                 )
                 self.log.warning(msg)
-                if self.source_object_required:
-                    raise AirflowException(msg)
+                raise AirflowException(msg)
 
         for source_obj in objects:
             if self.destination_object is None:

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -90,9 +90,8 @@ class GCSToGCSOperator(BaseOperator):
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
-    :param source_object_required: When source_object_required is True, if you want to copy / move a specific blob
-        and it doesn't exist, an exception is raised and the task is marked as failed.
-        This parameter doesn't have any effect when the source_object that you pass is a folder or pattern.
+    :param source_object_required: Whether you want to raise an exception when the source object
+        doesn't exist. It doesn't have any effect when the source objects are folders or patterns.
 
     :Example:
 
@@ -319,9 +318,7 @@ class GCSToGCSOperator(BaseOperator):
                     hook=hook, source_object=prefix, destination_object=self.destination_object
                 )
             elif self.source_object_required:
-                msg = (
-                    f'{prefix} does not exist in bucket {self.source_bucket}'
-                )
+                msg = f"{prefix} does not exist in bucket {self.source_bucket}"
                 self.log.warning(msg)
                 raise AirflowException(msg)
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -323,7 +323,7 @@ class GCSToGCSOperator(BaseOperator):
                     f'{prefix} does not exist in bucket {self.source_bucket}'
                 )
                 self.log.warning(msg)
-                if self.source_objects_required:
+                if self.source_object_required:
                     raise AirflowException(msg)
 
         for source_obj in objects:

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -556,11 +556,10 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             source_objects=SOURCE_OBJECTS_SINGLE_FILE,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=DESTINATION_OBJECT_PREFIX,
-            source_object_required=True
+            source_object_required=True,
         )
 
         with pytest.raises(
-            AirflowException,
-            match=f"{SOURCE_OBJECTS_SINGLE_FILE} does not exist in bucket {TEST_BUCKET}"
+            AirflowException, match=f"{SOURCE_OBJECTS_SINGLE_FILE} does not exist in bucket {TEST_BUCKET}"
         ):
             operator.execute(None)

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -537,7 +537,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             source_object=SOURCE_OBJECT_WILDCARD_SUFFIX,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=DESTINATION_OBJECT_PREFIX,
-            replace=False
+            replace=False,
         )
 
         operator.execute(None)

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -537,7 +537,7 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             source_object=SOURCE_OBJECT_WILDCARD_SUFFIX,
             destination_bucket=DESTINATION_BUCKET,
             destination_object=DESTINATION_OBJECT_PREFIX,
-            replace=False,
+            replace=False
         )
 
         operator.execute(None)
@@ -546,3 +546,21 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
             mock.call(DESTINATION_BUCKET, prefix="foo/bar", delimiter=""),
         ]
         mock_hook.return_value.list.assert_has_calls(mock_calls)
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook')
+    def test_execute_source_object_required_flag_true(self, mock_hook):
+        mock_hook.return_value.exists.return_value = False
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_objects=SOURCE_OBJECTS_SINGLE_FILE,
+            destination_bucket=DESTINATION_BUCKET,
+            destination_object=DESTINATION_OBJECT_PREFIX,
+            source_object_required=True
+        )
+
+        with pytest.raises(
+            AirflowException,
+            match=f"{SOURCE_OBJECTS_SINGLE_FILE} does not exist in bucket {TEST_BUCKET}"
+        ):
+            operator.execute(None)


### PR DESCRIPTION
Right now when using GCSToGCSOperator to copy a file from one bucket to another, if the source file does not exist, nothing happens and the task is considered successful. This could be good for some use cases, for example, when you want to copy all the files from a directory or that match a specific pattern.
But for some other cases, like when you only want to copy one specific blob, it might be useful to raise an exception if the source file can't be found. Otherwise, the task would be failing silently.

This PR adds the flag "source_object_required" to GCSToGCSOperator to enable this feature. By default, for backward compatibility, the value set to False. If we pass set the flag as True, then, if the source_objects are blobs (not folders or patterns) and they don't exist, the task will fail.

closes: https://github.com/apache/airflow/issues/21388

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
