### PR TITLE
Fix docs link for smart sensor deprecation

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -122,7 +122,7 @@ Note the use of `set` and `datetime` types, which are not JSON-serializable.  Th
 
 Smart sensors, an "early access" feature added in Airflow 2, are now deprecated and will be removed in Airflow 2.4.0. They have been superseded by Deferable Operators, added in Airflow 2.2.0.
 
-See [Migrating to Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/2.3.0/concepts/smart-sensors.html#migrating-to-deferrable-operators) for details on how to migrate.
+See [Migrating to Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/2.2.4/concepts/smart-sensors.html#migrating-to-deferrable-operators) for details on how to migrate.
 
 ### Task log templates are now read from the metadatabase instead of `airflow.cfg`
 


### PR DESCRIPTION
We are releasing the deprecation in version 2.2.4, not 2.3.0 like
originally planned.