### PR TITLE
Fix key typo in `template_fields_renderers` for `HiveOperator`

### DIFF
--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -69,7 +69,7 @@ class HiveOperator(BaseOperator):
         '.hql',
         '.sql',
     )
-    template_fields_renderers = {'sql': 'hql'}
+    template_fields_renderers = {'hql': 'hql'}
     ui_color = '#f0e4ec'
 
     def __init__(


### PR DESCRIPTION
The template field name is actually "hql" not "sql".

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
