### PR TITLE
Fix checking providers against a baseline

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -1974,10 +1974,14 @@ def build_provider_packages(
     try:
         provider_package_id = package_id
         with with_group(f"Prepare provider package for '{provider_package_id}'"):
-            current_tag = get_current_tag(provider_package_id, version_suffix, git_update, verbose)
-            if tag_exists_for_version(provider_package_id, current_tag, verbose):
-                console.print(f"[yellow]The tag {current_tag} exists. Skipping the package.[/]")
-                return False
+            if version_suffix.startswith("rc") or version_suffix == "":
+                # For RC and official releases we check if the "officially released" version exists
+                # and skip the released if it was. This allows to skip packages that have not been
+                # marked for release. For "dev" suffixes, we always build all packages
+                released_tag = get_current_tag(provider_package_id, "", git_update, verbose)
+                if tag_exists_for_version(provider_package_id, released_tag, verbose):
+                    console.print(f"[yellow]The tag {released_tag} exists. Skipping the package.[/]")
+                    return False
             console.print(f"Changing directory to ${TARGET_PROVIDER_PACKAGES_PATH}")
             os.chdir(TARGET_PROVIDER_PACKAGES_PATH)
             cleanup_remnants(verbose)


### PR DESCRIPTION
When bulk releasing rcn for providers we should check if the same
"full" version was released and only release if it was not,

We used to check against the rcN release, but this was only working
when we had rc1 previously released.

When releasing rc2 in bulk, we now skip the packages that have
the same "full release" tag.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
