### PR TITLE
Respect user-configured timezone when generating DAG run ID 

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -388,6 +388,7 @@ class DagRun(Base, LoggingMixin):
     @staticmethod
     def generate_run_id(run_type: DagRunType, execution_date: datetime) -> str:
         """Generate Run ID based on Run Type and Execution Date"""
+        execution_date = execution_date.astimezone(tz=timezone.TIMEZONE)
         return f"{run_type}__{execution_date.isoformat()}"
 
     @provide_session


### PR DESCRIPTION
The execution date is displayed using the time zone setting instead of
always +00:00.

default_timezone = Asia/Shanghai

| before | after|
| -- | -- |
![2022-02-21_23-53](https://user-images.githubusercontent.com/55907021/154988775-0bb930be-d73f-42f9-ad7a-ea0465f9451d.png) | ![2022-02-21_23-57](https://user-images.githubusercontent.com/55907021/154989487-5cf808f6-b771-4fd3-90f8-68a4fc8ee231.png)

Just better viewing

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
