### PR TITLE
Add conditional `template_fields_renderers` check for new SQL lexers

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_sql.py
+++ b/airflow/providers/amazon/aws/operators/redshift_sql.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -44,7 +45,10 @@ class RedshiftSQLOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql',)
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {"sql": "postgresql"}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        "sql": "postgresql" if "postgresql" in wwwutils.get_attr_renderer() else "sql"
+    }
 
     def __init__(
         self,

--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -24,9 +24,13 @@ from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveServer2Hook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.utils.operator_helpers import context_to_airflow_vars
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
+# TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+MYSQL_RENDERER = 'mysql' if 'mysql' in wwwutils.get_attr_renderer() else 'sql'
 
 
 class HiveToMySqlOperator(BaseOperator):
@@ -57,7 +61,11 @@ class HiveToMySqlOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql', 'mysql_table', 'mysql_preoperator', 'mysql_postoperator')
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {'sql': 'hql', 'mysql_preoperator': 'mysql', 'mysql_postoperator': 'mysql'}
+    template_fields_renderers = {
+        'sql': 'hql',
+        'mysql_preoperator': MYSQL_RENDERER,
+        'mysql_postoperator': MYSQL_RENDERER,
+    }
     ui_color = '#a0e08c'
 
     def __init__(

--- a/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -28,6 +28,7 @@ import unicodecsv as csv
 from airflow.models import BaseOperator
 from airflow.providers.apache.hive.hooks.hive import HiveCliHook
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -65,7 +66,8 @@ class MsSqlToHiveOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql', 'partition', 'hive_table')
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {'sql': 'tsql'}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {'sql': 'tsql' if 'tsql' in wwwutils.get_attr_renderer() else 'sql'}
     ui_color = '#a0e08c'
 
     def __init__(

--- a/airflow/providers/microsoft/mssql/operators/mssql.py
+++ b/airflow/providers/microsoft/mssql/operators/mssql.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.hooks.dbapi import DbApiHook
@@ -49,7 +50,8 @@ class MsSqlOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql',)
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {'sql': 'tsql'}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {'sql': 'tsql' if 'tsql' in wwwutils.get_attr_renderer() else 'sql'}
     ui_color = '#ededed'
 
     def __init__(

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, U
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -47,7 +48,11 @@ class MySqlOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = ('sql', 'parameters')
-    template_fields_renderers = {'sql': 'mysql', 'parameters': 'json'}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        'sql': 'mysql' if 'mysql' in wwwutils.get_attr_renderer() else 'sql',
+        'parameters': 'json',
+    }
     template_ext: Sequence[str] = ('.sql', '.json')
     ui_color = '#ededed'
 

--- a/airflow/providers/mysql/transfers/presto_to_mysql.py
+++ b/airflow/providers/mysql/transfers/presto_to_mysql.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Optional, Sequence
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.presto.hooks.presto import PrestoHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -44,7 +45,11 @@ class PrestoToMySqlOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql', 'mysql_table', 'mysql_preoperator')
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {"sql": "sql", "mysql_preoperator": "mysql"}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        "sql": "sql",
+        "mysql_preoperator": "mysql" if "mysql" in wwwutils.get_attr_renderer() else "sql",
+    }
     ui_color = '#a0e08c'
 
     def __init__(

--- a/airflow/providers/mysql/transfers/trino_to_mysql.py
+++ b/airflow/providers/mysql/transfers/trino_to_mysql.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Optional, Sequence
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.trino.hooks.trino import TrinoHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -44,7 +45,11 @@ class TrinoToMySqlOperator(BaseOperator):
 
     template_fields: Sequence[str] = ('sql', 'mysql_table', 'mysql_preoperator')
     template_ext: Sequence[str] = ('.sql',)
-    template_fields_renderers = {"sql": "sql", "mysql_preoperator": "mysql"}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        "sql": "sql",
+        "mysql_preoperator": "mysql" if "mysql" in wwwutils.get_attr_renderer() else "sql",
+    }
     ui_color = '#a0e08c'
 
     def __init__(

--- a/airflow/providers/mysql/transfers/vertica_to_mysql.py
+++ b/airflow/providers/mysql/transfers/vertica_to_mysql.py
@@ -26,9 +26,13 @@ import unicodecsv as csv
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.vertica.hooks.vertica import VerticaHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
+# TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+MYSQL_RENDERER = 'mysql' if 'mysql' in wwwutils.get_attr_renderer() else 'sql'
 
 
 class VerticaToMySqlOperator(BaseOperator):
@@ -57,8 +61,8 @@ class VerticaToMySqlOperator(BaseOperator):
     template_ext: Sequence[str] = ('.sql',)
     template_fields_renderers = {
         "sql": "sql",
-        "mysql_preoperator": "mysql",
-        "mysql_postoperator": "mysql",
+        "mysql_preoperator": MYSQL_RENDERER,
+        "mysql_postoperator": MYSQL_RENDERER,
     }
     ui_color = '#a0e08c'
 

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, U
 
 from airflow.models import BaseOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.www import utils as wwwutils
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -40,7 +41,10 @@ class PostgresOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = ('sql',)
-    template_fields_renderers = {'sql': 'postgresql'}
+    # TODO: Remove renderer check when the provider has an Airflow 2.3+ requirement.
+    template_fields_renderers = {
+        'sql': 'postgresql' if 'postgresql' in wwwutils.get_attr_renderer() else 'sql'
+    }
     template_ext: Sequence[str] = ('.sql',)
     ui_color = '#ededed'
 


### PR DESCRIPTION
Related: #21237 #21348

New SQL lexers were added as part of #21237, however, these new lexers won't be available for use as `template_fields_renderers` in operators until Airflow 2.3. This PR adds a check for the availability of the new SQL lexers (`mysql`, `postgresql`, and `tsql`) to be used as `template_field_renderers`. If they are not available, the renderer will fallback to `sql`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
