### PR TITLE
Addd deleting orphans on cascade for permission model

### DIFF
--- a/airflow/www/fab_security/sqla/models.py
+++ b/airflow/www/fab_security/sqla/models.py
@@ -125,7 +125,13 @@ class Role(Model):
 
     id = Column(Integer, get_sequence_or_identity("ab_role_id_seq"), primary_key=True)
     name = Column(String(64), unique=True, nullable=False)
-    permissions = relationship("Permission", secondary=assoc_permission_role, backref="role", lazy="joined")
+    permissions = relationship(
+        "Permission",
+        secondary=assoc_permission_role,
+        backref="role",
+        lazy="joined",
+        cascade="save-update, merge, delete, delete-orphan",
+    )
 
     def __repr__(self):
         return self.name
@@ -144,6 +150,7 @@ class Permission(Model):
         uselist=False,
         backref="permission",
         lazy="joined",
+        cascade="save-update, merge, delete, delete-orphan",
     )
     resource_id = Column("view_menu_id", Integer, ForeignKey("ab_view_menu.id"))
     resource = relationship(
@@ -152,6 +159,7 @@ class Permission(Model):
         uselist=False,
         backref="permission",
         lazy="joined",
+        cascade="save-update, merge, delete, delete-orphan",
     )
 
     def __repr__(self):


### PR DESCRIPTION
Apparently, sync_roles script might lead to leaving orphan
rows during syncing the permission model. Since the permission
model is only used as "static" model mostly, making sure that
there are no orphans left via modifying the cascade method seems
to be a good solution - it might lead to deletion and recration
of rows so we cannot track/audit changes easily but in case of
syncing it seems to be not really needed.

Based on discussion in
https://stackoverflow.com/questions/23699651/dependency-rule-tried-to-blank-out-primary-key-in-sqlalchemy-when-foreign-key-c

Probably Fixes: #21407

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
