### PR TITLE
Fix Resources __eq__ check

### DIFF
--- a/airflow/utils/operator_resources.py
+++ b/airflow/utils/operator_resources.py
@@ -50,6 +50,8 @@ class Resource:
         self._qty = qty
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self.__dict__ == other.__dict__
 
     def __repr__(self):
@@ -126,6 +128,8 @@ class Resources:
         self.gpus = GpuResource(gpus)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self.__dict__ == other.__dict__
 
     def __repr__(self):

--- a/tests/utils/test_operator_resources.py
+++ b/tests/utils/test_operator_resources.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow.utils.operator_resources import Resources
+
+
+class TestResources(unittest.TestCase):
+    def test_resource_eq(self):
+        r = Resources(**{"cpus": 0.1, "ram": 2048})
+        assert r not in [{}, [], None]
+        assert r == r
+
+        r2 = Resources(**{"cpus": 0.1, "ram": 2048})
+        assert r == r2
+        assert r2 == r
+
+        r3 = Resources(**{"cpus": 0.2, "ram": 2048})
+        assert r != r3

--- a/tests/utils/test_operator_resources.py
+++ b/tests/utils/test_operator_resources.py
@@ -23,13 +23,13 @@ from airflow.utils.operator_resources import Resources
 
 class TestResources(unittest.TestCase):
     def test_resource_eq(self):
-        r = Resources(**{"cpus": 0.1, "ram": 2048})
+        r = Resources(cpus=0.1, ram=2048)
         assert r not in [{}, [], None]
         assert r == r
 
-        r2 = Resources(**{"cpus": 0.1, "ram": 2048})
+        r2 = Resources(cpus=0.1, ram=2048)
         assert r == r2
         assert r2 == r
 
-        r3 = Resources(**{"cpus": 0.2, "ram": 2048})
+        r3 = Resources(cpus=0.2, ram=2048)
         assert r != r3


### PR DESCRIPTION
it should check if the compared item is the instance of `Resources`

Otherwise, the scheduler won't be able to serialize tasks with `resources` params, due to the following error:

![image](https://user-images.githubusercontent.com/8662365/153091479-09f2a6d4-7b7a-4352-bcdd-39f75999b0ac.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
