### PR TITLE
Bump upper bound version of jsonschema to 5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -565,7 +565,7 @@ repos:
         files: provider\.yaml$|scripts/ci/pre_commit/pre_commit_check_provider_yaml_files\.py$|^docs/
         additional_dependencies:
           - 'PyYAML==5.3.1'
-          - 'jsonschema==3.2.0'
+          - 'jsonschema>=3.2.0,<5.0.0'
           - 'tabulate==0.8.8'
           - 'jsonpath-ng==1.5.3'
           - 'rich==10.9.0'
@@ -618,7 +618,7 @@ repos:
         files: .*\.schema\.json$
         exclude: ^airflow/_vendor/
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: json-schema
         name: Lint NodePort Service with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py
@@ -629,7 +629,7 @@ repos:
         pass_filenames: true
         files: scripts/ci/kubernetes/nodeport.yaml
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: json-schema
         name: Lint Docker compose files with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py
@@ -640,7 +640,7 @@ repos:
         pass_filenames: true
         files: ^scripts/ci/docker-compose/.+\.ya?ml$|docker-compose\.ya?ml$
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: json-schema
         name: Lint chart/values.schema.json file with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py
@@ -652,7 +652,7 @@ repos:
         pass_filenames: false
         files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: vendor-k8s-json-schema
         name: Vendor k8s definitions into values.schema.json
         entry: ./scripts/ci/pre_commit/pre_commit_vendor_k8s_json_schema.py
@@ -671,7 +671,7 @@ repos:
         pass_filenames: false
         files: ^chart/values\.yaml$|^chart/values\.schema\.json$
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: json-schema
         name: Lint airflow/config_templates/config.yml file with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py
@@ -682,7 +682,7 @@ repos:
         pass_filenames: true
         files: airflow/config_templates/config\.yml$
         require_serial: true
-        additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+        additional_dependencies: ['jsonschema>=3.2.0,<5.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: persist-credentials-disabled
         name: Check that workflow files have persist-credentials disabled
         entry: ./scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
@@ -696,7 +696,6 @@ repos:
         language: python
         pass_filenames: true
         files: \.py$
-        pass_filenames: true
         exclude: ^airflow/_vendor/
         additional_dependencies: ['rich']
       - id: chart-schema-lint

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,9 +127,9 @@ install_requires =
     # break Flask 1.x, so we limit this for future compatibility. Remove this
     # when bumping Flask to >=2.
     jinja2>=2.10.1,<3.1
-    # We are using JSONSchema 3 for unknown reason
-    # TODO: we should attempt to remove the upper binding of JSONSchema
-    jsonschema~=3.0
+    # Because connexion upper-bound is 5.0.0 and we depend on connexion,
+    # we pin to the same upper-bound as connexion.
+    jsonschema>=3.2.0, <5.0
     lazy-object-proxy
     lockfile>=0.12.2
     markdown>=3.0


### PR DESCRIPTION
The upper bound is necessary because of connexion upper bound on jsonshema

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
