### PR TITLE
Unpin ``pandas-gbq`` and remove unused code

### DIFF
--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -24,8 +24,6 @@ from airflow.providers.google.cloud.hooks.bigquery import (  # noqa
     BigQueryConnection,
     BigQueryCursor,
     BigQueryHook,
-    BigQueryPandasConnector,
-    GbqConnector,
 )
 
 warnings.warn(

--- a/airflow/contrib/hooks/bigquery_hook.py
+++ b/airflow/contrib/hooks/bigquery_hook.py
@@ -24,6 +24,7 @@ from airflow.providers.google.cloud.hooks.bigquery import (  # noqa
     BigQueryConnection,
     BigQueryCursor,
     BigQueryHook,
+    GbqConnector,
 )
 
 warnings.warn(

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -46,11 +46,7 @@ from google.cloud.exceptions import NotFound
 from googleapiclient.discovery import Resource, build
 from pandas import DataFrame
 from pandas_gbq import read_gbq
-from pandas_gbq.gbq import (
-    GbqConnector,
-    _check_google_client_version as gbq_check_google_client_version,
-    _test_google_api_imports as gbq_test_google_api_imports,
-)
+from pandas_gbq.gbq import GbqConnector  # noqa
 from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException
@@ -2191,28 +2187,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         job = self.insert_job(configuration=configuration, project_id=self.project_id)
         self.running_job_id = job.job_id
         return job.job_id
-
-
-class BigQueryPandasConnector(GbqConnector):
-    """
-    This connector behaves identically to GbqConnector (from Pandas), except
-    that it allows the service to be injected, and disables a call to
-    self.get_credentials(). This allows Airflow to use BigQuery with Pandas
-    without forcing a three legged OAuth connection. Instead, we can inject
-    service account credentials into the binding.
-    """
-
-    def __init__(
-        self, project_id: str, service: str, reauth: bool = False, verbose: bool = False, dialect="legacy"
-    ) -> None:
-        super().__init__(project_id)
-        gbq_check_google_client_version()
-        gbq_test_google_api_imports()
-        self.project_id = project_id
-        self.reauth = reauth
-        self.service = service
-        self.verbose = verbose
-        self.dialect = dialect
 
 
 class BigQueryConnection:

--- a/setup.py
+++ b/setup.py
@@ -355,9 +355,7 @@ google = [
     'grpcio-gcp>=0.2.2',
     'httpx',
     'json-merge-patch>=0.2',
-    # pandas-gbq 0.15.0 release broke google provider's bigquery import
-    # _check_google_client_version (airflow/providers/google/cloud/hooks/bigquery.py:49)
-    'pandas-gbq<0.15.0',
+    'pandas-gbq',
     pandas_requirement,
     'sqlalchemy-bigquery>=1.2.1',
 ]


### PR DESCRIPTION
`BigQueryPandasConnector` was previously used by `BigqueryHook.get_pandas_df`. This was fixed in https://github.com/apache/airflow/commit/ad308ea441372f2b44b4292c3779eb745f2ed48c (**in 2018**). However we forgot to remove `BigQueryPandasConnector` which is age-old code (2016) and used private methods.

2016 code - https://github.com/apache/airflow/pull/1452/files

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
