### PR TITLE
Fix handling some None parameters in kubernetes 23 libs

### DIFF
--- a/airflow/kubernetes/pod_generator_deprecated.py
+++ b/airflow/kubernetes/pod_generator_deprecated.py
@@ -178,7 +178,8 @@ class PodGenerator:
 
         self.container.command = cmds or []
         self.container.args = args or []
-        self.container.image_pull_policy = image_pull_policy
+        if image_pull_policy:
+            self.container.image_pull_policy = image_pull_policy
         self.container.ports = ports or []
         self.container.resources = resources
         self.container.volume_mounts = volume_mounts or []
@@ -187,7 +188,8 @@ class PodGenerator:
         self.spec = k8s.V1PodSpec(containers=[])
         self.spec.security_context = security_context
         self.spec.tolerations = tolerations
-        self.spec.dns_policy = dnspolicy
+        if dnspolicy:
+            self.spec.dns_policy = dnspolicy
         self.spec.scheduler_name = schedulername
         self.spec.host_network = hostnetwork
         self.spec.affinity = affinity
@@ -195,7 +197,8 @@ class PodGenerator:
         self.spec.init_containers = init_containers
         self.spec.volumes = volumes or []
         self.spec.node_selector = node_selectors
-        self.spec.restart_policy = restart_policy
+        if restart_policy:
+            self.spec.restart_policy = restart_policy
         self.spec.priority_class_name = priority_class_name
 
         self.spec.image_pull_secrets = []


### PR DESCRIPTION
Kubernetes 23.* is more picky when it comes to values passed to
Pod Generator - it requires:

* imagePullPolicy
* dnsPolicy
* restartPolicy

to be not None.

We are fixing it in the way, that we simply skip setting those
if they are None.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
