### PR TITLE
Extract ClientInfo to module level

### DIFF
--- a/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
+++ b/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
@@ -21,17 +21,17 @@ from typing import Optional
 
 import google
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from cached_property import cached_property
 
 from google.api_core.exceptions import InvalidArgument, NotFound, PermissionDenied
-from google.api_core.gapic_v1.client_info import ClientInfo
 from google.cloud.secretmanager_v1 import SecretManagerServiceClient
 
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.version import version
 
 SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
@@ -65,9 +65,7 @@ class _SecretManagerClient(LoggingMixin):
     @cached_property
     def client(self) -> SecretManagerServiceClient:
         """Create an authenticated KMS client"""
-        _client = SecretManagerServiceClient(
-            credentials=self.credentials, client_info=ClientInfo(client_library_version='airflow_v' + version)
-        )
+        _client = SecretManagerServiceClient(credentials=self.credentials, client_info=CLIENT_INFO)
         return _client
 
     def get_secret(self, secret_id: str, project_id: str, secret_version: str = 'latest') -> Optional[str]:

--- a/airflow/providers/google/cloud/hooks/automl.py
+++ b/airflow/providers/google/cloud/hooks/automl.py
@@ -32,6 +32,8 @@ from google.cloud.automl_v1beta1.services.auto_ml.pagers import (
     ListTableSpecsPager,
 )
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
@@ -90,7 +92,7 @@ class CloudAutoMLHook(GoogleBaseHook):
         :rtype: google.cloud.automl_v1beta1.AutoMlClient
         """
         if self._client is None:
-            self._client = AutoMlClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = AutoMlClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @cached_property
@@ -101,7 +103,7 @@ class CloudAutoMLHook(GoogleBaseHook):
         :return: Google Cloud AutoML PredictionServiceClient client object.
         :rtype: google.cloud.automl_v1beta1.PredictionServiceClient
         """
-        return PredictionServiceClient(credentials=self._get_credentials(), client_info=self.client_info)
+        return PredictionServiceClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def create_model(

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -55,6 +55,7 @@ from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.dbapi import DbApiHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.utils.helpers import convert_camel_to_snake
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -146,7 +147,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :return:
         """
         return Client(
-            client_info=self.client_info,
+            client_info=CLIENT_INFO,
             project=project_id,
             location=location,
             credentials=self._get_credentials(),

--- a/airflow/providers/google/cloud/hooks/bigquery_dts.py
+++ b/airflow/providers/google/cloud/hooks/bigquery_dts.py
@@ -29,6 +29,7 @@ from google.cloud.bigquery_datatransfer_v1.types import (
 )
 from googleapiclient.discovery import Resource
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 
@@ -95,7 +96,7 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         """
         if not self._conn:
             self._conn = DataTransferServiceClient(
-                credentials=self._get_credentials(), client_info=self.client_info
+                credentials=self._get_credentials(), client_info=CLIENT_INFO
             )
         return self._conn
 

--- a/airflow/providers/google/cloud/hooks/bigtable.py
+++ b/airflow/providers/google/cloud/hooks/bigtable.py
@@ -27,6 +27,7 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable.table import ClusterState, Table
 from google.cloud.bigtable_admin_v2 import enums
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -56,7 +57,7 @@ class BigtableHook(GoogleBaseHook):
             self._client = Client(
                 project=project_id,
                 credentials=self._get_credentials(),
-                client_info=self.client_info,
+                client_info=CLIENT_INFO,
                 admin=True,
             )
         return self._client

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -26,6 +26,7 @@ from google.cloud.devtools.cloudbuild import CloudBuildClient
 from google.cloud.devtools.cloudbuild_v1.types import Build, BuildTrigger, RepoSource
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 # Time to sleep between active checks of the operation results
@@ -84,7 +85,7 @@ class CloudBuildHook(GoogleBaseHook):
         :rtype: `google.cloud.devtools.cloudbuild_v1.CloudBuildClient`
         """
         if not self._client:
-            self._client = CloudBuildClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = CloudBuildClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/cloud_composer.py
+++ b/airflow/providers/google/cloud/hooks/cloud_composer.py
@@ -29,6 +29,7 @@ from google.cloud.orchestration.airflow.service_v1.types import Environment
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -41,7 +42,7 @@ class CloudComposerHook(GoogleBaseHook):
         """Retrieves client library object that allow access Environments service."""
         return EnvironmentsClient(
             credentials=self._get_credentials(),
-            client_info=self.client_info,
+            client_info=CLIENT_INFO,
             client_options=self.client_options,
         )
 
@@ -51,7 +52,7 @@ class CloudComposerHook(GoogleBaseHook):
         """Retrieves client library object that allow access Image Versions service."""
         return ImageVersionsClient(
             credentials=self._get_credentials(),
-            client_info=self.client_info,
+            client_info=CLIENT_INFO,
             client_options=self.client_options,
         )
 

--- a/airflow/providers/google/cloud/hooks/datacatalog.py
+++ b/airflow/providers/google/cloud/hooks/datacatalog.py
@@ -32,6 +32,7 @@ from google.cloud.datacatalog import (
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 
@@ -69,9 +70,7 @@ class CloudDataCatalogHook(GoogleBaseHook):
     def get_conn(self) -> DataCatalogClient:
         """Retrieves client library object that allow access to Cloud Data Catalog service."""
         if not self._client:
-            self._client = DataCatalogClient(
-                credentials=self._get_credentials(), client_info=self.client_info
-            )
+            self._client = DataCatalogClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -41,6 +41,7 @@ from google.protobuf.duration_pb2 import Duration
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.version import version as airflow_version
 
@@ -214,7 +215,7 @@ class DataprocHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return ClusterControllerClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def get_template_client(
@@ -234,7 +235,7 @@ class DataprocHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return WorkflowTemplateServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def get_job_client(
@@ -254,7 +255,7 @@ class DataprocHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return JobControllerClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def get_batch_client(
@@ -274,7 +275,7 @@ class DataprocHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return BatchControllerClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def wait_for_operation(self, operation: Operation, timeout: Optional[float] = None):

--- a/airflow/providers/google/cloud/hooks/dataproc_metastore.py
+++ b/airflow/providers/google/cloud/hooks/dataproc_metastore.py
@@ -28,6 +28,7 @@ from google.cloud.metastore_v1.types.metastore import DatabaseDumpSpec, Restore
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -39,7 +40,7 @@ class DataprocMetastoreHook(GoogleBaseHook):
         client_options = {'api_endpoint': 'metastore.googleapis.com:443'}
 
         return DataprocMetastoreClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def wait_for_operation(self, timeout: Optional[float], operation: Operation):

--- a/airflow/providers/google/cloud/hooks/dlp.py
+++ b/airflow/providers/google/cloud/hooks/dlp.py
@@ -55,6 +55,7 @@ from google.cloud.dlp_v2.types import (
 )
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 DLP_JOB_PATH_PATTERN = "^projects/[^/]+/dlpJobs/(?P<job>.*?)$"
@@ -104,7 +105,7 @@ class CloudDLPHook(GoogleBaseHook):
         :rtype: google.cloud.dlp_v2.DlpServiceClient
         """
         if not self._client:
-            self._client = DlpServiceClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = DlpServiceClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -40,6 +40,7 @@ from google.cloud.exceptions import GoogleCloudError
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.utils.helpers import normalize_directory_path
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.utils import timezone
 from airflow.version import version
@@ -155,7 +156,7 @@ class GCSHook(GoogleBaseHook):
         """Returns a Google Cloud Storage service object."""
         if not self._conn:
             self._conn = storage.Client(
-                credentials=self._get_credentials(), client_info=self.client_info, project=self.project_id
+                credentials=self._get_credentials(), client_info=CLIENT_INFO, project=self.project_id
             )
 
         return self._conn

--- a/airflow/providers/google/cloud/hooks/kms.py
+++ b/airflow/providers/google/cloud/hooks/kms.py
@@ -25,6 +25,7 @@ from typing import Optional, Sequence, Tuple, Union
 from google.api_core.retry import Retry
 from google.cloud.kms_v1 import KeyManagementServiceClient
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -78,7 +79,7 @@ class CloudKMSHook(GoogleBaseHook):
         """
         if not self._conn:
             self._conn = KeyManagementServiceClient(
-                credentials=self._get_credentials(), client_info=self.client_info
+                credentials=self._get_credentials(), client_info=CLIENT_INFO
             )
         return self._conn
 

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -41,6 +41,7 @@ from google.protobuf.json_format import ParseDict
 
 from airflow import version
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 OPERATIONAL_POLL_INTERVAL = 15
@@ -77,9 +78,7 @@ class GKEHook(GoogleBaseHook):
         """
         if self._client is None:
             credentials = self._get_credentials()
-            self._client = container_v1.ClusterManagerClient(
-                credentials=credentials, client_info=self.client_info
-            )
+            self._client = container_v1.ClusterManagerClient(credentials=credentials, client_info=CLIENT_INFO)
         return self._client
 
     # To preserve backward compatibility

--- a/airflow/providers/google/cloud/hooks/natural_language.py
+++ b/airflow/providers/google/cloud/hooks/natural_language.py
@@ -31,6 +31,7 @@ from google.cloud.language_v1.types import (
     Document,
 )
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -73,9 +74,7 @@ class CloudNaturalLanguageHook(GoogleBaseHook):
         :rtype: google.cloud.language_v1.LanguageServiceClient
         """
         if not self._conn:
-            self._conn = LanguageServiceClient(
-                credentials=self._get_credentials(), client_info=self.client_info
-            )
+            self._conn = LanguageServiceClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._conn
 
     @GoogleBaseHook.quota_retry()

--- a/airflow/providers/google/cloud/hooks/os_login.py
+++ b/airflow/providers/google/cloud/hooks/os_login.py
@@ -27,6 +27,7 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 from google.api_core.retry import Retry
 from google.cloud.oslogin_v1 import ImportSshPublicKeyResponse, OsLoginServiceClient
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 
@@ -56,7 +57,7 @@ class OSLoginHook(GoogleBaseHook):
         if self._conn:
             return self._conn
 
-        self._conn = OsLoginServiceClient(credentials=self._get_credentials(), client_info=self.client_info)
+        self._conn = OsLoginServiceClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._conn
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -29,6 +29,8 @@ from base64 import b64decode
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
@@ -86,7 +88,7 @@ class PubSubHook(GoogleBaseHook):
         :rtype: google.cloud.pubsub_v1.PublisherClient
         """
         if not self._client:
-            self._client = PublisherClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = PublisherClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @cached_property
@@ -97,7 +99,7 @@ class PubSubHook(GoogleBaseHook):
         :return: Google Cloud Pub/Sub client object.
         :rtype: google.cloud.pubsub_v1.SubscriberClient
         """
-        return SubscriberClient(credentials=self._get_credentials(), client_info=self.client_info)
+        return SubscriberClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def publish(

--- a/airflow/providers/google/cloud/hooks/spanner.py
+++ b/airflow/providers/google/cloud/hooks/spanner.py
@@ -26,6 +26,7 @@ from google.cloud.spanner_v1.transaction import Transaction
 from google.longrunning.operations_grpc_pb2 import Operation
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -60,7 +61,7 @@ class SpannerHook(GoogleBaseHook):
         """
         if not self._client:
             self._client = Client(
-                project=project_id, credentials=self._get_credentials(), client_info=self.client_info
+                project=project_id, credentials=self._get_credentials(), client_info=CLIENT_INFO
             )
         return self._client
 

--- a/airflow/providers/google/cloud/hooks/speech_to_text.py
+++ b/airflow/providers/google/cloud/hooks/speech_to_text.py
@@ -22,6 +22,7 @@ from google.api_core.retry import Retry
 from google.cloud.speech_v1 import SpeechClient
 from google.cloud.speech_v1.types import RecognitionAudio, RecognitionConfig
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -64,7 +65,7 @@ class CloudSpeechToTextHook(GoogleBaseHook):
         :rtype: google.cloud.speech_v1.SpeechClient
         """
         if not self._client:
-            self._client = SpeechClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = SpeechClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.quota_retry()

--- a/airflow/providers/google/cloud/hooks/tasks.py
+++ b/airflow/providers/google/cloud/hooks/tasks.py
@@ -30,6 +30,7 @@ from google.cloud.tasks_v2.types import Queue, Task
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow.exceptions import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 
@@ -76,7 +77,7 @@ class CloudTasksHook(GoogleBaseHook):
         :rtype: google.cloud.tasks_v2.CloudTasksClient
         """
         if self._client is None:
-            self._client = CloudTasksClient(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = CloudTasksClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/hooks/text_to_speech.py
+++ b/airflow/providers/google/cloud/hooks/text_to_speech.py
@@ -27,6 +27,7 @@ from google.cloud.texttospeech_v1.types import (
     VoiceSelectionParams,
 )
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -73,9 +74,7 @@ class CloudTextToSpeechHook(GoogleBaseHook):
         """
         if not self._client:
 
-            self._client = TextToSpeechClient(
-                credentials=self._get_credentials(), client_info=self.client_info
-            )
+            self._client = TextToSpeechClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
 
         return self._client
 

--- a/airflow/providers/google/cloud/hooks/translate.py
+++ b/airflow/providers/google/cloud/hooks/translate.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Sequence, Union
 
 from google.cloud.translate_v2 import Client
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -52,7 +53,7 @@ class CloudTranslateHook(GoogleBaseHook):
         :rtype: google.cloud.translate_v2.Client
         """
         if not self._client:
-            self._client = Client(credentials=self._get_credentials(), client_info=self.client_info)
+            self._client = Client(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @GoogleBaseHook.quota_retry()

--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -38,6 +38,7 @@ from google.cloud.aiplatform_v1.services.pipeline_service.pagers import (
 from google.cloud.aiplatform_v1.types import CustomJob, PipelineJob, TrainingPipeline
 
 from airflow import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -73,7 +74,7 @@ class CustomJobHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-aiplatform.googleapis.com:443'}
 
         return PipelineServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def get_job_service_client(
@@ -86,7 +87,7 @@ class CustomJobHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-aiplatform.googleapis.com:443'}
 
         return JobServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def get_custom_container_training_job(

--- a/airflow/providers/google/cloud/hooks/vertex_ai/dataset.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/dataset.py
@@ -32,6 +32,7 @@ from google.cloud.aiplatform_v1.types import AnnotationSpec, Dataset, ExportData
 from google.protobuf.field_mask_pb2 import FieldMask
 
 from airflow import AirflowException
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -45,7 +46,7 @@ class DatasetHook(GoogleBaseHook):
             client_options = {'api_endpoint': f'{region}-aiplatform.googleapis.com:443'}
 
         return DatasetServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
+            credentials=self._get_credentials(), client_info=CLIENT_INFO, client_options=client_options
         )
 
     def wait_for_operation(self, operation: Operation, timeout: Optional[float] = None):

--- a/airflow/providers/google/cloud/hooks/video_intelligence.py
+++ b/airflow/providers/google/cloud/hooks/video_intelligence.py
@@ -23,6 +23,7 @@ from google.api_core.retry import Retry
 from google.cloud.videointelligence_v1 import VideoIntelligenceServiceClient
 from google.cloud.videointelligence_v1.types import VideoContext
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
@@ -68,7 +69,7 @@ class CloudVideoIntelligenceHook(GoogleBaseHook):
         """
         if not self._conn:
             self._conn = VideoIntelligenceServiceClient(
-                credentials=self._get_credentials(), client_info=self.client_info
+                credentials=self._get_credentials(), client_info=CLIENT_INFO
             )
         return self._conn
 

--- a/airflow/providers/google/cloud/hooks/vision.py
+++ b/airflow/providers/google/cloud/hooks/vision.py
@@ -20,6 +20,8 @@ import sys
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
@@ -146,9 +148,7 @@ class CloudVisionHook(GoogleBaseHook):
         :rtype: google.cloud.vision_v1.ProductSearchClient
         """
         if not self._client:
-            self._client = ProductSearchClient(
-                credentials=self._get_credentials(), client_info=self.client_info
-            )
+            self._client = ProductSearchClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
         return self._client
 
     @cached_property

--- a/airflow/providers/google/cloud/hooks/workflows.py
+++ b/airflow/providers/google/cloud/hooks/workflows.py
@@ -25,6 +25,7 @@ from google.cloud.workflows_v1beta import Workflow, WorkflowsClient
 from google.cloud.workflows_v1beta.services.workflows.pagers import ListWorkflowsPager
 from google.protobuf.field_mask_pb2 import FieldMask
 
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID, GoogleBaseHook
 
 
@@ -38,11 +39,11 @@ class WorkflowsHook(GoogleBaseHook):
 
     def get_workflows_client(self) -> WorkflowsClient:
         """Returns WorkflowsClient."""
-        return WorkflowsClient(credentials=self._get_credentials(), client_info=self.client_info)
+        return WorkflowsClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
 
     def get_executions_client(self) -> ExecutionsClient:
         """Returns ExecutionsClient."""
-        return ExecutionsClient(credentials=self._get_credentials(), client_info=self.client_info)
+        return ExecutionsClient(credentials=self._get_credentials(), client_info=CLIENT_INFO)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def create_workflow(

--- a/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -19,17 +19,16 @@ import os
 import sys
 from typing import Collection, Optional
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from cached_property import cached_property
 
-from google.api_core.client_info import ClientInfo
-
 # not sure why but mypy complains on missing `storage` but it is clearly there and is importable
 from google.cloud import storage  # type: ignore[attr-defined]
 
-from airflow import version
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -96,7 +95,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         )
         return storage.Client(
             credentials=credentials,
-            client_info=ClientInfo(client_library_version='airflow_v' + version.version),
+            client_info=CLIENT_INFO,
             project=self.project_id if self.project_id else project_id,
         )
 

--- a/airflow/providers/google/cloud/log/stackdriver_task_handler.py
+++ b/airflow/providers/google/cloud/log/stackdriver_task_handler.py
@@ -20,12 +20,13 @@ import sys
 from typing import Collection, Dict, List, Optional, Tuple, Type, Union
 from urllib.parse import urlencode
 
+from airflow.providers.google.common.consts import CLIENT_INFO
+
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from cached_property import cached_property
 
-from google.api_core.gapic_v1.client_info import ClientInfo
 from google.auth.credentials import Credentials
 from google.cloud import logging as gcp_logging
 from google.cloud.logging import Resource
@@ -33,7 +34,6 @@ from google.cloud.logging.handlers.transports import BackgroundThreadTransport, 
 from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
 from google.cloud.logging_v2.types import ListLogEntriesRequest, ListLogEntriesResponse
 
-from airflow import version
 from airflow.models import TaskInstance
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 
@@ -115,7 +115,7 @@ class StackdriverTaskHandler(logging.Handler):
         client = gcp_logging.Client(
             credentials=credentials,
             project=project,
-            client_info=ClientInfo(client_library_version='airflow_v' + version.version),
+            client_info=CLIENT_INFO,
         )
         return client
 
@@ -125,7 +125,7 @@ class StackdriverTaskHandler(logging.Handler):
         credentials, _ = self._credentials_and_project
         client = LoggingServiceV2Client(
             credentials=credentials,
-            client_info=ClientInfo(client_library_version='airflow_v' + version.version),
+            client_info=CLIENT_INFO,
         )
         return client
 

--- a/airflow/providers/google/common/consts.py
+++ b/airflow/providers/google/common/consts.py
@@ -14,5 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from google.api_core.gapic_v1.client_info import ClientInfo
+
+from airflow import version
 
 GOOGLE_DEFAULT_DEFERRABLE_METHOD_NAME = 'execute_complete'
+
+CLIENT_INFO = ClientInfo(client_library_version='airflow_v' + version.version)

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -22,6 +22,7 @@ import json
 import logging
 import os
 import tempfile
+import warnings
 from contextlib import ExitStack, contextmanager
 from subprocess import check_output
 from typing import Any, Callable, Dict, Optional, Sequence, Tuple, TypeVar, Union, cast
@@ -47,6 +48,7 @@ from airflow.providers.google.cloud.utils.credentials_provider import (
     _get_target_principal_and_delegates,
     get_credentials_and_project_id,
 )
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.utils.process_utils import patch_environ
 
 log = logging.getLogger(__name__)
@@ -348,8 +350,12 @@ class GoogleBaseHook(BaseHook):
         the Google Cloud. It is not supported by The Google APIs Python Client that use Discovery
         based APIs.
         """
-        client_info = ClientInfo(client_library_version='airflow_v' + version.version)
-        return client_info
+        warnings.warn(
+            "This method is deprecated, please use `airflow.providers.google.common.consts.CLIENT_INFO`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return CLIENT_INFO
 
     @property
     def scopes(self) -> Sequence[str]:

--- a/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
+++ b/tests/providers/google/cloud/_internal_client/test_secret_manager_client.py
@@ -21,28 +21,23 @@ from google.api_core.exceptions import NotFound, PermissionDenied
 from google.cloud.secretmanager_v1.types import AccessSecretVersionResponse
 
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
-from airflow.version import version
+from airflow.providers.google.common.consts import CLIENT_INFO
 
 INTERNAL_CLIENT_MODULE = "airflow.providers.google.cloud._internal_client.secret_manager_client"
+INTERNAL_COMMON_MODULE = "airflow.providers.google.common.consts"
 
 
 class TestSecretManagerClient(TestCase):
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_auth(self, mock_client_info, mock_secrets_client):
-        mock_client_info_mock = mock.MagicMock()
-        mock_client_info.return_value = mock_client_info_mock
+    def test_auth(self, mock_secrets_client):
         mock_secrets_client.return_value = mock.MagicMock()
         secrets_client = _SecretManagerClient(credentials="credentials")
         _ = secrets_client.client
-        mock_client_info.assert_called_with(client_library_version='airflow_v' + version)
-        mock_secrets_client.assert_called_with(credentials='credentials', client_info=mock_client_info_mock)
+        mock_secrets_client.assert_called_with(credentials='credentials', client_info=CLIENT_INFO)
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_get_non_existing_key(self, mock_client_info, mock_secrets_client):
+    def test_get_non_existing_key(self, mock_secrets_client):
         mock_client = mock.MagicMock()
-        mock_client_info.return_value = mock.MagicMock()
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         # The requested secret id or secret version does not exist
@@ -54,10 +49,8 @@ class TestSecretManagerClient(TestCase):
         mock_client.access_secret_version.assert_called_once_with('full-path')
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_get_no_permissions(self, mock_client_info, mock_secrets_client):
+    def test_get_no_permissions(self, mock_secrets_client):
         mock_client = mock.MagicMock()
-        mock_client_info.return_value = mock.MagicMock()
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         # No permissions for requested secret id
@@ -69,10 +62,8 @@ class TestSecretManagerClient(TestCase):
         mock_client.access_secret_version.assert_called_once_with('full-path')
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_get_invalid_id(self, mock_client_info, mock_secrets_client):
+    def test_get_invalid_id(self, mock_secrets_client):
         mock_client = mock.MagicMock()
-        mock_client_info.return_value = mock.MagicMock()
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         # The requested secret id is using invalid character
@@ -84,10 +75,8 @@ class TestSecretManagerClient(TestCase):
         mock_client.access_secret_version.assert_called_once_with('full-path')
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_get_existing_key(self, mock_client_info, mock_secrets_client):
+    def test_get_existing_key(self, mock_secrets_client):
         mock_client = mock.MagicMock()
-        mock_client_info.return_value = mock.MagicMock()
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         test_response = AccessSecretVersionResponse()
@@ -100,10 +89,8 @@ class TestSecretManagerClient(TestCase):
         mock_client.access_secret_version.assert_called_once_with('full-path')
 
     @mock.patch(INTERNAL_CLIENT_MODULE + ".SecretManagerServiceClient")
-    @mock.patch(INTERNAL_CLIENT_MODULE + ".ClientInfo")
-    def test_get_existing_key_with_version(self, mock_client_info, mock_secrets_client):
+    def test_get_existing_key_with_version(self, mock_secrets_client):
         mock_client = mock.MagicMock()
-        mock_client_info.return_value = mock.MagicMock()
         mock_secrets_client.return_value = mock_client
         mock_client.secret_version_path.return_value = "full-path"
         test_response = AccessSecretVersionResponse()

--- a/tests/providers/google/cloud/hooks/test_automl.py
+++ b/tests/providers/google/cloud/hooks/test_automl.py
@@ -22,10 +22,10 @@ from unittest import mock
 from google.cloud.automl_v1beta1 import AutoMlClient
 
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 CREDENTIALS = "test-creds"
-CLIENT_INFO = "client-info"
 TASK_ID = "test-automl-hook"
 GCP_PROJECT_ID = "test-project"
 GCP_LOCATION = "test-location"
@@ -58,21 +58,13 @@ class TestAuoMLHook(unittest.TestCase):
             self.hook = CloudAutoMLHook()
             self.hook._get_credentials = mock.MagicMock(return_value=CREDENTIALS)  # type: ignore
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.automl.GoogleBaseHook.client_info",
-        new_callable=lambda: CLIENT_INFO,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.automl.AutoMlClient")
-    def test_get_conn(self, mock_automl_client, mock_client_info):
+    def test_get_conn(self, mock_automl_client):
         self.hook.get_conn()
         mock_automl_client.assert_called_once_with(credentials=CREDENTIALS, client_info=CLIENT_INFO)
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.automl.GoogleBaseHook.client_info",
-        new_callable=lambda: CLIENT_INFO,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.automl.PredictionServiceClient")
-    def test_prediction_client(self, mock_prediction_client, mock_client_info):
+    def test_prediction_client(self, mock_prediction_client):
         client = self.hook.prediction_client  # noqa
         mock_prediction_client.assert_called_once_with(credentials=CREDENTIALS, client_info=CLIENT_INFO)
 

--- a/tests/providers/google/cloud/hooks/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_dts.py
@@ -23,7 +23,6 @@ from unittest import mock
 from google.cloud.bigquery_datatransfer_v1.types import TransferConfig
 
 from airflow.providers.google.cloud.hooks.bigquery_dts import BiqQueryDataTransferServiceHook
-from airflow.version import version
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 CREDENTIALS = "test-creds"
@@ -57,10 +56,6 @@ class BigQueryDataTransferHookTestCase(unittest.TestCase):
         ):
             self.hook = BiqQueryDataTransferServiceHook()
             self.hook._get_credentials = mock.MagicMock(return_value=CREDENTIALS)  # type: ignore
-
-    def test_version_information(self):
-        expected_version = "airflow_v" + version
-        assert expected_version == self.hook.client_info.client_library_version
 
     def test_disable_auto_scheduling(self):
         expected = deepcopy(TRANSFER_CONFIG)

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -26,6 +26,7 @@ from google.cloud.bigtable.instance import Instance
 from google.cloud.bigtable_admin_v2 import enums
 
 from airflow.providers.google.cloud.hooks.bigtable import BigtableHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST,
     mock_base_gcp_hook_default_project_id,
@@ -56,18 +57,14 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         ):
             self.bigtable_hook_no_default_project_id = BigtableHook(gcp_conn_id='test')
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.bigtable.BigtableHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigtable.BigtableHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.bigtable.Client")
-    def test_bigtable_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_bigtable_client_creation(self, mock_client, mock_get_creds):
         result = self.bigtable_hook_no_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
         mock_client.assert_called_once_with(
             project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
             credentials=mock_get_creds.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             admin=True,
         )
         assert mock_client.return_value == result
@@ -156,18 +153,14 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         ):
             self.bigtable_hook_default_project_id = BigtableHook(gcp_conn_id='test')
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.bigtable.BigtableHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigtable.BigtableHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.bigtable.Client")
-    def test_bigtable_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_bigtable_client_creation(self, mock_client, mock_get_creds):
         result = self.bigtable_hook_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
         mock_client.assert_called_once_with(
             project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
             credentials=mock_get_creds.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             admin=True,
         )
         assert mock_client.return_value == result

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -23,9 +23,10 @@ functions in CloudBuildHook
 
 
 import unittest
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 PROJECT_ID = "cloud-build-project"
@@ -60,17 +61,11 @@ class TestCloudBuildHook(unittest.TestCase):
         ):
             self.hook = CloudBuildHook(gcp_conn_id="test")
 
-    @patch(
-        "airflow.providers.google.cloud.hooks.cloud_build.CloudBuildHook.client_info",
-        new_callable=PropertyMock,
-    )
     @patch("airflow.providers.google.cloud.hooks.cloud_build.CloudBuildHook._get_credentials")
     @patch("airflow.providers.google.cloud.hooks.cloud_build.CloudBuildClient")
-    def test_cloud_build_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_cloud_build_service_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -24,6 +24,7 @@ from google.cloud.dataproc_v1 import JobStatus
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataproc import DataprocHook, DataProcJobBuilder
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.version import version
 
 AIRFLOW_VERSION = "v" + version.replace(".", "-").replace("+", "-")
@@ -61,33 +62,28 @@ class TestDataprocHook(unittest.TestCase):
             self.hook = DataprocHook(gcp_conn_id="test")
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
-    def test_get_cluster_client(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_cluster_client(self, mock_client, mock_get_credentials):
         self.hook.get_cluster_client(region=GCP_LOCATION)
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options=None,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
-    def test_get_cluster_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_cluster_client_region(self, mock_client, mock_get_credentials):
         self.hook.get_cluster_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
-    def test_get_cluster_client_region_deprecation_warning(
-        self, mock_client, mock_client_info, mock_get_credentials
-    ):
+    def test_get_cluster_client_region_deprecation_warning(self, mock_client, mock_get_credentials):
         warning_message = (
             "Parameter `location` will be deprecated. "
             "Please provide value through `region` parameter instead."
@@ -96,39 +92,34 @@ class TestDataprocHook(unittest.TestCase):
             self.hook.get_cluster_client(location='region1')
             mock_client.assert_called_once_with(
                 credentials=mock_get_credentials.return_value,
-                client_info=mock_client_info.return_value,
+                client_info=CLIENT_INFO,
                 client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
             )
             assert warning_message == str(warnings[0].message)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
-    def test_get_template_client_global(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_template_client_global(self, mock_client, mock_get_credentials):
         _ = self.hook.get_template_client()
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options=None,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
-    def test_get_template_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_template_client_region(self, mock_client, mock_get_credentials):
         _ = self.hook.get_template_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
-    def test_get_template_client_region_deprecation_warning(
-        self, mock_client, mock_client_info, mock_get_credentials
-    ):
+    def test_get_template_client_region_deprecation_warning(self, mock_client, mock_get_credentials):
         warning_message = (
             "Parameter `location` will be deprecated. "
             "Please provide value through `region` parameter instead."
@@ -137,39 +128,34 @@ class TestDataprocHook(unittest.TestCase):
             _ = self.hook.get_template_client(location='region1')
             mock_client.assert_called_once_with(
                 credentials=mock_get_credentials.return_value,
-                client_info=mock_client_info.return_value,
+                client_info=CLIENT_INFO,
                 client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
             )
             assert warning_message == str(warnings[0].message)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
-    def test_get_job_client(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_job_client(self, mock_client, mock_get_credentials):
         self.hook.get_job_client(region=GCP_LOCATION)
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options=None,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
-    def test_get_job_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_job_client_region(self, mock_client, mock_get_credentials):
         self.hook.get_job_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
-    def test_get_job_client_region_deprecation_warning(
-        self, mock_client, mock_client_info, mock_get_credentials
-    ):
+    def test_get_job_client_region_deprecation_warning(self, mock_client, mock_get_credentials):
         warning_message = (
             "Parameter `location` will be deprecated. "
             "Please provide value through `region` parameter instead."
@@ -178,39 +164,34 @@ class TestDataprocHook(unittest.TestCase):
             self.hook.get_job_client(location='region1')
             mock_client.assert_called_once_with(
                 credentials=mock_get_credentials.return_value,
-                client_info=mock_client_info.return_value,
+                client_info=CLIENT_INFO,
                 client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
             )
             assert warning_message == str(warnings[0].message)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("BatchControllerClient"))
-    def test_get_batch_client(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_batch_client(self, mock_client, mock_get_credentials):
         self.hook.get_batch_client(region=GCP_LOCATION)
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options=None,
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("BatchControllerClient"))
-    def test_get_batch_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_batch_client_region(self, mock_client, mock_get_credentials):
         self.hook.get_batch_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
             client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
-    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("BatchControllerClient"))
-    def test_get_batch_client_region_deprecation_warning(
-        self, mock_client, mock_client_info, mock_get_credentials
-    ):
+    def test_get_batch_client_region_deprecation_warning(self, mock_client, mock_get_credentials):
         warning_message = (
             "Parameter `location` will be deprecated. "
             "Please provide value through `region` parameter instead."
@@ -219,7 +200,7 @@ class TestDataprocHook(unittest.TestCase):
             self.hook.get_batch_client(location='region1')
             mock_client.assert_called_once_with(
                 credentials=mock_get_credentials.return_value,
-                client_info=mock_client_info.return_value,
+                client_info=CLIENT_INFO,
                 client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
             )
             assert warning_message == str(warnings[0].message)

--- a/tests/providers/google/cloud/hooks/test_dlp.py
+++ b/tests/providers/google/cloud/hooks/test_dlp.py
@@ -32,6 +32,7 @@ from google.cloud.dlp_v2.types import DlpJob
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dlp import CloudDLPHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 API_RESPONSE = {}  # type: Dict[Any, Any]
@@ -61,16 +62,11 @@ class TestCloudDLPHook(unittest.TestCase):
         ):
             self.hook = CloudDLPHook(gcp_conn_id="test")
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.dlp.CloudDLPHook.client_info", new_callable=mock.PropertyMock
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.dlp.CloudDLPHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.dlp.DlpServiceClient")
-    def test_dlp_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_dlp_service_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -34,6 +34,7 @@ from google.cloud import exceptions, storage  # type: ignore[attr-defined]
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks import gcs
 from airflow.providers.google.cloud.hooks.gcs import _fallback_object_url_to_object_name_and_bucket_name
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.utils import timezone
 from airflow.version import version
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
@@ -117,24 +118,17 @@ class TestGCSHook(unittest.TestCase):
             self.gcs_hook = gcs.GCSHook(gcp_conn_id='test')
 
     @mock.patch(
-        'airflow.providers.google.common.hooks.base_google.GoogleBaseHook.client_info',
-        new_callable=mock.PropertyMock,
-        return_value="CLIENT_INFO",
-    )
-    @mock.patch(
         BASE_STRING.format("GoogleBaseHook._get_credentials_and_project_id"),
         return_value=("CREDENTIALS", "PROJECT_ID"),
     )
     @mock.patch(GCS_STRING.format('GoogleBaseHook.get_connection'))
     @mock.patch('google.cloud.storage.Client')
-    def test_storage_client_creation(
-        self, mock_client, mock_get_connection, mock_get_creds_and_project_id, mock_client_info
-    ):
+    def test_storage_client_creation(self, mock_client, mock_get_connection, mock_get_creds_and_project_id):
         hook = gcs.GCSHook()
         result = hook.get_conn()
         # test that Storage Client is called with required arguments
         mock_client.assert_called_once_with(
-            client_info="CLIENT_INFO", credentials="CREDENTIALS", project="PROJECT_ID"
+            client_info=CLIENT_INFO, credentials="CREDENTIALS", project="PROJECT_ID"
         )
         assert mock_client.return_value == result
 

--- a/tests/providers/google/cloud/hooks/test_kms.py
+++ b/tests/providers/google/cloud/hooks/test_kms.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 from unittest import mock
 
 from airflow.providers.google.cloud.hooks.kms import CloudKMSHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 
 Response = namedtuple("Response", ["plaintext", "ciphertext"])
 
@@ -61,18 +62,11 @@ class TestCloudKMSHook(unittest.TestCase):
         ):
             self.kms_hook = CloudKMSHook(gcp_conn_id="test")
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.kms.CloudKMSHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.kms.CloudKMSHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.kms.KeyManagementServiceClient")
-    def test_kms_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_kms_client_creation(self, mock_client, mock_get_creds):
         result = self.kms_hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value,
-            client_info=mock_client_info.return_value,
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.kms_hook._conn == result
 

--- a/tests/providers/google/cloud/hooks/test_natural_language.py
+++ b/tests/providers/google/cloud/hooks/test_natural_language.py
@@ -23,6 +23,7 @@ from unittest import mock
 from google.cloud.language_v1.proto.language_service_pb2 import Document
 
 from airflow.providers.google.cloud.hooks.natural_language import CloudNaturalLanguageHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 API_RESPONSE = {}  # type: Dict[Any, Any]
@@ -41,18 +42,12 @@ class TestCloudNaturalLanguageHook(unittest.TestCase):
             self.hook = CloudNaturalLanguageHook(gcp_conn_id="test")
 
     @mock.patch(
-        "airflow.providers.google.cloud.hooks.natural_language.CloudNaturalLanguageHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch(
         "airflow.providers.google.cloud.hooks.natural_language.CloudNaturalLanguageHook._get_credentials"
     )
     @mock.patch("airflow.providers.google.cloud.hooks.natural_language.LanguageServiceClient")
-    def test_language_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_language_service_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._conn == result
 

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -29,6 +29,7 @@ from googleapiclient.errors import HttpError
 from parameterized import parameterized
 
 from airflow.providers.google.cloud.hooks.pubsub import PubSubException, PubSubHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.version import version
 
 BASE_STRING = 'airflow.providers.google.common.hooks.base_google.{}'
@@ -76,31 +77,21 @@ class TestPubSubHook(unittest.TestCase):
             for i in range(1, count + 1)
         ]
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.pubsub.PubSubHook.client_info", new_callable=mock.PropertyMock
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.pubsub.PubSubHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.pubsub.PublisherClient")
-    def test_publisher_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_publisher_client_creation(self, mock_client, mock_get_creds):
         assert self.pubsub_hook._client is None
         result = self.pubsub_hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.pubsub_hook._client == result
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.pubsub.PubSubHook.client_info", new_callable=mock.PropertyMock
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.pubsub.PubSubHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.pubsub.SubscriberClient")
-    def test_subscriber_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_subscriber_client_creation(self, mock_client, mock_get_creds):
         assert self.pubsub_hook._client is None
         result = self.pubsub_hook.subscriber_client
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
 
     @mock.patch(PUBSUB_STRING.format('PubSubHook.get_conn'))

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -21,6 +21,7 @@ from unittest import mock
 from unittest.mock import PropertyMock
 
 from airflow.providers.google.cloud.hooks.spanner import SpannerHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import (
     GCP_PROJECT_ID_HOOK_UNIT_TEST,
     mock_base_gcp_hook_default_project_id,
@@ -40,17 +41,14 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         ):
             self.spanner_hook_default_project_id = SpannerHook(gcp_conn_id='test')
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.spanner.SpannerHook.client_info", new_callable=mock.PropertyMock
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.spanner.SpannerHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.spanner.Client")
-    def test_spanner_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_spanner_client_creation(self, mock_client, mock_get_creds):
         result = self.spanner_hook_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
         mock_client.assert_called_once_with(
             project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
             credentials=mock_get_creds.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
         )
         assert mock_client.return_value == result
         assert self.spanner_hook_default_project_id._client == result
@@ -437,19 +435,16 @@ class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
             self.spanner_hook_no_default_project_id = SpannerHook(gcp_conn_id='test')
 
     @mock.patch(
-        "airflow.providers.google.cloud.hooks.spanner.SpannerHook.client_info", new_callable=mock.PropertyMock
-    )
-    @mock.patch(
         "airflow.providers.google.cloud.hooks.spanner.SpannerHook._get_credentials",
         return_value="CREDENTIALS",
     )
     @mock.patch("airflow.providers.google.cloud.hooks.spanner.Client")
-    def test_spanner_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_spanner_client_creation(self, mock_client, mock_get_creds):
         result = self.spanner_hook_no_default_project_id._get_client(GCP_PROJECT_ID_HOOK_UNIT_TEST)
         mock_client.assert_called_once_with(
             project=GCP_PROJECT_ID_HOOK_UNIT_TEST,
             credentials=mock_get_creds.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
         )
         assert mock_client.return_value == result
         assert self.spanner_hook_no_default_project_id._client == result

--- a/tests/providers/google/cloud/hooks/test_speech_to_text.py
+++ b/tests/providers/google/cloud/hooks/test_speech_to_text.py
@@ -18,9 +18,10 @@
 #
 
 import unittest
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from airflow.providers.google.cloud.hooks.speech_to_text import CloudSpeechToTextHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 PROJECT_ID = "project-id"
@@ -36,17 +37,11 @@ class TestTextToSpeechOperator(unittest.TestCase):
         ):
             self.gcp_speech_to_text_hook = CloudSpeechToTextHook(gcp_conn_id="test")
 
-    @patch(
-        "airflow.providers.google.cloud.hooks.speech_to_text.CloudSpeechToTextHook.client_info",
-        new_callable=PropertyMock,
-    )
     @patch("airflow.providers.google.cloud.hooks.speech_to_text.CloudSpeechToTextHook._get_credentials")
     @patch("airflow.providers.google.cloud.hooks.speech_to_text.SpeechClient")
-    def test_speech_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_speech_client_creation(self, mock_client, mock_get_creds):
         result = self.gcp_speech_to_text_hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.gcp_speech_to_text_hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -23,6 +23,7 @@ from unittest import mock
 from google.cloud.tasks_v2.types import Queue, Task
 
 from airflow.providers.google.cloud.hooks.tasks import CloudTasksHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_no_default_project_id
 
 API_RESPONSE = {}  # type: Dict[Any, Any]
@@ -52,17 +53,11 @@ class TestCloudTasksHook(unittest.TestCase):
         ):
             self.hook = CloudTasksHook(gcp_conn_id="test")
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.tasks.CloudTasksHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.tasks.CloudTasksHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.tasks.CloudTasksClient")
-    def test_cloud_tasks_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_cloud_tasks_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_text_to_speech.py
+++ b/tests/providers/google/cloud/hooks/test_text_to_speech.py
@@ -18,9 +18,10 @@
 #
 
 import unittest
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from airflow.providers.google.cloud.hooks.text_to_speech import CloudTextToSpeechHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 INPUT = {"text": "test text"}
@@ -36,17 +37,11 @@ class TestTextToSpeechHook(unittest.TestCase):
         ):
             self.gcp_text_to_speech_hook = CloudTextToSpeechHook(gcp_conn_id="test")
 
-    @patch(
-        "airflow.providers.google.cloud.hooks.text_to_speech.CloudTextToSpeechHook.client_info",
-        new_callable=PropertyMock,
-    )
     @patch("airflow.providers.google.cloud.hooks.text_to_speech.CloudTextToSpeechHook._get_credentials")
     @patch("airflow.providers.google.cloud.hooks.text_to_speech.TextToSpeechClient")
-    def test_text_to_speech_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_text_to_speech_client_creation(self, mock_client, mock_get_creds):
         result = self.gcp_text_to_speech_hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.gcp_text_to_speech_hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_translate.py
+++ b/tests/providers/google/cloud/hooks/test_translate.py
@@ -20,6 +20,7 @@ import unittest
 from unittest import mock
 
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 PROJECT_ID_TEST = 'project-id'
@@ -33,17 +34,11 @@ class TestCloudTranslateHook(unittest.TestCase):
         ):
             self.hook = CloudTranslateHook(gcp_conn_id='test')
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.translate.CloudTranslateHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.translate.CloudTranslateHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.translate.Client")
-    def test_translate_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_translate_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_video_intelligence.py
+++ b/tests/providers/google/cloud/hooks/test_video_intelligence.py
@@ -22,6 +22,7 @@ from unittest import mock
 from google.cloud.videointelligence_v1 import enums
 
 from airflow.providers.google.cloud.hooks.video_intelligence import CloudVideoIntelligenceHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 INPUT_URI = "gs://bucket-name/input-file"
@@ -41,18 +42,12 @@ class TestCloudVideoIntelligenceHook(unittest.TestCase):
             self.hook = CloudVideoIntelligenceHook(gcp_conn_id="test")
 
     @mock.patch(
-        "airflow.providers.google.cloud.hooks.video_intelligence.CloudVideoIntelligenceHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
-    @mock.patch(
         "airflow.providers.google.cloud.hooks.video_intelligence.CloudVideoIntelligenceHook._get_credentials"
     )
     @mock.patch("airflow.providers.google.cloud.hooks.video_intelligence.VideoIntelligenceServiceClient")
-    def test_video_intelligence_service_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_video_intelligence_service_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._conn == result
 

--- a/tests/providers/google/cloud/hooks/test_vision.py
+++ b/tests/providers/google/cloud/hooks/test_vision.py
@@ -32,6 +32,7 @@ from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.vision import ERR_DIFF_NAMES, ERR_UNABLE_TO_CREATE, CloudVisionHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 PROJECT_ID_TEST = 'project-id'
@@ -79,17 +80,11 @@ class TestGcpVisionHook(unittest.TestCase):
         ):
             self.hook = CloudVisionHook(gcp_conn_id='test')
 
-    @mock.patch(
-        "airflow.providers.google.cloud.hooks.vision.CloudVisionHook.client_info",
-        new_callable=mock.PropertyMock,
-    )
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook._get_credentials")
     @mock.patch("airflow.providers.google.cloud.hooks.vision.ProductSearchClient")
-    def test_product_search_client_creation(self, mock_client, mock_get_creds, mock_client_info):
+    def test_product_search_client_creation(self, mock_client, mock_get_creds):
         result = self.hook.get_conn()
-        mock_client.assert_called_once_with(
-            credentials=mock_get_creds.return_value, client_info=mock_client_info.return_value
-        )
+        mock_client.assert_called_once_with(credentials=mock_get_creds.return_value, client_info=CLIENT_INFO)
         assert mock_client.return_value == result
         assert self.hook._client == result
 

--- a/tests/providers/google/cloud/hooks/test_workflows.py
+++ b/tests/providers/google/cloud/hooks/test_workflows.py
@@ -18,6 +18,7 @@
 from unittest import mock
 
 from airflow.providers.google.cloud.hooks.workflows import WorkflowsHook
+from airflow.providers.google.common.consts import CLIENT_INFO
 
 BASE_PATH = "airflow.providers.google.cloud.hooks.workflows.{}"
 LOCATION = "europe-west1"
@@ -51,23 +52,21 @@ class TestWorkflowsHook:
             self.hook = WorkflowsHook(gcp_conn_id="test")
 
     @mock.patch(BASE_PATH.format("WorkflowsHook._get_credentials"))
-    @mock.patch(BASE_PATH.format("WorkflowsHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(BASE_PATH.format("WorkflowsClient"))
-    def test_get_workflows_client(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_workflows_client(self, mock_client, mock_get_credentials):
         self.hook.get_workflows_client()
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
         )
 
     @mock.patch(BASE_PATH.format("WorkflowsHook._get_credentials"))
-    @mock.patch(BASE_PATH.format("WorkflowsHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(BASE_PATH.format("ExecutionsClient"))
-    def test_get_executions_client(self, mock_client, mock_client_info, mock_get_credentials):
+    def test_get_executions_client(self, mock_client, mock_get_credentials):
         self.hook.get_executions_client()
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
-            client_info=mock_client_info.return_value,
+            client_info=CLIENT_INFO,
         )
 
     @mock.patch(BASE_PATH.format("WorkflowsHook.get_workflows_client"))


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/13231

Hello guys,

Here is a first draft for refactoring the code using the `ClientInfo`.

- [x] extract `ClientInfo` into a shared object at the google provider lvl (into `common.consts`)
- [x] mark `GoogleBaseHook.client_info` as deprecated
- [x] Modify all code using `.client_info` or `ClientInfo` to use this shared `CLIENT_INFO` constant