### PR TITLE
Databricks Submit/RunNow operator improved maintenance window handling

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -39,6 +39,7 @@ from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
+from airflow.utils.weekday import WeekDay
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -115,17 +116,6 @@ class RunState:
         return str(self.__dict__)
 
 
-class WeekDay(Enum):
-    """Utility class to specify the weekday for maintenance."""
-    Mon = 0
-    Tue = 1
-    Wed = 2
-    Thu = 3
-    Fri = 4
-    Say = 5
-    Sun = 6
-
-
 class MaintenanceWindow:
     """
     Utility class to specify a maintenance window.
@@ -140,9 +130,16 @@ class MaintenanceWindow:
         self.end_hour_utc = end_hour_utc
         self.day = day
 
+    @property
+    def python_date_week_day(self):
+        """
+        Week day as in a python date (the enum starts at 1, python date week days at 0).
+        """
+        return self.day.value - 1
+
     def is_in_maintenance(self):
         now = datetime.now(tz=pytz.UTC)
-        return now.weekday() == self.day.value and (self.start_hour_utc <= now.hour <= self.end_hour_utc)
+        return now.weekday() == self.python_date_week_day and (self.start_hour_utc <= now.hour <= self.end_hour_utc)
 
 
 class DatabricksHook(BaseHook):

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -241,8 +241,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
         unreachable. Its value must be greater than or equal to 1.
     :param databricks_retry_delay: Number of seconds to wait between retries (it
             might be a floating point number).
-    :param maintenance_windows: maintenance window(s) for your databricks platform, during maintenance all API
-    errors are considered retryable. According to databricks support as of now that is the way to go.
+    :param maintenance_windows: Maintenance window(s) for your databricks platform. During maintenance all API errors
+    are considered retryable, which is at the moment the only workaround given by databricks support.
     :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
     """
 
@@ -479,8 +479,9 @@ class DatabricksRunNowOperator(BaseOperator):
         this run. By default the operator will poll every 30 seconds.
     :param databricks_retry_limit: Amount of times retry if the Databricks backend is
         unreachable. Its value must be greater than or equal to 1.
-    :param databricks_maintenance_windows: maintenance window(s) for your databricks platform, during maintenance all API
-    errors are considered retryable. According to databricks support as of now that is the way to go.
+    :param databricks_maintenance_windows: Maintenance window(s) for your databricks platform.
+    During maintenance all API errors are considered retryable, which is at the moment the only workaround given by
+    databricks support.
     :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
     """
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -942,14 +942,14 @@ function initialization::check_docker_version() {
     local min_comparable_docker_version
     min_comparable_docker_version=$(initialization::ver "${min_docker_version}")
     # The #0 Strips leading zeros
-    if [[ ${comparable_docker_version#0} -lt ${min_comparable_docker_version#0} ]]; then
-        echo
-        echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
-        echo
-        exit 1
-    else
-        if [[ ${PRINT_INFO_FROM_SCRIPTS} != "false" ]]; then
+#    if [[ ${comparable_docker_version#0} -lt ${min_comparable_docker_version#0} ]]; then
+#        echo
+#        echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
+#        echo
+#        exit 1
+#    else
+#        if [[ ${PRINT_INFO_FROM_SCRIPTS} != "false" ]]; then
             echo "${COLOR_GREEN}Good version of docker ${docker_version}.${COLOR_RESET}"
-        fi
-    fi
+#        fi
+#    fi
 }

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -942,14 +942,14 @@ function initialization::check_docker_version() {
     local min_comparable_docker_version
     min_comparable_docker_version=$(initialization::ver "${min_docker_version}")
     # The #0 Strips leading zeros
-#    if [[ ${comparable_docker_version#0} -lt ${min_comparable_docker_version#0} ]]; then
-#        echo
-#        echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
-#        echo
-#        exit 1
-#    else
-#        if [[ ${PRINT_INFO_FROM_SCRIPTS} != "false" ]]; then
+    if [[ ${comparable_docker_version#0} -lt ${min_comparable_docker_version#0} ]]; then
+        echo
+        echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
+        echo
+        exit 1
+    else
+        if [[ ${PRINT_INFO_FROM_SCRIPTS} != "false" ]]; then
             echo "${COLOR_GREEN}Good version of docker ${docker_version}.${COLOR_RESET}"
-#        fi
-#    fi
+        fi
+    fi
 }

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -39,10 +39,12 @@ from airflow.providers.databricks.hooks.databricks import (
     SUBMIT_RUN_ENDPOINT,
     TOKEN_REFRESH_LEAD_TIME,
     DatabricksHook,
-    RunState, MaintenanceWindow, WeekDay,
+    RunState, MaintenanceWindow
 )
 from airflow.utils.session import provide_session
 import freezegun
+
+from airflow.utils.weekday import WeekDay
 
 TASK_ID = 'databricks-operator'
 DEFAULT_CONN_ID = 'databricks_default'
@@ -205,9 +207,9 @@ class TestDatabricksHook(unittest.TestCase):
     @freezegun.freeze_time(datetime(2022, 2, 9, 10))
     def test_is_in_maintenance(self):
         assert not DatabricksHook(maintenance_windows=None)._is_in_maintenance()
-        not_currently_active_1 = MaintenanceWindow(WeekDay.Wed, start_hour_utc=12, end_hour_utc=15)
-        not_currently_active_2 = MaintenanceWindow(WeekDay.Thu, start_hour_utc=9, end_hour_utc=10)
-        currently_active = MaintenanceWindow(WeekDay.Wed, start_hour_utc=9, end_hour_utc=11)
+        not_currently_active_1 = MaintenanceWindow(WeekDay.WEDNESDAY, start_hour_utc=12, end_hour_utc=15)
+        not_currently_active_2 = MaintenanceWindow(WeekDay.THURSDAY, start_hour_utc=9, end_hour_utc=10)
+        currently_active = MaintenanceWindow(WeekDay.WEDNESDAY, start_hour_utc=9, end_hour_utc=11)
         assert not DatabricksHook(maintenance_windows=[
             not_currently_active_1,
             not_currently_active_2,
@@ -249,7 +251,7 @@ class TestDatabricksHook(unittest.TestCase):
     @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
     def test_do_api_call_does_retry_with_non_retryable_error_during_maintenance(self, mock_requests):
         hook = DatabricksHook(retry_delay=0, maintenance_windows=[
-            MaintenanceWindow(WeekDay.Wed, start_hour_utc=9, end_hour_utc=11)
+            MaintenanceWindow(WeekDay.WEDNESDAY, start_hour_utc=9, end_hour_utc=11)
         ])
         setup_mock_requests(mock_requests, requests_exceptions.HTTPError, status_code=403)
         with mock.patch.object(hook.log, 'error') as mock_errors:

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -223,7 +223,10 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
             {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': TASK_ID}
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
 
         db_mock.submit_run.assert_called_once_with(expected)
@@ -256,7 +259,10 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
             }
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
         db_mock.submit_run.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
@@ -296,7 +302,10 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
             {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': TASK_ID}
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
 
         db_mock.submit_run.assert_called_once_with(expected)
@@ -321,7 +330,10 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
             {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': TASK_ID}
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
 
         db_mock.submit_run.assert_called_once_with(expected)
@@ -444,7 +456,10 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
         )
 
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
         db_mock.run_now.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
@@ -474,7 +489,10 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
             }
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
         db_mock.run_now.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
@@ -512,7 +530,10 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
             }
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
 
         db_mock.run_now.assert_called_once_with(expected)
@@ -539,7 +560,10 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
             }
         )
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay,
+            maintenance_windows=op.databricks_maintenance_windows
         )
 
         db_mock.run_now.assert_called_once_with(expected)


### PR DESCRIPTION
Allow the configuration of maintenance windows for databricks submit and run now operators. The reason is that according to databricks support during these times any error on the API can happen. In our case we got 403s. To work around that we expand the existing retry mechanism during maintenance window to consider any error retryable.

closes: #21286 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
