### PR TITLE
Log exception in local executor

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -125,12 +125,12 @@ class LocalWorkerBase(Process, LoggingMixin):
             ret = 0
             return State.SUCCESS
         except Exception as e:
-            self.log.error("Failed to execute task %s.", str(e))
+            self.log.exception("Failed to execute task %s.", e)
+            return State.FAILED
         finally:
             Sentry.flush()
             logging.shutdown()
             os._exit(ret)
-            raise RuntimeError('unreachable -- keep mypy happy')
 
     @abstractmethod
     def do_work(self):


### PR DESCRIPTION
The `log.error()` call swallows the traceback, making debugging much difficult. This makes the full traceback be logged instead.

The `RuntimeError` mypy hack seems to no longer be needed so I removed it (CI will tell if this is wrong).