### PR TITLE
Support different timeout value for dag file parsing

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -88,8 +88,6 @@ class DagBag(LoggingMixin):
         are not loaded to not run User code in Scheduler.
     """
 
-    DAGBAG_IMPORT_TIMEOUT = conf.getfloat('core', 'DAGBAG_IMPORT_TIMEOUT')
-
     def __init__(
         self,
         dag_folder: Union[str, "pathlib.Path", None] = None,
@@ -310,13 +308,7 @@ class DagBag(LoggingMixin):
         if mod_name in sys.modules:
             del sys.modules[mod_name]
 
-        timeout_msg = (
-            f"DagBag import timeout for {filepath} after {self.DAGBAG_IMPORT_TIMEOUT}s.\n"
-            "Please take a look at these docs to improve your DAG import time:\n"
-            f"* {get_docs_url('best-practices.html#top-level-python-code')}\n"
-            f"* {get_docs_url('best-practices.html#reducing-dag-complexity')}"
-        )
-        with timeout(self.DAGBAG_IMPORT_TIMEOUT, error_message=timeout_msg):
+        def parse(mod_name, filepath):
             try:
                 loader = importlib.machinery.SourceFileLoader(mod_name, filepath)
                 spec = importlib.util.spec_from_loader(mod_name, loader)
@@ -332,7 +324,26 @@ class DagBag(LoggingMixin):
                     )
                 else:
                     self.import_errors[filepath] = str(e)
-        return []
+                return []
+
+        dagbag_import_timeout = settings.get_dagbag_import_timeout(filepath)
+
+        if not isinstance(dagbag_import_timeout, (int, float)):
+            raise TypeError(
+                f'Value ({dagbag_import_timeout}) from get_dagbag_import_timeout must be int or float'
+            )
+
+        if dagbag_import_timeout <= 0:  # no parsing timeout
+            return parse(mod_name, filepath)
+
+        timeout_msg = (
+            f"DagBag import timeout for {filepath} after {dagbag_import_timeout}s.\n"
+            "Please take a look at these docs to improve your DAG import time:\n"
+            f"* {get_docs_url('best-practices.html#top-level-python-code')}\n"
+            f"* {get_docs_url('best-practices.html#reducing-dag-complexity')}"
+        )
+        with timeout(dagbag_import_timeout, error_message=timeout_msg):
+            return parse(mod_name, filepath)
 
     def _load_modules_from_zip(self, filepath, safe_mode):
         mods = []

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -22,7 +22,7 @@ import logging
 import os
 import sys
 import warnings
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import pendulum
 import sqlalchemy
@@ -207,6 +207,18 @@ def get_airflow_context_vars(context):
     :param context: The context for the task_instance of interest.
     """
     return {}
+
+
+def get_dagbag_import_timeout(dag_file_path: str) -> Union[int, float]:
+    """
+    This setting allows for dynamic control of the DAG file parsing timeout based on the DAG file path.
+
+    It is useful when there are a few DAG files requiring longer parsing times, while others do not.
+    You can control them separately instead of having one value for all DAG files.
+
+    If the return value is less than or equal to 0, it means no timeout during the DAG parsing.
+    """
+    return conf.getfloat('core', 'DAGBAG_IMPORT_TIMEOUT')
 
 
 def configure_vars():

--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -119,6 +119,35 @@ How do I trigger tasks based on another task's failure?
 
 You can achieve this with :ref:`concepts:trigger-rules`.
 
+How to control DAG file parsing timeout for different DAG files?
+----------------------------------------------------------------
+
+(only valid for Airflow >= 2.3.0)
+
+You can add a ``get_dagbag_import_timeout`` function in your ``airflow_local_settings.py`` which gets
+called right before a DAG file is parsed. You can return different timeout value based on the DAG file.
+When the return value is less than or equal to 0, it means no timeout during the DAG parsing.
+
+.. code-block:: python
+   :caption: airflow_local_settings.py
+   :name: airflow_local_settings.py
+
+    def get_dagbag_import_timeout(dag_file_path: str) -> Union[int, float]:
+        """
+        This setting allows to dynamically control the DAG file parsing timeout.
+
+        It is useful when there are a few DAG files requiring longer parsing times, while others do not.
+        You can control them separately instead of having one value for all DAG files.
+
+        If the return value is less than or equal to 0, it means no timeout during the DAG parsing.
+        """
+        if "slow" in dag_file_path:
+            return 90
+        if "no-timeout" in dag_file_path:
+            return 0
+        return conf.getfloat("core", "DAGBAG_IMPORT_TIMEOUT")
+
+
 When there are a lot (>1000) of dags files, how to speed up parsing of new files?
 ---------------------------------------------------------------------------------
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This adds a hook for infra users to dynamically control the dag file parsing timeout.

It is useful when there are a few dag files, requiring long parsing time while others not
You can control them separately instead of having one value for all dag files.

If the return value is less than 0, it means no timeout during the dag parsing.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
