### PR TITLE
Pause auto-refresh when page is hidden

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -92,6 +92,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
+    "react-query": "^3.34.16",
     "redoc": "^2.0.0-rc.63",
     "url-search-params-polyfill": "^8.1.0"
   },

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -393,9 +393,7 @@ const handleVisibilityChange = () => {
   if (document.hidden) {
     clearInterval(refreshInterval);
   } else {
-    refreshInterval = setInterval(() => {
-      handleRefresh();
-    }, autoRefreshInterval * 1000);
+    initRefresh();
   }
 };
 

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -24,7 +24,7 @@
   autoRefreshInterval, moment, convertSecsToHumanReadable
 */
 
-import { getMetaValue, finalStatesMap } from './utils';
+import { getMetaValue, finalStatesMap, getVisibilityVars } from './utils';
 import { escapeHtml } from './main';
 import tiTooltip, { taskNoInstanceTooltip } from './task_instances';
 import { callModal } from './dag';
@@ -376,6 +376,34 @@ function setFocusMap(state) {
 
 const stateIsSet = () => !!Object.keys(stateFocusMap).find((key) => stateFocusMap[key]);
 
+let refreshInterval;
+
+function startOrStopRefresh() {
+  if ($('#auto_refresh').is(':checked')) {
+    refreshInterval = setInterval(() => {
+      handleRefresh();
+    }, autoRefreshInterval * 1000);
+  } else {
+    clearInterval(refreshInterval);
+  }
+}
+
+const { hidden, visibilityChange } = getVisibilityVars();
+// pause autorefresh when the page is not active
+const handleVisibilityChange = () => {
+  if (document[hidden]) {
+    clearInterval(refreshInterval);
+  } else {
+    refreshInterval = setInterval(() => {
+      handleRefresh();
+    }, autoRefreshInterval * 1000);
+  }
+};
+
+if (hidden) {
+  document.addEventListener(visibilityChange, handleVisibilityChange);
+}
+
 let prevTis;
 
 function handleRefresh() {
@@ -411,18 +439,6 @@ function handleRefresh() {
       $('#chart_section').hide(1000);
       $('#datatable_section').hide(1000);
     });
-}
-
-let refreshInterval;
-
-function startOrStopRefresh() {
-  if ($('#auto_refresh').is(':checked')) {
-    refreshInterval = setInterval(() => {
-      handleRefresh();
-    }, autoRefreshInterval * 1000);
-  } else {
-    clearInterval(refreshInterval);
-  }
 }
 
 $('#auto_refresh').change(() => {

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -24,7 +24,7 @@
   autoRefreshInterval, moment, convertSecsToHumanReadable
 */
 
-import { getMetaValue, finalStatesMap, getVisibilityVars } from './utils';
+import { getMetaValue, finalStatesMap } from './utils';
 import { escapeHtml } from './main';
 import tiTooltip, { taskNoInstanceTooltip } from './task_instances';
 import { callModal } from './dag';
@@ -388,10 +388,9 @@ function startOrStopRefresh() {
   }
 }
 
-const { hidden, visibilityChange } = getVisibilityVars();
 // pause autorefresh when the page is not active
 const handleVisibilityChange = () => {
-  if (document[hidden]) {
+  if (document.hidden) {
     clearInterval(refreshInterval);
   } else {
     refreshInterval = setInterval(() => {
@@ -400,9 +399,7 @@ const handleVisibilityChange = () => {
   }
 };
 
-if (hidden) {
-  document.addEventListener(visibilityChange, handleVisibilityChange);
-}
+document.addEventListener('visibilitychange', handleVisibilityChange);
 
 let prevTis;
 

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -37,7 +37,8 @@ import DagRuns from './dagRuns';
 const Tree = () => {
   const containerRef = useRef();
   const scrollRef = useRef();
-  const { data: { groups = {} }, isRefreshOn, onToggleRefresh } = useTreeData();
+  const { data: { groups = {}, dagRuns = [] }, isRefreshOn, onToggleRefresh } = useTreeData();
+  const dagRunIds = dagRuns.map((dr) => dr.runId);
 
   useEffect(() => {
     // Set initial scroll to far right if it is scrollable
@@ -65,7 +66,7 @@ const Tree = () => {
               <DagRuns containerRef={containerRef} />
             </Thead>
             <Tbody>
-              {renderTaskRows({ task: groups, containerRef })}
+              {renderTaskRows({ task: groups, containerRef, dagRunIds })}
             </Tbody>
           </Table>
         </Box>

--- a/airflow/www/static/js/tree/dagRuns/index.test.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.test.jsx
@@ -23,12 +23,30 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { ChakraProvider, Table, Tbody } from '@chakra-ui/react';
 import moment from 'moment';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import DagRuns from './index';
 
 // Mock modal open function we take from dag.js
 jest.mock('../../dag', () => ({ callModalDag: () => {} }));
 global.moment = moment;
+
+const Wrapper = ({ children }) => {
+  const queryClient = new QueryClient();
+  return (
+    <React.StrictMode>
+      <ChakraProvider>
+        <QueryClientProvider client={queryClient}>
+          <Table>
+            <Tbody>
+              {children}
+            </Tbody>
+          </Table>
+        </QueryClientProvider>
+      </ChakraProvider>
+    </React.StrictMode>
+  );
+};
 
 describe('Test DagRuns', () => {
   const dagRuns = [
@@ -62,15 +80,7 @@ describe('Test DagRuns', () => {
       dagRuns,
     });
     const { queryAllByTestId, getByText, queryByText } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              <DagRuns containerRef={mockRef} />
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <DagRuns containerRef={mockRef} />, { wrapper: Wrapper },
     );
     expect(queryAllByTestId('run')).toHaveLength(2);
     expect(queryAllByTestId('manual-run')).toHaveLength(1);
@@ -108,15 +118,7 @@ describe('Test DagRuns', () => {
       ],
     });
     const { getByText } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              <DagRuns containerRef={mockRef} />
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <DagRuns containerRef={mockRef} />, { wrapper: Wrapper },
     );
     expect(getByText(moment.utc(dagRuns[0].executionDate).format('MMM DD, HH:mm'))).toBeInTheDocument();
   });
@@ -127,15 +129,7 @@ describe('Test DagRuns', () => {
       dagRuns: [],
     };
     const { queryByTestId } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              <DagRuns containerRef={mockRef} />
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <DagRuns containerRef={mockRef} />, { wrapper: Wrapper },
     );
     expect(queryByTestId('run')).toBeNull();
   });
@@ -143,15 +137,7 @@ describe('Test DagRuns', () => {
   test('Handles no data correctly', () => {
     global.treeData = {};
     const { queryByTestId } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              <DagRuns containerRef={mockRef} />
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <DagRuns containerRef={mockRef} />, { wrapper: Wrapper },
     );
     expect(queryByTestId('run')).toBeNull();
   });

--- a/airflow/www/static/js/tree/index.jsx
+++ b/airflow/www/static/js/tree/index.jsx
@@ -24,6 +24,7 @@ import ReactDOM from 'react-dom';
 import { ChakraProvider } from '@chakra-ui/react';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import Tree from './Tree';
 
 // create shadowRoot
@@ -35,13 +36,16 @@ const myCache = createCache({
 });
 const mainElement = document.getElementById('react-container');
 shadowRoot.appendChild(mainElement);
+const queryClient = new QueryClient();
 
 function App() {
   return (
     <React.StrictMode>
       <CacheProvider value={myCache}>
         <ChakraProvider>
-          <Tree />
+          <QueryClientProvider client={queryClient}>
+            <Tree />
+          </QueryClientProvider>
         </ChakraProvider>
       </CacheProvider>
     </React.StrictMode>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -31,7 +31,6 @@ import {
 } from '@chakra-ui/react';
 import { FiChevronUp, FiChevronDown } from 'react-icons/fi';
 
-import useTreeData from './useTreeData';
 import StatusBox from './StatusBox';
 
 import { getMetaValue } from '../utils';
@@ -40,7 +39,7 @@ import { getMetaValue } from '../utils';
 const dagId = getMetaValue('dag_id');
 
 const renderTaskRows = ({
-  task, containerRef, level = 0, isParentOpen,
+  task, containerRef, level = 0, isParentOpen, dagRunIds,
 }) => task.children.map((t) => (
   <Row
     key={t.id}
@@ -49,6 +48,7 @@ const renderTaskRows = ({
     containerRef={containerRef}
     prevTaskId={task.id}
     isParentOpen={isParentOpen}
+    dagRunIds={dagRunIds}
   />
 ));
 
@@ -85,30 +85,30 @@ const TaskName = ({
   </Box>
 );
 
-const TaskInstances = ({ task, containerRef, dagRuns }) => (
+const TaskInstances = ({ task, containerRef, dagRunIds }) => (
   <Flex justifyContent="flex-end">
-    {dagRuns.map((run) => {
+    {dagRunIds.map((runId) => {
       // Check if an instance exists for the run, or return an empty box
-      const instance = task.instances.find((gi) => gi.runId === run.runId);
+      const instance = task.instances.find((gi) => gi.runId === runId);
       return instance
         ? (
           <StatusBox
-            key={`${run.runId}-${task.id}`}
+            key={`${runId}-${task.id}`}
             instance={instance}
             containerRef={containerRef}
             extraLinks={task.extraLinks}
             group={task}
           />
         )
-        : <Box key={`${run.runId}-${task.id}`} width="18px" data-testid="blank-task" />;
+        : <Box key={`${runId}-${task.id}`} width="18px" data-testid="blank-task" />;
     })}
   </Flex>
 );
 
-const Row = ({
-  task, containerRef, level, prevTaskId, isParentOpen = true,
-}) => {
-  const { data: { dagRuns = [] } } = useTreeData();
+const Row = (props) => {
+  const {
+    task, containerRef, level, prevTaskId, isParentOpen = true, dagRunIds,
+  } = props;
   const isGroup = !!task.children;
 
   const taskName = prevTaskId ? task.id.replace(`${prevTaskId}.`, '') : task.id;
@@ -162,13 +162,13 @@ const Row = ({
         <Td width={0} p={0} borderBottom={0} />
         <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0}>
           <Collapse in={isFullyOpen}>
-            <TaskInstances dagRuns={dagRuns} task={task} containerRef={containerRef} />
+            <TaskInstances dagRunIds={dagRunIds} task={task} containerRef={containerRef} />
           </Collapse>
         </Td>
       </Tr>
       {isGroup && (
         renderTaskRows({
-          task, containerRef, level: level + 1, isParentOpen: isOpen,
+          ...props, level: level + 1, isParentOpen: isOpen,
         })
       )}
     </>

--- a/airflow/www/static/js/tree/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.test.jsx
@@ -23,6 +23,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { ChakraProvider, Table, Tbody } from '@chakra-ui/react';
 import moment from 'moment';
+import { QueryClient, QueryClientProvider } from 'react-query';
 
 import renderTaskRows from './renderTaskRows';
 
@@ -96,6 +97,23 @@ const mockTreeData = {
   ],
 };
 
+const Wrapper = ({ children }) => {
+  const queryClient = new QueryClient();
+  return (
+    <React.StrictMode>
+      <ChakraProvider>
+        <QueryClientProvider client={queryClient}>
+          <Table>
+            <Tbody>
+              {children}
+            </Tbody>
+          </Table>
+        </QueryClientProvider>
+      </ChakraProvider>
+    </React.StrictMode>
+  );
+};
+
 describe('Test renderTaskRows', () => {
   test('Group defaults to closed but clicking on the name will open a group', () => {
     global.treeData = mockTreeData;
@@ -103,15 +121,8 @@ describe('Test renderTaskRows', () => {
     const dagRunIds = mockTreeData.dagRuns.map((dr) => dr.runId);
 
     const { getByTestId, getByText, getAllByTestId } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              {renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds })}
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <>{renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds })}</>,
+      { wrapper: Wrapper },
     );
 
     const groupName = getByText('group_1');
@@ -153,15 +164,10 @@ describe('Test renderTaskRows', () => {
     const containerRef = {};
 
     const { queryByTestId, getByText } = render(
-      <React.StrictMode>
-        <ChakraProvider>
-          <Table>
-            <Tbody>
-              {renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds: [] })}
-            </Tbody>
-          </Table>
-        </ChakraProvider>
-      </React.StrictMode>,
+      <>
+        {renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds: [] })}
+      </>,
+      { wrapper: Wrapper },
     );
 
     expect(getByText('group_1')).toBeInTheDocument();

--- a/airflow/www/static/js/tree/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.test.jsx
@@ -100,13 +100,14 @@ describe('Test renderTaskRows', () => {
   test('Group defaults to closed but clicking on the name will open a group', () => {
     global.treeData = mockTreeData;
     const containerRef = {};
+    const dagRunIds = mockTreeData.dagRuns.map((dr) => dr.runId);
 
     const { getByTestId, getByText, getAllByTestId } = render(
       <React.StrictMode>
         <ChakraProvider>
           <Table>
             <Tbody>
-              {renderTaskRows({ task: mockTreeData.groups, containerRef })}
+              {renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds })}
             </Tbody>
           </Table>
         </ChakraProvider>
@@ -156,7 +157,7 @@ describe('Test renderTaskRows', () => {
         <ChakraProvider>
           <Table>
             <Tbody>
-              {renderTaskRows({ task: mockTreeData.groups, containerRef })}
+              {renderTaskRows({ task: mockTreeData.groups, containerRef, dagRunIds: [] })}
             </Tbody>
           </Table>
         </ChakraProvider>

--- a/airflow/www/static/js/tree/useTreeData.js
+++ b/airflow/www/static/js/tree/useTreeData.js
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-/* global treeData, localStorage, fetch, autoRefreshInterval, document */
+/* global treeData, localStorage, autoRefreshInterval, fetch */
 
-import { useState, useEffect, useCallback } from 'react';
 import { useDisclosure } from '@chakra-ui/react';
 import camelcaseKeys from 'camelcase-keys';
+import { useQuery } from 'react-query';
 
-import { getMetaValue, getVisibilityVars } from '../utils';
+import { getMetaValue } from '../utils';
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
@@ -32,6 +32,8 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const isPaused = getMetaValue('is_paused');
 const baseDate = getMetaValue('base_date');
+
+const autoRefreshKey = 'disabledAutoRefresh';
 
 const areActiveRuns = (runs) => runs.filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
 
@@ -45,75 +47,55 @@ const formatData = (data) => {
   let formattedData = data;
   // Convert to json if needed
   if (typeof data === 'string') formattedData = JSON.parse(data);
-  // change from pacal to camelcase
+  // change from pascal to camelcase
   formattedData = camelcaseKeys(formattedData, { deep: true });
   return formattedData;
 };
 
 const useTreeData = () => {
-  const [data, setData] = useState(formatData(treeData));
-  const defaultIsOpen = isPaused !== 'True' && !JSON.parse(localStorage.getItem('disableAutoRefresh')) && areActiveRuns(data.dagRuns);
+  const initialData = formatData(treeData);
+
+  const defaultIsOpen = isPaused !== 'True' && !JSON.parse(localStorage.getItem(autoRefreshKey)) && areActiveRuns(initialData.dagRuns);
   const { isOpen: isRefreshOn, onToggle, onClose } = useDisclosure({ defaultIsOpen });
 
-  const handleRefresh = useCallback(async () => {
+  const onToggleRefresh = () => {
+    if (isRefreshOn) {
+      localStorage.setItem(autoRefreshKey, 'true');
+    } else {
+      localStorage.removeItem(autoRefreshKey);
+    }
+    onToggle();
+  };
+
+  const query = useQuery('treeData', async () => {
     try {
       const root = urlRoot ? `&root=${urlRoot}` : '';
       const base = baseDate ? `&base_date=${baseDate}` : '';
       const resp = await fetch(`${treeDataUrl}?dag_id=${dagId}&num_runs=${numRuns}${root}${base}`);
-      let newData = await resp.json();
-      if (newData) {
+      if (resp) {
+        let newData = await resp.json();
         newData = formatData(newData);
-        if (JSON.stringify(newData) !== JSON.stringify(data)) {
-          setData(newData);
-        }
         // turn off auto refresh if there are no active runs
         if (!areActiveRuns(newData.dagRuns)) onClose();
+        return newData;
       }
     } catch (e) {
       onClose();
       console.error(e);
     }
-  }, [data, onClose]);
-
-  const onToggleRefresh = () => {
-    if (isRefreshOn) {
-      localStorage.setItem('disableAutoRefresh', 'true');
-    } else {
-      localStorage.removeItem('disableAutoRefresh');
-    }
-    onToggle();
-  };
-
-  useEffect(() => {
-    let refreshInterval;
-    const { hidden, visibilityChange } = getVisibilityVars();
-
-    // pause autorefresh when the page is not active
-    const handleVisibilityChange = () => {
-      if (document[hidden]) {
-        clearInterval(refreshInterval);
-      } else {
-        refreshInterval = setInterval(handleRefresh, autoRefreshInterval * 1000);
-      }
+    return {
+      groups: {},
+      dagRuns: [],
     };
-
-    if (isRefreshOn) {
-      refreshInterval = setInterval(handleRefresh, autoRefreshInterval * 1000);
-      if (hidden) {
-        document.addEventListener(visibilityChange, handleVisibilityChange);
-      }
-    } else {
-      clearInterval(refreshInterval);
-    }
-
-    return () => {
-      clearInterval(refreshInterval);
-      document.removeEventListener(visibilityChange, handleVisibilityChange);
-    };
-  }, [isRefreshOn, handleRefresh]);
+  }, {
+    // only enabled and refetch if the refresh switch is on
+    enabled: isRefreshOn,
+    refetchInterval: isRefreshOn && autoRefreshInterval * 1000,
+    initialData,
+  });
 
   return {
-    data,
+    ...query,
     isRefreshOn,
     onToggleRefresh,
   };

--- a/airflow/www/static/js/utils.js
+++ b/airflow/www/static/js/utils.js
@@ -41,3 +41,23 @@ export const finalStatesMap = () => new Map([
   ['skipped', 0],
   ['no_status', 0],
 ]);
+
+// Get hidden and visibility strings depending on browser
+export const getVisibilityVars = () => {
+  let hidden;
+  let visibilityChange;
+  if (typeof document.hidden !== 'undefined') { // Opera 12.10 and Firefox 18 and later support
+    hidden = 'hidden';
+    visibilityChange = 'visibilitychange';
+  } else if (typeof document.msHidden !== 'undefined') {
+    hidden = 'msHidden';
+    visibilityChange = 'msvisibilitychange';
+  } else if (typeof document.webkitHidden !== 'undefined') {
+    hidden = 'webkitHidden';
+    visibilityChange = 'webkitvisibilitychange';
+  }
+  return {
+    hidden,
+    visibilityChange,
+  };
+};

--- a/airflow/www/static/js/utils.js
+++ b/airflow/www/static/js/utils.js
@@ -41,23 +41,3 @@ export const finalStatesMap = () => new Map([
   ['skipped', 0],
   ['no_status', 0],
 ]);
-
-// Get hidden and visibility strings depending on browser
-export const getVisibilityVars = () => {
-  let hidden;
-  let visibilityChange;
-  if (typeof document.hidden !== 'undefined') { // Opera 12.10 and Firefox 18 and later support
-    hidden = 'hidden';
-    visibilityChange = 'visibilitychange';
-  } else if (typeof document.msHidden !== 'undefined') {
-    hidden = 'msHidden';
-    visibilityChange = 'msvisibilitychange';
-  } else if (typeof document.webkitHidden !== 'undefined') {
-    hidden = 'webkitHidden';
-    visibilityChange = 'webkitvisibilitychange';
-  }
-  return {
-    hidden,
-    visibilityChange,
-  };
-};

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -1263,7 +1263,7 @@
     core-js-pure "^3.16.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -3594,6 +3594,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -3681,6 +3686,20 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
@@ -3912,9 +3931,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001237"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz#4b7783661515b8e7151fc6376cfd97f0e427b9e5"
-  integrity sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw==
+  version "1.0.30001312"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
+  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -5081,6 +5100,11 @@ detect-node-es@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
   integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 diff-sequences@^27.0.6:
   version "27.0.6"
@@ -7621,6 +7645,11 @@ js-levenshtein@^1.1.6:
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8072,6 +8101,14 @@ marked@^4.0.10:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
   integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz#4ddadd67308e780cf16a47685878ee27b736a0a3"
@@ -8197,6 +8234,11 @@ micromatch@^4.0.2, micromatch@^4.0.4:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.2.3"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -8421,6 +8463,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.23:
   version "3.1.23"
@@ -8755,6 +8804,11 @@ object.values@^1.1.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.18.2"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -9735,6 +9789,15 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-query@^3.34.16:
+  version "3.34.16"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.34.16.tgz#279ea180bcaeaec49c7864b29d1711ee9f152594"
+  integrity sha512-7FvBvjgEM4YQ8nPfmAr+lJfbW95uyW/TVjFoi2GwCkF33/S8ajx45tuPHPFGWs4qYwPy1mzwxD4IQfpUDrefNQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-remove-scroll-bar@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.2.0.tgz#d4d545a7df024f75d67e151499a6ab5ac97c8cdd"
@@ -10007,6 +10070,11 @@ remark@^13.0.0:
     remark-stringify "^9.0.0"
     unified "^9.1.0"
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -10127,17 +10195,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -11364,6 +11432,14 @@ universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds an event listener for the grid and graph views to pause auto-refresh when the tab or browser is no longer active. When the page is refocused, auto-refresh will turn on if there are still pending tasks.

In our react grid view, we are using `react-query` as it comes with this and caching out-of-the-box. And will be more useful as we do more API calls in that view.

Also, I decided to pass the dagRun data to each table row via props instead of hooks cause it was causing extraneous rerenders.

Closes: #21302

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
