### PR TITLE
[de]serialize resources on task correctly

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -49,6 +49,7 @@ from airflow.settings import json
 from airflow.timetables.base import Timetable
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.module_loading import as_importable_string, import_string
+from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
 if TYPE_CHECKING:
@@ -319,6 +320,8 @@ class BaseSerialization:
             return cls._encode(json_pod, type_=DAT.POD)
         elif isinstance(var, DAG):
             return SerializedDAG.serialize_dag(var)
+        elif isinstance(var, Resources):
+            return var.to_dict()
         elif isinstance(var, MappedOperator):
             return SerializedBaseOperator.serialize_mapped_operator(var)
         elif isinstance(var, BaseOperator):
@@ -728,6 +731,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = cls._deserialize_timedelta(v)
             elif k in encoded_op["template_fields"]:
                 pass
+            elif k == "resources":
+                v = Resources.from_dict(v)
             elif k.endswith("_date"):
                 v = cls._deserialize_datetime(v)
             elif k == "_operator_extra_links":

--- a/airflow/utils/operator_resources.py
+++ b/airflow/utils/operator_resources.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import Dict
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
@@ -75,6 +76,13 @@ class Resource:
         """
         return self._qty
 
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'qty': self.qty,
+            'units_str': self.units_str,
+        }
+
 
 class CpuResource(Resource):
     """Represents a CPU requirement in an execution environment for an operator."""
@@ -134,3 +142,21 @@ class Resources:
 
     def __repr__(self):
         return str(self.__dict__)
+
+    def to_dict(self):
+        return {
+            'cpus': self.cpus.to_dict(),
+            'ram': self.ram.to_dict(),
+            'disk': self.disk.to_dict(),
+            'gpus': self.gpus.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, resources_dict: Dict):
+        """Create resources from resources dict"""
+        cpus = resources_dict['cpus']['qty']
+        ram = resources_dict['ram']['qty']
+        disk = resources_dict['disk']['qty']
+        gpus = resources_dict['gpus']['qty']
+
+        return cls(cpus=cpus, ram=ram, disk=disk, gpus=gpus)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -52,6 +52,7 @@ from airflow.serialization.serialized_objects import (
 from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.utils import timezone
 from airflow.utils.context import Context
+from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import TaskGroup
 from tests.test_utils.mock_operators import CustomOperator, CustomOpLink, GoogleLink, MockOperator
 from tests.test_utils.timetables import CustomSerializationTimetable, cron_timetable, delta_timetable
@@ -1175,6 +1176,24 @@ class TestStringifiedDAGs:
         serialized_op = SerializedBaseOperator.deserialize_operator(blob)
         assert serialized_op.downstream_task_ids == {'foo'}
 
+    def test_task_resources(self):
+        """
+        Test task resources serialization/deserialization.
+        """
+        from airflow.operators.dummy import DummyOperator
+
+        execution_date = datetime(2020, 1, 1)
+        task_id = 'task1'
+        with DAG("test_task_resources", start_date=execution_date) as dag:
+            task = DummyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
+
+        SerializedDAG.validate_schema(SerializedDAG.to_dict(dag))
+
+        json_dag = SerializedDAG.from_json(SerializedDAG.to_json(dag))
+        deserialized_task = json_dag.get_task(task_id)
+        assert deserialized_task.resources == task.resources
+        assert isinstance(deserialized_task.resources, Resources)
+
     def test_task_group_serialization(self):
         """
         Test TaskGroup serialization/deserialization.
@@ -1659,6 +1678,26 @@ def test_mapped_operator_xcomarg_serde():
     xcom_arg = serialized_dag.task_dict['task_2'].mapped_kwargs['arg2']
     assert isinstance(xcom_arg, XComArg)
     assert xcom_arg.operator is serialized_dag.task_dict['op1']
+
+
+def test_task_resources_serde():
+    """
+    Test task resources serialization/deserialization.
+    """
+    from airflow.operators.dummy import DummyOperator
+
+    execution_date = datetime(2020, 1, 1)
+    task_id = 'task1'
+    with DAG("test_task_resources", start_date=execution_date) as _:
+        task = DummyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
+
+    serialized = SerializedBaseOperator._serialize(task)
+    assert serialized['resources'] == {
+        "cpus": {"name": "CPU", "qty": 0.1, "units_str": "core(s)"},
+        "disk": {"name": "Disk", "qty": 512, "units_str": "MB"},
+        "gpus": {"name": "GPU", "qty": 0, "units_str": "gpu(s)"},
+        "ram": {"name": "RAM", "qty": 2048, "units_str": "MB"},
+    }
 
 
 def test_mapped_decorator_serde():

--- a/tests/utils/test_operator_resources.py
+++ b/tests/utils/test_operator_resources.py
@@ -33,3 +33,12 @@ class TestResources(unittest.TestCase):
 
         r3 = Resources(cpus=0.2, ram=2048)
         assert r != r3
+
+    def test_to_dict(self):
+        r = Resources(cpus=0.1, ram=2048, disk=1024, gpus=1)
+        assert r.to_dict() == {
+            'cpus': {'name': 'CPU', 'qty': 0.1, 'units_str': 'core(s)'},
+            'ram': {'name': 'RAM', 'qty': 2048, 'units_str': 'MB'},
+            'disk': {'name': 'Disk', 'qty': 1024, 'units_str': 'MB'},
+            'gpus': {'name': 'GPU', 'qty': 1, 'units_str': 'gpu(s)'},
+        }


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The `resources` field in the Operator is not correctly serialized and deserialized.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
