### PR TITLE
Add extra information about time synchronization needed

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1085,6 +1085,10 @@
         Secret key used to run your flask app. It should be as random as possible. However, when running
         more than 1 instances of webserver, make sure all of them use the same ``secret_key`` otherwise
         one of them will error with "CSRF session token is missing".
+        The webserver key is also used to authorize requests to Celery workers when logs are retrieved.
+        The token generated using the secret key has a short expiry time though - make sure that time on
+        ALL the machines that you run airflow components on is synchronized (for example using ntpd)
+        otherwise you might get "forbidden" errors when the logs are accessed.
       version_added: ~
       type: string
       sensitive: true

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -559,6 +559,10 @@ reload_on_plugin_change = False
 # Secret key used to run your flask app. It should be as random as possible. However, when running
 # more than 1 instances of webserver, make sure all of them use the same ``secret_key`` otherwise
 # one of them will error with "CSRF session token is missing".
+# The webserver key is also used to authorize requests to Celery workers when logs are retrieved.
+# The token generated using the secret key has a short expiry time though - make sure that time on
+# ALL the machines that you run airflow components on is synchronized (for example using ntpd)
+# otherwise you might get "forbidden" errors when the logs are accessed.
 secret_key = {SECRET_KEY}
 
 # Number of workers to run the Gunicorn web server

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -207,8 +207,9 @@ class FileTaskHandler(logging.Handler):
                 if response.status_code == 403:
                     log += (
                         "*** !!!! Please make sure that all your Airflow components (e.g. "
-                        "schedulers, webservers and workers) have"
-                        " the same 'secret_key' configured in 'webserver' section !!!!!\n***"
+                        "schedulers, webservers and workers) have "
+                        "the same 'secret_key' configured in 'webserver' section and "
+                        "time is synchronized on all your machines (for example with ntpd) !!!!!\n***"
                     )
                     log += (
                         "*** See more at https://airflow.apache.org/docs/apache-airflow/"

--- a/docs/apache-airflow/configurations-ref.rst
+++ b/docs/apache-airflow/configurations-ref.rst
@@ -27,6 +27,11 @@ does not require all, some configurations need to be same otherwise they would n
 work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
 should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.
 
+The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token
+generated using the secret key has a short expiry time though - make sure that time on ALL the machines
+that you run airflow components on is synchronized (for example using ntpd) otherwise you might get
+"forbidden" errors when the logs are accessed.
+
 .. note::
     For more information on setting the configuration, see :doc:`howto/set-config`
 

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -121,3 +121,8 @@ the example below.
     does not require all, some configurations need to be same otherwise they would not
     work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
     should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.
+
+    The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token
+    generated using the secret key has a short expiry time though - make sure that time on ALL the machines
+    that you run airflow components on is synchronized (for example using ntpd) otherwise you might get
+    "forbidden" errors when the logs are accessed.

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -339,6 +339,11 @@ the only supported UI.
     this via any configuration mechanism. The 1.10.15 bridge-release modifies this feature
     to use randomly generated secret keys instead of an insecure default and may break existing
     deployments that rely on the default.
+    The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token
+    generated using the secret key has a short expiry time though - make sure that time on ALL the machines
+    that you run airflow components on is synchronized (for example using ntpd) otherwise you might get
+    "forbidden" errors when the logs are accessed.
+
 
 The ``flask-oauthlib`` has been replaced with ``authlib`` because ``flask-oauthlib`` has
 been deprecated in favor of ``authlib``.

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -111,6 +111,11 @@ Example to create a Kubernetes Secret from ``kubectl``:
 
     kubectl create secret generic my-webserver-secret --from-literal="webserver-secret-key=$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
 
+The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token
+generated using the secret key has a short expiry time though - make sure that time on ALL the machines
+that you run airflow components on is synchronized (for example using ntpd) otherwise you might get
+"forbidden" errors when the logs are accessed.
+
 Extending and customizing Airflow Image
 ---------------------------------------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1060,6 +1060,7 @@ nosasl
 notificationChannels
 npm
 ntlm
+ntpd
 nullable
 num
 oauth


### PR DESCRIPTION
When you have several machines running Airflow and their time
is not synchronized, you might get very weird behaviour - some of
the log retrieval actions might randomly return "forbidden" error
because of expiring token. This is extremely difficult to
diagnose and figure out (some of our users spent days on
investigating that). Explicitly stating the requirement in the
forbidden error and whenever secret_key parameter is
mentioned, should help our users to diagnose it more easily
(and save maintainers from unnecessary questions and discussions
in Slack :))

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
