### PR TITLE
Fix oracle test connection

### DIFF
--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -67,6 +67,8 @@ class DbApiHook(BaseHook):
     supports_autocommit = False
     # Override with the object that exposes the connect method
     connector = None  # type: Optional[ConnectorProtocol]
+    # Override with db-specific query to check connection
+    _test_connection_sql = "select 1"
 
     def __init__(self, *args, schema: Optional[str] = None, **kwargs):
         super().__init__()
@@ -345,11 +347,13 @@ class DbApiHook(BaseHook):
         """
         raise NotImplementedError()
 
+    # TODO: Merge this implementation back to DbApiHook when dropping
+    # support for Airflow 2.2.
     def test_connection(self):
-        """Tests the connection by executing a select 1 query"""
+        """Tests the connection using db-specific query"""
         status, message = False, ''
         try:
-            if self.get_first("select 1"):
+            if self.get_first(self._test_connection_sql):
                 status = True
                 message = 'Connection successfully tested'
         except Exception as e:

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -347,8 +347,6 @@ class DbApiHook(BaseHook):
         """
         raise NotImplementedError()
 
-    # TODO: Merge this implementation back to DbApiHook when dropping
-    # support for Airflow 2.2.
     def test_connection(self):
         """Tests the connection using db-specific query"""
         status, message = False, ''

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -339,3 +339,16 @@ class OracleHook(DbApiHook):
         )
 
         return result
+
+    def test_connection(self):
+        """Tests the connection by executing a select 1 from dual query"""
+        status, message = False, ''
+        try:
+            if self.get_first("select 1 from dual"):
+                status = True
+                message = 'Connection successfully tested'
+        except Exception as e:
+            status = False
+            message = str(e)
+
+        return status, message

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -52,8 +52,6 @@ class OracleHook(DbApiHook):
 
     supports_autocommit = True
 
-    _test_connection_sql = "select 1 from dual"
-
     def get_conn(self) -> 'OracleHook':
         """
         Returns a oracle connection object
@@ -341,3 +339,18 @@ class OracleHook(DbApiHook):
         )
 
         return result
+
+    # TODO: Merge this implementation back to DbApiHook when dropping
+    # support for Airflow 2.2.
+    def test_connection(self):
+        """Tests the connection by executing a select 1 from dual query"""
+        status, message = False, ''
+        try:
+            if self.get_first("select 1 from dual"):
+                status = True
+                message = 'Connection successfully tested'
+        except Exception as e:
+            status = False
+            message = str(e)
+
+        return status, message

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -52,6 +52,8 @@ class OracleHook(DbApiHook):
 
     supports_autocommit = True
 
+    _test_connection_sql = "select 1 from dual"
+
     def get_conn(self) -> 'OracleHook':
         """
         Returns a oracle connection object
@@ -339,16 +341,3 @@ class OracleHook(DbApiHook):
         )
 
         return result
-
-    def test_connection(self):
-        """Tests the connection by executing a select 1 from dual query"""
-        status, message = False, ''
-        try:
-            if self.get_first("select 1 from dual"):
-                status = True
-                message = 'Connection successfully tested'
-        except Exception as e:
-            status = False
-            message = str(e)
-
-        return status, message

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -349,5 +349,7 @@ class TestOracleHook(unittest.TestCase):
         assert result == expected
 
     def test_test_connection_use_dual_table(self):
-        self.db_hook.test_connection()
+        status, message = self.db_hook.test_connection()
         self.cur.execute.assert_called_once_with("select 1 from dual")
+        assert status is True
+        assert message == 'Connection successfully tested'

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -347,3 +347,7 @@ class TestOracleHook(unittest.TestCase):
         expected = [1, 0, 0.0, False, '']
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END;', expected)]
         assert result == expected
+
+    def test_test_connection_use_dual_table(self):
+        self.db_hook.test_connection()
+        self.cur.execute.assert_called_once_with("select 1 from dual")


### PR DESCRIPTION
closes: #18967
Testing connection via "select 1" for Oracle database doesn't work. This PR replace it with checking connection using table dual which is automatically created by database. I added test to prevent future changes in method.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
