### PR TITLE
Tree view: Highlight dag run on hover

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -71,7 +71,7 @@
     "webpack-manifest-plugin": "^2.2.0"
   },
   "dependencies": {
-    "@chakra-ui/react": "^1.6.6",
+    "@chakra-ui/react": "^1.8.3",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11",

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -36,13 +36,14 @@ const StatusBox = ({
     executionDate, taskId, tryNumber = 0, operator, runId,
   } = instance;
   const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId);
+
+  // Fetch the corresponding column element and set its background color when hovering
   const onMouseOver = () => {
-    [...containerRef.current.getElementsByClassName(runId)]
+    [...containerRef.current.getElementsByClassName(`js-${runId}`)]
       .forEach((e) => { e.style.backgroundColor = 'rgba(113, 128, 150, 0.1)'; });
   };
-
   const onMouseLeave = () => {
-    [...containerRef.current.getElementsByClassName(runId)]
+    [...containerRef.current.getElementsByClassName(`js-${runId}`)]
       .forEach((e) => { e.style.backgroundColor = null; });
   };
 

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -55,6 +55,7 @@ const StatusBox = ({
         onClick={onClick}
         cursor={!group.children && 'pointer'}
         data-testid="task-instance"
+        zIndex={1}
         {...rest}
       >
         <Box

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -36,6 +36,15 @@ const StatusBox = ({
     executionDate, taskId, tryNumber = 0, operator, runId,
   } = instance;
   const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId);
+  const onMouseOver = () => {
+    [...containerRef.current.getElementsByClassName(runId)]
+      .forEach((e) => { e.style.backgroundColor = 'rgba(113, 128, 150, 0.1)'; });
+  };
+
+  const onMouseLeave = () => {
+    [...containerRef.current.getElementsByClassName(runId)]
+      .forEach((e) => { e.style.backgroundColor = null; });
+  };
 
   return (
     <Tooltip
@@ -44,7 +53,7 @@ const StatusBox = ({
       portalProps={{ containerRef }}
       hasArrow
       placement="top"
-      openDelay={100}
+      openDelay={400}
     >
       <Flex
         p="1px"
@@ -56,6 +65,8 @@ const StatusBox = ({
         cursor={!group.children && 'pointer'}
         data-testid="task-instance"
         zIndex={1}
+        onMouseEnter={onMouseOver}
+        onMouseLeave={onMouseLeave}
         {...rest}
       >
         <Box

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -47,7 +47,7 @@ const Tree = () => {
   }, []);
 
   return (
-    <Box position="relative">
+    <Box position="relative" ref={containerRef}>
       <FormControl display="flex" alignItems="center" justifyContent="flex-end" width="100%">
         {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
         <FormLabel htmlFor="auto-refresh" mb={0} fontSize="12px" fontWeight="normal">
@@ -67,7 +67,6 @@ const Tree = () => {
           </Table>
         </Box>
       </Box>
-      <div ref={containerRef} />
     </Box>
   );
 };

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -27,6 +27,7 @@ import {
   FormLabel,
   Spinner,
   Text,
+  Thead,
 } from '@chakra-ui/react';
 
 import useTreeData from './useTreeData';
@@ -60,8 +61,10 @@ const Tree = () => {
       <Box px="24px">
         <Box position="relative" width="100%" overflowX="auto" ref={scrollRef}>
           <Table>
-            <Tbody>
+            <Thead>
               <DagRuns containerRef={containerRef} />
+            </Thead>
+            <Tbody>
               {renderTaskRows({ task: groups, containerRef })}
             </Tbody>
           </Table>

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -50,7 +50,7 @@ const DagRunBar = ({
         callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
       }}
       position="relative"
-      role="group"
+      data-peer
     >
       <Tooltip
         label={<DagRunTooltip dagRun={run} />}
@@ -73,13 +73,12 @@ const DagRunBar = ({
           px="1px"
           zIndex={1}
           data-testid="run"
-
         >
           {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
         </Flex>
       </Tooltip>
-      <Box position="absolute" width="100%" top={0} height="100vh" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} zIndex={0} />
     </Flex>
+    <Box position="absolute" width="100%" top={0} height="100vh" className={run.runId} _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" zIndex={0} />
     {index < totalRuns - 3 && index % 10 === 0 && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -34,69 +34,76 @@ import { callModalDag } from '../../dag';
 
 const DagRunBar = ({
   run, max, index, totalRuns, containerRef,
-}) => (
-  <Box position="relative">
-    <Flex
-      height="102px"
-      alignItems="flex-end"
-      justifyContent="center"
-      pb="2px"
-      px="2px"
-      mx="1px"
-      cursor="pointer"
-      width="14px"
-      zIndex={1}
-      onClick={() => {
-        callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
-      }}
-      position="relative"
-      data-peer
-    >
-      <Tooltip
-        label={<DagRunTooltip dagRun={run} />}
-        hasArrow
-        portalProps={{ containerRef }}
-        placement="top"
-        openDelay={100}
+}) => {
+  let highlightHeight = '100%';
+  if (containerRef && containerRef.current) {
+    const table = containerRef.current.getElementsByTagName('table')[0];
+    highlightHeight = table.offsetHeight - 53; // subtract the height of the duration axis labels
+  }
+  return (
+    <Box position="relative">
+      <Flex
+        height="102px"
+        alignItems="flex-end"
+        justifyContent="center"
+        pb="2px"
+        px="2px"
+        mx="1px"
+        cursor="pointer"
+        width="14px"
+        zIndex={1}
+        onClick={() => {
+          callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
+        }}
+        position="relative"
+        data-peer
       >
-        <Flex
-          width="10px"
-          height={`${(run.duration / max) * 100}px`}
-          minHeight="12px"
-          backgroundColor={stateColors[run.state]}
-          borderRadius={2}
-          cursor="pointer"
-          pb="2px"
-          direction="column"
-          justifyContent="flex-end"
-          alignItems="center"
-          px="1px"
-          zIndex={1}
-          data-testid="run"
+        <Tooltip
+          label={<DagRunTooltip dagRun={run} />}
+          hasArrow
+          portalProps={{ containerRef }}
+          placement="top"
+          openDelay={100}
         >
-          {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
-        </Flex>
-      </Tooltip>
-    </Flex>
-    <Box
-      position="absolute"
-      width="100%"
-      top={0}
-      height="100vh"
-      className={`js-${run.runId}`}
-      _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}
-      zIndex={0}
-      transition="background-color 0.2s"
-    />
-    {index < totalRuns - 3 && index % 10 === 0 && (
+          <Flex
+            width="10px"
+            height={`${(run.duration / max) * 100}px`}
+            minHeight="12px"
+            backgroundColor={stateColors[run.state]}
+            borderRadius={2}
+            cursor="pointer"
+            pb="2px"
+            direction="column"
+            justifyContent="flex-end"
+            alignItems="center"
+            px="1px"
+            zIndex={1}
+            data-testid="run"
+          >
+            {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
+          </Flex>
+        </Tooltip>
+      </Flex>
+      <Box
+        position="absolute"
+        width="100%"
+        top="1px"
+        height={highlightHeight}
+        className={`js-${run.runId}`}
+        _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}
+        zIndex={0}
+        transition="background-color 0.2s"
+      />
+      {index < totalRuns - 3 && index % 10 === 0 && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
           {moment.utc(run.executionDate).format('MMM DD, HH:mm')}
         </Text>
         <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />
       </VStack>
-    )}
-  </Box>
-);
+      )}
+    </Box>
+  );
+};
 
 export default DagRunBar;

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -37,14 +37,20 @@ const DagRunBar = ({
 }) => (
   <Box position="relative">
     <Flex
-      height="100px"
+      height="102px"
       alignItems="flex-end"
       justifyContent="center"
       pb="2px"
-      px="3px"
+      px="2px"
+      mx="1px"
+      cursor="pointer"
+      width="14px"
+      zIndex={1}
       onClick={() => {
         callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
       }}
+      position="relative"
+      role="group"
     >
       <Tooltip
         label={<DagRunTooltip dagRun={run} />}
@@ -67,18 +73,20 @@ const DagRunBar = ({
           px="1px"
           zIndex={1}
           data-testid="run"
+
         >
           {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
         </Flex>
       </Tooltip>
+      <Box position="absolute" width="100%" top={0} height="100vh" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} zIndex={0} />
     </Flex>
     {index < totalRuns - 3 && index % 10 === 0 && (
-    <VStack position="absolute" top="0" left="-22px" spacing={0}>
-      <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
-        {moment.utc(run.executionDate).format('MMM DD, HH:mm')}
-      </Text>
-      <Box borderLeftWidth={1} zIndex={0} opacity={0.7} height="100px" />
-    </VStack>
+      <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
+        <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
+          {moment.utc(run.executionDate).format('MMM DD, HH:mm')}
+        </Text>
+        <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />
+      </VStack>
     )}
   </Box>
 );

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -78,7 +78,16 @@ const DagRunBar = ({
         </Flex>
       </Tooltip>
     </Flex>
-    <Box position="absolute" width="100%" top={0} height="100vh" className={run.runId} _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" zIndex={0} />
+    <Box
+      position="absolute"
+      width="100%"
+      top={0}
+      height="100vh"
+      className={`js-${run.runId}`}
+      _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}
+      zIndex={0}
+      transition="background-color 0.2s"
+    />
     {index < totalRuns - 3 && index % 10 === 0 && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -32,21 +32,24 @@ import { MdPlayArrow } from 'react-icons/md';
 import DagRunTooltip from './Tooltip';
 import { callModalDag } from '../../dag';
 
+const BAR_HEIGHT = 100;
+
 const DagRunBar = ({
   run, max, index, totalRuns, containerRef,
 }) => {
   let highlightHeight = '100%';
   if (containerRef && containerRef.current) {
-    const table = containerRef.current.getElementsByTagName('table')[0];
-    highlightHeight = table.offsetHeight - 53; // subtract the height of the duration axis labels
+    const table = containerRef.current.getElementsByTagName('tbody')[0];
+    highlightHeight = table.offsetHeight + BAR_HEIGHT;
   }
   return (
     <Box position="relative">
       <Flex
-        height="102px"
+        height={BAR_HEIGHT}
         alignItems="flex-end"
         justifyContent="center"
-        pb="2px"
+        mb="2px"
+        // py="2px"
         px="2px"
         mx="1px"
         cursor="pointer"
@@ -67,7 +70,7 @@ const DagRunBar = ({
         >
           <Flex
             width="10px"
-            height={`${(run.duration / max) * 100}px`}
+            height={`${(run.duration / max) * BAR_HEIGHT}px`}
             minHeight="12px"
             backgroundColor={stateColors[run.state]}
             borderRadius={2}

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -55,7 +55,7 @@ const renderTaskRows = ({
 const TaskName = ({
   isGroup, onToggle, isOpen, level, taskName,
 }) => (
-  <Box _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}>
+  <Box _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s">
     <Flex
       as={isGroup ? 'button' : 'div'}
       onClick={() => isGroup && onToggle()}
@@ -155,7 +155,7 @@ const Row = ({
           </Collapse>
         </Td>
         <Td width={0} p={0} borderBottom={0} />
-        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} borderBottom={0}>
+        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} sx={{ 'transition': 'background-color 0.2s'}} borderBottom={0}>
           <Collapse in={isFullyOpen}>
             <TaskInstances dagRuns={dagRuns} task={task} containerRef={containerRef} />
           </Collapse>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -155,7 +155,7 @@ const Row = ({
           </Collapse>
         </Td>
         <Td width={0} p={0} borderBottom={0} />
-        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} sx={{ 'transition': 'background-color 0.2s'}} borderBottom={0}>
+        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0}>
           <Collapse in={isFullyOpen}>
             <TaskInstances dagRuns={dagRuns} task={task} containerRef={containerRef} />
           </Collapse>

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -1106,10 +1106,10 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.13.10", "@babel/runtime@^7.7.2":
-  version "7.15.3"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
-  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1124,6 +1124,13 @@
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
   integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.7.2":
+  version "7.15.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.3.tgz#2e1c2880ca118e5b2f9988322bd8a7656a32502b"
+  integrity sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1203,532 +1210,559 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chakra-ui/accordion@1.3.5":
+"@chakra-ui/accordion@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.4.6.tgz#87137298e1a3d5505c600787d8ae1b96e3e3e207"
+  integrity sha512-dmHMMDM/TAdFb8LretCzk72QtjtTFkrk1BP8NvinSPsqF90UDsFUlzp9URgJfW1kdfgpwyEo9pry9U9uYX0PLg==
+  dependencies:
+    "@chakra-ui/descendant" "2.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/transition" "1.4.5"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/alert@1.3.5":
   version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.3.5.tgz#b150e47ed57d2a3aaf78c86af6dd62bc10dbe4c3"
-  integrity sha512-47bMQXqLhPDgUgC/L8+k+GQpAvhWIPrl3u/FTcbojZRwPcxOH1dEmWNZGftvFTKPS6bSv5vx1XpiDRfzZ0hohQ==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.3.5.tgz#6e632f406b9f2485841cbea4902c53d85f4a6b79"
+  integrity sha512-WvyyXvAD4QTiFgOqFhH1FuwAy1r3X/GxbT4k5DPix2S0gf2oRqxrb8uGffVT8bv7tid3grFM6OXy/jvioqcH9w==
   dependencies:
-    "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.4"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/alert@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.2.7.tgz#bba7489f6a2cf672218a4cffc62cb67e1abf64de"
-  integrity sha512-+3rjMDjCsR7fWUA9Ikg21s9mVOxU564fA1fX3PdkFlUQFjwroG4hPQCjtUVCOBWontVphKghsQOprpuuQhx2hQ==
+"@chakra-ui/anatomy@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/anatomy/-/anatomy-1.2.3.tgz#c3582942aa0e066fb09831c37992a27fa28fe9cd"
+  integrity sha512-aI07oTtCmFG2Ms69y6C4zGhFA4gFXtSOyu6/GkD52z1ZyAzBWLe3PK3wE9ISP8B1gZZs4jOZ8xiB+cG9yzOFJQ==
   dependencies:
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/theme-tools" "^1.3.4"
 
-"@chakra-ui/avatar@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.2.8.tgz#6d3467860cd5f2b2f29de2f89948ff87ebf0367e"
-  integrity sha512-/uZUyUhIRQZH2nz+nMDgFxwoaQX99TS/8yYLgeA5Trf63zkbabV3GWZXsIQVjvNUau8kFhPlbdJ6qqYfHyNpeQ==
+"@chakra-ui/avatar@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.3.6.tgz#f93298ef4e9a83fc86474ef7e187e0fda5eb1fb0"
+  integrity sha512-gyULR3Wfi0ARSw7UCgVCSl5aWdCNFK2lqMuBaDc628t71NXrBK8+PUtrn1jp0JXBg3++aX2A0CuUHXIESEC9Ew==
   dependencies:
-    "@chakra-ui/image" "1.0.18"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/image" "1.1.5"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/breadcrumb@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.2.8.tgz#95b7a61327da79e9984236b766481720e2699f21"
-  integrity sha512-hMr7GtQ9XaMDjjlJC/pOJCp1vG7Cq4E3o70uyHXuUZkwsTnEzr0hgqOmRGII+pLMVSzxO6ii1OEjvq+rZvKdVw==
+"@chakra-ui/breadcrumb@1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.3.4.tgz#00f36e6b7ae1884dc6c5311e3c488c6f556428a1"
+  integrity sha512-qk71qvf9s/DRBbUCVUg1weFnrXrdCe7pa9hE8++5UDQv6V5DU3TPN7jxp9yzkARI/mGFWpioIvQHxE1MDCTGAg==
   dependencies:
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/button@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.4.2.tgz#d4a2dc173aca0c4093c2a9089d4c647dec55e53a"
-  integrity sha512-Gw3W6ixkrTWaHVJRDOyvx1ZAdV/g2SjiGeHFBnfuBcZdZWqJLNy9vrS1rroBeYA953ISklyhEdtyLD9izwkzxA==
-  dependencies:
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/spinner" "1.1.12"
-    "@chakra-ui/utils" "1.8.2"
-
-"@chakra-ui/checkbox@1.5.5":
+"@chakra-ui/button@1.5.5":
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.5.5.tgz#00b30827a7b6ec2cd8f002f574e468b935db294a"
-  integrity sha512-KJf+1x1BCNI9LeHSvlEKkAjGaCCI1b6ImOzJcemtucfshzb0HEGGFNGxKEGYuWbVvz9N+AcUGM5WFfhSV71f3w==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.5.5.tgz#a105b44267c7ae9fe04bf6d1bae65255675f54ca"
+  integrity sha512-emUjpA/XBmFCgu8AG81EpL5+2SuoTF1ad1vmTJrM0hdNt1AXdz8DZoPou8ZMLaBPU3uO3tuZP73i2YAAflQKWQ==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/spinner" "1.2.4"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/clickable@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.1.7.tgz#ff7d87e5f2a208a596ebbd9cd23bbf6d116bb363"
-  integrity sha512-aRopd+wRhykwlkRPuBn6XiLxo7jYq2BtToD7dh8wLvhDOAgtFXgYcNfAl4RkNWIUU9ZFioS6HusRE+5LmQ8EPQ==
+"@chakra-ui/checkbox@1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.6.5.tgz#e5ff9b401c0af4222b0316f967b02e85af17aef7"
+  integrity sha512-wu5frQk3zkr87LPFq894dhM/YCd3zGRDkWxUCeJVPagRKG+O+WfB5J7Sc6ld/FzuMIhOEMemPLeDx2i+QOnPxQ==
   dependencies:
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/close-button@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.1.11.tgz#f8b5ed5969c98f23537a4d40420eb21306cf293f"
-  integrity sha512-3BFVGPKeOdD/q/YgtSDdQ7RJh1fQhX7VRvkj11KPfPlvXIEQDxLwvQQV5MeNdrnTEYXkqzc8jqMexZOWlfSXRg==
+"@chakra-ui/clickable@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.2.4.tgz#b3a7ca4ad6819627acf9dc6d3b71c3e12467148d"
+  integrity sha512-TYXKrJxeN1AXTRxgNViEw3uEJ4NlO7CptjoXqakrHCLNU2cf4ETTCd4C4OGDZiVwE1UTu155ffHGM+tiXgcGSA==
   dependencies:
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/color-mode@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.1.11.tgz#8773399c187bc3e82319c080a307bba2f3eda633"
-  integrity sha512-iJQ0WJlT1kKvDzIVanOHEKnqarbKLHRZwJ5OYRDCVTL2j7ZBPMR7f4vyru5ONZmNSb4NZrSGe4Srws4hi2fygQ==
+"@chakra-ui/close-button@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.2.5.tgz#9dfecc432aefe840fbbf75de123e5a8214eb3a67"
+  integrity sha512-XxK3wC+zzqwHk6+apNrcAtIwfcWYqi/0OF1rhRIM0PBcXEbjK4Zob4Fn4njetv/aZDzgKRZ9VY5iXtlBXig25Q==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/control-box@1.0.15":
-  version "1.0.15"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.15.tgz#cdc1102eb802c46b169a9905b8030349dcd3351d"
-  integrity sha512-sqQXKa9MjVo1mN/XRfudoM53yKhoXm6ozbE/soTgvLQJtSZtEltXVg9O8LP/h/i/AlfUKs5Nw8qSjij/7pfb2w==
+"@chakra-ui/color-mode@1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.4.3.tgz#df9dd9c469b24618f6b937521005a4711de6b884"
+  integrity sha512-2EFwsYZg3/wMH8DWtQic766N6gfw4Z/I8v57fmSSvkPV8k72pUdDn5ZjtnGhXU5R08aWl7w4exPo31ikLYlD6w==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-env" "1.1.4"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/counter@1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.1.8.tgz#75184c7f0c7fd704df5ea8da1aed4c1ca11c473e"
-  integrity sha512-ROoAl2FbRdiOp995FKG1I7kTUoqVGgUhfaqYoLKlmxh5RDB+pMyij4zd/kihu2ZQuoLXFp4ZwWMAE3qMeu9lzQ==
+"@chakra-ui/control-box@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.1.4.tgz#b8ac1188ef2a11d1fc3378764fbe083fa9cedb9f"
+  integrity sha512-uV/A6UIlu1/kEktY1YZCi1HOmX/ZaLTCsflJpmf5RLnZa5F7VMdT9E/lr6/PfMQiQKXIj4fpMQI56T6LuAp2Aw==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/css-reset@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/css-reset/-/css-reset-1.0.0.tgz#8395921b35ef27bee0579a4d730c5ab7f7b39734"
-  integrity sha512-UaPsImGHvCgFO3ayp6Ugafu2/3/EG8wlW/8Y9Ihfk1UFv8cpV+3BfWKmuZ7IcmxcBL9dkP6E8p3/M1T0FB92hg==
-
-"@chakra-ui/descendant@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-2.0.1.tgz#fc3bc9081aa01503035b2c9296bc4b9f87ceaae0"
-  integrity sha512-TeYp94iOhu5Gs2oVzewJaep0qft/JKMKfmcf4PGgzJF+h6TWZm6NGohk6Jq7JOh+y0rExa1ulknIgnMzFx5xaA==
+"@chakra-ui/counter@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.2.5.tgz#801e63d8e65f98be498770c2a511999566472d59"
+  integrity sha512-2pH98XnUoPwNzZjlONdKwtbFjahdd1gyvyx8QVrEqBNIKOuAGATXDb7arkh2EwAwy5xmpkticZ8ZtOz1gcDvmg==
   dependencies:
-    "@chakra-ui/react-utils" "^1.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/editable@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.2.8.tgz#ff52b60a3cc7aeb89c6de453387d6c19f8d2734f"
-  integrity sha512-SI2bzuAshGc/1U8DE532mufs+8tHeodrmkHUkmzhvjhhDIeLXeCtptvZ745WirlV6xa96tmmPYry/SVTubAEWQ==
-  dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+"@chakra-ui/css-reset@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/css-reset/-/css-reset-1.1.2.tgz#87535979aa20f72db989613a443dce17c44ea76b"
+  integrity sha512-7BQxaBtUQlAZsjl2gNnPtTK0p7MALb7f6/hn5C2tQR9OOy7o9tR1RQQIYd4+DsS/SGtBVdiWCix98eLdlwY/iQ==
 
-"@chakra-ui/focus-lock@1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.1.10.tgz#45418b46f8986aa597d2aed572d86a8c8327f871"
-  integrity sha512-LJqA+RscxqDBocJ1hjFde47g9E/8H2KqlHYcmOrQd5nITMcR88F2Z11cnFNMWJu++PJNHxspaXbUSKqPNj2TPQ==
+"@chakra-ui/descendant@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-2.1.2.tgz#6ebd9f000d01fea213d05e1477e5d273e4b20d71"
+  integrity sha512-o3WrYD0zGBdRB7aM9bENci7BWrFYBCMTcix/0iQQfsvIPeFKZOKOx/zUHXVby6nvmC7rIPep5yCn9UNNB+REkg==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
-    react-focus-lock "2.5.0"
+    "@chakra-ui/react-utils" "^1.2.2"
 
-"@chakra-ui/form-control@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.4.0.tgz#d97af757279a35bd72cb7a8ec54829a502ad13b6"
-  integrity sha512-Hpkrz8fAs/v1mtjoowglV46F4DjZgsXDr86y7cPGWoYsbVRpNQnEPYtYJZVTZMYT/bBV7o5gBbrPR56/+AELlg==
+"@chakra-ui/editable@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.3.5.tgz#28f50b63a76f263ab6d840c0757e0cdb88fa9985"
+  integrity sha512-6JQ5fMf8KsHJpzHZ6rt/5frz7VNmXUC4Phi5CbEsN1KcKPeIxjjdMh9MADvcrDMWkhj7Nx2Zcvii9Oeaa8kF2g==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/hooks@1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.5.5.tgz#7b455f1445d4b48111d3a4811ed6e1bd618c2c74"
-  integrity sha512-jwD+sRd+gOJvAeCM630n496CS5SAZFUHqOC7wwYN2Kj6BjCW7yHtxsq4atIlKSYJ+Ra96WNmZQ58Pr5Qj3r9Jg==
+"@chakra-ui/focus-lock@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.2.4.tgz#c27e2ccd93d6586373cfdd9b6a21a6ed1a27e6ec"
+  integrity sha512-irMhZLH02Ue88MM/36/cziD+VNRqZbtGTrnERB3/j5PdGZT6vF/9bv+TZDCKo3gNe2Z8pEJFfFsQ++f53xKyeg==
   dependencies:
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
+    react-focus-lock "2.5.2"
+
+"@chakra-ui/form-control@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.5.6.tgz#ffa6ccf0f4609a8c29964b1c136695035e7cf22a"
+  integrity sha512-+JPFkpK4EK/qBVCkyyiJYbDVVEGfzLzLewyn9vbnNmyM3HRqs9g2Lul5cau6tf1QmAwDD7Xy0yQceQ/1RPAgoA==
+  dependencies:
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/hooks@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.8.2.tgz#1149d93b58d8166570b08bda3c96fe341266a5ad"
+  integrity sha512-rmWfXTh7Ku0sg4bPaR9E5a53N4dzcgrdMt5lDVeaxjLUm2faE0U8LcG8yJgpxNOMKDmaKat8Nrj6H5DBYhVB+A==
+  dependencies:
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
     compute-scroll-into-view "1.0.14"
     copy-to-clipboard "3.3.1"
 
-"@chakra-ui/icon@1.1.11":
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.11.tgz#ab57002ca20b7726aa31da6e370692159280cadb"
-  integrity sha512-w+TkBr8eA8023j1SdhBzCFrEeU4lolf96cYVz0t/FVUBdIHYPGt56iHdaE2HYXW8Jyp15WLZcJJZQnZo91GRww==
+"@chakra-ui/icon@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-2.0.3.tgz#1e29784734eae558f3aa4815e5f2d5f24cb0d3b9"
+  integrity sha512-G2rB5DeeNM4VlsUv49OYGyRJhr6fKkSRDskOHE9yV9QmaIatnYmGZCnvrSALe1EmzJYD0g9wessEyPHId5KtaQ==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/image@1.0.18":
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.18.tgz#9b3b8ee5a9fac5f05699b4fc1705b30aea2073f3"
-  integrity sha512-hi123wYe+H0V3Yr3ujrbGdD/jPgrHpK/DB39R7IVVRPQz3kMRfffTfTXA57ah9iTwAG8jNyMckVyjeWClH3JPQ==
+"@chakra-ui/image@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.1.5.tgz#d3c988cd75dce9cae49df3eb15572112d5113594"
+  integrity sha512-xzCS7OFZeHUYkYz67J5nuIfVjCF0KyZ6lj1PuWZbQIzH2ZKkDq7eTYpWkAkCRyZ4Z6Cz+s/WtBL53FqCYQ6nwg==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/input@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.2.9.tgz#3b31d22abead621c816356f6200f0188853e0d6f"
-  integrity sha512-+qXmXQgud4MgP/+k2qsIUthY7jpEozJsd/4iZS/EXo3MHoODzXbcc2G7c7Tn5n5suxiX7JtJXZNkuflR6hcNgA==
+"@chakra-ui/input@1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.4.1.tgz#2ddea81b08778e4e90e2018bcc4b9e1dd3e964aa"
+  integrity sha512-CLFX8KCvoSdALxWsJrwIDTCFwok1f/YRRei8n/UDedPzzmOxaWX95wA2kL716PWzcnOhQdii7U6xqyZNPXgOXQ==
   dependencies:
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/layout@1.4.8":
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.4.8.tgz#3963eb8040dcdb5a8f68747e98abf7aa7af741c8"
-  integrity sha512-hBOkbmgbXnYAzQ4gXIaIFJx+WQMfAxAsmnmdkqpGUraGgR18PlgQNPKKo1QkT8THyxStmOAAgppuSwofMDOVHw==
+"@chakra-ui/layout@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.7.4.tgz#8cc176d372ca1517b7b5dd62066181adbdce3efa"
+  integrity sha512-WtjmyyxV5Cp4o99idFFzcZdR29Jdq/I3QL9daVbj1crD1byLytagDRQzEknh0mwNMOVBymMw2fDWT1ZCavW2VQ==
   dependencies:
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/live-region@1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.14.tgz#5264bdfc15d03566f72003046fab285e6c43aab8"
-  integrity sha512-683UXH5WpPsn6KFuqo6qyllk3lAInP8cGS43CNnd9FX+5WTlplMBUwg0Gl5HLU9zRCAUeerfGLDY7ZJt2TPBVQ==
+"@chakra-ui/live-region@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.1.4.tgz#a9d7b05edce9833bbd7a5ae9eea4145719407af2"
+  integrity sha512-OQq6ruL7503gdfyQkxyZLhl/wpDr1CZwMoKJM/KGcfr91ctAdUQ8gmgL47py/cRKzF1RKMd1dfn6E0ULIzQSqA==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/media-query@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.1.2.tgz#fbba8da0cff397061aee61fad491480ae4387375"
-  integrity sha512-KdH5C/YwJJx7A4BMePC4J7IlDUEe2F7lLqWk/CvvwD+m2w4+/Ju6scU5YGUsskHQulllNGOmyON6fHQ7bVL47g==
+"@chakra-ui/media-query@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-2.0.1.tgz#b7f4035579d2692508d55cf049536cdd5a97c059"
+  integrity sha512-sUaTCThH2mqnX0HuXgrQdXFFXEO70tu0HDTRaPDufiK9DY8lqoMCNCFMt20Tr6XLIDHoMM/YfWmY4Qaz1QjE6w==
   dependencies:
-    "@chakra-ui/react-env" "1.0.6"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/react-env" "1.1.4"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/menu@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.7.2.tgz#7886b7969c4ff6ba7acff2e3405b2f81cf8253f4"
-  integrity sha512-8aDWLj9ktkUpU23aq6k0PpsOqu6V9Zf6B9jIjn0PMmZvb4Z5qXQEixXP5Mbp1psqZMkSNQBaBFU69EJh0sLb4A==
+"@chakra-ui/menu@1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.8.6.tgz#d16e809539b6f11c2090a4945c8810a456d79737"
+  integrity sha512-b5KcXZFQRsgu7XXHz/3yyNB0K4NFvIYVSDTfMmRQKKExEjQ7az7mtVNAUFDQIYXXoj4QhLXPfWISw1Ijgw1LHA==
   dependencies:
-    "@chakra-ui/clickable" "1.1.7"
-    "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/popper" "2.2.1"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.4"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/clickable" "1.2.4"
+    "@chakra-ui/descendant" "2.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/popper" "2.4.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/transition" "1.4.5"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/modal@1.8.10":
-  version "1.8.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.8.10.tgz#19e9816dacb32c80795fbd0e77b60673df6bec32"
-  integrity sha512-NfIXzgxxs7UR4DiKsaDIh1onbHO8lpY0CVLP1mPKcjhCXo/yaLg3abT7IJi/3NBtYJsKAgFIrH0cxQdn/oZFiQ==
+"@chakra-ui/modal@1.10.7":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.10.7.tgz#8e45f6b2e61739dca8e0b49f53b0feb865252e82"
+  integrity sha512-4Ao9tIHZxOe1zUgmScw5SFeZgUAPjjvhAnqqt4Hp+OfFC7ML35GwYbU+yYGiYasvLXnqDwcrdZ4ggmDTMqUGdw==
   dependencies:
-    "@chakra-ui/close-button" "1.1.11"
-    "@chakra-ui/focus-lock" "1.1.10"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/portal" "1.2.8"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/transition" "1.3.4"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/close-button" "1.2.5"
+    "@chakra-ui/focus-lock" "1.2.4"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/portal" "1.3.5"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/transition" "1.4.5"
+    "@chakra-ui/utils" "1.10.2"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.4.1"
 
-"@chakra-ui/number-input@1.2.9":
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.2.9.tgz#7feb4cee10f8e623c721957e30de26e10f0283c4"
-  integrity sha512-/ewDeJ5VMs4AHBdqyWR6XJLsT4+JCzcjqm++ff2s2uXqDPVuvuyexNEIKtszDTYwFEZ4WQ8mu1p8CtWBz0p6tQ==
+"@chakra-ui/number-input@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.4.2.tgz#5fca73ca631958849a71dde68c576de62fd2abe5"
+  integrity sha512-+OOQRWDYQd8OL+zIafRN7hii6tssXuQ5hcmNUBmrcNMdwKvRPQW0hvzSuhc09NSA/rDV/TvsAFyqpo4lY7gGng==
   dependencies:
-    "@chakra-ui/counter" "1.1.8"
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/counter" "1.2.5"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/pin-input@1.6.4":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.6.4.tgz#5094d0ada3a8ae65da390daa7d6c5a51a3a6f39e"
-  integrity sha512-58y/OsDvcn0mML7VNUaG8PUYLtB1M4FHgtkWfaW6UgacqswuiqENSXtLo0vozc2D+ot5LBVqDab28PtCv9f6Fw==
+"@chakra-ui/pin-input@1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.7.5.tgz#1a298868cd8112d5cefe56ea9282dc51fc54a83b"
+  integrity sha512-1MwBRPpPy6HSr/f+c0jVUes/plNVUnm5uiUDgsI9IeV2SMj0pxz3+5RkMjX+ygsVuXqY4CaWGNtPkyQXivfy/w==
   dependencies:
-    "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/descendant" "2.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/popover@1.8.2":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.8.2.tgz#3b5a9ed81b4630099955dbf26b2284ca140dee66"
-  integrity sha512-W1A0CGpKytauQYeE5AMr06wX90xW4QON9UtTS9PvsNkwxNn1ih8ywSftSdrPG3DnubL/5Vxlf0IOZIu4Cq2ZnQ==
+"@chakra-ui/popover@1.11.4":
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.11.4.tgz#11221e9cbb0e11f226ef73a9759b0c69382f57ec"
+  integrity sha512-133NJABbmFD77HCJ2pAOF+JuXbYs3dkX6Oq0hGI5LtfTxCddIIHbwmVQ44IP8vpj5KRKLSy/DurgPngJ70aE/Q==
   dependencies:
-    "@chakra-ui/close-button" "1.1.11"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/popper" "2.2.1"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/close-button" "1.2.5"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/popper" "2.4.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/popper@2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-2.2.1.tgz#51d49933ee837b396d78d9daaab1d9809afea982"
-  integrity sha512-W0hMTBp2X62UooF3qPNmsEW0IJfz72gr2DN8nsCvHQrMiARB9s2jECEss6qEsB97tnmIG8k2TNee8IzTGLmMyA==
+"@chakra-ui/popper@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-2.4.2.tgz#f906b1fa406d5bf89248d1c857088dd7a2e94084"
+  integrity sha512-EMkiZShASubY/JfT2fbfkbJE+RUkJApNC1j8hYLApOTvHqBGY54iNRrexHGjm5oLr99Zdkg5jnb3DXIB9I9Zqw==
   dependencies:
-    "@chakra-ui/react-utils" "1.1.2"
-    "@popperjs/core" "2.4.4"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@popperjs/core" "^2.9.3"
 
-"@chakra-ui/portal@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.2.8.tgz#fd70a371b1cc332347ea9068bb514078d21fefdc"
-  integrity sha512-uDs9GYqK4DCcFOhy0Ip7oCQ4br/FNeeIJO5/IuHKU3P8qfwmi2oTdElKZD7oKrdz1EYU5iVdkfIuxnyUEtkOSg==
+"@chakra-ui/portal@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.3.5.tgz#3736eccc793179690ab70c31389878e3f761e0c9"
+  integrity sha512-nbaufsRGg7mHZRAZULu1EjkWB4mdu8X68gkd7OCKnVChkDoZnFWSrwd/195LoKW5GJ81wQWd3aKd8pUCzE+1Yw==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/progress@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.1.12.tgz#d7d11ccca70245329a2cd4a337b61332e86d770a"
-  integrity sha512-u7cTJue/R2t6HQxXq2CWiDpNM6FnSv7eUFm89rKa55rEQDIwW9SZZ3F/R2wrPK+9KN31gHEswtq3FB5KopeGvw==
+"@chakra-ui/progress@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.2.4.tgz#6fe3b4e25113afc5d223196663945ccff3aa4477"
+  integrity sha512-ukPf4G/nphfsx0ZPRnDPElFzWVrJSHG5PT7uLuT+hUmxmotSCI3qtHryySVfCXqaU2SKQDF1fy1XhRANO0AEMA==
   dependencies:
-    "@chakra-ui/theme-tools" "1.1.9"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/theme-tools" "1.3.4"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/radio@1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.3.9.tgz#dadd90913b1156eb7e431520ddc662c3d3c1e5ba"
-  integrity sha512-9hPZMNT1YV1K/VkIn7VVHfWyqjuj+YXy4YQZEHlED3QokQKcqeLgOupr/sGWTCc7vBcSrlyX+l/rAodLDKWrRQ==
+"@chakra-ui/provider@1.7.9":
+  version "1.7.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/provider/-/provider-1.7.9.tgz#81c18786590c84b2d90a108231575ca5b5832d6f"
+  integrity sha512-VQ8l1FzNlMyQZas0jEXuWNoMZfyMcv8CidIUboQtdkh+MXli7Q19O2MtOKeLGbQmzQ5ZZnMlQZTnWjkTWDpqCw==
   dependencies:
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/css-reset" "1.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/portal" "1.3.5"
+    "@chakra-ui/react-env" "1.1.4"
+    "@chakra-ui/system" "1.10.3"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/react-env@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react-env/-/react-env-1.0.6.tgz#931fb0dbbfe4b2aed04d08b0bb191820f61a7f3b"
-  integrity sha512-JE0MXrVv9exBaQP0oLescs1ZhFolet3ACoV41ow881aXptN02VJKOht04/9SqEAnaxn8ePdofG9BRB6dKDm0ow==
+"@chakra-ui/radio@1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.4.7.tgz#985917e3ba73bba5ff28db1d05496ae742d03ee5"
+  integrity sha512-skf03KkqhEsI4fAPvhjTr3A0MBhsHElEuZcZVZ+Q4j9SA3VmBH5neMy5zeJrVFHQTy8JuPi649jECE54BFkLTw==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/react-utils@1.1.2", "@chakra-ui/react-utils@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react-utils/-/react-utils-1.1.2.tgz#7ea80b6ae25bd7b182095cc9ffaad23c464408b5"
-  integrity sha512-S8jPVKGZH2qF7ZGxl/0DF/dXXI2AxDNGf4Ahi2LGHqajMvqBB7vtYIRRmIA7+jAnErhzO8WUi3i4Z7oScp6xSA==
+"@chakra-ui/react-env@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react-env/-/react-env-1.1.4.tgz#62977f15a7ede52d5b99a1f0f526d2216ceb006d"
+  integrity sha512-T3ABET1UUP8PAdE7rF6rc2Luo0xb539taFR7kES+MPK5Bmbu/mL55cj+xEKa2LSNKuzAVnvtmgWFZoX3V+PXsQ==
   dependencies:
-    "@chakra-ui/utils" "^1.7.0"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/react-utils@1.2.2", "@chakra-ui/react-utils@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react-utils/-/react-utils-1.2.2.tgz#048a6ee4296249440ce3bd91c49c17fbd2f1ae31"
+  integrity sha512-vdVtwEooRPVmB60+B9FEJNc+L4+DO6llA9qTk8ZFq7ocXLGagl+V5mFKJPLMzmTCafq6j5pNjoAF4A7bbh4U4Q==
+  dependencies:
+    "@chakra-ui/utils" "^1.10.2"
 
 "@chakra-ui/react@^1.6.6":
-  version "1.6.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.6.6.tgz#e347f946d9cfe1456e766eaee39f79a1a83724e6"
-  integrity sha512-ztUAevUUjeBeJ5MyoZmDphLwzns9M0ptt4zuQvROjTaBD8wLrQT93BBepMkigRrJFrt2oovIDUwN7D0un9u9dQ==
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.8.3.tgz#a1a132a151b60fda370decb6d278582a8da933b9"
+  integrity sha512-UkXy/GVM31tlqNbMKdmu+WJZk3Pn5hQVGFzHDkcf+aPuMCBvZv86BwrdghR/B5fvewKBywAS0vDrt8d8SuTI7g==
   dependencies:
-    "@chakra-ui/accordion" "1.3.5"
-    "@chakra-ui/alert" "1.2.7"
-    "@chakra-ui/avatar" "1.2.8"
-    "@chakra-ui/breadcrumb" "1.2.8"
-    "@chakra-ui/button" "1.4.2"
-    "@chakra-ui/checkbox" "1.5.5"
-    "@chakra-ui/close-button" "1.1.11"
-    "@chakra-ui/control-box" "1.0.15"
-    "@chakra-ui/counter" "1.1.8"
-    "@chakra-ui/css-reset" "1.0.0"
-    "@chakra-ui/editable" "1.2.8"
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/image" "1.0.18"
-    "@chakra-ui/input" "1.2.9"
-    "@chakra-ui/layout" "1.4.8"
-    "@chakra-ui/live-region" "1.0.14"
-    "@chakra-ui/media-query" "1.1.2"
-    "@chakra-ui/menu" "1.7.2"
-    "@chakra-ui/modal" "1.8.10"
-    "@chakra-ui/number-input" "1.2.9"
-    "@chakra-ui/pin-input" "1.6.4"
-    "@chakra-ui/popover" "1.8.2"
-    "@chakra-ui/popper" "2.2.1"
-    "@chakra-ui/portal" "1.2.8"
-    "@chakra-ui/progress" "1.1.12"
-    "@chakra-ui/radio" "1.3.9"
-    "@chakra-ui/react-env" "1.0.6"
-    "@chakra-ui/select" "1.1.13"
-    "@chakra-ui/skeleton" "1.1.17"
-    "@chakra-ui/slider" "1.2.8"
-    "@chakra-ui/spinner" "1.1.12"
-    "@chakra-ui/stat" "1.1.12"
-    "@chakra-ui/switch" "1.2.8"
-    "@chakra-ui/system" "1.7.2"
-    "@chakra-ui/table" "1.2.6"
-    "@chakra-ui/tabs" "1.5.4"
-    "@chakra-ui/tag" "1.1.12"
-    "@chakra-ui/textarea" "1.1.13"
-    "@chakra-ui/theme" "1.10.0"
-    "@chakra-ui/toast" "1.2.10"
-    "@chakra-ui/tooltip" "1.3.9"
-    "@chakra-ui/transition" "1.3.4"
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/accordion" "1.4.6"
+    "@chakra-ui/alert" "1.3.5"
+    "@chakra-ui/avatar" "1.3.6"
+    "@chakra-ui/breadcrumb" "1.3.4"
+    "@chakra-ui/button" "1.5.5"
+    "@chakra-ui/checkbox" "1.6.5"
+    "@chakra-ui/close-button" "1.2.5"
+    "@chakra-ui/control-box" "1.1.4"
+    "@chakra-ui/counter" "1.2.5"
+    "@chakra-ui/css-reset" "1.1.2"
+    "@chakra-ui/editable" "1.3.5"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/image" "1.1.5"
+    "@chakra-ui/input" "1.4.1"
+    "@chakra-ui/layout" "1.7.4"
+    "@chakra-ui/live-region" "1.1.4"
+    "@chakra-ui/media-query" "2.0.1"
+    "@chakra-ui/menu" "1.8.6"
+    "@chakra-ui/modal" "1.10.7"
+    "@chakra-ui/number-input" "1.4.2"
+    "@chakra-ui/pin-input" "1.7.5"
+    "@chakra-ui/popover" "1.11.4"
+    "@chakra-ui/popper" "2.4.2"
+    "@chakra-ui/portal" "1.3.5"
+    "@chakra-ui/progress" "1.2.4"
+    "@chakra-ui/provider" "1.7.9"
+    "@chakra-ui/radio" "1.4.7"
+    "@chakra-ui/react-env" "1.1.4"
+    "@chakra-ui/select" "1.2.6"
+    "@chakra-ui/skeleton" "1.2.9"
+    "@chakra-ui/slider" "1.5.6"
+    "@chakra-ui/spinner" "1.2.4"
+    "@chakra-ui/stat" "1.2.5"
+    "@chakra-ui/switch" "1.3.5"
+    "@chakra-ui/system" "1.10.3"
+    "@chakra-ui/table" "1.3.4"
+    "@chakra-ui/tabs" "1.6.5"
+    "@chakra-ui/tag" "1.2.5"
+    "@chakra-ui/textarea" "1.2.6"
+    "@chakra-ui/theme" "1.13.2"
+    "@chakra-ui/toast" "1.5.4"
+    "@chakra-ui/tooltip" "1.4.6"
+    "@chakra-ui/transition" "1.4.5"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/select@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.1.13.tgz#3707ddf26231ffa294339d760ac1802bad37c64c"
-  integrity sha512-o4Lj934xu76CLJ+dGmOKjgOBmvCQpO+5pHzXWKcu2fX9nJ//LyW1CBoCfWQz2tzylNgnXExwy6NWQj4T9HxDkA==
+"@chakra-ui/select@1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.2.6.tgz#3338a390ec89703ec162b86909b48a49f2578670"
+  integrity sha512-nn3cTSvze1PBpel9+pIkxAhXRnhhbuUVkSkwpMAYSKqdh5vd/6NhwArADvnjctY/7FYTxIwA0JCmUL4oDtF9AQ==
   dependencies:
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/skeleton@1.1.17":
-  version "1.1.17"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.1.17.tgz#f284c1e20aed3caa42576524607771e60ebe9ce4"
-  integrity sha512-CQ3fL7pRfoADYlI2zcXdLGHdxADqNZbRW+HpZ+jcwkAnztSGRsC2F+4Txesj/9HfO3iBQ5lrrfyhvzbSnXayPg==
+"@chakra-ui/skeleton@1.2.9":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.2.9.tgz#c9e6a7b80f70dbdcdd6f0542051d8fe79e57a61b"
+  integrity sha512-kMzVLJQVy+wyuE/uE2CZoG40qulS0YKZw36bkp23ANrkNVH0LhdcsxFTaIhcuA2PWy+P+GCY84zK+F3kHQmxHA==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/media-query" "1.1.2"
-    "@chakra-ui/system" "1.7.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/media-query" "2.0.1"
+    "@chakra-ui/system" "1.10.3"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/slider@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.2.8.tgz#d0b35c2c853bfc5c0520ae3f540a4cf7ae44d3a3"
-  integrity sha512-nxbqbgY+lz/+b8M2vM1JK8UeUzrcIKNeUKKX7+2++At9+++ftyF8WW0UAOuuXRCw2w761IpNcDqa8Fo1I8c1ng==
+"@chakra-ui/slider@1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.5.6.tgz#87c5b45efae4e45215948c0d527ded5a0ce07119"
+  integrity sha512-2LDbPeZI1kSTmRm0iQteRuezdheh9fM8b0rDyuIgts4KEEJmyyGzqrpWGzDb+cWl6b+S1QF/s1mthf0B05FMSA==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/spinner@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.1.12.tgz#1833cb46f48e6d002c2820724e3a1a580e6ebc92"
-  integrity sha512-cwchUCrZ2FEPSQilbCnJSFXmyDJC/9u29oitSNRVPF0DDvHUPZX1yG/DXZ0ZsWqodBw16/FZuRe2VRKOCGm0Iw==
+"@chakra-ui/spinner@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.2.4.tgz#64c7c16067588d4f982231eaf9d816ba6891904b"
+  integrity sha512-TDK9s3USnaMvrtfBZFUbo6KxJKBFEqxhnoPH3cuqZwXfkA0djmiN9tm4kFNsc7ETIE9raMOZ1OLgU76AJEW6mQ==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/stat@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.1.12.tgz#0471d230a62e63bd522d67a346b3b11e8c4bd16b"
-  integrity sha512-vhoW4zFF1BSlMpEZ179hCXLBT+TLtoW1JESObcOv/lAbFko5YBJAkPs4cws5eKdZsSqVUORtwKcJN+BjWUrkJw==
+"@chakra-ui/stat@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.2.5.tgz#edc9cc5adc4d1deb53e023ea66ea31c83be75fd8"
+  integrity sha512-uZY1nrpGBxXI23HQj6gDI2mhDbRJ+BmeAu1bWYoHiiRX3qMjhubJyAGHA/DOGNSAtdqR1EIvwTOJ6zxvwlVp3w==
   dependencies:
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/styled-system@1.12.2":
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.12.2.tgz#918cedf92e12e3b3c053a4d6a8eeab9315d0980c"
-  integrity sha512-wJvEgy93DLe0Tz2F9YFRTDnAz8YMC8O2Y0reI6WIDix0QL7dLWxrTA2reqMLaEmKnr965a/LDfyY21tWOB+6TQ==
+"@chakra-ui/styled-system@1.17.2":
+  version "1.17.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.17.2.tgz#4b94066c774b09578f6affcdd389d666b0956be0"
+  integrity sha512-isRmQZ41YULv5ANM/+JnLLpLYM7/V35hnGBZzC6y8n2duWtvG4ubrY60SBrFvphI2IKSk4kg9uM83Wf+M/eV4A==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
-    csstype "^3.0.6"
+    "@chakra-ui/utils" "1.10.2"
+    csstype "^3.0.9"
 
-"@chakra-ui/switch@1.2.8":
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.2.8.tgz#fd81f41b70db37dbfe56042e6b8bc90f83483e34"
-  integrity sha512-xWkNJiKivE5gdTXm6kGll/aTxlIdPE6Hw7/NOLBOjaDaBLHDcLokPg/ZFY+FsaasGEM73ukjt5uxYymYeWSD7A==
+"@chakra-ui/switch@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.3.5.tgz#730cbe2cf1b18b62ef3554df5a3252a6b476c3ed"
+  integrity sha512-m1q5zVvy4fI902YjRkr+1BSRKpAEW0CtvWcHO2CK/TL//enGbo/STX6yMo/smtSynqUlldrQ3U1/H8pJZ5k1NQ==
   dependencies:
-    "@chakra-ui/checkbox" "1.5.5"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/checkbox" "1.6.5"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/system@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.7.2.tgz#c06874a95108be959e54542d7019d179138843ef"
-  integrity sha512-/j4VJdsK61fD51uZRltN1t+FiteVAq+Np2lj5RMscieD8/jwYxRvl2j6kK+QdEogJjNK4VrRg66D6882mL+8qw==
+"@chakra-ui/system@1.10.3":
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.10.3.tgz#b45948060bdcc3a2823ae6a2da91fa219dd4afbc"
+  integrity sha512-am/0EvK+F+kiZ99ulhUfaYYADlP1wI4Zw8IWrsaliSfqSB3qgKahNC/U2A0nWG9T7wwLHVGO/ehCNfAKP1aK2g==
   dependencies:
-    "@chakra-ui/color-mode" "1.1.11"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/styled-system" "1.12.2"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/color-mode" "1.4.3"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/styled-system" "1.17.2"
+    "@chakra-ui/utils" "1.10.2"
     react-fast-compare "3.2.0"
 
-"@chakra-ui/table@1.2.6":
+"@chakra-ui/table@1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.3.4.tgz#301dd889fc8431c87e832de3a85a29be97fdaf24"
+  integrity sha512-o0a+EPLEi4wWCFxnb3HYlUf4NXlzQUlUtB2Y3eGrBbZK5ClDFZFdNL8t6v8X3zMrGRcfHDBgQyxPhT7E1c4Gqw==
+  dependencies:
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/tabs@1.6.5":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.6.5.tgz#e0069448cc1d710d432bf358f9f1c24ba49420a8"
+  integrity sha512-GKQI289qvjPHsURdu9JjLRZdfDweN7qRk9xLt4vPHAml5bRkhej1l+Fn20SVWUU5Sjn4PoP2xJmutvIqal48qw==
+  dependencies:
+    "@chakra-ui/clickable" "1.2.4"
+    "@chakra-ui/descendant" "2.1.2"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/tag@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.2.5.tgz#dc08c614f969fe481e8b755f503736bf594a43fd"
+  integrity sha512-aZTAJ4HxGFDIIgURd35jvB8InFMmx4DX510ytWN9zy3Ec4jPPXgnGFKCETFNL2kGMnZDv2SOcxOHUIsWpmBSnQ==
+  dependencies:
+    "@chakra-ui/icon" "2.0.3"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/textarea@1.2.6":
   version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.2.6.tgz#1402fd1479f07453067864d35967d8e6251114d4"
-  integrity sha512-fwIBGRLCxhDjt17qfNESC51FIX9YDGJeSD9tC1vZKXveaJmYwVHOdoke1Vv/n++FoFkWPoJHplNOYgDFUiAPBA==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.2.6.tgz#7569ed4bd9fc2ffbbc80b51c5ddc03edb7524ce1"
+  integrity sha512-D8ZWA3mbYtYoj32NprHMO0yD/MRaj8LPVuCwZLr8+IUku9RDtnS4MUtvoUU7j9BDSuEjWtHvYXmQgal2q2X/1w==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/form-control" "1.5.6"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/tabs@1.5.4":
+"@chakra-ui/theme-tools@1.3.4", "@chakra-ui/theme-tools@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.3.4.tgz#9b6c8c9ee411726fa9cc950832869e94ba091887"
+  integrity sha512-JHpJ2Aw22uiYLRHlhsPQGCn3CYmps/ExYoON7sZ9RlyofaWjKI687X7ZJKCednPkjMeg7oaPv2j3aCdbie5flw==
+  dependencies:
+    "@chakra-ui/utils" "1.10.2"
+    "@ctrl/tinycolor" "^3.4.0"
+
+"@chakra-ui/theme@1.13.2":
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.13.2.tgz#af3f688c4f9ae125309331d9db0f2e08a1c94db4"
+  integrity sha512-tepbAUOpNLTgVwizEDto4UFJdIKXUYdyI9GIuNceB7RGWJdLoX4A/xNnGhq251OQEiyXjNE07rz/x70tJo4HnA==
+  dependencies:
+    "@chakra-ui/anatomy" "1.2.3"
+    "@chakra-ui/theme-tools" "1.3.4"
+    "@chakra-ui/utils" "1.10.2"
+
+"@chakra-ui/toast@1.5.4":
   version "1.5.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.5.4.tgz#7be53cb1ee06ef2a6a052c35f3fa5e20e1f091ac"
-  integrity sha512-nMBlMCUd9gxUyG1wmpA+4YkR9UHY6ggGSxVoxjJW5DrHLujfgfvxVhSilpt2sq+XiGfTIesFtfdgL8svfzEENQ==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.5.4.tgz#847c13ae34ac21b32b04ce3d474728b5449013fd"
+  integrity sha512-Vz3YV5hlE95qdXAAjy+eV+uM6idvKG2EwJU2AqDUIHgIDhOeNTTEGScSiS6xnLu/IYUD9XtQGdXe3pKg4jEDZQ==
   dependencies:
-    "@chakra-ui/clickable" "1.1.7"
-    "@chakra-ui/descendant" "2.0.1"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
-
-"@chakra-ui/tag@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.1.12.tgz#36f19cb886eb6f079f4ed03e4ed7ca4dadc654ef"
-  integrity sha512-/tTHhfFNFJUCZwfs7xDCc2kLpBYD/WElt1cl37wLBkODM5ai22BzD1SRvRtd3UJmJtFop/P8+9cdM3+ZuO//UQ==
-  dependencies:
-    "@chakra-ui/icon" "1.1.11"
-    "@chakra-ui/utils" "1.8.2"
-
-"@chakra-ui/textarea@1.1.13":
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.1.13.tgz#5274c42af0450d04007d842bb48829a75a5152fb"
-  integrity sha512-wj4C9Y7zwxm/jev+eFkVrOOGBbxK8zUQzDLX7YSSPY2QbvwakH4D311+8yW+My2Lg901DQ1BMvzjI80bOAiarg==
-  dependencies:
-    "@chakra-ui/form-control" "1.4.0"
-    "@chakra-ui/utils" "1.8.2"
-
-"@chakra-ui/theme-tools@1.1.9":
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.1.9.tgz#24b6a0820eccd1b17786170c2577f521bd75744c"
-  integrity sha512-nul8TE6EUzubaOS6B1bwy6IQvUlRjhI1vJtsoyxlOkyscFY6BMJzWIVDaO7wKwsc/nwF+fkNITF40p3AmG3Usw==
-  dependencies:
-    "@chakra-ui/utils" "1.8.2"
-    "@types/tinycolor2" "1.4.2"
-    tinycolor2 "1.4.2"
-
-"@chakra-ui/theme@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.10.0.tgz#a4614b7c3b8d3b0cd927c0a71212c8e5f0c27f4f"
-  integrity sha512-2M70cgsOEjOgiP9EKN0xgREqkgcQbepNwqyd9VY2sTTGb9DOrD4HoQrUlQV++EmaFQEIxem8eZ9lMQ4zlaWC/g==
-  dependencies:
-    "@chakra-ui/theme-tools" "1.1.9"
-    "@chakra-ui/utils" "1.8.2"
-
-"@chakra-ui/toast@1.2.10":
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.2.10.tgz#f44eb8900e98146944956168aca12e0ae5d9adad"
-  integrity sha512-xOoB5k0+2mVGnqLJVwcCZ9xeperywc4aB6QUOenirnFiVVKNCui9ASosgjM9ZCtTcX9XlOoDMe+lh2Ky//8WMA==
-  dependencies:
-    "@chakra-ui/alert" "1.2.7"
-    "@chakra-ui/close-button" "1.1.11"
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/theme" "1.10.0"
-    "@chakra-ui/transition" "1.3.4"
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/alert" "1.3.5"
+    "@chakra-ui/close-button" "1.2.5"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/theme" "1.13.2"
+    "@chakra-ui/transition" "1.4.5"
+    "@chakra-ui/utils" "1.10.2"
     "@reach/alert" "0.13.2"
 
-"@chakra-ui/tooltip@1.3.9":
-  version "1.3.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.3.9.tgz#06883813355bde22232277c3b5b44d3059a67d07"
-  integrity sha512-rvZpqSeR/s9yV3RMSTc7Wo369D1CehFFUkHNnER3a0AC3t+CLAM0fVw1qhqFreGcAViz7xNc/Kgjx2PCfYNySQ==
+"@chakra-ui/tooltip@1.4.6":
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.4.6.tgz#a6220fc15bb2728526f7929d44d00d328f369e2e"
+  integrity sha512-rZs/q/E7H37rV63hTEXJw6GOwHgxYOOY9GdDA2AxzeOfQfSFazxACh3a+PEP02aNXAqnFZrLAAowHp4EqxtrGw==
   dependencies:
-    "@chakra-ui/hooks" "1.5.5"
-    "@chakra-ui/popper" "2.2.1"
-    "@chakra-ui/portal" "1.2.8"
-    "@chakra-ui/react-utils" "1.1.2"
-    "@chakra-ui/utils" "1.8.2"
-    "@chakra-ui/visually-hidden" "1.0.14"
+    "@chakra-ui/hooks" "1.8.2"
+    "@chakra-ui/popper" "2.4.2"
+    "@chakra-ui/portal" "1.3.5"
+    "@chakra-ui/react-utils" "1.2.2"
+    "@chakra-ui/utils" "1.10.2"
+    "@chakra-ui/visually-hidden" "1.1.4"
 
-"@chakra-ui/transition@1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.3.4.tgz#36d610e98913a371dcea0ac248ad09bf6b34535d"
-  integrity sha512-FYBJzTKEUoozoSfOGruPuv1/GBL0mZniBPh+wjHYcXbIJdp8S2gbPFlHPN+4S9NDXz+c9p+OLHZAEEv3Vcvt7A==
+"@chakra-ui/transition@1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.4.5.tgz#f502a7b5e97686d1b21b6bdd1b850eca81c3d1ad"
+  integrity sha512-DGRURmiWOdHJEh30ZKgM6az+Zae1ZpMjxhfbBHcNPyuU+GLzCSMOzmC8XieJGHe/yZ3+X93LdYAMX+yDF16rqQ==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
 
-"@chakra-ui/utils@1.8.2", "@chakra-ui/utils@^1.7.0":
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.8.2.tgz#5a9f1f67c5f2232769fe7d009fcf96eebf3c2b4e"
-  integrity sha512-MnE4czCQCE87Ch1DfAdmZvObgRviw9wQ9Zti372P8VD1ILEdff/C5WBWHW6mgG3YcorPAxgnrNF3MmNE95jRkA==
+"@chakra-ui/utils@1.10.2", "@chakra-ui/utils@^1.10.2":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.10.2.tgz#e79a8923d2779b1698a34d978bb9e9bc9f37f499"
+  integrity sha512-V4nGBkebZpz6P7AgbZBiXi2Pn3RNSuzR1A6VsQCzAvxYU2+csqZGLqmC07pvCSACNB75sT1en+Xd3XT0QKr0sA==
   dependencies:
     "@types/lodash.mergewith" "4.6.6"
     css-box-model "1.2.1"
     framesync "5.3.0"
     lodash.mergewith "4.6.2"
 
-"@chakra-ui/visually-hidden@1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.14.tgz#75fb92916c1f0c949d3a1e05584911a24122182c"
-  integrity sha512-4OoF0kDmfAVX1IS5kcJ35iOGVHXmk7EZgwH5U4kB32z/81kmG0KW/VeEFnilOknH6a5Mf3fZr8rYRVb/gLfvGg==
+"@chakra-ui/visually-hidden@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.1.4.tgz#8795fd9042f317bf6794bcc5376e5e184313b109"
+  integrity sha512-T+n3AABuhe3vjGnlwxEpq9aU9xUBoCBG8DDTEwYQzJdXqY/ftTCpraGEfHeUFixfuCkdSELxXyeAbZfsizj37Q==
   dependencies:
-    "@chakra-ui/utils" "1.8.2"
+    "@chakra-ui/utils" "1.10.2"
+
+"@ctrl/tinycolor@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
+  integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
 
 "@emotion/babel-plugin@^11.3.0":
   version "11.3.0"
@@ -2091,10 +2125,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@popperjs/core@2.4.4":
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
-  integrity sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg==
+"@popperjs/core@^2.9.3":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.2.tgz#830beaec4b4091a9e9398ac50f865ddea52186b9"
+  integrity sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==
 
 "@reach/alert@0.13.2":
   version "0.13.2"
@@ -2338,9 +2372,9 @@
     "@types/lodash" "*"
 
 "@types/lodash@*":
-  version "4.14.172"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
-  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
+  version "4.14.178"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.178.tgz#341f6d2247db528d4a13ddbb374bcdc80406f4f8"
+  integrity sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==
 
 "@types/mdast@^3.0.0":
   version "3.0.3"
@@ -2438,11 +2472,6 @@
   integrity sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==
   dependencies:
     "@types/jest" "*"
-
-"@types/tinycolor2@1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
-  integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==
 
 "@types/uglify-js@*":
   version "3.13.0"
@@ -4293,10 +4322,15 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^3.0.2, csstype@^3.0.6:
+csstype@^3.0.2:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
   integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+
+csstype@^3.0.9:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -5669,12 +5703,12 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.8.1.tgz#bb36968abf77a2063fa173cb6c47b12ac8599d33"
-  integrity sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
+focus-lock@^0.9.1:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.9.2.tgz#9d30918aaa99b1b97677731053d017f82a540d5b"
+  integrity sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.0.3"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -9152,7 +9186,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9160,6 +9194,15 @@ prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+prop-types@^15.6.2, prop-types@^15.7.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
 
 prr@~1.0.1:
   version "1.0.1"
@@ -9263,7 +9306,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-clientside-effect@^1.2.2:
+react-clientside-effect@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.5.tgz#e2c4dc3c9ee109f642fac4f5b6e9bf5bcd2219a3"
   integrity sha512-2bL8qFW1TGBHozGGbVeyvnggRpMjibeZM2536AKNENLECutp2yfs44IL8Hmpn8qjFQ2K7A9PnYf3vc7aQq/cPA==
@@ -9291,24 +9334,24 @@ react-fast-compare@3.2.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-focus-lock@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.0.tgz#12e3a3940e897c26e2c2a0408cd25ea3c99b3709"
-  integrity sha512-XLxj6uTXgz0US8TmqNU2jMfnXwZG0mH2r/afQqvPEaX6nyEll5LHVcEXk2XDUQ34RVeLPkO/xK5x6c/qiuSq/A==
+react-focus-lock@2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.2.tgz#f1e4db5e25cd8789351f2bd5ebe91e9dcb9c2922"
+  integrity sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.8.1"
+    focus-lock "^0.9.1"
     prop-types "^15.6.2"
-    react-clientside-effect "^1.2.2"
-    use-callback-ref "^1.2.1"
-    use-sidecar "^1.0.1"
+    react-clientside-effect "^1.2.5"
+    use-callback-ref "^1.2.5"
+    use-sidecar "^1.0.5"
 
 react-icons@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
   integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9513,9 +9556,9 @@ regenerator-runtime@^0.11.0:
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
 regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"
@@ -10684,14 +10727,9 @@ tiny-emitter@^2.0.0:
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tiny-invariant@^1.0.6:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tinycolor2@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
-  integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -10796,7 +10834,7 @@ tslib@^1.0.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
+tslib@^2.0.3, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -11017,12 +11055,12 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-callback-ref@^1.2.1, use-callback-ref@^1.2.3:
+use-callback-ref@^1.2.3, use-callback-ref@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
-use-sidecar@^1.0.1:
+use-sidecar@^1.0.1, use-sidecar@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.5.tgz#ffff2a17c1df42e348624b699ba6e5c220527f2b"
   integrity sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -1535,7 +1535,7 @@
   dependencies:
     "@chakra-ui/utils" "^1.10.2"
 
-"@chakra-ui/react@^1.6.6":
+"@chakra-ui/react@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.8.3.tgz#a1a132a151b60fda370decb6d278582a8da933b9"
   integrity sha512-UkXy/GVM31tlqNbMKdmu+WJZk3Pn5hQVGFzHDkcf+aPuMCBvZv86BwrdghR/B5fvewKBywAS0vDrt8d8SuTI7g==


### PR DESCRIPTION
Before, when a user hovered over a task instance, we only highlighted the row to show what task it belonged to. This PR also highlights the column to show the dag run. This now creates a "crosshair" to let a user more easily which task instance they are hovering on.

<img width="712" alt="Screen Shot 2022-02-09 at 3 16 01 PM" src="https://user-images.githubusercontent.com/4600967/153282888-4af2c1b6-1184-48cb-a5b6-4eba976a7de2.png">

|Before |After |
--- | --- |
|![Feb-09-2022 13-12-14](https://user-images.githubusercontent.com/4600967/153278932-7ef195ff-aa9a-4585-bb49-dced6939343e.gif)|![Feb-09-2022 13-02-35](https://user-images.githubusercontent.com/4600967/153278801-8e074ee4-d11b-4995-a1b1-3e5a0eafbce5.gif) |


