### PR TITLE
S3KeySensor to use S3Hook url parser

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3.py
+++ b/airflow/providers/amazon/aws/sensors/s3.py
@@ -21,7 +21,7 @@ import os
 import re
 import sys
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Set, Union
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -77,39 +77,33 @@ class S3KeySensor(BaseSensorOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.bucket_key = bucket_key
+        self.bucket_name = bucket_name
         self.wildcard_match = wildcard_match
         self.aws_conn_id = aws_conn_id
         self.verify = verify
         self.hook: Optional[S3Hook] = None
-        if bucket_name is None:
-            self.bucket_name, self.bucket_key = self._parse_object_from_uri(bucket_key)
+
+    def _resolve_bucket_and_key(self):
+        """
+        If key is URI we should parse the bucket and leave only key portion under
+        the ``bucket_key`` attr.
+        """
+        if self.bucket_name is None:
+            self.bucket_name, self.bucket_key = S3Hook.parse_s3_url(self.bucket_key)
         else:
-            self.bucket_name = bucket_name
-            self._validate_key(bucket_key)
-            self.bucket_key = bucket_key
-
-    @staticmethod
-    def _parse_object_from_uri(uri) -> Tuple[str, str]:
-        parsed = urlparse(uri)
-        if parsed.netloc == '':
-            raise AirflowException('If key is a relative path from root, please provide a bucket_name')
-        bucket = parsed.netloc
-        key = parsed.path.lstrip('/')
-        return bucket, key
-
-    @staticmethod
-    def _validate_key(key):
-        parsed = urlparse(key)
-        if parsed.scheme != '' or parsed.netloc != '':
-            raise AirflowException(
-                'If bucket_name is provided, bucket_key should be relative path from root level, '
-                'rather than a full s3:// url'
-            )
+            parsed = urlparse(self.bucket_key)
+            if parsed.scheme != '' or parsed.netloc != '':
+                raise AirflowException(
+                    'If bucket_name is provided, bucket_key should be relative path from root level, '
+                    'rather than a full s3:// url'
+                )
 
     def poke(self, context: 'Context'):
+        self._resolve_bucket_and_key()
         self.log.info('Poking for key : s3://%s/%s', self.bucket_name, self.bucket_key)
         if self.wildcard_match:
-            return self.get_hook().check_for_wildcard_key(self.bucket_key, self.bucket_name)
+            return self.get_hook().f(self.bucket_key, self.bucket_name)
         return self.get_hook().check_for_key(self.bucket_key, self.bucket_name)
 
     def get_hook(self) -> S3Hook:

--- a/airflow/providers/amazon/aws/sensors/s3.py
+++ b/airflow/providers/amazon/aws/sensors/s3.py
@@ -103,7 +103,7 @@ class S3KeySensor(BaseSensorOperator):
         self._resolve_bucket_and_key()
         self.log.info('Poking for key : s3://%s/%s', self.bucket_name, self.bucket_key)
         if self.wildcard_match:
-            return self.get_hook().f(self.bucket_key, self.bucket_name)
+            return self.get_hook().check_for_wildcard_key(self.bucket_key, self.bucket_name)
         return self.get_hook().check_for_key(self.bucket_key, self.bucket_name)
 
     def get_hook(self) -> S3Hook:

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -104,36 +104,36 @@ class TestS3KeySensor(unittest.TestCase):
         op = S3KeySensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
 
         mock_check.return_value = False
-        assert not op.poke(None)
+        assert op.poke(None) is False
         mock_check.assert_called_once_with(op.bucket_key, op.bucket_name)
 
         mock_check.return_value = True
-        assert op.poke(None)
+        assert op.poke(None) is True
 
     @mock.patch('airflow.providers.amazon.aws.sensors.s3.S3Hook.check_for_wildcard_key')
     def test_poke_wildcard(self, mock_check):
         op = S3KeySensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file', wildcard_match=True)
 
         mock_check.return_value = False
-        assert not op.poke(None)
+        assert op.poke(None) is False
         mock_check.assert_called_once_with(op.bucket_key, op.bucket_name)
 
         mock_check.return_value = True
-        assert op.poke(None)
+        assert op.poke(None) is True
 
 
 class TestS3KeySizeSensor(unittest.TestCase):
     @mock.patch('airflow.providers.amazon.aws.sensors.s3.S3Hook.check_for_key', return_value=False)
     def test_poke_check_for_key_false(self, mock_check_for_key):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
-        assert not op.poke(None)
+        assert op.poke(None) is False
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
 
     @mock.patch('airflow.providers.amazon.aws.sensors.s3.S3KeySizeSensor.get_files', return_value=[])
     @mock.patch('airflow.providers.amazon.aws.sensors.s3.S3Hook.check_for_key', return_value=True)
     def test_poke_get_files_false(self, mock_check_for_key, mock_get_files):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
-        assert not op.poke(None)
+        assert op.poke(None) is False
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
         mock_get_files.assert_called_once_with(s3_hook=op.get_hook())
 
@@ -167,5 +167,5 @@ class TestS3KeySizeSensor(unittest.TestCase):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file', wildcard_match=True)
 
         mock_check.return_value = False
-        assert not op.poke(None)
+        assert op.poke(None) is False
         mock_check.assert_called_once_with(op.bucket_key, op.bucket_name)


### PR DESCRIPTION
S3KeySensor resolves the bucket_name and key in the poke method.

Pulling this "resolution" logic out into a `_resolve_bucket_and_key` method makes it a little clearer what's happening there.

Unfortunately we can't just do it in `__init__` because we have to wait for templates to render first.

I took the opportunity here to remove redundant s3 uri parsing logic, which already exists in a static method on the hook.

And since we use that hook method now, I had to update the tests to not mock the entire hook class but only the check methods.

Finally, since while I was at it I strengthened the test slightly, replacing `assert op.poke(None)` with `assert op.poke(None) is True` etc, since mocks can evaluate to "truthy"