### PR TITLE
fix keys in type map in presto_to_gcs & trino_to_gcs operators

### DIFF
--- a/airflow/providers/google/cloud/transfers/presto_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/presto_to_gcs.py
@@ -150,12 +150,12 @@ class PrestoToGCSOperator(BaseSQLToGCSOperator):
 
     type_map = {
         "BOOLEAN": "BOOL",
-        "TINYINT": "INT64",
-        "SMALLINT": "INT64",
-        "INTEGER": "INT64",
-        "BIGINT": "INT64",
-        "REAL": "FLOAT64",
-        "DOUBLE": "FLOAT64",
+        "TINYINT": "INTEGER",
+        "SMALLINT": "INTEGER",
+        "INTEGER": "INTEGER",
+        "BIGINT": "INTEGER",
+        "REAL": "FLOAT",
+        "DOUBLE": "FLOAT",
         "DECIMAL": "NUMERIC",
         "VARCHAR": "STRING",
         "CHAR": "STRING",

--- a/airflow/providers/google/cloud/transfers/trino_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/trino_to_gcs.py
@@ -150,12 +150,12 @@ class TrinoToGCSOperator(BaseSQLToGCSOperator):
 
     type_map = {
         "BOOLEAN": "BOOL",
-        "TINYINT": "INT64",
-        "SMALLINT": "INT64",
-        "INTEGER": "INT64",
-        "BIGINT": "INT64",
-        "REAL": "FLOAT64",
-        "DOUBLE": "FLOAT64",
+        "TINYINT": "INTEGER",
+        "SMALLINT": "INTEGER",
+        "INTEGER": "INTEGER",
+        "BIGINT": "INTEGER",
+        "REAL": "FLOAT",
+        "DOUBLE": "FLOAT",
         "DECIMAL": "NUMERIC",
         "VARCHAR": "STRING",
         "CHAR": "STRING",

--- a/tests/providers/google/cloud/transfers/test_presto_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_presto_to_gcs.py
@@ -42,7 +42,7 @@ CSV_LINES = [
     b"44,mock_row_content_3\r\n",
 ]
 SCHEMA_FILENAME = "schema_test.json"
-SCHEMA_JSON = b'[{"name": "some_num", "type": "INT64"}, {"name": "some_str", "type": "STRING"}]'
+SCHEMA_JSON = b'[{"name": "some_num", "type": "INTEGER"}, {"name": "some_str", "type": "STRING"}]'
 
 
 @pytest.mark.integration("presto")

--- a/tests/providers/google/cloud/transfers/test_trino_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_trino_to_gcs.py
@@ -42,7 +42,7 @@ CSV_LINES = [
     b"44,mock_row_content_3\r\n",
 ]
 SCHEMA_FILENAME = "schema_test.json"
-SCHEMA_JSON = b'[{"name": "some_num", "type": "INT64"}, {"name": "some_str", "type": "STRING"}]'
+SCHEMA_JSON = b'[{"name": "some_num", "type": "INTEGER"}, {"name": "some_str", "type": "STRING"}]'
 
 
 @pytest.mark.integration("trino")


### PR DESCRIPTION

Fix the keys (integer & float) of type map in presto_to_gcs & trino_to_gcs operators.
The type map is used to converting the field type from the source data types to bigQuery data types.
The BaseSQLToGCSOperator will also use another type map to convert from bigQuery data types to parquet data types, and it cause mismatch and fallback to parquet string([code](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/transfers/sql_to_gcs.py#L272)) when converting to the parquet in presto_to_gcs & trino_to_gcs operators.

Check [code here](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/transfers/sql_to_gcs.py#L256-L267) to see the type map used to convert from bigQuery data types to parquet data types.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
