### PR TITLE
Databricks: add support for triggering jobs by name

### DIFF
--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -47,6 +47,7 @@ EXISTING_CLUSTER_ID = 'existing-cluster-id'
 RUN_NAME = 'run-name'
 RUN_ID = 1
 JOB_ID = "42"
+JOB_NAME = "job-name"
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
 RENDERED_TEMPLATED_JAR_PARAMS = [f'/test-{DATE}']
@@ -545,3 +546,59 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
         db_mock.run_now.assert_called_once_with(expected)
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_not_called()
+
+    def test_init_exeption_with_job_name_and_job_id(self):
+        exception_message = "Argument 'job_name' is not allowed with argument 'job_id'"
+
+        with pytest.raises(AirflowException, match=exception_message):
+            DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, job_name=JOB_NAME)
+
+        with pytest.raises(AirflowException, match=exception_message):
+            run = {'job_id': JOB_ID, 'job_name': JOB_NAME}
+            DatabricksRunNowOperator(task_id=TASK_ID, json=run)
+
+        with pytest.raises(AirflowException, match=exception_message):
+            run = {'job_id': JOB_ID}
+            DatabricksRunNowOperator(task_id=TASK_ID, json=run, job_name=JOB_NAME)
+
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_exec_with_job_name(self, db_mock_class):
+        run = {'notebook_params': NOTEBOOK_PARAMS, 'notebook_task': NOTEBOOK_TASK, 'jar_params': JAR_PARAMS}
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_name=JOB_NAME, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.find_job_id_by_name.return_value = JOB_ID
+        db_mock.run_now.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce(
+            {
+                'notebook_params': NOTEBOOK_PARAMS,
+                'notebook_task': NOTEBOOK_TASK,
+                'jar_params': JAR_PARAMS,
+                'job_id': JOB_ID,
+            }
+        )
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID, retry_limit=op.databricks_retry_limit, retry_delay=op.databricks_retry_delay
+        )
+        db_mock.find_job_id_by_name.assert_called_once_with(JOB_NAME)
+        db_mock.run_now.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        assert RUN_ID == op.run_id
+
+    @mock.patch('airflow.providers.databricks.operators.databricks.DatabricksHook')
+    def test_exec_failure_if_job_id_not_found(self, db_mock_class):
+        run = {'notebook_params': NOTEBOOK_PARAMS, 'notebook_task': NOTEBOOK_TASK, 'jar_params': JAR_PARAMS}
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_name=JOB_NAME, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.find_job_id_by_name.return_value = None
+
+        exception_message = f"Job ID for job name {JOB_NAME} could not be found"
+        with pytest.raises(AirflowException, match=exception_message):
+            op.execute(None)
+
+        db_mock.find_job_id_by_name.assert_called_once_with(JOB_NAME)

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -597,7 +597,7 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
         db_mock = db_mock_class.return_value
         db_mock.find_job_id_by_name.return_value = None
 
-        exception_message = f"Job ID for job name {JOB_NAME} could not be found"
+        exception_message = f"Job ID for job name {JOB_NAME} can not be found"
         with pytest.raises(AirflowException, match=exception_message):
             op.execute(None)
 


### PR DESCRIPTION
closes: #21380

The PR adds support for triggering Databricks jobs by name.
If according argument for `DatabricksRunNowOperator` is specified, then during execution it'll list all jobs and search for necessary job.
In case there're no jobs found or multiple jobs with the same name, the operator will fail.

Many thanks to @allebacco for the hints with implementing this functionality. 
