### PR TITLE
Fix cannot pickle module object error in PythonVirtualenvOperator

### DIFF
--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -35,6 +35,11 @@ if sys.version_info >= (3,6):
 {% if op_args or op_kwargs %}
 with open(sys.argv[1], "rb") as file:
     arg_dict = {{ pickling_library }}.load(file)
+    {% if "macros" in op_kwargs %}
+    {# Because we have set macros to 'macros' during pickling, here we set it to real macros#}
+    import airflow.macros
+    arg_dict["macros"] = airflow.macros
+    {% endif %}
 {% else %}
 arg_dict = {"args": [], "kwargs": {}}
 {% endif %}
@@ -51,5 +56,6 @@ res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
 
 # Write output
 with open(sys.argv[2], "wb") as file:
+    print(res)
     if res is not None:
         {{ pickling_library }}.dump(res, file)


### PR DESCRIPTION
When the system_site_packages arg is set and the python_callable has wildcard keyword parameters, the task fails with error that it can't
pickle module object. Here we warn users not to use both

Closes: https://github.com/apache/airflow/issues/20974

cc: @uranusjr WDYT


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
