### PR TITLE
Capture Integrity Error when adding permission, roles etc

### DIFF
--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -244,7 +244,7 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.commit()
                 log.info(c.LOGMSG_INF_SEC_ADD_ROLE.format(name))
                 return role
-            except IntegrityError:
+            except IntegrityError as e:
                 log.warning(c.LOGMSG_ERR_SEC_ADD_ROLE.format(str(e)))
                 self.get_session.rollback()
             except Exception as e:
@@ -420,7 +420,7 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.add(resource)
                 self.get_session.commit()
                 return resource
-            except IntegrityError:
+            except IntegrityError as e:
                 log.warning(c.LOGMSG_ERR_SEC_ADD_VIEWMENU.format(str(e)))
                 self.get_session.rollback()
             except Exception as e:
@@ -451,7 +451,7 @@ class SecurityManager(BaseSecurityManager):
             self.get_session.delete(resource)
             self.get_session.commit()
             return True
-        except IntegrityError:
+        except IntegrityError as e:
             log.warning(c.LOGMSG_ERR_SEC_DEL_PERMISSION.format(str(e)))
             self.get_session.rollback()
             return False
@@ -518,7 +518,7 @@ class SecurityManager(BaseSecurityManager):
             self.get_session.commit()
             log.info(c.LOGMSG_INF_SEC_ADD_PERMVIEW.format(str(perm)))
             return perm
-        except IntegrityError:
+        except IntegrityError as e:
             log.warning(c.LOGMSG_ERR_SEC_ADD_PERMVIEW.format(str(e)))
             self.get_session.rollback()
             return None
@@ -581,7 +581,7 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.merge(role)
                 self.get_session.commit()
                 log.info(c.LOGMSG_INF_SEC_ADD_PERMROLE.format(str(permission), role.name))
-            except IntegrityError:
+            except IntegrityError as e:
                 log.warning(c.LOGMSG_ERR_SEC_ADD_PERMROLE.format(str(e)))
                 self.get_session.rollback()
             except Exception as e:

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -24,6 +24,7 @@ from flask_appbuilder.models.sqla import Base
 from flask_appbuilder.models.sqla.interface import SQLAInterface
 from sqlalchemy import and_, func, literal
 from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import MultipleResultsFound
 from werkzeug.security import generate_password_hash
 
@@ -243,6 +244,9 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.commit()
                 log.info(c.LOGMSG_INF_SEC_ADD_ROLE.format(name))
                 return role
+            except IntegrityError:
+                log.warning(c.LOGMSG_ERR_SEC_ADD_ROLE.format(str(e)))
+                self.get_session.rollback()
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_ROLE.format(str(e)))
                 self.get_session.rollback()
@@ -416,6 +420,9 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.add(resource)
                 self.get_session.commit()
                 return resource
+            except IntegrityError:
+                log.warning(c.LOGMSG_ERR_SEC_ADD_VIEWMENU.format(str(e)))
+                self.get_session.rollback()
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_VIEWMENU.format(str(e)))
                 self.get_session.rollback()
@@ -444,6 +451,10 @@ class SecurityManager(BaseSecurityManager):
             self.get_session.delete(resource)
             self.get_session.commit()
             return True
+        except IntegrityError:
+            log.warning(c.LOGMSG_ERR_SEC_DEL_PERMISSION.format(str(e)))
+            self.get_session.rollback()
+            return False
         except Exception as e:
             log.error(c.LOGMSG_ERR_SEC_DEL_PERMISSION.format(str(e)))
             self.get_session.rollback()
@@ -507,6 +518,10 @@ class SecurityManager(BaseSecurityManager):
             self.get_session.commit()
             log.info(c.LOGMSG_INF_SEC_ADD_PERMVIEW.format(str(perm)))
             return perm
+        except IntegrityError:
+            log.warning(c.LOGMSG_ERR_SEC_ADD_PERMVIEW.format(str(e)))
+            self.get_session.rollback()
+            return None
         except Exception as e:
             log.error(c.LOGMSG_ERR_SEC_ADD_PERMVIEW.format(str(e)))
             self.get_session.rollback()
@@ -566,6 +581,9 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.merge(role)
                 self.get_session.commit()
                 log.info(c.LOGMSG_INF_SEC_ADD_PERMROLE.format(str(permission), role.name))
+            except IntegrityError:
+                log.warning(c.LOGMSG_ERR_SEC_ADD_PERMROLE.format(str(e)))
+                self.get_session.rollback()
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_PERMROLE.format(str(e)))
                 self.get_session.rollback()


### PR DESCRIPTION
I think we shouldn't error when there's an integrity error while adding permission, roles etc.
Warnings should be better or not warn at all, because this error comes up because we are adding an already existing item.

Another option would be to make sure that an object doesn't exist before adding it?


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
