### PR TITLE
py files doesn't have to be checked is_zipfiles in refresh_dag

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -626,7 +626,7 @@ class DagFileProcessorManager(LoggingMixin):
             # Likewise DagCode.remove_deleted_code
             dag_filelocs = []
             for fileloc in self._file_paths:
-                if zipfile.is_zipfile(fileloc):
+                if not fileloc.endswith(".py") and zipfile.is_zipfile(fileloc):
                     with zipfile.ZipFile(fileloc) as z:
                         dag_filelocs.extend(
                             [


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Skip to check is_zipfile for py files in DAGs folder during refresh_dags.

As refresh_dags try to access all files in DAGs folder, this helps use much less IO in the repetitive process.

This concept was approved in prior PR.  Actually this should have been part of it.
 - https://github.com/apache/airflow/pull/21538

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
