### PR TITLE
Implement mapped value unpacking

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -224,7 +224,6 @@ RAW_TASK_UNSUPPORTED_OPTION = [
 
 def _run_raw_task(args, ti: TaskInstance) -> None:
     """Runs the main task handling code"""
-    ti.task = ti.task.unmap()
     ti._run_raw_task(
         mark_success=args.mark_success,
         job_id=args.job_id,
@@ -530,7 +529,6 @@ def task_render(args):
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
     ti = _get_ti(task, args.execution_date_or_run_id, args.map_index, create_if_necessary=True)
-    ti.task = ti.task.unmap()
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -17,9 +17,9 @@
 
 import functools
 import inspect
-import itertools
 import re
 import sys
+import unittest.mock
 from typing import (
     Any,
     Callable,
@@ -45,13 +45,14 @@ from airflow.exceptions import AirflowException
 from airflow.models.abstractoperator import DEFAULT_RETRIES, DEFAULT_RETRY_DELAY
 from airflow.models.baseoperator import BaseOperator, coerce_resources, coerce_retry_delay, parse_retries
 from airflow.models.dag import DAG, DagContext
-from airflow.models.mappedoperator import MappedOperator
+from airflow.models.mappedoperator import MAPPABLE_TYPES, MapArgument, MappedOperator
 from airflow.models.pool import Pool
 from airflow.models.xcom_arg import XComArg
 from airflow.typing_compat import Protocol
 from airflow.utils import timezone
 from airflow.utils.context import Context
 from airflow.utils.task_group import TaskGroup, TaskGroupContext
+from airflow.utils.types import NOTSET
 
 
 def validate_python_callable(python_callable: Any) -> None:
@@ -269,22 +270,22 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             op.doc_md = self.function.__doc__
         return XComArg(op)
 
-    def _validate_arg_names(self, funcname: str, kwargs: Dict[str, Any], valid_names: Set[str] = set()):
-        unknown_args = kwargs.copy()
-        for name in itertools.chain(self.function_arg_names, valid_names):
-            unknown_args.pop(name, None)
+    def _validate_arg_names(self, funcname: str, kwargs: Dict[str, Any]):
+        kwargs_left = kwargs.copy()
+        for arg_name in self.function_arg_names:
+            value = kwargs_left.pop(arg_name, NOTSET)
+            if value is NOTSET or isinstance(value, MAPPABLE_TYPES):
+                continue
+            type_name = type(value).__name__
+            raise ValueError(f"{funcname} got unexpected type {type_name!r} for keyword argument {arg_name}")
 
-            if not unknown_args:
-                # If we have no args left ot check, we are valid
-                return
+        if len(kwargs_left) == 1:
+            raise TypeError(f"{funcname} got unexpected keyword argument {next(iter(kwargs_left))!r}")
+        elif kwargs_left:
+            names = ", ".join(repr(n) for n in kwargs_left)
+            raise TypeError(f"{funcname} got unexpected keyword arguments {names}")
 
-        if len(unknown_args) == 1:
-            raise TypeError(f'{funcname} got unexpected keyword argument {next(iter(unknown_args))!r}')
-        else:
-            names = ", ".join(repr(n) for n in unknown_args)
-            raise TypeError(f'{funcname} got unexpected keyword arguments {names}')
-
-    def map(self, **kwargs) -> XComArg:
+    def map(self, **kwargs: MapArgument) -> XComArg:
         self._validate_arg_names("map", kwargs)
 
         partial_kwargs = self.kwargs.copy()
@@ -293,7 +294,6 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         task_group = partial_kwargs.pop("task_group", TaskGroupContext.get_current_task_group(dag))
         task_id = get_unique_task_id(partial_kwargs.pop("task_id"), dag, task_group)
         params = partial_kwargs.pop("params", None)
-        partial_op_kwargs = partial_kwargs.pop("op_kwargs", {})
 
         # Logic here should be kept in sync with BaseOperatorMeta.partial().
         if "task_concurrency" in partial_kwargs:
@@ -311,12 +311,13 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         partial_kwargs["resources"] = coerce_resources(partial_kwargs.get("resources"))
         partial_kwargs.setdefault("executor_config", {})
         partial_kwargs.setdefault("op_args", [])
+        partial_kwargs.setdefault("op_kwargs", {})
 
         # Mypy does not work well with a subclassed attrs class :(
         _MappedOperator = cast(Any, DecoratedMappedOperator)
         operator = _MappedOperator(
             operator_class=self.operator_class,
-            mapped_kwargs={"op_kwargs": kwargs},
+            mapped_kwargs={},
             partial_kwargs=partial_kwargs,
             task_id=task_id,
             params=params,
@@ -335,7 +336,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             end_date=end_date,
             multiple_outputs=self.multiple_outputs,
             python_callable=self.function,
-            partial_op_kwargs=partial_op_kwargs,
+            mapped_op_kwargs=kwargs,
         )
         return XComArg(operator=operator)
 
@@ -348,12 +349,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         return attr.evolve(self, kwargs={**self.kwargs, "op_kwargs": op_kwargs})
 
 
-def _merge_kwargs(
-    kwargs1: Dict[str, XComArg],
-    kwargs2: Dict[str, XComArg],
-    *,
-    fail_reason: str,
-) -> Dict[str, XComArg]:
+def _merge_kwargs(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail_reason: str) -> Dict[str, Any]:
     duplicated_keys = set(kwargs1).intersection(kwargs2)
     if len(duplicated_keys) == 1:
         raise TypeError(f"{fail_reason} argument: {duplicated_keys.pop()}")
@@ -370,9 +366,9 @@ class DecoratedMappedOperator(MappedOperator):
     multiple_outputs: bool
     python_callable: Callable
 
-    # We can't save these in partial_kwargs because op_kwargs need to be present
-    # in mapped_kwargs, and MappedOperator prevents duplication.
-    partial_op_kwargs: Dict[str, Any]
+    # We can't save these in mapped_kwargs because op_kwargs need to be present
+    # in partial_kwargs, and MappedOperator prevents duplication.
+    mapped_op_kwargs: Dict[str, MapArgument]
 
     @classmethod
     @cache
@@ -380,21 +376,27 @@ class DecoratedMappedOperator(MappedOperator):
         # The magic argument-less super() does not work well with @cache
         # (actually lru_cache in general), so we use the explicit form instead.
         sup = super(DecoratedMappedOperator, DecoratedMappedOperator)
-        return sup.get_serialized_fields() | {"partial_op_kwargs"}
+        return sup.get_serialized_fields() | {"mapped_op_kwargs"}
 
-    def _create_unmapped_operator(
-        self,
-        *,
-        mapped_kwargs: Dict[str, Any],
-        partial_kwargs: Dict[str, Any],
-        real: bool,
-    ) -> "BaseOperator":
+    def _get_expansion_kwargs(self) -> Dict[str, MapArgument]:
+        """The kwargs to calculate expansion length against.
+
+        Different from classic operators, a decorated (taskflow) operator's
+        ``map()`` contributes to the ``op_kwargs`` operator argument (not the
+        operator arguments themselves), and should therefore expand against it.
+        """
+        return self.mapped_op_kwargs
+
+    def _create_unmapped_operator(self, *, mapped_kwargs: Dict[str, Any], real: bool) -> "BaseOperator":
         assert not isinstance(self.operator_class, str)
-        mapped_kwargs = mapped_kwargs.copy()
-        del mapped_kwargs["op_kwargs"]
+        partial_kwargs = self.partial_kwargs.copy()
+        if real:
+            mapped_op_kwargs: Dict[str, Any] = self.mapped_op_kwargs
+        else:
+            mapped_op_kwargs = {k: unittest.mock.MagicMock(name=k) for k in self.mapped_op_kwargs}
         op_kwargs = _merge_kwargs(
-            self.partial_op_kwargs,
-            self.mapped_kwargs["op_kwargs"],  # We want to "original" op_kwargs.
+            partial_kwargs.pop("op_kwargs"),
+            mapped_op_kwargs,
             fail_reason="mapping already partial",
         )
         return self.operator_class(
@@ -425,7 +427,7 @@ class Task(Generic[Function]):
 
     function: Function
 
-    def map(self, **kwargs: Any) -> XComArg:
+    def map(self, **kwargs: MapArgument) -> XComArg:
         ...
 
     def partial(self, **kwargs: Any) -> "Task[Function]":

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -20,7 +20,6 @@ import functools
 import inspect
 import re
 import sys
-import unittest.mock
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -48,7 +47,12 @@ from airflow.exceptions import AirflowException
 from airflow.models.abstractoperator import DEFAULT_RETRIES, DEFAULT_RETRY_DELAY
 from airflow.models.baseoperator import BaseOperator, coerce_resources, coerce_retry_delay, parse_retries
 from airflow.models.dag import DAG, DagContext
-from airflow.models.mappedoperator import MappedOperator, ValidationSource, get_mappable_types
+from airflow.models.mappedoperator import (
+    MappedOperator,
+    ValidationSource,
+    create_mocked_kwargs,
+    get_mappable_types,
+)
 from airflow.models.pool import Pool
 from airflow.models.xcom_arg import XComArg
 from airflow.typing_compat import Protocol
@@ -404,7 +408,7 @@ class DecoratedMappedOperator(MappedOperator):
         if real:
             mapped_op_kwargs: Dict[str, Any] = self.mapped_op_kwargs
         else:
-            mapped_op_kwargs = {k: unittest.mock.MagicMock(name=k) for k in self.mapped_op_kwargs}
+            mapped_op_kwargs = create_mocked_kwargs(self.mapped_op_kwargs)
         op_kwargs = _merge_kwargs(
             partial_kwargs.pop("op_kwargs"),
             mapped_op_kwargs,

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -310,12 +310,13 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         )
         partial_kwargs["resources"] = coerce_resources(partial_kwargs.get("resources"))
         partial_kwargs.setdefault("executor_config", {})
+        partial_kwargs.setdefault("op_args", [])
 
         # Mypy does not work well with a subclassed attrs class :(
         _MappedOperator = cast(Any, DecoratedMappedOperator)
         operator = _MappedOperator(
             operator_class=self.operator_class,
-            mapped_kwargs={"op_args": [], "op_kwargs": kwargs},
+            mapped_kwargs={"op_kwargs": kwargs},
             partial_kwargs=partial_kwargs,
             task_id=task_id,
             params=params,
@@ -369,8 +370,8 @@ class DecoratedMappedOperator(MappedOperator):
     multiple_outputs: bool
     python_callable: Callable
 
-    # We can't save these in partial_kwargs because op_args and op_kwargs need
-    # to be present in mapped_kwargs, and MappedOperator prevents duplication.
+    # We can't save these in partial_kwargs because op_kwargs need to be present
+    # in mapped_kwargs, and MappedOperator prevents duplication.
     partial_op_kwargs: Dict[str, Any]
 
     @classmethod

--- a/airflow/executors/debug_executor.py
+++ b/airflow/executors/debug_executor.py
@@ -76,7 +76,6 @@ class DebugExecutor(BaseExecutor):
         key = ti.key
         try:
             params = self.tasks_params.pop(ti.key, {})
-            ti.task = ti.task.unmap()
             ti._run_raw_task(job_id=ti.job_id, **params)
             self.change_state(key, State.SUCCESS)
             ti._run_finished_callback()

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -265,7 +265,7 @@ class BackfillJob(BaseJob):
             if ti.state not in self.STATES_COUNT_AS_RUNNING:
                 for node in ti.task.mapped_dependants():
                     assert isinstance(node, MappedOperator)
-                    yield node, ti.run_id, node.expand_mapped_task(ti, session)
+                    yield node, ti.run_id, node.expand_mapped_task(ti.run_id, session=session)
 
     @provide_session
     def _get_dag_run(self, dagrun_info: DagRunInfo, dag: DAG, session: Session = None):

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -254,6 +254,22 @@ class AbstractOperator(LoggingMixin, DAGNode):
             return self.global_operator_extra_link_dict[link_name].get_link(self, dttm)
         return None
 
+    def render_template_fields(
+        self,
+        context: Context,
+        jinja_env: Optional["jinja2.Environment"] = None,
+    ) -> Optional["BaseOperator"]:
+        """Template all attributes listed in template_fields.
+
+        If the operator is mapped, this should return the unmapped, fully
+        rendered, and map-expanded operator. The mapped operator should not be
+        modified.
+
+        If the operator is not mapped, this should modify the operator in-place
+        and return either *None* (for backwards compatibility) or *self*.
+        """
+        raise NotImplementedError()
+
     @provide_session
     def _do_render_template_fields(
         self,

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -283,17 +283,17 @@ class AbstractOperator(LoggingMixin, DAGNode):
     ) -> None:
         for attr_name in template_fields:
             try:
-                content = getattr(parent, attr_name)
+                value = getattr(parent, attr_name)
             except AttributeError:
                 raise AttributeError(
                     f"{attr_name!r} is configured as a template field "
                     f"but {parent.task_type} does not have this attribute."
                 )
-            if not content:
+            if not value:
                 continue
             rendered_content = self._render_template_field(
                 attr_name,
-                content,
+                value,
                 context,
                 jinja_env,
                 seen_oids,
@@ -304,7 +304,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def _render_template_field(
         self,
         key: str,
-        content: Any,
+        value: Any,
         context: Context,
         jinja_env: Optional["jinja2.Environment"] = None,
         seen_oids: Optional[Set] = None,
@@ -312,7 +312,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
         session: Session,
     ) -> Any:
         """Override point for MappedOperator to perform further resolution."""
-        return self.render_template(content, context, jinja_env, seen_oids)
+        return self.render_template(value, context, jinja_env, seen_oids)
 
     def render_template(
         self,
@@ -335,58 +335,62 @@ class AbstractOperator(LoggingMixin, DAGNode):
             *RecursionError* on circular dependencies)
         :return: Templated content
         """
+        # "content" is a bad name, but we're stuck to it being public API.
+        value = content
+        del content
+
         if not jinja_env:
             jinja_env = self.get_template_env()
 
         from airflow.models.param import DagParam
         from airflow.models.xcom_arg import XComArg
 
-        if isinstance(content, str):
-            if any(content.endswith(ext) for ext in self.template_ext):  # Content contains a filepath.
-                template = jinja_env.get_template(content)
+        if isinstance(value, str):
+            if any(value.endswith(ext) for ext in self.template_ext):  # A filepath.
+                template = jinja_env.get_template(value)
             else:
-                template = jinja_env.from_string(content)
+                template = jinja_env.from_string(value)
             dag = self.get_dag()
             if dag and dag.render_template_as_native_obj:
                 return render_template_as_native(template, context)
             return render_template_to_string(template, context)
 
-        if isinstance(content, (DagParam, XComArg)):
-            return content.resolve(context)
+        if isinstance(value, (DagParam, XComArg)):
+            return value.resolve(context)
 
         # Fast path for common built-in collections.
-        if content.__class__ is tuple:
-            return tuple(self.render_template(element, context, jinja_env) for element in content)
-        elif isinstance(content, tuple):  # Special case for named tuples.
-            return content.__class__(*(self.render_template(el, context, jinja_env) for el in content))
-        elif isinstance(content, list):
-            return [self.render_template(element, context, jinja_env) for element in content]
-        elif isinstance(content, dict):
-            return {key: self.render_template(value, context, jinja_env) for key, value in content.items()}
-        elif isinstance(content, set):
-            return {self.render_template(element, context, jinja_env) for element in content}
+        if value.__class__ is tuple:
+            return tuple(self.render_template(element, context, jinja_env) for element in value)
+        elif isinstance(value, tuple):  # Special case for named tuples.
+            return value.__class__(*(self.render_template(el, context, jinja_env) for el in value))
+        elif isinstance(value, list):
+            return [self.render_template(element, context, jinja_env) for element in value]
+        elif isinstance(value, dict):
+            return {key: self.render_template(value, context, jinja_env) for key, value in value.items()}
+        elif isinstance(value, set):
+            return {self.render_template(element, context, jinja_env) for element in value}
 
         # More complex collections.
         if seen_oids is None:
             oids = set()
         else:
             oids = seen_oids
-        self._render_nested_template_fields(content, context, jinja_env, oids)
-        return content
+        self._render_nested_template_fields(value, context, jinja_env, oids)
+        return value
 
     def _render_nested_template_fields(
         self,
-        content: Any,
+        value: Any,
         context: Context,
         jinja_env: "jinja2.Environment",
         seen_oids: Set[int],
     ) -> None:
-        if id(content) in seen_oids:
+        if id(value) in seen_oids:
             return
-        seen_oids.add(id(content))
+        seen_oids.add(id(value))
         try:
-            nested_template_fields = content.template_fields
+            nested_template_fields = value.template_fields
         except AttributeError:
             # content has no inner template fields
             return
-        self._do_render_template_fields(content, nested_template_fields, context, jinja_env, seen_oids)
+        self._do_render_template_fields(value, nested_template_fields, context, jinja_env, seen_oids)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -83,7 +83,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.triggers.base import BaseTrigger
 from airflow.utils import timezone
 from airflow.utils.context import Context
-from airflow.utils.helpers import render_template_as_native, render_template_to_string, validate_key
+from airflow.utils.helpers import validate_key
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.trigger_rule import TriggerRule
@@ -1151,7 +1151,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     def render_template_fields(
         self, context: Context, jinja_env: Optional["jinja2.Environment"] = None
-    ) -> None:
+    ) -> "BaseOperator":
         """
         Template all attributes listed in template_fields. Note this operation is irreversible.
 
@@ -1160,103 +1160,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         """
         if not jinja_env:
             jinja_env = self.get_template_env()
-
         self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())
-
-    def _do_render_template_fields(
-        self,
-        parent: Any,
-        template_fields: Iterable[str],
-        context: Context,
-        jinja_env: "jinja2.Environment",
-        seen_oids: Set,
-    ) -> None:
-        for attr_name in template_fields:
-            try:
-                content = getattr(parent, attr_name)
-            except AttributeError:
-                raise AttributeError(
-                    f"{attr_name!r} is configured as a template field "
-                    f"but {parent.task_type} does not have this attribute."
-                )
-
-            if content:
-                rendered_content = self.render_template(content, context, jinja_env, seen_oids)
-                setattr(parent, attr_name, rendered_content)
-
-    def render_template(
-        self,
-        content: Any,
-        context: Context,
-        jinja_env: Optional["jinja2.Environment"] = None,
-        seen_oids: Optional[Set] = None,
-    ) -> Any:
-        """
-        Render a templated string. The content can be a collection holding multiple templated strings and will
-        be templated recursively.
-
-        :param content: Content to template. Only strings can be templated (may be inside collection).
-        :param context: Dict with values to apply on templated content
-        :param jinja_env: Jinja environment. Can be provided to avoid re-creating Jinja environments during
-            recursion.
-        :param seen_oids: template fields already rendered (to avoid RecursionError on circular dependencies)
-        :return: Templated content
-        """
-        if not jinja_env:
-            jinja_env = self.get_template_env()
-
-        # Imported here to avoid circular dependency
-        from airflow.models.param import DagParam
-        from airflow.models.xcom_arg import XComArg
-
-        if isinstance(content, str):
-            if any(content.endswith(ext) for ext in self.template_ext):  # Content contains a filepath.
-                template = jinja_env.get_template(content)
-            else:
-                template = jinja_env.from_string(content)
-            if self.has_dag() and self.dag.render_template_as_native_obj:
-                return render_template_as_native(template, context)
-            return render_template_to_string(template, context)
-
-        elif isinstance(content, (XComArg, DagParam)):
-            return content.resolve(context)
-
-        if isinstance(content, tuple):
-            if type(content) is not tuple:
-                # Special case for named tuples
-                return content.__class__(
-                    *(self.render_template(element, context, jinja_env) for element in content)
-                )
-            else:
-                return tuple(self.render_template(element, context, jinja_env) for element in content)
-
-        elif isinstance(content, list):
-            return [self.render_template(element, context, jinja_env) for element in content]
-
-        elif isinstance(content, dict):
-            return {key: self.render_template(value, context, jinja_env) for key, value in content.items()}
-
-        elif isinstance(content, set):
-            return {self.render_template(element, context, jinja_env) for element in content}
-
-        else:
-            if seen_oids is None:
-                seen_oids = set()
-            self._render_nested_template_fields(content, context, jinja_env, seen_oids)
-            return content
-
-    def _render_nested_template_fields(
-        self, content: Any, context: Context, jinja_env: "jinja2.Environment", seen_oids: Set
-    ) -> None:
-        if id(content) not in seen_oids:
-            seen_oids.add(id(content))
-            try:
-                nested_template_fields = content.template_fields
-            except AttributeError:
-                # content has no inner template fields
-                return
-
-            self._do_render_template_fields(content, nested_template_fields, context, jinja_env, seen_oids)
+        return self
 
     @provide_session
     def clear(

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1150,10 +1150,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self._log = logging.getLogger("airflow.task.operators")
 
     def render_template_fields(
-        self, context: Context, jinja_env: Optional["jinja2.Environment"] = None
-    ) -> "BaseOperator":
-        """
-        Template all attributes listed in template_fields. Note this operation is irreversible.
+        self,
+        context: Context,
+        jinja_env: Optional["jinja2.Environment"] = None,
+    ) -> Optional["BaseOperator"]:
+        """Template all attributes listed in template_fields.
+
+        This mutates the attributes in-place and is irreversible.
 
         :param context: Dict with values to apply on content
         :param jinja_env: Jinja environment

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -629,7 +629,3 @@ class MappedOperator(AbstractOperator):
             if i == found_index:
                 return k, v
         raise IndexError(f"index {map_index} is over mapped length")
-
-
-class _FieldNotMapped(Exception):
-    """Raised by _expand_mapped_field if a field is not mapped."""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -17,6 +17,9 @@
 # under the License.
 
 import datetime
+import functools
+import itertools
+import operator
 import unittest.mock
 import warnings
 from typing import (
@@ -60,33 +63,49 @@ from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.utils.operator_resources import Resources
-from airflow.utils.session import NEW_SESSION
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.trigger_rule import TriggerRule
+from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.models.dag import DAG
     from airflow.models.taskinstance import TaskInstance
 
+# BaseOperator.map() can be called on an XComArg, sequence, or dict (not any
+# mapping since we need the value to be ordered).
+MapArgument = Union[XComArg, Sequence, dict]
+
+# For isinstance() check.
+MAPPABLE_TYPES = (XComArg, dict, list)
+
 
 def validate_mapping_kwargs(op: Type["BaseOperator"], func: str, value: Dict[str, Any]) -> None:
     # use a dict so order of args is same as code order
     unknown_args = value.copy()
     for klass in op.mro():
-        init = klass.__init__  # type: ignore
+        init = klass.__init__  # type: ignore[misc]
         try:
             param_names = init._BaseOperatorMeta__param_names
         except AttributeError:
             continue
         for name in param_names:
-            unknown_args.pop(name, None)
+            value = unknown_args.pop(name, NOTSET)
+            if func != "map":
+                continue
+            if value is NOTSET:
+                continue
+            if isinstance(value, MAPPABLE_TYPES):
+                continue
+            type_name = type(value).__name__
+            error = f"{op.__name__}.map() got unexpected type {type_name!r} for keyword argument {name}"
+            raise ValueError(error)
         if not unknown_args:
             return  # If we have no args left ot check: stop looking at the MRO chian.
 
     if len(unknown_args) == 1:
-        error = f"unexpected keyword argument {unknown_args.popitem()[0]!r}"
+        error = f"an unexpected keyword argument {unknown_args.popitem()[0]!r}"
     else:
         names = ", ".join(repr(n) for n in unknown_args)
         error = f"unexpected keyword arguments {names}"
@@ -132,7 +151,7 @@ class OperatorPartial:
         if not self._map_called:
             warnings.warn(f"{self!r} was never mapped!")
 
-    def map(self, **mapped_kwargs) -> "MappedOperator":
+    def map(self, **mapped_kwargs: MapArgument) -> "MappedOperator":
         from airflow.operators.dummy import DummyOperator
 
         validate_mapping_kwargs(self.operator_class, "map", mapped_kwargs)
@@ -174,7 +193,7 @@ class MappedOperator(AbstractOperator):
     """Object representing a mapped operator in a DAG."""
 
     operator_class: Union[Type["BaseOperator"], str]
-    mapped_kwargs: Dict[str, Any]
+    mapped_kwargs: Dict[str, MapArgument]
     partial_kwargs: Dict[str, Any]
 
     # Needed for serialization.
@@ -245,11 +264,8 @@ class MappedOperator(AbstractOperator):
         """
         if isinstance(self.operator_class, str):
             return  # No need to validate deserialized operator.
-        operator = self._create_unmapped_operator(
-            mapped_kwargs={k: unittest.mock.MagicMock(name=k) for k in self.mapped_kwargs},
-            partial_kwargs=self.partial_kwargs,
-            real=False,
-        )
+        mocked_mapped_kwargs = {k: unittest.mock.MagicMock(name=k) for k in self.mapped_kwargs}
+        operator = self._create_unmapped_operator(mapped_kwargs=mocked_mapped_kwargs, real=False)
         if operator.task_group:
             operator.task_group._remove(operator)
         dag = operator.get_dag()
@@ -384,13 +400,16 @@ class MappedOperator(AbstractOperator):
         """Implementing DAGNode."""
         return DagAttributeTypes.OP, self.task_id
 
-    def _create_unmapped_operator(
-        self,
-        *,
-        mapped_kwargs: Dict[str, Any],
-        partial_kwargs: Dict[str, Any],
-        real: bool,
-    ) -> "BaseOperator":
+    def _create_unmapped_operator(self, *, mapped_kwargs: Dict[str, Any], real: bool) -> "BaseOperator":
+        """Create a task of the underlying class based on this mapped operator.
+
+        :param mapped_kwargs: Mapped keyword arguments to be used to create the
+            task. Do not use ``self.mapped_kwargs``.
+        :param real: Whether the task should be created "for real" (i.e. *False*
+            means the operator is only created for validation purposes and not
+            going to be added to the actual DAG). This is simply forwarded to
+            the operator's ``_airflow_map_validation`` argument.
+        """
         assert not isinstance(self.operator_class, str)
         return self.operator_class(
             task_id=self.task_id,
@@ -400,8 +419,8 @@ class MappedOperator(AbstractOperator):
             start_date=self.start_date,
             end_date=self.end_date,
             _airflow_map_validation=not real,
+            **self.partial_kwargs,
             **mapped_kwargs,
-            **partial_kwargs,
         )
 
     def unmap(self) -> "BaseOperator":
@@ -410,47 +429,44 @@ class MappedOperator(AbstractOperator):
         if not dag:
             raise RuntimeError("Cannot unmap a task without a DAG")
         dag._remove_task(self.task_id)
-        return self._create_unmapped_operator(
-            mapped_kwargs=self.mapped_kwargs,
-            partial_kwargs=self.partial_kwargs,
-            real=True,
-        )
+        return self._create_unmapped_operator(mapped_kwargs=self.mapped_kwargs, real=True)
 
-    def expand_mapped_task(
-        self,
-        upstream_ti: "TaskInstance",
-        session: Session = NEW_SESSION,
-    ) -> Sequence["TaskInstance"]:
+    def _get_expansion_kwargs(self) -> Dict[str, MapArgument]:
+        """The kwargs to calculate expansion length against.
+
+        This is ``self.mapped_kwargs`` for classic operators because kwargs to
+        ``BaseOperator.map()`` contribute to operator arguments.
+        """
+        return self.mapped_kwargs
+
+    def expand_mapped_task(self, run_id: str, *, session: Session) -> Sequence["TaskInstance"]:
         """Create the mapped task instances for mapped task.
 
         :return: The mapped task instances, in ascending order by map index.
         """
-        # TODO: support having multiuple mapped upstreams?
         from airflow.models.taskinstance import TaskInstance
         from airflow.models.taskmap import TaskMap
         from airflow.settings import task_instance_mutation_hook
 
-        task_map_info_length: Optional[int] = (
-            session.query(TaskMap.length)
-            .filter_by(
-                dag_id=upstream_ti.dag_id,
-                task_id=upstream_ti.task_id,
-                run_id=upstream_ti.run_id,
-                map_index=upstream_ti.map_index,
-            )
-            .scalar()
-        )
-        if task_map_info_length is None:
-            # TODO: What would lead to this? How can this be better handled?
-            raise RuntimeError("mapped operator cannot be expanded; upstream not found")
+        expansion_kwargs = self._get_expansion_kwargs()
 
-        state = None
+        literal_lengths = (len(v) for v in expansion_kwargs.values() if not isinstance(v, XComArg))
+        upstream_ids = [v.operator.task_id for v in expansion_kwargs.values() if isinstance(v, XComArg)]
+        upstream_length_query = session.query(TaskMap.length).filter(
+            TaskMap.dag_id == self.dag_id,
+            TaskMap.run_id == run_id,
+            TaskMap.task_id.in_(upstream_ids),
+        )
+        upstream_lengths = (r for r, in upstream_length_query)
+        total_length = functools.reduce(operator.mul, itertools.chain(literal_lengths, upstream_lengths))
+
+        state: Optional[TaskInstanceState] = None
         unmapped_ti: Optional[TaskInstance] = (
             session.query(TaskInstance)
             .filter(
-                TaskInstance.dag_id == upstream_ti.dag_id,
-                TaskInstance.run_id == upstream_ti.run_id,
+                TaskInstance.dag_id == self.dag_id,
                 TaskInstance.task_id == self.task_id,
+                TaskInstance.run_id == run_id,
                 TaskInstance.map_index == -1,
                 or_(TaskInstance.state.in_(State.unfinished), TaskInstance.state.is_(None)),
             )
@@ -462,10 +478,14 @@ class MappedOperator(AbstractOperator):
         if unmapped_ti:
             # The unmapped task instance still exists and is unfinished, i.e. we
             # haven't tried to run it before.
-            if task_map_info_length < 1:
+            if total_length < 1:
                 # If the upstream maps this to a zero-length value, simply marked the
                 # unmapped task instance as SKIPPED (if needed).
-                self.log.info("Marking %s as SKIPPED since the map has 0 values to expand", unmapped_ti)
+                self.log.info(
+                    "Marking %s as SKIPPED since the map has %d values to expand",
+                    unmapped_ti,
+                    total_length,
+                )
                 unmapped_ti.state = TaskInstanceState.SKIPPED
                 session.flush()
                 return ret
@@ -475,24 +495,24 @@ class MappedOperator(AbstractOperator):
             state = unmapped_ti.state
             self.log.debug("Updated in place to become %s", unmapped_ti)
             ret.append(unmapped_ti)
-            indexes_to_map = range(1, task_map_info_length)
+            indexes_to_map = range(1, total_length)
         else:
             # Only create "missing" ones.
             current_max_mapping = (
                 session.query(func.max(TaskInstance.map_index))
                 .filter(
-                    TaskInstance.dag_id == upstream_ti.dag_id,
+                    TaskInstance.dag_id == self.dag_id,
                     TaskInstance.task_id == self.task_id,
-                    TaskInstance.run_id == upstream_ti.run_id,
+                    TaskInstance.run_id == run_id,
                 )
                 .scalar()
             )
-            indexes_to_map = range(current_max_mapping + 1, task_map_info_length)
+            indexes_to_map = range(current_max_mapping + 1, total_length)
 
         for index in indexes_to_map:
             # TODO: Make more efficient with bulk_insert_mappings/bulk_save_mappings.
             # TODO: Change `TaskInstance` ctor to take Operator, not BaseOperator
-            ti = TaskInstance(self, run_id=upstream_ti.run_id, map_index=index, state=state)  # type: ignore
+            ti = TaskInstance(self, run_id=run_id, map_index=index, state=state)  # type: ignore
             self.log.debug("Expanding TIs upserted %s", ti)
             task_instance_mutation_hook(ti)
             ret.append(session.merge(ti))
@@ -500,10 +520,10 @@ class MappedOperator(AbstractOperator):
         # Set to "REMOVED" any (old) TaskInstances with map indices greater
         # than the current map value
         session.query(TaskInstance).filter(
-            TaskInstance.dag_id == upstream_ti.dag_id,
+            TaskInstance.dag_id == self.dag_id,
             TaskInstance.task_id == self.task_id,
-            TaskInstance.run_id == upstream_ti.run_id,
-            TaskInstance.map_index >= task_map_info_length,
+            TaskInstance.run_id == run_id,
+            TaskInstance.map_index >= total_length,
         ).update({TaskInstance.state: TaskInstanceState.REMOVED})
 
         session.flush()

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -587,7 +587,7 @@ class MappedOperator(AbstractOperator):
     def _render_template_field(
         self,
         key: str,
-        content: Any,
+        value: Any,
         context: Context,
         jinja_env: Optional["jinja2.Environment"] = None,
         seen_oids: Optional[Set] = None,
@@ -599,13 +599,13 @@ class MappedOperator(AbstractOperator):
         Specifically, if we're rendering a mapped argument, we need to "unmap"
         the value as well to assign it to the unmapped operator.
         """
-        content = super()._render_template_field(key, content, context, jinja_env, seen_oids, session=session)
-        return self._expand_mapped_field(key, content, context, session=session)
+        value = super()._render_template_field(key, value, context, jinja_env, seen_oids, session=session)
+        return self._expand_mapped_field(key, value, context, session=session)
 
-    def _expand_mapped_field(self, key: str, content: Any, context: Context, *, session: Session) -> Any:
+    def _expand_mapped_field(self, key: str, value: Any, context: Context, *, session: Session) -> Any:
         map_index = context["ti"].map_index
         if map_index < 0:
-            return content
+            return value
         expansion_kwargs = self._get_expansion_kwargs()
         all_lengths = self._get_map_lengths(context["run_id"], session=session)
 
@@ -620,12 +620,12 @@ class MappedOperator(AbstractOperator):
 
         found_index = _find_index_for_this_field(map_index)
         if found_index < 0:
-            return content
-        if isinstance(content, collections.abc.Sequence):
-            return content[found_index]
-        if not isinstance(content, dict):
-            raise TypeError(f"can't map over value of type {type(content)}")
-        for i, (k, v) in enumerate(content.items()):
+            return value
+        if isinstance(value, collections.abc.Sequence):
+            return value[found_index]
+        if not isinstance(value, dict):
+            raise TypeError(f"can't map over value of type {type(value)}")
+        for i, (k, v) in enumerate(value.items()):
             if i == found_index:
                 return k, v
         raise IndexError(f"index {map_index} is over mapped length")

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -298,8 +298,6 @@ class MappedOperator(AbstractOperator):
             return  # No need to validate deserialized operator.
         mocked_mapped_kwargs = create_mocked_kwargs(self.mapped_kwargs)
         op = self._create_unmapped_operator(mapped_kwargs=mocked_mapped_kwargs, real=False)
-        if op.task_group:
-            op.task_group._remove(op)
         dag = op.get_dag()
         if dag:
             dag._remove_task(op.task_id)

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -562,7 +562,7 @@ class MappedOperator(AbstractOperator):
         self,
         context: Context,
         jinja_env: Optional["jinja2.Environment"] = None,
-    ) -> "BaseOperator":
+    ) -> Optional["BaseOperator"]:
         """Template all attributes listed in template_fields.
 
         Different from the BaseOperator implementation, this renders the

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -47,11 +47,11 @@ class RenderedTaskInstanceFields(Base):
     def __init__(self, ti: TaskInstance, render_templates=True):
         self.dag_id = ti.dag_id
         self.task_id = ti.task_id
-        self.task = ti.task
         self.execution_date = ti.execution_date
         self.ti = ti
         if render_templates:
             ti.render_templates()
+        self.task = ti.task
         if os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", None):
             self.k8s_pod_yaml = ti.render_k8s_pod_yaml()
         self.rendered_fields = {

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -122,7 +122,6 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
@@ -1651,6 +1650,8 @@ class TaskInstance(Base, LoggingMixin):
 
     def dry_run(self):
         """Only Renders Templates for the TI"""
+        from airflow.models.baseoperator import BaseOperator
+
         self.task = self.task.prepare_for_execution()
         self.render_templates()
         assert isinstance(self.task, BaseOperator)  # For Mypy.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -122,6 +122,7 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
@@ -1311,14 +1312,8 @@ class TaskInstance(Base, LoggingMixin):
         :param pool: specifies the pool to use to run the task instance
         :param session: SQLAlchemy ORM Session
         """
-        if self.task.is_mapped:
-            raise RuntimeError(
-                f'task property of {self.task_id!r} was still a MappedOperator -- it should have been '
-                'expanded already!'
-            )
-        task = self.task.unmap()
         self.test_mode = test_mode
-        self.refresh_from_task(task, pool_override=pool)
+        self.refresh_from_task(self.task, pool_override=pool)
         self.refresh_from_db(session=session)
         self.job_id = job_id
         self.hostname = get_hostname()
@@ -1330,7 +1325,7 @@ class TaskInstance(Base, LoggingMixin):
         Stats.incr(f'ti.start.{self.task.dag_id}.{self.task.task_id}')
         try:
             if not mark_success:
-                self.task = task.prepare_for_execution()
+                self.task = self.task.prepare_for_execution()
                 context = self.get_template_context(ignore_param_exceptions=False)
                 self._execute_task_with_callbacks(context)
             if not test_mode:
@@ -1393,7 +1388,7 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
             raise
         finally:
-            Stats.incr(f'ti.finish.{task.dag_id}.{task.task_id}.{self.state}')
+            Stats.incr(f'ti.finish.{self.dag_id}.{self.task_id}.{self.state}')
 
         # Recording SKIPPED or SUCCESS
         self.clear_next_method_args()
@@ -1656,11 +1651,10 @@ class TaskInstance(Base, LoggingMixin):
 
     def dry_run(self):
         """Only Renders Templates for the TI"""
-        task_copy = self.task.unmap().prepare_for_execution()
-        self.task = task_copy
-
+        self.task = self.task.prepare_for_execution()
         self.render_templates()
-        task_copy.dry_run()
+        assert isinstance(self.task, BaseOperator)  # For Mypy.
+        self.task.dry_run()
 
     @provide_session
     def _handle_reschedule(
@@ -1985,24 +1979,25 @@ class TaskInstance(Base, LoggingMixin):
         return Context(context)  # type: ignore
 
     @provide_session
-    def get_rendered_template_fields(self, session=NEW_SESSION):
+    def get_rendered_template_fields(self, session: Session = NEW_SESSION) -> None:
         """Fetch rendered template fields from DB"""
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
         rendered_task_instance_fields = RenderedTaskInstanceFields.get_templated_fields(self, session=session)
         if rendered_task_instance_fields:
+            task = self.task.unmap()
             for field_name, rendered_value in rendered_task_instance_fields.items():
                 setattr(self.task, field_name, rendered_value)
-        else:
-            try:
-                self.render_templates()
-            except (TemplateAssertionError, UndefinedError) as e:
-                raise AirflowException(
-                    "Webserver does not have access to User-defined Macros or Filters "
-                    "when Dag Serialization is enabled. Hence for the task that have not yet "
-                    "started running, please use 'airflow tasks render' for debugging the "
-                    "rendering of template_fields."
-                ) from e
+            self.task = task
+        try:
+            self.render_templates()
+        except (TemplateAssertionError, UndefinedError) as e:
+            raise AirflowException(
+                "Webserver does not have access to User-defined Macros or Filters "
+                "when Dag Serialization is enabled. Hence for the task that have not yet "
+                "started running, please use 'airflow tasks render' for debugging the "
+                "rendering of template_fields."
+            ) from e
 
     @provide_session
     def get_rendered_k8s_spec(self, session=NEW_SESSION):
@@ -2024,15 +2019,14 @@ class TaskInstance(Base, LoggingMixin):
             params.update(dag_run.conf)
 
     def render_templates(self, context: Optional[Context] = None) -> None:
-        """Render templates in the operator fields."""
-        if self.task.is_mapped:
-            raise RuntimeError(
-                f'task property of {self.task_id!r} was still a MappedOperator -- it should have been '
-                'expanded already!'
-            )
+        """Render templates in the operator fields.
+
+        If the task was originally mapped, this may replace ``self.task`` with
+        the unmapped, fully rendered BaseOperator.
+        """
         if not context:
             context = self.get_template_context()
-        self.task.unmap().render_template_fields(context)
+        self.task = self.task.render_template_fields(context)
 
     def render_k8s_pod_yaml(self) -> Optional[dict]:
         """Render k8s pod yaml"""

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2027,7 +2027,9 @@ class TaskInstance(Base, LoggingMixin):
         """
         if not context:
             context = self.get_template_context()
-        self.task = self.task.render_template_fields(context)
+        task = self.task.render_template_fields(context)
+        if task is not None:
+            self.task = task
 
     def render_k8s_pod_yaml(self) -> Optional[dict]:
         """Render k8s pod yaml"""

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -597,9 +597,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             assert op_kwargs[Encoding.TYPE] == DAT.DICT
             serialized_op["partial_kwargs"]["op_kwargs"] = op_kwargs[Encoding.VAR]
         with contextlib.suppress(KeyError):
-            op_kwargs = serialized_op["partial_op_kwargs"]
+            op_kwargs = serialized_op["mapped_op_kwargs"]
             assert op_kwargs[Encoding.TYPE] == DAT.DICT
-            serialized_op["partial_op_kwargs"] = op_kwargs[Encoding.VAR]
+            serialized_op["mapped_op_kwargs"] = op_kwargs[Encoding.VAR]
 
         serialized_op["_is_mapped"] = True
         return serialized_op
@@ -758,7 +758,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = {arg: cls._deserialize(value) for arg, value in v.items()}
                 if op_kwargs is not None:
                     v["op_kwargs"] = op_kwargs
-            elif k == "partial_op_kwargs":
+            elif k == "mapped_op_kwargs":
                 v = {arg: cls._deserialize(value) for arg, value in v.items()}
             elif k in cls._decorated_fields or k not in op.get_serialized_fields():
                 v = cls._deserialize(v)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1207,7 +1207,7 @@ class Airflow(AirflowBaseView):
         logging.info("Retrieving rendered templates.")
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
-        task = copy.copy(dag.get_task(task_id).unmap())
+        task = dag.get_task(task_id).prepare_for_execution()
 
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this
@@ -1230,6 +1230,8 @@ class Airflow(AirflowBaseView):
             flash(msg, "error")
         except Exception as e:
             flash("Error rendering template: " + str(e), "error")
+        else:
+            task = ti.task
 
         title = "Rendered Template"
         html_dict = {}

--- a/tests/dags/test_mapped_classic.py
+++ b/tests/dags/test_mapped_classic.py
@@ -22,13 +22,13 @@ from airflow.utils.dates import days_ago
 
 
 @task
-def make_list():
-    return [1, 2, {'a': 'b'}]
+def make_arg_lists():
+    return [[1], [2], [{'a': 'b'}]]
 
 
-def consumer(*args):
-    print(repr(args))
+def consumer(value):
+    print(repr(value))
 
 
 with DAG(dag_id='test_mapped_classic', start_date=days_ago(2)) as dag:
-    PythonOperator.partial(task_id='consumer', python_callable=consumer).map(op_args=make_list())
+    PythonOperator.partial(task_id='consumer', python_callable=consumer).map(op_args=make_arg_lists())

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -505,9 +505,11 @@ def test_mapped_decorator_invalid_args() -> None:
         literal = [1, 2, 3]
 
         with pytest.raises(TypeError, match="arguments 'other', 'b'"):
-            double.partial(other=1, b='a')
+            double.partial(other=[1], b=['a'])
         with pytest.raises(TypeError, match="argument 'other'"):
-            double.map(number=literal, other=1)
+            double.map(number=literal, other=[1])
+        with pytest.raises(ValueError, match="argument 'other'"):
+            double.map(number=literal, other=1)  # type: ignore[arg-type]
 
 
 def test_partial_mapped_decorator() -> None:
@@ -532,11 +534,11 @@ def test_partial_mapped_decorator() -> None:
 
     assert isinstance(doubled, XComArg)
     assert isinstance(doubled.operator, DecoratedMappedOperator)
-    assert doubled.operator.mapped_kwargs == {"op_args": [], "op_kwargs": {"number": literal}}
-    assert doubled.operator.partial_op_kwargs == {"multiple": 2}
+    assert doubled.operator.mapped_op_kwargs == {"number": literal}
+    assert doubled.operator.partial_kwargs["op_kwargs"] == {"multiple": 2}
 
     assert isinstance(trippled.operator, DecoratedMappedOperator)  # For type-checking on partial_kwargs.
-    assert trippled.operator.partial_op_kwargs == {"multiple": 3}
+    assert trippled.operator.partial_kwargs["op_kwargs"] == {"multiple": 3}
 
     assert doubled.operator is not trippled.operator
 

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -845,7 +845,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
         session.add(ti)
     session.flush()
 
-    mapped.expand_mapped_task(upstream_ti=dr.get_task_instance(task1.task_id), session=session)
+    mapped.expand_mapped_task(dr.run_id, session=session)
 
     indices = (
         session.query(TaskInstance.map_index, TaskInstance.state)
@@ -869,7 +869,7 @@ def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
         TaskMap(dag_id=dr.dag_id, task_id=task1.task_id, run_id=dr.run_id, map_index=-1, length=0, keys=None)
     )
 
-    mapped.expand_mapped_task(upstream_ti=dr.get_task_instance(task1.task_id), session=session)
+    mapped.expand_mapped_task(dr.run_id, session=session)
 
     indices = (
         session.query(TaskInstance.map_index, TaskInstance.state)

--- a/tests/providers/snowflake/transfers/test_snowflake_to_slack.py
+++ b/tests/providers/snowflake/transfers/test_snowflake_to_slack.py
@@ -15,20 +15,26 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 from unittest import mock
 
 from airflow.models import DAG
 from airflow.providers.snowflake.transfers.snowflake_to_slack import SnowflakeToSlackOperator
 from airflow.utils import timezone
+from tests.test_utils.db import clear_db_runs
 
 TEST_DAG_ID = 'snowflake_to_slack_unit_test'
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 
-class TestSnowflakeToSlackOperator(unittest.TestCase):
-    def setUp(self):
+class TestSnowflakeToSlackOperator:
+    def setup_class(self):
+        clear_db_runs()
+
+    def setup_method(self):
         self.example_dag = DAG('unit_test_dag_snowflake_to_slack', start_date=DEFAULT_DATE)
+
+    def teardown_method(self):
+        clear_db_runs()
 
     @staticmethod
     def _construct_operator(**kwargs):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1712,12 +1712,15 @@ def test_mapped_decorator_serde():
     assert deserialized.upstream_task_ids == set()
     assert deserialized.downstream_task_ids == set()
 
-    assert deserialized.mapped_kwargs["op_kwargs"] == {
+    assert deserialized.mapped_op_kwargs == {
         "arg2": {"a": 1, "b": 2},
         "arg3": _XComRef("op1", "my_key"),
     }
-    assert deserialized.partial_kwargs == {"retry_delay": timedelta(seconds=30)}
-    assert deserialized.partial_op_kwargs == {"arg1": [1, 2, {"a": "b"}]}
+    assert deserialized.partial_kwargs == {
+        "op_args": [],
+        "op_kwargs": {"arg1": [1, 2, {"a": "b"}]},
+        "retry_delay": timedelta(seconds=30),
+    }
 
 
 def test_mapped_task_group_serde():

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1688,14 +1688,15 @@ def test_mapped_decorator_serde():
         '_task_module': 'airflow.decorators.python',
         '_task_type': '_PythonDecoratedOperator',
         'downstream_task_ids': [],
-        'partial_op_kwargs': {'arg1': [1, 2, {"__type": "dict", "__var": {'a': 'b'}}]},
-        'partial_kwargs': {'retry_delay': {'__type': 'timedelta', '__var': 30.0}},
-        'mapped_kwargs': {
+        'partial_kwargs': {
             'op_args': [],
-            'op_kwargs': {
-                'arg2': {"__type": "dict", "__var": {'a': 1, 'b': 2}},
-                'arg3': {'__type': 'xcomref', '__var': {'task_id': 'op1', 'key': 'my_key'}},
-            },
+            'op_kwargs': {'arg1': [1, 2, {"__type": "dict", "__var": {'a': 'b'}}]},
+            'retry_delay': {'__type': 'timedelta', '__var': 30.0},
+        },
+        'mapped_kwargs': {},
+        'mapped_op_kwargs': {
+            'arg2': {"__type": "dict", "__var": {'a': 1, 'b': 2}},
+            'arg3': {'__type': 'xcomref', '__var': {'task_id': 'op1', 'key': 'my_key'}},
         },
         'operator_extra_links': [],
         'ui_color': '#ffefeb',


### PR DESCRIPTION
This is another PR that is likely much too big. Many (sort of interrelated) things done in one.

#### Rewrite `@task` mapped operators expansion so it behave correctly

Previously, a mapped `@task` was not expanded correctly because its mapped argument would look something like this:

```python
mapped_arguments={
    "op_kwargs": {
        "arg": [1, 2, 3],
    },
}
```

this cannot be expanded using normal logic, because `PythonOperator` natively expects something like this instead:

```python
mapped_arguments={
    "op_kwargs": [
        {"arg": 1},
        {"arg": 2},
        {"arg": 3},
    ],
}
```

so additional logic is implemented to modify `expand_mapped_task` to correctly expand.

#### Re-implement `expand_mapped_task` logic to be able to expand literals

Previously, `expand_mapped_task` only looks in TaskMap and cannot expand e.g. `.map(arg=[1, 2, 3])`. This implements a more sophisticated logic to collect information from mapped arguments and expand literal and XComArg inputs properly. Some refactoring was also done so the same logic can be reused for task-runtime value unpacking.

#### Additional checks added to ensure correct literal types are passed to `.map()`

Basically making sure it only receives lists and dicts (or XComArg, which is already checked separately when the upstream pushes to XCom).

#### Extend `TaskInstance.render_templates` to “unpack” mapped values for task execution

This is the main thing. After all template fields are rendered, additional process is done to “unpack” mapped values into individual ones based on map_index, which further mutates the operator object held by a TaskInstance. This reuses similar logic from `expand_mapped_task` to calculate the total length of map, so it can locate its map_index inside the series.

Previously, `render_template_fields` was only implemented on BaseOperator, and a MappedOperator is first unmapped before templates are rendered. This approach was unforuantely wrong, since value unpacking (which needs to happen after template rendering resolves XComArg) needs to be aware of the original MappedOperator (mainly to access the user-supplied mapped kwargs). So the new logic delays unmapping until _during_ `render_templates`. If a TaskInstance’s `task` is a MappedOperator, its `render_templates` would call the MappedOperator’s `render_template_fields`, which unmaps itself, calls `render_template_fields` on the unmapped operator, unpacks values for the unmapped operator, _and then returns the unmapped operator_. The TaskInstance would reassign its `task` to the unmapped, rendered, unpacked operator. This means that `TaskInstance.render_templates` now may have a side effect of mutating its own `task` attribute. I don’t particularly like this, but couldn’t find a cleaner approach without breaking much of the existing interface (complicated by the fact that both `BaseOperator.render_template_fields` and `BaseOperator.render_template` are public API). I think this is close to the best possible interface considering existing constraints (and I try to document this as clearly as possible for future maintainability).

A few tests were added to check this is working (see `TestMappedTaskInstanceReceiveValue`).