### PR TITLE
Airflow `db downgrade` cli command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -212,7 +212,10 @@ ARG_STDERR = Arg(("--stderr",), help="Redirect stderr to this file")
 ARG_STDOUT = Arg(("--stdout",), help="Redirect stdout to this file")
 ARG_LOG_FILE = Arg(("-l", "--log-file"), help="Location of the log file")
 ARG_YES = Arg(
-    ("-y", "--yes"), help="Do not prompt to confirm. Use with care!", action="store_true", default=False
+    ("-y", "--yes"),
+    help="Do not prompt to confirm. Use with care!",
+    action="store_true",
+    default=False,
 )
 ARG_OUTPUT = Arg(
     (
@@ -510,11 +513,41 @@ ARG_JOB_ID = Arg(("-j", "--job-id"), help=argparse.SUPPRESS)
 ARG_CFG_PATH = Arg(("--cfg-path",), help="Path to config file to use instead of airflow.cfg")
 ARG_MAP_INDEX = Arg(('--map-index',), type=int, default=-1, help="Mapped task index")
 
+
+# database
 ARG_MIGRATION_TIMEOUT = Arg(
     ("-t", "--migration-wait-timeout"),
     help="timeout to wait for db to migrate ",
     type=int,
     default=60,
+)
+ARG_DB_VERSION = Arg(
+    (
+        "-n",
+        "--version",
+    ),
+    help="The airflow version to downgrade to",
+)
+ARG_DB_FROM_VERSION = Arg(
+    ("--from-version",),
+    help="(Optional) if generating sql, may supply a _from_ version",
+)
+ARG_DB_REVISION = Arg(
+    (
+        "-r",
+        "--revision",
+    ),
+    help="The airflow revision to downgrade to",
+)
+ARG_DB_FROM_REVISION = Arg(
+    ("--from-revision",),
+    help="(Optional) if generating sql, may supply a _from_ revision",
+)
+ARG_DB_SQL = Arg(
+    ("-s", "--sql-only"),
+    help="Don't actually run migrations; just print out sql scripts for offline migration.",
+    action="store_true",
+    default=False,
 )
 
 # webserver
@@ -1326,6 +1359,19 @@ DB_COMMANDS = (
         help="Upgrade the metadata database to latest version",
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
         args=(ARG_VERSION_RANGE, ARG_REVISION_RANGE),
+    ),
+    ActionCommand(
+        name='downgrade',
+        help="Downgrade the schema of the metadata database",
+        func=lazy_load_command('airflow.cli.commands.db_command.downgrade'),
+        args=(
+            ARG_DB_REVISION,
+            ARG_DB_VERSION,
+            ARG_DB_SQL,
+            ARG_YES,
+            ARG_DB_FROM_REVISION,
+            ARG_DB_FROM_VERSION,
+        ),
     ),
     ActionCommand(
         name='shell',

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1174,7 +1174,16 @@ def resetdb(session: Session = NEW_SESSION):
 
 @provide_session
 def downgrade(to_revision, sql=False, from_revision=None, session: Session = NEW_SESSION):
-    """Downgrade the airflow metastore schema to a prior version."""
+    """
+    Downgrade the airflow metastore schema to a prior version.
+
+    :param to_revision: The alembic revision to downgrade *to*.
+    :param sql: if True, print sql statements but do not run them
+    :param from_revision: if supplied, alembic revision to dawngrade *from*. This may only
+        be used in conjunction with ``sql=True`` because if we actually run the commands,
+        we should only downgrade from the *current* revision.
+    :param session: sqlalchemy session for connection to airflow metadata database
+    """
     if from_revision and not sql:
         raise ValueError(
             "`from_revision` can't be combined with `sql=False`. When actually "

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1034,12 +1034,12 @@ def _check_migration_errors(session: Session = NEW_SESSION) -> Iterable[str]:
         session.commit()
 
 
-def _offline_migration(command, config, revision):
+def _offline_migration(migration_func: Callable, config, revision):
     log.info("Running offline migrations for revision range %s", revision)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         logging.disable(logging.CRITICAL)
-        command.upgrade(config, revision, sql=True)
+        migration_func(config, revision, sql=True)
         logging.disable(logging.NOTSET)
 
 
@@ -1134,10 +1134,10 @@ def upgradedb(
         revision = _validate_version_range(command, config, version_range)
         if not revision:
             return
-        return _offline_migration(command, config, revision)
+        return _offline_migration(command.upgrade, config, revision)
     elif revision_range:
         _validate_revision(command, config, revision_range)
-        return _offline_migration(command, config, revision_range)
+        return _offline_migration(command.upgrade, config, revision_range)
 
     errors_seen = False
     for err in _check_migration_errors(session=session):
@@ -1170,6 +1170,56 @@ def resetdb(session: Session = NEW_SESSION):
         drop_flask_models(connection)
 
     initdb(session=session)
+
+
+@provide_session
+def downgrade(to_revision, sql=False, from_revision=None, session: Session = NEW_SESSION):
+    """Downgrade the airflow metastore schema to a prior version."""
+    if from_revision and not sql:
+        raise ValueError(
+            "`from_revision` can't be combined with `sql=False`. When actually "
+            "applying a downgrade (instead of just generating sql), we always "
+            "downgrade from current revision."
+        )
+
+    if not settings.SQL_ALCHEMY_CONN:
+        raise RuntimeError("The settings.SQL_ALCHEMY_CONN not set.")
+
+    # alembic adds significant import time, so we import it lazily
+    from alembic import command
+
+    log.info("Attempting downgrade to revision %s", to_revision)
+
+    config = _get_alembic_config()
+
+    config.set_main_option('sqlalchemy.url', settings.SQL_ALCHEMY_CONN.replace('%', '%%'))
+
+    errors_seen = False
+    for err in _check_migration_errors(session=session):
+        if not errors_seen:
+            log.error("Automatic migration failed.  You may need to apply downgrades manually.  ")
+            errors_seen = True
+        log.error("%s", err)
+
+    if errors_seen:
+        exit(1)
+
+    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
+        if sql:
+            log.warning("Generating sql scripts for manual migration.")
+
+            conn = session.connection()
+
+            from alembic.migration import MigrationContext
+
+            migration_ctx = MigrationContext.configure(conn)
+            if not from_revision:
+                from_revision = migration_ctx.get_current_revision()
+            revision_range = f"{from_revision}:{to_revision}"
+            _offline_migration(command.downgrade, config=config, revision=revision_range)
+        else:
+            log.info("Applying downgrade migrations.")
+            command.downgrade(config, revision=to_revision, sql=sql)
 
 
 def drop_airflow_models(connection):


### PR DESCRIPTION
Add `db downgrade` CLI command

Adds the ability to migrate the airflow metastore schema to a previous alembic revision.

Features:
* can use version or revision
* can generate sql for "offline" migration
* can generate sql for downgrade with from / to revison or versions.