### PR TITLE
add an option for run id in the ui trigger screen

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -333,15 +333,16 @@ class DagRun(Base, LoggingMixin):
         dag_ids = [dag_id] if isinstance(dag_id, str) else dag_id
         if dag_ids:
             qry = qry.filter(cls.dag_id.in_(dag_ids))
-
+        if run_id is not None or execution_date is not None:
+            qry = qry.filter((cls.run_id == run_id) | (cls.execution_date == execution_date))
+        elif execution_date is not None and run_id is None:
+            qry = qry.filter(cls.execution_date == execution_date)
+        elif run_id is not None and execution_date is None:
+            qry = qry.filter(cls.run_id == run_id)
         if is_container(run_id):
             qry = qry.filter(cls.run_id.in_(run_id))
-        elif run_id is not None:
-            qry = qry.filter(cls.run_id == run_id)
         if is_container(execution_date):
             qry = qry.filter(cls.execution_date.in_(execution_date))
-        elif execution_date is not None:
-            qry = qry.filter(cls.execution_date == execution_date)
         if execution_start_date and execution_end_date:
             qry = qry.filter(cls.execution_date.between(execution_start_date, execution_end_date))
         elif execution_start_date:
@@ -356,7 +357,6 @@ class DagRun(Base, LoggingMixin):
             qry = qry.filter(cls.run_type == run_type)
         if no_backfills:
             qry = qry.filter(cls.run_type != DagRunType.BACKFILL_JOB)
-
         return qry.order_by(cls.execution_date).all()
 
     @classmethod

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -333,16 +333,18 @@ class DagRun(Base, LoggingMixin):
         dag_ids = [dag_id] if isinstance(dag_id, str) else dag_id
         if dag_ids:
             qry = qry.filter(cls.dag_id.in_(dag_ids))
-        if run_id is not None or execution_date is not None:
+        if is_container(run_id) and is_container(execution_date):
+            qry = qry.filter((cls.run_id.in_(run_id)) | (cls.execution_date.in_(execution_date)))
+        elif is_container(run_id):
+            qry = qry.filter(cls.run_id.in_(run_id))
+        elif is_container(execution_date):
+            qry = qry.filter(cls.execution_date.in_(execution_date))
+        elif run_id is not None or execution_date is not None:
             qry = qry.filter((cls.run_id == run_id) | (cls.execution_date == execution_date))
         elif execution_date is not None and run_id is None:
             qry = qry.filter(cls.execution_date == execution_date)
         elif run_id is not None and execution_date is None:
             qry = qry.filter(cls.run_id == run_id)
-        if is_container(run_id):
-            qry = qry.filter(cls.run_id.in_(run_id))
-        if is_container(execution_date):
-            qry = qry.filter(cls.execution_date.in_(execution_date))
         if execution_start_date and execution_end_date:
             qry = qry.filter(cls.execution_date.between(execution_start_date, execution_end_date))
         elif execution_start_date:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -333,18 +333,15 @@ class DagRun(Base, LoggingMixin):
         dag_ids = [dag_id] if isinstance(dag_id, str) else dag_id
         if dag_ids:
             qry = qry.filter(cls.dag_id.in_(dag_ids))
-        if is_container(run_id) and is_container(execution_date):
-            qry = qry.filter((cls.run_id.in_(run_id)) | (cls.execution_date.in_(execution_date)))
-        elif is_container(run_id):
+
+        if is_container(run_id):
             qry = qry.filter(cls.run_id.in_(run_id))
-        elif is_container(execution_date):
-            qry = qry.filter(cls.execution_date.in_(execution_date))
-        elif run_id is not None or execution_date is not None:
-            qry = qry.filter((cls.run_id == run_id) | (cls.execution_date == execution_date))
-        elif execution_date is not None and run_id is None:
-            qry = qry.filter(cls.execution_date == execution_date)
-        elif run_id is not None and execution_date is None:
+        elif run_id is not None:
             qry = qry.filter(cls.run_id == run_id)
+        if is_container(execution_date):
+            qry = qry.filter(cls.execution_date.in_(execution_date))
+        elif execution_date is not None:
+            qry = qry.filter(cls.execution_date == execution_date)
         if execution_start_date and execution_end_date:
             qry = qry.filter(cls.execution_date.between(execution_start_date, execution_end_date))
         elif execution_start_date:
@@ -359,6 +356,7 @@ class DagRun(Base, LoggingMixin):
             qry = qry.filter(cls.run_type == run_type)
         if no_backfills:
             qry = qry.filter(cls.run_type != DagRunType.BACKFILL_JOB)
+
         return qry.order_by(cls.execution_date).all()
 
     @classmethod

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -35,15 +35,20 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="hidden" name="dag_id" value="{{ dag_id }}">
     <input type="hidden" name="origin" value="{{ origin }}">
-  <div class="form-group">
+    <div class="form-group">
       <label class="sr-only" for="execution_date">Logical date</label>
       <div class="input-group">
         {{ form.execution_date(class_="form-control", disabled=False) }}
       </div>
     </div>
-
+    <div class="form-group row">
+      <div class="col-md-2">
+        <label for="run_id">Run id (optional)</label>
+        <input type="text" class="form-control" placeholder="Run ID" name="run_id" >
+      </div>
+    </div>
     <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
-      <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>
+    <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>
     </div>
     <p>
       To access configuration in your DAG use <code>{{ '{{ dag_run.conf }}' }}</code>.

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -43,7 +43,7 @@
     </div>
     <div class="form-group row">
       <div class="col-md-2">
-        <label for="run_id">Run id (optional)</label>
+        <label for="run_id">Run id (Optional)</label>
         <input type="text" class="form-control" placeholder="Run ID" name="run_id" >
       </div>
     </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1841,10 +1841,7 @@ class Airflow(AirflowBaseView):
             )
         # if run_id is not None, filter dag runs based on run id and ignore execution date
         dr = DagRun.find(
-            dag_id=dag_id,
-            run_type=DagRunType.MANUAL,
-            run_id=run_id,
-            execution_date=execution_date if run_id is None else None,
+            dag_id=dag_id, run_type=DagRunType.MANUAL, run_id=run_id, execution_date=execution_date
         )
         if dr:
             flash(f"The run_id {run_id} already exists", "error")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1735,7 +1735,7 @@ class Airflow(AirflowBaseView):
             ignore_ti_state=ignore_ti_state,
         )
         executor.heartbeat()
-        flash(f"Sent {ti} to the message queue, run id: {dag_run_id} it should start any moment now.")
+        flash(f"Sent {ti} to the message queue, it should start any moment now.")
         return redirect(origin)
 
     @expose('/delete', methods=['POST'])

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1842,7 +1842,7 @@ class Airflow(AirflowBaseView):
         # if run_id is not None, filter dag runs based on run id and ignore execution date
         dr = DagRun.find_duplicate(dag_id=dag_id, run_id=run_id, execution_date=execution_date)
         if dr:
-            flash(f"The run_id {run_id} already exists", "error")
+            flash(f"The run_id {dr.run_id} already exists", "error")
             return redirect(origin)
 
         run_conf = {}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1903,7 +1903,7 @@ class Airflow(AirflowBaseView):
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
             )
 
-        flash(f"Triggered {dag_id},TALLL it should start any moment now.")
+        flash(f"Triggered {dag_id}, it should start any moment now.")
         return redirect(origin)
 
     def _clear_dag_tis(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1840,9 +1840,7 @@ class Airflow(AirflowBaseView):
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
             )
         # if run_id is not None, filter dag runs based on run id and ignore execution date
-        dr = DagRun.find(
-            dag_id=dag_id, run_type=DagRunType.MANUAL, run_id=run_id, execution_date=execution_date
-        )
+        dr = DagRun.find_duplicate(dag_id=dag_id, run_id=run_id, execution_date=execution_date)
         if dr:
             flash(f"The run_id {run_id} already exists", "error")
             return redirect(origin)

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -214,3 +214,16 @@ def test_viewer_cant_trigger_dag(app):
         resp = client.get(url, follow_redirects=True)
         response_data = resp.data.decode()
         assert "Access is Denied" in response_data
+
+
+def test_trigger_dag_run_id(admin_client):
+    test_dag_id = "example_bash_operator"
+    test_run_id = "test_id"
+
+    admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={test_run_id}')
+
+    with create_session() as session:
+        run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
+    assert run is not None
+    assert run.run_type == DagRunType.MANUAL
+    assert run.run_id == test_run_id

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -44,15 +44,18 @@ def test_trigger_dag_button_normal_exist(admin_client):
     assert "return confirmDeleteDag(this, 'example_bash_operator')" in resp.data.decode('utf-8')
 
 
-@pytest.mark.quarantined
-def test_trigger_dag_button(admin_client):
-    test_dag_id = "example_bash_operator"
-    admin_client.post(f'trigger?dag_id={test_dag_id}')
+# test trigger button with and without run_id
+@pytest.mark.parametrize(
+    "req , expected_run_id", [('', DagRunType.MANUAL), ('&run_id=test_run_id', 'test_run_id')]
+)
+def test_trigger_dag_button(admin_client, req, expected_run_id):
+    test_dag_id = 'example_bash_operator'
+    admin_client.post(f'trigger?dag_id={test_dag_id}{req}')
     with create_session() as session:
         run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
     assert run is not None
-    assert DagRunType.MANUAL in run.run_id
     assert run.run_type == DagRunType.MANUAL
+    assert expected_run_id in run.run_id
 
 
 def test_trigger_dag_conf(admin_client):
@@ -216,9 +219,9 @@ def test_viewer_cant_trigger_dag(app):
         assert "Access is Denied" in response_data
 
 
-def test_trigger_dag_run_id(admin_client):
+@pytest.mark.parametrize("test_run_id , expected_run_id", [('test_id', 'test_id'), (None, DagRunType.MANUAL)])
+def test_trigger_dag_run_id(admin_client, test_run_id, expected_run_id):
     test_dag_id = "example_bash_operator"
-    test_run_id = "test_id"
 
     admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={test_run_id}')
 
@@ -226,4 +229,4 @@ def test_trigger_dag_run_id(admin_client):
         run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
     assert run is not None
     assert run.run_type == DagRunType.MANUAL
-    assert run.run_id == test_run_id
+    assert expected_run_id in run.run_id

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -58,6 +58,14 @@ def test_trigger_dag_button(admin_client, req, expected_run_id):
     assert expected_run_id in run.run_id
 
 
+def test_duplicate_run_id(admin_client):
+    test_dag_id = 'example_bash_operator'
+    run_id = 'test_run'
+    admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={run_id}', follow_redirects=True)
+    response = admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={run_id}', follow_redirects=True)
+    check_content_in_response(f'The run_id {run_id} already exists', response)
+
+
 def test_trigger_dag_conf(admin_client):
     test_dag_id = "example_bash_operator"
     conf_dict = {'string': 'Hello, World!'}

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -217,16 +217,3 @@ def test_viewer_cant_trigger_dag(app):
         resp = client.get(url, follow_redirects=True)
         response_data = resp.data.decode()
         assert "Access is Denied" in response_data
-
-
-@pytest.mark.parametrize("test_run_id , expected_run_id", [('test_id', 'test_id'), (None, DagRunType.MANUAL)])
-def test_trigger_dag_run_id(admin_client, test_run_id, expected_run_id):
-    test_dag_id = "example_bash_operator"
-
-    admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={test_run_id}')
-
-    with create_session() as session:
-        run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
-    assert run is not None
-    assert run.run_type == DagRunType.MANUAL
-    assert expected_run_id in run.run_id


### PR DESCRIPTION
Added an option for custom run_id in the trigger dag screen.
this option was already supported in the API.
This commit includes:

-  changes to the static template of the trigger screen
- extraction of the run_id in the views.py
- changes to models/dagrun.py - filter dag runs by run_id if exists or execution date 
- unittest for: triggering dagrun with and without run_id, handling duplicate run_id 

closes: #21336 

Before:
![image](https://user-images.githubusercontent.com/7373236/156122454-aafbfa4b-1c3e-4321-857d-0dcacc826669.png)

After:
![image](https://user-images.githubusercontent.com/7373236/156122338-717bbf97-0acb-46b9-b635-a68f09dccc63.png)
