### PR TITLE
eks_hook log level fatal -> FATAL 

### DIFF
--- a/airflow/providers/amazon/aws/hooks/eks.py
+++ b/airflow/providers/amazon/aws/hooks/eks.py
@@ -577,7 +577,7 @@ class EksHook(AwsBaseHook):
                             "env": [
                                 {
                                     "name": "AIRFLOW__LOGGING__LOGGING_LEVEL",
-                                    "value": "fatal",
+                                    "value": "FATAL",
                                 }
                             ],
                             "interactiveMode": "Never",

--- a/tests/providers/amazon/aws/hooks/test_eks.py
+++ b/tests/providers/amazon/aws/hooks/test_eks.py
@@ -1271,7 +1271,7 @@ class TestEksHook:
                                 'apiVersion': 'client.authentication.k8s.io/v1alpha1',
                                 'args': expected_args,
                                 'command': sys.executable,
-                                'env': [{'name': 'AIRFLOW__LOGGING__LOGGING_LEVEL', 'value': 'fatal'}],
+                                'env': [{'name': 'AIRFLOW__LOGGING__LOGGING_LEVEL', 'value': 'FATAL'}],
                                 'interactiveMode': 'Never',
                             }
                         },


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: [#ISSUE](https://github.com/apache/airflow/issues/21421)
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

There is an issue with the value being set to override  `AIRFLOW__LOGGING__LOGGING_LEVEL`.  Where it requires an all capitalized value 

```
airflow.exceptions.AirflowConfigException: `[logging] logging_level` should not be 'fatal'. Possible values: CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG.
```


closes: [#21421 ](https://github.com/apache/airflow/issues/21421)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
