### PR TITLE
Refactor query polling logic for athena queries

### DIFF
--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -72,7 +72,7 @@ class TestAthenaOperator(unittest.TestCase):
 
         assert self.athena.hook.sleep_time == 0
 
-    @mock.patch.object(AthenaHook, 'check_query_status', side_effect=("SUCCESS",))
+    @mock.patch.object(AthenaHook, 'check_query_status', side_effect=("SUCCEEDED",))
     @mock.patch.object(AthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)
     @mock.patch.object(AthenaHook, 'get_conn')
     def test_hook_run_small_success_query(self, mock_conn, mock_run_query, mock_check_query_status):
@@ -92,7 +92,7 @@ class TestAthenaOperator(unittest.TestCase):
         side_effect=(
             "RUNNING",
             "RUNNING",
-            "SUCCESS",
+            "SUCCEEDED",
         ),
     )
     @mock.patch.object(AthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)
@@ -202,7 +202,7 @@ class TestAthenaOperator(unittest.TestCase):
         )
         assert mock_check_query_status.call_count == 3
 
-    @mock.patch.object(AthenaHook, 'check_query_status', side_effect=("SUCCESS",))
+    @mock.patch.object(AthenaHook, 'check_query_status', side_effect=("SUCCEEDED",))
     @mock.patch.object(AthenaHook, 'run_query', return_value=ATHENA_QUERY_ID)
     @mock.patch.object(AthenaHook, 'get_conn')
     def test_return_value(self, mock_conn, mock_run_query, mock_check_query_status):


### PR DESCRIPTION
Query status polling logic currently polls until the query is not in intermmediate state. It should instead poll until query is not in the terminal state.
Similar to https://github.com/apache/airflow/issues/19877