### PR TITLE
Minor cleanup on Celery config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1588,15 +1588,15 @@
         https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
       version_added: 2.0.0
       type: integer
-      example: "1"
-      default: ~
+      example: ~
+      default: "1"
     - name: worker_enable_remote_control
       description: |
         Specify if remote control of the workers is enabled.
-        When using SQS as the broker, Celery creates lots of .*reply-celery-pidbox queues. You can turn off
-        this by setting this value as false. However, if the value is false, the flower won't work.
+        When using Amazon SQS as the broker, Celery creates lots of ``.*reply-celery-pidbox`` queues. You can
+        prevent this by setting this to false. However, with this disabled Flower won't work.
       version_added: 2.3.0
-      type: string
+      type: boolean
       example: ~
       default: "true"
     - name: worker_umask

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -799,12 +799,11 @@ worker_concurrency = 16
 # running tasks while another worker has unutilized processes that are unable to process the already
 # claimed blocked tasks.
 # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
-# Example: worker_prefetch_multiplier = 1
-# worker_prefetch_multiplier =
+worker_prefetch_multiplier = 1
 
 # Specify if remote control of the workers is enabled.
-# When using SQS as the broker, Celery creates lots of .*reply-celery-pidbox queues. You can turn off
-# this by setting this value as false. However, if the value is false, the flower won't work.
+# When using Amazon SQS as the broker, Celery creates lots of ``.*reply-celery-pidbox`` queues. You can
+# prevent this by setting this to false. However, with this disabled Flower won't work.
 worker_enable_remote_control = true
 
 # Umask that will be used when starting workers with the ``airflow celery worker``

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -39,16 +39,16 @@ if 'visibility_timeout' not in broker_transport_options:
 DEFAULT_CELERY_CONFIG = {
     'accept_content': ['json'],
     'event_serializer': 'json',
-    'worker_prefetch_multiplier': conf.getint('celery', 'worker_prefetch_multiplier', fallback=1),
+    'worker_prefetch_multiplier': conf.getint('celery', 'worker_prefetch_multiplier'),
     'task_acks_late': True,
     'task_default_queue': conf.get('operators', 'DEFAULT_QUEUE'),
     'task_default_exchange': conf.get('operators', 'DEFAULT_QUEUE'),
-    'task_track_started': conf.get('celery', 'task_track_started', fallback=True),
+    'task_track_started': conf.getboolean('celery', 'task_track_started'),
     'broker_url': broker_url,
     'broker_transport_options': broker_transport_options,
     'result_backend': conf.get('celery', 'RESULT_BACKEND'),
     'worker_concurrency': conf.getint('celery', 'WORKER_CONCURRENCY'),
-    'worker_enable_remote_control': conf.get('celery', 'worker_enable_remote_control'),
+    'worker_enable_remote_control': conf.getboolean('celery', 'worker_enable_remote_control'),
 }
 
 celery_ssl_active = False


### PR DESCRIPTION
This rewords the description and changes the type of
``worker_enable_remote_control`` and sets a default for
``worker_prefetch_multiplier`` instead of relying on fallback.