### PR TITLE
Fix Amazon SES emailer signature

### DIFF
--- a/airflow/providers/amazon/aws/utils/emailer.py
+++ b/airflow/providers/amazon/aws/utils/emailer.py
@@ -16,14 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow module for email backend using AWS SES"""
-
 from typing import List, Optional, Union
 
 from airflow.providers.amazon.aws.hooks.ses import SesHook
 
 
 def send_email(
-    from_email: str,
     to: Union[List[str], str],
     subject: str,
     html_content: str,
@@ -33,9 +31,12 @@ def send_email(
     mime_subtype: str = 'mixed',
     mime_charset: str = 'utf-8',
     conn_id: str = 'aws_default',
+    from_email: Optional[str] = None,
     **kwargs,
 ) -> None:
     """Email backend for SES."""
+    if from_email is None:
+        raise RuntimeError("The `from_email' configuration has to be set for the SES emailer.")
     hook = SesHook(aws_conn_id=conn_id)
     hook.send_email(
         mail_from=from_email,

--- a/docs/apache-airflow/howto/email-config.rst
+++ b/docs/apache-airflow/howto/email-config.rst
@@ -118,8 +118,9 @@ Follow the steps below to enable it:
       [email]
       email_backend = airflow.providers.amazon.aws.utils.emailer.send_email
       email_conn_id = aws_default
+      from_email = From email <email@example.com>
+
+Note that for SES, you must configure from_email to the valid email that can send messages from SES.
 
 3. Create a connection called ``aws_default``, or choose a custom connection
    name and set it in ``email_conn_id``. The type of connection should be ``Amazon Web Services``.
-
-4. Configure sender's email address in your ``airflow.cfg`` by setting ``from_email`` in the ``[email]`` section.

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -18,6 +18,8 @@
 #
 from unittest import TestCase, mock
 
+import pytest
+
 from airflow.providers.amazon.aws.utils.emailer import send_email
 
 
@@ -25,10 +27,10 @@ class TestSendEmailSes(TestCase):
     @mock.patch("airflow.providers.amazon.aws.utils.emailer.SesHook")
     def test_send_ses_email(self, mock_hook):
         send_email(
-            from_email="From Test <from@test.com>",
             to="to@test.com",
             subject="subject",
             html_content="content",
+            from_email="From Test <from@test.com>",
         )
 
         mock_hook.return_value.send_email.assert_called_once_with(
@@ -42,3 +44,10 @@ class TestSendEmailSes(TestCase):
             mime_charset="utf-8",
             mime_subtype="mixed",
         )
+
+    @mock.patch("airflow.providers.amazon.aws.utils.emailer.SesHook")
+    def test_send_ses_email_no_from_mail(self, mock_hook):
+        with pytest.raises(
+            RuntimeError, match="The `from_email' configuration has to be set for the SES emailer."
+        ):
+            send_email(to="to@test.com", subject="subject", html_content="content")


### PR DESCRIPTION
Amazon SES Had a wrong signature to become a mailer in Airflow
introduced in #18042. As the result setting SES emailer as
email backend resulted in:

```
TypeError: send_email() missing 1 required positional argument:
'html_content'
```

Fixes: #21671

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
