### PR TITLE
Some refactoring work on scheduling code

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -69,8 +69,8 @@ class TISchedulingDecision(NamedTuple):
     tis: List[TI]
     schedulable_tis: List[TI]
     changed_tis: bool
-    unfinished_tasks: List[TI]
-    finished_tasks: List[TI]
+    unfinished_tis: List[TI]
+    finished_tis: List[TI]
 
 
 class DagRun(Base, LoggingMixin):
@@ -395,7 +395,7 @@ class DagRun(Base, LoggingMixin):
         self,
         state: Optional[Iterable[Optional[TaskInstanceState]]] = None,
         session: Session = NEW_SESSION,
-    ) -> Iterable[TI]:
+    ) -> List[TI]:
         """Returns the task instances for this dag run"""
         tis = (
             session.query(TI)
@@ -508,22 +508,18 @@ class DagRun(Base, LoggingMixin):
             tis = info.tis
             schedulable_tis = info.schedulable_tis
             changed_tis = info.changed_tis
-            finished_tasks = info.finished_tasks
-            unfinished_tasks = info.unfinished_tasks
+            finished_tis = info.finished_tis
+            unfinished_tis = info.unfinished_tis
 
-            none_depends_on_past = all(
-                not t.task.depends_on_past for t in unfinished_tasks  # type: ignore[has-type]
-            )
-            none_task_concurrency = all(
-                t.task.max_active_tis_per_dag is None for t in unfinished_tasks  # type: ignore[has-type]
-            )
-            none_deferred = all(t.state != State.DEFERRED for t in unfinished_tasks)
+            none_depends_on_past = all(not t.task.depends_on_past for t in unfinished_tis)
+            none_task_concurrency = all(t.task.max_active_tis_per_dag is None for t in unfinished_tis)
+            none_deferred = all(t.state != State.DEFERRED for t in unfinished_tis)
 
-            if unfinished_tasks and none_depends_on_past and none_task_concurrency and none_deferred:
+            if unfinished_tis and none_depends_on_past and none_task_concurrency and none_deferred:
                 # small speed up
                 are_runnable_tasks = (
                     schedulable_tis
-                    or self._are_premature_tis(unfinished_tasks, finished_tasks, session)
+                    or self._are_premature_tis(unfinished_tis, finished_tis, session)
                     or changed_tis
                 )
 
@@ -531,7 +527,7 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids]
 
         # if all roots finished and at least one failed, the run failed
-        if not unfinished_tasks and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):
+        if not unfinished_tis and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):
             self.log.error('Marking run %s failed', self)
             self.set_state(DagRunState.FAILED)
             if execute_callbacks:
@@ -546,7 +542,7 @@ class DagRun(Base, LoggingMixin):
                 )
 
         # if all leaves succeeded and no unfinished tasks, the run succeeded
-        elif not unfinished_tasks and all(leaf_ti.state in State.success_states for leaf_ti in leaf_tis):
+        elif not unfinished_tis and all(leaf_ti.state in State.success_states for leaf_ti in leaf_tis):
             self.log.info('Marking run %s successful', self)
             self.set_state(DagRunState.SUCCESS)
             if execute_callbacks:
@@ -562,7 +558,7 @@ class DagRun(Base, LoggingMixin):
 
         # if *all tasks* are deadlocked, the run failed
         elif (
-            unfinished_tasks
+            unfinished_tis
             and none_depends_on_past
             and none_task_concurrency
             and none_deferred
@@ -610,7 +606,7 @@ class DagRun(Base, LoggingMixin):
                 self.dag_hash,
             )
 
-        self._emit_true_scheduling_delay_stats_for_finished_state(finished_tasks)
+        self._emit_true_scheduling_delay_stats_for_finished_state(finished_tis)
         self._emit_duration_stats_for_finished_state()
 
         session.merge(self)
@@ -635,25 +631,25 @@ class DagRun(Base, LoggingMixin):
                 ti.state = State.REMOVED
                 session.flush()
 
-        unfinished_tasks = [t for t in tis if t.state in State.unfinished]
-        finished_tasks = [t for t in tis if t.state in State.finished]
-        if unfinished_tasks:
-            scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
-            self.log.debug("number of scheduleable tasks for %s: %s task(s)", self, len(scheduleable_tasks))
-            schedulable_tis, changed_tis = self._get_ready_tis(scheduleable_tasks, finished_tasks, session)
+        unfinished_tis = [t for t in tis if t.state in State.unfinished]
+        finished_tis = [t for t in tis if t.state in State.finished]
+        if unfinished_tis:
+            schedulable_tis = [ut for ut in unfinished_tis if ut.state in SCHEDULEABLE_STATES]
+            self.log.debug("number of scheduleable tasks for %s: %s task(s)", self, len(schedulable_tis))
+            schedulable_tis, changed_tis = self._get_ready_tis(schedulable_tis, finished_tis, session)
 
         return TISchedulingDecision(
             tis=tis,
             schedulable_tis=schedulable_tis,
             changed_tis=changed_tis,
-            unfinished_tasks=unfinished_tasks,
-            finished_tasks=finished_tasks,
+            unfinished_tis=unfinished_tis,
+            finished_tis=finished_tis,
         )
 
     def _get_ready_tis(
         self,
         scheduleable_tasks: List[TI],
-        finished_tasks: List[TI],
+        finished_tis: List[TI],
         session: Session,
     ) -> Tuple[List[TI], bool]:
         old_states = {}
@@ -667,7 +663,7 @@ class DagRun(Base, LoggingMixin):
         for st in scheduleable_tasks:
             old_state = st.state
             if st.are_dependencies_met(
-                dep_context=DepContext(flag_upstream_failed=True, finished_tasks=finished_tasks),
+                dep_context=DepContext(flag_upstream_failed=True, finished_tis=finished_tis),
                 session=session,
             ):
                 ready_tis.append(st)
@@ -684,26 +680,26 @@ class DagRun(Base, LoggingMixin):
 
     def _are_premature_tis(
         self,
-        unfinished_tasks: List[TI],
-        finished_tasks: List[TI],
+        unfinished_tis: List[TI],
+        finished_tis: List[TI],
         session: Session,
     ) -> bool:
         # there might be runnable tasks that are up for retry and for some reason(retry delay, etc) are
         # not ready yet so we set the flags to count them in
-        for ut in unfinished_tasks:
+        for ut in unfinished_tis:
             if ut.are_dependencies_met(
                 dep_context=DepContext(
                     flag_upstream_failed=True,
                     ignore_in_retry_period=True,
                     ignore_in_reschedule_period=True,
-                    finished_tasks=finished_tasks,
+                    finished_tis=finished_tis,
                 ),
                 session=session,
             ):
                 return True
         return False
 
-    def _emit_true_scheduling_delay_stats_for_finished_state(self, finished_tis):
+    def _emit_true_scheduling_delay_stats_for_finished_state(self, finished_tis: List[TI]) -> None:
         """
         This is a helper method to emit the true scheduling delay stats, which is defined as
         the time when the first task in DAG starts minus the expected DAG run datetime.
@@ -727,7 +723,7 @@ class DagRun(Base, LoggingMixin):
         try:
             dag = self.get_dag()
 
-            if not self.dag.timetable.periodic:
+            if not dag.timetable.periodic:
                 # We can't emit this metric if there is no following schedule to calculate from!
                 return
 

--- a/airflow/ti_deps/dep_context.py
+++ b/airflow/ti_deps/dep_context.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 from sqlalchemy.orm.session import Session
 
@@ -56,7 +56,7 @@ class DepContext:
     :param ignore_task_deps: Ignore task-specific dependencies such as depends_on_past and
         trigger rule
     :param ignore_ti_state: Ignore the task instance's previous failure/success
-    :param finished_tasks: A list of all the finished tasks of this run
+    :param finished_tis: A list of all the finished task instances of this run
     """
 
     def __init__(
@@ -69,7 +69,7 @@ class DepContext:
         ignore_in_reschedule_period: bool = False,
         ignore_task_deps: bool = False,
         ignore_ti_state: bool = False,
-        finished_tasks=None,
+        finished_tis: Optional[List["TaskInstance"]] = None,
     ):
         self.deps = deps or set()
         self.flag_upstream_failed = flag_upstream_failed
@@ -79,17 +79,20 @@ class DepContext:
         self.ignore_in_reschedule_period = ignore_in_reschedule_period
         self.ignore_task_deps = ignore_task_deps
         self.ignore_ti_state = ignore_ti_state
-        self.finished_tasks = finished_tasks
+        self.finished_tis = finished_tis
 
-    def ensure_finished_tasks(self, dag_run: "DagRun", session: Session) -> "List[TaskInstance]":
+    def ensure_finished_tis(self, dag_run: "DagRun", session: Session) -> List["TaskInstance"]:
         """
-        This method makes sure finished_tasks is populated if it's currently None.
+        This method makes sure finished_tis is populated if it's currently None.
         This is for the strange feature of running tasks without dag_run.
 
         :param dag_run: The DagRun for which to find finished tasks
         :return: A list of all the finished tasks of this DAG and execution_date
         :rtype: list[airflow.models.TaskInstance]
         """
-        if self.finished_tasks is None:
-            self.finished_tasks = dag_run.get_task_instances(state=State.finished, session=session)
-        return self.finished_tasks
+        if self.finished_tis is None:
+            finished_tis = dag_run.get_task_instances(state=State.finished, session=session)
+            self.finished_tis = finished_tis
+        else:
+            finished_tis = self.finished_tis
+        return finished_tis

--- a/airflow/ti_deps/deps/not_previously_skipped_dep.py
+++ b/airflow/ti_deps/deps/not_previously_skipped_dep.py
@@ -39,9 +39,9 @@ class NotPreviouslySkippedDep(BaseTIDep):
 
         upstream = ti.task.get_direct_relatives(upstream=True)
 
-        finished_tasks = dep_context.ensure_finished_tasks(ti.get_dagrun(session), session)
+        finished_tis = dep_context.ensure_finished_tis(ti.get_dagrun(session), session)
 
-        finished_task_ids = {t.task_id for t in finished_tasks}
+        finished_task_ids = {t.task_id for t in finished_tis}
 
         for parent in upstream:
             if isinstance(parent, SkipMixin):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -17,16 +17,16 @@
 # under the License.
 
 import datetime
-import unittest
+from typing import Mapping, Optional
 from unittest import mock
 from unittest.mock import call
 
+import pendulum
 import pytest
-from parameterized import parameterized
+from sqlalchemy.orm.session import Session
 
-from airflow import models, settings
-from airflow.models import DAG, DagBag, DagModel, TaskInstance as TI, clear_task_instances
-from airflow.models.dagrun import DagRun
+from airflow import settings
+from airflow.models import DAG, DagBag, DagModel, DagRun, TaskInstance as TI, clear_task_instances
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.serialization.serialized_objects import SerializedDAG
@@ -34,56 +34,58 @@ from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.callback_requests import DagCallbackRequest
 from airflow.utils.dates import days_ago
-from airflow.utils.state import State
+from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
-from tests.models import DEFAULT_DATE
+from tests.models import DEFAULT_DATE as _DEFAULT_DATE
 from tests.test_utils.db import clear_db_dags, clear_db_pools, clear_db_runs
 from tests.test_utils.mock_operators import MockOperator
 
+DEFAULT_DATE = pendulum.instance(_DEFAULT_DATE)
 
-class TestDagRun(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.dagbag = DagBag(include_examples=True)
 
-    def setUp(self):
+class TestDagRun:
+    dagbag = DagBag(include_examples=True)
+
+    def setup_class(self) -> None:
         clear_db_runs()
         clear_db_pools()
         clear_db_dags()
 
-    def tearDown(self) -> None:
+    def teardown_method(self) -> None:
         clear_db_runs()
         clear_db_pools()
         clear_db_dags()
 
     def create_dag_run(
         self,
-        dag,
-        state=State.RUNNING,
-        task_states=None,
-        execution_date=None,
-        is_backfill=False,
-        creating_job_id=None,
+        dag: DAG,
+        *,
+        task_states: Optional[Mapping[str, TaskInstanceState]] = None,
+        execution_date: Optional[datetime.datetime] = None,
+        is_backfill: bool = False,
+        session: Session,
     ):
         now = timezone.utcnow()
         if execution_date is None:
             execution_date = now
+        execution_date = pendulum.instance(execution_date)
         if is_backfill:
             run_type = DagRunType.BACKFILL_JOB
+            data_interval = dag.infer_automated_data_interval(execution_date)
         else:
             run_type = DagRunType.MANUAL
+            data_interval = dag.timetable.infer_manual_data_interval(run_after=execution_date)
         dag_run = dag.create_dagrun(
             run_type=run_type,
             execution_date=execution_date,
+            data_interval=data_interval,
             start_date=now,
-            state=state,
+            state=DagRunState.RUNNING,
             external_trigger=False,
-            creating_job_id=creating_job_id,
         )
 
         if task_states is not None:
-            session = settings.Session()
             for task_id, task_state in task_states.items():
                 ti = dag_run.get_task_instance(task_id)
                 ti.set_state(task_state, session)
@@ -91,15 +93,14 @@ class TestDagRun(unittest.TestCase):
 
         return dag_run
 
-    def test_clear_task_instances_for_backfill_dagrun(self):
+    def test_clear_task_instances_for_backfill_dagrun(self, session):
         now = timezone.utcnow()
-        session = settings.Session()
         dag_id = 'test_clear_task_instances_for_backfill_dagrun'
         dag = DAG(dag_id=dag_id, start_date=now)
-        self.create_dag_run(dag, execution_date=now, is_backfill=True)
+        dag_run = self.create_dag_run(dag, execution_date=now, is_backfill=True, session=session)
 
         task0 = DummyOperator(task_id='backfill_task_0', owner='test', dag=dag)
-        ti0 = TI(task=task0, execution_date=now)
+        ti0 = TI(task=task0, run_id=dag_run.run_id)
         ti0.run()
 
         qry = session.query(TI).filter(TI.dag_id == dag.dag_id).all()
@@ -107,71 +108,69 @@ class TestDagRun(unittest.TestCase):
         session.commit()
         ti0.refresh_from_db()
         dr0 = session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.execution_date == now).first()
-        assert dr0.state == State.QUEUED
+        assert dr0.state == DagRunState.QUEUED
 
-    def test_dagrun_find(self):
-        session = settings.Session()
+    def test_dagrun_find(self, session):
         now = timezone.utcnow()
 
         dag_id1 = "test_dagrun_find_externally_triggered"
-        dag_run = models.DagRun(
+        dag_run = DagRun(
             dag_id=dag_id1,
             run_id=dag_id1,
             run_type=DagRunType.MANUAL,
             execution_date=now,
             start_date=now,
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             external_trigger=True,
         )
         session.add(dag_run)
 
         dag_id2 = "test_dagrun_find_not_externally_triggered"
-        dag_run = models.DagRun(
+        dag_run = DagRun(
             dag_id=dag_id2,
             run_id=dag_id2,
             run_type=DagRunType.MANUAL,
             execution_date=now,
             start_date=now,
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             external_trigger=False,
         )
         session.add(dag_run)
 
         session.commit()
 
-        assert 1 == len(models.DagRun.find(dag_id=dag_id1, external_trigger=True))
-        assert 1 == len(models.DagRun.find(run_id=dag_id1))
-        assert 2 == len(models.DagRun.find(run_id=[dag_id1, dag_id2]))
-        assert 2 == len(models.DagRun.find(execution_date=[now, now]))
-        assert 2 == len(models.DagRun.find(execution_date=now))
-        assert 0 == len(models.DagRun.find(dag_id=dag_id1, external_trigger=False))
-        assert 0 == len(models.DagRun.find(dag_id=dag_id2, external_trigger=True))
-        assert 1 == len(models.DagRun.find(dag_id=dag_id2, external_trigger=False))
+        assert 1 == len(DagRun.find(dag_id=dag_id1, external_trigger=True))
+        assert 1 == len(DagRun.find(run_id=dag_id1))
+        assert 2 == len(DagRun.find(run_id=[dag_id1, dag_id2]))
+        assert 2 == len(DagRun.find(execution_date=[now, now]))
+        assert 2 == len(DagRun.find(execution_date=now))
+        assert 0 == len(DagRun.find(dag_id=dag_id1, external_trigger=False))
+        assert 0 == len(DagRun.find(dag_id=dag_id2, external_trigger=True))
+        assert 1 == len(DagRun.find(dag_id=dag_id2, external_trigger=False))
 
-    def test_dagrun_find_duplicate(self):
-        session = settings.Session()
+    def test_dagrun_find_duplicate(self, session):
         now = timezone.utcnow()
 
         dag_id = "test_dagrun_find_duplicate"
-        dag_run = models.DagRun(
+        dag_run = DagRun(
             dag_id=dag_id,
             run_id=dag_id,
             run_type=DagRunType.MANUAL,
             execution_date=now,
             start_date=now,
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             external_trigger=True,
         )
         session.add(dag_run)
 
         session.commit()
 
-        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=now) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=None) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=now) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=None) is None
+        assert DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=now) is not None
+        assert DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=None) is not None
+        assert DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=now) is not None
+        assert DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=None) is None
 
-    def test_dagrun_success_when_all_skipped(self):
+    def test_dagrun_success_when_all_skipped(self, session):
         """
         Tests that a DAG run succeeds when all tasks are skipped
         """
@@ -185,18 +184,16 @@ class TestDagRun(unittest.TestCase):
         dag_task2.set_downstream(dag_task3)
 
         initial_task_states = {
-            'test_short_circuit_false': State.SUCCESS,
-            'test_state_skipped1': State.SKIPPED,
-            'test_state_skipped2': State.SKIPPED,
+            'test_short_circuit_false': TaskInstanceState.SUCCESS,
+            'test_state_skipped1': TaskInstanceState.SKIPPED,
+            'test_state_skipped2': TaskInstanceState.SKIPPED,
         }
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         dag_run.update_state()
-        assert State.SUCCESS == dag_run.state
+        assert DagRunState.SUCCESS == dag_run.state
 
-    def test_dagrun_success_conditions(self):
-        session = settings.Session()
-
+    def test_dagrun_success_conditions(self, session):
         dag = DAG('test_dagrun_success_conditions', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         # A -> B
@@ -212,14 +209,18 @@ class TestDagRun(unittest.TestCase):
 
         dag.clear()
 
-        now = timezone.utcnow()
+        now = pendulum.now("UTC")
         dr = dag.create_dagrun(
-            run_id='test_dagrun_success_conditions', state=State.RUNNING, execution_date=now, start_date=now
+            run_id='test_dagrun_success_conditions',
+            state=DagRunState.RUNNING,
+            execution_date=now,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=now),
+            start_date=now,
         )
 
         # op1 = root
         ti_op1 = dr.get_task_instance(task_id=op1.task_id)
-        ti_op1.set_state(state=State.SUCCESS, session=session)
+        ti_op1.set_state(state=TaskInstanceState.SUCCESS, session=session)
 
         ti_op2 = dr.get_task_instance(task_id=op2.task_id)
         ti_op3 = dr.get_task_instance(task_id=op3.task_id)
@@ -227,17 +228,16 @@ class TestDagRun(unittest.TestCase):
 
         # root is successful, but unfinished tasks
         dr.update_state()
-        assert State.RUNNING == dr.state
+        assert DagRunState.RUNNING == dr.state
 
         # one has failed, but root is successful
-        ti_op2.set_state(state=State.FAILED, session=session)
-        ti_op3.set_state(state=State.SUCCESS, session=session)
-        ti_op4.set_state(state=State.SUCCESS, session=session)
+        ti_op2.set_state(state=TaskInstanceState.FAILED, session=session)
+        ti_op3.set_state(state=TaskInstanceState.SUCCESS, session=session)
+        ti_op4.set_state(state=TaskInstanceState.SUCCESS, session=session)
         dr.update_state()
-        assert State.SUCCESS == dr.state
+        assert DagRunState.SUCCESS == dr.state
 
-    def test_dagrun_deadlock(self):
-        session = settings.Session()
+    def test_dagrun_deadlock(self, session):
         dag = DAG('text_dagrun_deadlock', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         with dag:
@@ -247,26 +247,29 @@ class TestDagRun(unittest.TestCase):
             op2.set_upstream(op1)
 
         dag.clear()
-        now = timezone.utcnow()
+        now = pendulum.now("UTC")
         dr = dag.create_dagrun(
-            run_id='test_dagrun_deadlock', state=State.RUNNING, execution_date=now, start_date=now
+            run_id='test_dagrun_deadlock',
+            state=DagRunState.RUNNING,
+            execution_date=now,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=now),
+            start_date=now,
         )
 
         ti_op1 = dr.get_task_instance(task_id=op1.task_id)
-        ti_op1.set_state(state=State.SUCCESS, session=session)
+        ti_op1.set_state(state=TaskInstanceState.SUCCESS, session=session)
         ti_op2 = dr.get_task_instance(task_id=op2.task_id)
-        ti_op2.set_state(state=State.NONE, session=session)
+        ti_op2.set_state(state=None, session=session)
 
         dr.update_state()
-        assert dr.state == State.RUNNING
+        assert dr.state == DagRunState.RUNNING
 
-        ti_op2.set_state(state=State.NONE, session=session)
+        ti_op2.set_state(state=None, session=session)
         op2.trigger_rule = 'invalid'
         dr.update_state()
-        assert dr.state == State.FAILED
+        assert dr.state == DagRunState.FAILED
 
-    def test_dagrun_no_deadlock_with_shutdown(self):
-        session = settings.Session()
+    def test_dagrun_no_deadlock_with_shutdown(self, session):
         dag = DAG('test_dagrun_no_deadlock_with_shutdown', start_date=DEFAULT_DATE)
         with dag:
             op1 = DummyOperator(task_id='upstream_task')
@@ -275,18 +278,18 @@ class TestDagRun(unittest.TestCase):
 
         dr = dag.create_dagrun(
             run_id='test_dagrun_no_deadlock_with_shutdown',
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             execution_date=DEFAULT_DATE,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
             start_date=DEFAULT_DATE,
         )
         upstream_ti = dr.get_task_instance(task_id='upstream_task')
-        upstream_ti.set_state(State.SHUTDOWN, session=session)
+        upstream_ti.set_state(TaskInstanceState.SHUTDOWN, session=session)
 
         dr.update_state()
-        assert dr.state == State.RUNNING
+        assert dr.state == DagRunState.RUNNING
 
-    def test_dagrun_no_deadlock_with_depends_on_past(self):
-        session = settings.Session()
+    def test_dagrun_no_deadlock_with_depends_on_past(self, session):
         dag = DAG('test_dagrun_no_deadlock', start_date=DEFAULT_DATE)
         with dag:
             DummyOperator(task_id='dop', depends_on_past=True)
@@ -295,33 +298,36 @@ class TestDagRun(unittest.TestCase):
         dag.clear()
         dr = dag.create_dagrun(
             run_id='test_dagrun_no_deadlock_1',
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             execution_date=DEFAULT_DATE,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=DEFAULT_DATE),
             start_date=DEFAULT_DATE,
         )
+        next_date = DEFAULT_DATE + datetime.timedelta(days=1)
         dr2 = dag.create_dagrun(
             run_id='test_dagrun_no_deadlock_2',
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE + datetime.timedelta(days=1),
-            start_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            state=DagRunState.RUNNING,
+            execution_date=next_date,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=next_date),
+            start_date=next_date,
         )
         ti1_op1 = dr.get_task_instance(task_id='dop')
         dr2.get_task_instance(task_id='dop')
         ti2_op1 = dr.get_task_instance(task_id='tc')
         dr.get_task_instance(task_id='tc')
-        ti1_op1.set_state(state=State.RUNNING, session=session)
+        ti1_op1.set_state(state=TaskInstanceState.RUNNING, session=session)
         dr.update_state()
         dr2.update_state()
-        assert dr.state == State.RUNNING
-        assert dr2.state == State.RUNNING
+        assert dr.state == DagRunState.RUNNING
+        assert dr2.state == DagRunState.RUNNING
 
-        ti2_op1.set_state(state=State.RUNNING, session=session)
+        ti2_op1.set_state(state=TaskInstanceState.RUNNING, session=session)
         dr.update_state()
         dr2.update_state()
-        assert dr.state == State.RUNNING
-        assert dr2.state == State.RUNNING
+        assert dr.state == DagRunState.RUNNING
+        assert dr2.state == DagRunState.RUNNING
 
-    def test_dagrun_success_callback(self):
+    def test_dagrun_success_callback(self, session):
         def on_success_callable(context):
             assert context['dag_run'].dag_id == 'test_dagrun_success_callback'
 
@@ -335,20 +341,20 @@ class TestDagRun(unittest.TestCase):
         dag_task1.set_downstream(dag_task2)
 
         initial_task_states = {
-            'test_state_succeeded1': State.SUCCESS,
-            'test_state_succeeded2': State.SUCCESS,
+            'test_state_succeeded1': TaskInstanceState.SUCCESS,
+            'test_state_succeeded2': TaskInstanceState.SUCCESS,
         }
 
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         _, callback = dag_run.update_state()
-        assert State.SUCCESS == dag_run.state
+        assert DagRunState.SUCCESS == dag_run.state
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
         assert callback is None
 
-    def test_dagrun_failure_callback(self):
+    def test_dagrun_failure_callback(self, session):
         def on_failure_callable(context):
             assert context['dag_run'].dag_id == 'test_dagrun_failure_callback'
 
@@ -361,21 +367,21 @@ class TestDagRun(unittest.TestCase):
         dag_task2 = DummyOperator(task_id='test_state_failed2', dag=dag)
 
         initial_task_states = {
-            'test_state_succeeded1': State.SUCCESS,
-            'test_state_failed2': State.FAILED,
+            'test_state_succeeded1': TaskInstanceState.SUCCESS,
+            'test_state_failed2': TaskInstanceState.FAILED,
         }
         dag_task1.set_downstream(dag_task2)
 
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         _, callback = dag_run.update_state()
-        assert State.FAILED == dag_run.state
+        assert DagRunState.FAILED == dag_run.state
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
         assert callback is None
 
-    def test_dagrun_update_state_with_handle_callback_success(self):
+    def test_dagrun_update_state_with_handle_callback_success(self, session):
         def on_success_callable(context):
             assert context['dag_run'].dag_id == 'test_dagrun_update_state_with_handle_callback_success'
 
@@ -389,17 +395,17 @@ class TestDagRun(unittest.TestCase):
         dag_task1.set_downstream(dag_task2)
 
         initial_task_states = {
-            'test_state_succeeded1': State.SUCCESS,
-            'test_state_succeeded2': State.SUCCESS,
+            'test_state_succeeded1': TaskInstanceState.SUCCESS,
+            'test_state_succeeded2': TaskInstanceState.SUCCESS,
         }
 
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
 
         _, callback = dag_run.update_state(execute_callbacks=False)
-        assert State.SUCCESS == dag_run.state
+        assert DagRunState.SUCCESS == dag_run.state
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
 
         assert callback == DagCallbackRequest(
@@ -410,7 +416,7 @@ class TestDagRun(unittest.TestCase):
             msg="success",
         )
 
-    def test_dagrun_update_state_with_handle_callback_failure(self):
+    def test_dagrun_update_state_with_handle_callback_failure(self, session):
         def on_failure_callable(context):
             assert context['dag_run'].dag_id == 'test_dagrun_update_state_with_handle_callback_failure'
 
@@ -424,17 +430,17 @@ class TestDagRun(unittest.TestCase):
         dag_task1.set_downstream(dag_task2)
 
         initial_task_states = {
-            'test_state_succeeded1': State.SUCCESS,
-            'test_state_failed2': State.FAILED,
+            'test_state_succeeded1': TaskInstanceState.SUCCESS,
+            'test_state_failed2': TaskInstanceState.FAILED,
         }
 
         # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
 
         _, callback = dag_run.update_state(execute_callbacks=False)
-        assert State.FAILED == dag_run.state
+        assert DagRunState.FAILED == dag_run.state
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
 
         assert callback == DagCallbackRequest(
@@ -445,26 +451,28 @@ class TestDagRun(unittest.TestCase):
             msg="task_failure",
         )
 
-    def test_dagrun_set_state_end_date(self):
-        session = settings.Session()
-
+    def test_dagrun_set_state_end_date(self, session):
         dag = DAG('test_dagrun_set_state_end_date', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         dag.clear()
 
-        now = timezone.utcnow()
+        now = pendulum.now("UTC")
         dr = dag.create_dagrun(
-            run_id='test_dagrun_set_state_end_date', state=State.RUNNING, execution_date=now, start_date=now
+            run_id='test_dagrun_set_state_end_date',
+            state=DagRunState.RUNNING,
+            execution_date=now,
+            data_interval=dag.timetable.infer_manual_data_interval(now),
+            start_date=now,
         )
 
         # Initial end_date should be NULL
-        # State.SUCCESS and State.FAILED are all ending state and should set end_date
-        # State.RUNNING set end_date back to NULL
+        # DagRunState.SUCCESS and DagRunState.FAILED are all ending state and should set end_date
+        # DagRunState.RUNNING set end_date back to NULL
         session.add(dr)
         session.commit()
         assert dr.end_date is None
 
-        dr.set_state(State.SUCCESS)
+        dr.set_state(DagRunState.SUCCESS)
         session.merge(dr)
         session.commit()
 
@@ -472,7 +480,7 @@ class TestDagRun(unittest.TestCase):
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
-        dr.set_state(State.RUNNING)
+        dr.set_state(DagRunState.RUNNING)
         session.merge(dr)
         session.commit()
 
@@ -480,7 +488,7 @@ class TestDagRun(unittest.TestCase):
 
         assert dr_database.end_date is None
 
-        dr.set_state(State.FAILED)
+        dr.set_state(DagRunState.FAILED)
         session.merge(dr)
         session.commit()
         dr_database = session.query(DagRun).filter(DagRun.run_id == 'test_dagrun_set_state_end_date').one()
@@ -488,9 +496,7 @@ class TestDagRun(unittest.TestCase):
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
-    def test_dagrun_update_state_end_date(self):
-        session = settings.Session()
-
+    def test_dagrun_update_state_end_date(self, session):
         dag = DAG(
             'test_dagrun_update_state_end_date', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'}
         )
@@ -503,25 +509,26 @@ class TestDagRun(unittest.TestCase):
 
         dag.clear()
 
-        now = timezone.utcnow()
+        now = pendulum.now("UTC")
         dr = dag.create_dagrun(
             run_id='test_dagrun_update_state_end_date',
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             execution_date=now,
+            data_interval=dag.timetable.infer_manual_data_interval(now),
             start_date=now,
         )
 
         # Initial end_date should be NULL
-        # State.SUCCESS and State.FAILED are all ending state and should set end_date
-        # State.RUNNING set end_date back to NULL
+        # DagRunState.SUCCESS and DagRunState.FAILED are all ending state and should set end_date
+        # DagRunState.RUNNING set end_date back to NULL
         session.merge(dr)
         session.commit()
         assert dr.end_date is None
 
         ti_op1 = dr.get_task_instance(task_id=op1.task_id)
-        ti_op1.set_state(state=State.SUCCESS, session=session)
+        ti_op1.set_state(state=TaskInstanceState.SUCCESS, session=session)
         ti_op2 = dr.get_task_instance(task_id=op2.task_id)
-        ti_op2.set_state(state=State.SUCCESS, session=session)
+        ti_op2.set_state(state=TaskInstanceState.SUCCESS, session=session)
 
         dr.update_state()
 
@@ -529,18 +536,18 @@ class TestDagRun(unittest.TestCase):
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
-        ti_op1.set_state(state=State.RUNNING, session=session)
-        ti_op2.set_state(state=State.RUNNING, session=session)
+        ti_op1.set_state(state=TaskInstanceState.RUNNING, session=session)
+        ti_op2.set_state(state=TaskInstanceState.RUNNING, session=session)
         dr.update_state()
 
         dr_database = session.query(DagRun).filter(DagRun.run_id == 'test_dagrun_update_state_end_date').one()
 
-        assert dr._state == State.RUNNING
+        assert dr._state == DagRunState.RUNNING
         assert dr.end_date is None
         assert dr_database.end_date is None
 
-        ti_op1.set_state(state=State.FAILED, session=session)
-        ti_op2.set_state(state=State.FAILED, session=session)
+        ti_op1.set_state(state=TaskInstanceState.FAILED, session=session)
+        ti_op2.set_state(state=TaskInstanceState.FAILED, session=session)
         dr.update_state()
 
         dr_database = session.query(DagRun).filter(DagRun.run_id == 'test_dagrun_update_state_end_date').one()
@@ -548,26 +555,24 @@ class TestDagRun(unittest.TestCase):
         assert dr_database.end_date is not None
         assert dr.end_date == dr_database.end_date
 
-    def test_get_task_instance_on_empty_dagrun(self):
+    def test_get_task_instance_on_empty_dagrun(self, session):
         """
         Make sure that a proper value is returned when a dagrun has no task instances
         """
         dag = DAG(dag_id='test_get_task_instance_on_empty_dagrun', start_date=timezone.datetime(2017, 1, 1))
         ShortCircuitOperator(task_id='test_short_circuit_false', dag=dag, python_callable=lambda: False)
 
-        session = settings.Session()
-
         now = timezone.utcnow()
 
         # Don't use create_dagrun since it will create the task instances too which we
         # don't want
-        dag_run = models.DagRun(
+        dag_run = DagRun(
             dag_id=dag.dag_id,
             run_id="test_get_task_instance_on_empty_dagrun",
             run_type=DagRunType.MANUAL,
             execution_date=now,
             start_date=now,
-            state=State.RUNNING,
+            state=DagRunState.RUNNING,
             external_trigger=False,
         )
         session.add(dag_run)
@@ -576,49 +581,48 @@ class TestDagRun(unittest.TestCase):
         ti = dag_run.get_task_instance('test_short_circuit_false')
         assert ti is None
 
-    def test_get_latest_runs(self):
-        session = settings.Session()
+    def test_get_latest_runs(self, session):
         dag = DAG(dag_id='test_latest_runs_1', start_date=DEFAULT_DATE)
-        self.create_dag_run(dag, execution_date=timezone.datetime(2015, 1, 1))
-        self.create_dag_run(dag, execution_date=timezone.datetime(2015, 1, 2))
-        dagruns = models.DagRun.get_latest_runs(session)
+        self.create_dag_run(dag, execution_date=timezone.datetime(2015, 1, 1), session=session)
+        self.create_dag_run(dag, execution_date=timezone.datetime(2015, 1, 2), session=session)
+        dagruns = DagRun.get_latest_runs(session)
         session.close()
         for dagrun in dagruns:
             if dagrun.dag_id == 'test_latest_runs_1':
                 assert dagrun.execution_date == timezone.datetime(2015, 1, 2)
 
-    def test_removed_task_instances_can_be_restored(self):
+    def test_removed_task_instances_can_be_restored(self, session):
         def with_all_tasks_removed(dag):
             return DAG(dag_id=dag.dag_id, start_date=dag.start_date)
 
         dag = DAG('test_task_restoration', start_date=DEFAULT_DATE)
         dag.add_task(DummyOperator(task_id='flaky_task', owner='test'))
 
-        dagrun = self.create_dag_run(dag)
+        dagrun = self.create_dag_run(dag, session=session)
         flaky_ti = dagrun.get_task_instances()[0]
         assert 'flaky_task' == flaky_ti.task_id
-        assert State.NONE == flaky_ti.state
+        assert flaky_ti.state is None
 
         dagrun.dag = with_all_tasks_removed(dag)
 
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
-        assert State.NONE == flaky_ti.state
+        assert flaky_ti.state is None
 
         dagrun.dag.add_task(DummyOperator(task_id='flaky_task', owner='test'))
 
         dagrun.verify_integrity()
         flaky_ti.refresh_from_db()
-        assert State.NONE == flaky_ti.state
+        assert flaky_ti.state is None
 
-    def test_already_added_task_instances_can_be_ignored(self):
+    def test_already_added_task_instances_can_be_ignored(self, session):
         dag = DAG('triggered_dag', start_date=DEFAULT_DATE)
         dag.add_task(DummyOperator(task_id='first_task', owner='test'))
 
-        dagrun = self.create_dag_run(dag)
+        dagrun = self.create_dag_run(dag, session=session)
         first_ti = dagrun.get_task_instances()[0]
         assert 'first_task' == first_ti.task_id
-        assert State.NONE == first_ti.state
+        assert first_ti.state is None
 
         # Lets assume that the above TI was added into DB by webserver, but if scheduler
         # is running the same method at the same time it would find 0 TIs for this dag
@@ -628,11 +632,11 @@ class TestDagRun(unittest.TestCase):
             mock_gtis.return_value = []
             dagrun.verify_integrity()
             first_ti.refresh_from_db()
-            assert State.NONE == first_ti.state
+            assert first_ti.state is None
 
-    @parameterized.expand([(state,) for state in State.task_states])
+    @pytest.mark.parametrize("state", State.task_states)
     @mock.patch.object(settings, 'task_instance_mutation_hook', autospec=True)
-    def test_task_instance_mutation_hook(self, state, mock_hook):
+    def test_task_instance_mutation_hook(self, mock_hook, session, state):
         def mutate_task_instance(task_instance):
             if task_instance.queue == 'queue1':
                 task_instance.queue = 'queue2'
@@ -644,9 +648,8 @@ class TestDagRun(unittest.TestCase):
         dag = DAG('test_task_instance_mutation_hook', start_date=DEFAULT_DATE)
         dag.add_task(DummyOperator(task_id='task_to_mutate', owner='test', queue='queue1'))
 
-        dagrun = self.create_dag_run(dag)
+        dagrun = self.create_dag_run(dag, session=session)
         task = dagrun.get_task_instances()[0]
-        session = settings.Session()
         task.state = state
         session.merge(task)
         session.commit()
@@ -656,64 +659,86 @@ class TestDagRun(unittest.TestCase):
         task = dagrun.get_task_instances()[0]
         assert task.queue == 'queue1'
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "prev_ti_state, is_ti_success",
         [
-            (State.SUCCESS, True),
-            (State.SKIPPED, True),
-            (State.RUNNING, False),
-            (State.FAILED, False),
-            (State.NONE, False),
-        ]
+            (TaskInstanceState.SUCCESS, True),
+            (TaskInstanceState.SKIPPED, True),
+            (TaskInstanceState.RUNNING, False),
+            (TaskInstanceState.FAILED, False),
+            (None, False),
+        ],
     )
-    def test_depends_on_past(self, prev_ti_state, is_ti_success):
+    def test_depends_on_past(self, session, prev_ti_state, is_ti_success):
         dag_id = 'test_depends_on_past'
 
         dag = self.dagbag.get_dag(dag_id)
         task = dag.tasks[0]
 
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0), is_backfill=True)
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0), is_backfill=True)
+        dag_run_1 = self.create_dag_run(
+            dag,
+            execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0),
+            is_backfill=True,
+            session=session,
+        )
+        dag_run_2 = self.create_dag_run(
+            dag,
+            execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0),
+            is_backfill=True,
+            session=session,
+        )
 
-        prev_ti = TI(task, timezone.datetime(2016, 1, 1, 0, 0, 0))
-        ti = TI(task, timezone.datetime(2016, 1, 2, 0, 0, 0))
+        prev_ti = TI(task, run_id=dag_run_1.run_id)
+        ti = TI(task, run_id=dag_run_2.run_id)
 
         prev_ti.set_state(prev_ti_state)
-        ti.set_state(State.QUEUED)
+        ti.set_state(TaskInstanceState.QUEUED)
         ti.run()
-        assert (ti.state == State.SUCCESS) == is_ti_success
+        assert (ti.state == TaskInstanceState.SUCCESS) == is_ti_success
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "prev_ti_state, is_ti_success",
         [
-            (State.SUCCESS, True),
-            (State.SKIPPED, True),
-            (State.RUNNING, False),
-            (State.FAILED, False),
-            (State.NONE, False),
-        ]
+            (TaskInstanceState.SUCCESS, True),
+            (TaskInstanceState.SKIPPED, True),
+            (TaskInstanceState.RUNNING, False),
+            (TaskInstanceState.FAILED, False),
+            (None, False),
+        ],
     )
-    def test_wait_for_downstream(self, prev_ti_state, is_ti_success):
+    def test_wait_for_downstream(self, session, prev_ti_state, is_ti_success):
         dag_id = 'test_wait_for_downstream'
         dag = self.dagbag.get_dag(dag_id)
         upstream, downstream = dag.tasks
 
         # For ti.set_state() to work, the DagRun has to exist,
         # Otherwise ti.previous_ti returns an unpersisted TI
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0), is_backfill=True)
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0), is_backfill=True)
+        dag_run_1 = self.create_dag_run(
+            dag,
+            execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0),
+            is_backfill=True,
+            session=session,
+        )
+        dag_run_2 = self.create_dag_run(
+            dag,
+            execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0),
+            is_backfill=True,
+            session=session,
+        )
 
-        prev_ti_downstream = TI(task=downstream, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0))
-        ti = TI(task=upstream, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0))
+        prev_ti_downstream = TI(task=downstream, run_id=dag_run_1.run_id)
+        ti = TI(task=upstream, run_id=dag_run_2.run_id)
         prev_ti = ti.get_previous_ti()
-        prev_ti.set_state(State.SUCCESS)
-        assert prev_ti.state == State.SUCCESS
+        prev_ti.set_state(TaskInstanceState.SUCCESS)
+        assert prev_ti.state == TaskInstanceState.SUCCESS
 
         prev_ti_downstream.set_state(prev_ti_state)
-        ti.set_state(State.QUEUED)
+        ti.set_state(TaskInstanceState.QUEUED)
         ti.run()
-        assert (ti.state == State.SUCCESS) == is_ti_success
+        assert (ti.state == TaskInstanceState.SUCCESS) == is_ti_success
 
-    @parameterized.expand([(State.QUEUED,), (State.RUNNING,)])
-    def test_next_dagruns_to_examine_only_unpaused(self, state):
+    @pytest.mark.parametrize("state", [DagRunState.QUEUED, DagRunState.RUNNING])
+    def test_next_dagruns_to_examine_only_unpaused(self, session, state):
         """
         Check that "next_dagruns_to_examine" ignores runs from paused/inactive DAGs
         and gets running/queued dagruns
@@ -722,7 +747,6 @@ class TestDagRun(unittest.TestCase):
         dag = DAG(dag_id='test_dags', start_date=DEFAULT_DATE)
         DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
-        session = settings.Session()
         orm_dag = DagModel(
             dag_id=dag.dag_id,
             has_task_concurrency_limits=False,
@@ -736,7 +760,8 @@ class TestDagRun(unittest.TestCase):
             run_type=DagRunType.SCHEDULED,
             state=state,
             execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE if state == State.RUNNING else None,
+            data_interval=dag.infer_automated_data_interval(DEFAULT_DATE),
+            start_date=DEFAULT_DATE if state == DagRunState.RUNNING else None,
             session=session,
         )
 
@@ -751,7 +776,7 @@ class TestDagRun(unittest.TestCase):
         assert runs == []
 
     @mock.patch.object(Stats, 'timing')
-    def test_no_scheduling_delay_for_nonscheduled_runs(self, stats_mock):
+    def test_no_scheduling_delay_for_nonscheduled_runs(self, stats_mock, session):
         """
         Tests that dag scheduling delay stat is not called if the dagrun is not a scheduled run.
         This case is manual run. Simple test for coherence check.
@@ -760,21 +785,22 @@ class TestDagRun(unittest.TestCase):
         dag_task = DummyOperator(task_id='dummy', dag=dag)
 
         initial_task_states = {
-            dag_task.task_id: State.SUCCESS,
+            dag_task.task_id: TaskInstanceState.SUCCESS,
         }
 
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         dag_run.update_state()
         assert call(f'dagrun.{dag.dag_id}.first_task_scheduling_delay') not in stats_mock.mock_calls
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "schedule_interval, expected",
         [
             ("*/5 * * * *", True),
             (None, False),
             ("@once", False),
-        ]
+        ],
     )
-    def test_emit_scheduling_delay(self, schedule_interval, expected):
+    def test_emit_scheduling_delay(self, session, schedule_interval, expected):
         """
         Tests that dag scheduling delay stat is set properly once running scheduled dag.
         dag_run.update_state() invokes the _emit_true_scheduling_delay_stats_for_finished_state method.
@@ -782,7 +808,6 @@ class TestDagRun(unittest.TestCase):
         dag = DAG(dag_id='test_emit_dag_stats', start_date=days_ago(1), schedule_interval=schedule_interval)
         dag_task = DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
-        session = settings.Session()
         try:
             info = dag.next_dagrun_info(None)
             orm_dag_kwargs = {"dag_id": dag.dag_id, "has_task_concurrency_limits": False, "is_active": True}
@@ -799,13 +824,14 @@ class TestDagRun(unittest.TestCase):
             session.flush()
             dag_run = dag.create_dagrun(
                 run_type=DagRunType.SCHEDULED,
-                state=State.SUCCESS,
+                state=DagRunState.SUCCESS,
                 execution_date=dag.start_date,
+                data_interval=dag.infer_automated_data_interval(dag.start_date),
                 start_date=dag.start_date,
                 session=session,
             )
             ti = dag_run.get_task_instance(dag_task.task_id, session)
-            ti.set_state(State.SUCCESS, session)
+            ti.set_state(TaskInstanceState.SUCCESS, session)
             session.flush()
 
             with mock.patch.object(Stats, 'timing') as stats_mock:
@@ -826,7 +852,7 @@ class TestDagRun(unittest.TestCase):
             session.rollback()
             session.close()
 
-    def test_states_sets(self):
+    def test_states_sets(self, session):
         """
         Tests that adding State.failed_states and State.success_states work as expected.
         """
@@ -835,10 +861,10 @@ class TestDagRun(unittest.TestCase):
         dag_task_failed = DummyOperator(task_id='dummy2', dag=dag)
 
         initial_task_states = {
-            dag_task_success.task_id: State.SUCCESS,
-            dag_task_failed.task_id: State.FAILED,
+            dag_task_success.task_id: TaskInstanceState.SUCCESS,
+            dag_task_failed.task_id: TaskInstanceState.FAILED,
         }
-        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        dag_run = self.create_dag_run(dag=dag, task_states=initial_task_states, session=session)
         ti_success = dag_run.get_task_instance(dag_task_success.task_id)
         ti_failed = dag_run.get_task_instance(dag_task_failed.task_id)
         assert ti_success.state in State.success_states

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -604,11 +604,11 @@ class TestTriggerRuleDep:
         session.commit()
 
         # check handling with cases that tasks are triggered from backfill with no finished tasks
-        finished_tasks = DepContext().ensure_finished_tasks(ti_op2.dag_run, session)
-        assert get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op2) == (1, 0, 0, 0, 1)
-        finished_tasks = dr.get_task_instances(state=State.finished, session=session)
-        assert get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op4) == (1, 0, 1, 0, 2)
-        assert get_states_count_upstream_ti(finished_tasks=finished_tasks, ti=ti_op5) == (2, 0, 1, 0, 3)
+        finished_tis = DepContext().ensure_finished_tis(ti_op2.dag_run, session)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op2) == (1, 0, 0, 0, 1)
+        finished_tis = dr.get_task_instances(state=State.finished, session=session)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op4) == (1, 0, 1, 0, 2)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op5) == (2, 0, 1, 0, 3)
 
         dr.update_state()
         assert State.SUCCESS == dr.state


### PR DESCRIPTION
* Modernise `TestDagRun` to use more modern test setup, and squelch most deprecation warnings.
* Rename some `xxxx_tasks` variables to `xxxx_tis` since thise are collections of _TaskInstance_, not tasks.

No functionalies are changed.