### PR TITLE
Set larger limit get_partitions_by_filter in HiveMetastoreHook

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -556,7 +556,9 @@ class HiveMetastoreHook(BaseHook):
         True
         """
         with self.metastore as client:
-            partitions = client.get_partitions_by_filter(schema, table, partition, 1)
+            partitions = client.get_partitions_by_filter(
+                schema, table, partition, HiveMetastoreHook.MAX_PART_COUNT
+            )
 
         return bool(partitions)
 

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -456,7 +456,9 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
 
         assert self.hook.check_for_partition(self.database, self.table, partition)
 
-        metastore.get_partitions_by_filter(self.database, self.table, partition, 1)
+        metastore.get_partitions_by_filter(
+            self.database, self.table, partition, HiveMetastoreHook.MAX_PART_COUNT
+        )
 
         # Check for non-existent partition.
         missing_partition = f"{self.partition_by}='{self.next_day}'"
@@ -464,7 +466,9 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
 
         assert not self.hook.check_for_partition(self.database, self.table, missing_partition)
 
-        metastore.get_partitions_by_filter.assert_called_with(self.database, self.table, missing_partition, 1)
+        metastore.get_partitions_by_filter.assert_called_with(
+            self.database, self.table, missing_partition, HiveMetastoreHook.MAX_PART_COUNT
+        )
 
     def test_check_for_named_partition(self):
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

With the large size of the hive metastore, setting limit to 1 will create a scan query that is too heavy to handle. Setting the limit to HiveMetastoreHook.MAX_PART_COUNT will generate a query using index and scan much less rows( not guaranteed, depending on the table, some table may still got a scan query but we are limited by thrift lib as the limit is a short int).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
