### PR TITLE
Dispose not used connection pool

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -319,11 +319,11 @@ def task_run(args, dag=None):
 
     settings.MASK_SECRETS_IN_LOGS = True
 
-    # IMPORTANT, have to use the NullPool, otherwise, each "run" command may leave
+    # IMPORTANT, have to re-configure ORM with the NullPool, otherwise, each "run" command may leave
     # behind multiple open sleeping connections while heartbeating, which could
     # easily exceed the database connection limit when
     # processing hundreds of simultaneous tasks.
-    settings.configure_orm(disable_connection_pool=True)
+    settings.reconfigure_orm(disable_connection_pool=True)
 
     if args.pickle:
         print(f'Loading pickle id: {args.pickle}')

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -380,6 +380,12 @@ def dispose_orm():
         engine = None
 
 
+def reconfigure_orm(disable_connection_pool=False):
+    """Properly close database connections and re-configure ORM"""
+    dispose_orm()
+    configure_orm(disable_connection_pool=disable_connection_pool)
+
+
 def configure_adapters():
     """Register Adapters and DB Converters"""
     from pendulum import DateTime as Pendulum


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In the `task_run`, it has to dispose the ORM then configure orm, otherwise, the existing db connection won't be closed. When there are lots of running tasks, the DB is likely to get connection error.


Test:



### before the change

i put a `time.sleep(1000)`  right after the `settings.configure_orm(disable_connection_pool=True)`

![image](https://user-images.githubusercontent.com/8662365/153932192-2b8cf2dc-aa94-4fb4-a446-c92c26175d62.png)






### After the change

i put a `time.sleep(1000)`  right after the `settings.reconfigure_orm(disable_connection_pool=True)`


![image](https://user-images.githubusercontent.com/8662365/153931761-e51839e8-fc0b-4eb0-9005-369a88d99ea0.png)



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
