### PR TITLE
Normalize *_conn_id parameters in BigQuery sensors

### DIFF
--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains a Google Bigquery sensor."""
-from typing import TYPE_CHECKING, Optional, Sequence, Union
 import warnings
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.sensors.base import BaseSensorOperator

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -95,7 +95,7 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         table_uri = f'{self.project_id}:{self.dataset_id}.{self.table_id}'
         self.log.info('Sensor checks existence of table: %s', table_uri)
         hook = BigQueryHook(
-            bigquery_conn_id=self.gcp_conn_id,
+            gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -17,12 +17,18 @@
 # under the License.
 """This module contains a Google Bigquery sensor."""
 from typing import TYPE_CHECKING, Optional, Sequence, Union
+import warnings
 
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
+
+
+_DEPRECATION_MSG = (
+    "The bigquery_conn_id parameter has been deprecated. You should pass the gcp_conn_id parameter."
+)
 
 
 class BigQueryTableExistenceSensor(BaseSensorOperator):
@@ -35,8 +41,9 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
     :param dataset_id: The name of the dataset in which to look for the table.
         storage bucket.
     :param table_id: The name of the table to check the existence of.
-    :param bigquery_conn_id: The connection ID to use when connecting to
-        Google BigQuery.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
+    :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
+        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :param delegate_to: The account to impersonate using domain-wide delegation of authority,
         if any. For this to work, the service account making the request must have
         domain-wide delegation enabled.
@@ -64,17 +71,23 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         project_id: str,
         dataset_id: str,
         table_id: str,
-        bigquery_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = 'google_cloud_default',
+        bigquery_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
 
         super().__init__(**kwargs)
+
+        if bigquery_conn_id:
+            warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
+            gcp_conn_id = bigquery_conn_id
+
         self.project_id = project_id
         self.dataset_id = dataset_id
         self.table_id = table_id
-        self.bigquery_conn_id = bigquery_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
@@ -82,7 +95,7 @@ class BigQueryTableExistenceSensor(BaseSensorOperator):
         table_uri = f'{self.project_id}:{self.dataset_id}.{self.table_id}'
         self.log.info('Sensor checks existence of table: %s', table_uri)
         hook = BigQueryHook(
-            bigquery_conn_id=self.bigquery_conn_id,
+            bigquery_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )
@@ -102,8 +115,9 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         storage bucket.
     :param table_id: The name of the table to check the existence of.
     :param partition_id: The name of the partition to check the existence of.
-    :param bigquery_conn_id: The connection ID to use when connecting to
-        Google BigQuery.
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
+    :param bigquery_conn_id: (Deprecated) The connection ID used to connect to Google Cloud.
+        This parameter has been deprecated. You should pass the gcp_conn_id parameter instead.
     :param delegate_to: The account to impersonate, if any.
         For this to work, the service account making the request must
         have domain-wide delegation enabled.
@@ -133,18 +147,24 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         dataset_id: str,
         table_id: str,
         partition_id: str,
-        bigquery_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = 'google_cloud_default',
+        bigquery_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
 
         super().__init__(**kwargs)
+
+        if bigquery_conn_id:
+            warnings.warn(_DEPRECATION_MSG, DeprecationWarning, stacklevel=3)
+            gcp_conn_id = bigquery_conn_id
+
         self.project_id = project_id
         self.dataset_id = dataset_id
         self.table_id = table_id
         self.partition_id = partition_id
-        self.bigquery_conn_id = bigquery_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
@@ -152,7 +172,7 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
         table_uri = f'{self.project_id}:{self.dataset_id}.{self.table_id}'
         self.log.info('Sensor checks existence of partition: "%s" in table: %s', self.partition_id, table_uri)
         hook = BigQueryHook(
-            bigquery_conn_id=self.bigquery_conn_id,
+            gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             impersonation_chain=self.impersonation_chain,
         )

--- a/tests/providers/google/cloud/sensors/test_bigquery.py
+++ b/tests/providers/google/cloud/sensors/test_bigquery.py
@@ -39,7 +39,7 @@ class TestBigqueryTableExistenceSensor(TestCase):
             project_id=TEST_PROJECT_ID,
             dataset_id=TEST_DATASET_ID,
             table_id=TEST_TABLE_ID,
-            bigquery_conn_id=TEST_GCP_CONN_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -49,7 +49,7 @@ class TestBigqueryTableExistenceSensor(TestCase):
         assert results is True
 
         mock_hook.assert_called_once_with(
-            bigquery_conn_id=TEST_GCP_CONN_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -67,7 +67,7 @@ class TestBigqueryTablePartitionExistenceSensor(TestCase):
             dataset_id=TEST_DATASET_ID,
             table_id=TEST_TABLE_ID,
             partition_id=TEST_PARTITION_ID,
-            bigquery_conn_id=TEST_GCP_CONN_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )
@@ -77,7 +77,7 @@ class TestBigqueryTablePartitionExistenceSensor(TestCase):
         assert results is True
 
         mock_hook.assert_called_once_with(
-            bigquery_conn_id=TEST_GCP_CONN_ID,
+            gcp_conn_id=TEST_GCP_CONN_ID,
             delegate_to=TEST_DELEGATE_TO,
             impersonation_chain=TEST_IMPERSONATION_CHAIN,
         )


### PR DESCRIPTION
Add `gcp_conn_id` parameter to BigQuery sensors and deprecate `bigquery_conn_id` parameter.
Pass `gcp_conn_id` to `BigQueryHook` using `gcp_conn_id` to avoid deprecation warning in hook code.
Please note that a similar change for BigQuery operators was already performed in commit 042a9ba2c285772fcc2208847198c2e2c31d4424