### PR TITLE
Fix multi query scenario in bigquery example DAG

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -138,10 +138,7 @@ for index, location in enumerate(locations, 1):
             task_id="execute_multi_query",
             configuration={
                 "query": {
-                    "query": [
-                        f"SELECT * FROM {DATASET}.{TABLE_2}",
-                        f"SELECT COUNT(*) FROM {DATASET}.{TABLE_2}",
-                    ],
+                    "query": f"SELECT * FROM {DATASET}.{TABLE_2};SELECT COUNT(*) FROM {DATASET}.{TABLE_2}",
                     "useLegacySql": False,
                 }
             },


### PR DESCRIPTION
- When multiple queries are passed in a list to the BigQueryInsertJobOperator, then it ends up executing first query only.
- Ideally  multiple queries should be passed in a string separated by the semicolon, rather than a list. This is because
the Google Bigquery Jobs api can only accept multiple queries passed in a string separated by a semicolon. 

cc @kaxil @ashb @ephraimbuddy @dstandish 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
