### PR TITLE
Fix annotations not getting added to cleanup pods

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -58,6 +58,12 @@ spec:
 {{- end }}
           annotations:
             sidecar.istio.io/inject: "false"
+            {{- if .Values.airflowPodAnnotations }}
+            {{- toYaml .Values.airflowPodAnnotations | nindent 12 }}
+            {{- end }}
+            {{- if .Values.cleanup.podAnnotations }}
+            {{- toYaml .Values.cleanup.podAnnotations | nindent 12 }}
+            {{- end }}
         spec:
           restartPolicy: Never
           nodeSelector:

--- a/chart/tests/test_airflow_common.py
+++ b/chart/tests/test_airflow_common.py
@@ -76,6 +76,7 @@ class TestAirflowCommon:
             name=release_name,
             values={
                 "airflowPodAnnotations": {"test-annotation/safe-to-evict": "true"},
+                "cleanup": {"enabled": True},
             },
             show_only=[
                 "templates/scheduler/scheduler-deployment.yaml",
@@ -83,13 +84,18 @@ class TestAirflowCommon:
                 "templates/webserver/webserver-deployment.yaml",
                 "templates/flower/flower-deployment.yaml",
                 "templates/triggerer/triggerer-deployment.yaml",
+                "templates/cleanup/cleanup-cronjob.yaml",
             ],
         )
 
-        assert 5 == len(k8s_objects)
+        assert 6 == len(k8s_objects)
 
         for k8s_object in k8s_objects:
-            annotations = k8s_object["spec"]["template"]["metadata"]["annotations"]
+            if k8s_object['kind'] == 'CronJob':
+                annotations = k8s_object["spec"]["jobTemplate"]["spec"]["template"]["metadata"]["annotations"]
+            else:
+                annotations = k8s_object["spec"]["template"]["metadata"]["annotations"]
+
             assert "test-annotation/safe-to-evict" in annotations
             assert "true" in annotations["test-annotation/safe-to-evict"]
 

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -199,3 +199,18 @@ class CleanupPodsTest(unittest.TestCase):
         assert resources == jmespath.search(
             "spec.jobTemplate.spec.template.spec.containers[0].resources", docs[0]
         )
+
+    def test_cleanup_job_annotations(self):
+        docs = render_chart(
+            values={
+                "cleanup": {
+                    "enabled": True,
+                    "podAnnotations": {"foo.net/prop": "bar"},
+                },
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        assert "bar" == jmespath.search(
+            "spec.jobTemplate.spec.template.metadata.annotations.\"foo.net/prop\"", docs[0]
+        )

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -199,18 +199,3 @@ class CleanupPodsTest(unittest.TestCase):
         assert resources == jmespath.search(
             "spec.jobTemplate.spec.template.spec.containers[0].resources", docs[0]
         )
-
-    def test_cleanup_job_annotations(self):
-        docs = render_chart(
-            values={
-                "cleanup": {
-                    "enabled": True,
-                    "podAnnotations": {"foo.net/prop": "bar"},
-                },
-            },
-            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
-        )
-
-        assert "bar" == jmespath.search(
-            "spec.jobTemplate.spec.template.metadata.annotations.\"foo.net/prop\"", docs[0]
-        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3846,6 +3846,14 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.Toleration"
                     }
                 },
+                "podAnnotations": {
+                    "description": "Annotations to add to cleanup pods.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
                 "resources": {
                     "description": "Resources for or cleanup pods",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1330,6 +1330,8 @@ cleanup:
   affinity: {}
   tolerations: []
 
+  podAnnotations: {}
+
   resources: {}
   #  limits:
   #   cpu: 100m


### PR DESCRIPTION
closes: #21469 

This PR propagates the `airflowPodAnnotations` that the documentation says is applied to all airflow pods to the pods launched by the `cleanup` cronojob. It also allows for setting `podAnnotations` specifically for the cleanup pods.


