### PR TITLE
Tweak origin parameter

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -63,7 +63,7 @@
       </label>
     </div>
     <button type="submit" class="btn btn-primary">Trigger</button>
-    <button type="button" class="btn" onclick="location.href = '{{ origin }}'; return false">Cancel</button>
+    <a class="btn" href="{{ html_attr_escaped_origin }}">Cancel</a>
   </form>
 {% endblock %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -18,6 +18,7 @@
 #
 import collections
 import copy
+import html
 import json
 import logging
 import math
@@ -1760,6 +1761,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=default_conf,
                 doc_md=doc_md,
                 form=form,
@@ -1775,6 +1777,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1796,6 +1799,7 @@ class Airflow(AirflowBaseView):
                         'airflow/trigger.html',
                         dag_id=dag_id,
                         origin=origin,
+                        html_attr_escaped_origin=html.escape(origin, quote=True),
                         conf=request_conf,
                         form=form,
                         is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1807,6 +1811,7 @@ class Airflow(AirflowBaseView):
                     'airflow/trigger.html',
                     dag_id=dag_id,
                     origin=origin,
+                    html_attr_escaped_origin=html.escape(origin, quote=True),
                     conf=request_conf,
                     form=form,
                     is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1832,6 +1837,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a simpler alternative to #21310.

The `origin` parameter is used to take users back to a previous page they were on. This PR fixes the way this parameter was handled.

The tiny [`html`](https://docs.python.org/3/library/html.html) library was added in Python 3.2 and expanded in Python 3.4.

I changed the `<button class="btn">` to a normal `<a class="btn">`, since it is more appropriate. The [commit](https://github.com/apache/airflow/pull/11195/files#diff-c7993103f49b0ad44fbe04d22a72f17989dd8908efd88c2ee92ce47ae21dc3c4R37) that introduced the `<button class="btn">` behavior was part of the [2.0 UI refresh PR](https://github.com/apache/airflow/pull/11195).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
