### PR TITLE
Change the default auth backend to session

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -145,6 +145,10 @@ Previously, only one backend was used to authorize use of the REST API. In 2.3 t
 
 This setting is also used for the deprecated experimental API, which only uses the first option even if multiple are given.
 
+### `auth_backends` includes session
+
+To allow the Airflow UI to use the API, the previous default authorization backend `airflow.api.auth.backend.deny_all` is changed to `airflow.api.auth.backend.session`, and this is automatically added to the list of API authorization backends if a non-default value is set.
+
 ## Airflow 2.2.4
 
 ### Smart sensors deprecated

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -810,7 +810,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "airflow.api.auth.backend.deny_all"
+      default: "airflow.api.auth.backend.session"
     - name: maximum_page_limit
       description: |
         Used to set the maximum page limit for API requests

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -438,7 +438,7 @@ enable_experimental_api = False
 # How to authenticate users of the API. See
 # https://airflow.apache.org/docs/apache-airflow/stable/security.html for possible values.
 # ("airflow.api.auth.backend.default" allows all requests for historic reasons)
-auth_backends = airflow.api.auth.backend.deny_all
+auth_backends = airflow.api.auth.backend.session
 
 # Used to set the maximum page limit for API requests
 maximum_page_limit = 100

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -354,7 +354,7 @@ class AirflowConfigParser(ConfigParser):
     def _update_env_var(self, section, name, new_value):
         env_var = self._env_var_name(section, name)
         # If the config comes from environment, set it there so that any subprocesses keep the same override!
-        if os.environ.get(env_var):
+        if env_var in os.environ:
             os.environ[env_var] = new_value
             return
         if not self.has_section(section):

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -352,10 +352,11 @@ class AirflowConfigParser(ConfigParser):
         return old.search(current_value) is not None
 
     def _update_env_var(self, section, name, new_value):
-        # Make sure the env var option is removed, otherwise it
-        # would be read and used instead of the value we set
         env_var = self._env_var_name(section, name)
-        os.environ.pop(env_var, None)
+        # If the config comes from environment, set it there so that any subprocesses keep the same override!
+        if os.environ.get(env_var):
+            os.environ[env_var] = new_value
+            return
         if not self.has_section(section):
             self.add_section(section)
         self.set(section, name, new_value)

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -303,12 +303,11 @@ class AirflowConfigParser(ConfigParser):
         elif old_value.find('airflow.api.auth.backend.session') == -1:
             new_value = old_value + "\nairflow.api.auth.backend.session"
             self._update_env_var(section="api", name="auth_backends", new_value=new_value)
-            self._create_future_warning(
-                name="auth_backends",
-                section="api",
-                current_value=old_value,
-                new_value=new_value,
-                version="3.0",
+            warnings.warn(
+                'The auth_backends setting in [api] has had airflow.api.auth.backend.session added '
+                'in the running config, which is needed by the UI. Please update your config before '
+                'Apache Airflow 3.0.',
+                FutureWarning,
             )
 
     def _validate_enums(self):

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -59,6 +59,12 @@ The default Airflow image that is used with the Chart is now ``2.2.3``, previous
 
 The old parameter names will continue to work, however support for them will be removed in a future release so please update your values file.
 
+Removed ``config.api``
+""""""""""""""""""""""
+
+This section configured the authentication backend for the Airflow API but used the same values as the Airflow default setting, which made it unnecessary to
+declare the same again.
+
 Fixed precedence of ``nodeSelector``, ``affinity`` and ``tolerations`` params
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1419,7 +1419,7 @@ config:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
   # Authentication backend used for the experimental API
   api:
-    auth_backends: airflow.api.auth.backend.deny_all
+    auth_backends: airflow.api.auth.backend.session
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1417,9 +1417,6 @@ config:
     # For Airflow 1.10, backward compatibility; moved to [logging] in 2.0
     colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
-  # Authentication backend used for the experimental API
-  api:
-    auth_backends: airflow.api.auth.backend.session
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -22,12 +22,12 @@ API Authentication
 ------------------
 
 Authentication for the API is handled separately to the Web Authentication. The default is to
-deny all requests:
+check the user session:
 
 .. code-block:: ini
 
     [api]
-    auth_backends = airflow.api.auth.backend.deny_all
+    auth_backends = airflow.api.auth.backend.session
 
 .. versionchanged:: 1.10.11
 


### PR DESCRIPTION
As part of AIP-42, change the default auth backend to validate using the session, so that the UI can use the API. If `auth_backends` has been set to a non-default value, include the session in the list of backends.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
