### PR TITLE
Fix graph autorefresh on page load

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -478,7 +478,6 @@ function groupTooltip(node, tis) {
 function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
     const { elem } = g.node(nodeId);
-
     if (elem) {
       const classes = `node enter ${getNodeState(nodeId, tis)}`;
       elem.setAttribute('class', classes);

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -58,6 +58,15 @@ const stateFocusMap = {
   deferred: false,
   no_status: false,
 };
+
+const isFinal = () => {
+  const states = Object.values(taskInstances).map((ti) => ti.state);
+
+  // end refresh if all states are final
+  return !states.some((state) => (
+    ['success', 'failed', 'upstream_failed', 'skipped', 'removed'].indexOf(state) === -1));
+};
+
 const taskTip = d3.tip()
   .attr('class', 'tooltip d3-tip')
   .html((toolTipHtml) => toolTipHtml);
@@ -363,13 +372,10 @@ function handleRefresh() {
         if (prevTis !== tis) {
         // eslint-disable-next-line no-global-assign
           taskInstances = JSON.parse(tis);
-          const states = Object.values(taskInstances).map((ti) => ti.state);
           updateNodesStates(taskInstances);
 
           // end refresh if all states are final
-          if (!states.some((state) => (
-            ['success', 'failed', 'upstream_failed', 'skipped', 'removed'].indexOf(state) === -1))
-          ) {
+          if (isFinal()) {
             $('#auto_refresh').prop('checked', false);
             clearInterval(refreshInterval);
           }
@@ -411,9 +417,8 @@ $('#auto_refresh').change(() => {
 });
 
 function initRefresh() {
-  if (localStorage.getItem('disableAutoRefresh')) {
-    $('#auto_refresh').prop('checked', false);
-  }
+  const isDisabled = localStorage.getItem('disableAutoRefresh');
+  $('#auto_refresh').prop('checked', !(isDisabled || isFinal()));
   startOrStopRefresh();
   d3.select('#refresh_button').on('click', () => handleRefresh());
 }
@@ -472,14 +477,15 @@ function groupTooltip(node, tis) {
 // Initiating the tooltips
 function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
-    const { elem } = g.node(nodeId);
+    const node = g.node(nodeId);
+    const { elem } = node;
+    const taskId = nodeId;
+
     if (elem) {
       const classes = `node enter ${getNodeState(nodeId, tis)}`;
       elem.setAttribute('class', classes);
       elem.setAttribute('data-toggle', 'tooltip');
 
-      const taskId = nodeId;
-      const node = g.node(nodeId);
       elem.onmouseover = (evt) => {
         let tt;
         if (taskId in tis) {

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -59,10 +59,8 @@ const stateFocusMap = {
   no_status: false,
 };
 
-const isFinal = () => {
+const checkRunState = () => {
   const states = Object.values(taskInstances).map((ti) => ti.state);
-
-  // end refresh if all states are final
   return !states.some((state) => (
     ['success', 'failed', 'upstream_failed', 'skipped', 'removed'].indexOf(state) === -1));
 };
@@ -375,7 +373,8 @@ function handleRefresh() {
           updateNodesStates(taskInstances);
 
           // end refresh if all states are final
-          if (isFinal()) {
+          const isFinal = checkRunState();
+          if (isFinal) {
             $('#auto_refresh').prop('checked', false);
             clearInterval(refreshInterval);
           }
@@ -418,7 +417,8 @@ $('#auto_refresh').change(() => {
 
 function initRefresh() {
   const isDisabled = localStorage.getItem('disableAutoRefresh');
-  $('#auto_refresh').prop('checked', !(isDisabled || isFinal()));
+  const isFinal = checkRunState();
+  $('#auto_refresh').prop('checked', !(isDisabled || isFinal));
   startOrStopRefresh();
   d3.select('#refresh_button').on('click', () => handleRefresh());
 }
@@ -477,15 +477,15 @@ function groupTooltip(node, tis) {
 // Initiating the tooltips
 function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
-    const node = g.node(nodeId);
-    const { elem } = node;
-    const taskId = nodeId;
+    const { elem } = g.node(nodeId);
 
     if (elem) {
       const classes = `node enter ${getNodeState(nodeId, tis)}`;
       elem.setAttribute('class', classes);
       elem.setAttribute('data-toggle', 'tooltip');
 
+      const taskId = nodeId;
+      const node = g.node(nodeId);
       elem.onmouseover = (evt) => {
         let tt;
         if (taskId in tis) {


### PR DESCRIPTION
Problem:
When the graph view loaded, if the selected run was active (`queued`, `running`), nothing happened. A user had to manually turn on the autorefresh.

Solution:
On page load, turn on autorefresh automatically if the run is active.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
