### PR TITLE
Add celery_logging_level

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -134,6 +134,10 @@ def worker(args):
             # it, we raced to create the tables and lost.
             pass
 
+    # backwards-compatible: https://github.com/apache/airflow/pull/21506#pullrequestreview-879893763
+    celery_log_level = conf.get('logging', 'CELERY_LOGGING_LEVEL')
+    if not celery_log_level:
+        celery_log_level = conf.get('logging', 'LOGGING_LEVEL')
     # Setup Celery worker
     options = [
         'worker',
@@ -146,7 +150,7 @@ def worker(args):
         '--hostname',
         args.celery_hostname,
         '--loglevel',
-        conf.get('logging', 'LOGGING_LEVEL'),
+        celery_log_level,
         '--pidfile',
         pid_file_path,
     ]

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -531,6 +531,15 @@
       type: string
       example: ~
       default: "INFO"
+    - name: celery_logging_level
+      description: |
+        Logging level for celery. If not set, it uses the value of logging_level
+
+        Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
+      version_added: 2.3.0
+      type: string
+      example: ~
+      default: ""
     - name: fab_logging_level
       description: |
         Logging level for Flask-appbuilder UI.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -302,6 +302,11 @@ encrypt_s3_logs = False
 # Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
 logging_level = INFO
 
+# Logging level for celery. If not set, it uses the value of logging_level
+#
+# Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
+celery_logging_level =
+
 # Logging level for Flask-appbuilder UI.
 #
 # Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -50,6 +50,7 @@ store_serialized_dags = False
 [logging]
 base_log_folder = {AIRFLOW_HOME}/logs
 logging_level = INFO
+celery_logging_level = WARN
 fab_logging_level = WARN
 log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
 log_processor_filename_template = {{{{ filename }}}}.log

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -211,6 +211,8 @@ class AirflowConfigParser(ConfigParser):
         ("scheduler", "file_parsing_sort_mode"): ["modified_time", "random_seeded_by_host", "alphabetical"],
         ("logging", "logging_level"): _available_logging_levels,
         ("logging", "fab_logging_level"): _available_logging_levels,
+        # celery_logging_level can be empty, which uses logging_level as fallback
+        ("logging", "celery_logging_level"): _available_logging_levels + [''],
     }
 
     # This method transforms option names on every read, get, or set operation.

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -221,7 +221,7 @@ class TestWorkerStart(unittest.TestCase):
                 '--hostname',
                 celery_hostname,
                 '--loglevel',
-                conf.get('logging', 'LOGGING_LEVEL'),
+                conf.get('logging', 'CELERY_LOGGING_LEVEL'),
                 '--pidfile',
                 pid_file,
                 '--autoscale',


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
so that we don't need to change the log level for task execution if we want celery debug level log.

This allows us to control the log level separately.

test when with the `celery_logging_level = DEBUG`:

```
[2022-02-10 14:47:15,302: INFO/MainProcess] Task airflow.executors.celery_executor.execute_command[eff889b8-cdae-40f8-8548-f848d0828f66] received
[2022-02-10 14:47:15,302: DEBUG/MainProcess] TaskPool: Apply <function fast_trace_task at 0x160e8c790> (args:('airflow.executors.celery_executor.execute_command', 'eff889b8-cdae-40f8-8548-f848d0828f66', {'lang': 'py', 'task': 'airflow.executors.celery_executor.execute_command', 'id': 'eff889b8-cdae-40f8-8548-f848d0828f66', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'retries': 0, 'timelimit': [None, None], 'root_id': 'eff889b8-cdae-40f8-8548-f848d0828f66', 'parent_id': None, 'argsrepr': "[['airflow', 'run', '1_ping_lots_lost', 'run_after_loop', '2022-01-30T00:00:00+00:00', '--local', '--pool', 'default_pool', '-sd', '/Users/ping_zhang/airflow/dags/hi.py']]", 'kwargsrepr': '{}', 'origin': 'gen68186@Pings-MacBook-Pro.local', 'redelivered': True, 'properties': {'correlation_id': 'eff889b8-cdae-40f8-8548-f848d0828f66', 'reply_to': '6cdc675b-bcc0-3a27-a68a-76a94d625eb6', 'delivery_mode': 2, 'delivery_info': {'exchange': '', 'routing_key': 'default'}, 'priority': 0, 'body_encoding': 'base64', 'delivery_tag': 'd672c17a-c2fc-4ff5-aa44-aac9b1bbbe84'}, 'reply_to': '6cdc675b-bcc0-3a27-a68a-76a94d625eb6',... kwargs:{})
[2022-02-10 14:47:15,310: INFO/MainProcess] Task airflow.executors.celery_executor.execute_command[97946e5a-8b48-460a-a0d6-c6acb7f9bebf] received
[2022-02-10 14:47:15,310: DEBUG/MainProcess] TaskPool: Apply <function fast_trace_task at 0x160e8c790> (args:('airflow.executors.celery_executor.execute_command', '97946e5a-8b48-460a-a0d6-c6acb7f9bebf', {'lang': 'py', 'task': 'airflow.executors.celery_executor.execute_command', 'id': '97946e5a-8b48-460a-a0d6-c6acb7f9bebf', 'shadow': None, 'eta': None, 'expires': None, 'group': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '97946e5a-8b48-460a-a0d6-c6acb7f9bebf', 'parent_id': None, 'argsrepr': "[['airflow', 'run', '1_ping_lots_lost', 'run_after_loop', '2022-02-01T00:00:00+00:00', '--local', '--pool', 'default_pool', '-sd', '/Users/ping_zhang/airflow/dags/hi.py']]", 'kwargsrepr': '{}', 'origin': 'gen68186@Pings-MacBook-Pro.local', 'redelivered': True, 'properties': {'correlation_id': '97946e5a-8b48-460a-a0d6-c6acb7f9bebf', 'reply_to': '6cdc675b-bcc0-3a27-a68a-76a94d625eb6', 'delivery_mode': 2, 'delivery_info': {'exchange': '', 'routing_key': 'default'}, 'priority': 0, 'body_encoding': 'base64', 'delivery_tag': 'a8fe536f-51c2-41d6-8eec-88ad1ed23a75'}, 'reply_to': '6cdc675b-bcc0-3a27-a68a-76a94d625eb6',... kwargs:{})
[2022-02-10 14:47:15,322: INFO/MainProcess] Task airflow.executors.celery_executor.execute_command[5b93b8e4-94a6-449f-8ef7-77b4dcbf34b8] received
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
