### PR TITLE
Chart: Default to Airflow 2.2.4

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 1.5.0-dev
-appVersion: 2.2.3
+appVersion: 2.2.4
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/
@@ -47,18 +47,20 @@ annotations:
       url: https://airflow.apache.org/docs/helm-chart/1.5.0/
   artifacthub.io/screenshots: |
     - title: DAGs View
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/dags.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/dags.png
     - title: Tree View
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/tree.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/tree.png
+    - title: Graph View
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/graph.png
     - title: Calendar View
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/calendar.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/calendar.png
     - title: Variable View
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/variable_hidden1.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/variable_hidden.png
     - title: Gantt Chart
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/gantt.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/gantt.png
     - title: Task Duration
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/duration.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/duration.png
     - title: Code View
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/code.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/code.png
     - title: Task Instance Context Menu
-      url: https://airflow.apache.org/docs/apache-airflow/2.2.3/_images/context.png
+      url: https://airflow.apache.org/docs/apache-airflow/2.2.4/_images/context.png

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -35,6 +35,15 @@ assists users migrating to a new version.
 
 Run ``helm repo update`` before upgrading the chart to the latest version.
 
+
+Airflow Helm Chart 1.5.0
+------------------------
+
+Default Airflow image is updated to ``2.2.4``
+"""""""""""""""""""""""""""""""""""""""""""""
+
+The default Airflow image that is used with the Chart is now ``2.2.4``, previously it was ``2.2.3``.
+
 Airflow Helm Chart 1.4.0
 ------------------------
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -67,13 +67,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.2.3",
+            "default": "2.2.4",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.2.3",
+            "default": "2.2.4",
             "x-docsSection": "Common"
         },
         "securityContext": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,10 +46,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.2.3"
+defaultAirflowTag: "2.2.4"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.2.3"
+airflowVersion: "2.2.4"
 
 # Images
 images:


### PR DESCRIPTION
Use Airflow `2.2.4` as the chart's default image.