### PR TITLE
Straighten up MappedOperator hierarchy and typing

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -130,6 +130,10 @@ Previously, a task’s log is dynamically rendered from the `[core] log_filename
 
 A new `log_template` table is introduced to solve this problem. This table is synchronised with the aforementioned config values every time Airflow starts, and a new field `log_template_id` is added to every DAG run to point to the format used by tasks (`NULL` indicates the first ever entry for compatibility).
 
+### `airflow.models.base.Operator` is removed
+
+Previously, there was an empty class `airflow.models.base.Operator` for “type hinting”. This class was never really useful for anything (everything it did could be done better with `airflow.models.baseoperator.BaseOperator`), and has been removed. If you are relying on the class’s existence, use `BaseOperator` (for concrete operators), `airflow.models.abstractoperator.AbstractOperator` (the base class of both `BaseOperator` and the AIP-42 `MappedOperator`), or `airflow.models.operator.Operator` (a union type `BaseOperator | MappedOperator` for type annotation).
+
 ## Airflow 2.2.3
 
 No breaking changes.

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm.session import Session as SASession
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
+from airflow.models.operator import Operator
 from airflow.models.taskinstance import TaskInstance
 from airflow.operators.subdag import SubDagOperator
 from airflow.utils import timezone
@@ -78,7 +79,7 @@ def _create_dagruns(
 @provide_session
 def set_state(
     *,
-    tasks: Iterable[BaseOperator],
+    tasks: Iterable[Operator],
     dag_run_id: Optional[str] = None,
     execution_date: Optional[datetime] = None,
     upstream: bool = False,
@@ -242,7 +243,7 @@ def verify_dagruns(
     commit: bool,
     state: DagRunState,
     session: SASession,
-    current_task: BaseOperator,
+    current_task: Operator,
 ):
     """Verifies integrity of dag_runs.
 

--- a/airflow/api_connexion/schemas/common_schema.py
+++ b/airflow/api_connexion/schemas/common_schema.py
@@ -24,6 +24,7 @@ from dateutil import relativedelta
 from marshmallow import Schema, fields, validate
 from marshmallow_oneofschema import OneOfSchema
 
+from airflow.models.mappedoperator import MappedOperator
 from airflow.serialization.serialized_objects import SerializedBaseOperator
 from airflow.utils.weight_rule import WeightRule
 
@@ -154,12 +155,12 @@ class ClassReferenceSchema(Schema):
     class_name = fields.Method("_get_class_name", required=True)
 
     def _get_module(self, obj):
-        if isinstance(obj, SerializedBaseOperator):
+        if isinstance(obj, (MappedOperator, SerializedBaseOperator)):
             return obj._task_module
         return inspect.getmodule(obj).__name__
 
     def _get_class_name(self, obj):
-        if isinstance(obj, SerializedBaseOperator):
+        if isinstance(obj, (MappedOperator, SerializedBaseOperator)):
             return obj._task_type
         if isinstance(obj, type):
             return obj.__name__

--- a/airflow/api_connexion/schemas/task_schema.py
+++ b/airflow/api_connexion/schemas/task_schema.py
@@ -26,7 +26,7 @@ from airflow.api_connexion.schemas.common_schema import (
     WeightRuleField,
 )
 from airflow.api_connexion.schemas.dag_schema import DAGSchema
-from airflow.models.baseoperator import BaseOperator
+from airflow.models.operator import Operator
 
 
 class TaskSchema(Schema):
@@ -73,7 +73,7 @@ class TaskSchema(Schema):
 class TaskCollection(NamedTuple):
     """List of Tasks with metadata"""
 
-    tasks: List[BaseOperator]
+    tasks: List[Operator]
     total_entries: int
 
 

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -445,7 +445,7 @@ class DagFileProcessor(LoggingMixin):
             blocking_tis: List[TI] = []
             for ti in fetched_tis:
                 if ti.task_id in dag.task_ids:
-                    ti.task = dag.get_task(ti.task_id)
+                    ti.task = dag.get_task(ti.task_id)  # type: ignore[assignment]  # TODO: Fix task: Operator
                     blocking_tis.append(ti)
                 else:
                     session.delete(ti)

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -375,7 +375,10 @@ class DecoratedMappedOperator(MappedOperator):
     @classmethod
     @cache
     def get_serialized_fields(cls):
-        return MappedOperator.get_serialized_fields() | {"partial_op_kwargs"}
+        # The magic argument-less super() does not work well with @cache
+        # (actually lru_cache in general), so we use the explicit form instead.
+        sup = super(DecoratedMappedOperator, DecoratedMappedOperator)
+        return sup.get_serialized_fields() | {"partial_op_kwargs"}
 
     def _create_unmapped_operator(
         self,

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -291,7 +291,8 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         task_id = get_unique_task_id(partial_kwargs.pop("task_id"), dag, task_group)
         params = ParamsDict(partial_kwargs.pop("params", None))
 
-        operator = DecoratedMappedOperator(
+        # Mypy does not work well with a subclassed attrs class :(
+        operator = cast(Any, DecoratedMappedOperator)(
             operator_class=self.operator_class,
             mapped_kwargs={"op_args": list(args), "op_kwargs": kwargs},
             partial_kwargs=partial_kwargs,
@@ -301,6 +302,8 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             operator_extra_links=self.operator_class.operator_extra_links,
             template_ext=self.operator_class.template_ext,
             template_fields=self.operator_class.template_fields,
+            ui_color=self.operator_class.ui_color,
+            ui_fgcolor=self.operator_class.ui_fgcolor,
             is_dummy=False,
             task_module=self.operator_class.__module__,
             task_type=self.operator_class.__name__,

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -392,10 +392,12 @@ class DecoratedMappedOperator(MappedOperator):
         real: bool,
     ) -> "BaseOperator":
         assert not isinstance(self.operator_class, str)
-        op_args = self.partial_op_args + mapped_kwargs.pop("op_args", [])
+        del mapped_kwargs["op_args"]
+        del mapped_kwargs["op_kwargs"]
+        op_args = self.partial_op_args + self.mapped_kwargs["op_args"]
         op_kwargs = _merge_kwargs(
             self.partial_op_kwargs,
-            mapped_kwargs.pop("op_kwargs", {}),
+            self.mapped_kwargs["op_kwargs"],
             fail_reason="mapping already partial",
         )
         return self.operator_class(

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -335,9 +335,6 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             python_callable=self.function,
             partial_op_kwargs=partial_op_kwargs,
         )
-
-        for arg in kwargs.values():
-            XComArg.apply_upstream_relationship(operator, arg)
         return XComArg(operator=operator)
 
     def partial(self, **kwargs) -> "_TaskDecorator[Function, OperatorSubclass]":

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -386,10 +386,11 @@ class DecoratedMappedOperator(MappedOperator):
         real: bool,
     ) -> "BaseOperator":
         assert not isinstance(self.operator_class, str)
+        mapped_kwargs = mapped_kwargs.copy()
         del mapped_kwargs["op_kwargs"]
         op_kwargs = _merge_kwargs(
             self.partial_op_kwargs,
-            self.mapped_kwargs.get("op_kwargs", {}),
+            self.mapped_kwargs["op_kwargs"],  # We want to "original" op_kwargs.
             fail_reason="mapping already partial",
         )
         return self.operator_class(

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -336,6 +336,8 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             partial_op_kwargs=partial_op_kwargs,
         )
 
+        for arg in kwargs.values():
+            XComArg.apply_upstream_relationship(operator, arg)
         return XComArg(operator=operator)
 
     def partial(self, **kwargs) -> "_TaskDecorator[Function, OperatorSubclass]":
@@ -362,7 +364,7 @@ def _merge_kwargs(
     return {**kwargs1, **kwargs2}
 
 
-@attr.define(kw_only=True)
+@attr.define(kw_only=True, repr=False)
 class DecoratedMappedOperator(MappedOperator):
     """MappedOperator implementation for @task-decorated task function."""
 

--- a/airflow/decorators/python.py
+++ b/airflow/decorators/python.py
@@ -41,17 +41,19 @@ class _PythonDecoratedOperator(DecoratedOperator, PythonOperator):
     # there are some cases we can't deepcopy the objects (e.g protobuf).
     shallow_copy_attrs: Sequence[str] = ('python_callable',)
 
-    def __init__(
-        self,
-        **kwargs,
-    ) -> None:
+    def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
         kwargs_to_upstream = {
-            "python_callable": kwargs["python_callable"],
-            "op_args": kwargs["op_args"],
-            "op_kwargs": kwargs["op_kwargs"],
+            "python_callable": python_callable,
+            "op_args": op_args,
+            "op_kwargs": op_kwargs,
         }
-
-        super().__init__(kwargs_to_upstream=kwargs_to_upstream, **kwargs)
+        super().__init__(
+            kwargs_to_upstream=kwargs_to_upstream,
+            python_callable=python_callable,
+            op_args=op_args,
+            op_kwargs=op_kwargs,
+            **kwargs,
+        )
 
 
 T = TypeVar("T", bound=Callable)

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -44,16 +44,19 @@ class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOper
     # there are some cases we can't deepcopy the objects (e.g protobuf).
     shallow_copy_attrs: Sequence[str] = ('python_callable',)
 
-    def __init__(
-        self,
-        **kwargs,
-    ) -> None:
+    def __init__(self, *, python_callable, op_args, op_kwargs, **kwargs) -> None:
         kwargs_to_upstream = {
-            "python_callable": kwargs["python_callable"],
-            "op_args": kwargs["op_args"],
-            "op_kwargs": kwargs["op_kwargs"],
+            "python_callable": python_callable,
+            "op_args": op_args,
+            "op_kwargs": op_kwargs,
         }
-        super().__init__(kwargs_to_upstream=kwargs_to_upstream, **kwargs)
+        super().__init__(
+            kwargs_to_upstream=kwargs_to_upstream,
+            python_callable=python_callable,
+            op_args=op_args,
+            op_kwargs=op_kwargs,
+            **kwargs,
+        )
 
     def get_python_source(self):
         raw_source = inspect.getsource(self.python_callable)

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -49,7 +49,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import MappedOperator
+    from airflow.models.mappedoperator import MappedOperator
 
 
 class BackfillJob(BaseJob):
@@ -235,7 +235,7 @@ class BackfillJob(BaseJob):
         :param running: dict of key, task to verify
         :return: An iterable of expanded TaskInstance per MappedTask
         """
-        from airflow.models.baseoperator import MappedOperator
+        from airflow.models.mappedoperator import MappedOperator
 
         executor = self.executor
 

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -250,12 +250,12 @@ class LocalTaskJob(BaseJob):
                 session=session,
             ).one()
 
-            # Get a partial dag with just the specific tasks we want to
-            # examine. In order for dep checks to work correctly, we
-            # include ourself (so TriggerRuleDep can check the state of the
-            # task we just executed)
             task = self.task_instance.task
+            assert task.dag  # For Mypy.
 
+            # Get a partial DAG with just the specific tasks we want to examine.
+            # In order for dep checks to work correctly, we include ourself (so
+            # TriggerRuleDep can check the state of the task we just executed).
             partial_dag = task.dag.partial_subset(
                 task.downstream_task_ids,
                 include_downstream=True,

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1131,7 +1131,7 @@ class SchedulerJob(BaseJob):
         if not settings.CHECK_SLAS:
             return
 
-        if not any(isinstance(ti.sla, timedelta) for ti in dag.tasks):
+        if not any(isinstance(task.sla, timedelta) for task in dag.tasks):
             self.log.debug("Skipping SLA check for %s because no tasks in DAG have SLAs", dag)
             return
 

--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -141,11 +141,11 @@ def prepare_lineage(func: T) -> T:
 
     @wraps(func)
     def wrapper(self, context, *args, **kwargs):
-        from airflow.models.base import Operator
+        from airflow.models.abstractoperator import AbstractOperator
 
         self.log.debug("Preparing lineage inlets and outlets")
 
-        if isinstance(self._inlets, (str, Operator)) or attr.has(self._inlets):
+        if isinstance(self._inlets, (str, AbstractOperator)) or attr.has(self._inlets):
             self._inlets = [
                 self._inlets,
             ]
@@ -153,8 +153,8 @@ def prepare_lineage(func: T) -> T:
         if self._inlets and isinstance(self._inlets, list):
             # get task_ids that are specified as parameter and make sure they are upstream
             task_ids = (
-                set(filter(lambda x: isinstance(x, str) and x.lower() != AUTO, self._inlets))
-                .union(map(lambda op: op.task_id, filter(lambda op: isinstance(op, Operator), self._inlets)))
+                {o for o in self._inlets if isinstance(o, str)}
+                .union(op.task_id for op in self._inlets if isinstance(op, AbstractOperator))
                 .intersection(self.get_flat_relative_ids(upstream=True))
             )
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow models"""
+from typing import Union
+
 from airflow.models.base import ID_LEN, Base
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
@@ -25,10 +27,12 @@ from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.errors import ImportError
 from airflow.models.log import Log
+from airflow.models.mappedoperator import MappedOperator
+from airflow.models.operator import Operator
 from airflow.models.param import Param
 from airflow.models.pool import Pool
 from airflow.models.renderedtifields import RenderedTaskInstanceFields
-from airflow.models.sensorinstance import SensorInstance  # noqa: F401
+from airflow.models.sensorinstance import SensorInstance
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.slamiss import SlaMiss
 from airflow.models.taskfail import TaskFail
@@ -37,3 +41,35 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.trigger import Trigger
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
+
+__all__ = [
+    "DAG",
+    "ID_LEN",
+    "XCOM_RETURN_KEY",
+    "Base",
+    "BaseOperator",
+    "BaseOperatorLink",
+    "Connection",
+    "DagBag",
+    "DagModel",
+    "DagPickle",
+    "DagRun",
+    "DagTag",
+    "ImportError",
+    "Log",
+    "MappedOperator",
+    "Operator",
+    "Param",
+    "Pool",
+    "RenderedTaskInstanceFields",
+    "SensorInstance",
+    "SkipMixin",
+    "SlaMiss",
+    "TaskFail",
+    "TaskInstance",
+    "TaskReschedule",
+    "Trigger",
+    "Variable",
+    "XCom",
+    "clear_task_instances",
+]

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -1,0 +1,168 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import TYPE_CHECKING, Collection, Optional, Set
+
+import jinja2
+
+from airflow.models.taskmixin import DAGNode
+from airflow.templates import SandboxedEnvironment
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.weight_rule import WeightRule
+
+if TYPE_CHECKING:
+    from airflow.models.dag import DAG
+
+
+class AbstractOperator(LoggingMixin, DAGNode):
+    """Common implementation for operators, including unmapped and mapped.
+
+    This base class is more about sharing implementations, not defining a common
+    interface. Unfortunately it's difficult to use this as the common base class
+    for typing due to BaseOperator carrying too much historical baggage.
+
+    The union type ``from airflow.models.operator import Operator`` is easier
+    to use for typing purposes.
+
+    :meta private:
+    """
+
+    weight_rule: str
+    priority_weight: int
+
+    # For derived classes to define which fields will get jinjaified.
+    template_fields: Collection[str]
+    # Defines which files extensions to look for in the templated fields.
+    template_ext: Collection[str]
+    owner: str
+    task_id: str
+
+    def get_dag(self) -> "Optional[DAG]":
+        raise NotImplementedError()
+
+    @property
+    def task_type(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def inherits_from_dummy_operator(self) -> bool:
+        raise NotImplementedError()
+
+    @property
+    def dag_id(self) -> str:
+        """Returns dag id if it has one or an adhoc + owner"""
+        dag = self.get_dag()
+        if dag:
+            return dag.dag_id
+        return f"adhoc_{self.owner}"
+
+    @property
+    def node_id(self) -> str:
+        return self.task_id
+
+    def get_template_env(self) -> jinja2.Environment:
+        """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
+        dag = self.get_dag()
+        if dag:
+            return dag.get_template_env()
+        return SandboxedEnvironment(cache_size=0)
+
+    def prepare_template(self) -> None:
+        """Hook triggered after the templated fields get replaced by their content.
+
+        If you need your operator to alter the content of the file before the
+        template is rendered, it should override this method to do so.
+        """
+
+    def resolve_template_files(self) -> None:
+        """Getting the content of files for template_field / template_ext."""
+        if self.template_ext:
+            for field in self.template_fields:
+                content = getattr(self, field, None)
+                if content is None:
+                    continue
+                elif isinstance(content, str) and any(content.endswith(ext) for ext in self.template_ext):
+                    env = self.get_template_env()
+                    try:
+                        setattr(self, field, env.loader.get_source(env, content)[0])  # type: ignore
+                    except Exception:
+                        self.log.exception("Failed to resolve template field %r", field)
+                elif isinstance(content, list):
+                    env = self.get_template_env()
+                    for i, item in enumerate(content):
+                        if isinstance(item, str) and any(item.endswith(ext) for ext in self.template_ext):
+                            try:
+                                content[i] = env.loader.get_source(env, item)[0]  # type: ignore
+                            except Exception as e:
+                                self.log.exception(e)
+        self.prepare_template()
+
+    def get_direct_relative_ids(self, upstream: bool = False) -> Set[str]:
+        """Get direct relative IDs to the current task, upstream or downstream."""
+        if upstream:
+            return self.upstream_task_ids
+        return self.downstream_task_ids
+
+    def get_flat_relative_ids(
+        self,
+        upstream: bool = False,
+        found_descendants: Optional[Set[str]] = None,
+    ) -> Set[str]:
+        """Get a flat set of relative IDs, upstream or downstream."""
+        dag = self.get_dag()
+        if not dag:
+            return set()
+
+        if not found_descendants:
+            found_descendants = set()
+        relative_ids = self.get_direct_relative_ids(upstream)
+
+        for relative_id in relative_ids:
+            if relative_id not in found_descendants:
+                found_descendants.add(relative_id)
+                relative_task = dag.task_dict[relative_id]
+                relative_task.get_flat_relative_ids(upstream, found_descendants)
+
+        return found_descendants
+
+    @property
+    def priority_weight_total(self) -> int:
+        """
+        Total priority weight for the task. It might include all upstream or downstream tasks.
+
+        Depending on the weight rule:
+
+        - WeightRule.ABSOLUTE - only own weight
+        - WeightRule.DOWNSTREAM - adds priority weight of all downstream tasks
+        - WeightRule.UPSTREAM - adds priority weight of all upstream tasks
+        """
+        if self.weight_rule == WeightRule.ABSOLUTE:
+            return self.priority_weight
+        elif self.weight_rule == WeightRule.DOWNSTREAM:
+            upstream = False
+        elif self.weight_rule == WeightRule.UPSTREAM:
+            upstream = True
+        else:
+            upstream = False
+        dag = self.get_dag()
+        if dag is None:
+            return self.priority_weight
+        return self.priority_weight + sum(
+            dag.task_dict[task_id].priority_weight
+            for task_id in self.get_flat_relative_ids(upstream=upstream)
+        )

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -27,6 +27,7 @@ from airflow.utils.weight_rule import WeightRule
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
+    from airflow.models.operator import Operator
 
 
 class AbstractOperator(LoggingMixin, DAGNode):
@@ -139,6 +140,13 @@ class AbstractOperator(LoggingMixin, DAGNode):
                 relative_task.get_flat_relative_ids(upstream, found_descendants)
 
         return found_descendants
+
+    def get_flat_relatives(self, upstream: bool = False) -> Collection["Operator"]:
+        """Get a flat list of relatives, either upstream or downstream."""
+        dag = self.get_dag()
+        if not dag:
+            return set()
+        return [dag.task_dict[task_id] for task_id in self.get_flat_relative_ids(upstream)]
 
     @property
     def priority_weight_total(self) -> int:

--- a/airflow/models/base.py
+++ b/airflow/models/base.py
@@ -17,19 +17,12 @@
 # under the License.
 
 import functools
-import logging
-from typing import TYPE_CHECKING, Any, Collection, Optional, Set, Type
+from typing import Any, Type
 
-import jinja2
 from sqlalchemy import MetaData, String
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow.configuration import conf
-from airflow.templates import SandboxedEnvironment
-from airflow.utils.weight_rule import WeightRule
-
-if TYPE_CHECKING:
-    from airflow.models.dag import DAG
 
 SQL_ALCHEMY_SCHEMA = conf.get("core", "SQL_ALCHEMY_SCHEMA")
 
@@ -39,126 +32,6 @@ metadata = (
 Base = declarative_base(metadata=metadata)  # type: Any
 
 ID_LEN = 250
-
-
-class Operator:
-    """Common interface for operators, including unmapped and mapped."""
-
-    log: logging.Logger
-
-    upstream_task_ids: Set[str]
-    downstream_task_ids: Set[str]
-    weight_rule: str
-    priority_weight: int
-
-    # For derived classes to define which fields will get jinjaified.
-    template_fields: Collection[str]
-    # Defines which files extensions to look for in the templated fields.
-    template_ext: Collection[str]
-    owner: str
-
-    def get_dag(self) -> "Optional[DAG]":
-        raise NotImplementedError()
-
-    @property
-    def dag_id(self) -> str:
-        """Returns dag id if it has one or an adhoc + owner"""
-        dag = self.get_dag()
-        if dag:
-            return dag.dag_id
-        return f"adhoc_{self.owner}"
-
-    def get_template_env(self) -> jinja2.Environment:
-        """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
-        dag = self.get_dag()
-        if dag:
-            return dag.get_template_env()
-        return SandboxedEnvironment(cache_size=0)
-
-    def prepare_template(self) -> None:
-        """Hook triggered after the templated fields get replaced by their content.
-
-        If you need your operator to alter the content of the file before the
-        template is rendered, it should override this method to do so.
-        """
-
-    def resolve_template_files(self) -> None:
-        """Getting the content of files for template_field / template_ext."""
-        if self.template_ext:
-            for field in self.template_fields:
-                content = getattr(self, field, None)
-                if content is None:
-                    continue
-                elif isinstance(content, str) and any(content.endswith(ext) for ext in self.template_ext):
-                    env = self.get_template_env()
-                    try:
-                        setattr(self, field, env.loader.get_source(env, content)[0])  # type: ignore
-                    except Exception:
-                        self.log.exception("Failed to resolve template field %r", field)
-                elif isinstance(content, list):
-                    env = self.get_template_env()
-                    for i, item in enumerate(content):
-                        if isinstance(item, str) and any(item.endswith(ext) for ext in self.template_ext):
-                            try:
-                                content[i] = env.loader.get_source(env, item)[0]  # type: ignore
-                            except Exception as e:
-                                self.log.exception(e)
-        self.prepare_template()
-
-    def get_direct_relative_ids(self, upstream: bool = False) -> Set[str]:
-        """Get direct relative IDs to the current task, upstream or downstream."""
-        if upstream:
-            return self.upstream_task_ids
-        return self.downstream_task_ids
-
-    def get_flat_relative_ids(
-        self,
-        upstream: bool = False,
-        found_descendants: Optional[Set[str]] = None,
-    ) -> Set[str]:
-        """Get a flat set of relative IDs, upstream or downstream."""
-        dag = self.get_dag()
-        if not dag:
-            return set()
-
-        if not found_descendants:
-            found_descendants = set()
-        relative_ids = self.get_direct_relative_ids(upstream)
-
-        for relative_id in relative_ids:
-            if relative_id not in found_descendants:
-                found_descendants.add(relative_id)
-                relative_task = dag.task_dict[relative_id]
-                relative_task.get_flat_relative_ids(upstream, found_descendants)
-
-        return found_descendants
-
-    @property
-    def priority_weight_total(self) -> int:
-        """
-        Total priority weight for the task. It might include all upstream or downstream tasks.
-
-        Depending on the weight rule:
-
-        - WeightRule.ABSOLUTE - only own weight
-        - WeightRule.DOWNSTREAM - adds priority weight of all downstream tasks
-        - WeightRule.UPSTREAM - adds priority weight of all upstream tasks
-        """
-        if self.weight_rule == WeightRule.ABSOLUTE:
-            return self.priority_weight
-        elif self.weight_rule == WeightRule.DOWNSTREAM:
-            upstream = False
-        elif self.weight_rule == WeightRule.UPSTREAM:
-            upstream = True
-        else:
-            upstream = False
-        dag = self.get_dag()
-        if dag is None:
-            return self.priority_weight
-        return self.priority_weight + sum(
-            dag.task_dict[task_id].priority_weight
-            for task_id in self.get_flat_relative_ids(upstream=upstream)
-        )
 
 
 def get_id_collation_args():

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -361,11 +361,12 @@ class BaseOperatorMeta(abc.ABCMeta):
             # Store the args passed to init -- we need them to support task.map serialzation!
             self._BaseOperator__init_kwargs.update(kwargs)  # type: ignore
 
-            # Here we set upstream task defined by XComArgs passed to template fields of the operator
-            self.set_xcomargs_dependencies()
+            if not kwargs.get("_airflow_map_validation"):
+                # Set upstream task defined by XComArgs passed to template fields of the operator.
+                self.set_xcomargs_dependencies()
+                # Mark instance as instantiated.
+                self._BaseOperator__instantiated = True
 
-            # Mark instance as instantiated https://docs.python.org/3/tutorial/classes.html#private-variables
-            self._BaseOperator__instantiated = True
             return result
 
         apply_defaults.__non_optional_args = non_optional_args  # type: ignore
@@ -715,7 +716,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         super().__init__()
 
         # This keyword is used internally to signify whether the operator is
-        # instantiated to validate a MappedOperator; only accessed in __new__.
+        # instantiated to validate a MappedOperator.
         kwargs.pop("_airflow_map_validation", None)
 
         if kwargs:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -62,12 +62,13 @@ from airflow import settings, utils
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound, TaskNotFound
+from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.base import ID_LEN, Base
-from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagbag import DagBag
 from airflow.models.dagcode import DagCode
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
+from airflow.models.operator import Operator
 from airflow.models.param import DagParam, ParamsDict
 from airflow.models.taskinstance import Context, TaskInstance, TaskInstanceKey, clear_task_instances
 from airflow.security import permissions
@@ -373,7 +374,7 @@ class DAG(LoggingMixin):
         # set file location to caller source path
         back = sys._getframe().f_back
         self.fileloc = back.f_code.co_filename if back else ""
-        self.task_dict: Dict[str, BaseOperator] = {}
+        self.task_dict: Dict[str, Operator] = {}
 
         # set timezone from start_date
         tz = None
@@ -979,7 +980,7 @@ class DAG(LoggingMixin):
         return DagParam(current_dag=self, name=name, default=default)
 
     @property
-    def tasks(self) -> List[BaseOperator]:
+    def tasks(self) -> List[Operator]:
         return list(self.task_dict.values())
 
     @tasks.setter
@@ -1686,12 +1687,12 @@ class DAG(LoggingMixin):
         return altered
 
     @property
-    def roots(self) -> List[BaseOperator]:
+    def roots(self) -> List[Operator]:
         """Return nodes with no parents. These are first to execute and are called roots or root nodes."""
         return [task for task in self.tasks if not task.upstream_list]
 
     @property
-    def leaves(self) -> List[BaseOperator]:
+    def leaves(self) -> List[Operator]:
         """Return nodes with no children. These are last to execute and are called leaves or leaf nodes."""
         return [task for task in self.tasks if not task.downstream_list]
 
@@ -1711,7 +1712,7 @@ class DAG(LoggingMixin):
         # convert into an OrderedDict to speedup lookup while keeping order the same
         graph_unsorted = OrderedDict((task.task_id, task) for task in self.tasks)
 
-        graph_sorted = []  # type: List[BaseOperator]
+        graph_sorted: List[Operator] = []
 
         # special case
         if len(self.tasks) == 0:
@@ -1986,6 +1987,9 @@ class DAG(LoggingMixin):
         :param include_upstream: Include all upstream tasks of matched tasks,
             in addition to matched tasks.
         """
+        from airflow.models.baseoperator import BaseOperator
+        from airflow.models.mappedoperator import MappedOperator
+
         # deep-copying self.task_dict and self._task_group takes a long time, and we don't want all
         # the tasks anyway, so we copy the tasks manually later
         memo = {id(self.task_dict): None, id(self._task_group): None}
@@ -1996,14 +2000,15 @@ class DAG(LoggingMixin):
         else:
             matched_tasks = [t for t in self.tasks if t.task_id in task_ids_or_regex]
 
-        also_include = []
+        also_include: List[Operator] = []
         for t in matched_tasks:
             if include_downstream:
-                also_include += t.get_flat_relatives(upstream=False)
+                also_include.extend(t.get_flat_relatives(upstream=False))
             if include_upstream:
-                also_include += t.get_flat_relatives(upstream=True)
+                also_include.extend(t.get_flat_relatives(upstream=True))
             elif include_direct_upstream:
-                also_include += t.upstream_list
+                upstream = (u for u in t.upstream_list if isinstance(u, (BaseOperator, MappedOperator)))
+                also_include.extend(upstream)
 
         # Compiling the unique list of tasks that made the cut
         # Make sure to not recursively deepcopy the dag while copying the task
@@ -2021,7 +2026,7 @@ class DAG(LoggingMixin):
             copied.children = {}
 
             for child in group.children.values():
-                if isinstance(child, BaseOperator):
+                if isinstance(child, AbstractOperator):
                     if child.task_id in dag.task_dict:
                         copied.children[child.task_id] = dag.task_dict[child.task_id]
                     else:
@@ -2060,7 +2065,7 @@ class DAG(LoggingMixin):
     def has_task(self, task_id: str):
         return task_id in self.task_dict
 
-    def get_task(self, task_id: str, include_subdags: bool = False) -> BaseOperator:
+    def get_task(self, task_id: str, include_subdags: bool = False) -> Operator:
         if task_id in self.task_dict:
             return self.task_dict[task_id]
         if include_subdags:
@@ -2116,7 +2121,7 @@ class DAG(LoggingMixin):
 
         return cast("TaskDecoratorCollection", functools.partial(task, dag=self))
 
-    def add_task(self, task):
+    def add_task(self, task: Operator) -> None:
         """
         Add a task to the DAG
 
@@ -2152,7 +2157,7 @@ class DAG(LoggingMixin):
 
         self.task_count = len(self.task_dict)
 
-    def add_tasks(self, tasks):
+    def add_tasks(self, tasks: Iterable[Operator]) -> None:
         """
         Add a list of tasks to the DAG
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -209,8 +209,12 @@ class MappedOperator(AbstractOperator):
             self.task_group.add(self)
         if self.dag:
             self.dag.add_task(self)
-        XComArg.apply_upstream_relationship(self, self.mapped_kwargs)
-        XComArg.apply_upstream_relationship(self, self.partial_kwargs)
+        for k, v in self.mapped_kwargs.items():
+            if k in self.template_fields:
+                XComArg.apply_upstream_relationship(self, v)
+        for k, v in self.partial_kwargs.items():
+            if k in self.template_fields:
+                XComArg.apply_upstream_relationship(self, v)
 
     @classmethod
     @cache

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -403,7 +403,7 @@ class MappedOperator(AbstractOperator):
     ) -> Sequence["TaskInstance"]:
         """Create the mapped task instances for mapped task.
 
-        :return: The mapped task instances, ascendingly ordered by map index.
+        :return: The mapped task instances, in ascending order by map index.
         """
         # TODO: support having multiuple mapped upstreams?
         from airflow.models.taskinstance import TaskInstance

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -1,0 +1,374 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import unittest.mock
+import warnings
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
+
+import attr
+from sqlalchemy import func, or_
+from sqlalchemy.orm.session import Session
+
+from airflow.compat.functools import cache
+from airflow.models.abstractoperator import AbstractOperator
+from airflow.models.param import ParamsDict
+from airflow.serialization.enums import DagAttributeTypes
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
+from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
+from airflow.utils import timezone
+from airflow.utils.session import NEW_SESSION
+from airflow.utils.state import State, TaskInstanceState
+from airflow.utils.task_group import TaskGroup
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
+    from airflow.models.dag import DAG
+    from airflow.models.taskinstance import TaskInstance
+
+
+def _validate_mapping_kwargs(op: Type["BaseOperator"], func: str, value: Dict[str, Any]) -> None:
+    # use a dict so order of args is same as code order
+    unknown_args = value.copy()
+    for klass in op.mro():
+        init = klass.__init__  # type: ignore
+        try:
+            param_names = init._BaseOperatorMeta__param_names
+        except AttributeError:
+            continue
+        for name in param_names:
+            unknown_args.pop(name, None)
+        if not unknown_args:
+            return  # If we have no args left ot check: stop looking at the MRO chian.
+    if len(unknown_args) == 1:
+        error = f"unexpected keyword argument {unknown_args.popitem()[0]!r}"
+    else:
+        names = ", ".join(repr(n) for n in unknown_args)
+        error = f"unexpected keyword arguments {names}"
+    raise TypeError(f"{op.__name__}.{func}() got {error}")
+
+
+def prevent_duplicates(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail_reason: str) -> None:
+    duplicated_keys = set(kwargs1).intersection(kwargs2)
+    if not duplicated_keys:
+        return
+    if len(duplicated_keys) == 1:
+        raise TypeError(f"{fail_reason} argument: {duplicated_keys.pop()}")
+    duplicated_keys_display = ", ".join(sorted(duplicated_keys))
+    raise TypeError(f"{fail_reason} arguments: {duplicated_keys_display}")
+
+
+@attr.define(kw_only=True, repr=False)
+class OperatorPartial:
+    """An "intermediate state" returned by ``BaseOperator.partial()``.
+
+    This only exists at DAG-parsing time; the only intended usage is for the
+    user to call ``.map()`` on it at some point (usually in a method chain) to
+    create a ``MappedOperator`` to add into the DAG.
+    """
+
+    operator_class: Type["BaseOperator"]
+    kwargs: Dict[str, Any]
+
+    def __attrs_post_init__(self):
+        _validate_mapping_kwargs(self.operator_class, "partial", self.kwargs)
+
+    @classmethod
+    def from_baseoperator(
+        cls,
+        operator_class: Type["BaseOperator"],
+        *,
+        task_id: str,
+        dag: Optional["DAG"],
+        task_group: Optional["TaskGroup"],
+        start_date: Optional[datetime.datetime],
+        end_date: Optional[datetime.datetime],
+        **kwargs,
+    ) -> "OperatorPartial":
+        from airflow.models.dag import DagContext
+        from airflow.utils.task_group import TaskGroupContext
+
+        _validate_mapping_kwargs(operator_class, "partial", kwargs)
+
+        task_group = task_group or TaskGroupContext.get_current_task_group(dag)
+        if task_group:
+            task_id = task_group.child_id(task_id)
+
+        # Store these in kwargs so they are automatically excluded from map().
+        kwargs["dag"] = dag or DagContext.get_current_dag()
+        kwargs["task_group"] = task_group
+        kwargs["task_id"] = task_id
+        kwargs["start_date"] = timezone.convert_to_utc(start_date)
+        kwargs["end_date"] = timezone.convert_to_utc(end_date)
+
+        return cls(operator_class=operator_class, kwargs=kwargs)
+
+    def __repr__(self) -> str:
+        args = ", ".join(f"{k}={v!r}" for k, v in self.kwargs.items())
+        return f"{self.operator_class.__name__}.partial({args})"
+
+    def __del__(self):
+        if "__map_called" not in self.__dict__:
+            warnings.warn(f"{self!r} was never mapped!")
+
+    def map(self, **mapped_kwargs) -> "MappedOperator":
+        from airflow.operators.dummy import DummyOperator
+
+        _validate_mapping_kwargs(self.operator_class, "map", mapped_kwargs)
+
+        partial_kwargs = self.kwargs.copy()
+        task_id = partial_kwargs.pop("task_id")
+        params = partial_kwargs.pop("params", {})
+        dag = partial_kwargs.pop("dag")
+        task_group = partial_kwargs.pop("task_group")
+
+        operator = MappedOperator(
+            operator_class=self.operator_class,
+            mapped_kwargs=mapped_kwargs,
+            partial_kwargs=partial_kwargs,
+            task_id=task_id,
+            params=params,
+            deps=MappedOperator.deps_for(self.operator_class),
+            operator_extra_links=self.operator_class.operator_extra_links,
+            template_ext=self.operator_class.template_ext,
+            template_fields=self.operator_class.template_fields,
+            is_dummy=issubclass(self.operator_class, DummyOperator),
+            task_module=self.operator_class.__module__,
+            task_type=self.operator_class.__name__,
+            dag=dag,
+            task_group=task_group,
+        )
+        self.__dict__["__map_called"] = True
+        return operator
+
+
+@attr.define(kw_only=True)
+class MappedOperator(AbstractOperator):
+    """Object representing a mapped operator in a DAG."""
+
+    operator_class: Union[Type["BaseOperator"], str]
+    mapped_kwargs: Dict[str, Any]
+    partial_kwargs: Dict[str, Any]
+
+    # Needed for serialization.
+    task_id: str
+    params: Union[dict, ParamsDict]
+    deps: FrozenSet[BaseTIDep]
+    operator_extra_links: Collection["BaseOperatorLink"]
+    template_ext: Collection[str]
+    template_fields: Collection[str]
+    _is_dummy: bool
+    _task_module: str
+    _task_type: str
+
+    # These need extra work on init time.
+    dag: Optional["DAG"]
+    task_group: Optional[TaskGroup]
+    upstream_task_ids: Set[str] = attr.ib(factory=set, init=False)
+    downstream_task_ids: Set[str] = attr.ib(factory=set, init=False)
+
+    def __attrs_post_init__(self):
+        prevent_duplicates(self.partial_kwargs, self.mapped_kwargs, fail_reason="mapping already partial")
+        self._validate_argument_count()
+        if self.task_group:
+            self.task_group.add(self)
+
+    @classmethod
+    @cache
+    def get_serialized_fields(cls):
+        return frozenset(attr.fields_dict(cls)) - {
+            "dag",
+            "deps",
+            "task_group",
+            "upstream_task_ids",
+        }
+
+    @staticmethod
+    @cache
+    def deps_for(operator_class: Type["BaseOperator"]) -> FrozenSet[BaseTIDep]:
+        return operator_class.deps | {MappedTaskIsExpanded()}
+
+    def _validate_argument_count(self) -> None:
+        """Validate mapping arguments by unmapping with mocked values.
+
+        This ensures the user passed enough arguments in the DAG definition for
+        the operator to work in the task runner. This does not guarantee the
+        arguments are *valid* (that depends on the actual mapping values), but
+        makes sure there are *enough* of them.
+        """
+        if isinstance(self.operator_class, str):
+            return  # No need to validate deserialized operator.
+        mapped_kwargs = {k: unittest.mock.Mock() for k in self.mapped_kwargs}
+        self.operator_class(
+            dag=None,  # Intentionally omitting so this doesn't get added.
+            task_group=None,  # Intentionally omitting so this doesn't get added.
+            **self.partial_kwargs,
+            **mapped_kwargs,
+        )
+
+    @property
+    def task_type(self) -> str:
+        """Implementing Operator."""
+        return self._task_type
+
+    @property
+    def inherits_from_dummy_operator(self) -> bool:
+        """Implementing Operator."""
+        return self._is_dummy
+
+    @property
+    def roots(self) -> Sequence[AbstractOperator]:
+        """Implementing DAGNode."""
+        return [self]
+
+    @property
+    def leaves(self) -> Sequence[AbstractOperator]:
+        """Implementing DAGNode."""
+        return [self]
+
+    def get_dag(self) -> Optional["DAG"]:
+        """Implementing Operator."""
+        return self.dag
+
+    def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
+        """Implementing DAGNode."""
+        return DagAttributeTypes.OP, self.task_id
+
+    def create_unmapped_operator(self) -> BaseOperator:
+        assert not isinstance(self.operator_class, str)
+        return self.operator_class(
+            dag=self.dag,
+            task_id=self.task_id,
+            **self.partial_kwargs,
+            **self.mapped_kwargs,
+        )
+
+    def unmap(self) -> BaseOperator:
+        """Get the "normal" Operator after applying the current mapping"""
+        dag = self.dag
+        if not dag:
+            raise RuntimeError("Cannot unmap a task without a DAG")
+        dag._remove_task(self.task_id)
+        return self.create_unmapped_operator()
+
+    def expand_mapped_task(
+        self,
+        upstream_ti: "TaskInstance",
+        session: Session = NEW_SESSION,
+    ) -> Sequence["TaskInstance"]:
+        """Create the mapped task instances for mapped task.
+
+        :return: The mapped task instances, ascendingly ordered by map index.
+        """
+        # TODO: support having multiuple mapped upstreams?
+        from airflow.models.taskinstance import TaskInstance
+        from airflow.models.taskmap import TaskMap
+        from airflow.settings import task_instance_mutation_hook
+
+        task_map_info_length: Optional[int] = (
+            session.query(TaskMap.length)
+            .filter_by(
+                dag_id=upstream_ti.dag_id,
+                task_id=upstream_ti.task_id,
+                run_id=upstream_ti.run_id,
+                map_index=upstream_ti.map_index,
+            )
+            .scalar()
+        )
+        if task_map_info_length is None:
+            # TODO: What would lead to this? How can this be better handled?
+            raise RuntimeError("mapped operator cannot be expanded; upstream not found")
+
+        state = None
+        unmapped_ti: Optional[TaskInstance] = (
+            session.query(TaskInstance)
+            .filter(
+                TaskInstance.dag_id == upstream_ti.dag_id,
+                TaskInstance.run_id == upstream_ti.run_id,
+                TaskInstance.task_id == self.task_id,
+                TaskInstance.map_index == -1,
+                or_(TaskInstance.state.in_(State.unfinished), TaskInstance.state.is_(None)),
+            )
+            .one_or_none()
+        )
+
+        ret: List[TaskInstance] = []
+
+        if unmapped_ti:
+            # The unmapped task instance still exists and is unfinished, i.e. we
+            # haven't tried to run it before.
+            if task_map_info_length < 1:
+                # If the upstream maps this to a zero-length value, simply marked the
+                # unmapped task instance as SKIPPED (if needed).
+                self.log.info("Marking %s as SKIPPED since the map has 0 values to expand", unmapped_ti)
+                unmapped_ti.state = TaskInstanceState.SKIPPED
+                session.flush()
+                return ret
+            # Otherwise convert this into the first mapped index, and create
+            # TaskInstance for other indexes.
+            unmapped_ti.map_index = 0
+            state = unmapped_ti.state
+            self.log.debug("Updated in place to become %s", unmapped_ti)
+            ret.append(unmapped_ti)
+            indexes_to_map = range(1, task_map_info_length)
+        else:
+            # Only create "missing" ones.
+            current_max_mapping = (
+                session.query(func.max(TaskInstance.map_index))
+                .filter(
+                    TaskInstance.dag_id == upstream_ti.dag_id,
+                    TaskInstance.task_id == self.task_id,
+                    TaskInstance.run_id == upstream_ti.run_id,
+                )
+                .scalar()
+            )
+            indexes_to_map = range(current_max_mapping + 1, task_map_info_length)
+
+        for index in indexes_to_map:
+            # TODO: Make more efficient with bulk_insert_mappings/bulk_save_mappings.
+            # TODO: Change `TaskInstance` ctor to take Operator, not BaseOperator
+            ti = TaskInstance(self, run_id=upstream_ti.run_id, map_index=index, state=state)  # type: ignore
+            self.log.debug("Expanding TIs upserted %s", ti)
+            task_instance_mutation_hook(ti)
+            ret.append(session.merge(ti))
+
+        # Set to "REMOVED" any (old) TaskInstances with map indices greater
+        # than the current map value
+        session.query(TaskInstance).filter(
+            TaskInstance.dag_id == upstream_ti.dag_id,
+            TaskInstance.task_id == self.task_id,
+            TaskInstance.run_id == upstream_ti.run_id,
+            TaskInstance.map_index >= task_map_info_length,
+        ).update({TaskInstance.state: TaskInstanceState.REMOVED})
+
+        session.flush()
+
+        return ret

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -55,6 +55,7 @@ from airflow.models.abstractoperator import (
     TaskStateChangeCallback,
 )
 from airflow.models.pool import Pool
+from airflow.models.xcom_arg import XComArg
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
@@ -208,6 +209,8 @@ class MappedOperator(AbstractOperator):
             self.task_group.add(self)
         if self.dag:
             self.dag.add_task(self)
+        XComArg.apply_upstream_relationship(self, self.mapped_kwargs)
+        XComArg.apply_upstream_relationship(self, self.partial_kwargs)
 
     @classmethod
     @cache

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -345,7 +345,7 @@ class MappedOperator(AbstractOperator):
         """Implementing DAGNode."""
         return DagAttributeTypes.OP, self.task_id
 
-    def create_unmapped_operator(self) -> BaseOperator:
+    def create_unmapped_operator(self) -> "BaseOperator":
         assert not isinstance(self.operator_class, str)
         return self.operator_class(
             dag=self.dag,
@@ -354,7 +354,7 @@ class MappedOperator(AbstractOperator):
             **self.mapped_kwargs,
         )
 
-    def unmap(self) -> BaseOperator:
+    def unmap(self) -> "BaseOperator":
         """Get the "normal" Operator after applying the current mapping"""
         dag = self.dag
         if not dag:

--- a/airflow/models/operator.py
+++ b/airflow/models/operator.py
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Union
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.mappedoperator import MappedOperator
+
+Operator = Union[BaseOperator, MappedOperator]
+
+__all__ = ["Operator"]

--- a/airflow/models/skipmixin.py
+++ b/airflow/models/skipmixin.py
@@ -146,6 +146,7 @@ class SkipMixin(LoggingMixin):
         dag_run = ti.get_dagrun()
         task = ti.task
         dag = task.dag
+        assert dag  # For Mypy.
 
         # At runtime, the downstream list will only be operators
         downstream_tasks = cast("List[BaseOperator]", task.downstream_list)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1822,8 +1822,8 @@ class TaskInstance(Base, LoggingMixin):
         integrate_macros_plugins()
 
         task = self.task
-        dag: Optional[DAG] = task.dag
-        assert dag is not None  # For Mypy.
+        assert task.dag  # For Mypy.
+        dag: DAG = task.dag
 
         dag_run = self.get_dagrun(session)
         data_interval = dag.get_run_data_interval(dag_run)
@@ -1851,7 +1851,7 @@ class TaskInstance(Base, LoggingMixin):
 
         def _get_previous_dagrun_data_interval_success() -> Optional["DataInterval"]:
             dagrun = _get_previous_dagrun_success()
-            if dagrun is None or dag is None:
+            if dagrun is None:
                 return None
             return dag.get_run_data_interval(dagrun)
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -123,7 +123,9 @@ log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator
-    from airflow.models.dag import DAG, DagModel, DagRun
+    from airflow.models.dag import DAG, DagModel
+    from airflow.models.dagrun import DagRun
+    from airflow.models.operator import Operator
 
 
 @contextlib.contextmanager
@@ -421,9 +423,15 @@ class TaskInstance(Base, LoggingMixin):
 
     execution_date = association_proxy("dag_run", "execution_date")
 
+    # TODO: Investigate TaskInstance's lifecycle and call stack to determine
+    # when self.task is guaranteed to be unmapped, and when it may be mapped.
+    # Add 'assert isinstance(self.task, BaseOperator) to methods accordingly,
+    # and change this to 'task: Operator' instead.
+    task: "BaseOperator"  # Not always set...
+
     def __init__(
         self,
-        task: "BaseOperator",
+        task: "Operator",
         execution_date: Optional[datetime] = None,
         run_id: Optional[str] = None,
         state: Optional[str] = None,
@@ -452,6 +460,7 @@ class TaskInstance(Base, LoggingMixin):
                     execution_date,
                 )
                 if self.task.has_dag():
+                    assert self.task.dag  # For Mypy.
                     execution_date = timezone.make_aware(execution_date, self.task.dag.timezone)
                 else:
                     execution_date = timezone.make_aware(execution_date)
@@ -484,7 +493,7 @@ class TaskInstance(Base, LoggingMixin):
         self.test_mode = False
 
     @staticmethod
-    def insert_mapping(run_id: str, task: "BaseOperator", map_index: int) -> dict:
+    def insert_mapping(run_id: str, task: "Operator", map_index: int) -> dict:
         """:meta private:"""
         return {
             'dag_id': task.dag_id,
@@ -790,14 +799,14 @@ class TaskInstance(Base, LoggingMixin):
         else:
             self.state = None
 
-    def refresh_from_task(self, task: "BaseOperator", pool_override=None):
+    def refresh_from_task(self, task: "Operator", pool_override=None):
         """
         Copy common attributes from the given task.
 
         :param task: The task object to copy from
         :param pool_override: Use the pool_override instead of task's pool
         """
-        self.task = task
+        self.task = task  # type: ignore[assignment]  # TODO: Fix task: Operator
         self.queue = task.queue
         self.pool = pool_override or task.pool
         self.pool_slots = task.pool_slots
@@ -1812,8 +1821,10 @@ class TaskInstance(Base, LoggingMixin):
 
         integrate_macros_plugins()
 
-        task: "BaseOperator" = self.task
-        dag: DAG = task.dag
+        task = self.task
+        dag: Optional[DAG] = task.dag
+        assert dag is not None  # For Mypy.
+
         dag_run = self.get_dagrun(session)
         data_interval = dag.get_run_data_interval(dag_run)
 
@@ -1840,7 +1851,7 @@ class TaskInstance(Base, LoggingMixin):
 
         def _get_previous_dagrun_data_interval_success() -> Optional["DataInterval"]:
             dagrun = _get_previous_dagrun_success()
-            if dagrun is None:
+            if dagrun is None or dag is None:
                 return None
             return dag.get_run_data_interval(dagrun)
 
@@ -1884,6 +1895,8 @@ class TaskInstance(Base, LoggingMixin):
             # for manually triggered tasks, i.e. triggered_date == execution_date.
             if dag_run.external_trigger:
                 return logical_date
+            if dag is None:
+                return None
             next_info = dag.next_dagrun_info(data_interval, restricted=False)
             if next_info is None:
                 return None

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -311,4 +311,4 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         only contains operators, not task groups. In the future, we should
         provide a way to record an DAG node's all downstream nodes instead.
         """
-        return any(self.mapped_dependants())
+        return next(self.mapped_dependants(), None) is not None

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -154,7 +154,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         edge_modifier: Optional["EdgeModifier"] = None,
     ) -> None:
         """Sets relatives for the task or task list."""
-        from airflow.models.baseoperator import BaseOperator, MappedOperator
+        from airflow.models.base import Operator
 
         if not isinstance(task_or_task_list, Sequence):
             task_or_task_list = [task_or_task_list]
@@ -164,7 +164,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
             task_object.update_relative(self, not upstream)
             relatives = task_object.leaves if upstream else task_object.roots
             for task in relatives:
-                if not isinstance(task, (BaseOperator, MappedOperator)):
+                if not isinstance(task, Operator):
                     raise AirflowException(
                         f"Relationships can only be set between Operators; received {task.__class__.__name__}"
                     )
@@ -276,7 +276,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         only contains operators, not task groups. In the future, we should
         provide a way to record an DAG node's all downstream nodes instead.
         """
-        from airflow.models.baseoperator import MappedOperator
+        from airflow.models.mappedoperator import MappedOperator
         from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
         def _walk_group(group: TaskGroup) -> Iterable[Tuple[str, DAGNode]]:

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -311,4 +311,4 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         only contains operators, not task groups. In the future, we should
         provide a way to record an DAG node's all downstream nodes instead.
         """
-        return next(self.mapped_dependants(), None) is not None
+        return any(self.mapped_dependants())

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -154,17 +154,19 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         edge_modifier: Optional["EdgeModifier"] = None,
     ) -> None:
         """Sets relatives for the task or task list."""
-        from airflow.models.base import Operator
+        from airflow.models.baseoperator import BaseOperator
+        from airflow.models.mappedoperator import MappedOperator
+        from airflow.models.operator import Operator
 
         if not isinstance(task_or_task_list, Sequence):
             task_or_task_list = [task_or_task_list]
 
-        task_list: List[DAGNode] = []
+        task_list: List[Operator] = []
         for task_object in task_or_task_list:
             task_object.update_relative(self, not upstream)
             relatives = task_object.leaves if upstream else task_object.roots
             for task in relatives:
-                if not isinstance(task, Operator):
+                if not isinstance(task, (BaseOperator, MappedOperator)):
                     raise AirflowException(
                         f"Relationships can only be set between Operators; received {task.__class__.__name__}"
                     )

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -23,7 +23,8 @@ from airflow.utils.context import Context
 from airflow.utils.edgemodifier import EdgeModifier
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator, MappedOperator
+    from airflow.models.baseoperator import BaseOperator
+    from airflow.models.mappedoperator import MappedOperator
 
 
 class XComArg(DependencyMixin):

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -23,8 +23,7 @@ from airflow.utils.context import Context
 from airflow.utils.edgemodifier import EdgeModifier
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
-    from airflow.models.mappedoperator import MappedOperator
+    from airflow.models.operator import Operator
 
 
 class XComArg(DependencyMixin):
@@ -60,7 +59,7 @@ class XComArg(DependencyMixin):
     :param key: key value which is used for xcom_pull (key in the XCom table)
     """
 
-    def __init__(self, operator: "Union[BaseOperator, MappedOperator]", key: str = XCOM_RETURN_KEY):
+    def __init__(self, operator: "Operator", key: str = XCOM_RETURN_KEY):
         self.operator = operator
         self.key = key
 
@@ -137,7 +136,7 @@ class XComArg(DependencyMixin):
         return resolved_value
 
     @staticmethod
-    def apply_upstream_relationship(op: "Union[BaseOperator, MappedOperator]", arg: Any):
+    def apply_upstream_relationship(op: "Operator", arg: Any):
         """
         Set dependency for XComArgs.
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -671,6 +671,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 task_type=encoded_op["_task_type"],
                 dag=None,
                 task_group=None,
+                start_date=None,
+                end_date=None,
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op['task_id'])

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -91,7 +91,7 @@ class DagRunInfo(NamedTuple):
         return cls(run_after=end, data_interval=DataInterval(start, end))
 
     @property
-    def logical_date(self) -> DateTime:
+    def logical_date(self: "DagRunInfo") -> DateTime:
         """Infer the logical date to represent a DagRun.
 
         This replaces ``execution_date`` in Airflow 2.1 and prior. The idea is

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -61,7 +61,7 @@ def validate_key(k: str, max_length: int = 250):
         raise AirflowException(f"The key has to be less than {max_length} characters")
     if not KEY_REGEX.match(k):
         raise AirflowException(
-            f"The key ({k}) has to be made of alphanumeric characters, dashes, "
+            f"The key {k!r} has to be made of alphanumeric characters, dashes, "
             f"dots and underscores exclusively"
         )
 
@@ -74,7 +74,7 @@ def validate_group_key(k: str, max_length: int = 200):
         raise AirflowException(f"The key has to be less than {max_length} characters")
     if not GROUP_KEY_REGEX.match(k):
         raise AirflowException(
-            f"The key ({k!r}) has to be made of alphanumeric characters, dashes and underscores exclusively"
+            f"The key {k!r} has to be made of alphanumeric characters, dashes and underscores exclusively"
         )
 
 

--- a/tests/dags/test_mapped_classic.py
+++ b/tests/dags/test_mapped_classic.py
@@ -31,4 +31,4 @@ def consumer(*args):
 
 
 with DAG(dag_id='test_mapped_classic', start_date=days_ago(2)) as dag:
-    PythonOperator(task_id='consumer', python_callable=consumer).map(op_args=make_list())
+    PythonOperator.partial(task_id='consumer', python_callable=consumer).map(op_args=make_list())

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -26,7 +26,7 @@ import pytest
 from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
-from airflow.models.baseoperator import MappedOperator
+from airflow.models.mappedoperator import MappedOperator
 from airflow.models.xcom_arg import XComArg
 from airflow.utils import timezone
 from airflow.utils.state import State

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -319,7 +319,7 @@ class TestBaseOperator:
         with pytest.raises(jinja2.exceptions.TemplateSyntaxError):
             task.render_template("{{ invalid expression }}", {})
 
-    @mock.patch("airflow.models.abstractoperator.SandboxedEnvironment", autospec=True)
+    @mock.patch("airflow.templates.SandboxedEnvironment", autospec=True)
     def test_jinja_env_creation(self, mock_jinja_env):
         """Verify if a Jinja environment is created only once when templating."""
         task = MockOperator(task_id="op1", arg1="{{ foo }}", arg2="{{ bar }}")

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -29,13 +29,8 @@ from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException
 from airflow.lineage.entities import File
 from airflow.models import DAG
-from airflow.models.baseoperator import (
-    BaseOperator,
-    BaseOperatorMeta,
-    MappedOperator,
-    chain,
-    cross_downstream,
-)
+from airflow.models.baseoperator import BaseOperator, BaseOperatorMeta, chain, cross_downstream
+from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom_arg import XComArg
@@ -784,7 +779,7 @@ def test_partial_on_instance() -> None:
 def test_partial_on_class() -> None:
     # Test that we accept args for superclasses too
     op = MockOperator.partial(task_id='a', arg1="a", trigger_rule=TriggerRule.ONE_FAILED)
-    assert op.partial_kwargs == {'arg1': 'a', 'trigger_rule': TriggerRule.ONE_FAILED}
+    assert op.kwargs == {'arg1': 'a', 'trigger_rule': TriggerRule.ONE_FAILED}
 
 
 def test_partial_on_class_invalid_ctor_args() -> None:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1642,6 +1642,9 @@ def test_mapped_operator_xcomarg_serde():
         'task_id': 'task_2',
         'template_fields': ['arg1', 'arg2'],
         'template_ext': [],
+        'operator_extra_links': [],
+        'ui_color': '#fff',
+        'ui_fgcolor': '#000',
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -178,13 +178,13 @@ class TestHelpers:
             ("root.group.simple-key", None, None),
             (
                 "key with space",
-                "The key (key with space) has to be made of alphanumeric "
+                "The key 'key with space' has to be made of alphanumeric "
                 "characters, dashes, dots and underscores exclusively",
                 AirflowException,
             ),
             (
                 "key_with_!",
-                "The key (key_with_!) has to be made of alphanumeric "
+                "The key 'key_with_!' has to be made of alphanumeric "
                 "characters, dashes, dots and underscores exclusively",
                 AirflowException,
             ),
@@ -207,25 +207,25 @@ class TestHelpers:
             ("simple-key", None, None),
             (
                 "group.simple_key",
-                "The key ('group.simple_key') has to be made of alphanumeric "
+                "The key 'group.simple_key' has to be made of alphanumeric "
                 "characters, dashes and underscores exclusively",
                 AirflowException,
             ),
             (
                 "root.group-name.simple_key",
-                "The key ('root.group-name.simple_key') has to be made of alphanumeric "
+                "The key 'root.group-name.simple_key' has to be made of alphanumeric "
                 "characters, dashes and underscores exclusively",
                 AirflowException,
             ),
             (
                 "key with space",
-                "The key ('key with space') has to be made of alphanumeric "
+                "The key 'key with space' has to be made of alphanumeric "
                 "characters, dashes and underscores exclusively",
                 AirflowException,
             ),
             (
                 "key_with_!",
-                "The key ('key_with_!') has to be made of alphanumeric "
+                "The key 'key_with_!' has to be made of alphanumeric "
                 "characters, dashes and underscores exclusively",
                 AirflowException,
             ),

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.decorators import dag, task_group as task_group_decorator
 from airflow.models import DAG
-from airflow.models.baseoperator import MappedOperator
+from airflow.models.mappedoperator import MappedOperator
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator


### PR DESCRIPTION
This PR may be too large.

~~Details to come later. Submitted for CI at the moment.~~

After some discussion with @ashb, this simplfies the operator mapping API to implement only what’s described in [AIP-42](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-42+Dynamic+Task+Mapping)). Specifically, only the following syntax variants are implemented:

```python
# Classic operator syntax. The .partial call is required.
MyOperator.partial(task_id="my_task", ...).map(option=mapped_value, ...)

# Taskflow syntax.
@task
def my_func(a, b):
    ...

my_func.partial(a=mapped_value).map(b=another_value)
my_func.map(a=mapped_value, b=another_value)  # .partial is optional.
```

This greatly simplifies the implementation, and resolves an existing issue that a mapped operator is added multiple times to the DAG (once when the non-mapped operator is instantiated, and once when .map() is called).

The implementation, from a high level, is like this:

```python
class BaseOperator(AbstractOperator):
    @classmethod
    def partial(cls, **kwargs):
        OperatorPartial(kwargs)

class OperatorPartial:  # This is *not* added to the DAG.
    def map(self, **kwargs):
        return MappedOperator(self.kwargs, kwargs)

class MappedOperator(AbstractOperator):
    ...
```

I needed to change and review a lot of implementation for the above redesign, and had much difficulty following the current code structure. So to achieve the above, I also refactored the code base a bit to

1. Rename `airflow.models.base.Operator` to `AbstractOperator` (to make it clearer it holds the basic implementation of both `BaseOperator` and `MappedOperator`). The class is moved to `airflow.models.abstractoperator` to clean up module dependencies. Currently (in main), `airflow.models.base` very strangely _depends on_ `airflow.models.taskmixin`.
2. Move `MappedOperator` out of `airflow.models.baseoperator`, to a new module `airflow.models.mappedoperator`. The `baseoperator` module was already over 1000 lines long before AIP-42, and `MappedOperator` (and its relatives) grew a lot in this PR that IMO warrants a new module (~500 lines).
3. Refactor `.partial()` to correctly coerce arguments using the same (either copied or reused) logic as `BaseOperator.__init__()`, e.g. `retry_timeout`, `params`, `start_date`, `end_date`.
4. For easier type annotation, add a `Operator = Union[BaseOperator, MappedOperator]`. This is put in a new module `airflow.models.operator` because I can’t figure out a better place.
5. Annotate `DAG.add_task()` to take `MappedOperator`. Because it should. This cascades to a ton of typing changes that helped catch many subtle issues in the implementation and is well worth the effort.

---

The type annotation changes are not finished. I stopped at the boundary of `TaskInstance` since it is clear the class needs a ton more work. For a mapped task, `TaskInstance.task` is initially a `MappedOperator`, but when the task instance gets unmapped, it will become `BaseOperator`. This means that in _some_ functions we can expect `TaskInstance.task` to be a concrete `BaseOperator`, not just an abstract operator. But tracing the call stack is a big undertaking that should be done separately.