### PR TITLE
Fix Kubernetes example with wrong operator casing

### DIFF
--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -70,7 +70,7 @@ affinity = k8s.V1Affinity(
                 weight=1,
                 preference=k8s.V1NodeSelectorTerm(
                     match_expressions=[
-                        k8s.V1NodeSelectorRequirement(key="disktype", operator="in", values=["ssd"])
+                        k8s.V1NodeSelectorRequirement(key="disktype", operator="In", values=["ssd"])
                     ]
                 ),
             )


### PR DESCRIPTION
The Kubernetes exampe of ours had bad casing in "In" operator
("in" and recent kubernetes client library started to fail importing
the example).

This PR fixes case for the operator.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
