### PR TITLE
Update invalid arg from snippet in TaskFlow tutorial doc

### DIFF
--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -312,7 +312,7 @@ The reverse can also be done: passing the output of a TaskFlow function as an in
 
 .. code-block:: python
 
-    @task
+    @task(retries=3)
     def create_queue():
         """This is a Python function that creates an SQS queue"""
         hook = SqsHook()

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -301,7 +301,7 @@ to a TaskFlow function which parses the response as JSON.
     )
 
 
-    @task(max_retries=2)
+    @task
     def parse_results(api_results):
         return json.loads(api_results)
 


### PR DESCRIPTION
~~Doesn't really add anything to the documentation to substitute with a different arg either.~~
Updated from `max_retries` to `retries` and added to the following example in the doc since using `retries` when simply deserializing an output _probably_ isn't a great use case to showcase using that arg. The next task tries to create a queue which seems like a more plausible place to use `retries`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
