### PR TITLE
Fix bug incorrectly removing action from role, rather than permission.

### DIFF
--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1381,12 +1381,11 @@ class BaseSecurityManager:
                 if perm.action.name not in base_action_names:
                     # perm to delete
                     roles = self.get_all_roles()
-                    action = self.get_action(perm.action.name)
                     # del permission from all roles
                     for role in roles:
                         # TODO: An action can't be removed from a role.
                         # This is a bug in FAB. It has been reported.
-                        self.remove_permission_from_role(role, action)
+                        self.remove_permission_from_role(role, perm)
                     self.delete_permission(perm.action.name, resource_name)
                 elif self.auth_role_admin not in self.builtin_roles and perm not in admin_role.permissions:
                     # Role Admin must have all permissions

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4033,6 +4033,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'action_set_success': 'edit',
     }
     base_permissions = [
+        permissions.ACTION_CAN_CREATE,
         permissions.ACTION_CAN_READ,
         permissions.ACTION_CAN_EDIT,
         permissions.ACTION_CAN_DELETE,
@@ -4377,6 +4378,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     base_permissions = [
         permissions.ACTION_CAN_CREATE,
         permissions.ACTION_CAN_READ,
+        permissions.ACTION_CAN_EDIT,
         permissions.ACTION_CAN_DELETE,
         permissions.ACTION_CAN_ACCESS_MENU,
     ]


### PR DESCRIPTION
Fixes the bug causing an assertion warning about refusal to delete permission that's already still associated with a role.

```
[2022-02-08 10:51:59,436] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Permissions.menu_access Admin
[2022-02-08 10:51:59,461] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Permissions.menu_access Admin
[2022-02-08 10:51:59,474] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Permissions.menu_access Admin
[2022-02-08 10:51:59,529] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Permissions.menu_access Admin
[2022-02-08 10:51:59,593] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists DAG Runs.can_create Admin
[2022-02-08 10:51:59,621] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists DAG Runs.can_create Admin
[2022-02-08 10:51:59,658] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists DAG Runs.can_create Admin
[2022-02-08 10:51:59,708] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists DAG Runs.can_create Admin
[2022-02-08 10:51:59,723] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Task Instances.can_edit Admin
[2022-02-08 10:51:59,756] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Task Instances.can_edit Admin
[2022-02-08 10:51:59,791] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Task Instances.can_edit Admin
[2022-02-08 10:51:59,834] {manager.py:534} WARNING - Refused to delete permission view, assoc with role exists Task Instances.can_edit Admin
```)
```

https://github.com/apache/airflow/issues/21407#issuecomment-1032473648