### PR TITLE
Restore image rendering in AWS Secrets Manager Backend doc

### DIFF
--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
@@ -37,8 +37,9 @@ environment variables like ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``.
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""
 You can store the different values for a secret in two forms: storing the conn URI in one field (default mode) or using different
-fields in Amazon Secrets Manager (setting ``full_url_mode`` as ``false`` in the backend config), as follow:
-.. image:: img/aws-secrets-manager.png
+fields in Amazon Secrets Manager (setting ``full_url_mode`` as ``false`` in the backend config), as follows:
+
+.. image:: /img/aws-secrets-manager.png
 
 By default you must use some of the following words for each kind of field:
 


### PR DESCRIPTION
The image in the doc showing an example of storing connection info in AWS Secrets Manager does not render in the doc. This PR restores the image.

**Before**
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/48934154/155408987-1da915f1-ee07-4ecc-aae1-c813b4d5f954.png">

**After**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/48934154/155409054-60634f56-d59c-4b79-81b9-e9749776b85a.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
