### PR TITLE
(AzureCosmosDBHook) Update to latest Cosmos API

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -67,7 +67,7 @@ class AzureCosmosDBHook(BaseHook):
         }
 
     @staticmethod
-    def get_ui_field_behaviour() -> Dict:
+    def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ['schema', 'port', 'host', 'extra'],

--- a/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
@@ -62,10 +62,10 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         )
 
         expected_calls = [
-            mock.call().CreateItem(
-                'dbs/' + self.test_database_name + '/colls/' + self.test_collection_name,
-                {'data': 'sometestdata', 'id': test_id},
-            )
+            mock.call()
+            .get_database_client('test_database_name')
+            .get_container_client('test_collection_name')
+            .upsert_item({'data': 'sometestdata', 'id': test_id})
         ]
 
         op.execute(None)


### PR DESCRIPTION
The AzureCosmosDBHook was still using the API of an older version of the Azure Cosmos SDK. These changes bring it up to date with v4.2.0 of the SDK

closes: #21412
