### PR TITLE
py files doesn't have to be checked is_zipfiles in process_files

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,12 +80,9 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-### You can't name zip files as ending with .py for DAGs
+### Zip files in the DAGs folder can no longer have a `.py` extension 
 
-It was previously possible to load any files as zip files in the DAGs folder via `zipfile.is_zipfile`.
-
-Now .py (extension) files are going to be loaded as modules without checking whether it is zipfile. (Less IO)
-If .py file in the DAGs folder were a zip compressed file, processing it would be failed with exception.
+It was previously possible to have any extension for zip files in the DAGs folder. Now `.py` files are going to be loaded as modules without checking whether it is a zip file, as it leads to less IO. If a `.py` file in the DAGs folder is a zip compressed file, parsing it will fail with an exception.
 
 ### You have to use `postgresql://` instead of `postgres://` in `sql_alchemy_conn` for SQLAlchemy 1.4.0+
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,7 +80,7 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-### Zip files in the DAGs folder can no longer have a `.py` extension 
+### Zip files in the DAGs folder can no longer have a `.py` extension
 
 It was previously possible to have any extension for zip files in the DAGs folder. Now `.py` files are going to be loaded as modules without checking whether it is a zip file, as it leads to less IO. If a `.py` file in the DAGs folder is a zip compressed file, parsing it will fail with an exception.
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,6 +80,13 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### You can't name zip files as ending with .py for DAGs
+
+It was previously possible to load any files as zip files in the DAGs folder via `zipfile.is_zipfile`.
+
+Now .py (extension) files are going to be loaded as modules without checking whether it is zipfile. (Less IO)
+If .py file in the DAGs folder were a zip compressed file, processing it would be failed with exception.
+
 ### You have to use `postgresql://` instead of `postgres://` in `sql_alchemy_conn` for SQLAlchemy 1.4.0+
 
 When you use SQLAlchemy 1.4.0+, you need ot use `postgresql://` as the database in the `sql_alchemy_conn`.

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -284,10 +284,7 @@ class DagBag(LoggingMixin):
             self.log.exception(e)
             return []
 
-        _, file_ext = os.path.splitext(os.path.split(filepath)[-1])
-        is_zipfile = file_ext != '.py' and zipfile.is_zipfile(filepath)
-
-        if not is_zipfile:
+        if not filepath.endswith(".py") and zipfile.is_zipfile(filepath):
             mods = self._load_modules_from_file(filepath, safe_mode)
         else:
             mods = self._load_modules_from_zip(filepath, safe_mode)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -284,7 +284,10 @@ class DagBag(LoggingMixin):
             self.log.exception(e)
             return []
 
-        if not zipfile.is_zipfile(filepath):
+        _, file_ext = os.path.splitext(os.path.split(filepath)[-1])
+        is_zipfile = file_ext != '.py' and zipfile.is_zipfile(filepath)
+
+        if not is_zipfile:
             mods = self._load_modules_from_file(filepath, safe_mode)
         else:
             mods = self._load_modules_from_zip(filepath, safe_mode)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -284,7 +284,7 @@ class DagBag(LoggingMixin):
             self.log.exception(e)
             return []
 
-        if not filepath.endswith(".py") and zipfile.is_zipfile(filepath):
+        if filepath.endswith(".py") or not zipfile.is_zipfile(filepath):
             mods = self._load_modules_from_file(filepath, safe_mode)
         else:
             mods = self._load_modules_from_zip(filepath, safe_mode)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

py files doesn't have to be checked with is_zipfiles in process_files 
like find_dag_file_paths in file.
https://github.com/apache/airflow/blob/0a2d0d1ecbb7a72677f96bc17117799ab40853e0/airflow/utils/file.py#L192-L201

zipfile.is_zipfile could take longer than anticipated in case of remote file mount (DAG_DIR).
So, I want py files (generaly almost dag files are py) skip to check is_zipfile.

(It is simple change. Exist tests cover this one)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
