### PR TITLE
Change upgrade to init

### DIFF
--- a/docs/apache-airflow/installation/setting-up-the-database.rst
+++ b/docs/apache-airflow/installation/setting-up-the-database.rst
@@ -22,7 +22,7 @@ Airflow requires a database. If you're just experimenting and learning Airflow, 
 default SQLite option. If you don't want to use SQLite, then take a look at
 :doc:`/howto/set-up-database` to setup a different database.
 
-Usually, you need to run ``airflow db upgrade`` in order to create the database schema that Airflow can use.
+Usually, you need to run ``airflow db init`` in order to create the database schema that Airflow can use.
 
 Similarly, upgrading Airflow usually requires an extra step of upgrading the database. This is done
 with ``airflow db upgrade`` CLI command. You should make sure that Airflow components are


### PR DESCRIPTION
Change `airflow db upgrade` to `airflow db init` in setting-up-the-database.rst

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
