### PR TITLE
Run mapped tasks via the normal Scheduler

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -679,6 +679,9 @@ class DagRun(Base, LoggingMixin):
 
                         assert isinstance(schedulable.task, MappedOperator)
                         new_tis = schedulable.task.expand_mapped_task(upstream, session=session)
+                        if schedulable.state == TaskInstanceState.SKIPPED:
+                            # Task is now skipped (likely cos upstream returned 0 tasks
+                            continue
                         assert new_tis[0] is schedulable
                         expanded_tis.extend(new_tis[1:])
                         break

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -495,7 +495,9 @@ class MappedOperator(AbstractOperator):
             ti = TaskInstance(self, run_id=upstream_ti.run_id, map_index=index, state=state)  # type: ignore
             self.log.debug("Expanding TIs upserted %s", ti)
             task_instance_mutation_hook(ti)
-            ret.append(session.merge(ti))
+            ti = session.merge(ti)
+            ti.task = self
+            ret.append(ti)
 
         # Set to "REMOVED" any (old) TaskInstances with map indices greater
         # than the current map value

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3600,6 +3600,9 @@ class TestSchedulerJob:
 
         This needs a DagRun to be pre-created (it can be in running or queued state) as no more will be
         created as we turn off creating new DagRuns via setting USE_JOB_SCHEDULE to false
+
+        Note: This doesn't currently account for tasks that go into retry -- the scheduler would be detected
+        as idle in that circumstance
         """
         # Spy on _do_scheduling and _process_executor_events so we can notice
         # if nothing happened, and abort early! Given we are using


### PR DESCRIPTION
The last remaining step to get (simple) Mapped tasks running in the scheduler was to expand the unmapped TIs when necessary. The interface of `MappedOperator.expand_mapped_task` is not right, and will be changed shortly, but this is enough to get work on the UI and APIs unblocked.

Since there are a lot of moving parts in mapped tasks I have created the tests as "integration"/"end-to-end" tests rather than pure unit tests, and marked them as long_running (even if they only take sub 20s right now.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).