### PR TITLE
Fix some migrations

### DIFF
--- a/airflow/migrations/versions/30867afad44a_rename_concurrency_column_in_dag_table_.py
+++ b/airflow/migrations/versions/30867afad44a_rename_concurrency_column_in_dag_table_.py
@@ -36,6 +36,11 @@ depends_on = None
 
 def upgrade():
     """Apply Rename concurrency column in dag table to max_active_tasks"""
+    conn = op.get_bind()
+    is_sqlite = bool(conn.dialect.name == "sqlite")
+
+    if is_sqlite:
+        op.execute("PRAGMA foreign_keys=off")
     with op.batch_alter_table('dag') as batch_op:
         batch_op.alter_column(
             'concurrency',
@@ -43,6 +48,8 @@ def upgrade():
             type_=sa.Integer(),
             nullable=False,
         )
+    if is_sqlite:
+        op.execute("PRAGMA foreign_keys=on")
 
 
 def downgrade():

--- a/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
+++ b/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
@@ -25,7 +25,7 @@ Create Date: 2022-01-19 03:20:35.329037
 from typing import Sequence
 
 from alembic import op
-from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, select
+from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, and_, select
 
 from airflow.migrations.db_types import TIMESTAMP, StringID
 
@@ -80,6 +80,9 @@ def upgrade():
     data pre-populated, adding back constraints we need, and renaming it to
     replace the existing XCom table.
     """
+    conn = op.get_bind()
+    is_sqlite = bool(conn.dialect.name == "sqlite")
+
     op.create_table("__airflow_tmp_xcom", *_get_new_xcom_columns())
 
     xcom = Table("xcom", metadata, *_get_old_xcom_columns())
@@ -96,14 +99,20 @@ def upgrade():
         ],
     ).select_from(
         xcom.join(
-            dagrun,
-            xcom.c.dag_id == dagrun.c.dag_id,
-            xcom.c.execution_date == dagrun.c.execution_date,
+            right=dagrun,
+            onclause=and_(
+                xcom.c.dag_id == dagrun.c.dag_id,
+                xcom.c.execution_date == dagrun.c.execution_date,
+            ),
         ),
     )
     op.execute(f"INSERT INTO __airflow_tmp_xcom {query.selectable.compile(op.get_bind())}")
 
+    if is_sqlite:
+        op.execute("PRAGMA foreign_keys=off")
     op.drop_table("xcom")
+    if is_sqlite:
+        op.execute("PRAGMA foreign_keys=on")
     op.rename_table("__airflow_tmp_xcom", "xcom")
 
     with op.batch_alter_table("xcom") as batch_op:
@@ -132,9 +141,11 @@ def downgrade():
         ],
     ).select_from(
         xcom.join(
-            dagrun,
-            xcom.c.dag_id == dagrun.c.dag_id,
-            xcom.c.run_id == dagrun.c.run_id,
+            right=dagrun,
+            onclause=and_(
+                xcom.c.dag_id == dagrun.c.dag_id,
+                xcom.c.run_id == dagrun.c.run_id,
+            ),
         ),
     )
     op.execute(f"INSERT INTO __airflow_tmp_xcom {query.selectable.compile(op.get_bind())}")

--- a/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
+++ b/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
@@ -81,7 +81,7 @@ def upgrade():
     replace the existing XCom table.
     """
     conn = op.get_bind()
-    is_sqlite = bool(conn.dialect.name == "sqlite")
+    is_sqlite = conn.dialect.name == "sqlite"
 
     op.create_table("__airflow_tmp_xcom", *_get_new_xcom_columns())
 


### PR DESCRIPTION
Fixes issues with two migrations: 
```
30867afad44a_rename_concurrency_column_in_dag_table_.py <-- 2.2
c306b5b5ae4a_switch_xcom_table_to_use_run_id.py <-- 2.3
```

In both, for sqlite we need to temporarily suspend FK enforcement.

In the xcom migration, there's a bad join.  The clauses need to be wrapped in `and_`.
