### PR TITLE
[Oracle] Oracle Improved backwards compatibility of change PR #19084

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -159,7 +159,8 @@ class OracleHook(DbApiHook):
         # if Connection.schema is defined, set schema after connecting successfully
         # cannot be part of conn_config
         # https://cx-oracle.readthedocs.io/en/latest/api_manual/connection.html?highlight=schema#Connection.current_schema
-        if schema is not None:
+        # Only set schema when not using conn.schema as Service Name
+        if schema and service_name:
             conn.current_schema = schema
 
         return conn

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -178,6 +178,8 @@ class TestOracleHookConn(unittest.TestCase):
 
     @mock.patch('airflow.providers.oracle.hooks.oracle.cx_Oracle.connect')
     def test_set_current_schema(self, mock_connect):
+        self.connection.schema = "schema_name"
+        self.connection.extra = json.dumps({'service_name': 'service_name'})
         assert self.db_hook.get_conn().current_schema == self.connection.schema
 
 


### PR DESCRIPTION
This Pull Requests improves the backwards compatibility of PR https://github.com/apache/airflow/pull/19084.
In some cases it is not intended to change the current_schema (for example when using conn.schema field for the Oracle Service Name)