### PR TITLE
Fix EcsOperatorError, so it can be loaded from a picklefile

### DIFF
--- a/airflow/providers/amazon/aws/exceptions.py
+++ b/airflow/providers/amazon/aws/exceptions.py
@@ -29,6 +29,10 @@ class EcsOperatorError(Exception):
         self.message = message
         super().__init__(message)
 
+    def __reduce__(self):
+        return EcsOperatorError, (self.failures, self.message)
+
+
 
 class ECSOperatorError(EcsOperatorError):
     """

--- a/airflow/providers/amazon/aws/exceptions.py
+++ b/airflow/providers/amazon/aws/exceptions.py
@@ -33,7 +33,6 @@ class EcsOperatorError(Exception):
         return EcsOperatorError, (self.failures, self.message)
 
 
-
 class ECSOperatorError(EcsOperatorError):
     """
     This class is deprecated.


### PR DESCRIPTION
Had a similar issue as described [here](https://github.com/apache/airflow/issues/17045).
Found out that `EcsOperatorError` was not correctly implemented and couldn't be loaded from a pickle dump. 
The proposed fix solves this issue. (for reference: https://stackoverflow.com/questions/41808912/cannot-unpickle-exception-subclass)