### PR TITLE
Fix postgres hook import pipeline tutorial

### DIFF
--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -413,7 +413,7 @@ Let's break this down into 2 steps: get data & merge data:
 
   import requests
   from airflow.decorators import task
-  from airflow.hooks.postgres import PostgresHook
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
   @task
@@ -478,7 +478,7 @@ Lets look at our DAG:
 
   import requests
   from airflow.decorators import dag, task
-  from airflow.hooks.postgres import PostgresHook
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
   @dag(

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -413,7 +413,7 @@ Let's break this down into 2 steps: get data & merge data:
 
   import requests
   from airflow.decorators import task
-  from airflow.providers.postgres.hooks.postgres import PostgresHook
+  from airflow.hooks.postgres import PostgresHook
 
 
   @task
@@ -478,7 +478,7 @@ Lets look at our DAG:
 
   import requests
   from airflow.decorators import dag, task
-  from airflow.providers.postgres.hooks.postgres import PostgresHook
+  from airflow.hooks.postgres import PostgresHook
 
 
   @dag(


### PR DESCRIPTION
related: #21457 

Following @potiuk and @ashb [comments](https://github.com/apache/airflow/issues/21457#issuecomment-1034005672) I just quickly corrected the `PostgresHook` imports of the [pipeline tutorial](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/tutorial.html#pipeline-example).


