### PR TITLE
Change BaseOperatorLink interface to take a ti_key, not a datetime

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -163,6 +163,16 @@ This setting is also used for the deprecated experimental API, which only uses t
 
 To allow the Airflow UI to use the API, the previous default authorization backend `airflow.api.auth.backend.deny_all` is changed to `airflow.api.auth.backend.session`, and this is automatically added to the list of API authorization backends if a non-default value is set.
 
+### BaseOperatorLink's `get_link` method changed to take a `ti_key` keyword argument
+
+In v2.2 we "deprecated" passing an execution date to XCom.get methods, but there was no other option for operator links as they were only passed an execution_date.
+
+Now in 2.3 as part of Dynamic Task Mapping (AIP-42) we will need to add map_index to the XCom row to support the "reduce" part of the API.
+
+In order to support that cleanly we have changed the interface for BaseOperatorLink to take an TaskInstanceKey as the `ti_key` keyword argument (as execution_date + task is no longer unique for mapped operators).
+
+The existing signature will be detected (by the absence of the `ti_key` argument) and continue to work.
+
 ## Airflow 2.2.4
 
 ### Smart sensors deprecated

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -246,6 +246,8 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def get_extra_links(self, ti: "TaskInstance", link_name: str) -> Optional[str]:
         """For an operator, gets the URLs that the ``extra_links`` entry points to.
 
+        :meta private:
+
         :raise ValueError: The error message of a ValueError will be passed on through to
             the fronted to show up as a tooltip on the disabled link.
         :param ti: The TaskInstance for the URL being searched for.

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -263,7 +263,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
         if "ti_key" in args:
             return link.get_link(self, ti_key=ti.key)
         else:
-            return link.get_link(self, ti.dag_run.logical_date)
+            return link.get_link(self, ti.dag_run.logical_date)  # type: ignore[misc]
         return None
 
     def render_template_fields(

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import datetime
+import inspect
 from typing import TYPE_CHECKING, Any, Callable, Collection, Dict, Iterable, List, Optional, Set, Type, Union
 
 from sqlalchemy.orm import Session
@@ -32,23 +33,25 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 
+TaskStateChangeCallback = Callable[[Context], None]
+
 if TYPE_CHECKING:
     import jinja2  # Slow import.
 
-    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
+    from airflow.models.taskinstance import TaskInstance
 
-DEFAULT_OWNER = conf.get("operators", "default_owner")
-DEFAULT_POOL_SLOTS = 1
-DEFAULT_PRIORITY_WEIGHT = 1
-DEFAULT_QUEUE = conf.get("operators", "default_queue")
-DEFAULT_RETRIES = conf.getint("core", "default_task_retries", fallback=0)
-DEFAULT_RETRY_DELAY = datetime.timedelta(seconds=300)
-DEFAULT_WEIGHT_RULE = conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
-DEFAULT_TRIGGER_RULE = TriggerRule.ALL_SUCCESS
-
-TaskStateChangeCallback = Callable[[Context], None]
+DEFAULT_OWNER: str = conf.get("operators", "default_owner")
+DEFAULT_POOL_SLOTS: int = 1
+DEFAULT_PRIORITY_WEIGHT: int = 1
+DEFAULT_QUEUE: str = conf.get("operators", "default_queue")
+DEFAULT_RETRIES: int = conf.getint("core", "default_task_retries", fallback=0)
+DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(seconds=300)
+DEFAULT_WEIGHT_RULE: WeightRule = WeightRule(
+    conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
+)
+DEFAULT_TRIGGER_RULE: TriggerRule = TriggerRule.ALL_SUCCESS
 
 
 class AbstractOperator(LoggingMixin, DAGNode):
@@ -239,19 +242,27 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def extra_links(self) -> List[str]:
         return list(set(self.operator_extra_link_dict).union(self.global_operator_extra_link_dict))
 
-    def get_extra_links(self, dttm: datetime.datetime, link_name: str) -> Optional[Dict[str, Any]]:
+    def get_extra_links(self, ti: "TaskInstance", link_name: str) -> Optional[str]:
         """For an operator, gets the URLs that the ``extra_links`` entry points to.
 
         :raise ValueError: The error message of a ValueError will be passed on through to
             the fronted to show up as a tooltip on the disabled link.
-        :param dttm: The datetime parsed execution date for the URL being searched for.
+        :param ti: The TaskInstance for the URL being searched for.
         :param link_name: The name of the link we're looking for the URL for. Should be
             one of the options specified in ``extra_links``.
         """
-        if link_name in self.operator_extra_link_dict:
-            return self.operator_extra_link_dict[link_name].get_link(self, dttm)
-        elif link_name in self.global_operator_extra_link_dict:
-            return self.global_operator_extra_link_dict[link_name].get_link(self, dttm)
+        link: Optional["BaseOperatorLink"] = self.operator_extra_link_dict.get(
+            link_name
+        ) or self.global_operator_extra_link_dict.get(link_name)
+        if not link:
+            return None
+        # Check for old function signature
+        parameters = inspect.signature(link.get_link).parameters
+        args = [name for name, p in parameters.items() if p.kind != p.VAR_KEYWORD]
+        if "ti_key" in args:
+            return link.get_link(self, ti_key=ti.key)
+        else:
+            return link.get_link(self, ti.dag_run.logical_date)
         return None
 
     def render_template_fields(
@@ -394,3 +405,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
             # content has no inner template fields
             return
         self._do_render_template_fields(value, nested_template_fields, context, jinja_env, seen_oids)
+
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator, BaseOperatorLink

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -45,7 +45,6 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload,
 )
 
 import attr
@@ -1731,33 +1730,13 @@ class BaseOperatorLink(metaclass=ABCMeta):
         :return: link name
         """
 
-    @overload
     @abstractmethod
     def get_link(self, operator: AbstractOperator, *, ti_key: "TaskInstanceKey") -> str:
         """
         Link to external system.
 
-        :param operator: airflow operator
-        :param ti_key: TaskInstance ID to return link for
-        :return: link to external system
-        """
-
-    @overload
-    @abstractmethod
-    def get_link(self, operator: AbstractOperator, dttm: datetime) -> str:
-        """:meta private:"""
-        # Deprecated form of get_link callback
-
-    @abstractmethod
-    def get_link(
-        self,
-        operator: AbstractOperator,
-        dttm: Optional[datetime] = None,
-        *,
-        ti_key: Optional["TaskInstanceKey"] = None,
-    ) -> str:
-        """
-        Link to external system.
+        Note: The old signature of this function was ``(self, operator, dttm: datetime)``. That is still
+        supported at runtime but is deprecated.
 
         :param operator: airflow operator
         :param ti_key: TaskInstance ID to return link for

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -93,6 +93,7 @@ if TYPE_CHECKING:
     import jinja2  # Slow import.
 
     from airflow.models.dag import DAG
+    from airflow.models.taskinstance import TaskInstanceKey
     from airflow.utils.task_group import TaskGroup
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
@@ -1730,11 +1731,17 @@ class BaseOperatorLink(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def get_link(self, operator: BaseOperator, dttm: datetime) -> str:
+    def get_link(
+        self,
+        operator: AbstractOperator,
+        dttm: Optional[datetime] = None,
+        *,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
         """
         Link to external system.
 
         :param operator: airflow operator
-        :param dttm: datetime
+        :param ti_key: TaskInstance ID to return link for
         :return: link to external system
         """

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -45,6 +45,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload,
 )
 
 import attr
@@ -1729,6 +1730,23 @@ class BaseOperatorLink(metaclass=ABCMeta):
 
         :return: link name
         """
+
+    @overload
+    @abstractmethod
+    def get_link(self, operator: AbstractOperator, *, ti_key: "TaskInstanceKey") -> str:
+        """
+        Link to external system.
+
+        :param operator: airflow operator
+        :param ti_key: TaskInstance ID to return link for
+        :return: link to external system
+        """
+
+    @overload
+    @abstractmethod
+    def get_link(self, operator: AbstractOperator, dttm: datetime) -> str:
+        """:meta private:"""
+        # Deprecated form of get_link callback
 
     @abstractmethod
     def get_link(

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -50,6 +50,9 @@ XCOM_RETURN_KEY = 'return_value'
 # run without storing it in the database.
 IN_MEMORY_DAGRUN_ID = "__airflow_in_memory_dagrun__"
 
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstanceKey
+
 
 class BaseXCom(Base, LoggingMixin):
     """Base class for XCom objects."""
@@ -205,11 +208,8 @@ class BaseXCom(Base, LoggingMixin):
     def get_one(
         cls,
         *,
-        run_id: str,
         key: Optional[str] = None,
-        task_id: Optional[str] = None,
-        dag_id: Optional[str] = None,
-        include_prior_dates: bool = False,
+        ti_key: "TaskInstanceKey",
         session: Session = NEW_SESSION,
     ) -> Optional[Any]:
         """Retrieve an XCom value, optionally meeting certain criteria.
@@ -223,19 +223,28 @@ class BaseXCom(Base, LoggingMixin):
         A deprecated form of this function accepts ``execution_date`` instead of
         ``run_id``. The two arguments are mutually exclusive.
 
-        :param run_id: DAG run ID for the task.
+        :param ti_key: The TaskInstanceKey to look up the XCom for
         :param key: A key for the XCom. If provided, only XCom with matching
             keys will be returned. Pass *None* (default) to remove the filter.
-        :param task_id: Only XCom from task with matching ID will be pulled.
-            Pass *None* (default) to remove the filter.
-        :param dag_id: Only pull XCom from this DAG. If *None* (default), the
-            DAG of the calling task is used.
         :param include_prior_dates: If *False* (default), only XCom from the
             specified DAG run is returned. If *True*, the latest matching XCom is
             returned regardless of the run it belongs to.
         :param session: Database session. If not given, a new session will be
             created for this function.
         """
+
+    @overload
+    @classmethod
+    def get_one(
+        cls,
+        *,
+        key: Optional[str] = None,
+        task_id: str,
+        dag_id: str,
+        run_id: str,
+        session: Session = NEW_SESSION,
+    ) -> Optional[Any]:
+        ...
 
     @overload
     @classmethod
@@ -256,24 +265,35 @@ class BaseXCom(Base, LoggingMixin):
         cls,
         execution_date: Optional[datetime.datetime] = None,
         key: Optional[str] = None,
-        task_id: Optional[Union[str, Iterable[str]]] = None,
-        dag_id: Optional[Union[str, Iterable[str]]] = None,
+        task_id: Optional[str] = None,
+        dag_id: Optional[str] = None,
         include_prior_dates: bool = False,
         session: Session = NEW_SESSION,
         *,
         run_id: Optional[str] = None,
+        ti_key: Optional["TaskInstanceKey"] = None,
     ) -> Optional[Any]:
         """:sphinx-autoapi-skip:"""
-        if not exactly_one(execution_date is not None, run_id is not None):
-            raise ValueError("Exactly one of run_id or execution_date must be passed")
+        if not exactly_one(execution_date is not None, ti_key is not None, run_id is not None):
+            raise ValueError("Exactly one of ti_key, run_id, or execution_date must be passed")
 
-        if run_id is not None:
+        if ti_key is not None:
+            query = session.query(cls).filter_by(
+                dag_id=ti_key.dag_id,
+                run_id=ti_key.run_id,
+                task_id=ti_key.task_id,
+            )
+            if key:
+                query = query.filter_by(key=key)
+            query = query.limit(1)
+        elif run_id:
             query = cls.get_many(
                 run_id=run_id,
                 key=key,
                 task_ids=task_id,
                 dag_ids=dag_id,
                 include_prior_dates=include_prior_dates,
+                limit=1,
                 session=session,
             )
         elif execution_date is not None:
@@ -288,6 +308,7 @@ class BaseXCom(Base, LoggingMixin):
                     task_ids=task_id,
                     dag_ids=dag_id,
                     include_prior_dates=include_prior_dates,
+                    limit=1,
                     session=session,
                 )
         else:

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -51,23 +51,12 @@ class TriggerDagRunLink(BaseOperatorLink):
     def get_link(
         self,
         operator: "AbstractOperator",
-        dttm: Optional[datetime.datetime] = None,
         *,
-        ti_key: Optional["TaskInstanceKey"] = None,
+        ti_key: "TaskInstanceKey",
     ) -> str:
         # Fetch the correct execution date for the triggerED dag which is
         # stored in xcom during execution of the triggerING task.
-        if ti_key:
-            when = XCom.get_one(ti_key=ti_key, key=XCOM_EXECUTION_DATE_ISO)
-        else:
-            assert dttm
-            when = XCom.get_one(
-                execution_date=dttm,
-                key=XCOM_EXECUTION_DATE_ISO,
-                task_id=operator.task_id,
-                dag_id=operator.dag_id,
-            )
-
+        when = XCom.get_one(ti_key=ti_key, key=XCOM_EXECUTION_DATE_ISO)
         query = {"dag_id": cast(TriggerDagRunOperator, operator).trigger_dag_id, "base_date": when}
         return build_airflow_url_with_query(query)
 

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -19,7 +19,7 @@
 import datetime
 import json
 import time
-from typing import Dict, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union, cast
 
 from airflow.api.common.trigger_dag import trigger_dag
 from airflow.exceptions import AirflowException, DagNotFound, DagRunAlreadyExists
@@ -35,6 +35,11 @@ XCOM_EXECUTION_DATE_ISO = "trigger_execution_date_iso"
 XCOM_RUN_ID = "trigger_run_id"
 
 
+if TYPE_CHECKING:
+    from airflow.models.abstractoperator import AbstractOperator
+    from airflow.models.taskinstance import TaskInstanceKey
+
+
 class TriggerDagRunLink(BaseOperatorLink):
     """
     Operator link for TriggerDagRunOperator. It allows users to access
@@ -43,14 +48,27 @@ class TriggerDagRunLink(BaseOperatorLink):
 
     name = 'Triggered DAG'
 
-    def get_link(self, operator, dttm):
+    def get_link(
+        self,
+        operator: "AbstractOperator",
+        dttm: Optional[datetime.datetime] = None,
+        *,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
         # Fetch the correct execution date for the triggerED dag which is
         # stored in xcom during execution of the triggerING task.
-        trigger_execution_date_iso = XCom.get_one(
-            execution_date=dttm, key=XCOM_EXECUTION_DATE_ISO, task_id=operator.task_id, dag_id=operator.dag_id
-        )
+        if ti_key:
+            when = XCom.get_one(ti_key=ti_key, key=XCOM_EXECUTION_DATE_ISO)
+        else:
+            assert dttm
+            when = XCom.get_one(
+                execution_date=dttm,
+                key=XCOM_EXECUTION_DATE_ISO,
+                task_id=operator.task_id,
+                dag_id=operator.dag_id,
+            )
 
-        query = {"dag_id": operator.trigger_dag_id, "base_date": trigger_execution_date_iso}
+        query = {"dag_id": cast(TriggerDagRunOperator, operator).trigger_dag_id, "base_date": when}
         return build_airflow_url_with_query(query)
 
 

--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -33,7 +33,7 @@ class DbtCloudRunJobOperatorLink(BaseOperatorLink):
 
     name = "Monitor Job Run"
 
-    def get_link(self, operator, dttm, *, ti_key):
+    def get_link(self, operator, dttm=None, *, ti_key=None):
         if ti_key:
             job_run_url = XCom.get_one(key="job_run_url", ti_key=ti_key)
         else:

--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -33,10 +33,14 @@ class DbtCloudRunJobOperatorLink(BaseOperatorLink):
 
     name = "Monitor Job Run"
 
-    def get_link(self, operator, dttm):
-        job_run_url = XCom.get_one(
-            dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm, key="job_run_url"
-        )
+    def get_link(self, operator, dttm, *, ti_key):
+        if ti_key:
+            job_run_url = XCom.get_one(key="job_run_url", ti_key=ti_key)
+        else:
+            assert dttm
+            job_run_url = XCom.get_one(
+                dag_id=operator.dag.dag_id, task_id=operator.task_id, execution_date=dttm, key="job_run_url"
+            )
 
         return job_run_url
 

--- a/airflow/providers/google/cloud/links/base.py
+++ b/airflow/providers/google/cloud/links/base.py
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+from airflow.models import BaseOperatorLink, XCom
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstanceKey
+
+
+class BaseGoogleLink(BaseOperatorLink):
+    """:meta private:"""
+
+    name: ClassVar[str]
+    key: ClassVar[str]
+    format_str: ClassVar[str]
+
+    def get_link(
+        self,
+        operator,
+        dttm: Optional[datetime] = None,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
+        if ti_key:
+            conf = XCom.get_one(key=self.key, ti_key=ti_key)
+        else:
+            assert dttm
+            conf = XCom.get_one(
+                key=self.key,
+                dag_id=operator.dag.dag_id,
+                task_id=operator.task_id,
+                execution_date=dttm,
+            )
+
+        return self.format_str.format(**conf) if conf else ""

--- a/airflow/providers/google/cloud/links/dataflow.py
+++ b/airflow/providers/google/cloud/links/dataflow.py
@@ -16,10 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains Google Dataflow links."""
-from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from airflow.models import BaseOperator, BaseOperatorLink, XCom
+from airflow.models import BaseOperator
+from airflow.providers.google.cloud.links.base import BaseGoogleLink
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -28,11 +28,12 @@ DATAFLOW_BASE_LINK = "https://pantheon.corp.google.com/dataflow/jobs"
 DATAFLOW_JOB_LINK = DATAFLOW_BASE_LINK + "/{region}/{job_id}?project={project_id}"
 
 
-class DataflowJobLink(BaseOperatorLink):
+class DataflowJobLink(BaseGoogleLink):
     """Helper class for constructing Dataflow Job Link"""
 
     name = "Dataflow Job"
     key = "dataflow_job_config"
+    format_str = DATAFLOW_JOB_LINK
 
     @staticmethod
     def persist(
@@ -46,19 +47,4 @@ class DataflowJobLink(BaseOperatorLink):
             context,
             key=DataflowJobLink.key,
             value={"project_id": project_id, "location": region, "job_id": job_id},
-        )
-
-    def get_link(self, operator: BaseOperator, dttm: datetime) -> str:
-        conf = XCom.get_one(
-            key=DataflowJobLink.key,
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-        )
-        return (
-            DATAFLOW_JOB_LINK.format(
-                project_id=conf["project_id"], region=conf['region'], job_id=conf['job_id']
-            )
-            if conf
-            else ""
         )

--- a/airflow/providers/google/cloud/links/vertex_ai.py
+++ b/airflow/providers/google/cloud/links/vertex_ai.py
@@ -14,13 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module contains a links for Vertex AI assets."""
 
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.xcom import XCom
+from airflow.providers.google.cloud.links.base import BaseGoogleLink
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -36,11 +33,12 @@ VERTEX_AI_DATASET_LINK = (
 VERTEX_AI_DATASET_LIST_LINK = VERTEX_AI_BASE_LINK + "/datasets?project={project_id}"
 
 
-class VertexAIModelLink(BaseOperatorLink):
+class VertexAIModelLink(BaseGoogleLink):
     """Helper class for constructing Vertex AI Model link"""
 
     name = "Vertex AI Model"
     key = "model_conf"
+    format_str = VERTEX_AI_MODEL_LINK
 
     @staticmethod
     def persist(
@@ -58,29 +56,13 @@ class VertexAIModelLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        model_conf = XCom.get_one(
-            key=VertexAIModelLink.key,
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-        )
-        return (
-            VERTEX_AI_MODEL_LINK.format(
-                region=model_conf["region"],
-                model_id=model_conf["model_id"],
-                project_id=model_conf["project_id"],
-            )
-            if model_conf
-            else ""
-        )
 
-
-class VertexAITrainingPipelinesLink(BaseOperatorLink):
+class VertexAITrainingPipelinesLink(BaseGoogleLink):
     """Helper class for constructing Vertex AI Training Pipelines link"""
 
     name = "Vertex AI Training Pipelines"
     key = "pipelines_conf"
+    format_str = VERTEX_AI_TRAINING_PIPELINES_LINK
 
     @staticmethod
     def persist(
@@ -95,27 +77,13 @@ class VertexAITrainingPipelinesLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        pipelines_conf = XCom.get_one(
-            key=VertexAITrainingPipelinesLink.key,
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-        )
-        return (
-            VERTEX_AI_TRAINING_PIPELINES_LINK.format(
-                project_id=pipelines_conf["project_id"],
-            )
-            if pipelines_conf
-            else ""
-        )
 
-
-class VertexAIDatasetLink(BaseOperatorLink):
+class VertexAIDatasetLink(BaseGoogleLink):
     """Helper class for constructing Vertex AI Dataset link"""
 
     name = "Dataset"
     key = "dataset_conf"
+    format_str = VERTEX_AI_DATASET_LINK
 
     @staticmethod
     def persist(context: "Context", task_instance, dataset_id: str):
@@ -129,29 +97,13 @@ class VertexAIDatasetLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        dataset_conf = XCom.get_one(
-            key=VertexAIDatasetLink.key,
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-        )
-        return (
-            VERTEX_AI_DATASET_LINK.format(
-                region=dataset_conf["region"],
-                dataset_id=dataset_conf["dataset_id"],
-                project_id=dataset_conf["project_id"],
-            )
-            if dataset_conf
-            else ""
-        )
 
-
-class VertexAIDatasetListLink(BaseOperatorLink):
+class VertexAIDatasetListLink(BaseGoogleLink):
     """Helper class for constructing Vertex AI Datasets Link"""
 
     name = "Dataset List"
     key = "datasets_conf"
+    format_str = VERTEX_AI_DATASET_LIST_LINK
 
     @staticmethod
     def persist(
@@ -164,19 +116,4 @@ class VertexAIDatasetListLink(BaseOperatorLink):
             value={
                 "project_id": task_instance.project_id,
             },
-        )
-
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        datasets_conf = XCom.get_one(
-            key=VertexAIDatasetListLink.key,
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-        )
-        return (
-            VERTEX_AI_DATASET_LIST_LINK.format(
-                project_id=datasets_conf["project_id"],
-            )
-            if datasets_conf
-            else ""
         )

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -16,16 +16,15 @@
 # under the License.
 
 """This module contains Google DataFusion operators."""
-from datetime import datetime
 from time import sleep
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 
 from google.api_core.retry import exponential_sleep_generator
 from googleapiclient.errors import HttpError
 
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.xcom import XCom
+from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.datafusion import SUCCESS_STATES, DataFusionHook, PipelineStates
+from airflow.providers.google.cloud.links.base import BaseGoogleLink
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -47,11 +46,12 @@ class DataFusionPipelineLinkHelper:
         return project_id
 
 
-class DataFusionInstanceLink(BaseOperatorLink):
+class DataFusionInstanceLink(BaseGoogleLink):
     """Helper class for constructing Data Fusion Instance link"""
 
     name = "Data Fusion Instance"
     key = "instance_conf"
+    format_str = DATAFUSION_INSTANCE_LINK
 
     @staticmethod
     def persist(
@@ -74,29 +74,13 @@ class DataFusionInstanceLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        instance_conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=DataFusionInstanceLink.key,
-        )
-        return (
-            DATAFUSION_INSTANCE_LINK.format(
-                region=instance_conf["region"],
-                instance_name=instance_conf["instance_name"],
-                project_id=instance_conf["project_id"],
-            )
-            if instance_conf
-            else ""
-        )
 
-
-class DataFusionPipelineLink(BaseOperatorLink):
+class DataFusionPipelineLink(BaseGoogleLink):
     """Helper class for constructing Data Fusion Pipeline link"""
 
     name = "Data Fusion Pipeline"
     key = "pipeline_conf"
+    format_str = DATAFUSION_PIPELINE_LINK
 
     @staticmethod
     def persist(
@@ -117,28 +101,13 @@ class DataFusionPipelineLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        pipeline_conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=DataFusionPipelineLink.key,
-        )
-        return (
-            DATAFUSION_PIPELINE_LINK.format(
-                uri=pipeline_conf["uri"],
-                pipeline_name=pipeline_conf["pipeline_name"],
-            )
-            if pipeline_conf
-            else ""
-        )
 
-
-class DataFusionPipelinesLink(BaseOperatorLink):
+class DataFusionPipelinesLink(BaseGoogleLink):
     """Helper class for constructing list of Data Fusion Pipelines link"""
 
     name = "Data Fusion Pipelines"
     key = "pipelines_conf"
+    format_str = DATAFUSION_PIPELINES_LINK
 
     @staticmethod
     def persist(
@@ -152,21 +121,6 @@ class DataFusionPipelinesLink(BaseOperatorLink):
             value={
                 "uri": uri,
             },
-        )
-
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        pipelines_conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=DataFusionPipelinesLink.key,
-        )
-        return (
-            DATAFUSION_PIPELINES_LINK.format(
-                uri=pipelines_conf["uri"],
-            )
-            if pipelines_conf
-            else ""
         )
 
 

--- a/airflow/providers/google/cloud/operators/dataproc_metastore.py
+++ b/airflow/providers/google/cloud/operators/dataproc_metastore.py
@@ -36,6 +36,7 @@ from airflow.providers.google.cloud.hooks.dataproc_metastore import DataprocMeta
 from airflow.providers.google.common.links.storage import StorageLink
 
 if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstanceKey
     from airflow.utils.context import Context
 
 
@@ -78,13 +79,22 @@ class DataprocMetastoreLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=DataprocMetastoreLink.key,
-        )
+    def get_link(
+        self,
+        operator,
+        dttm: Optional[datetime] = None,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
+        if ti_key:
+            conf = XCom.get_one(key=self.key, ti_key=ti_key)
+        else:
+            assert dttm
+            conf = XCom.get_one(
+                dag_id=operator.dag.dag_id,
+                task_id=operator.task_id,
+                execution_date=dttm,
+                key=self.key,
+            )
         return (
             conf["url"].format(
                 region=conf["region"],
@@ -124,13 +134,22 @@ class DataprocMetastoreDetailedLink(BaseOperatorLink):
             },
         )
 
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=DataprocMetastoreDetailedLink.key,
-        )
+    def get_link(
+        self,
+        operator,
+        dttm: Optional[datetime] = None,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
+        if ti_key:
+            conf = XCom.get_one(key=self.key, ti_key=ti_key)
+        else:
+            assert dttm
+            conf = XCom.get_one(
+                dag_id=operator.dag.dag_id,
+                task_id=operator.task_id,
+                execution_date=dttm,
+                key=DataprocMetastoreDetailedLink.key,
+            )
         return (
             conf["url"].format(
                 region=conf["region"],

--- a/airflow/providers/google/common/links/storage.py
+++ b/airflow/providers/google/common/links/storage.py
@@ -15,11 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains a link for GCS Storage assets."""
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from airflow.models import BaseOperator, BaseOperatorLink
-from airflow.models.xcom import XCom
+from airflow.providers.google.cloud.links.base import BaseGoogleLink
 
 BASE_LINK = "https://console.cloud.google.com"
 GCS_STORAGE_LINK = BASE_LINK + "/storage/browser/{uri};tab=objects?project={project_id}"
@@ -28,11 +26,12 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class StorageLink(BaseOperatorLink):
+class StorageLink(BaseGoogleLink):
     """Helper class for constructing GCS Storage link"""
 
     name = "GCS Storage"
     key = "storage_conf"
+    format_str = GCS_STORAGE_LINK
 
     @staticmethod
     def persist(context: "Context", task_instance, uri: str):
@@ -40,20 +39,4 @@ class StorageLink(BaseOperatorLink):
             context=context,
             key=StorageLink.key,
             value={"uri": uri, "project_id": task_instance.project_id},
-        )
-
-    def get_link(self, operator: BaseOperator, dttm: datetime):
-        storage_conf = XCom.get_one(
-            dag_id=operator.dag.dag_id,
-            task_id=operator.task_id,
-            execution_date=dttm,
-            key=StorageLink.key,
-        )
-        return (
-            GCS_STORAGE_LINK.format(
-                uri=storage_conf["uri"],
-                project_id=storage_conf["project_id"],
-            )
-            if storage_conf
-            else ""
         )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -31,7 +31,7 @@ from datetime import timedelta
 from functools import wraps
 from json import JSONDecodeError
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import parse_qsl, unquote, urlencode, urlparse
 
 import lazy_object_proxy
@@ -140,9 +140,6 @@ LINECHART_X_AXIS_TICKFORMAT = (
     "if (i === undefined) {xLabel = d3.time.format('%H:%M, %d %b %Y')(new Date(parseInt(d)));"
     "} else {xLabel = d3.time.format('%H:%M, %d %b')(new Date(parseInt(d)));} return xLabel;}"
 )
-
-if TYPE_CHECKING:
-    from airflow.models.abstractoperator import AbstractOperator
 
 
 def truncate_task_duration(task_duration):

--- a/docs/apache-airflow/plugins.rst
+++ b/docs/apache-airflow/plugins.rst
@@ -93,6 +93,8 @@ config setting to True, resulting in launching a whole new python interpreter fo
 (Modules only imported by DAG files on the other hand do not suffer this problem, as DAG files are not
 loaded/parsed in any long-running Airflow process.)
 
+.. _plugins:interface:
+
 Interface
 ---------
 
@@ -172,7 +174,6 @@ definitions in Airflow.
 
     # Importing base classes that we need to derive
     from airflow.hooks.base import BaseHook
-    from airflow.models.baseoperator import BaseOperatorLink
     from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
     # Will show up in Connections screen in a future version
@@ -234,30 +235,6 @@ definitions in Airflow.
         "href": "https://www.apache.org/",
     }
 
-    # A global operator extra link that redirect you to
-    # task logs stored in S3
-    class GoogleLink(BaseOperatorLink):
-        name = "Google"
-
-        def get_link(self, operator, dttm):
-            return "https://www.google.com"
-
-
-    # A list of operator extra links to override or add operator links
-    # to existing Airflow Operators.
-    # These extra links will be available on the task page in form of
-    # buttons.
-    class S3LogLink(BaseOperatorLink):
-        name = "S3"
-        operators = [GCSToS3Operator]
-
-        def get_link(self, operator, dttm):
-            return "https://s3.amazonaws.com/airflow-logs/{dag_id}/{task_id}/{logical_date}".format(
-                dag_id=operator.dag_id,
-                task_id=operator.task_id,
-                logical_date=dttm,
-            )
-
 
     # Defining the plugin class
     class AirflowTestPlugin(AirflowPlugin):
@@ -267,13 +244,8 @@ definitions in Airflow.
         flask_blueprints = [bp]
         appbuilder_views = [v_appbuilder_package, v_appbuilder_nomenu_package]
         appbuilder_menu_items = [appbuilder_mitem, appbuilder_mitem_toplevel]
-        global_operator_extra_links = [
-            GoogleLink(),
-        ]
-        operator_extra_links = [
-            S3LogLink(),
-        ]
 
+.. seealso:: :doc:`/howto/define_extra_link`
 
 Note on role based views
 ------------------------

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -77,8 +77,7 @@ class TestDagRunOperator(TestCase):
 
         pathlib.Path(self._tmpfile).unlink()
 
-    @mock.patch('airflow.operators.trigger_dagrun.build_airflow_url_with_query')
-    def assert_extra_link(self, triggering_exec_date, triggered_dag_run, triggering_task, mock_build_url):
+    def assert_extra_link(self, triggered_dag_run, triggering_task, session):
         """
         Asserts whether the correct extra links url will be created.
 
@@ -87,7 +86,16 @@ class TestDagRunOperator(TestCase):
         Note: We can't run that method to generate the url itself because the Flask app context
         isn't available within the test logic, so it is mocked here.
         """
-        triggering_task.get_extra_links(triggering_exec_date, 'Triggered DAG')
+        triggering_ti = (
+            session.query(TaskInstance)
+            .filter_by(
+                task_id=triggering_task.task_id,
+                dag_id=triggering_task.dag_id,
+            )
+            .one()
+        )
+        with mock.patch('airflow.operators.trigger_dagrun.build_airflow_url_with_query') as mock_build_url:
+            triggering_task.get_extra_links(triggering_ti, 'Triggered DAG')
         assert mock_build_url.called
         args, _ = mock_build_url.call_args
         expected_args = {
@@ -105,7 +113,7 @@ class TestDagRunOperator(TestCase):
             dagrun = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).one()
             assert dagrun.external_trigger
             assert dagrun.run_id == DagRun.generate_run_id(DagRunType.MANUAL, dagrun.execution_date)
-            self.assert_extra_link(DEFAULT_DATE, dagrun, task)
+            self.assert_extra_link(dagrun, task, session)
 
     def test_trigger_dagrun_custom_run_id(self):
         task = TriggerDagRunOperator(
@@ -137,7 +145,7 @@ class TestDagRunOperator(TestCase):
             assert dagrun.external_trigger
             assert dagrun.execution_date == custom_execution_date
             assert dagrun.run_id == DagRun.generate_run_id(DagRunType.MANUAL, custom_execution_date)
-            self.assert_extra_link(DEFAULT_DATE, dagrun, task)
+            self.assert_extra_link(dagrun, task, session)
 
     def test_trigger_dagrun_twice(self):
         """Test TriggerDagRunOperator with custom execution_date."""
@@ -169,7 +177,7 @@ class TestDagRunOperator(TestCase):
             triggered_dag_run = dagruns[0]
             assert triggered_dag_run.external_trigger
             assert triggered_dag_run.execution_date == utc_now
-            self.assert_extra_link(DEFAULT_DATE, triggered_dag_run, task)
+            self.assert_extra_link(triggered_dag_run, task, session)
 
     def test_trigger_dagrun_with_templated_execution_date(self):
         """Test TriggerDagRunOperator with templated execution_date."""
@@ -187,7 +195,7 @@ class TestDagRunOperator(TestCase):
             triggered_dag_run = dagruns[0]
             assert triggered_dag_run.external_trigger
             assert triggered_dag_run.execution_date == DEFAULT_DATE
-            self.assert_extra_link(DEFAULT_DATE, triggered_dag_run, task)
+            self.assert_extra_link(triggered_dag_run, task, session)
 
     def test_trigger_dagrun_operator_conf(self):
         """Test passing conf to the triggered DagRun."""
@@ -316,7 +324,7 @@ class TestDagRunOperator(TestCase):
             assert len(dagruns) == 2
             triggered_dag_run = dagruns[1]
             assert triggered_dag_run.state == State.QUEUED
-            self.assert_extra_link(execution_date, triggered_dag_run, task)
+            self.assert_extra_link(triggered_dag_run, task, session)
 
     def test_trigger_dagrun_triggering_itself_with_execution_date(self):
         """Test TriggerDagRunOperator that triggers itself with execution date,

--- a/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
@@ -183,20 +183,20 @@ def test_operator_extra_links(dag_maker, create_task_instance_of_operator):
     ), "Operator link type should be preserved during deserialization"
 
     assert (
-        ti.task.get_extra_links(DEFAULT_DATE, EmrClusterLink.name) == ""
+        ti.task.get_extra_links(ti, EmrClusterLink.name) == ""
     ), "Operator link should only be added if job id is available in XCom"
 
     assert (
-        deserialized_task.get_extra_links(DEFAULT_DATE, EmrClusterLink.name) == ""
+        deserialized_task.get_extra_links(ti, EmrClusterLink.name) == ""
     ), "Operator link should be empty for deserialized task with no XCom push"
 
     ti.xcom_push(key=XCOM_RETURN_KEY, value='j-SomeClusterId')
 
     expected = "https://console.aws.amazon.com/elasticmapreduce/home#cluster-details:j-SomeClusterId"
     assert (
-        deserialized_task.get_extra_links(DEFAULT_DATE, EmrClusterLink.name) == expected
+        deserialized_task.get_extra_links(ti, EmrClusterLink.name) == expected
     ), "Operator link should be preserved in deserialized tasks after execution"
 
     assert (
-        ti.task.get_extra_links(DEFAULT_DATE, EmrClusterLink.name) == expected
+        ti.task.get_extra_links(ti, EmrClusterLink.name) == expected
     ), "Operator link should be preserved after execution"

--- a/tests/providers/dbt/cloud/operators/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/operators/test_dbt_cloud.py
@@ -252,7 +252,7 @@ class TestDbtCloudRunJobOperator:
 
         ti.xcom_push(key="job_run_url", value=_run_response["data"]["href"])
 
-        url = ti.task.get_extra_links(DEFAULT_DATE, "Monitor Job Run")
+        url = ti.task.get_extra_links(ti, "Monitor Job Run")
 
         assert url == (
             EXPECTED_JOB_RUN_OP_EXTRA_LINK.format(

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -578,7 +578,7 @@ class TestBigQueryOperator:
 
         ti.xcom_push('job_id', 12345)
 
-        url = simple_task.get_extra_links(DEFAULT_DATE, BigQueryConsoleLink.name)
+        url = simple_task.get_extra_links(ti, BigQueryConsoleLink.name)
         assert url == 'https://console.cloud.google.com/bigquery?j=12345'
 
     @pytest.mark.need_serialized_dag
@@ -620,25 +620,26 @@ class TestBigQueryOperator:
         assert {'BigQuery Console #1', 'BigQuery Console #2'} == simple_task.operator_extra_link_dict.keys()
 
         assert 'https://console.cloud.google.com/bigquery?j=123' == simple_task.get_extra_links(
-            DEFAULT_DATE, 'BigQuery Console #1'
+            ti, 'BigQuery Console #1'
         )
 
         assert 'https://console.cloud.google.com/bigquery?j=45' == simple_task.get_extra_links(
-            DEFAULT_DATE, 'BigQuery Console #2'
+            ti, 'BigQuery Console #2'
         )
 
     @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
     def test_bigquery_operator_extra_link_when_missing_job_id(
         self, mock_hook, create_task_instance_of_operator
     ):
-        bigquery_task = create_task_instance_of_operator(
+        ti = create_task_instance_of_operator(
             BigQueryExecuteQueryOperator,
             dag_id=TEST_DAG_ID,
             task_id=TASK_ID,
             sql='SELECT * FROM test_table',
-        ).task
+        )
+        bigquery_task = ti.task
 
-        assert '' == bigquery_task.get_extra_links(DEFAULT_DATE, BigQueryConsoleLink.name)
+        assert '' == bigquery_task.get_extra_links(ti, BigQueryConsoleLink.name)
 
     @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
     def test_bigquery_operator_extra_link_when_single_query(
@@ -657,7 +658,7 @@ class TestBigQueryOperator:
         ti.xcom_push(key='job_id', value=job_id)
 
         assert f'https://console.cloud.google.com/bigquery?j={job_id}' == bigquery_task.get_extra_links(
-            DEFAULT_DATE, BigQueryConsoleLink.name
+            ti, BigQueryConsoleLink.name
         )
 
     @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
@@ -679,11 +680,11 @@ class TestBigQueryOperator:
         assert {'BigQuery Console #1', 'BigQuery Console #2'} == bigquery_task.operator_extra_link_dict.keys()
 
         assert 'https://console.cloud.google.com/bigquery?j=123' == bigquery_task.get_extra_links(
-            DEFAULT_DATE, 'BigQuery Console #1'
+            ti, 'BigQuery Console #1'
         )
 
         assert 'https://console.cloud.google.com/bigquery?j=45' == bigquery_task.get_extra_links(
-            DEFAULT_DATE, 'BigQuery Console #2'
+            ti, 'BigQuery Console #2'
         )
 
 

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -617,20 +617,18 @@ def test_create_cluster_operator_extra_links(dag_maker, create_task_instance_of_
     assert isinstance(deserialized_task.operator_extra_links[0], DataprocLink)
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == ""
 
     # Assert operator link is empty for deserialized task when no XCom push occurred
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == ""
 
     ti.xcom_push(key="conf", value=DATAPROC_CLUSTER_CONF_EXPECTED)
 
     # Assert operator links are preserved in deserialized tasks after execution
-    assert (
-        deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
-    )
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
     # Assert operator links after execution
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
 
 class TestDataprocClusterScaleOperator(DataprocClusterTestBase):
@@ -712,20 +710,18 @@ def test_scale_cluster_operator_extra_links(dag_maker, create_task_instance_of_o
     assert isinstance(deserialized_task.operator_extra_links[0], DataprocLink)
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == ""
 
     # Assert operator link is empty for deserialized task when no XCom push occurred
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == ""
 
     ti.xcom_push(key="conf", value=DATAPROC_CLUSTER_CONF_EXPECTED)
 
     # Assert operator links are preserved in deserialized tasks after execution
-    assert (
-        deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
-    )
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
     # Assert operator links after execution
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
 
 class TestDataprocClusterDeleteOperator(unittest.TestCase):
@@ -986,18 +982,18 @@ def test_submit_job_operator_extra_links(mock_hook, dag_maker, create_task_insta
     assert isinstance(deserialized_task.operator_extra_links[0], DataprocLink)
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == ""
 
     # Assert operator link is empty for deserialized task when no XCom push occurred
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == ""
 
     ti.xcom_push(key="conf", value=DATAPROC_JOB_CONF_EXPECTED)
 
     # Assert operator links are preserved in deserialized tasks
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
 
     # Assert operator links after execution
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
 
 
 class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
@@ -1154,20 +1150,18 @@ def test_update_cluster_operator_extra_links(dag_maker, create_task_instance_of_
     assert isinstance(deserialized_task.operator_extra_links[0], DataprocLink)
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == ""
 
     # Assert operator link is empty for deserialized task when no XCom push occurred
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == ""
 
     ti.xcom_push(key="conf", value=DATAPROC_CLUSTER_CONF_EXPECTED)
 
     # Assert operator links are preserved in deserialized tasks
-    assert (
-        deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
-    )
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
     # Assert operator links after execution
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_CLUSTER_LINK_EXPECTED
 
 
 class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
@@ -1523,18 +1517,18 @@ def test_submit_spark_job_operator_extra_links(mock_hook, dag_maker, create_task
     assert isinstance(deserialized_task.operator_extra_links[0], DataprocLink)
 
     # Assert operator link is empty when no XCom push occurred
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == ""
 
     # Assert operator link is empty for deserialized task when no XCom push occurred
-    assert deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == ""
+    assert deserialized_task.get_extra_links(ti, DataprocLink.name) == ""
 
     ti.xcom_push(key="conf", value=DATAPROC_JOB_CONF_EXPECTED)
 
     # Assert operator links after task execution
-    assert ti.task.get_extra_links(DEFAULT_DATE, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
+    assert ti.task.get_extra_links(ti, DataprocLink.name) == DATAPROC_JOB_LINK_EXPECTED
 
     # Assert operator links are preserved in deserialized tasks
-    link = deserialized_task.get_extra_links(DEFAULT_DATE, DataprocLink.name)
+    link = deserialized_task.get_extra_links(ti, DataprocLink.name)
     assert link == DATAPROC_JOB_LINK_EXPECTED
 
 

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -584,7 +584,7 @@ class TestMLEngineStartTrainingJobOperator:
 
         assert (
             f"https://console.cloud.google.com/ai-platform/jobs/{job_id}?project={project_id}"
-            == ti.task.get_extra_links(DEFAULT_DATE, AIPlatformConsoleLink.name)
+            == ti.task.get_extra_links(ti, AIPlatformConsoleLink.name)
         )
 
     @pytest.mark.need_serialized_dag
@@ -618,7 +618,7 @@ class TestMLEngineStartTrainingJobOperator:
 
         assert (
             f"https://console.cloud.google.com/ai-platform/jobs/{job_id}?project={project_id}"
-            == simple_task.get_extra_links(DEFAULT_DATE, AIPlatformConsoleLink.name)
+            == simple_task.get_extra_links(ti, AIPlatformConsoleLink.name)
         )
 
 

--- a/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
@@ -231,7 +231,7 @@ class TestAzureDataFactoryRunPipelineOperator:
         )
         ti.xcom_push(key="run_id", value=PIPELINE_RUN_RESPONSE["run_id"])
 
-        url = ti.task.get_extra_links(DEFAULT_DATE, "Monitor Pipeline Run")
+        url = ti.task.get_extra_links(ti, "Monitor Pipeline Run")
         EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
             "https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
             "?factory=/subscriptions/{subscription_id}/"

--- a/tests/providers/qubole/operators/test_qubole.py
+++ b/tests/providers/qubole/operators/test_qubole.py
@@ -120,10 +120,10 @@ class TestQuboleOperator:
             task.get_hook().create_cmd_args({'run_id': 'dummy'})[5] == "s3n://airflow/destination_hadoopcmd"
         )
 
-    def test_get_redirect_url(self, create_task_instance_of_operator):
+    def test_get_link(self, create_task_instance_of_operator):
         ti = create_task_instance_of_operator(
             QuboleOperator,
-            dag_id="test_get_redirect_url",
+            dag_id="test_get_link",
             execution_date=DEFAULT_DATE,
             task_id=TASK_ID,
             qubole_conn_id=TEST_CONN,
@@ -132,7 +132,7 @@ class TestQuboleOperator:
         )
         ti.xcom_push('qbol_cmd_id', 12345)
 
-        url = ti.task.get_extra_links(DEFAULT_DATE, 'Go to QDS')
+        url = ti.task.get_extra_links(ti, 'Go to QDS')
         assert url == 'http://localhost/v2/analyze?command_id=12345'
 
     @pytest.mark.need_serialized_dag
@@ -156,7 +156,7 @@ class TestQuboleOperator:
         assert isinstance(list(simple_task.operator_extra_links)[0], QDSLink)
 
         ti.xcom_push('qbol_cmd_id', 12345)
-        url = simple_task.get_extra_links(DEFAULT_DATE, 'Go to QDS')
+        url = simple_task.get_extra_links(ti, 'Go to QDS')
         assert url == 'http://localhost/v2/analyze?command_id=12345'
 
     def test_parameter_pool_passed(self):

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -425,7 +425,7 @@ def test_external_task_sensor_templated(dag_maker, app):
     # Verify that the operator link uses the rendered value of ``external_dag_id``.
     app.config['SERVER_NAME'] = ""
     with app.app_context():
-        url = instance.task.get_extra_links(DEFAULT_DATE, "External DAG")
+        url = instance.task.get_extra_links(instance, "External DAG")
 
         assert f"tree?dag_id=dag_{DEFAULT_DATE.date()}" in url
 

--- a/tests/test_utils/mock_operators.py
+++ b/tests/test_utils/mock_operators.py
@@ -45,7 +45,7 @@ class AirflowLink(BaseOperatorLink):
 
     name = 'airflow'
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         return 'https://airflow.apache.org'
 
 
@@ -75,9 +75,9 @@ class CustomBaseIndexOpLink(BaseOperatorLink):
     def name(self) -> str:
         return f'BigQuery Console #{self.index + 1}'
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         search_queries = XCom.get_one(
-            task_id=operator.task_id, dag_id=operator.dag_id, execution_date=dttm, key='search_query'
+            task_id=ti_key.task_id, dag_id=ti_key.dag_id, run_id=ti_key.run_id, key='search_query'
         )
         if not search_queries:
             return None
@@ -90,9 +90,9 @@ class CustomBaseIndexOpLink(BaseOperatorLink):
 class CustomOpLink(BaseOperatorLink):
     name = 'Google Custom'
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         search_query = XCom.get_one(
-            task_id=operator.task_id, dag_id=operator.dag_id, execution_date=dttm, key='search_query'
+            task_id=ti_key.task_id, dag_id=ti_key.dag_id, run_id=ti_key.run_id, key='search_query'
         )
         return f'http://google.com/custom_base_link?search={search_query}'
 
@@ -127,7 +127,7 @@ class GoogleLink(BaseOperatorLink):
     name = 'google'
     operators = [Dummy3TestOperator, CustomOperator]
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         return 'https://www.google.com'
 
 
@@ -139,7 +139,7 @@ class AirflowLink2(BaseOperatorLink):
     name = 'airflow'
     operators = [Dummy2TestOperator, Dummy3TestOperator]
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         return 'https://airflow.apache.org/1.10.5/'
 
 
@@ -150,7 +150,7 @@ class GithubLink(BaseOperatorLink):
 
     name = 'github'
 
-    def get_link(self, operator, dttm):
+    def get_link(self, operator, *, ti_key):
         return 'https://github.com/apache/airflow'
 
 


### PR DESCRIPTION
In 2.2 we "deprecated" passing an execution date to XCom.get methods, but there was no other option for operator links.

Now in 2.3 as part of Dynamic Task Mapping (AIP-42) we will need to add map_index to the XCom row to support the "reduce" part of the API.

In order to support that cleanly we need to change the interface for BaseOperatorLink to take an identifier (as dttm/execution_date + task is no longer unique)

This PR adds support for passing a `ti_key` to operator link callbacks if the signature supports it.

Todo:

- [x] Add note in UPDATING.md about the change.