### PR TITLE
Raise import error if a task uses a non-existent pool

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -330,9 +330,6 @@ class SchedulerJob(BaseJob):
 
         for pool, task_instances in pool_to_task_instances.items():
             pool_name = pool
-            if pool not in pools:
-                self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool)
-                continue
 
             pool_total = pools[pool]["total"]
             for task_instance in task_instances:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2643,7 +2643,7 @@ class DAG(LoggingMixin):
         task_pools = {task.pool for task in self.tasks}
         diff = task_pools - pools
         if diff:
-            raise PoolNotFound(f"The following pools: `{sorted(diff)}` do not exist in the database")
+            raise PoolNotFound(f"The following pools do not exist in the database: `{sorted(diff)}`")
 
 
 class DagTag(Base):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2639,7 +2639,7 @@ class DAG(LoggingMixin):
         task_pools = {task.pool for task in self.tasks}
         diff = task_pools - pools
         if diff:
-            raise PoolNotFound(f"The following pools: `{list(diff)}` does not exist in the database")
+            raise PoolNotFound(f"The following pools: `{sorted(diff)}` do not exist in the database")
 
 
 class DagTag(Base):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2631,8 +2631,12 @@ class DAG(LoggingMixin):
                 )
 
     @provide_session
-    def validate_task_pools(self, session=NEW_SESSION):
-        """Validates and raise exception if any task in a dag is using a non-existent pool"""
+    def validate_task_pools(self, session: Session = NEW_SESSION):
+        """
+        Validates and raise exception if any task in a dag is using a non-existent pool
+
+        :meta private:
+        """
         from airflow.models.pool import Pool
 
         pools = {p.pool for p in Pool.get_pools(session)}

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -41,6 +41,7 @@ from airflow.exceptions import (
     AirflowDagDuplicatedIdException,
     AirflowTimetableInvalid,
     ParamValidationError,
+    PoolNotFound,
 )
 from airflow.stats import Stats
 from airflow.utils import timezone
@@ -405,6 +406,8 @@ class DagBag(LoggingMixin):
                 dag.timetable.validate()
                 # validate dag params
                 dag.params.validate()
+                # validate pools
+                dag.validate_task_pools()
                 self.bag_dag(dag=dag, root_dag=dag)
                 found_dags.append(dag)
                 found_dags += dag.subdags
@@ -417,6 +420,7 @@ class DagBag(LoggingMixin):
                 AirflowDagDuplicatedIdException,
                 AirflowClusterPolicyViolation,
                 ParamValidationError,
+                PoolNotFound,
             ) as exception:
                 self.log.exception("Failed to bag_dag: %s", dag.fileloc)
                 self.import_errors[dag.fileloc] = str(exception)

--- a/tests/dags/test_invalid_pool.py
+++ b/tests/dags/test_invalid_pool.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.bash import BashOperator
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+
+dag = DAG(dag_id='test_invalid_pool', start_date=DEFAULT_DATE)
+
+
+task = BashOperator(task_id='test_superuser', bash_command='sleep 1', dag=dag, pool='mypool')

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -43,7 +43,7 @@ dag1 = DAG(dag_id='test_backfill_pooled_task_dag', default_args=default_args)
 dag1_task1 = DummyOperator(
     task_id='test_backfill_pooled_task',
     dag=dag1,
-    pool='test_backfill_pooled_task_pool',
+    pool='default_pool',
 )
 
 # dag2 has been moved to test_prev_dagrun_dep.py

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -783,11 +783,6 @@ class TestBackfillJob:
         """
         Test that queued tasks are executed by BackfillJob
         """
-        session = settings.Session()
-        pool = Pool(pool='test_backfill_pooled_task_pool', slots=1)
-        session.add(pool)
-        session.commit()
-        session.close()
 
         dag = self.dagbag.get_dag('test_backfill_pooled_task_dag')
         dag.clear()

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -283,6 +283,18 @@ class TestDagBag:
         assert len(dagbag.import_errors) == len(invalid_dag_files)
         assert len(dagbag.dags) == 0
 
+    def test_process_file_invalid_pool_name_check(self):
+        """
+        test that non-existing pool name raises import error
+        """
+        non_existing_pool = "test_invalid_pool.py"
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+
+        assert len(dagbag.import_errors) == 0
+        dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, non_existing_pool))
+        assert len(dagbag.import_errors) == 1
+        assert len(dagbag.dags) == 0
+
     @patch.object(DagModel, 'get_current')
     def test_get_dag_without_refresh(self, mock_dagmodel):
         """


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/20788

This PR proposes to raise import error if a task in a DAG is using
a non-existent pool. This will free the scheduler from continuously
trying to schedule a task with a non-existing pool

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
