### PR TITLE
<Fix>(bigquery-hook): forgot to pass engine_kwargs in

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -163,6 +163,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param engine_kwargs: Kwargs used in :func:`~sqlalchemy.create_engine`.
         :return: the created engine.
         """
+        if engine_kwargs is None:
+            engine_kwargs = {}
         connection = self.get_connection(self.gcp_conn_id)
         if connection.extra_dejson.get("extra__google_cloud_platform__key_path"):
             credentials_path = connection.extra_dejson['extra__google_cloud_platform__key_path']

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -951,7 +951,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
         return_value=(CREDENTIALS, PROJECT_ID),
     )
-    def test_dbapi_get_sqlalchemy_engine_success(self):
+    def test_dbapi_get_sqlalchemy_engine_success(self, mock_get_creds_and_proj_id):
         bq_hook = BigQueryHook(use_legacy_sql=False)
         assert isinstance(bq_hook.get_sqlalchemy_engine(), sqlalchemy.engine.base.Engine) is True
 

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -947,14 +947,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         ):
             self.hook.get_sqlalchemy_engine()
 
-    @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook._get_credentials_and_project_id',
-        return_value=(CREDENTIALS, PROJECT_ID),
-    )
-    def test_dbapi_get_sqlalchemy_engine_success(self, mock_get_creds_and_proj_id):
-        bq_hook = BigQueryHook(use_legacy_sql=False)
-        assert isinstance(bq_hook.get_sqlalchemy_engine(), sqlalchemy.engine.base.Engine) is True
-
 
 class TestBigQueryTableSplitter(unittest.TestCase):
     def test_internal_need_default_project(self):

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -22,7 +22,6 @@ import unittest
 from unittest import mock
 
 import pytest
-import sqlalchemy
 from google.cloud.bigquery import DEFAULT_RETRY, DatasetReference, Table, TableReference
 from google.cloud.bigquery.dataset import AccessEntry, Dataset, DatasetListItem
 from google.cloud.exceptions import NotFound


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/21443

my bad, forgot to pass the `engine_kwargs` to instantiate a sqlalchemy engine

this is how I test it on my local

1. open localhost:8080 and then create a bigquery connection
2. test this snippet in shell
```python
from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
connection = BigQueryHook('bigquery')
isinstance(connection.get_sqlalchemy_engine(), sqlalchemy.engine.base.Engine) is True
```
---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
