### PR TITLE
Fix BigQueryCreateEmptyDatasetOperator to use the provided project_id

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -470,7 +470,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         dataset: Dataset = Dataset.from_api_repr(dataset_reference)
         self.log.info('Creating dataset: %s in project: %s ', dataset.dataset_id, dataset.project)
-        self.get_client(location=location).create_dataset(dataset=dataset, exists_ok=exists_ok)
+        self.get_client(project_id=project_id, location=location).create_dataset(dataset=dataset, exists_ok=exists_ok)
         self.log.info('Dataset created successfully.')
 
     @GoogleBaseHook.fallback_to_default_project_id


### PR DESCRIPTION
This PR fixes the issue that occurs in the `BigQueryCreateEmptyDatasetOperator` when the BigQuery client can't infer the Google Cloud project_id from the environment or the credentials, in which case the user provides the project_id as an argument to the operator.

It is fixed by adding the project_id as an argument to the BigQuery client when it's called from `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`. This is on par with how the rest of the BigQuery hook's methods call the client, but it was originally omitted from the `create_empty_dataset` method.

closes: #21600
related: #21600
<!--

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
