### PR TITLE
Limit yandexcloud to < 0.142

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -551,9 +551,9 @@ winrm = [
     'pywinrm>=0.4',
 ]
 yandex = [
-    # Yandexcloud 0.145 broke logging of the yandexcloud provider. The limitation can be removed once
+    # Yandexcloud 0.142 broke logging of the yandexcloud provider. The limitation can be removed once
     # https://github.com/yandex-cloud/python-sdk/issues/47 is fixed.
-    'yandexcloud>=0.122.0, <0.145.0',
+    'yandexcloud>=0.122.0, <0.142.0',
 ]
 zendesk = [
     'zenpy>=2.0.24',


### PR DESCRIPTION
It turned out the yandexcloud bugfix attempt from #21899 was not
successful. The bug was present already in 0.142

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
