### PR TITLE
Typing support for operator mapping functions

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -20,9 +20,9 @@
 # necessarily exist at run time. See "Creating Custom @task Decorators"
 # documentation for more details.
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, TypeVar, Union, overload
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Union, overload
 
-from airflow.decorators.base import TaskDecorator
+from airflow.decorators.base import Function, Task, TaskDecorator
 from airflow.decorators.python import python_task
 from airflow.decorators.python_virtualenv import virtualenv_task
 from airflow.decorators.task_group import task_group
@@ -38,8 +38,6 @@ __all__ = [
     "python_task",
     "virtualenv_task",
 ]
-
-Function = TypeVar("Function", bound=Callable)
 
 class TaskDecoratorCollection:
     @overload
@@ -70,7 +68,7 @@ class TaskDecoratorCollection:
         """
     # [START mixin_for_typing]
     @overload
-    def python(self, python_callable: Function) -> Function: ...
+    def python(self, python_callable: Function) -> Task[Function]: ...
     # [END mixin_for_typing]
     @overload
     def __call__(
@@ -83,7 +81,7 @@ class TaskDecoratorCollection:
     ) -> TaskDecorator:
         """Aliasing ``python``; signature should match exactly."""
     @overload
-    def __call__(self, python_callable: Function) -> Function:
+    def __call__(self, python_callable: Function) -> Task[Function]:
         """Aliasing ``python``; signature should match exactly."""
     @overload
     def virtualenv(
@@ -126,7 +124,7 @@ class TaskDecoratorCollection:
             such as transmission a large amount of XCom to TaskAPI.
         """
     @overload
-    def virtualenv(self, python_callable: Function) -> Function: ...
+    def virtualenv(self, python_callable: Function) -> Task[Function]: ...
     # [START decorator_signature]
     def docker(
         self,

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -306,15 +306,42 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         return attr.evolve(self, kwargs=partial_kwargs)
 
 
+class Task(Generic[Function]):
+    """Declaration of a @task-decorated callable for type-checking.
+
+    An instance of this type inherits the call signature of the decorated
+    function wrapped in it (not *exactly* since it actually returns an XComArg,
+    but there's no way to express that right now), and provides two additional
+    methods for task-mapping.
+
+    This type is implemented by ``_TaskDecorator`` at runtime.
+    """
+
+    __call__: Function
+
+    function: Function
+
+    def map(self, **kwargs: Any) -> XComArg:
+        ...
+
+    def partial(self, **kwargs: Any) -> "Task[Function]":
+        ...
+
+
 class TaskDecorator(Protocol):
     """Type declaration for ``task_decorator_factory`` return type."""
 
     @overload
-    def __call__(self, python_callable: Function) -> Function:
+    def __call__(self, python_callable: Function) -> Task[Function]:
         """For the "bare decorator" ``@task`` case."""
 
     @overload
-    def __call__(self, *, multiple_outputs: Optional[bool], **kwargs: Any) -> Callable[[Function], Function]:
+    def __call__(
+        self,
+        *,
+        multiple_outputs: Optional[bool],
+        **kwargs: Any,
+    ) -> Callable[[Function], Task[Function]]:
         """For the decorator factory ``@task()`` case."""
 
 

--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -31,8 +31,7 @@ from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
 
-F = TypeVar("F", bound=Callable[..., Any])
-T = TypeVar("T", bound=Callable)
+F = TypeVar("F", bound=Callable)
 R = TypeVar("R")
 
 task_group_sig = signature(TaskGroup.__init__)
@@ -130,6 +129,29 @@ class MappedTaskGroupDecorator(TaskGroupDecorator[R]):
             warnings.warn(f"Partial task group {self.function.__name__} was never mapped!")
 
 
+class Group(Generic[F]):
+    """Declaration of a @task_group-decorated callable for type-checking.
+
+    An instance of this type inherits the call signature of the decorated
+    function wrapped in it (not *exactly* since it actually turns the function
+    into an XComArg-compatible, but there's no way to express that right now),
+    and provides two additional methods for task-mapping.
+
+    This type is implemented by ``TaskGroupDecorator`` at runtime.
+    """
+
+    __call__: F
+
+    function: F
+
+    # Return value should match F's return type, but that's impossible to declare.
+    def map(self, **kwargs: Any) -> Any:
+        ...
+
+    def partial(self, **kwargs: Any) -> "Group[F]":
+        ...
+
+
 # This covers the @task_group() case. Annotations are copied from the TaskGroup
 # class, only providing a default to 'group_id' (this is optional for the
 # decorator and defaults to the decorated function's name). Please keep them in
@@ -141,24 +163,24 @@ class MappedTaskGroupDecorator(TaskGroupDecorator[R]):
 def task_group(
     group_id: Optional[str] = None,
     prefix_group_id: bool = True,
-    parent_group: Optional["TaskGroup"] = None,
+    parent_group: Optional[TaskGroup] = None,
     dag: Optional["DAG"] = None,
     default_args: Optional[Dict[str, Any]] = None,
     tooltip: str = "",
     ui_color: str = "CornflowerBlue",
     ui_fgcolor: str = "#000",
     add_suffix_on_collision: bool = False,
-) -> Callable[[F], F]:
+) -> Callable[[F], Group[F]]:
     ...
 
 
 # This covers the @task_group case (no parentheses).
 @overload
-def task_group(python_callable: F) -> F:
+def task_group(python_callable: F) -> Group[F]:
     ...
 
 
-def task_group(python_callable=None, *tg_args, **tg_kwargs):
+def task_group(python_callable=None, **tg_kwargs):
     """
     Python TaskGroup decorator.
 
@@ -167,9 +189,8 @@ def task_group(python_callable=None, *tg_args, **tg_kwargs):
     TaskGroup class. Can be used to parametrize TaskGroup.
 
     :param python_callable: Function to decorate.
-    :param tg_args: Positional arguments for the TaskGroup object.
     :param tg_kwargs: Keyword arguments for the TaskGroup object.
     """
     if callable(python_callable):
         return TaskGroupDecorator(function=python_callable, kwargs=tg_kwargs)
-    return cast("Callable[[T], T]", functools.partial(TaskGroupDecorator, kwargs=tg_kwargs))
+    return cast(Callable[[F], F], functools.partial(TaskGroupDecorator, kwargs=tg_kwargs))


### PR DESCRIPTION
Alternative to #21402 but more structured. Mostly extracted from #21328. I also implemented the same for `@task_group`; it doesn’t emit errors right now, but will start to once we implement mapping for it.