### PR TITLE
Rename operator mapping map() to apply()

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -261,7 +261,7 @@ def partial(
     partial_kwargs.setdefault("outlets", outlets)
     partial_kwargs.setdefault("resources", resources)
 
-    # Post-process arguments. Should be kept in sync with _TaskDecorator.map().
+    # Post-process arguments. Should be kept in sync with _TaskDecorator.apply().
     if "task_concurrency" in kwargs:  # Reject deprecated option.
         raise TypeError("unexpected argument: task_concurrency")
     if partial_kwargs["wait_for_downstream"]:
@@ -671,7 +671,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_group = task_group or TaskGroupContext.get_current_task_group(dag)
 
         if not _airflow_map_validation and isinstance(task_group, MappedTaskGroup):
-            return cls.partial(dag=dag, task_group=task_group, **kwargs).map()
+            return cls.partial(dag=dag, task_group=task_group, **kwargs).apply()
         return super().__new__(cls)
 
     def __init__(

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -380,7 +380,7 @@ class TaskGroup(DAGNode):
 
         return DagAttributeTypes.TASK_GROUP, SerializedTaskGroup.serialize_task_group(self)
 
-    def map(self, arg: Iterable) -> "MappedTaskGroup":
+    def apply(self, arg: Iterable) -> "MappedTaskGroup":
         if self.children:
             raise RuntimeError("Cannot map a TaskGroup that already has children")
         if not self.group_id:

--- a/tests/dags/test_mapped_classic.py
+++ b/tests/dags/test_mapped_classic.py
@@ -31,4 +31,4 @@ def consumer(value):
 
 
 with DAG(dag_id='test_mapped_classic', start_date=days_ago(2)) as dag:
-    PythonOperator.partial(task_id='consumer', python_callable=consumer).map(op_args=make_arg_lists())
+    PythonOperator.partial(task_id='consumer', python_callable=consumer).apply(op_args=make_arg_lists())

--- a/tests/dags/test_mapped_taskflow.py
+++ b/tests/dags/test_mapped_taskflow.py
@@ -28,4 +28,4 @@ with DAG(dag_id='test_mapped_taskflow', start_date=days_ago(2)) as dag:
     def consumer(value):
         print(repr(value))
 
-    consumer.map(value=make_list())
+    consumer.apply(value=make_list())

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -487,8 +487,8 @@ def test_mapped_decorator_shadow_context() -> None:
     assert str(ctx.value) == "cannot call partial() on task context variable 'run_id'"
 
     with pytest.raises(ValueError) as ctx:
-        print_info.map(run_id=["hi", "there"])
-    assert str(ctx.value) == "cannot call map() on task context variable 'run_id'"
+        print_info.apply(run_id=["hi", "there"])
+    assert str(ctx.value) == "cannot call apply() on task context variable 'run_id'"
 
 
 def test_mapped_decorator_wrong_argument() -> None:
@@ -501,12 +501,12 @@ def test_mapped_decorator_wrong_argument() -> None:
     assert str(ct.value) == "partial() got an unexpected keyword argument 'wrong_name'"
 
     with pytest.raises(TypeError) as ct:
-        print_info.map(wrong_name=["hi", "there"])
-    assert str(ct.value) == "map() got an unexpected keyword argument 'wrong_name'"
+        print_info.apply(wrong_name=["hi", "there"])
+    assert str(ct.value) == "apply() got an unexpected keyword argument 'wrong_name'"
 
     with pytest.raises(ValueError) as cv:
-        print_info.map(message="hi")
-    assert str(cv.value) == "map() got an unexpected type 'str' for keyword argument 'message'"
+        print_info.apply(message="hi")
+    assert str(cv.value) == "apply() got an unexpected type 'str' for keyword argument 'message'"
 
 
 def test_mapped_decorator():
@@ -519,9 +519,9 @@ def test_mapped_decorator():
         print(kwargs)
 
     with DAG("test_mapped_decorator", start_date=DEFAULT_DATE):
-        t0 = print_info.map(m1=["a", "b"], m2={"foo": "bar"})
-        t1 = print_info.partial(m1="hi").map(m2=[1, 2, 3])
-        t2 = print_everything.partial(whatever="123").map(any_key=[1, 2], works=t1)
+        t0 = print_info.apply(m1=["a", "b"], m2={"foo": "bar"})
+        t1 = print_info.partial(m1="hi").apply(m2=[1, 2, 3])
+        t2 = print_everything.partial(whatever="123").apply(any_key=[1, 2], works=t1)
 
     assert isinstance(t2, XComArg)
     assert isinstance(t2.operator, DecoratedMappedOperator)
@@ -542,9 +542,9 @@ def test_mapped_decorator_invalid_args() -> None:
     with pytest.raises(TypeError, match="arguments 'other', 'b'"):
         double.partial(other=[1], b=['a'])
     with pytest.raises(TypeError, match="argument 'other'"):
-        double.map(number=literal, other=[1])
+        double.apply(number=literal, other=[1])
     with pytest.raises(ValueError, match="argument 'number'"):
-        double.map(number=1)  # type: ignore[arg-type]
+        double.apply(number=1)  # type: ignore[arg-type]
 
 
 def test_partial_mapped_decorator() -> None:
@@ -555,9 +555,9 @@ def test_partial_mapped_decorator() -> None:
     literal = [1, 2, 3]
 
     with DAG('test_dag', start_date=DEFAULT_DATE) as dag:
-        quadrupled = product.partial(multiple=3).map(number=literal)
-        doubled = product.partial(multiple=2).map(number=literal)
-        trippled = product.partial(multiple=3).map(number=literal)
+        quadrupled = product.partial(multiple=3).apply(number=literal)
+        doubled = product.partial(multiple=2).apply(number=literal)
+        trippled = product.partial(multiple=3).apply(number=literal)
 
         product.partial(multiple=2)  # No operator is actually created.
 
@@ -589,7 +589,7 @@ def test_mapped_decorator_unmap_merge_op_kwargs():
         def task2(arg1, arg2):
             ...
 
-        task2.partial(arg1=1).map(arg2=task1())
+        task2.partial(arg1=1).apply(arg2=task1())
 
     unmapped = dag.get_task("task2").unmap()
     assert set(unmapped.op_kwargs) == {"arg1", "arg2"}
@@ -606,7 +606,7 @@ def test_mapped_decorator_converts_partial_kwargs():
         def task2(arg1, arg2):
             ...
 
-        task2.partial(arg1=1).map(arg2=task1.map(arg=[1, 2]))
+        task2.partial(arg1=1).apply(arg2=task1.apply(arg=[1, 2]))
 
     mapped_task2 = dag.get_task("task2")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -704,7 +704,7 @@ def test_task_mapping_with_dag():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         task1 = BaseOperator(task_id="op1")
         literal = ['a', 'b', 'c']
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=literal)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
         finish = MockOperator(task_id="finish")
 
         task1 >> mapped >> finish
@@ -723,7 +723,7 @@ def test_task_mapping_without_dag_context():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         task1 = BaseOperator(task_id="op1")
     literal = ['a', 'b', 'c']
-    mapped = MockOperator.partial(task_id='task_2').map(arg2=literal)
+    mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
 
     task1 >> mapped
 
@@ -740,7 +740,7 @@ def test_task_mapping_default_args():
     with DAG("test-dag", start_date=DEFAULT_DATE, default_args=default_args):
         task1 = BaseOperator(task_id="op1")
         literal = ['a', 'b', 'c']
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=literal)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
 
         task1 >> mapped
 
@@ -750,7 +750,7 @@ def test_task_mapping_default_args():
 
 def test_map_unknown_arg_raises():
     with pytest.raises(TypeError, match=r"argument 'file'"):
-        BaseOperator.partial(task_id='a').map(file=[1, 2, {'a': 'b'}])
+        BaseOperator.partial(task_id='a').apply(file=[1, 2, {'a': 'b'}])
 
 
 def test_map_xcom_arg():
@@ -758,7 +758,7 @@ def test_map_xcom_arg():
     with DAG("test-dag", start_date=DEFAULT_DATE):
         task1 = BaseOperator(task_id="op1")
         xcomarg = XComArg(task1, "test_key")
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=xcomarg)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=xcomarg)
         finish = MockOperator(task_id="finish")
 
         mapped >> finish
@@ -817,7 +817,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
         xcomarg = XComArg(task1, "test_key")
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=xcomarg)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=xcomarg)
 
     dr = dag_maker.create_dagrun()
 
@@ -861,7 +861,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=XComArg(task1, XCOM_RETURN_KEY))
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1, XCOM_RETURN_KEY))
 
     dr = dag_maker.create_dagrun()
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -910,7 +910,7 @@ def test_verify_integrity_task_start_date(Stats_incr, session, run_type, expecte
 def test_expand_mapped_task_instance(dag_maker, session):
     literal = [1, 2, {'a': 'b'}]
     with dag_maker(session=session):
-        mapped = MockOperator(task_id='task_2').map(arg2=literal)
+        mapped = MockOperator(task_id='task_2').apply(arg2=literal)
 
     dr = dag_maker.create_dagrun()
     indices = (
@@ -926,7 +926,7 @@ def test_expand_mapped_task_instance(dag_maker, session):
 def test_ti_scheduling_mapped_zero_length(dag_maker, session):
     with dag_maker(session=session):
         task = BaseOperator(task_id='task_1')
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=XComArg(task))
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task))
 
     dr: DagRun = dag_maker.create_dagrun()
     ti1, _ = sorted(dr.task_instances, key=lambda ti: ti.task_id)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2289,7 +2289,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.map(value=push_something())
+            pull_something.apply(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         with pytest.raises(UnmappableXComTypePushed) as ctx:
@@ -2312,7 +2312,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.map(value=push_something())
+            pull_something.apply(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         with pytest.raises(UnmappableXComLengthPushed) as ctx:
@@ -2341,7 +2341,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.map(value=push_something())
+            pull_something.apply(value=push_something())
 
         dag_run = dag_maker.create_dagrun()
         ti = next(ti for ti in dag_run.task_instances if ti.task_id == "push_something")
@@ -2373,7 +2373,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(value):
                 outputs.append(value)
 
-            show.map(value=literal)
+            show.apply(value=literal)
 
         dag_run = dag_maker.create_dagrun()
         show_task = dag.get_task("show")
@@ -2405,7 +2405,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(value):
                 outputs.append(value)
 
-            show.map(value=emit())
+            show.apply(value=emit())
 
         dag_run = dag_maker.create_dagrun()
         emit_ti = dag_run.get_task_instance("emit", session=session)
@@ -2438,7 +2438,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(number, letter):
                 outputs.append((number, letter))
 
-            show.map(number=emit_numbers(), letter=emit_letters())
+            show.apply(number=emit_numbers(), letter=emit_letters())
 
         dag_run = dag_maker.create_dagrun()
         for task_id in ["emit_numbers", "emit_letters"]:
@@ -2477,7 +2477,7 @@ class TestMappedTaskInstanceReceiveValue:
                 outputs.append((a, b))
 
             emit_task = emit_numbers()
-            show.map(a=emit_task, b=emit_task)
+            show.apply(a=emit_task, b=emit_task)
 
         dag_run = dag_maker.create_dagrun()
         ti = dag_run.get_task_instance("emit_numbers", session=session)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1600,7 +1600,7 @@ def test_kubernetes_optional():
 
 def test_mapped_operator_serde():
     literal = [1, 2, {'a': 'b'}]
-    real_op = BashOperator.partial(task_id='a', executor_config={'dict': {'sub': 'value'}}).map(
+    real_op = BashOperator.partial(task_id='a', executor_config={'dict': {'sub': 'value'}}).apply(
         bash_command=literal
     )
 
@@ -1650,7 +1650,7 @@ def test_mapped_operator_xcomarg_serde():
     with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
         task1 = BaseOperator(task_id="op1")
         xcomarg = XComArg(task1, "test_key")
-        mapped = MockOperator.partial(task_id='task_2').map(arg2=xcomarg)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=xcomarg)
 
     serialized = SerializedBaseOperator._serialize(mapped)
     assert serialized == {
@@ -1716,7 +1716,7 @@ def test_mapped_decorator_serde():
         def x(arg1, arg2, arg3):
             print(arg1, arg2, arg3)
 
-        x.partial(arg1=[1, 2, {"a": "b"}]).map(arg2={"a": 1, "b": 2}, arg3=xcomarg)
+        x.partial(arg1=[1, 2, {"a": "b"}]).apply(arg2={"a": 1, "b": 2}, arg3=xcomarg)
 
     original = dag.get_task("x")
 
@@ -1767,7 +1767,7 @@ def test_mapped_task_group_serde():
 
     literal = [1, 2, {'a': 'b'}]
     with DAG("test", start_date=execution_date) as dag:
-        with TaskGroup("process_one", dag=dag).map(literal) as process_one:
+        with TaskGroup("process_one", dag=dag).apply(literal) as process_one:
             BaseOperator(task_id='one')
 
     serialized = SerializedTaskGroup.serialize_task_group(process_one)

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1044,7 +1044,7 @@ def test_map() -> None:
         start = MockOperator(task_id="start")
         end = MockOperator(task_id="end")
         literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").map(literal) as process_one:
+        with TaskGroup("process_one").apply(literal) as process_one:
             one = MockOperator(task_id='one')
             two = MockOperator(task_id='two')
             three = MockOperator(task_id='three')
@@ -1073,10 +1073,10 @@ def test_nested_map() -> None:
         start = MockOperator(task_id="start")
         end = MockOperator(task_id="end")
         literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").map(literal) as process_one:
+        with TaskGroup("process_one").apply(literal) as process_one:
             one = MockOperator(task_id='one')
 
-            with TaskGroup("process_two").map(literal) as process_one_two:
+            with TaskGroup("process_two").apply(literal) as process_one_two:
                 two = MockOperator(task_id='two')
                 three = MockOperator(task_id='three')
                 two >> three
@@ -1147,7 +1147,7 @@ def test_decorator_map():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         lines = ["foo", "bar", "baz"]
 
-        (task_1, task_2, task_3) = my_task_group.partial(unmapped=True).map(my_arg_1=lines)
+        (task_1, task_2, task_3) = my_task_group.partial(unmapped=True).apply(my_arg_1=lines)
 
     assert task_1 in dag.tasks
 


### PR DESCRIPTION
According to the design discussion, we’re going to use `map()` for something else that matches more closely to the FP `map` concept.

Do we also want to rename `mapped_kwargs` to something else? (to what?)