### PR TITLE
Fix mypy issues in `example_twitter_dag`

### DIFF
--- a/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
+++ b/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
@@ -80,12 +80,12 @@ with DAG(
     tags=['example'],
     catchup=False,
 ) as dag:
-    fetch_tweets = fetch_tweets()
-    clean_tweets = clean_tweets()
-    analyze_tweets = analyze_tweets()
+    fetch = fetch_tweets()
+    clean = clean_tweets()
+    analyze = analyze_tweets()
     hive_to_mysql = transfer_to_db()
 
-    fetch_tweets >> clean_tweets >> analyze_tweets
+    fetch >> clean >> analyze
 
     # --------------------------------------------------------------------------------
     # The following tasks are generated using for loop. The first task puts the eight
@@ -124,7 +124,7 @@ with DAG(
             ),
         )
 
-        analyze_tweets >> load_to_hdfs >> load_to_hive >> hive_to_mysql
+        analyze >> load_to_hdfs >> load_to_hive >> hive_to_mysql
 
     for channel in from_channels:
         file_name = f"from_{channel}_{dt}.csv"
@@ -144,4 +144,4 @@ with DAG(
             ),
         )
 
-        analyze_tweets >> load_to_hdfs >> load_to_hive >> hive_to_mysql
+        analyze >> load_to_hdfs >> load_to_hive >> hive_to_mysql


### PR DESCRIPTION
This fixes mypy issues in the `example_twitter_dag`:

```
mypy airflow/providers/apache/hive/example_dags/example_twitter_dag.py 
airflow/providers/apache/hive/example_dags/example_twitter_dag.py:88: error: Unsupported left operand type for >> ("Task[Callable[[], Any]]")  [operator]
        fetch_tweets >> clean_tweets >> analyze_tweets
        ^
airflow/providers/apache/hive/example_dags/example_twitter_dag.py:127: error: Unsupported operand types for >> ("Task[Callable[[], Any]]" and "BashOperator") 
[operator]
            analyze_tweets >> load_to_hdfs >> load_to_hive >> hive_to_mysql
            ^
airflow/providers/apache/hive/example_dags/example_twitter_dag.py:147: error: Unsupported operand types for >> ("Task[Callable[[], Any]]" and "BashOperator") 
[operator]
            analyze_tweets >> load_to_hdfs >> load_to_hive >> hive_to_mysql
            ^
Found 3 errors in 1 file (checked 1 source file)
```