### PR TITLE
Add oss_task_handler into alibaba-provider and enable remote logging to OSS

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -248,6 +248,17 @@ if REMOTE_LOGGING:
         }
 
         DEFAULT_LOGGING_CONFIG['handlers'].update(STACKDRIVER_REMOTE_HANDLERS)
+    elif REMOTE_BASE_LOG_FOLDER.startswith('oss://'):
+        OSS_REMOTE_HANDLERS = {
+            'task': {
+                'class': 'airflow.providers.alibaba.cloud.log.oss_task_handler.OSSTaskHandler',
+                'formatter': 'airflow',
+                'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
+                'oss_log_folder': REMOTE_BASE_LOG_FOLDER,
+                'filename_template': FILENAME_TEMPLATE
+            },
+        }
+        DEFAULT_LOGGING_CONFIG['handlers'].update(OSS_REMOTE_HANDLERS)
     elif ELASTICSEARCH_HOST:
         ELASTICSEARCH_LOG_ID_TEMPLATE: str = conf.get('elasticsearch', 'LOG_ID_TEMPLATE')
         ELASTICSEARCH_END_OF_LOG_MARK: str = conf.get('elasticsearch', 'END_OF_LOG_MARK')

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -255,7 +255,7 @@ if REMOTE_LOGGING:
                 'formatter': 'airflow',
                 'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
                 'oss_log_folder': REMOTE_BASE_LOG_FOLDER,
-                'filename_template': FILENAME_TEMPLATE
+                'filename_template': FILENAME_TEMPLATE,
             },
         }
         DEFAULT_LOGGING_CONFIG['handlers'].update(OSS_REMOTE_HANDLERS)

--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -322,7 +322,7 @@ class OSSHook(BaseHook):
         :param bucket_name: the name of the bucket
         :param key: oss bucket key
         """
-        self.log.info("Head Object oss key: " + key)
+        self.log.info("Head Object oss key: %s", key)
         try:
             return self.get_bucket(bucket_name).head_object(key)
         except Exception as e:
@@ -339,7 +339,7 @@ class OSSHook(BaseHook):
         :param key: oss bucket key
         """
         # full_path = None
-        self.log.info(f"Looking up oss bucket {bucket_name} for bucket key {key} ...")
+        self.log.info('Looking up oss bucket %s for bucket key %s ...', bucket_name, key)
         try:
             return self.get_bucket(bucket_name).object_exists(key)
         except Exception as e:

--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -281,7 +281,7 @@ class OSSHook(BaseHook):
 
     @provide_bucket_name
     @unify_bucket_name_and_key
-    def append_string(self, bucket_name: Optional[str], content: str, key: str, pos: int):
+    def append_string(self, bucket_name: Optional[str], content: str, key: str, pos: int) -> None:
         """
         Append string to a remote existing file
 
@@ -290,8 +290,7 @@ class OSSHook(BaseHook):
         :param key: oss bucket key
         :param pos: position of the existing file where the content will be appended
         """
-        self.log.info("Write oss bucket key: " + key)
-        self.log.info("Write oss bucket pos: " + str(pos))
+        self.log.info("Write oss bucket. key: %s, pos: %s", key, pos)
         try:
             self.get_bucket(bucket_name).append_object(key, pos, content)
         except Exception as e:
@@ -307,7 +306,7 @@ class OSSHook(BaseHook):
         :param bucket_name: the name of the bucket
         :param key: oss bucket key
         """
-        self.log.info("Read oss key: " + key)
+        self.log.info("Read oss key: %s", key)
         try:
             return self.get_bucket(bucket_name).get_object(key).read().decode("utf-8")
         except Exception as e:

--- a/airflow/providers/alibaba/cloud/hooks/oss.py
+++ b/airflow/providers/alibaba/cloud/hooks/oss.py
@@ -92,7 +92,7 @@ class OSSHook(BaseHook):
     def __init__(self, region: Optional[str] = None, oss_conn_id='oss_default', *args, **kwargs) -> None:
         self.oss_conn_id = oss_conn_id
         self.oss_conn = self.get_connection(oss_conn_id)
-        if region == None:
+        if region is None:
             self.region = self.get_default_region()
         else:
             self.region = region
@@ -147,6 +147,7 @@ class OSSHook(BaseHook):
         :rtype: oss2.api.Bucket
         """
         auth = self.get_credential()
+        assert self.region is not None
         return oss2.Bucket(auth, 'http://oss-' + self.region + '.aliyuncs.com', bucket_name)
 
     @provide_bucket_name
@@ -363,7 +364,7 @@ class OSSHook(BaseHook):
         else:
             raise Exception("Unsupported auth_type: " + auth_type)
 
-    def get_default_region(self) -> str:
+    def get_default_region(self) -> Optional[str]:
         extra_config = self.oss_conn.extra_dejson
         auth_type = extra_config.get('auth_type', None)
         if not auth_type:

--- a/airflow/providers/alibaba/cloud/log/__init__.py
+++ b/airflow/providers/alibaba/cloud/log/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -48,7 +48,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
     @cached_property
     def hook(self):
         remote_conn_id = conf.get('logging', 'REMOTE_LOG_CONN_ID')
-        self.log.info("remote_conn_id: " + remote_conn_id)
+        self.log.info("remote_conn_id: %s", remote_conn_id)
         try:
             return OSSHook(oss_conn_id=remote_conn_id)
         except Exception as e:
@@ -131,8 +131,9 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         :param remote_log_location: log's location in remote storage
         :return: True if location exists else False
         """
+        oss_remote_log_location = self.base_folder + '/' + remote_log_location
         try:
-            return self.hook.key_exist(self.bucket_name, remote_log_location)
+            return self.hook.key_exist(self.bucket_name, oss_remote_log_location)
         except Exception:
             pass
         return False
@@ -172,16 +173,14 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         if append and self.oss_log_exists(oss_remote_log_location):
             head = self.hook.head_key(self.bucket_name, oss_remote_log_location)
             pos = head.content_length
-        self.log.info("log write pos is: " + str(pos))
+        self.log.info("log write pos is: %s", str(pos))
         try:
-            self.log.info("writing remote log: " + oss_remote_log_location)
+            self.log.info("writing remote log: %s", oss_remote_log_location)
             self.hook.append_string(self.bucket_name, log, oss_remote_log_location, pos)
         except Exception:
             self.log.exception(
-                'Could not write logs to '
-                + oss_remote_log_location
-                + ' log write pos is: '
-                + str(pos)
-                + ' Append is '
-                + str(append)
+                'Could not write logs to %s, log write pos is: %s, Append is %s',
+                oss_remote_log_location,
+                str(pos),
+                str(append),
             )

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+import sys
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from cached_property import cached_property
+
+from airflow.configuration import conf
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.file_task_handler import FileTaskHandler
+from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
+
+
+class OSSTaskHandler(FileTaskHandler, LoggingMixin):
+    """
+    OSSTaskHandler is a python log handler that handles and reads
+    task instance logs. It extends airflow FileTaskHandler and
+    uploads to and reads from OSS remote storage.
+    """
+    def __init__(self, base_log_folder, oss_log_folder, filename_template):
+        self.log.info("Using oss_task_handler v0.2")
+        super(OSSTaskHandler, self).__init__(base_log_folder, filename_template)
+        (self.bucket_name, self.base_folder) = OSSHook.parse_oss_url(oss_log_folder)
+        self.log_relative_path = ''
+        self._hook = None
+        self.closed = False
+        self.upload_on_close = True
+
+    @cached_property
+    def hook(self):
+        remote_conn_id = conf.get('logging', 'REMOTE_LOG_CONN_ID')
+        self.log.info("remote_conn_id: " + remote_conn_id)
+        try:
+            return OSSHook(oss_conn_id=remote_conn_id)
+        except Exception as e:
+            self.log.error(e, exc_info=True)
+            self.log.error(
+                'Could not create an OSSHook with connection id "%s". '
+                'Please make sure that airflow[oss] is installed and '
+                'the OSS connection exists.', remote_conn_id
+            )
+
+    def set_context(self, ti):
+        super(OSSTaskHandler, self).set_context(ti)
+        # Local location and remote location is needed to open and
+        # upload local log file to OSS remote storage.
+        self.log_relative_path = self._render_filename(ti, ti.try_number)
+        self.upload_on_close = not ti.raw
+
+        # Clear the file first so that duplicate data is not uploaded
+        # when re-using the same path (e.g. with rescheduled sensors)
+        if self.upload_on_close:
+            with open(self.handler.baseFilename, 'w'):
+                pass
+
+    def close(self):
+        """
+        Close and upload local log file to remote storage OSS.
+        """
+        # When application exit, system shuts down all handlers by
+        # calling close method. Here we check if logger is already
+        # closed to prevent uploading the log to remote storage multiple
+        # times when `logging.shutdown` is called.
+        if self.closed:
+            return
+
+        super(OSSTaskHandler, self).close()
+
+        if not self.upload_on_close:
+            return
+
+        local_loc = os.path.join(self.local_base, self.log_relative_path)
+        remote_loc = self.log_relative_path
+        if os.path.exists(local_loc):
+            # read log and remove old logs to get just the latest additions
+            with open(local_loc, 'r') as logfile:
+                log = logfile.read()
+            self.oss_write(log, remote_loc)
+
+        # Mark closed so we don't double write if close is called twice
+        self.closed = True
+
+    def _read(self, ti, try_number, metadata=None):
+        """
+        Read logs of given task instance and try_number from OSS remote storage.
+        If failed, read the log from task instance host machine.
+
+        :param ti: task instance object
+        :param try_number: task instance try_number to read logs from
+        :param metadata: log metadata,
+                         can be used for steaming log reading and auto-tailing.
+        """
+        # Explicitly getting log relative path is necessary as the given
+        # task instance might be different than task instance passed in
+        # in set_context method.
+        log_relative_path = self._render_filename(ti, try_number)
+        remote_loc = log_relative_path
+
+        if self.oss_log_exists(remote_loc):
+            # If OSS remote file exists, we do not fetch logs from task instance
+            # local machine even if there are errors reading remote logs, as
+            # returned remote_log will contain error messages.
+            remote_log = self.oss_read(remote_loc, return_error=True)
+            log = '*** Reading remote log from {}.\n{}\n'.format(
+                remote_loc, remote_log)
+            return log, {'end_of_log': True}
+        else:
+            return super(OSSTaskHandler, self)._read(ti, try_number)
+
+    def oss_log_exists(self, remote_log_location):
+        """
+        Check if remote_log_location exists in remote storage
+
+        :param remote_log_location: log's location in remote storage
+        :return: True if location exists else False
+        """
+        try:
+            return self.hook.key_exist(self.bucket_name, remote_log_location)
+        except Exception:
+            pass
+        return False
+
+    def oss_read(self, remote_log_location, return_error=False):
+        """
+        Returns the log found at the remote_log_location. Returns '' if no
+        logs are found or there is an error.
+
+        :param remote_log_location: the log's location in remote storage
+        :type remote_log_location: str (path)
+        :param return_error: if True, returns a string error message if an
+            error occurs. Otherwise returns '' when an error occurs.
+        :type return_error: bool
+        """
+        try:
+            oss_remote_log_location = self.base_folder + '/' + remote_log_location
+            self.log.info("read remote log: " + oss_remote_log_location)
+            return self.hook.read_key(self.bucket_name, oss_remote_log_location)
+        except Exception:
+            msg = 'Could not read logs from {}'.format(oss_remote_log_location)
+            self.log.exception(msg)
+            # return error if needed
+            if return_error:
+                return msg
+
+    def oss_write(self, log, remote_log_location, append=True):
+        """
+        Writes the log to the remote_log_location. Fails silently if no hook
+        was created.
+
+        :param log: the log to write to the remote_log_location
+        :type log: str
+        :param remote_log_location: the log's location in remote storage
+        :type remote_log_location: str (path)
+        :param append: if False, any existing log file is overwritten. If True,
+            the new log is appended to any existing logs.
+        :type append: bool
+        """
+        oss_remote_log_location = self.base_folder + '/' + remote_log_location
+        pos = 0
+        if append and self.oss_log_exists(oss_remote_log_location):
+            head = self.hook.head_key(self.bucket_name, oss_remote_log_location)
+            pos = head.content_length
+        self.log.info("log write pos is: " + str(pos))
+        try:
+            self.log.info("writing remote log: " + oss_remote_log_location)
+            self.hook.append_string(
+                self.bucket_name,
+                log,
+                oss_remote_log_location,
+                pos
+            )
+        except Exception:
+            self.log.exception('Could not write logs to ' + oss_remote_log_location + ' log write pos is: ' + str(pos) + ' Append is ' + str(append))
+
+

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -149,7 +149,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         """
         try:
             oss_remote_log_location = self.base_folder + '/' + remote_log_location
-            self.log.info("read remote log: " + oss_remote_log_location)
+            self.log.info("read remote log: %s", oss_remote_log_location)
             return self.hook.read_key(self.bucket_name, oss_remote_log_location)
         except Exception:
             msg = f'Could not read logs from {oss_remote_log_location}'

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -57,3 +57,6 @@ hook-class-names:  # deprecated - to be removed after providers add dependency o
 connection-types:
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.oss.OSSHook
     connection-type: oss
+
+logging:
+  - airflow.providers.alibaba.cloud.log.oss_task_handler.OSSTaskHandler

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -436,7 +436,8 @@ def create_default_connections(session: Session = NEW_SESSION):
             extra='''{
                 "auth_type": "AK",
                 "access_key_id": "<ACCESS_KEY_ID>",
-                "access_key_secret": "<ACCESS_KEY_SECRET>"}
+                "access_key_secret": "<ACCESS_KEY_SECRET>",
+                "region": "<YOUR_OSS_REGION>"}
                 ''',
         ),
         session,

--- a/docs/apache-airflow-providers-alibaba/index.rst
+++ b/docs/apache-airflow-providers-alibaba/index.rst
@@ -27,6 +27,7 @@ Content
 
     Connection types <connections/alibaba>
     Operators <operators/index>
+    Logging for Tasks <logging/index>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/apache-airflow-providers-alibaba/logging/index.rst
+++ b/docs/apache-airflow-providers-alibaba/logging/index.rst
@@ -1,0 +1,25 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Logging for Tasks
+=================
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/docs/apache-airflow-providers-alibaba/logging/oss-task-handler.rst
+++ b/docs/apache-airflow-providers-alibaba/logging/oss-task-handler.rst
@@ -1,0 +1,42 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _write-logs-alibaba-oss:
+
+Writing logs to Alibaba OSS
+---------------------------
+
+Remote logging to Alibaba OSS uses an existing Airflow connection to read or write logs. If you
+don't have a connection properly setup, this process will fail.
+
+
+Enabling remote logging
+'''''''''''''''''''''''
+
+To enable this feature, ``airflow.cfg`` must be configured as follows:
+
+.. code-block:: ini
+
+    [logging]
+    # Airflow can store logs remotely in Alibaba OSS. Users must supply a remote
+    # location URL (starting with either 'oss://...') and an Airflow connection
+    # id that provides access to the storage location.
+    remote_logging = True
+    remote_base_log_folder = oss://my-bucket/path/to/logs
+    remote_log_conn_id = oss_default
+
+In the above example, Airflow will try to use ``OSSHook('oss_default')``.

--- a/tests/providers/alibaba/cloud/log/__init__.py
+++ b/tests/providers/alibaba/cloud/log/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
+++ b/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import os
+import unittest
+
+import oss2
+
+from airflow.exceptions import AirflowException
+from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
+from airflow.providers.alibaba.cloud.log.oss_task_handler import OSSTaskHandler
+from tests.providers.alibaba.cloud.utils.test_utils import skip_test_if_no_valid_conn_id
+from tests.test_utils.config import conf_vars
+
+TEST_CONN_ID = os.environ.get('TEST_OSS_CONN_ID', 'oss_default')
+TEST_REGION = os.environ.get('TEST_OSS_REGION', 'us-east-1')
+TEST_BUCKET = os.environ.get('TEST_OSS_BUCKET', 'test-bucket')
+
+
+class TestOSSTaskHandler(unittest.TestCase):
+    @conf_vars({('logging', 'remote_log_conn_id'): 'oss_default'})
+    def setUp(self):
+        self.remote_log_base = f'oss://{TEST_BUCKET}/airflow/logs'
+        self.remote_log_location = f'oss://{TEST_BUCKET}/airflow/logs/1.log'
+        self.local_log_location = 'local/airflow/logs/1.log'
+        self.filename_template = '{try_number}.log'
+        self.remote_log_key = 'airflow/logs/1.log'
+        try:
+            self.hook = OSSHook(region=TEST_REGION, oss_conn_id=TEST_CONN_ID)
+            self.hook.object_exists(key='test-obj', bucket_name=TEST_BUCKET)
+            self.oss_task_handler = OSSTaskHandler(
+                self.local_log_location, self.remote_log_base, self.filename_template
+            )
+            # Vivfy the hook now with the config override
+            assert self.oss_task_handler.hook is not None
+            # Make sure the connection to oss is set up
+        except AirflowException:
+            self.hook = None
+        except oss2.exceptions.ServerError as e:
+            if e.status == 403:
+                self.hook = None
+
+    @skip_test_if_no_valid_conn_id
+    def test_oss_log_exists(self):
+        self.hook.load_string("1.log", "task1 log", TEST_BUCKET)
+        assert self.oss_task_handler.oss_log_exists(self.remote_log_location) == True
+
+    @skip_test_if_no_valid_conn_id
+    def test_oss_read(self):
+        self.hook.load_string("a simple test string", self.remote_log_location, TEST_BUCKET)
+        assert self.oss_task_handler.oss_read(self.remote_log_location) == "a simple test string"
+
+    @skip_test_if_no_valid_conn_id
+    def test_oss_write(self):
+        self.oss_task_handler.oss_write("a new test string", self.remote_log_location, append=False)
+        assert self.hook.read_key(TEST_BUCKET, self.remote_log_key) == "a new test string"

--- a/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
+++ b/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
@@ -58,7 +58,7 @@ class TestOSSTaskHandler(unittest.TestCase):
     @skip_test_if_no_valid_conn_id
     def test_oss_log_exists(self):
         self.hook.load_string("1.log", "task1 log", TEST_BUCKET)
-        assert self.oss_task_handler.oss_log_exists(self.remote_log_location) == True
+        assert self.oss_task_handler.oss_log_exists(self.remote_log_location) is True
 
     @skip_test_if_no_valid_conn_id
     def test_oss_read(self):

--- a/tests/providers/alibaba/cloud/utils/oss_mock.py
+++ b/tests/providers/alibaba/cloud/utils/oss_mock.py
@@ -30,6 +30,7 @@ def mock_oss_hook_default_project_id(self, oss_conn_id='mock_oss_default', regio
                 'auth_type': 'AK',
                 'access_key_id': 'mock_access_key_id',
                 'access_key_secret': 'mock_access_key_secret',
+                'region': 'mock_region',
             }
         )
     )


### PR DESCRIPTION
- In order to add more support for Alibaba Cloud(related: #17200), we could add oss_task_handler into alibaba-provider to enable remote-logging to OSS(alibaba cloud object storage service)
- Currently there's no python lib directly providing mocked oss to use in test, we may find a way to mock oss and add more unit tests later but not in this pr. It will probably take some more time. related: #17617
- This pr closes: #21748 