### PR TITLE
Bug Fix - S3DeleteObjectsOperator will try and delete all keys

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -368,7 +368,7 @@ class S3DeleteObjectsOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
-        if not keys is None ^ prefix is None:
+        if not bool(keys is None) ^ bool(prefix is None):
             raise AirflowException("Either keys or prefix should be set.")
 
     def execute(self, context: 'Context'):

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -364,9 +364,6 @@ class S3DeleteObjectsOperator(BaseOperator):
         **kwargs,
     ):
 
-        if not bool(keys) ^ bool(prefix):
-            raise ValueError("Either keys or prefix should be set.")
-
         super().__init__(**kwargs)
         self.bucket = bucket
         self.keys = keys
@@ -375,6 +372,8 @@ class S3DeleteObjectsOperator(BaseOperator):
         self.verify = verify
 
     def execute(self, context: 'Context'):
+        if not bool(self.keys) ^ bool(self.prefix):
+            raise AirflowException("Either keys or prefix should be set.")        
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -323,8 +323,6 @@ class S3DeleteObjectsOperator(BaseOperator):
     To enable users to delete single object or multiple objects from
     a bucket using a single HTTP request.
 
-    Users may specify up to 1000 keys to delete.
-
     :param bucket: Name of the bucket in which you are going to delete object(s). (templated)
     :param keys: The key(s) to delete from S3 bucket. (templated)
 
@@ -334,7 +332,6 @@ class S3DeleteObjectsOperator(BaseOperator):
         When ``keys`` is a list, it's supposed to be the list of the
         keys to delete.
 
-        You may specify up to 1000 keys.
     :param prefix: Prefix of objects to delete. (templated)
         All objects matching this prefix in the bucket will be deleted.
     :param aws_conn_id: Connection id of the S3 connection to use
@@ -371,9 +368,15 @@ class S3DeleteObjectsOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
-    def execute(self, context: 'Context'):
-        if not bool(self.keys) ^ bool(self.prefix):
+        if not bool(keys is None) ^ bool(prefix is None):
             raise AirflowException("Either keys or prefix should be set.")
+
+    def execute(self, context: 'Context'):
+        if not bool(self.keys is None) ^ bool(self.prefix is None):
+            raise AirflowException("Either keys or prefix should be set.")
+
+        if isinstance(self.keys, (list, str)) and not bool(self.keys):
+            return
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -323,8 +323,6 @@ class S3DeleteObjectsOperator(BaseOperator):
     To enable users to delete single object or multiple objects from
     a bucket using a single HTTP request.
 
-    Users may specify up to 1000 keys to delete.
-
     :param bucket: Name of the bucket in which you are going to delete object(s). (templated)
     :param keys: The key(s) to delete from S3 bucket. (templated)
 
@@ -334,7 +332,6 @@ class S3DeleteObjectsOperator(BaseOperator):
         When ``keys`` is a list, it's supposed to be the list of the
         keys to delete.
 
-        You may specify up to 1000 keys.
     :param prefix: Prefix of objects to delete. (templated)
         All objects matching this prefix in the bucket will be deleted.
     :param aws_conn_id: Connection id of the S3 connection to use
@@ -371,14 +368,21 @@ class S3DeleteObjectsOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
-    def execute(self, context: 'Context'):
-        if not bool(self.keys) ^ bool(self.prefix):
+        if not keys is None ^ prefix is None:
             raise AirflowException("Either keys or prefix should be set.")
+    
+    def execute(self, context: 'Context'):
+        if not self.keys is None ^ self.prefix is None:
+            raise AirflowException("Either keys or prefix should be set.")
+        if isinstance(self.keys, list) and len(self.keys) == 0:
+            return
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
         if keys:
             s3_hook.delete_objects(bucket=self.bucket, keys=keys)
+            
+     
 
 
 class S3FileTransformOperator(BaseOperator):

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -370,19 +370,18 @@ class S3DeleteObjectsOperator(BaseOperator):
 
         if not keys is None ^ prefix is None:
             raise AirflowException("Either keys or prefix should be set.")
-    
+
     def execute(self, context: 'Context'):
-        if not self.keys is None ^ self.prefix is None:
+        if not bool(self.keys is None) ^ bool(self.prefix is None):
             raise AirflowException("Either keys or prefix should be set.")
-        if isinstance(self.keys, list) and len(self.keys) == 0:
+
+        if isinstance(self.keys, (list, str)) and not bool(self.keys):
             return
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
         if keys:
             s3_hook.delete_objects(bucket=self.bucket, keys=keys)
-            
-     
 
 
 class S3FileTransformOperator(BaseOperator):

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -373,7 +373,7 @@ class S3DeleteObjectsOperator(BaseOperator):
 
     def execute(self, context: 'Context'):
         if not bool(self.keys) ^ bool(self.prefix):
-            raise AirflowException("Either keys or prefix should be set.")        
+            raise AirflowException("Either keys or prefix should be set.")
         s3_hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)

--- a/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
+++ b/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
@@ -24,7 +24,6 @@ from moto import mock_s3
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
-from airflow.exceptions import AirflowException
 
 
 class TestS3DeleteObjectsOperator(unittest.TestCase):

--- a/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
+++ b/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
@@ -23,6 +23,7 @@ import boto3
 from moto import mock_s3
 
 from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
+from airflow.exceptions import AirflowException
 
 
 class TestS3DeleteObjectsOperator(unittest.TestCase):
@@ -91,3 +92,98 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
 
         # There should be no object found in the bucket created earlier
         assert 'Contents' not in conn.list_objects(Bucket=bucket, Prefix=key_pattern)
+
+    @mock_s3
+    def test_s3_delete_empty_list(self):
+        bucket = "testbucket"
+        key_of_test = "path/data.txt"
+        keys = []
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+        conn.upload_fileobj(Bucket=bucket, Key=key_of_test, Fileobj=io.BytesIO(b"input"))
+
+        # The object should be detected before the DELETE action is tested
+        objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=key_of_test)
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test
+
+        op = S3DeleteObjectsOperator(task_id="test_s3_delete_empty_list", bucket=bucket, keys=keys)
+        op.execute(None)
+
+        # The object found in the bucket created earlier should still be there
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test
+
+    @mock_s3
+    def test_s3_delete_empty_string(self):
+        bucket = "testbucket"
+        key_of_test = "path/data.txt"
+        keys = ""
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+        conn.upload_fileobj(Bucket=bucket, Key=key_of_test, Fileobj=io.BytesIO(b"input"))
+
+        # The object should be detected before the DELETE action is tested
+        objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=key_of_test)
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test
+
+        op = S3DeleteObjectsOperator(task_id="test_s3_delete_empty_string", bucket=bucket, keys=keys)
+        op.execute(None)
+
+        # The object found in the bucket created earlier should still be there
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test
+
+    @mock_s3
+    def test_assert_s3_both_keys_and_prifix_given(self):
+        bucket = "testbucket"
+        keys = "path/data.txt"
+        key_pattern = "path/data"
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+        conn.upload_fileobj(Bucket=bucket, Key=keys, Fileobj=io.BytesIO(b"input"))
+
+        # The object should be detected before the DELETE action is tested
+        objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=keys)
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == keys
+        with self.assertRaises(AirflowException):
+            op = S3DeleteObjectsOperator(
+                task_id="test_assert_s3_both_keys_and_prifix_given",
+                bucket=bucket,
+                keys=keys,
+                prefix=key_pattern,
+            )
+            op.execute(None)
+
+        # The object found in the bucket created earlier should still be there
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == keys
+
+    @mock_s3
+    def test_assert_s3_no_keys_or_prifix_given(self):
+        bucket = "testbucket"
+        key_of_test = "path/data.txt"
+
+        conn = boto3.client('s3')
+        conn.create_bucket(Bucket=bucket)
+        conn.upload_fileobj(Bucket=bucket, Key=key_of_test, Fileobj=io.BytesIO(b"input"))
+
+        # The object should be detected before the DELETE action is tested
+        objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=key_of_test)
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test
+        with self.assertRaises(AirflowException):
+            op = S3DeleteObjectsOperator(task_id="test_assert_s3_no_keys_or_prifix_given", bucket=bucket)
+            op.execute(None)
+        # The object found in the bucket created earlier should still be there
+        assert len(objects_in_dest_bucket['Contents']) == 1
+        # the object found should be consistent with dest_key specified earlier
+        assert objects_in_dest_bucket['Contents'][0]['Key'] == key_of_test

--- a/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
+++ b/tests/providers/amazon/aws/operators/test_s3_delete_objects.py
@@ -22,8 +22,8 @@ import unittest
 import boto3
 from moto import mock_s3
 
-from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
 from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.operators.s3 import S3DeleteObjectsOperator
 
 
 class TestS3DeleteObjectsOperator(unittest.TestCase):


### PR DESCRIPTION
There is a bug when an empty list is passed into S3DeleteObjectsOperator from another task it will try and deleted all keys on the bucket. While the intent of passing in an empty prefix might be to delete all keys, the intent of passing in a empty keys list would be to delete no keys.

This is because I assume templating does something with __init__ so the check for this condition is not run.

The case is:
In line 379 because keys is an empty list it is false so keys is now assigned the return values from list_keys which when passed no prefix will return all keys.

The change is to move the xor check of keys or prefix is inside the execute function to ensure it is checked at run time
 