### PR TITLE
Simplify trigger cancel button

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -63,7 +63,7 @@
       </label>
     </div>
     <button type="submit" class="btn btn-primary">Trigger</button>
-    <a class="btn" href="{{ html_attr_escaped_origin }}">Cancel</a>
+    <a class="btn" href="{{ origin }}">Cancel</a>
   </form>
 {% endblock %}
 

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -63,7 +63,7 @@
       </label>
     </div>
     <button type="submit" class="btn btn-primary">Trigger</button>
-    <button type="button" class="btn" onclick="location.href = '{{ origin }}'; return false">Cancel</button>
+    <a class="btn" href="{{ html_attr_escaped_origin }}">Cancel</a>
   </form>
 {% endblock %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -18,6 +18,7 @@
 #
 import collections
 import copy
+import html
 import json
 import logging
 import math
@@ -1817,6 +1818,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=default_conf,
                 doc_md=doc_md,
                 form=form,
@@ -1832,6 +1834,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1853,6 +1856,7 @@ class Airflow(AirflowBaseView):
                         'airflow/trigger.html',
                         dag_id=dag_id,
                         origin=origin,
+                        html_attr_escaped_origin=html.escape(origin, quote=True),
                         conf=request_conf,
                         form=form,
                         is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1864,6 +1868,7 @@ class Airflow(AirflowBaseView):
                     'airflow/trigger.html',
                     dag_id=dag_id,
                     origin=origin,
+                    html_attr_escaped_origin=html.escape(origin, quote=True),
                     conf=request_conf,
                     form=form,
                     is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1889,6 +1894,7 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
+                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -18,7 +18,6 @@
 #
 import collections
 import copy
-import html
 import json
 import logging
 import math
@@ -1818,7 +1817,6 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
-                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=default_conf,
                 doc_md=doc_md,
                 form=form,
@@ -1834,7 +1832,6 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
-                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1856,7 +1853,6 @@ class Airflow(AirflowBaseView):
                         'airflow/trigger.html',
                         dag_id=dag_id,
                         origin=origin,
-                        html_attr_escaped_origin=html.escape(origin, quote=True),
                         conf=request_conf,
                         form=form,
                         is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1868,7 +1864,6 @@ class Airflow(AirflowBaseView):
                     'airflow/trigger.html',
                     dag_id=dag_id,
                     origin=origin,
-                    html_attr_escaped_origin=html.escape(origin, quote=True),
                     conf=request_conf,
                     form=form,
                     is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
@@ -1894,7 +1889,6 @@ class Airflow(AirflowBaseView):
                 'airflow/trigger.html',
                 dag_id=dag_id,
                 origin=origin,
-                html_attr_escaped_origin=html.escape(origin, quote=True),
                 conf=request_conf,
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,


### PR DESCRIPTION
This is an simpler-yet alternative to #21406 (and #21310).

It still moves to using an anchor over a button, however doesn't double encode as jinja already does it for us.