### PR TITLE
Support globally override task run_as_user

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -299,6 +299,14 @@
       type: string
       example: ~
       default: ""
+    - name: global_impersonation_override
+      description: |
+        If set, it will override ``run_as_user`` argument on tasks
+        this is useful when infra wants to have strict control over the task ``run_as_user``
+      version_added: 2.3.0
+      type: string
+      example: ~
+      default: ""
     - name: security
       description: |
         What security module to use (for example kerberos)

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -181,6 +181,10 @@ task_runner = StandardTaskRunner
 # Can be used to de-elevate a sudo user running Airflow when executing tasks
 default_impersonation =
 
+# If set, it will override ``run_as_user`` argument on tasks
+# this is useful when infra wants to have strict control over the task ``run_as_user``
+global_impersonation_override =
+
 # What security module to use (for example kerberos)
 security =
 

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -55,7 +55,11 @@ class BaseTaskRunner(LoggingMixin):
         self._task_instance = local_task_job.task_instance
 
         popen_prepend = []
-        if self._task_instance.run_as_user:
+        global_run_as_user = conf.get('core', 'global_impersonation_override')
+
+        if global_run_as_user:
+            self.run_as_user = global_run_as_user
+        elif self._task_instance.run_as_user:
             self.run_as_user = self._task_instance.run_as_user
         else:
             try:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

It is very useful for the infra to set up their staging/dev airflow clusters and strictly control the task `run_as_user`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
