### PR TITLE
Update Zendesk example DAG to use TaskFlow API

### DIFF
--- a/airflow/providers/zendesk/example_dags/example_zendesk_custom_get.py
+++ b/airflow/providers/zendesk/example_dags/example_zendesk_custom_get.py
@@ -19,11 +19,12 @@ from datetime import datetime
 from typing import Dict, List
 
 from airflow import DAG
-from airflow.operators.python import PythonOperator
+from airflow.decorators import task
 from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
 
 
-def zendesk_custom_get_request() -> List[Dict]:
+@task
+def fetch_organizations() -> List[Dict]:
     hook = ZendeskHook()
     response = hook.get(
         url="https://yourdomain.zendesk.com/api/v2/organizations.json",
@@ -37,7 +38,4 @@ with DAG(
     start_date=datetime(2021, 1, 1),
     catchup=False,
 ) as dag:
-    fetch_organizations = PythonOperator(
-        task_id="trigger_zendesk_hook",
-        python_callable=zendesk_custom_get_request,
-    )
+    fetch_organizations()


### PR DESCRIPTION
Related: #9415

Staying consistent with previous work that was done to convert example DAGs to the functional style of authoring, this PR updates the example DAG for Zendesk to use the TaskFlow API.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
