### PR TITLE
Simply imports in dev github script

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -25,6 +25,8 @@ import sys
 from collections import Counter, defaultdict
 from typing import List, Optional
 
+import git
+import rich_click as click
 from github import Github
 from github.Issue import Issue
 from github.PullRequest import PullRequest
@@ -33,17 +35,6 @@ GIT_COMMIT_FIELDS = ['id', 'author_name', 'author_email', 'date', 'subject', 'bo
 GIT_LOG_FORMAT = '%x1f'.join(['%h', '%an', '%ae', '%ad', '%s', '%b']) + '%x1e'
 pr_title_re = re.compile(r".*\((#[0-9]{1,6})\)$")
 
-try:
-    import rich_click as click
-except ImportError:
-    print("Could not find the click library. Run 'sudo pip install click' to install.")
-    sys.exit(-1)
-
-try:
-    import git
-except ImportError:
-    print("Could not import git. Run 'sudo pip install gitpython' to install")
-    sys.exit(-1)
 
 STATUS_COLOR_MAP = {
     'Closed': 'green',


### PR DESCRIPTION
Especially given the audience of this script, we don't need to have special handling of the error message when an import fails.

Instead of:
```
Could not find the click library. Run 'sudo pip install click' to install.
```

Allow the built in failure to bubble up instead:
```
Traceback (most recent call last):                                                                                                                                                
  File "./dev/airflow-github", line 29, in <module>                                                                                                                               
    import rich_click as click                                                                                                                                                    
ModuleNotFoundError: No module named 'rich_click'
``` 

Of course I hit this because of the new `rich_click` vs `click` thing and was confused since I had `click`, but either way, we don't need the extra hand holding I don't think.