### PR TITLE
Add unit tests to infer `multiple_outputs` when invoking decorator `__call__`

### DIFF
--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -97,6 +97,13 @@ class TestAirflowTaskDecorator:
 
         assert identity_dict(5, 5).operator.multiple_outputs is True
 
+        # Check invoking ``@task_decorator.__call__()`` yields the correct inference.
+        @task_decorator()
+        def identity_dict_with_decorator_call(x: int, y: int) -> resolve(annotation):
+            return {"x": x, "y": y}
+
+        assert identity_dict_with_decorator_call(5, 5).operator.multiple_outputs is True
+
     def test_infer_multiple_outputs_using_other_typing(self):
         @task_decorator
         def identity_tuple(x: int, y: int) -> Tuple[int, int]:
@@ -115,6 +122,25 @@ class TestAirflowTaskDecorator:
             return x
 
         assert identity_notyping(5).operator.multiple_outputs is False
+
+        # The following cases ensure invoking ``@task_decorator.__call__()`` yields the correct inference.
+        @task_decorator()
+        def identity_tuple_with_decorator_call(x: int, y: int) -> Tuple[int, int]:
+            return x, y
+
+        assert identity_tuple_with_decorator_call(5, 5).operator.multiple_outputs is False
+
+        @task_decorator()
+        def identity_int_with_decorator_call(x: int) -> int:
+            return x
+
+        assert identity_int_with_decorator_call(5).operator.multiple_outputs is False
+
+        @task_decorator()
+        def identity_notyping_with_decorator_call(x: int):
+            return x
+
+        assert identity_notyping_with_decorator_call(5).operator.multiple_outputs is False
 
     def test_manual_multiple_outputs_false_with_typings(self):
         @task_decorator(multiple_outputs=False)


### PR DESCRIPTION
When testing the RC for 2.2.4, the `multiple_outputs` inference did not function correctly when a `@task` decorator was simply "called" or had args passed.

For example, given the below task definition, we should expect `multiple_outputs` to be True and `XComs` to unroll into separate keys.
```python
    def do_stuff():
        return {"First": 1, "Second": 2}
    
    @task()
    def call_task_dec() -> Dict:
        my_stuff = do_stuff()
        return my_stuff
```
Unfortunately this does not occur:
<img width="658" alt="image" src="https://user-images.githubusercontent.com/48934154/155414911-96849f67-4948-4e21-a809-f656446bea37.png">

However, when testing this on `main` the `multiple_outputs` inference does function as expected:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/48934154/155415051-2c1848c6-450f-4adb-9d65-a081a37ee8d6.png">

While this behavior is not a regression since I confirmed the inference in this scenario _does not_ work as well in 2.2.3, cherry-picking the `main` changes would not be trivial since this logic was refactored.

A [discussion](https://github.com/apache/airflow/issues/21669#issuecomment-1048160108) on this can be found in the RC testing issue.

In order to guard against future regressions, this PR adds some unit tests to ensure the inference works as expected when invoking a decorator's `__call__()` method.

Happy to hear any feedback on possibly parameterizing these tests as well to decrease some duplication.

CC: @jedcunningham 



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
