### PR TITLE
Deprecate non-JSON conn.extra

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -109,9 +109,18 @@ a JSON-encoded python dict.
 
 For users of providers that are included in the Airflow codebase, you should not have to make any changes
 because in the Airflow codebase we should not allow hooks to misuse the `Connection.extra` field in this way.
+
 However, if you have any custom hooks that store something other than JSON dict, you will have to update it.
 If you do, you should see a warning any time that this connection is retrieved or instantiated (e.g. it should show up in
 task logs).
+
+To see if you have any connections that will need to be updated, you can run this command:
+
+```shell
+airflow connections export - 2>&1 >/dev/null | grep 'non-JSON'
+```
+
+This will catch any warnings about connections that are storing something other than JSON-encoded python dict in the `extra` field.
 
 ### Zip files in the DAGs folder can no longer have a `.py` extension
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -85,7 +85,7 @@ https://developers.google.com/style/inclusive-documentation
 
 #### TLDR
 
-From Airflow 3.0, the `extra` field in airflow connections must be a JSON-encoded python dict.
+From Airflow 3.0, the `extra` field in airflow connections must be a JSON-encoded Python dict.
 
 #### What, why, and when?
 
@@ -103,7 +103,7 @@ value, what happens if you need to add more information, such as the API endpoin
 you would need to convert the string to a dict, and this would be a breaking change.
 
 For these reason, starting in Airflow 3.0 we will require that the `Connection.extra` field store
-a JSON-encoded python dict.
+a JSON-encoded Python dict.
 
 #### How will I be affected?
 
@@ -120,7 +120,7 @@ To see if you have any connections that will need to be updated, you can run thi
 airflow connections export - 2>&1 >/dev/null | grep 'non-JSON'
 ```
 
-This will catch any warnings about connections that are storing something other than JSON-encoded python dict in the `extra` field.
+This will catch any warnings about connections that are storing something other than JSON-encoded Python dict in the `extra` field.
 
 ### Zip files in the DAGs folder can no longer have a `.py` extension
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -81,6 +81,38 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Deprecation: `Connection.extra` must be JSON-encoded dict
+
+#### TLDR
+
+From Airflow 3.0, the `extra` field in airflow connections must be a JSON-encoded python dict.
+
+#### What, why, and when?
+
+Airflow's Connection is used for storing credentials.  For storage of information that does not
+fit into user / password / host / schema / port, we have the `extra` string field.  Its intention
+was always to provide for storage of arbitrary key-value pairs, like `no_host_key_check` in the SSH
+hook, or `keyfile_dict` in GCP.
+
+But since the field is string, it's technically been permissible to store any string value.  For example
+one could have stored the string value `'my-website.com'` and used this in the hook.  But this is a very
+bad practice. One reason is intelligibility: when you look at the value for `extra`, you don't have any idea
+what its purpose is.  Better would be to store `{"api_host": "my-website.com"}` which at least tells you
+*something* about the value.  Another reason is extensibility: if you store the API host as a simple string
+value, what happens if you need to add more information, such as the API endpoint, or credentials?  Then
+you would need to convert the string to a dict, and this would be a breaking change.
+
+For these reason, starting in Airflow 3.0 we will require that the `Connection.extra` field store
+a JSON-encoded python dict.
+
+#### How will I be affected?
+
+For users of providers that are included in the Airflow codebase, you should not have to make any changes
+because in the Airflow codebase we should not allow hooks to misuse the `Connection.extra` field in this way.
+However, if you have any custom hooks that store something other than JSON dict, you will have to update it.
+If you do, you should see a warning any time that this connection is retrieved or instantiated (e.g. it should show up in
+task logs).
+
 ### Zip files in the DAGs folder can no longer have a `.py` extension
 
 It was previously possible to have any extension for zip files in the DAGs folder. Now `.py` files are going to be loaded as modules without checking whether it is a zip file, as it leads to less IO. If a `.py` file in the DAGs folder is a zip compressed file, parsing it will fail with an exception.

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -141,7 +141,13 @@ class Connection(Base, LoggingMixin):
             mask_secret(self.password)
 
     @staticmethod
-    def _validate_extra(extra, conn_id):
+    def _validate_extra(extra, conn_id) -> None:
+        """
+        Here we verify that ``extra`` is a JSON-encoded python dict.  From Airflow 3.0, we should no
+        longer suppress these errors but raise instead.
+        """
+        if extra is None:
+            return None
         try:
             extra_parsed = json.loads(extra)
             if not isinstance(extra_parsed, dict):
@@ -159,6 +165,7 @@ class Connection(Base, LoggingMixin):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        return None
 
     @reconstructor
     def on_db_load(self):

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -143,14 +143,14 @@ class Connection(Base, LoggingMixin):
     @staticmethod
     def _validate_extra(extra, conn_id):
         try:
-            _extra_parsed = json.loads(extra)
-            if not isinstance(_extra_parsed, dict):
+            extra_parsed = json.loads(extra)
+            if not isinstance(extra_parsed, dict):
                 warnings.warn(
                     "Encountered JSON value in `extra` which does not parse as a dictionary in "
                     f"connection {conn_id!r}. From Airflow 3.0, the `extra` field must contain a JSON "
                     "representation of a python dict.",
                     DeprecationWarning,
-                    stacklevel=2,
+                    stacklevel=3,
                 )
         except json.JSONDecodeError:
             warnings.warn(

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -143,7 +143,7 @@ class Connection(Base, LoggingMixin):
     @staticmethod
     def _validate_extra(extra, conn_id) -> None:
         """
-        Here we verify that ``extra`` is a JSON-encoded python dict.  From Airflow 3.0, we should no
+        Here we verify that ``extra`` is a JSON-encoded Python dict.  From Airflow 3.0, we should no
         longer suppress these errors but raise instead.
         """
         if extra is None:
@@ -154,7 +154,7 @@ class Connection(Base, LoggingMixin):
                 warnings.warn(
                     "Encountered JSON value in `extra` which does not parse as a dictionary in "
                     f"connection {conn_id!r}. From Airflow 3.0, the `extra` field must contain a JSON "
-                    "representation of a python dict.",
+                    "representation of a Python dict.",
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -276,15 +276,19 @@ class Connection(Base, LoggingMixin):
                     f"Can't decrypt `extra` params for login={self.login}, "
                     f"FERNET_KEY configuration is missing"
                 )
-            return fernet.decrypt(bytes(self._extra, 'utf-8')).decode()
+            extra_val = fernet.decrypt(bytes(self._extra, 'utf-8')).decode()
         else:
-            return self._extra
+            extra_val = self._extra
+        if extra_val:
+            self._validate_extra(extra_val, self.conn_id)
+        return extra_val
 
     def set_extra(self, value: str):
         """Encrypt extra-data and save in object attribute to object."""
         if value:
             fernet = get_fernet()
             self._extra = fernet.encrypt(bytes(value, 'utf-8')).decode()
+            self._validate_extra(self._extra, self.conn_id)
             self.is_extra_encrypted = fernet.is_encrypted
         else:
             self._extra = value

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -682,3 +682,11 @@ class TestConnection(unittest.TestCase):
         res = conn.test_connection()
         assert res[0] is False
         assert res[1] == "Hook FTPHook doesn't implement or inherit test_connection method"
+
+    def test_extra_warnings_non_json(self):
+        with pytest.warns(DeprecationWarning, match='non-JSON'):
+            Connection(conn_id='test_extra', conn_type='none', extra='hi')
+
+    def test_extra_warnings_non_dict_json(self):
+        with pytest.warns(DeprecationWarning, match='not parse as a dictionary'):
+            Connection(conn_id='test_extra', conn_type='none', extra='"hi"')


### PR DESCRIPTION
Connection extra field is generally assumed to be JSON but we don't actually require it.  Here we deprecate non-JSON extra so that in 3.0 we can require it.  Further, we require that it not just be any json but must also parse as dict, because a string value such as '"hi"' or '[1,2,3]' is json, but a very bad practice.
