### PR TITLE
Rename `dagrun_id` to `dag_run_id`

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -80,7 +80,7 @@ def _create_dagruns(
 def set_state(
     *,
     tasks: Iterable[Operator],
-    dag_run_id: Optional[str] = None,
+    run_id: Optional[str] = None,
     execution_date: Optional[datetime] = None,
     upstream: bool = False,
     downstream: bool = False,
@@ -98,7 +98,7 @@ def set_state(
     on the schedule (but it will as for subdag dag runs if needed).
 
     :param tasks: the iterable of tasks from which to work. task.task.dag needs to be set
-    :param dag_run_id: the run_id of the dagrun to start looking from
+    :param run_id: the run_id of the dagrun to start looking from
     :param execution_date: the execution date from which to start looking(deprecated)
     :param upstream: Mark all parents (upstream tasks)
     :param downstream: Mark all siblings (downstream tasks) of task_id, including SubDags
@@ -113,7 +113,7 @@ def set_state(
     if not tasks:
         return []
 
-    if not exactly_one(execution_date, dag_run_id):
+    if not exactly_one(execution_date, run_id):
         raise ValueError("Exactly one of dag_run_id and execution_date must be set")
 
     if execution_date and not timezone.is_localized(execution_date):
@@ -127,11 +127,11 @@ def set_state(
         raise ValueError("Received tasks with no DAG")
 
     if execution_date:
-        dag_run_id = dag.get_dagrun(execution_date=execution_date).run_id
-    if not dag_run_id:
-        raise ValueError("Received tasks with no dag_run_id")
+        run_id = dag.get_dagrun(execution_date=execution_date).run_id
+    if not run_id:
+        raise ValueError("Received tasks with no run_id")
 
-    dag_run_ids = get_run_ids(dag, dag_run_id, future, past)
+    dag_run_ids = get_run_ids(dag, run_id, future, past)
 
     task_ids = list(find_task_relatives(tasks, downstream, upstream))
 
@@ -407,7 +407,7 @@ def set_dag_run_state_to_success(
     # Mark all task instances of the dag run to success.
     for task in dag.tasks:
         task.dag = dag
-    return set_state(tasks=dag.tasks, dag_run_id=run_id, state=State.SUCCESS, commit=commit, session=session)
+    return set_state(tasks=dag.tasks, run_id=run_id, state=State.SUCCESS, commit=commit, session=session)
 
 
 @provide_session
@@ -469,7 +469,7 @@ def set_dag_run_state_to_failed(
         task.dag = dag
         tasks.append(task)
 
-    return set_state(tasks=tasks, dag_run_id=run_id, state=State.FAILED, commit=commit, session=session)
+    return set_state(tasks=tasks, run_id=run_id, state=State.FAILED, commit=commit, session=session)
 
 
 @provide_session

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -344,16 +344,16 @@ def get_run_ids(dag: DAG, run_id: str, future: bool, past: bool, session: SASess
     return run_ids
 
 
-def _set_dag_run_state(dag_id: str, dag_run_id: str, state: DagRunState, session: SASession = NEW_SESSION):
+def _set_dag_run_state(dag_id: str, run_id: str, state: DagRunState, session: SASession = NEW_SESSION):
     """
     Helper method that set dag run state in the DB.
 
     :param dag_id: dag_id of target dag run
-    :param dag_run_id: dag run id of target dag run
+    :param run_id: run id of target dag run
     :param state: target state
     :param session: database session
     """
-    dag_run = session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id).one()
+    dag_run = session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.run_id == run_id).one()
     dag_run.state = state
     if state == State.RUNNING:
         dag_run.start_date = timezone.utcnow()

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -357,7 +357,7 @@ def post_set_task_instances_state(*, dag_id: str, session: Session = NEW_SESSION
 
     tis = dag.set_task_instance_state(
         task_id=task_id,
-        dag_run_id=run_id,
+        run_id=run_id,
         execution_date=execution_date,
         state=data["new_state"],
         upstream=data["include_upstream"],

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -173,7 +173,7 @@ def string_list_type(val):
 ARG_DAG_ID = Arg(("dag_id",), help="The id of the dag")
 ARG_TASK_ID = Arg(("task_id",), help="The id of the task")
 ARG_EXECUTION_DATE = Arg(("execution_date",), help="The execution date of the DAG", type=parsedate)
-ARG_EXECUTION_DATE_OR_DAGRUN_ID = Arg(
+ARG_EXECUTION_DATE_OR_RUN_ID = Arg(
     ('execution_date_or_run_id',), help="The execution_date of the DAG or run_id of the DAGRun"
 )
 ARG_TASK_REGEX = Arg(
@@ -1174,7 +1174,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_EXECUTION_DATE_OR_RUN_ID,
             ARG_SUBDIR,
             ARG_VERBOSE,
             ARG_MAP_INDEX,
@@ -1189,7 +1189,7 @@ TASKS_COMMANDS = (
             "and then run by an executor."
         ),
         func=lazy_load_command('airflow.cli.commands.task_command.task_failed_deps'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_MAP_INDEX),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_RUN_ID, ARG_SUBDIR, ARG_MAP_INDEX),
     ),
     ActionCommand(
         name='render',
@@ -1198,7 +1198,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_EXECUTION_DATE_OR_RUN_ID,
             ARG_SUBDIR,
             ARG_VERBOSE,
             ARG_MAP_INDEX,
@@ -1211,7 +1211,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_EXECUTION_DATE_OR_RUN_ID,
             ARG_SUBDIR,
             ARG_MARK_SUCCESS,
             ARG_FORCE,
@@ -1242,7 +1242,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
+            ARG_EXECUTION_DATE_OR_RUN_ID,
             ARG_SUBDIR,
             ARG_DRY_RUN,
             ARG_TASK_PARAMS,
@@ -1255,7 +1255,7 @@ TASKS_COMMANDS = (
         name='states-for-dag-run',
         help="Get the status of all task instances in a dag run",
         func=lazy_load_command('airflow.cli.commands.task_command.task_states_for_dag_run'),
-        args=(ARG_DAG_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_EXECUTION_DATE_OR_RUN_ID, ARG_OUTPUT, ARG_VERBOSE),
     ),
 )
 POOLS_COMMANDS = (

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -39,7 +39,7 @@ from airflow.models import DagPickle, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
-from airflow.models.xcom import IN_MEMORY_DAGRUN_ID
+from airflow.models.xcom import IN_MEMORY_RUN_ID
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
 from airflow.utils import cli as cli_utils
@@ -98,7 +98,7 @@ def _get_dag_run(
             ) from None
 
     if execution_date is not None:
-        return DagRun(dag.dag_id, run_id=IN_MEMORY_DAGRUN_ID, execution_date=execution_date)
+        return DagRun(dag.dag_id, run_id=IN_MEMORY_RUN_ID, execution_date=execution_date)
     return DagRun(dag.dag_id, run_id=exec_date_or_run_id, execution_date=timezone.utcnow())
 
 

--- a/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
+++ b/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
@@ -158,7 +158,7 @@ def upgrade():
                 mssql_where=sa.text("state='queued'"),
             )
     else:
-        # Make sure DagRun id columns are non-nullable
+        # Make sure DagRun PK columns are non-nullable
         with op.batch_alter_table('dag_run', schema=None) as batch_op:
             batch_op.alter_column('dag_id', existing_type=string_id_col_type, nullable=False)
             batch_op.alter_column('execution_date', existing_type=dt_type, nullable=False)

--- a/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
+++ b/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
@@ -42,7 +42,7 @@ metadata = MetaData()
 
 def _get_new_xcom_columns() -> Sequence[Column]:
     return [
-        Column("dagrun_id", Integer(), nullable=False),
+        Column("dag_run_id", Integer(), nullable=False),
         Column("task_id", StringID(), nullable=False),
         Column("key", StringID(length=512), nullable=False),
         Column("value", LargeBinary),
@@ -117,7 +117,7 @@ def upgrade():
     op.rename_table("__airflow_tmp_xcom", "xcom")
 
     with op.batch_alter_table("xcom") as batch_op:
-        batch_op.create_primary_key("xcom_pkey", ["dagrun_id", "task_id", "key"])
+        batch_op.create_primary_key("xcom_pkey", ["dag_run_id", "task_id", "key"])
         batch_op.create_index("idx_xcom_key", ["key"])
         batch_op.create_index("idx_xcom_ti_id", ["dag_id", "task_id", "run_id"])
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1613,7 +1613,7 @@ class DAG(LoggingMixin):
         *,
         task_id: str,
         execution_date: Optional[datetime] = None,
-        dag_run_id: Optional[str] = None,
+        run_id: Optional[str] = None,
         state: TaskInstanceState,
         upstream: bool = False,
         downstream: bool = False,
@@ -1628,7 +1628,7 @@ class DAG(LoggingMixin):
 
         :param task_id: Task ID of the TaskInstance
         :param execution_date: Execution date of the TaskInstance
-        :param dag_run_id: The run_id of the TaskInstance
+        :param run_id: The run_id of the TaskInstance
         :param state: State to set the TaskInstance to
         :param upstream: Include all upstream tasks of the given task_id
         :param downstream: Include all downstream tasks of the given task_id
@@ -1638,12 +1638,12 @@ class DAG(LoggingMixin):
         """
         from airflow.api.common.mark_tasks import set_state
 
-        if not exactly_one(execution_date, dag_run_id):
-            raise ValueError("Exactly one of execution_date or dag_run_id must be provided")
+        if not exactly_one(execution_date, run_id):
+            raise ValueError("Exactly one of execution_date or run_id must be provided")
 
         if execution_date is None:
             dag_run = (
-                session.query(DagRun).filter(DagRun.run_id == dag_run_id, DagRun.dag_id == self.dag_id).one()
+                session.query(DagRun).filter(DagRun.run_id == run_id, DagRun.dag_id == self.dag_id).one()
             )  # Raises an error if not found
             resolve_execution_date = dag_run.execution_date
         else:
@@ -1655,7 +1655,7 @@ class DAG(LoggingMixin):
         altered = set_state(
             tasks=[task],
             execution_date=execution_date,
-            dag_run_id=dag_run_id,
+            run_id=run_id,
             upstream=upstream,
             downstream=downstream,
             future=future,

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -48,7 +48,7 @@ XCOM_RETURN_KEY = 'return_value'
 
 # Stand-in value for 'airflow task test' generating a temporary in-memory DAG
 # run without storing it in the database.
-IN_MEMORY_DAGRUN_ID = "__airflow_in_memory_dagrun__"
+IN_MEMORY_RUN_ID = "__airflow_in_memory_dagrun__"
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstanceKey
@@ -170,7 +170,7 @@ class BaseXCom(Base, LoggingMixin):
                 )
             except NoResultFound:
                 raise ValueError(f"DAG run not found on DAG {dag_id!r} at {execution_date}") from None
-        elif run_id == IN_MEMORY_DAGRUN_ID:
+        elif run_id == IN_MEMORY_RUN_ID:
             dagrun_id = -1
         else:
             dagrun_id = session.query(DagRun.id).filter_by(dag_id=dag_id, run_id=run_id).scalar()
@@ -410,7 +410,7 @@ class BaseXCom(Base, LoggingMixin):
             if execution_date is not None:
                 query = query.filter(DagRun.execution_date <= execution_date)
             else:
-                # This returns an empty query result for IN_MEMORY_DAGRUN_ID,
+                # This returns an empty query result for IN_MEMORY_RUN_ID,
                 # but that is impossible to implement. Sorry?
                 dr = session.query(DagRun.execution_date).filter(DagRun.run_id == run_id).subquery()
                 query = query.filter(cls.execution_date <= dr.c.execution_date)

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -182,7 +182,7 @@ class BaseXCom(Base, LoggingMixin):
             key=key,
             task_id=task_id,
             dag_id=dag_id,
-            run_id=dag_run_id,
+            run_id=run_id,
         )
 
         # Remove duplicate XComs and insert a new one.

--- a/airflow/ti_deps/dependencies_deps.py
+++ b/airflow/ti_deps/dependencies_deps.py
@@ -23,8 +23,8 @@ from airflow.ti_deps.dependencies_states import (
 )
 from airflow.ti_deps.deps.dag_ti_slots_available_dep import DagTISlotsAvailableDep
 from airflow.ti_deps.deps.dag_unpaused_dep import DagUnpausedDep
+from airflow.ti_deps.deps.dagrun_backfill_dep import DagRunNotBackfillDep
 from airflow.ti_deps.deps.dagrun_exists_dep import DagrunRunningDep
-from airflow.ti_deps.deps.dagrun_id_dep import DagrunIdDep
 from airflow.ti_deps.deps.exec_date_after_start_date_dep import ExecDateAfterStartDateDep
 from airflow.ti_deps.deps.pool_slots_available_dep import PoolSlotsAvailableDep
 from airflow.ti_deps.deps.runnable_exec_date_dep import RunnableExecDateDep
@@ -85,7 +85,7 @@ SCHEDULER_QUEUED_DEPS = {
     TaskConcurrencyDep(),
     PoolSlotsAvailableDep(),
     DagrunRunningDep(),
-    DagrunIdDep(),
+    DagRunNotBackfillDep(),
     DagUnpausedDep(),
     ExecDateAfterStartDateDep(),
     TaskNotRunningDep(),

--- a/airflow/ti_deps/deps/dagrun_backfill_dep.py
+++ b/airflow/ti_deps/deps/dagrun_backfill_dep.py
@@ -16,17 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module defines dep for DagRun ID validation"""
+"""This module defines dep for making sure DagRun not a backfill."""
 
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.utils.session import provide_session
 from airflow.utils.types import DagRunType
 
 
-class DagrunIdDep(BaseTIDep):
-    """Dep for valid DagRun ID to schedule from scheduler"""
+class DagRunNotBackfillDep(BaseTIDep):
+    """Dep for valid DagRun run_id to schedule from scheduler"""
 
-    NAME = "Dagrun run_id is not backfill job ID"
+    NAME = "DagRun is not backfill job"
     IGNORABLE = True
 
     @provide_session

--- a/airflow/ti_deps/deps/dagrun_backfill_dep.py
+++ b/airflow/ti_deps/deps/dagrun_backfill_dep.py
@@ -37,7 +37,7 @@ class DagRunNotBackfillDep(BaseTIDep):
         :param ti: the task instance to get the dependency status for
         :param session: database session
         :param dep_context: the context for which this dependency should be evaluated for
-        :return: True if DagRun ID is valid for scheduling from scheduler.
+        :return: True if DagRun is valid for scheduling from scheduler.
         """
         dagrun = ti.get_dagrun(session)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2221,7 +2221,7 @@ class Airflow(AirflowBaseView):
 
         altered = dag.set_task_instance_state(
             task_id=task_id,
-            dag_run_id=dag_run_id,
+            run_id=dag_run_id,
             state=state,
             upstream=upstream,
             downstream=downstream,
@@ -2283,7 +2283,7 @@ class Airflow(AirflowBaseView):
 
         to_be_altered = set_state(
             tasks=[task],
-            dag_run_id=dag_run_id,
+            run_id=dag_run_id,
             upstream=upstream,
             downstream=downstream,
             future=future,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3592,7 +3592,7 @@ class XComModelView(AirflowModelView):
 
     search_columns = ['key', 'value', 'timestamp', 'dag_id', 'task_id', 'run_id']
     list_columns = ['key', 'value', 'timestamp', 'dag_id', 'task_id', 'run_id']
-    base_order = ('dagrun_id', 'desc')
+    base_order = ('dag_run_id', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]
 

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -153,7 +153,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag1.dag_id, execution_date=self.execution_dates[0])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -167,7 +167,7 @@ class TestMarkTasks:
         # set one and only one task to success
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -181,7 +181,7 @@ class TestMarkTasks:
         # set no tasks
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -195,7 +195,7 @@ class TestMarkTasks:
         # set task to other than success
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -211,7 +211,7 @@ class TestMarkTasks:
         task = self.dag1.get_task("runme_0")
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -228,7 +228,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag3.dag_id, execution_date=self.dag3_execution_dates[1])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -255,7 +255,7 @@ class TestMarkTasks:
 
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=True,
             future=False,
@@ -277,7 +277,7 @@ class TestMarkTasks:
 
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=True,
             downstream=False,
             future=False,
@@ -295,7 +295,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag1.dag_id, execution_date=self.execution_dates[0])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=True,
@@ -311,7 +311,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag3.dag_id, execution_date=self.dag3_execution_dates[1])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=True,
@@ -330,7 +330,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag1.dag_id, execution_date=self.execution_dates[1])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -346,7 +346,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag3.dag_id, execution_date=self.dag3_execution_dates[1])[0]
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -365,7 +365,7 @@ class TestMarkTasks:
         dr = DagRun.find(dag_id=self.dag1.dag_id, execution_date=self.execution_dates[0])[0]
         altered = set_state(
             tasks=tasks,
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=False,
             future=False,
@@ -392,7 +392,7 @@ class TestMarkTasks:
 
         altered = set_state(
             tasks=[task],
-            dag_run_id=dr.run_id,
+            run_id=dr.run_id,
             upstream=False,
             downstream=True,
             future=False,

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -266,7 +266,7 @@ class TestGetLog:
 
     def test_raises_404_for_invalid_dag_run_id(self):
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/NO_DAG_RUN/"  # invalid dagrun_id
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/NO_DAG_RUN/"  # invalid run_id
             f"taskInstances/{self.TASK_ID}/logs/1?",
             headers={'Accept': 'application/json'},
             environ_overrides={'REMOTE_USER': "test"},

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -1126,7 +1126,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
         mock_set_task_instance_state.assert_called_once_with(
             commit=False,
             downstream=True,
-            dag_run_id=None,
+            run_id=None,
             execution_date=DEFAULT_DATETIME_1,
             future=True,
             past=True,
@@ -1175,7 +1175,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
         mock_set_task_instance_state.assert_called_once_with(
             commit=False,
             downstream=True,
-            dag_run_id=run_id,
+            run_id=run_id,
             execution_date=None,
             future=True,
             past=True,

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -443,7 +443,7 @@ class TestPaginationGetXComEntries(TestXComEndpoint):
         with create_session() as session:
             for i in range(1, 11):
                 xcom = XCom(
-                    dagrun_id=dagrun.id,
+                    dag_run_id=dagrun.id,
                     key=f"TEST_XCOM_KEY{i}",
                     value=b"null",
                     run_id=self.dag_run_id,

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -214,7 +214,7 @@ class TestSetTaskInstanceStateFormSchema:
             ({"include_future": "foo"},),
             ({"execution_date": "NOW"},),
             ({"new_state": "INVALID_STATE"},),
-            ({"execution_date": "2020-01-01T00:00:00+00:00", "dag_run_id": "dagrun_id"},),
+            ({"execution_date": "2020-01-01T00:00:00+00:00", "dag_run_id": "dag_run_id"},),
         ]
     )
     def test_validation_error(self, override_data):

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -214,7 +214,7 @@ class TestSetTaskInstanceStateFormSchema:
             ({"include_future": "foo"},),
             ({"execution_date": "NOW"},),
             ({"new_state": "INVALID_STATE"},),
-            ({"execution_date": "2020-01-01T00:00:00+00:00", "dag_run_id": "dag_run_id"},),
+            ({"execution_date": "2020-01-01T00:00:00+00:00", "dag_run_id": "some-run-id"},),
         ]
     )
     def test_validation_error(self, override_data):

--- a/tests/api_connexion/schemas/test_xcom_schema.py
+++ b/tests/api_connexion/schemas/test_xcom_schema.py
@@ -48,7 +48,7 @@ def create_xcom(create_task_instance, session):
         )
         run: DagRun = ti.dag_run
         xcom = XCom(
-            dagrun_id=run.id,
+            dag_run_id=run.id,
             task_id=ti.task_id,
             key=key,
             value=value,

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2260,7 +2260,7 @@ def test_set_task_instance_state(run_id, execution_date, session, dag_maker):
 
     altered = dag.set_task_instance_state(
         task_id=task_1.task_id,
-        dag_run_id=run_id,
+        run_id=run_id,
         execution_date=execution_date,
         state=State.SUCCESS,
         session=session,

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -25,7 +25,7 @@ import pytest
 from airflow.configuration import conf
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.models.taskinstance import TaskInstanceKey
-from airflow.models.xcom import IN_MEMORY_DAGRUN_ID, XCOM_RETURN_KEY, BaseXCom, XCom, resolve_xcom_backend
+from airflow.models.xcom import IN_MEMORY_RUN_ID, XCOM_RETURN_KEY, BaseXCom, XCom, resolve_xcom_backend
 from airflow.settings import json
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -202,7 +202,7 @@ class TestXCom:
             key=XCOM_RETURN_KEY,
             dag_id="test_dag",
             task_id="test_task",
-            run_id=IN_MEMORY_DAGRUN_ID,
+            run_id=IN_MEMORY_RUN_ID,
         )
 
         XCom = resolve_xcom_backend()
@@ -244,7 +244,7 @@ class TestXCom:
             key=XCOM_RETURN_KEY,
             dag_id="test_dag",
             task_id="test_task",
-            run_id=IN_MEMORY_DAGRUN_ID,
+            run_id=IN_MEMORY_RUN_ID,
         )
         expected = {**kwargs, 'run_id': -1}
         XCom = resolve_xcom_backend()

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -246,7 +246,7 @@ class TestXCom:
             task_id="test_task",
             run_id=IN_MEMORY_RUN_ID,
         )
-        expected = {**kwargs, 'run_id': -1}
+        expected = {**kwargs, 'run_id': '__airflow_in_memory_dagrun__'}
         XCom = resolve_xcom_backend()
         XCom.set(**kwargs)
         serialize_watcher.assert_called_once_with(**expected)

--- a/tests/providers/apache/hive/operators/test_hive.py
+++ b/tests/providers/apache/hive/operators/test_hive.py
@@ -79,10 +79,10 @@ class HiveOperatorTest(TestHiveEnvironment):
         mock_get_hook.return_value = mock_hook
         op = HiveOperator(task_id='test_mapred_job_name', hql=self.hql, dag=self.dag)
 
-        fake_dagrun_id = "test_mapred_job_name"
+        fake_run_id = "test_mapred_job_name"
         fake_execution_date = timezone.datetime(2018, 6, 19)
         fake_ti = TaskInstance(task=op)
-        fake_ti.dag_run = DagRun(run_id=fake_dagrun_id, execution_date=fake_execution_date)
+        fake_ti.dag_run = DagRun(run_id=fake_run_id, execution_date=fake_execution_date)
         fake_ti.hostname = 'fake_hostname'
         fake_context = {'ti': fake_ti}
 

--- a/tests/ti_deps/deps/test_dagrun_id_dep.py
+++ b/tests/ti_deps/deps/test_dagrun_id_dep.py
@@ -26,9 +26,9 @@ from airflow.utils.types import DagRunType
 
 
 class TestDagrunRunningDep(unittest.TestCase):
-    def test_dagrun_id_is_backfill(self):
+    def test_run_id_is_backfill(self):
         """
-        Task instances whose dagrun ID is a backfill dagrun ID should fail this dep.
+        Task instances whose run_id is a backfill dagrun run_id should fail this dep.
         """
         dagrun = DagRun()
         dagrun.run_id = "anything"
@@ -36,9 +36,9 @@ class TestDagrunRunningDep(unittest.TestCase):
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
         assert not DagRunNotBackfillDep().is_met(ti=ti)
 
-    def test_dagrun_id_is_not_backfill(self):
+    def test_run_id_is_not_backfill(self):
         """
-        Task instances whose dagrun ID is not a backfill dagrun ID should pass this dep.
+        Task instances whose run_id is not a backfill run_id should pass this dep.
         """
         dagrun = DagRun()
         dagrun.run_type = 'custom_type'

--- a/tests/ti_deps/deps/test_dagrun_id_dep.py
+++ b/tests/ti_deps/deps/test_dagrun_id_dep.py
@@ -21,7 +21,7 @@ import unittest
 from unittest.mock import Mock
 
 from airflow.models.dagrun import DagRun
-from airflow.ti_deps.deps.dagrun_id_dep import DagrunIdDep
+from airflow.ti_deps.deps.dagrun_backfill_dep import DagRunNotBackfillDep
 from airflow.utils.types import DagRunType
 
 
@@ -34,7 +34,7 @@ class TestDagrunRunningDep(unittest.TestCase):
         dagrun.run_id = "anything"
         dagrun.run_type = DagRunType.BACKFILL_JOB
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
-        assert not DagrunIdDep().is_met(ti=ti)
+        assert not DagRunNotBackfillDep().is_met(ti=ti)
 
     def test_dagrun_id_is_not_backfill(self):
         """
@@ -43,9 +43,9 @@ class TestDagrunRunningDep(unittest.TestCase):
         dagrun = DagRun()
         dagrun.run_type = 'custom_type'
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
-        assert DagrunIdDep().is_met(ti=ti)
+        assert DagRunNotBackfillDep().is_met(ti=ti)
 
         dagrun = DagRun()
         dagrun.run_id = None
         ti = Mock(get_dagrun=Mock(return_value=dagrun))
-        assert DagrunIdDep().is_met(ti=ti)
+        assert DagRunNotBackfillDep().is_met(ti=ti)


### PR DESCRIPTION
I think we can call this attribute `dag_run_id` without suffering too much ambiguity, principally because _dag_ does  not, strictly speaking, have a `run_id`; it's the dag _run_ that has a `run_id`.

For a long time, the codebase has used `dag_run_id` or "dagrun id" to refer to the dagrun.run_id column.

As of recently, we now have `dagrun_id` alongside `dag_run_id` -- the former is supposed to refer to `DagRun.id` and the latter to `DagRun.run_id`.  But personally I think that retains too much ambiguity.  When reading it, you're not sure if it maybe is just a typo, or what exactly it is / how it is different from dag_run_id.  And it doesn't obey standard camel-to-snake conversion.

I think we can do a better job of reducing ambiguity by using, wherever possible, `run_id` to mean `DagRun.run_id` and `dag_run_id` to mean the integer PK. (i don't think we have to resort to the painfully verbose `dag run run id`).

So, this PR hopes to rename `dagrun_id` to `dag_run_id`, and tries to replace any old references to "dag run id" to simply "run id".

The one wrinkle is the API.  There are references to "dag_run_id".  What I've done here is leave that alone.  We could think  of the DagRun.id as internal, and not user-facing from the rest API perspective.  We could consider deprecating / renaming this param, but I'm considering that out of scope since it's already been out there and is unaffected by the recent changes (which this PR hopes to address before they go out in 2.3.
