### PR TITLE
Don't track changes to task_log_prefix_template

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -126,7 +126,7 @@ See [Migrating to Deferrable Operators](https://airflow.apache.org/docs/apache-a
 
 ### Task log templates are now read from the metadatabase instead of `airflow.cfg`
 
-Previously, a task’s log is dynamically rendered from the `[core] log_filename_template`, `[core] task_log_prefix_template`, and `[elasticsearch] log_id_template` config values at runtime. This resulted in unfortunate characteristics, e.g. it is impractical to modify the config value after an Airflow instance is running for a while, since all existing task logs have be saved under the previous format and cannot be found with the new config value.
+Previously, a task’s log is dynamically rendered from the `[core] log_filename_template` and `[elasticsearch] log_id_template` config values at runtime. This resulted in unfortunate characteristics, e.g. it is impractical to modify the config value after an Airflow instance is running for a while, since all existing task logs have be saved under the previous format and cannot be found with the new config value.
 
 A new `log_template` table is introduced to solve this problem. This table is synchronised with the aforementioned config values every time Airflow starts, and a new field `log_template_id` is added to every DAG run to point to the format used by tasks (`NULL` indicates the first ever entry for compatibility).
 

--- a/airflow/migrations/versions/f9da662e7089_add_task_log_filename_template_model.py
+++ b/airflow/migrations/versions/f9da662e7089_add_task_log_filename_template_model.py
@@ -41,7 +41,6 @@ def upgrade():
         "log_template",
         Column("id", Integer, primary_key=True, autoincrement=True),
         Column("filename", Text, nullable=False),
-        Column("task_prefix", Text, nullable=False),
         Column("elasticsearch_id", Text, nullable=False),
         Column("created_at", UtcDateTime, nullable=False),
     )

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -964,16 +964,3 @@ class DagRun(Base, LoggingMixin):
                 f"Please make sure you set up the metadatabase correctly."
             )
         return template
-
-    @provide_session
-    def get_task_prefix_template(self, *, session: Session = NEW_SESSION) -> str:
-        if self.log_template_id is None:  # DagRun created before LogTemplate introduction.
-            template = session.query(LogTemplate.task_prefix).order_by(LogTemplate.id).limit(1).scalar()
-        else:
-            template = session.query(LogTemplate.task_prefix).filter_by(id=self.log_template_id).scalar()
-        if template is None:
-            raise AirflowException(
-                f"No log_template entry found for ID {self.log_template_id!r}. "
-                f"Please make sure you set up the metadatabase correctly."
-            )
-        return template

--- a/airflow/models/tasklog.py
+++ b/airflow/models/tasklog.py
@@ -24,7 +24,7 @@ from airflow.utils.sqlalchemy import UtcDateTime
 
 
 class LogTemplate(Base):
-    """Changes to ``log_filename_template`` and ``task_log_prefix_template``.
+    """Changes to ``log_filename_template`` and ``elasticsearch_id``.
 
     This table is automatically populated when Airflow starts up, to store the
     config's value if it does not match the last row in the table.
@@ -34,10 +34,9 @@ class LogTemplate(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     filename = Column(Text, nullable=False)
-    task_prefix = Column(Text, nullable=False)
     elasticsearch_id = Column(Text, nullable=False)
     created_at = Column(UtcDateTime, nullable=False, default=timezone.utcnow)
 
     def __repr__(self) -> str:
-        attrs = ", ".join(f"{k}={getattr(self, k)}" for k in ("filename", "task_prefix", "elasticsearch_id"))
+        attrs = ", ".join(f"{k}={getattr(self, k)}" for k in ("filename", "elasticsearch_id"))
         return f"LogTemplate({attrs})"

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -734,16 +734,10 @@ def synchronize_log_template(*, session: Session = NEW_SESSION) -> None:
     """
     stored = session.query(LogTemplate).order_by(LogTemplate.id.desc()).first()
     filename = conf.get("logging", "log_filename_template")
-    task_prefix = conf.get("logging", "task_log_prefix_template")
     elasticsearch_id = conf.get("elasticsearch", "log_id_template")
-    if (
-        stored
-        and stored.filename == filename
-        and stored.task_prefix == task_prefix
-        and stored.elasticsearch_id == elasticsearch_id
-    ):
+    if stored and stored.filename == filename and stored.elasticsearch_id == elasticsearch_id:
         return
-    session.merge(LogTemplate(filename=filename, task_prefix=task_prefix, elasticsearch_id=elasticsearch_id))
+    session.merge(LogTemplate(filename=filename, elasticsearch_id=elasticsearch_id))
 
 
 def check_conn_id_duplicates(session: Session) -> Iterable[str]:

--- a/airflow/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/utils/log/task_handler_with_custom_formatter.py
@@ -19,12 +19,11 @@
 import logging
 from typing import TYPE_CHECKING, Optional
 
+from airflow.configuration import conf
 from airflow.utils.helpers import parse_template_string, render_template_to_string
-from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from jinja2 import Template
-    from sqlalchemy.orm import Session
 
     from airflow.models.taskinstance import TaskInstance
 
@@ -34,8 +33,7 @@ class TaskHandlerWithCustomFormatter(logging.StreamHandler):
 
     prefix_jinja_template: Optional["Template"] = None
 
-    @provide_session
-    def set_context(self, ti, *, session: "Session" = NEW_SESSION) -> None:
+    def set_context(self, ti) -> None:
         """
         Accept the run-time context (i.e. the current task) and configure the formatter accordingly.
 
@@ -44,7 +42,7 @@ class TaskHandlerWithCustomFormatter(logging.StreamHandler):
         """
         if ti.raw or self.formatter is None:
             return
-        prefix = ti.get_dagrun().get_task_prefix_template(session=session)
+        prefix = conf.get('logging', 'task_log_prefix_template')
 
         if prefix:
             _, self.prefix_jinja_template = parse_template_string(prefix)

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -20,11 +20,9 @@ import logging
 import pytest
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.tasklog import LogTemplate
+from airflow.models import DAG, TaskInstance
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.log.logging_mixin import set_context
-from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
@@ -65,26 +63,6 @@ def task_instance():
     clear_db_runs()
 
 
-@pytest.fixture()
-def custom_prefix_template(task_instance):
-    run_filters = [DagRun.dag_id == DAG_ID, DagRun.execution_date == DEFAULT_DATE]
-    custom_prefix_template = "{{ ti.dag_id }}-{{ ti.task_id }}"
-    with create_session() as session:
-        log_template = session.merge(
-            LogTemplate(
-                filename="irrelevant",
-                task_prefix=custom_prefix_template,
-                elasticsearch_id="irrelevant",
-            ),
-        )
-        session.flush()  # To populate 'log_template.id'.
-        session.query(DagRun).filter(*run_filters).update({"log_template_id": log_template.id})
-    yield custom_prefix_template
-    with create_session() as session:
-        session.query(DagRun).filter(*run_filters).update({"log_template_id": None})
-        session.query(LogTemplate).filter(LogTemplate.id == log_template.id).delete()
-
-
 def assert_prefix(task_instance: TaskInstance, prefix: str) -> None:
     handler = next((h for h in task_instance.log.handlers if h.name == TASK_HANDLER), None)
     assert handler is not None, "custom task log handler not set up correctly"
@@ -99,18 +77,6 @@ def test_custom_formatter_default_format(task_instance):
     assert_prefix(task_instance, "")
 
 
-@conf_vars({("logging", "task_log_prefix_template"): "this is wrong"})
-def test_custom_formatter_default_format_not_affected_by_config(task_instance):
-    assert_prefix(task_instance, "")
-
-
-@pytest.mark.usefixtures("custom_prefix_template")
-def test_custom_formatter_custom_format(task_instance):
-    """Use the prefix specified from the metadatabase."""
-    assert_prefix(task_instance, f"{DAG_ID}-{TASK_ID}")
-
-
-@pytest.mark.usefixtures("custom_prefix_template")
-@conf_vars({("logging", "task_log_prefix_template"): "this is wrong"})
+@conf_vars({("logging", "task_log_prefix_template"): "{{ti.dag_id }}-{{ ti.task_id }}"})
 def test_custom_formatter_custom_format_not_affected_by_config(task_instance):
     assert_prefix(task_instance, f"{DAG_ID}-{TASK_ID}")

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -268,7 +268,6 @@ def dag_run_with_log_filename():
         log_template = session.merge(
             LogTemplate(
                 filename=DIFFERENT_LOG_FILENAME,
-                task_prefix="irrelevant",
                 elasticsearch_id="irrelevant",
             ),
         )


### PR DESCRIPTION
It only gets used in the produced logs (and not to find logs) so we don't care about historic values of it

Since the migration to add this table hasnt been released I have edited it in place.

This undoes ("reverts" very much in air quotes) #20435.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).