### PR TITLE
Add 'method' to attributes in HttpSensor

### DIFF
--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -83,6 +83,7 @@ class HttpSensor(BaseSensorOperator):
         super().__init__(**kwargs)
         self.endpoint = endpoint
         self.http_conn_id = http_conn_id
+        self.method = method
         self.request_params = request_params or {}
         self.headers = headers or {}
         self.extra_options = extra_options or {}


### PR DESCRIPTION
To allow subclass of `HttpSensor` access `method`, for example

```python
class HttpSensorAsync(HttpSensor):
    def execute(self, context):
        self.defer(
            trigger=HttpTrigger(
                http_conn_id=self.http_conn_id,
                method=self.method, # AttributeError: 'HttpSensorAsync' object has no attribute 'method'
                endpoint=self.endpoint,
                request_params=self.request_params,
                extra_options=self.extra_options,
            ),
            method_name="execute_complete",
        )

    def execute_complete(self, context, event=None):
        return None
```