### PR TITLE
Add mssql-cli to devel extra in Airflow

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -280,6 +280,15 @@ RUN echo -e "\n\e[32mThe 'Running pip as the root user' warnings below are not v
         bash /scripts/docker/install_airflow_dependencies_from_branch_tip.sh; \
     fi
 
+# The PATH is needed for PIPX to find the tools installed
+ENV PATH="/root/.local/bin:${PATH}"
+
+COPY scripts/docker/install_pipx_tools.sh /scripts/docker/
+
+# Install useful command line tools in their own virtualenv so that they do not clash with
+# dependencies installed in Airflow
+RUN bash /scripts/docker/install_pipx_tools.sh
+
 # Copy package.json and yarn.lock to install node modules
 # this way even if other static check files change, node modules will not need to be installed
 # we want to keep node_modules so we can do this step separately from compiling assets

--- a/scripts/docker/install_pipx_tools.sh
+++ b/scripts/docker/install_pipx_tools.sh
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# shellcheck shell=bash disable=SC2086
+# shellcheck source=scripts/docker/common.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
+
+function install_pipx_tools() {
+    echo
+    echo "${COLOR_BLUE}Installing pipx tools${COLOR_RESET}"
+    echo
+    # Make sure PIPX is installed in latest version
+    pip install --upgrade pipx
+    # Install all the tools we need available in command line but without impacting the current environment
+    pipx install mssql-cli
+
+    # Unfortunately mssql-cli installed by `pipx` does not work out of the box because it uses
+    # its own execution bash script which is not compliant with the auto-activation of
+    # pipx venvs - we need to manually patch Python executable in the script to fix it: ¯\_(ツ)_/¯
+    sed "s/python /\/root\/\.local\/pipx\/venvs\/mssql-cli\/bin\/python /" -i /root/.local/bin/mssql-cli
+}
+
+common::get_colors
+
+install_pipx_tools


### PR DESCRIPTION
The change #21511 added support for db shell for MSSQL. This change
follows up with adding mssql-cli adding to [devel] extra of airlfow
so that it is automatically installed in Airflow Breeze CI image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
