### PR TITLE
Add GCSToTrinoOperator

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -691,6 +691,7 @@ salesforce                 tableau
 sftp                       ssh
 slack                      http
 snowflake                  slack
+trino                      google
 ========================== ===========================
 
   .. END PACKAGE DEPENDENCIES HERE

--- a/airflow/providers/dependencies.json
+++ b/airflow/providers/dependencies.json
@@ -84,5 +84,8 @@
   ],
   "snowflake": [
     "slack"
+  ],
+  "trino": [
+    "google"
   ]
 }

--- a/airflow/providers/trino/example_dags/__init__.py
+++ b/airflow/providers/trino/example_dags/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/trino/example_dags/example_gcs_to_trino.py
+++ b/airflow/providers/trino/example_dags/example_gcs_to_trino.py
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example DAG using GCSToTrinoOperator.
+"""
+
+import os
+from datetime import datetime
+
+from airflow import models
+from airflow.providers.trino.transfers.gcs_to_trino import GCSToTrinoOperator
+
+BUCKET = os.environ.get("GCP_GCS_BUCKET", "test28397yeo")
+PATH_TO_FILE = os.environ.get("GCP_PATH", "path/to/file")
+TRINO_TABLE = os.environ.get("TRINO_TABLE", "test_table")
+
+with models.DAG(
+    dag_id="example_gcs_to_trino",
+    schedule_interval='@once',  # Override to match your needs
+    start_date=datetime(2022, 1, 1),
+    catchup=False,
+    tags=["example"],
+) as dag:
+    # [START gcs_csv_to_trino_table]
+    gcs_csv_to_trino_table = GCSToTrinoOperator(
+        task_id="gcs_csv_to_trino_table",
+        source_bucket=BUCKET,
+        source_object=PATH_TO_FILE,
+        trino_table=TRINO_TABLE,
+    )
+    # [END gcs_csv_to_trino_table]

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -41,6 +41,12 @@ hooks:
     python-modules:
       - airflow.providers.trino.hooks.trino
 
+transfers:
+  - source-integration-name: Google Cloud Storage (GCS)
+    target-integration-name: Trino
+    how-to-guide: /docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
+    python-module: airflow.providers.trino.transfers.gcs_to_trino
+
 hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
   - airflow.providers.trino.hooks.trino.TrinoHook
 

--- a/airflow/providers/trino/transfers/__init__.py
+++ b/airflow/providers/trino/transfers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/trino/transfers/gcs_to_trino.py
+++ b/airflow/providers/trino/transfers/gcs_to_trino.py
@@ -1,0 +1,124 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains Google Cloud Storage to Trino operator."""
+
+import csv
+import json
+from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Iterable, Optional, Sequence, Union
+
+from airflow.models import BaseOperator
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.trino.hooks.trino import TrinoHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class GCSToTrinoOperator(BaseOperator):
+    """
+    Loads a csv file from Google Cloud Storage into a Trino table.
+    Assumptions:
+    1. CSV file should not have headers
+    2. Trino table with requisite columns is already created
+    3. Optionally, a separate JSON file with headers can be provided
+
+    :param source_bucket: Source GCS bucket that contains the csv
+    :param source_object: csv file including the path
+    :param trino_table: trino table to upload the data
+    :param trino_conn_id: destination trino connection
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud and
+        interact with the Google Cloud Storage service.
+    :param schema_fields: The names of the columns to fill in the table. If schema_fields is
+        provided, any path provided in the schema object will be
+    :param schema_object: JSON file with schema fields
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account.
+    """
+
+    template_fields: Sequence[str] = (
+        'source_bucket',
+        'source_object',
+        'trino_table',
+    )
+
+    def __init__(
+        self,
+        *,
+        source_bucket: str,
+        source_object: str,
+        trino_table: str,
+        trino_conn_id: str = "trino_default",
+        gcp_conn_id: str = "google_cloud_default",
+        schema_fields: Optional[Iterable[str]] = None,
+        schema_object: Optional[str] = None,
+        delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.source_bucket = source_bucket
+        self.source_object = source_object
+        self.trino_table = trino_table
+        self.trino_conn_id = trino_conn_id
+        self.gcp_conn_id = gcp_conn_id
+        self.schema_fields = schema_fields
+        self.schema_object = schema_object
+        self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
+
+    def execute(self, context: 'Context') -> None:
+        gcs_hook = GCSHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
+
+        trino_hook = TrinoHook(trino_conn_id=self.trino_conn_id)
+
+        with NamedTemporaryFile("w+") as temp_file:
+            self.log.info("Downloading data from %s", self.source_object)
+            gcs_hook.download(
+                bucket_name=self.source_bucket,
+                object_name=self.source_object,
+                filename=temp_file.name,
+            )
+
+            data = csv.reader(temp_file)
+            rows = (tuple(row) for row in data)
+            self.log.info("Inserting data into %s", self.trino_table)
+            if self.schema_fields:
+                trino_hook.insert_rows(table=self.trino_table, rows=rows, target_fields=self.schema_fields)
+            elif self.schema_object:
+                blob = gcs_hook.download(
+                    bucket_name=self.source_bucket,
+                    object_name=self.schema_object,
+                )
+                schema_fields = json.loads(blob.decode("utf-8"))
+                trino_hook.insert_rows(table=self.trino_table, rows=rows, target_fields=schema_fields)
+            else:
+                trino_hook.insert_rows(table=self.trino_table, rows=rows)

--- a/docs/apache-airflow-providers-trino/index.rst
+++ b/docs/apache-airflow-providers-trino/index.rst
@@ -24,6 +24,12 @@ Content
 
 .. toctree::
     :maxdepth: 1
+    :caption: Guides
+
+    TrinoTransferOperator types <operators/transfer/gcs_to_trino>
+
+.. toctree::
+    :maxdepth: 1
     :caption: References
 
     Python API <_api/airflow/providers/trino/index>
@@ -32,6 +38,7 @@ Content
     :maxdepth: 1
     :caption: Resources
 
+    Example DAGs <https://github.com/apache/airflow/tree/main/airflow/providers/trino/example_dags>
     PyPI Repository <https://pypi.org/project/apache-airflow-providers-trino/>
     Installing from sources <installing-providers-from-sources>
 

--- a/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
+++ b/docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
@@ -1,0 +1,52 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Storage to Trino Transfer Operator
+===============================================
+
+Google has a service `Google Cloud Storage <https://cloud.google.com/storage/>`__. This service is
+used to store large data from various applications.
+
+`Trino <https://trino.io/>`__ is an open source, fast, distributed SQL query engine for running interactive
+analytic queries against data sources of all sizes ranging from gigabytes to petabytes. Trino allows
+querying data where it lives, including Hive, Cassandra, relational databases or even proprietary data stores.
+A single Trino query can combine data from multiple sources, allowing for analytics across your entire
+organization.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:GCSToPresto:
+
+Load CSV from GCS to Trino Table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To load a CSV file from Google Cloud Storage to a Trino table you can use the
+:class:`~airflow.providers.trino.transfers.gcs_to_trino.GCSToTrinoOperator`.
+
+This operator assumes that CSV does not have headers and the data is corresponding to the columns in a
+pre-existing presto table. Optionally, you can provide schema as tuple/list of strings or as a path to a
+JSON file in the same bucket as the CSV file.
+
+.. exampleinclude:: /../../airflow/providers/trino/example_dags/example_gcs_to_trino.py
+    :language: python
+    :dedent: 4
+    :start-after: [START gcs_csv_to_trino_table]
+    :end-before: [END gcs_csv_to_trino_table]

--- a/tests/providers/trino/transfers/__init__.py
+++ b/tests/providers/trino/transfers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/trino/transfers/test_gcs_trino.py
+++ b/tests/providers/trino/transfers/test_gcs_trino.py
@@ -1,0 +1,145 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from unittest import mock
+
+from airflow.providers.trino.transfers.gcs_to_trino import GCSToTrinoOperator
+
+BUCKET = "source_bucket"
+PATH = "path/to/file.csv"
+GCP_CONN_ID = "test_gcp"
+IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
+TRINO_CONN_ID = "test_trino"
+TRINO_TABLE = "test_table"
+TASK_ID = "test_gcs_to_trino"
+SCHEMA_FIELDS = ["colA", "colB", "colC"]
+SCHEMA_JSON = "path/to/file.json"
+
+
+class TestGCSToTrinoOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.trino.transfers.gcs_to_trino.TrinoHook')
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.GCSHook")
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.NamedTemporaryFile")
+    def test_execute_without_schema(self, mock_tempfile, mock_gcs_hook, mock_trino_hook):
+        filename = "file://97g23r"
+        file_handle = mock.MagicMock()
+        mock_tempfile.return_value.__enter__.return_value = file_handle
+        mock_tempfile.return_value.__enter__.return_value.name = filename
+
+        op = GCSToTrinoOperator(
+            task_id=TASK_ID,
+            source_bucket=BUCKET,
+            source_object=PATH,
+            trino_table=TRINO_TABLE,
+            trino_conn_id=TRINO_CONN_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        op.execute(None)
+
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        mock_trino_hook.assert_called_once_with(trino_conn_id=TRINO_CONN_ID)
+
+        mock_download = mock_gcs_hook.return_value.download
+
+        mock_download.assert_called_once_with(bucket_name=BUCKET, object_name=PATH, filename=filename)
+
+        mock_insert = mock_trino_hook.return_value.insert_rows
+
+        mock_insert.assert_called_once()
+
+    @mock.patch('airflow.providers.trino.transfers.gcs_to_trino.TrinoHook')
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.GCSHook")
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.NamedTemporaryFile")
+    def test_execute_schema_fields(self, mock_tempfile, mock_gcs_hook, mock_trino_hook):
+        filename = "file://97g23r"
+        file_handle = mock.MagicMock()
+        mock_tempfile.return_value.__enter__.return_value = file_handle
+        mock_tempfile.return_value.__enter__.return_value.name = filename
+
+        op = GCSToTrinoOperator(
+            task_id=TASK_ID,
+            source_bucket=BUCKET,
+            source_object=PATH,
+            trino_table=TRINO_TABLE,
+            trino_conn_id=TRINO_CONN_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            schema_fields=SCHEMA_FIELDS,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        op.execute(None)
+
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        mock_trino_hook.assert_called_once_with(trino_conn_id=TRINO_CONN_ID)
+
+        mock_download = mock_gcs_hook.return_value.download
+
+        mock_download.assert_called_once_with(bucket_name=BUCKET, object_name=PATH, filename=filename)
+
+        mock_insert = mock_trino_hook.return_value.insert_rows
+
+        mock_insert.assert_called_once()
+
+    @mock.patch('airflow.providers.trino.transfers.gcs_to_trino.json.loads')
+    @mock.patch('airflow.providers.trino.transfers.gcs_to_trino.TrinoHook')
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.GCSHook")
+    @mock.patch("airflow.providers.trino.transfers.gcs_to_trino.NamedTemporaryFile")
+    def test_execute_schema_json(self, mock_tempfile, mock_gcs_hook, mock_trino_hook, mock_json_loader):
+        filename = "file://97g23r"
+        file_handle = mock.MagicMock()
+        mock_tempfile.return_value.__enter__.return_value = file_handle
+        mock_tempfile.return_value.__enter__.return_value.name = filename
+        mock_json_loader.return_value = SCHEMA_FIELDS
+
+        op = GCSToTrinoOperator(
+            task_id=TASK_ID,
+            source_bucket=BUCKET,
+            source_object=PATH,
+            trino_table=TRINO_TABLE,
+            trino_conn_id=TRINO_CONN_ID,
+            gcp_conn_id=GCP_CONN_ID,
+            schema_object=SCHEMA_JSON,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        op.execute(None)
+
+        mock_gcs_hook.assert_called_once_with(
+            gcp_conn_id=GCP_CONN_ID,
+            delegate_to=None,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+
+        mock_trino_hook.assert_called_once_with(trino_conn_id=TRINO_CONN_ID)
+
+        mock_download = mock_gcs_hook.return_value.download
+
+        assert mock_download.call_count == 2
+
+        mock_insert = mock_trino_hook.return_value.insert_rows
+
+        mock_insert.assert_called_once()


### PR DESCRIPTION
Follow-up PR as discussed in https://github.com/apache/airflow/pull/21084

Logic followed is similar to the above PR.
Loads a csv file from Google Cloud Storage into a Trino table.
Assumptions:
1. First row of the csv contains headers
2. Trino table with requisite columns is already created
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
