### PR TITLE
Action log on Browse Views

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -49,19 +49,21 @@ def action_logging(f: T) -> T:
                 user = g.user.username
 
             fields_skip_logging = {'csrf_token', '_csrf_token'}
-            log_fields = {
-                k: v
-                for k, v in chain(request.values.items(), request.view_args.items())
+            extra_fields = [
+                (k, v)
+                for k, v in chain(request.values.items(multi=True), request.view_args.items())
                 if k not in fields_skip_logging
-            }
+            ]
+
+            params = {k: v for k, v in chain(request.values.items(), request.view_args.items())}
 
             log = Log(
                 event=f.__name__,
                 task_instance=None,
                 owner=user,
-                extra=str([(k, log_fields[k]) for k in log_fields]),
-                task_id=log_fields.get('task_id'),
-                dag_id=log_fields.get('dag_id'),
+                extra=str(extra_fields),
+                task_id=params.get('task_id'),
+                dag_id=params.get('dag_id'),
             )
 
             if 'execution_date' in request.values:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4315,6 +4315,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?", single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_muldelete(self, items: List[DagRun]):
         """Multiple delete."""
         self.datamodel.delete_all(items)
@@ -4323,12 +4324,14 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_queued', "Set state to 'queued'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_queued(self, drs: List[DagRun]):
         """Set state to queued."""
         return self._set_dag_runs_to_active_state(drs, State.QUEUED)
 
     @action('set_running', "Set state to 'running'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_running(self, drs: List[DagRun]):
         """Set state to running."""
         return self._set_dag_runs_to_active_state(drs, State.RUNNING)
@@ -4358,6 +4361,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
+    @action_logging
     def action_set_failed(self, drs: List[DagRun], session=None):
         """Set state to failed."""
         try:
@@ -4382,6 +4386,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
+    @action_logging
     def action_set_success(self, drs: List[DagRun], session=None):
         """Set state to success."""
         try:
@@ -4401,6 +4406,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     @action('clear', "Clear the state", "All task instances would be cleared, are you sure?", single=False)
     @action_has_dag_edit_access
     @provide_session
+    @action_logging
     def action_clear(self, drs: List[DagRun], session=None):
         """Clears the state."""
         try:
@@ -4690,6 +4696,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
+    @action_logging
     def action_clear(self, task_instances, session=None):
         """Clears the action."""
         try:
@@ -4711,6 +4718,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('muldelete', 'Delete', "Are you sure you want to delete selected records?", single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_muldelete(self, items):
         self.datamodel.delete_all(items)
         self.update_redirect()
@@ -4730,6 +4738,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_running', "Set state to 'running'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_running(self, tis):
         """Set state to 'running'"""
         self.set_task_instance_state(tis, State.RUNNING)
@@ -4738,6 +4747,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_failed', "Set state to 'failed'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_failed(self, tis):
         """Set state to 'failed'"""
         self.set_task_instance_state(tis, State.FAILED)
@@ -4746,6 +4756,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_success', "Set state to 'success'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_success(self, tis):
         """Set state to 'success'"""
         self.set_task_instance_state(tis, State.SUCCESS)
@@ -4754,6 +4765,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_retry', "Set state to 'up_for_retry'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_retry(self, tis):
         """Set state to 'up_for_retry'"""
         self.set_task_instance_state(tis, State.UP_FOR_RETRY)
@@ -4762,6 +4774,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
 
     @action('set_skipped', "Set state to 'skipped'", '', single=False)
     @action_has_dag_edit_access
+    @action_logging
     def action_set_skipped(self, tis):
         """Set state to skipped."""
         self.set_task_instance_state(tis, TaskInstanceState.SKIPPED)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Current, `actions` under `Browse` are not logged.

`request.values` is a `MultiDict`, `items()` with default `multi=False` only returns one of the values with the same key

After the fix:

![image](https://user-images.githubusercontent.com/8662365/153992223-539a0d80-4c05-4725-abf2-5012ae30759e.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
