### PR TITLE
Fixed dag level access permissions

### DIFF
--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -74,6 +74,4 @@ def resource_name_for_dag(dag_id):
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    # To account for SubDags
-    root_dag_id = dag_id.split(".")[0]
-    return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
+    return f"{RESOURCE_DAG_PREFIX}{dag_id}"

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -47,7 +47,10 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
                     403,
                 )
 
-            if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
+            dag_id = (
+                request.args.get("dag_id") or request.form.get("dag_id") or (request.json or {}).get("dag_id")
+            )
+            if appbuilder.sm.check_authorization(permissions, dag_id):
                 return func(*args, **kwargs)
             else:
                 access_denied = "Access is Denied"


### PR DESCRIPTION
This PR addresses two bugs concerning dag level access permissions.

1.  Dag level permissions are not checked properly if a post request is sent from within the web ui (i.e. clear a task or dag run). If a user has can_read on any dag any operation that involves a post request is allowed even though the user does not have the can_write permission for this dag as far as the appropriate other permissions like edit_task_instance or edit_dag_run were granted. This is caused by the dag_id being extracted from `request.args` which only exists for get requests (i.e. change the status of a task). Otherwise `None` is used as dag_id in `appbuilder.sm.check_authorization` which essentially leads to ignoring the dag level access permissions.
2. The inheritance of dag level access permissions for subdags makes dag level (edit) access unusable for any dag that contains a dot in its id. Consider two dags `A` and `A.B` where the later is not a subdag. The current implementation makes it impossible to define dag level access permissions for `A.B`. Instead the dag level permissions of `A` are silently applied to `A.B`. I couldn't find any hint in the documentation that either addresses this behaviour nor states that you can or sould not use a dot in the dag id.

**Concerning 1.**
We changed the extraction of dag_id from the request object to first try the query string, then the form data and lastly the json body if it exists.

**Concerning 2.**
We removed the special logic of splitting the dag id after the first dot. 
This essentially removes the dag level permission inheritance for subdags in favour of enabling dag level access permissions for all dags with dots in its ids. Since we could not think of an easy way to enable both and subdags are considered deprecated, as far as we understood, we think this to be the more sustainable version.


At last let me thank you all for your great work and this outstanding piece of software.