### PR TITLE
Add dependency to the running_deps

### DIFF
--- a/airflow/ti_deps/dependencies_deps.py
+++ b/airflow/ti_deps/dependencies_deps.py
@@ -54,6 +54,7 @@ RUNNING_DEPS = {
     DagTISlotsAvailableDep(),
     TaskConcurrencyDep(),
     PoolSlotsAvailableDep(),
+    ExecDateAfterStartDateDep(),
     TaskNotRunningDep(),
 }
 

--- a/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
+++ b/airflow/ti_deps/deps/exec_date_after_start_date_dep.py
@@ -28,7 +28,7 @@ class ExecDateAfterStartDateDep(BaseTIDep):
 
     @provide_session
     def _get_dep_statuses(self, ti, session, dep_context):
-        if ti.task.start_date and ti.execution_date < ti.task.start_date:
+        if ti.task.start_date and ti.get_dagrun(session=session).execution_date < ti.task.start_date:
             yield self._failing_status(
                 reason=(
                     f"The execution date is {ti.execution_date.isoformat()} but this is before "
@@ -36,7 +36,11 @@ class ExecDateAfterStartDateDep(BaseTIDep):
                 )
             )
 
-        if ti.task.dag and ti.task.dag.start_date and ti.execution_date < ti.task.dag.start_date:
+        if (
+            ti.task.dag
+            and ti.task.dag.start_date
+            and ti.get_dagrun(session=session).execution_date < ti.task.dag.start_date
+        ):
             yield self._failing_status(
                 reason=(
                     f"The execution date is {ti.execution_date.isoformat()} but this is "

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -94,14 +94,14 @@ class TestCliTasks(unittest.TestCase):
     def test_test(self):
         """Test the `airflow test` command"""
         args = self.parser.parse_args(
-            ["tasks", "test", "example_python_operator", 'print_the_context', '2018-01-01']
+            ["tasks", "test", "example_python_operator", 'print_the_context', '2021-01-01']
         )
 
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_test(args)
 
         # Check that prints, and log messages, are shown
-        assert "'example_python_operator__print_the_context__20180101'" in stdout.getvalue()
+        assert "'example_python_operator__print_the_context__20210101'" in stdout.getvalue()
 
     @pytest.mark.filterwarnings("ignore::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_test_with_existing_dag_run(self):

--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
     skip_tls_tests = True
 
-DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 SUCCESS_COMMAND = ['airflow', 'tasks', 'run', '--help']
 FAIL_COMMAND = ['airflow', 'tasks', 'run', 'false']
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2029,14 +2029,14 @@ class TestQueries(unittest.TestCase):
 
 
 class TestDagDecorator(unittest.TestCase):
+    DEFAULT_DATE = timezone.datetime(2016, 1, 1)
     DEFAULT_ARGS = {
         "owner": "test",
         "depends_on_past": True,
-        "start_date": timezone.utcnow(),
+        "start_date": DEFAULT_DATE,
         "retries": 1,
         "retry_delay": timedelta(minutes=1),
     }
-    DEFAULT_DATE = timezone.datetime(2016, 1, 1)
     VALUE = 42
 
     def setUp(self):


### PR DESCRIPTION
closes: #20461

Problem: Airflow is trying to schedule tasks prior to DAG's start_date.
Solution: Added ExecDateAfterStartDateDep to the dependencies that need to be met for a given task instance to be set to 'RUNNING' state.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
