### PR TITLE
Add map_index to pods launched by KubernetesExecutor

### DIFF
--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -63,6 +63,7 @@ def annotations_to_key(annotations: Dict[str, str]) -> Optional[TaskInstanceKey]
     task_id = annotations['task_id']
     try_number = int(annotations['try_number'])
     annotation_run_id = annotations.get('run_id')
+    map_index = int(annotations.get('map_index', -1))
 
     if not annotation_run_id and 'execution_date' in annotations:
         # Compat: Look up the run_id from the TI table!
@@ -87,4 +88,10 @@ def annotations_to_key(annotations: Dict[str, str]) -> Optional[TaskInstanceKey]
     else:
         task_instance_run_id = annotation_run_id
 
-    return TaskInstanceKey(dag_id, task_id, task_instance_run_id, try_number)
+    return TaskInstanceKey(
+        dag_id=dag_id,
+        task_id=task_id,
+        run_id=task_instance_run_id,
+        try_number=try_number,
+        map_index=map_index,
+    )

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -328,6 +328,7 @@ class PodGenerator:
         namespace: str,
         scheduler_job_id: str,
         run_id: Optional[str] = None,
+        map_index: int = -1,
     ) -> k8s.V1Pod:
         """
         Construct a pod by gathering and consolidating the configuration from 3 places:
@@ -355,6 +356,9 @@ class PodGenerator:
             'airflow_version': airflow_version.replace('+', '-'),
             'kubernetes_executor': 'True',
         }
+        if map_index >= 0:
+            annotations['map_index'] = str(map_index)
+            labels['map_index'] = str(map_index)
         if date:
             annotations['execution_date'] = date.isoformat()
             labels['execution_date'] = datetime_to_label_safe_datestring(date)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2077,11 +2077,13 @@ class TaskInstance(Base, LoggingMixin):
         kube_config = KubeConfig()
         pod = PodGenerator.construct_pod(
             dag_id=self.dag_id,
+            run_id=self.run_id,
             task_id=self.task_id,
+            map_index=self.map_index,
+            date=None,
             pod_id=create_pod_id(self.dag_id, self.task_id),
             try_number=self.try_number,
             kube_image=kube_config.kube_image,
-            date=self.execution_date,
             args=self.command_as_list(),
             pod_override_object=PodGenerator.from_obj(self.executor_config),
             scheduler_job_id="0",

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2004,7 +2004,7 @@ class TestTaskInstance:
             'metadata': {
                 'annotations': {
                     'dag_id': 'test_render_k8s_pod_yaml',
-                    'execution_date': '2016-01-01T00:00:00+00:00',
+                    'run_id': 'test_run_id',
                     'task_id': 'op1',
                     'try_number': '1',
                 },
@@ -2012,7 +2012,7 @@ class TestTaskInstance:
                     'airflow-worker': '0',
                     'airflow_version': version,
                     'dag_id': 'test_render_k8s_pod_yaml',
-                    'execution_date': '2016-01-01T00_00_00_plus_00_00',
+                    'run_id': 'test_run_id',
                     'kubernetes_executor': 'True',
                     'task_id': 'op1',
                     'try_number': '1',


### PR DESCRIPTION
I also did a slight drive-by-refactor (sorry!) to rename `queued_tasks and `task` inside `clear_not_launched_queued_tasks` to `queued_tis` and `ti` to reflect what they are.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).