### PR TITLE
Revert Handle stuck queued tasks in Celery for db backend

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1766,13 +1766,6 @@
       type: string
       example: ~
       default: "False"
-    - name: stuck_queued_task_check_interval
-      description: |
-        How often to check for stuck queued task (in seconds)
-      version_added: 2.2.4
-      type: integer
-      example: ~
-      default: "300"
 - name: celery_broker_transport_options
   description: |
     This section is for specifying options which can be passed to the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -887,9 +887,6 @@ task_publish_max_retries = 3
 # Worker initialisation check to validate Metadata Database connection
 worker_precheck = False
 
-# How often to check for stuck queued task (in seconds)
-stuck_queued_task_check_interval = 300
-
 [celery_broker_transport_options]
 
 # This section is for specifying options which can be passed to the

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -237,7 +237,7 @@ class CeleryExecutor(BaseExecutor):
         self.task_adoption_timeout = datetime.timedelta(
             seconds=conf.getint('celery', 'task_adoption_timeout', fallback=600)
         )
-        self.stuck_tasks_last_check_time: int = time.time()
+        self.stuck_tasks_last_check_time: float = time.time()
         self.stuck_queued_task_check_interval = conf.getint(
             'celery', 'stuck_queued_task_check_interval', fallback=300
         )
@@ -345,8 +345,10 @@ class CeleryExecutor(BaseExecutor):
 
         if self.adopted_task_timeouts:
             self._check_for_stalled_adopted_tasks()
+
         if time.time() - self.stuck_tasks_last_check_time > self.stuck_queued_task_check_interval:
             self._clear_stuck_queued_tasks()
+            self.stuck_tasks_last_check_time = time.time()
 
     def _check_for_stalled_adopted_tasks(self):
         """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -350,7 +350,8 @@ class CeleryExecutor(BaseExecutor):
                 with timeout(seconds=OPERATION_TIMEOUT):
                     self._clear_stuck_queued_tasks()
             except Exception:
-                self.log.exception("Error while checking for stuck tasks")
+                # This timeout is not important, we should skip
+                pass
 
     def _check_for_stalled_adopted_tasks(self):
         """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -413,7 +413,7 @@ class CeleryExecutor(BaseExecutor):
             .filter(TaskInstance.state == State.QUEUED, TaskInstance.queued_dttm < max_allowed_time)
             .all()
         )
-
+        celery_task_ids: List[str] = []
         if queued_too_log:
             # We use this instead of using bulk_state_fetcher because we
             # may not have the stuck task in self.tasks and we don't want

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -40,7 +40,6 @@ from celery.backends.database import DatabaseBackend, Task as TaskDb, session_cl
 from celery.result import AsyncResult
 from celery.signals import import_modules as celery_import_modules
 from setproctitle import setproctitle
-from sqlalchemy.orm.session import Session
 
 import airflow.settings as settings
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
@@ -51,7 +50,6 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
-from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.timezone import utcnow
@@ -237,10 +235,6 @@ class CeleryExecutor(BaseExecutor):
         self.task_adoption_timeout = datetime.timedelta(
             seconds=conf.getint('celery', 'task_adoption_timeout', fallback=600)
         )
-        self.stuck_tasks_last_check_time: float = time.time()
-        self.stuck_queued_task_check_interval = conf.getint(
-            'celery', 'stuck_queued_task_check_interval', fallback=300
-        )
         self.task_publish_retries: Dict[TaskInstanceKey, int] = OrderedDict()
         self.task_publish_max_retries = conf.getint('celery', 'task_publish_max_retries', fallback=3)
 
@@ -346,10 +340,6 @@ class CeleryExecutor(BaseExecutor):
         if self.adopted_task_timeouts:
             self._check_for_stalled_adopted_tasks()
 
-        if time.time() - self.stuck_tasks_last_check_time > self.stuck_queued_task_check_interval:
-            self._clear_stuck_queued_tasks()
-            self.stuck_tasks_last_check_time = time.time()
-
     def _check_for_stalled_adopted_tasks(self):
         """
         See if any of the tasks we adopted from another Executor run have not
@@ -388,66 +378,6 @@ class CeleryExecutor(BaseExecutor):
             )
             for key in timedout_keys:
                 self.change_state(key, State.FAILED)
-
-    @provide_session
-    def _clear_stuck_queued_tasks(self, session: Session = NEW_SESSION) -> None:
-        """
-        Tasks can get stuck in queued state in DB while still not in
-        worker. This happens when the worker is autoscaled down and
-        the task is queued but has not been picked up by any worker prior to the scaling.
-
-        In such situation, we update the task instance state to scheduled so that
-        it can be queued again. We chose to use task_adoption_timeout to decide when
-        a queued task is considered stuck and should be reschelduled.
-        """
-        if not isinstance(app.backend, DatabaseBackend):
-            # We only want to do this for database backends where
-            # this case has been spotted
-            return
-        self.log.debug("Checking for stuck queued tasks")
-
-        max_allowed_time = utcnow() - self.task_adoption_timeout
-
-        queued_too_log = (
-            session.query(TaskInstance)
-            .filter(TaskInstance.state == State.QUEUED, TaskInstance.queued_dttm < max_allowed_time)
-            .all()
-        )
-        celery_task_ids: List[str] = []
-        if queued_too_log:
-            # We use this instead of using bulk_state_fetcher because we
-            # may not have the stuck task in self.tasks and we don't want
-            # to clear task in self.tasks too
-            session_ = app.backend.ResultSession()
-            task_cls = getattr(app.backend, "task_cls", TaskDb)
-            with session_cleanup(session_):
-                try:
-                    with timeout(seconds=15):
-                        celery_task_ids = [
-                            t.task_id
-                            for t in session_.query(task_cls.task_id)
-                            .filter(~task_cls.status.in_([celery_states.SUCCESS, celery_states.FAILURE]))
-                            .filter(task_cls.task_id.in_([ti.external_executor_id for ti in queued_too_log]))
-                            .all()
-                        ]
-                except Exception:
-                    # This timeout is not important, we should skip
-                    pass
-
-        for task in queued_too_log:
-            # If the task is still queued, then it's stuck
-            # Check if it's in celery_task_ids, if so, it's now running
-            if task.external_executor_id in celery_task_ids:
-                # The task is still running in the worker
-                continue
-
-            self.log.info(
-                'TaskInstance: %s found in queued state for more than %s seconds, rescheduling',
-                task,
-                self.task_adoption_timeout.total_seconds(),
-            )
-            task.state = State.SCHEDULED
-            session.merge(task)
 
     def debug_dump(self) -> None:
         """Called in response to SIGUSR2 by the scheduler"""

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -559,7 +559,7 @@ class TestCeleryExecutor:
             mock_backend = DatabaseBackend(app=celery_executor.app, url="sqlite3://")
             with mock.patch('airflow.executors.celery_executor.Celery.backend', mock_backend):
                 mock_session = mock_backend.ResultSession.return_value
-                mock_session.query.return_value.filter.return_value.all.return_value = [
+                mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [
                     result_obj("SUCCESS", task_id)
                 ]
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -431,10 +431,10 @@ class TestCeleryExecutor:
         assert ti.state == state
 
     @pytest.mark.backend("mysql", "postgres")
-    def test_task_in_queued_tasks_dict_are_not_cleared(
+    def test_task_in_queued_tasks_dict_are_cleared(
         self, session, dag_maker, create_dummy_dag, create_task_instance
     ):
-        """Test that clear_stuck_queued_tasks doesn't clear tasks in executor.queued_tasks"""
+        """Test that clear_stuck_queued_tasks clears tasks in executor.queued_tasks"""
         ti = create_task_instance(state=State.QUEUED)
         ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
         ti.external_executor_id = '231'
@@ -446,13 +446,13 @@ class TestCeleryExecutor:
         session.flush()
         ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
         assert executor.queued_tasks == {ti.key: AsyncResult("231")}
-        assert ti.state == State.QUEUED
+        assert ti.state == State.SCHEDULED
 
     @pytest.mark.backend("mysql", "postgres")
-    def test_task_in_running_dict_are_not_cleared(
+    def test_task_in_running_dict_are_cleared(
         self, session, dag_maker, create_dummy_dag, create_task_instance
     ):
-        """Test that clear_stuck_queued_tasks doesn't clear tasks in executor.running"""
+        """Test that clear_stuck_queued_tasks clears tasks in executor.running"""
         ti = create_task_instance(state=State.QUEUED)
         ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
         ti.external_executor_id = '231'
@@ -464,7 +464,7 @@ class TestCeleryExecutor:
         session.flush()
         ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
         assert executor.running == {ti.key: AsyncResult("231")}
-        assert ti.state == State.QUEUED
+        assert ti.state == State.SCHEDULED
 
     @pytest.mark.backend("mysql", "postgres")
     def test_only_database_result_backend_supports_clearing_queued_task(

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -21,9 +21,7 @@ import logging
 import os
 import signal
 import sys
-import time
 import unittest
-from collections import namedtuple
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -35,14 +33,13 @@ from celery.backends.base import BaseBackend, BaseKeyValueStoreBackend
 from celery.backends.database import DatabaseBackend
 from celery.contrib.testing.worker import start_worker
 from celery.result import AsyncResult
-from freezegun import freeze_time
 from kombu.asynchronous import set_event_loop
 from parameterized import parameterized
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.executors import celery_executor
-from airflow.executors.celery_executor import BulkStateFetcher, CeleryExecutor
+from airflow.executors.celery_executor import BulkStateFetcher
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
@@ -405,179 +402,6 @@ class TestCeleryExecutor:
         assert executor.tasks == {key_2: AsyncResult('232')}
         assert executor.running == {key_2}
         assert executor.adopted_task_timeouts == {key_2: queued_dttm_2 + executor.task_adoption_timeout}
-
-    @pytest.mark.backend("mysql", "postgres")
-    @pytest.mark.parametrize(
-        "state, queued_dttm, executor_id",
-        [
-            (State.SCHEDULED, timezone.utcnow() - timedelta(days=2), '231'),
-            (State.QUEUED, timezone.utcnow(), '231'),
-            (State.QUEUED, timezone.utcnow(), None),
-        ],
-    )
-    def test_stuck_queued_tasks_are_cleared(
-        self, state, queued_dttm, executor_id, session, dag_maker, create_dummy_dag, create_task_instance
-    ):
-        """Test that clear_stuck_queued_tasks works"""
-        ti = create_task_instance(state=State.QUEUED)
-        ti.queued_dttm = queued_dttm
-        ti.external_executor_id = executor_id
-        session.merge(ti)
-        session.flush()
-        executor = celery_executor.CeleryExecutor()
-        executor._clear_stuck_queued_tasks()
-        session.flush()
-        ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-        assert ti.state == state
-
-    @pytest.mark.backend("mysql", "postgres")
-    def test_task_in_queued_tasks_dict_are_cleared(
-        self, session, dag_maker, create_dummy_dag, create_task_instance
-    ):
-        """Test that clear_stuck_queued_tasks clears tasks in executor.queued_tasks"""
-        ti = create_task_instance(state=State.QUEUED)
-        ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
-        ti.external_executor_id = '231'
-        session.merge(ti)
-        session.flush()
-        executor = celery_executor.CeleryExecutor()
-        executor.queued_tasks = {ti.key: AsyncResult("231")}
-        executor._clear_stuck_queued_tasks()
-        session.flush()
-        ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-        assert executor.queued_tasks == {ti.key: AsyncResult("231")}
-        assert ti.state == State.SCHEDULED
-
-    @pytest.mark.backend("mysql", "postgres")
-    def test_task_in_running_dict_are_cleared(
-        self, session, dag_maker, create_dummy_dag, create_task_instance
-    ):
-        """Test that clear_stuck_queued_tasks clears tasks in executor.running"""
-        ti = create_task_instance(state=State.QUEUED)
-        ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
-        ti.external_executor_id = '231'
-        session.merge(ti)
-        session.flush()
-        executor = celery_executor.CeleryExecutor()
-        executor.running = {ti.key: AsyncResult("231")}
-        executor._clear_stuck_queued_tasks()
-        session.flush()
-        ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-        assert executor.running == {ti.key: AsyncResult("231")}
-        assert ti.state == State.SCHEDULED
-
-    @pytest.mark.backend("mysql", "postgres")
-    def test_only_database_result_backend_supports_clearing_queued_task(
-        self, session, dag_maker, create_dummy_dag, create_task_instance
-    ):
-        with _prepare_app():
-            mock_backend = BaseKeyValueStoreBackend(app=celery_executor.app)
-            with mock.patch('airflow.executors.celery_executor.Celery.backend', mock_backend):
-                ti = create_task_instance(state=State.QUEUED)
-                ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
-                ti.external_executor_id = '231'
-                session.merge(ti)
-                session.flush()
-                executor = celery_executor.CeleryExecutor()
-                executor.tasks = {ti.key: AsyncResult("231")}
-                executor._clear_stuck_queued_tasks()
-                session.flush()
-                ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-                # Not cleared
-                assert ti.state == State.QUEUED
-                assert executor.tasks == {ti.key: AsyncResult("231")}
-
-    @mock.patch("celery.backends.database.DatabaseBackend.ResultSession")
-    @pytest.mark.backend("mysql", "postgres")
-    @freeze_time("2020-01-01")
-    @pytest.mark.parametrize(
-        "state",
-        [
-            (State.SCHEDULED),
-            (State.QUEUED),
-        ],
-    )
-    def test_the_check_interval_to_clear_stuck_queued_task_is_correct(
-        self,
-        mock_result_session,
-        state,
-        session,
-        dag_maker,
-        create_dummy_dag,
-        create_task_instance,
-    ):
-        with _prepare_app():
-            mock_backend = DatabaseBackend(app=celery_executor.app, url="sqlite3://")
-            with mock.patch('airflow.executors.celery_executor.Celery.backend', mock_backend):
-                mock_session = mock_backend.ResultSession.return_value
-                mock_session.query.return_value.all.return_value = [
-                    mock.MagicMock(**{"to_dict.return_value": {"status": "SUCCESS", "task_id": "123"}})
-                ]
-                if state == State.SCHEDULED:
-                    last_check_time = time.time() - 302  # should clear ti state
-                else:
-                    last_check_time = time.time() - 298  # should not clear ti state
-
-                ti = create_task_instance(state=State.QUEUED)
-                ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
-                ti.external_executor_id = '231'
-                session.merge(ti)
-                session.flush()
-                executor = celery_executor.CeleryExecutor()
-                executor.tasks = {ti.key: AsyncResult("231")}
-                executor.stuck_tasks_last_check_time = last_check_time
-                executor.sync()
-                assert executor.stuck_tasks_last_check_time != last_check_time  # should be updated
-                session.flush()
-                ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-                assert ti.state == state
-
-    @mock.patch("celery.backends.database.DatabaseBackend.ResultSession")
-    @mock.patch.object(CeleryExecutor, "update_all_task_states")
-    @pytest.mark.backend("mysql", "postgres")
-    @freeze_time("2020-01-01")
-    @pytest.mark.parametrize(
-        "task_id, state",
-        [
-            ('231', State.QUEUED),
-            ('111', State.SCHEDULED),
-        ],
-    )
-    def test_the_check_interval_to_clear_stuck_queued_task_is_correct_for_db_query(
-        self,
-        mock_update_all_task_states,
-        mock_result_session,
-        task_id,
-        state,
-        session,
-        dag_maker,
-        create_dummy_dag,
-        create_task_instance,
-    ):
-        """Here we test that task are not cleared if found in celery database"""
-        result_obj = namedtuple('Result', ['status', 'task_id'])
-        with _prepare_app():
-            mock_backend = DatabaseBackend(app=celery_executor.app, url="sqlite3://")
-            with mock.patch('airflow.executors.celery_executor.Celery.backend', mock_backend):
-                mock_session = mock_backend.ResultSession.return_value
-                mock_session.query.return_value.filter.return_value.filter.return_value.all.return_value = [
-                    result_obj("SUCCESS", task_id)
-                ]
-
-                last_check_time = time.time() - 302  # should clear ti state
-
-                ti = create_task_instance(state=State.QUEUED)
-                ti.queued_dttm = timezone.utcnow() - timedelta(days=2)
-                ti.external_executor_id = '231'
-                session.merge(ti)
-                session.flush()
-                executor = celery_executor.CeleryExecutor()
-                executor.tasks = {ti.key: AsyncResult("231")}
-                executor.stuck_tasks_last_check_time = last_check_time
-                executor.sync()
-                session.flush()
-                ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
-                assert ti.state == state
 
 
 def test_operation_timeout_config():

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -527,6 +527,7 @@ class TestCeleryExecutor:
                 executor.tasks = {ti.key: AsyncResult("231")}
                 executor.stuck_tasks_last_check_time = last_check_time
                 executor.sync()
+                assert executor.stuck_tasks_last_check_time != last_check_time  # should be updated
                 session.flush()
                 ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
                 assert ti.state == state


### PR DESCRIPTION
This reverts #19769 and #21335



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
