### PR TITLE
Fix filesystem sensor for directories

### DIFF
--- a/airflow/sensors/filesystem.py
+++ b/airflow/sensors/filesystem.py
@@ -63,7 +63,7 @@ class FileSensor(BaseSensorOperator):
                 self.log.info('Found File %s last modified: %s', str(path), mod_time)
                 return True
 
-            for _, _, files in os.walk(full_path):
+            for _, _, files in os.walk(path):
                 if len(files) > 0:
                     return True
         return False


### PR DESCRIPTION
Fix walking through wildcarded directory in `FileSensor.poke` method