### PR TITLE
Fix handling cached parameters for Breeze2

### DIFF
--- a/dev/breeze/src/airflow_breeze/breeze.py
+++ b/dev/breeze/src/airflow_breeze/breeze.py
@@ -158,7 +158,10 @@ def build_ci_image(
     """Builds docker CI image without entering the container."""
 
     if verbose:
-        console.print(f"\n[blue]Building image of airflow from {__AIRFLOW_SOURCES_ROOT}[/]\n")
+        console.print(
+            f"\n[blue]Building image of airflow from {__AIRFLOW_SOURCES_ROOT} "
+            f"python version: {python}[/]\n"
+        )
     build_image(
         verbose,
         additional_extras=additional_extras,

--- a/dev/breeze/src/airflow_breeze/cache.py
+++ b/dev/breeze/src/airflow_breeze/cache.py
@@ -42,10 +42,11 @@ def touch_cache_file(param_name: str):
 
 def write_to_cache_file(param_name: str, param_value: str, check_allowed_values: bool = True) -> None:
     allowed = False
+    allowed_values = None
     if check_allowed_values:
         allowed, allowed_values = check_if_values_allowed(param_name, param_value)
     if allowed or not check_allowed_values:
-        print('BUID CACHE DIR:', BUILD_CACHE_DIR)
+        print('BUILD CACHE DIR:', BUILD_CACHE_DIR)
         Path(BUILD_CACHE_DIR, f".{param_name}").write_text(param_value)
     else:
         console.print(f'[cyan]You have sent the {param_value} for {param_name}')
@@ -58,7 +59,6 @@ def check_cache_and_write_if_not_cached(
     param_name: str, default_param_value: str
 ) -> Tuple[bool, Optional[str]]:
     is_cached = False
-    allowed = False
     cached_value = read_from_cache_file(param_name)
     if cached_value is None:
         write_to_cache_file(param_name, default_param_value)

--- a/dev/breeze/tests/test_build_image.py
+++ b/dev/breeze/tests/test_build_image.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest.mock import patch
+
+import pytest
+
+from airflow_breeze.ci.build_image import get_image_build_params
+
+
+@pytest.mark.parametrize(
+    'parameters, expected_build_params, cached_values, written_cache_version',
+    [
+        ({}, {"python_version": "3.7"}, {}, False),  # default value no params
+        ({"python_version": "3.8"}, {"python_version": "3.8"}, {}, "3.8"),  # default value override params
+        ({}, {"python_version": "3.8"}, {'PYTHON_MAJOR_MINOR_VERSION': "3.8"}, False),  # value from cache
+        (
+            {"python_version": "3.9"},
+            {"python_version": "3.9"},
+            {'PYTHON_MAJOR_MINOR_VERSION': "3.8"},
+            "3.9",
+        ),  # override cache with passed param
+    ],
+)
+def test_get_image_params(parameters, expected_build_params, cached_values, written_cache_version):
+    with patch('airflow_breeze.cache.read_from_cache_file') as read_from_cache_mock, patch(
+        'airflow_breeze.cache.check_if_cache_exists'
+    ) as check_if_cache_exists_mock, patch(
+        'airflow_breeze.ci.build_image.write_to_cache_file'
+    ) as write_to_cache_file_mock, patch(
+        'airflow_breeze.ci.build_image.check_cache_and_write_if_not_cached'
+    ) as check_cache_and_write_mock:
+        check_if_cache_exists_mock.return_value = True
+        check_cache_and_write_mock.side_effect = lambda cache_key, default_value: (
+            cache_key in cached_values,
+            cached_values[cache_key] if cache_key in cached_values else default_value,
+        )
+        read_from_cache_mock.side_effect = lambda param_name: cached_values.get(param_name)
+        build_parameters = get_image_build_params(parameters)
+        for param, param_value in expected_build_params.items():
+            assert getattr(build_parameters, param) == param_value
+        if written_cache_version:
+            write_to_cache_file_mock.assert_called_once_with(
+                "PYTHON_MAJOR_MINOR_VERSION", written_cache_version, check_allowed_values=True
+            )
+        else:
+            write_to_cache_file_mock.assert_not_called()


### PR DESCRIPTION
* if parameter is not passed and not in cache - default is used
* if parameter is passed as --<parameter> it is stored in cache
  and used
* if parameter is not passed and in cache - it is retrieved from
  cache and used.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
