### PR TITLE
Limits GitHub3.py in order to avoid backtracking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -606,7 +606,7 @@ devel_only = [
     # are 3 versions with PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and fails
     # to resolve that github3 3.0.0 is the right version to use.
     # This limitation could be removed if PyJWT limitation < 2.0.0 is dropped from FAB or when
-    # pip resolution is improved to handle the case, The issue which describes this PIP behaviour
+    # pip resolution is improved to handle the case. The issue which describes this PIP behaviour
     # and hopefully allowing to improve it is tracked in https://github.com/pypa/pip/issues/10924
     'github3.py<3.1.0',
     'gitpython',

--- a/setup.py
+++ b/setup.py
@@ -599,7 +599,16 @@ devel_only = [
     'flake8-colors',
     'flaky',
     'freezegun',
-    'github3.py',
+    # Github3 version 3.1.2 requires PyJWT>=2.3.0 which clashes with Flask App Builder where PyJWT is <2.0.0
+    # Actually GitHub3.1.0 already introduced PyJWT>=2.3.0 but so far `pip` was able to resolve it without
+    # getting into a long backtracking loop and figure out that github3 3.0.0 version is the right version
+    # similarly limiting it to 3.1.2 causes pip not to enter the backtracking loop. Apparently when there
+    # Are 3 versions with PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and fails
+    # to resolve that github3 3.0.0 is the right version to use.
+    # This limitation could be removed if PyJWT limitation < 2.0.0 is dropped from FAB or when
+    # pip resolution is improved to handle the case, The issue which describes this PIP behaviour
+    # and hopefully allowing to improve it is tracked in https://github.com/pypa/pip/issues/10924
+    'github3.py<3.1.0',
     'gitpython',
     'ipdb',
     'jira',

--- a/setup.py
+++ b/setup.py
@@ -603,7 +603,7 @@ devel_only = [
     # Actually GitHub3.1.0 already introduced PyJWT>=2.3.0 but so far `pip` was able to resolve it without
     # getting into a long backtracking loop and figure out that github3 3.0.0 version is the right version
     # similarly limiting it to 3.1.2 causes pip not to enter the backtracking loop. Apparently when there
-    # Are 3 versions with PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and fails
+    # are 3 versions with PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and fails
     # to resolve that github3 3.0.0 is the right version to use.
     # This limitation could be removed if PyJWT limitation < 2.0.0 is dropped from FAB or when
     # pip resolution is improved to handle the case, The issue which describes this PIP behaviour


### PR DESCRIPTION
Github3 version 3.1.2 requires PyJWT>=2.3.0 which clashes with Flask App
Builder where PyJWT is <2.0.0 Actually GitHub3.1.0 already introduced
PyJWT>=2.3.0 but so far `pip` was able to resolve it without getting
into a long backtracking loop and figure out that github3 3.0.0 version
is the right version similarly limiting it to 3.1.2 causes pip not to
enter the backtracking loop. Apparently when there Are 3 versions with
PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and
fails to resolve that github3 3.0.0 is the right version to use.
This limitation could be removed if PyJWT limitation < 2.0.0 is dropped
from FAB or when pip resolution is improved to handle the case, The
issue which describes this PIP behaviour and hopefully allowing to
improve it is tracked in https://github.com/pypa/pip/issues/10924.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
