### PR TITLE
Increase timeout for constraints job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1269,7 +1269,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   constraints:
     permissions:
       contents: write
-    timeout-minutes: 25
+    timeout-minutes: 35
     name: "Constraints"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:


### PR DESCRIPTION
This job seems to be taking just longer than the current timeout, so
increase it so it works consistently on public runners.

e.g: https://github.com/apache/airflow/runs/5235848874?check_suite_focus=true