### PR TITLE
rich_click 1.1.0 has a bug

### DIFF
--- a/dev/breeze/setup.cfg
+++ b/dev/breeze/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     pytest
     pytest-xdist
     rich
-    rich_click
+    rich_click!=1.1.0
     click_completion
     requests
 


### PR DESCRIPTION
There appears to be an errant/unused import of `turtle` which needs tkinter which in turn needs libtk, which is not installed on our runners (and likely not in windows either)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).