### PR TITLE
[scheduler HA]catch sqlalchemy leaking LockNotAvailable Exception during multiple scheduler instances comes up

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -868,23 +868,30 @@ class SchedulerJob(BaseJob):
                 timer.stop(send=True)
             except (OperationalError, LockNotAvailable) as e:
                 timer.stop(send=False)
-                if isinstance(e, OperationalError) and is_lock_not_available_error(error=e) or isinstance(e,
-                                                                                                          LockNotAvailable):
+                if (
+                    isinstance(e, OperationalError)
+                    and is_lock_not_available_error(error=e)
+                    or isinstance(e, LockNotAvailable)
+                ):
                     self.log.debug("Critical section lock held by another Scheduler")
                     Stats.incr('scheduler.critical_section_busy')
                     session.rollback()
                     return 0
-                self.log.debug("If block didnt work with exception {}".format(e))
+                self.log.debug(f"If block didn't work with exception {e}")
                 raise
             except Exception as exc:
-                self.log.debug("General Exception: {}, context: {}".format(exc, exc.__context__))
+                self.log.debug(f"General Exception: {exc}, context: {exc.__context__}")
                 e = exc.__context__
-                if isinstance(e, OperationalError) and is_lock_not_available_error(error=e)or isinstance(e, LockNotAvailable):
+                if (
+                    isinstance(e, OperationalError)
+                    and is_lock_not_available_error(error=e)
+                    or isinstance(e, LockNotAvailable)
+                ):
                     self.log.debug("Critical section lock held by another Scheduler")
                     Stats.incr('scheduler.critical_section_busy')
                     session.rollback()
                     return 0
-                self.log.debug("If block didnt work with exception {}".format(e))
+                self.log.debug(f"If block didn't work with exception {e}")
                 raise
 
             guard.commit()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -877,7 +877,6 @@ class SchedulerJob(BaseJob):
                     Stats.incr('scheduler.critical_section_busy')
                     session.rollback()
                     return 0
-                self.log.debug(f"If block didn't work with exception {e}")
                 raise
             except Exception as exc:
                 self.log.debug(f"General Exception: {exc}, context: {exc.__context__}")
@@ -891,7 +890,6 @@ class SchedulerJob(BaseJob):
                     Stats.incr('scheduler.critical_section_busy')
                     session.rollback()
                     return 0
-                self.log.debug(f"If block didn't work with exception {e}")
                 raise
 
             guard.commit()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
catch sqlalchemy leaks LockNotAvailable Exception during multiple scheduler comes up with postgres. catching the exception is allowing mutliple scheduler instances up and running with same postgres DB.
Issues details:

https://github.com/apache/airflow/issues/20695

Discussion detials:

https://github.com/apache/airflow/discussions/21038

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
