### PR TITLE
Fix stray order_by(TaskInstance.execution_date)

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1208,18 +1208,18 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         end_date: Optional[datetime] = None,
         session: Session = NEW_SESSION,
     ) -> List[TaskInstance]:
-        """
-        Get a set of task instance related to this task for a specific date
-        range.
-        """
+        """Get task instances related to this task for a specific date range."""
+        from airflow.models import DagRun
+
         end_date = end_date or timezone.utcnow()
         return (
             session.query(TaskInstance)
+            .join(TaskInstance.dag_run)
             .filter(TaskInstance.dag_id == self.dag_id)
             .filter(TaskInstance.task_id == self.task_id)
-            .filter(TaskInstance.execution_date >= start_date)
-            .filter(TaskInstance.execution_date <= end_date)
-            .order_by(TaskInstance.execution_date)
+            .filter(DagRun.execution_date >= start_date)
+            .filter(DagRun.execution_date <= end_date)
+            .order_by(DagRun.execution_date)
             .all()
         )
 


### PR DESCRIPTION
Fix #21656.

Nobody noticed this exists because the function `BaseOperator.get_task_instances()` is not used anywhere in the code base. But since this is public API, we should still fix it.

A quick search for `order_by(TaskInstance.execution_date)` and `order_by(TI.execution_date)` yielded no other results; this is probably the only one we missed.