### PR TITLE
Show Task Map Index in  task instance table

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4685,7 +4685,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         """Only show indices of mapped tasks"""
         map_index = self.get('map_index')
         if map_index < 0:
-            return ' '
+            return Markup("&nbsp;")
         return None
 
     formatters_columns = {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4607,6 +4607,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         'dag_id',
         'task_id',
         'run_id',
+        'map_index',
         'dag_run.execution_date',
         'operator',
         'start_date',
@@ -4680,10 +4681,18 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
             return td_format(timedelta(seconds=duration))
         return None
 
+    def format_map_index(self):
+        """Only show indices of mapped tasks"""
+        map_index = self.get('map_index')
+        if map_index < 0:
+            return ' '
+        return None
+
     formatters_columns = {
         'log_url': log_url_formatter,
         'task_id': wwwutils.task_instance_link,
         'run_id': wwwutils.dag_run_link,
+        'map_index': format_map_index,
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
         'dag_run.execution_date': wwwutils.datetime_f('dag_run.execution_date'),


### PR DESCRIPTION
With AIP-42, task instances are now keyed by, run_id, task_id and map_index. Therefore, this PR adds a column to the Task Instance table UI. By default, `map_index` is `-1` so those indices are hidden to make it easier to see mapped ones.

<img width="925" alt="Screen Shot 2022-02-23 at 6 40 51 PM" src="https://user-images.githubusercontent.com/4600967/155429283-342f6433-a308-4c34-8238-bca32975ef83.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
