### PR TITLE
Add-showing-runtime-error-feature-to-DatabricksSubmitRunOperator

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -38,6 +38,7 @@ RUN_NOW_ENDPOINT = ('POST', 'api/2.1/jobs/run-now')
 SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/submit')
 GET_RUN_ENDPOINT = ('GET', 'api/2.1/jobs/runs/get')
 CANCEL_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/cancel')
+OUTPUT_RUNS_JOB_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get-output')
 
 INSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/install')
 UNINSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/uninstall')
@@ -261,6 +262,17 @@ class DatabricksHook(BaseDatabricksHook):
         :return: string with state message
         """
         return self.get_run_state(run_id).state_message
+
+    def get_run_output(self, run_id: int) -> dict:
+        """
+        Retrieves run output of the run.
+
+        :param run_id: id of the run
+        :return: output of the run
+        """
+        json = {'run_id': run_id}
+        run_output = self._do_api_call(OUTPUT_RUNS_JOB_ENDPOINT, json)
+        return run_output
 
     def cancel_run(self, run_id: int) -> None:
         """

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -38,7 +38,7 @@ RUN_NOW_ENDPOINT = ('POST', 'api/2.1/jobs/run-now')
 SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/submit')
 GET_RUN_ENDPOINT = ('GET', 'api/2.1/jobs/runs/get')
 CANCEL_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/cancel')
-OUTPUT_RUNS_JOB_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get-output')
+OUTPUT_RUNS_JOB_ENDPOINT = ('GET', 'api/2.1/jobs/runs/get-output')
 
 INSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/install')
 UNINSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/uninstall')

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -86,7 +86,10 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                     log.info('View run status, Spark UI, and logs at %s', run_page_url)
                     return
                 else:
-                    error_message = f'{operator.task_id} failed with terminal state: {run_state}'
+                    run_output = hook.get_run_output(operator.run_id)
+                    notebook_error = run_output['error']
+                    error_message = f'{operator.task_id} failed with terminal state: {run_state} ' \
+                                    f'and with the error {notebook_error}'
                     raise AirflowException(error_message)
             else:
                 log.info('%s in run state: %s', operator.task_id, run_state)

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -88,8 +88,10 @@ def _handle_databricks_operator_execution(operator, hook, log, context) -> None:
                 else:
                     run_output = hook.get_run_output(operator.run_id)
                     notebook_error = run_output['error']
-                    error_message = f'{operator.task_id} failed with terminal state: {run_state} ' \
-                                    f'and with the error {notebook_error}'
+                    error_message = (
+                        f'{operator.task_id} failed with terminal state: {run_state} '
+                        f'and with the error {notebook_error}'
+                    )
                     raise AirflowException(error_message)
             else:
                 log.info('%s in run state: %s', operator.task_id, run_state)

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -331,7 +331,7 @@ class TestDatabricksHook(unittest.TestCase):
                 'new_cluster': NEW_CLUSTER,
             },
             params=None,
-            auth=(LOGIN, PASSWORD),
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds,
         )

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -59,10 +59,16 @@ USER_AGENT_HEADER = {'user-agent': f'airflow-{__version__}'}
 RUN_PAGE_URL = 'https://XX.cloud.databricks.com/#jobs/1/runs/1'
 LIFE_CYCLE_STATE = 'PENDING'
 STATE_MESSAGE = 'Waiting for cluster'
+ERROR_MESSAGE = "error message from databricks API"
 GET_RUN_RESPONSE = {
     'job_id': JOB_ID,
     'run_page_url': RUN_PAGE_URL,
     'state': {'life_cycle_state': LIFE_CYCLE_STATE, 'state_message': STATE_MESSAGE},
+}
+GET_RUN_OUTPUT_RESPONSE= {
+   "metadata":{},
+   "error":ERROR_MESSAGE,
+   "notebook_output":{}
 }
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
@@ -103,6 +109,13 @@ def get_run_endpoint(host):
     Utility function to generate the get run endpoint given the host.
     """
     return f'https://{host}/api/2.1/jobs/runs/get'
+
+
+def get_run_output_endpoint(host):
+    """
+    Utility function to generate the get run output endpoint given the host.
+    """
+    return f'https://{host}/api/2.1/jobs/runs/get-output'
 
 
 def cancel_run_endpoint(host):
@@ -318,7 +331,7 @@ class TestDatabricksHook(unittest.TestCase):
                 'new_cluster': NEW_CLUSTER,
             },
             params=None,
-            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            auth=(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds,
         )
@@ -387,6 +400,22 @@ class TestDatabricksHook(unittest.TestCase):
         assert job_id == JOB_ID
         mock_requests.get.assert_called_once_with(
             get_run_endpoint(HOST),
+            json=None,
+            params={'run_id': RUN_ID},
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+        )
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks_base.requests')
+    def test_get_run_output(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_OUTPUT_RESPONSE
+
+        run_output_error = self.hook.get_run_output(RUN_ID).get('error')
+
+        assert run_output_error == ERROR_MESSAGE
+        mock_requests.get.assert_called_once_with(
+            get_run_output_endpoint(HOST),
             json=None,
             params={'run_id': RUN_ID},
             auth=HTTPBasicAuth(LOGIN, PASSWORD),

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -65,11 +65,7 @@ GET_RUN_RESPONSE = {
     'run_page_url': RUN_PAGE_URL,
     'state': {'life_cycle_state': LIFE_CYCLE_STATE, 'state_message': STATE_MESSAGE},
 }
-GET_RUN_OUTPUT_RESPONSE= {
-   "metadata":{},
-   "error":ERROR_MESSAGE,
-   "notebook_output":{}
-}
+GET_RUN_OUTPUT_RESPONSE = {"metadata": {}, "error": ERROR_MESSAGE, "notebook_output": {}}
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
 RESULT_STATE = ''


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

As its known in Airflow when we have a failed step (submitted a run for a Databricks notebook), we are not able to see the error in Airflow logs and need to visit the run page via the given link. 

In order to see the notebook error directly in Airflow step logs as in below
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/27499720/154935687-3920cda3-4349-409d-bd7e-b6acb004a9f8.png">
, in airflow.providers.databricks.operators.databricks - DatabricksSubmitRunOperator, I enriched the AirflowException error message with the error key value from run output by using the Databricks api/2.0/jobs/runs/get-output API and additional method in databricks hook (airflow.providers.databricks.hooks.databricks - DatabricksHook). The operator and hook has been already tested with an example DAG in local setup by running test on both with succeed and fail cases.

The new operator has all the functionality of prev version DatabricksSubmitRunOperator. Besides it has the functionality that with the API endpoint fetches the notebook error and shows the notebook error directly in step logs in Airflow.
