### PR TITLE
Add --platform as parameter of image building

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1272,6 +1272,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  3.7 3.8 3.9
 
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
+
   -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           Uses different version of Airflow when building PROD image.
 
@@ -1472,6 +1479,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  3.7 3.8 3.9
 
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
+
   -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           Uses different version of Airflow when building PROD image.
 
@@ -1531,6 +1545,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
           One of:
 
                  3.7 3.8 3.9
+
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
 
   -I, --production-image
           Use production image for entering the environment and builds (not for tests).
@@ -1599,6 +1620,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  3.7 3.8 3.9
 
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
+
   -v, --verbose
           Show verbose information about executed docker, kind, kubectl, helm commands. Useful for
           debugging - when you run breeze with --verbose flags you will be able to see the commands
@@ -1634,6 +1662,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
           One of:
 
                  3.7 3.8 3.9
+
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
 
 
   ####################################################################################################
@@ -1830,6 +1865,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  3.7 3.8 3.9
 
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
+
   -b, --backend BACKEND
           Backend to use for tests - it determines which database is used.
           One of:
@@ -1898,6 +1940,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
           One of:
 
                  3.7 3.8 3.9
+
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
 
   -F, --force-build-images
           Forces building of the local docker images. The images are rebuilt
@@ -2297,6 +2346,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
           One of:
 
                  3.7 3.8 3.9
+
+  --platform PLATFORM
+          Builds image for the platform specified.
+
+          One of:
+
+                 linux/amd64
 
   ****************************************************************************************************
    Choose backend to run for Airflow

--- a/breeze
+++ b/breeze
@@ -499,6 +499,7 @@ EOF
 
                                Branch name:            ${BRANCH_NAME}
                                Docker image:           ${AIRFLOW_PROD_IMAGE}
+                               Platform:               ${PLATFORM}
                                Airflow source version: $(build_images::get_airflow_version_from_production_image)
 EOF
         else
@@ -508,6 +509,7 @@ EOF
 
                                Branch name:            ${BRANCH_NAME}
                                Docker image:           ${AIRFLOW_CI_IMAGE_WITH_TAG}
+                               Platform:               ${PLATFORM}
                                Airflow source version: ${AIRFLOW_VERSION}
 EOF
         fi
@@ -530,6 +532,7 @@ EOF
 
    Branch name:             ${BRANCH_NAME}
    Docker image:            ${AIRFLOW_PROD_IMAGE}
+   Platform:                ${PLATFORM}
 EOF
         else
             cat <<EOF
@@ -538,6 +541,7 @@ EOF
 
    Branch name:             ${BRANCH_NAME}
    Docker image:            ${AIRFLOW_CI_IMAGE}
+   Platform:                ${PLATFORM}
 
 EOF
         fi
@@ -628,6 +632,7 @@ export PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION}"
 export BACKEND="${BACKEND}"
 export AIRFLOW_VERSION="${AIRFLOW_VERSION}"
 export INSTALL_AIRFLOW_VERSION="${INSTALL_AIRFLOW_VERSION}"
+export PLATFORM="${PLATFORM}"
 export SSH_PORT="${SSH_PORT}"
 export WEBSERVER_HOST_PORT="${WEBSERVER_HOST_PORT}"
 export FLOWER_HOST_PORT="${FLOWER_HOST_PORT}"
@@ -814,6 +819,12 @@ function breeze::parse_arguments() {
         -b | --backend)
             export BACKEND="${2}"
             echo "Backend: ${BACKEND}"
+            echo
+            shift 2
+            ;;
+        ---platform)
+            export PLATFORM="${2}"
+            echo "Backend: ${PLATFORM}"
             echo
             shift 2
             ;;
@@ -1537,6 +1548,10 @@ function breeze::prepare_formatted_versions() {
         fold -w "${indented_screen_width}" -s | sed "s/^/${list_prefix}/")
     readonly FORMATTED_BACKENDS
 
+    FORMATTED_PLATFORMS=$(echo "${_breeze_allowed_platforms=""}" |
+        tr '\n' ' ' | fold -w "${indented_screen_width}" -s | sed "s/^/${list_prefix}/")
+    readonly FORMATTED_PLATFORMS
+
     FORMATTED_STATIC_CHECKS=$(echo "${_breeze_allowed_static_checks=""}" | tr '\n' ' ' |
         fold -w "${indented_screen_width}" -s | sed "s/^/${list_prefix}/")
     readonly FORMATTED_STATIC_CHECKS
@@ -2237,6 +2252,14 @@ function breeze::flag_airflow_variants() {
         One of:
 
 ${FORMATTED_PYTHON_MAJOR_MINOR_VERSIONS}
+
+--platform PLATFORM
+        Builds image for the platform specified.
+
+        One of:
+
+${FORMATTED_PLATFORMS}
+
 "
 }
 
@@ -3091,6 +3114,7 @@ function breeze::check_and_save_all_params() {
     fi
 
     parameters::check_and_save_allowed_param "BACKEND" "backend" "--backend"
+    parameters::check_and_save_allowed_param "PLATFORM" "platform" "--platform"
     parameters::check_and_save_allowed_param "KUBERNETES_MODE" "Kubernetes mode" "--kubernetes-mode"
     parameters::check_and_save_allowed_param "KUBERNETES_VERSION" "Kubernetes version" "--kubernetes-version"
     parameters::check_and_save_allowed_param "KIND_VERSION" "KinD version" "--kind-version"

--- a/breeze-complete
+++ b/breeze-complete
@@ -38,6 +38,7 @@ _breeze_allowed_executors="KubernetesExecutor CeleryExecutor LocalExecutor Celer
 _breeze_allowed_test_types="All Always Core Providers API CLI Integration Other WWW Postgres MySQL Helm Quarantined"
 _breeze_allowed_package_formats="both sdist wheel"
 _breeze_allowed_installation_methods=". apache-airflow"
+_breeze_allowed_platforms="linux/amd64"
 
 # shellcheck disable=SC2034
 {
@@ -54,6 +55,7 @@ _breeze_allowed_installation_methods=". apache-airflow"
     _breeze_default_mssql_version=$(echo "${_breeze_allowed_mssql_versions}" | awk '{print $1}')
     _breeze_default_test_type=$(echo "${_breeze_allowed_test_types}" | awk '{print $1}')
     _breeze_default_package_format=$(echo "${_breeze_allowed_package_formats}" | awk '{print $1}')
+    _breeze_default_platform=$(echo "${_breeze_allowed_platforms}" | awk '{print $1}')
 }
 
 _breeze_allowed_install_airflow_versions=$(cat <<-EOF
@@ -175,7 +177,7 @@ S: N:
 "
 
 _breeze_long_options="
-help python: backend: integration:
+help python: backend: integration: platform:
 kubernetes-mode: kubernetes-version: helm-version: kind-version:
 skip-mounting-local-sources mount-all-local-sources install-airflow-version: install-airflow-reference: db-reset
 verbose assume-yes assume-no assume-quit forward-credentials init-script:

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -482,6 +482,7 @@ function build_images::build_ci_image() {
     docker_v "${BUILD_COMMAND[@]}" \
         "${extra_docker_ci_flags[@]}" \
         --pull \
+        --platform "${PLATFORM}" \
         --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
         --build-arg AIRFLOW_VERSION="${AIRFLOW_VERSION}" \
         --build-arg AIRFLOW_BRANCH="${BRANCH_NAME}" \
@@ -630,6 +631,7 @@ function build_images::build_prod_images() {
     docker_v "${BUILD_COMMAND[@]}" \
         "${EXTRA_DOCKER_PROD_BUILD_FLAGS[@]}" \
         --pull \
+        --platform "${PLATFORM}" \
         --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
         --build-arg INSTALL_MYSQL_CLIENT="${INSTALL_MYSQL_CLIENT}" \
         --build-arg INSTALL_MSSQL_CLIENT="${INSTALL_MSSQL_CLIENT}" \

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -83,9 +83,9 @@ function initialization::create_directories() {
 
 # Very basic variables that MUST be set
 function initialization::initialize_base_variables() {
-    # until we have support for ARM images, we set docker default platform to AMD
+    # until we have support for ARM images, we set docker default platform to linux/AMD
     # so that all breeze commands use emulation
-    export DOCKER_DEFAULT_PLATFORM=linux/amd64
+    export PLATFORM=${PLATFORM:="linux/amd64"}
 
     # enable buildkit for builds
     export DOCKER_BUILDKIT=1


### PR DESCRIPTION
Building image for now shoudl be forced to linux/amd64 as this is
the only supported platform. When using BUILDKIT, the default
platform depends on the OS/processor, but until we implement
multi-platform images we force them to linux/amd64.

Setting it as parameter of docker build instead of env variables
is more explicit and allows to copy&paste the whole command
to reproduce it outside of breeze when verbose is used
independently if you are on Linux, MacOS Intel/ARM.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
