### PR TITLE
Fix test CreateUserJobTest::test_should_disable_default_helm_hooks

### DIFF
--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -113,7 +113,7 @@ class CreateUserJobTest(unittest.TestCase):
             values={"createUserJob": {"useHelmHooks": False}},
             show_only=["templates/jobs/create-user-job.yaml"],
         )
-        annotations = jmespath.search("spec.template.metadata.annotations", docs[0])
+        annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations is None
 
     def test_should_set_correct_helm_hooks_weight(self):


### PR DESCRIPTION
These hooks are required for a proper synchronization with _Kubernetes_ jobs when deploying with _ArgoCD_, since the jobs are not synchronized when updating with new values.

I tested this configuration in my environment successfully.

closes: #21615
