### PR TITLE
[ISSUE-21603]  Reenabled passing cmd configuration

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -92,7 +92,7 @@ class BaseTaskRunner(LoggingMixin):
             # we are running as the same user, and can pass through environment
             # variables then we don't need to include those in the config copy
             # - the runner can read/execute those values as it needs
-            cfg_path = tmp_configuration_copy(chmod=0o600, include_env=False, include_cmds=False)
+            cfg_path = tmp_configuration_copy(chmod=0o600, include_env=False)
 
         self._cfg_path = cfg_path
         self._command = (


### PR DESCRIPTION
## Problem?

Not including `_cmd` configuration options broke configuration for
`sql_alchemy_conn_cmd` and `fernet_key_cmd` which caused all tasks to
fail with a mysterious sqlite error.

## Solution!

Reenabled including `_cmd` configuration values when creating the
temporary configuration used to run tasks.
