### PR TITLE
add celery.execute_command.failure metric

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -82,9 +82,8 @@ app = Celery(conf.get('celery', 'CELERY_APP_NAME'), config_source=celery_configu
 def execute_command(command_to_exec: CommandType) -> None:
     """Executes command."""
     BaseExecutor.validate_command(command_to_exec)
-    log.info("Executing command in Celery: %s", command_to_exec)
     celery_task_id = app.current_task.request.id
-    log.info(f"Celery task ID: {celery_task_id}")
+    log.info("[%s] Executing command in Celery: %s", celery_task_id, command_to_exec)
 
     if settings.EXECUTE_TASKS_NEW_PYTHON_INTERPRETER:
         _execute_in_subprocess(command_to_exec, celery_task_id)
@@ -100,7 +99,8 @@ def _execute_in_fork(command_to_exec: CommandType, celery_task_id: Optional[str]
         if ret == 0:
             return
 
-        raise AirflowException('Celery command failed on host: ' + get_hostname())
+        msg = f'Celery command failed on host: {get_hostname()} with celery_task_id {celery_task_id}'
+        raise AirflowException(msg)
 
     from airflow.sentry import Sentry
 
@@ -123,7 +123,7 @@ def _execute_in_fork(command_to_exec: CommandType, celery_task_id: Optional[str]
         args.func(args)
         ret = 0
     except Exception as e:
-        log.exception("Failed to execute task %s.", str(e))
+        log.exception("[%s] Failed to execute task %s.", celery_task_id, str(e))
         ret = 1
     finally:
         Sentry.flush()
@@ -138,9 +138,9 @@ def _execute_in_subprocess(command_to_exec: CommandType, celery_task_id: Optiona
     try:
         subprocess.check_output(command_to_exec, stderr=subprocess.STDOUT, close_fds=True, env=env)
     except subprocess.CalledProcessError as e:
-        log.exception('execute_command encountered a CalledProcessError')
+        log.exception('[%s] execute_command encountered a CalledProcessError', celery_task_id)
         log.error(e.output)
-        msg = 'Celery command failed on host: ' + get_hostname()
+        msg = f'Celery command failed on host: {get_hostname()} with celery_task_id {celery_task_id}'
         raise AirflowException(msg)
 
 

--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -107,6 +107,7 @@ Name                                        Description
 ``dag.callback_exceptions``                 Number of exceptions raised from DAG callbacks. When this happens, it
                                             means DAG callback is not working.
 ``celery.task_timeout_error``               Number of ``AirflowTaskTimeout`` errors raised when publishing Task to Celery Broker.
+``celery.execute_command.failure``          Number of non-zero exit code from Celery task.
 ``task_removed_from_dag.<dag_id>``          Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
 ``task_restored_to_dag.<dag_id>``           Number of tasks restored for a given dag (i.e. task instance which was
                                             previously in REMOVED state in the DB is added to DAG file)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This metric can quickly tell the infra if there are non-zero exit codes while running celery tasks, especially failures happening before airflow process starts or dag file parsing failure on some bad hosts.

Also logging the `celery_task_id` along with the log message can help the infra to coordinate log messages more easily. This is helpful when the celery concurrency is high.

for example:

![image](https://user-images.githubusercontent.com/8662365/154168204-46afa83c-81f1-403f-8bd2-cab3601eb53f.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
