### PR TITLE
Allow templates in more DataprocUpdateClusterOperator fields

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1913,7 +1913,14 @@ class DataprocUpdateClusterOperator(BaseOperator):
         account from the list granting this role to the originating account (templated).
     """
 
-    template_fields: Sequence[str] = ('impersonation_chain', 'cluster_name')
+    template_fields: Sequence[str] = (
+        'cluster_name',
+        'cluster',
+        'region',
+        'request_id',
+        'project_id',
+        'impersonation_chain',
+    )
     operator_extra_links = (DataprocLink(),)
 
     def __init__(


### PR DESCRIPTION
Add more fields in `DataprocUpdateClusterOperator` to template fields:

* `cluster`
* `region`
* `request_id`
* `project_id`

It makes its behavior more consistent with other operators.