### PR TITLE
REST API: add rendered fields in task instance.

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -39,6 +39,7 @@ from airflow.api_connexion.schemas.task_instance_schema import (
 from airflow.api_connexion.types import APIResponse
 from airflow.models import SlaMiss
 from airflow.models.dagrun import DagRun as DR
+from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.taskinstance import TaskInstance as TI, clear_task_instances
 from airflow.security import permissions
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -77,6 +78,14 @@ def get_task_instance(
         )
         .add_entity(SlaMiss)
     )
+    query = query.outerjoin(
+        RTIF,
+        and_(
+            RTIF.dag_id == TI.dag_id,
+            RTIF.execution_date == DR.execution_date,
+            RTIF.task_id == TI.task_id,
+        ),
+    ).add_entity(RTIF)
     task_instance = query.one_or_none()
     if task_instance is None:
         raise NotFound("Task instance not found")
@@ -178,8 +187,15 @@ def get_task_instances(
             SlaMiss.execution_date == DR.execution_date,
         ),
         isouter=True,
-    )
-    ti_query = base_query.add_entity(SlaMiss)
+    ).add_entity(SlaMiss)
+    ti_query = base_query.outerjoin(
+        RTIF,
+        and_(
+            RTIF.dag_id == TI.dag_id,
+            RTIF.task_id == TI.task_id,
+            RTIF.execution_date == DR.execution_date,
+        ),
+    ).add_entity(RTIF)
     task_instances = ti_query.offset(offset).limit(limit).all()
 
     return task_instance_collection_schema.dump(
@@ -237,8 +253,15 @@ def get_task_instances_batch(session: Session = NEW_SESSION) -> APIResponse:
             SlaMiss.execution_date == DR.execution_date,
         ),
         isouter=True,
-    )
-    ti_query = base_query.add_entity(SlaMiss)
+    ).add_entity(SlaMiss)
+    ti_query = base_query.outerjoin(
+        RTIF,
+        and_(
+            RTIF.dag_id == TI.dag_id,
+            RTIF.task_id == TI.task_id,
+            RTIF.execution_date == DR.execution_date,
+        ),
+    ).add_entity(RTIF)
     task_instances = ti_query.all()
 
     return task_instance_collection_schema.dump(

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2496,6 +2496,10 @@ components:
         sla_miss:
           $ref: '#/components/schemas/SLAMiss'
           nullable: true
+        rendered_fields:
+          type: object
+          description: |
+            JSON object describing rendered fields.
 
     TaskInstanceCollection:
       type: object

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2497,9 +2497,11 @@ components:
           $ref: '#/components/schemas/SLAMiss'
           nullable: true
         rendered_fields:
-          type: object
           description: |
             JSON object describing rendered fields.
+
+            *New in version 2.3.0*
+          type: object
 
     TaskInstanceCollection:
       type: object

--- a/airflow/api_connexion/schemas/common_schema.py
+++ b/airflow/api_connexion/schemas/common_schema.py
@@ -17,6 +17,7 @@
 
 import datetime
 import inspect
+import json
 import typing
 
 import marshmallow
@@ -165,3 +166,17 @@ class ClassReferenceSchema(Schema):
         if isinstance(obj, type):
             return obj.__name__
         return type(obj).__name__
+
+
+class JsonObjectField(fields.Field):
+    """JSON object field."""
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        if not value:
+            return {}
+        return json.loads(value) if isinstance(value, str) else value
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if isinstance(value, str):
+            return json.loads(value)
+        return value

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -22,6 +22,7 @@ from marshmallow.utils import get_value
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.parameters import validate_istimezone
+from airflow.api_connexion.schemas.common_schema import JsonObjectField
 from airflow.api_connexion.schemas.enum_schemas import TaskInstanceStateField
 from airflow.api_connexion.schemas.sla_miss_schema import SlaMissSchema
 from airflow.models import SlaMiss, TaskInstance
@@ -58,6 +59,7 @@ class TaskInstanceSchema(SQLAlchemySchema):
     pid = auto_field()
     executor_config = auto_field()
     sla_miss = fields.Nested(SlaMissSchema, dump_default=None)
+    rendered_fields = JsonObjectField()
 
     def get_attribute(self, obj, attr, default):
         if attr == "sla_miss":
@@ -66,6 +68,8 @@ class TaskInstanceSchema(SQLAlchemySchema):
             # corresponding to the attr.
             slamiss_instance = {"sla_miss": obj[1]}
             return get_value(slamiss_instance, attr, default)
+        elif attr == "rendered_fields":
+            return get_value(obj[2], attr, None)
         return get_value(obj[0], attr, default)
 
 

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -22,6 +22,7 @@ from parameterized import parameterized
 from sqlalchemy.orm import contains_eager
 
 from airflow.models import DagRun, SlaMiss, TaskInstance
+from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.security import permissions
 from airflow.utils.platform import getuser
 from airflow.utils.session import provide_session
@@ -29,7 +30,7 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_roles, delete_user
-from tests.test_utils.db import clear_db_runs, clear_db_sla_miss
+from tests.test_utils.db import clear_db_runs, clear_db_sla_miss, clear_rendered_ti_fields
 
 DEFAULT_DATETIME_1 = datetime(2020, 1, 1)
 DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00+00:00"
@@ -105,6 +106,7 @@ class TestTaskInstanceEndpoint:
         self.client = self.app.test_client()  # type:ignore
         clear_db_runs()
         clear_db_sla_miss()
+        clear_rendered_ti_fields()
         self.dagbag = dagbag
 
     def create_task_instances(
@@ -127,6 +129,7 @@ class TestTaskInstanceEndpoint:
         execution_date = self.ti_init.pop("execution_date", self.default_time)
         dr = None
 
+        tis = []
         for i in range(counter):
             if task_instances is None:
                 pass
@@ -155,8 +158,10 @@ class TestTaskInstanceEndpoint:
             for key, value in self.ti_extras.items():
                 setattr(ti, key, value)
             session.add(ti)
+            tis.append(ti)
 
         session.commit()
+        return tis
 
 
 class TestGetTaskInstance(TestTaskInstanceEndpoint):
@@ -198,6 +203,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": "TEST_DAG_RUN_ID",
+            "rendered_fields": {},
         }
 
     def test_should_respond_200_with_task_state_in_removed(self, session):
@@ -229,10 +235,11 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": "TEST_DAG_RUN_ID",
+            "rendered_fields": {},
         }
 
-    def test_should_respond_200_task_instance_with_sla(self, session):
-        self.create_task_instances(session)
+    def test_should_respond_200_task_instance_with_sla_and_rendered(self, session):
+        tis = self.create_task_instances(session)
         session.query()
         sla_miss = SlaMiss(
             task_id="print_the_context",
@@ -241,6 +248,8 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             timestamp=self.default_time,
         )
         session.add(sla_miss)
+        rendered_fields = RTIF(tis[0], render_templates=False)
+        session.add(rendered_fields)
         session.commit()
         response = self.client.get(
             "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context",
@@ -278,6 +287,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": "TEST_DAG_RUN_ID",
+            "rendered_fields": {'op_args': [], 'op_kwargs': {}},
         }
 
     def test_should_raises_401_unauthenticated(self):

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -27,7 +27,7 @@ from airflow.api_connexion.schemas.task_instance_schema import (
     set_task_instance_state_form,
     task_instance_schema,
 )
-from airflow.models import SlaMiss, TaskInstance as TI
+from airflow.models import RenderedTaskInstanceFields as RTIF, SlaMiss, TaskInstance as TI
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.platform import getuser
 from airflow.utils.state import State
@@ -62,11 +62,11 @@ class TestTaskInstanceSchema:
 
         session.rollback()
 
-    def test_task_instance_schema_without_sla(self, session):
+    def test_task_instance_schema_without_sla_and_rendered(self, session):
         ti = TI(task=self.task, **self.default_ti_init)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
-        serialized_ti = task_instance_schema.dump((ti, None))
+        serialized_ti = task_instance_schema.dump((ti, None, None))
         expected_json = {
             "dag_id": "TEST_DAG_ID",
             "duration": 10000.0,
@@ -89,10 +89,11 @@ class TestTaskInstanceSchema:
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": None,
+            "rendered_fields": {},
         }
         assert serialized_ti == expected_json
 
-    def test_task_instance_schema_with_sla(self, session):
+    def test_task_instance_schema_with_sla_and_rendered(self, session):
         sla_miss = SlaMiss(
             task_id="TEST_TASK_ID",
             dag_id="TEST_DAG_ID",
@@ -103,7 +104,10 @@ class TestTaskInstanceSchema:
         ti = TI(task=self.task, **self.default_ti_init)
         for key, value in self.default_ti_extras.items():
             setattr(ti, key, value)
-        serialized_ti = task_instance_schema.dump((ti, sla_miss))
+        self.task.template_fields = ["partitions"]
+        setattr(self.task, "partitions", "data/ds=2022-02-17")
+        rendered_fields = RTIF(ti, render_templates=False)
+        serialized_ti = task_instance_schema.dump((ti, sla_miss, rendered_fields))
         expected_json = {
             "dag_id": "TEST_DAG_ID",
             "duration": 10000.0,
@@ -134,6 +138,7 @@ class TestTaskInstanceSchema:
             "try_number": 0,
             "unixname": getuser(),
             "dag_run_id": None,
+            "rendered_fields": {"partitions": "data/ds=2022-02-17"},
         }
         assert serialized_ti == expected_json
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Make task instance rendered template fields available in the REST API issue #21447
- added rendered_fields as json object in TaskInstanceSchema.
- updated api unit tests to cover the new field.

@ephraimbuddy

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
