### PR TITLE
Type TaskInstance.task to Operator and call unmap() when needed

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -113,9 +113,9 @@ def _get_ti(
 ) -> TaskInstance:
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way"""
     if task.is_mapped:
-        if map_index == -1:
+        if map_index < 0:
             raise RuntimeError("No map_index passed to mapped task")
-    elif map_index != -1:
+    elif map_index >= 0:
         raise RuntimeError("map_index passed to non-mapped task")
     dag_run = _get_dag_run(
         dag=task.dag,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -224,8 +224,7 @@ RAW_TASK_UNSUPPORTED_OPTION = [
 
 def _run_raw_task(args, ti: TaskInstance) -> None:
     """Runs the main task handling code"""
-    if ti.task.is_mapped:
-        ti.task = ti.task.unmap()
+    ti.task = ti.task.unmap()
     ti._run_raw_task(
         mark_success=args.mark_success,
         job_id=args.job_id,
@@ -531,8 +530,7 @@ def task_render(args):
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
     ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
-    if ti.task.is_mapped:
-        ti.task = ti.task.unmap()
+    ti.task = ti.task.unmap()
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -531,6 +531,8 @@ def task_render(args):
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
     ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
+    if ti.task.is_mapped:
+        ti.task = ti.task.unmap()
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -445,7 +445,7 @@ class DagFileProcessor(LoggingMixin):
             blocking_tis: List[TI] = []
             for ti in fetched_tis:
                 if ti.task_id in dag.task_ids:
-                    ti.task = dag.get_task(ti.task_id)  # type: ignore[assignment]  # TODO: Fix task: Operator
+                    ti.task = dag.get_task(ti.task_id)
                     blocking_tis.append(ti)
                 else:
                     session.delete(ti)

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -43,7 +43,7 @@ import typing_extensions
 from airflow.compat.functools import cache, cached_property
 from airflow.exceptions import AirflowException
 from airflow.models.abstractoperator import DEFAULT_RETRIES, DEFAULT_RETRY_DELAY
-from airflow.models.baseoperator import BaseOperator, coerce_retry_delay, parse_retries
+from airflow.models.baseoperator import BaseOperator, coerce_resources, coerce_retry_delay, parse_retries
 from airflow.models.dag import DAG, DagContext
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.pool import Pool
@@ -308,6 +308,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         partial_kwargs["retry_delay"] = coerce_retry_delay(
             partial_kwargs.get("retry_delay", DEFAULT_RETRY_DELAY),
         )
+        partial_kwargs["resources"] = coerce_resources(partial_kwargs.get("resources"))
         partial_kwargs.setdefault("executor_config", {})
 
         # Mypy does not work well with a subclassed attrs class :(

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -76,8 +76,7 @@ class DebugExecutor(BaseExecutor):
         key = ti.key
         try:
             params = self.tasks_params.pop(ti.key, {})
-            if ti.task.is_mapped:
-                ti.task = ti.task.unmap()
+            ti.task = ti.task.unmap()
             ti._run_raw_task(job_id=ti.job_id, **params)
             self.change_state(key, State.SUCCESS)
             ti._run_finished_callback()

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -107,8 +107,7 @@ class LocalTaskJob(BaseJob):
             # Unmap the task _after_ it has forked/execed. (This is a bit of a kludge, but if we unmap before
             # fork, then the "run_raw_task" command will see the mapping index and an Non-mapped task and
             # fail)
-            if self.task_instance.task.is_mapped:
-                self.task_instance.task = self.task_instance.task.unmap()
+            self.task_instance.task = self.task_instance.task.unmap()
 
             heartbeat_time_limit = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -48,7 +48,6 @@ from typing import (
 )
 
 import attr
-import jinja2
 import pendulum
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import Session
@@ -91,6 +90,8 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 
 if TYPE_CHECKING:
+    import jinja2  # Slow import.
+
     from airflow.models.dag import DAG
     from airflow.utils.task_group import TaskGroup
 
@@ -1149,7 +1150,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._log = logging.getLogger("airflow.task.operators")
 
     def render_template_fields(
-        self, context: Context, jinja_env: Optional[jinja2.Environment] = None
+        self, context: Context, jinja_env: Optional["jinja2.Environment"] = None
     ) -> None:
         """
         Template all attributes listed in template_fields. Note this operation is irreversible.
@@ -1167,7 +1168,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         parent: Any,
         template_fields: Iterable[str],
         context: Context,
-        jinja_env: jinja2.Environment,
+        jinja_env: "jinja2.Environment",
         seen_oids: Set,
     ) -> None:
         for attr_name in template_fields:
@@ -1187,7 +1188,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         content: Any,
         context: Context,
-        jinja_env: Optional[jinja2.Environment] = None,
+        jinja_env: Optional["jinja2.Environment"] = None,
         seen_oids: Optional[Set] = None,
     ) -> Any:
         """
@@ -1245,7 +1246,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             return content
 
     def _render_nested_template_fields(
-        self, content: Any, context: Context, jinja_env: jinja2.Environment, seen_oids: Set
+        self, content: Any, context: Context, jinja_env: "jinja2.Environment", seen_oids: Set
     ) -> None:
         if id(content) not in seen_oids:
             seen_oids.add(id(content))

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1563,8 +1563,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     def unmap(self) -> "BaseOperator":
         """:meta private:"""
-        # Exists to make typing easier
-        raise TypeError("Internal code error: Do not call unmap on BaseOperator!")
+        return self
 
 
 # TODO: Deprecate for Airflow 3.0

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -624,7 +624,7 @@ class DagRun(Base, LoggingMixin):
         dag = self.get_dag()
         for ti in tis:
             try:
-                ti.task = dag.get_task(ti.task_id)  # type: ignore[assignment]  # TODO: Fix task: Operator
+                ti.task = dag.get_task(ti.task_id)
             except TaskNotFound:
                 self.log.warning(
                     "Failed to get task '%s' for dag '%s'. Marking it as removed.", ti, ti.dag_id

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -59,6 +59,7 @@ from airflow.models.xcom_arg import XComArg
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
+from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
@@ -338,6 +339,10 @@ class MappedOperator(AbstractOperator):
     @property
     def max_active_tis_per_dag(self) -> Optional[int]:
         return self.partial_kwargs.get("max_active_tis_per_dag")
+
+    @property
+    def resources(self) -> Optional[Resources]:
+        return self.partial_kwargs.get("resources")
 
     @property
     def on_execute_callback(self) -> Optional[TaskStateChangeCallback]:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -122,7 +122,6 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
@@ -423,11 +422,7 @@ class TaskInstance(Base, LoggingMixin):
 
     execution_date = association_proxy("dag_run", "execution_date")
 
-    # TODO: Investigate TaskInstance's lifecycle and call stack to determine
-    # when self.task is guaranteed to be unmapped, and when it may be mapped.
-    # Add 'assert isinstance(self.task, BaseOperator) to methods accordingly,
-    # and change this to 'task: Operator' instead.
-    task: "BaseOperator"  # Not always set...
+    task: "Operator"  # Not always set...
 
     def __init__(
         self,
@@ -806,7 +801,7 @@ class TaskInstance(Base, LoggingMixin):
         :param task: The task object to copy from
         :param pool_override: Use the pool_override instead of task's pool
         """
-        self.task = task  # type: ignore[assignment]  # TODO: Fix task: Operator
+        self.task = task
         self.queue = task.queue
         self.pool = pool_override or task.pool
         self.pool_slots = task.pool_slots
@@ -1321,8 +1316,9 @@ class TaskInstance(Base, LoggingMixin):
                 f'task property of {self.task_id!r} was still a MappedOperator -- it should have been '
                 'expanded already!'
             )
+        task = self.task.unmap()
         self.test_mode = test_mode
-        self.refresh_from_task(self.task, pool_override=pool)
+        self.refresh_from_task(task, pool_override=pool)
         self.refresh_from_db(session=session)
         self.job_id = job_id
         self.hostname = get_hostname()
@@ -1334,7 +1330,7 @@ class TaskInstance(Base, LoggingMixin):
         Stats.incr(f'ti.start.{self.task.dag_id}.{self.task.task_id}')
         try:
             if not mark_success:
-                self.task = self.task.prepare_for_execution()
+                self.task = task.prepare_for_execution()
                 context = self.get_template_context(ignore_param_exceptions=False)
                 self._execute_task_with_callbacks(context)
             if not test_mode:
@@ -1397,7 +1393,7 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
             raise
         finally:
-            Stats.incr(f'ti.finish.{self.task.dag_id}.{self.task.task_id}.{self.state}')
+            Stats.incr(f'ti.finish.{task.dag_id}.{task.task_id}.{self.state}')
 
         # Recording SKIPPED or SUCCESS
         self.clear_next_method_args()
@@ -1660,10 +1656,7 @@ class TaskInstance(Base, LoggingMixin):
 
     def dry_run(self):
         """Only Renders Templates for the TI"""
-        task = self.task
-        if task.is_mapped:
-            task = task.unmap()
-        task_copy = task.prepare_for_execution()
+        task_copy = self.task.unmap().prepare_for_execution()
         self.task = task_copy
 
         self.render_templates()
@@ -1744,9 +1737,7 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             self.refresh_from_db(session)
 
-        task = self.task
-        if task.is_mapped:
-            task = task.unmap()
+        task = self.task.unmap()
         self.end_date = timezone.utcnow()
         self.set_duration()
         Stats.incr(f'operator_failures_{task.task_type}', 1, 1)
@@ -1952,13 +1943,13 @@ class TaskInstance(Base, LoggingMixin):
             'ds': ds,
             'ds_nodash': ds_nodash,
             'execution_date': logical_date,
-            'inlets': task.inlets,
+            'inlets': task.inlets,  # type: ignore  # TODO: Wait for MappedOperator.inlets
             'logical_date': logical_date,
             'macros': macros,
             'next_ds': get_next_ds(),
             'next_ds_nodash': get_next_ds_nodash(),
             'next_execution_date': get_next_execution_date(),
-            'outlets': task.outlets,
+            'outlets': task.outlets,  # type: ignore  # TODO: Wait for MappedOperator.outlets
             'params': validated_params,
             'prev_data_interval_start_success': get_prev_data_interval_start_success(),
             'prev_data_interval_end_success': get_prev_data_interval_end_success(),
@@ -2041,8 +2032,7 @@ class TaskInstance(Base, LoggingMixin):
             )
         if not context:
             context = self.get_template_context()
-
-        self.task.render_template_fields(context)
+        self.task.unmap().render_template_fields(context)
 
     def render_k8s_pod_yaml(self) -> Optional[dict]:
         """Render k8s pod yaml"""

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1943,13 +1943,13 @@ class TaskInstance(Base, LoggingMixin):
             'ds': ds,
             'ds_nodash': ds_nodash,
             'execution_date': logical_date,
-            'inlets': task.inlets,  # type: ignore  # TODO: Wait for MappedOperator.inlets
+            'inlets': task.inlets,
             'logical_date': logical_date,
             'macros': macros,
             'next_ds': get_next_ds(),
             'next_ds_nodash': get_next_ds_nodash(),
             'next_execution_date': get_next_execution_date(),
-            'outlets': task.outlets,  # type: ignore  # TODO: Wait for MappedOperator.outlets
+            'outlets': task.outlets,
             'params': validated_params,
             'prev_data_interval_start_success': get_prev_data_interval_start_success(),
             'prev_data_interval_end_success': get_prev_data_interval_end_success(),

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1661,6 +1661,8 @@ class TaskInstance(Base, LoggingMixin):
     def dry_run(self):
         """Only Renders Templates for the TI"""
         task = self.task
+        if task.is_mapped:
+            task = task.unmap()
         task_copy = task.prepare_for_execution()
         self.task = task_copy
 
@@ -2032,6 +2034,11 @@ class TaskInstance(Base, LoggingMixin):
 
     def render_templates(self, context: Optional[Context] = None) -> None:
         """Render templates in the operator fields."""
+        if self.task.is_mapped:
+            raise RuntimeError(
+                f'task property of {self.task_id!r} was still a MappedOperator -- it should have been '
+                'expanded already!'
+            )
         if not context:
             context = self.get_template_context()
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -104,8 +104,10 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
 
     def _render_log_id(self, ti: TaskInstance, try_number: int) -> str:
         dag_run = ti.get_dagrun()
+        dag = ti.task.dag
+        assert dag is not None  # For Mypy.
         try:
-            data_interval: Tuple[datetime, datetime] = ti.task.dag.get_run_data_interval(dag_run)
+            data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
         except AttributeError:  # ti.task is not always set.
             data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -84,8 +84,10 @@ class FileTaskHandler(logging.Handler):
             return render_template_to_string(self.filename_jinja_template, context)
         elif self.filename_template:
             dag_run = ti.get_dagrun()
+            dag = ti.task.dag
+            assert dag is not None  # For Mypy.
             try:
-                data_interval: Tuple[datetime, datetime] = ti.task.dag.get_run_data_interval(dag_run)
+                data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
             except AttributeError:  # ti.task is not always set.
                 data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
             if data_interval[0]:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1207,10 +1207,7 @@ class Airflow(AirflowBaseView):
         logging.info("Retrieving rendered templates.")
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
-        task = dag.get_task(task_id)
-        if task.is_mapped:
-            task = task.unmap()
-        task = copy.copy(task)
+        task = copy.copy(dag.get_task(task_id).unmap())
 
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1205,9 +1205,12 @@ class Airflow(AirflowBaseView):
         root = request.args.get('root', '')
 
         logging.info("Retrieving rendered templates.")
-        dag = current_app.dag_bag.get_dag(dag_id)
+        dag: DAG = current_app.dag_bag.get_dag(dag_id)
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
-        task = copy.copy(dag.get_task(task_id))
+        task = dag.get_task(task_id)
+        if task.is_mapped:
+            task = task.unmap()
+        task = copy.copy(task)
 
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this


### PR DESCRIPTION
I traced all the `TaskInstance.task` calls I could find (may not be comprehensive but I did what I could), and analysed whether `task` can be mapped or not on each of their call paths. I added a runtime check when they are guaranteed to be _not_ mapped, and additional `unmap` calls when needed. I also implemented `MappedOperator.resources` since it is needed.

This also depends on the `inlets` and `outlets` properties proposed in #21495 (right now they are type-ignored so CI can pass).