### PR TITLE
Update link in Postgres connection doc

### DIFF
--- a/docs/apache-airflow-providers-postgres/connections/postgres.rst
+++ b/docs/apache-airflow-providers-postgres/connections/postgres.rst
@@ -58,7 +58,7 @@ Extra (optional)
     * ``keepalives_idle`` - Controls the number of seconds of inactivity after which TCP
       should send a keepalive message to the server.
     * ``client_encoding``: specifies client encoding(character set) of the client connection.
-      Refer to `Postgres supported character sets <https://www.postgresql.org/docs/9.3/multibyte.html>`_
+      Refer to `Postgres supported character sets <https://www.postgresql.org/docs/current/multibyte.html>`_
 
     More details on all Postgres parameters supported can be found in
     `Postgres documentation <https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING>`_.


### PR DESCRIPTION
Lets not point to specific Postgres version in the link as it's outdated.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
