### PR TITLE
Rename xcom.dagrun_id to xcom.dag_run_id

### DIFF
--- a/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
+++ b/airflow/migrations/versions/c306b5b5ae4a_switch_xcom_table_to_use_run_id.py
@@ -42,7 +42,7 @@ metadata = MetaData()
 
 def _get_new_xcom_columns() -> Sequence[Column]:
     return [
-        Column("dagrun_id", Integer(), nullable=False),
+        Column("dag_run_id", Integer(), nullable=False),
         Column("task_id", StringID(), nullable=False),
         Column("key", StringID(length=512), nullable=False),
         Column("value", LargeBinary),
@@ -117,7 +117,7 @@ def upgrade():
     op.rename_table("__airflow_tmp_xcom", "xcom")
 
     with op.batch_alter_table("xcom") as batch_op:
-        batch_op.create_primary_key("xcom_pkey", ["dagrun_id", "task_id", "key"])
+        batch_op.create_primary_key("xcom_pkey", ["dag_run_id", "task_id", "key"])
         batch_op.create_index("idx_xcom_key", ["key"])
         batch_op.create_index("idx_xcom_ti_id", ["dag_id", "task_id", "run_id"])
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -59,7 +59,7 @@ class BaseXCom(Base, LoggingMixin):
 
     __tablename__ = "xcom"
 
-    dagrun_id = Column(Integer(), nullable=False, primary_key=True)
+    dagrun_id = Column('dag_run_id', Integer(), nullable=False, primary_key=True)
     task_id = Column(String(ID_LEN, **COLLATION_ARGS), nullable=False, primary_key=True)
     key = Column(String(512, **COLLATION_ARGS), nullable=False, primary_key=True)
 


### PR DESCRIPTION
In the database layer, we use snake case.  And unless there is some collision, we should refer to `<table>.id` with `f"{table}_id"`.
