### PR TITLE
Return string type if picking is disabled

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -17,7 +17,7 @@
 # under the License.
 
 import warnings
-from base64 import b64encode
+from base64 import b64encode,b64decode
 from select import select
 from typing import Optional, Union
 
@@ -194,7 +194,7 @@ class SSHOperator(BaseOperator):
                     if enable_pickling:
                         return agg_stdout
                     else:
-                        return b64encode(agg_stdout).decode('utf-8')
+                        return b64decode(b64encode(agg_stdout)).decode('utf-8')
 
                 else:
                     error_msg = agg_stderr.decode('utf-8')


### PR DESCRIPTION
Return string type if pickling is disabled
SSH operator returns bytes object if the pickling is not enabled.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
