### PR TITLE
[doc] Improve s3 operator example by adding task upload_keys

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
@@ -28,6 +28,7 @@ from airflow.providers.amazon.aws.operators.s3 import S3CreateBucketOperator, S3
 BUCKET_NAME = os.environ.get('BUCKET_NAME', 'test-airflow-12345')
 
 
+# [START howto_operator_s3_bucket]
 @task(task_id="s3_bucket_dag_add_keys_to_bucket")
 def upload_keys():
     """This is a python callback to add keys into the s3 bucket"""
@@ -41,7 +42,6 @@ def upload_keys():
         )
 
 
-# [START howto_operator_s3_bucket]
 with DAG(
     dag_id='s3_bucket_dag',
     schedule_interval=None,


### PR DESCRIPTION
for now, our s3 bucket example does without declaring task `upload_keys` but we set dependence with it. I think we should better add `upload_keys` declare to the example for more sence.
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/15820530/152972428-81550ceb-9bf0-44b1-9b48-aab927188c87.png">
