### PR TITLE
Only allow mapping against return value XCom

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -50,6 +50,7 @@ from airflow.models.mappedoperator import (
     MappedOperator,
     ValidationSource,
     create_mocked_kwargs,
+    ensure_xcomarg_return_value,
     get_mappable_types,
     prevent_duplicates,
 )
@@ -266,9 +267,8 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
 
     @cached_property
     def _function_is_vararg(self):
-        return any(
-            v.kind == inspect.Parameter.VAR_KEYWORD for v in self.function_signature.parameters.values()
-        )
+        parameters = self.function_signature.parameters
+        return any(v.kind == inspect.Parameter.VAR_KEYWORD for v in parameters.values())
 
     @cached_property
     def _mappable_function_argument_names(self) -> Set[str]:
@@ -304,6 +304,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
     def apply(self, **map_kwargs: "Mappable") -> XComArg:
         self._validate_arg_names("apply", map_kwargs)
         prevent_duplicates(self.kwargs, map_kwargs, fail_reason="mapping already partial")
+        ensure_xcomarg_return_value(map_kwargs)
 
         partial_kwargs = self.kwargs.copy()
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -64,6 +64,7 @@ from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.typing_compat import Literal
 from airflow.utils.context import Context
+from airflow.utils.helpers import is_container
 from airflow.utils.operator_resources import Resources
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
@@ -134,6 +135,22 @@ def prevent_duplicates(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail
     raise TypeError(f"{fail_reason} arguments: {duplicated_keys_display}")
 
 
+def ensure_xcomarg_return_value(arg: Any) -> None:
+    from airflow.models.xcom_arg import XCOM_RETURN_KEY, XComArg
+
+    if isinstance(arg, XComArg):
+        if arg.key != XCOM_RETURN_KEY:
+            raise ValueError(f"cannot map over XCom with custom key {arg.key!r} from {arg.operator}")
+    elif not is_container(arg):
+        return
+    elif isinstance(arg, collections.abc.Mapping):
+        for v in arg.values():
+            ensure_xcomarg_return_value(v)
+    elif isinstance(arg, collections.abc.Iterable):
+        for v in arg:
+            ensure_xcomarg_return_value(v)
+
+
 def create_mocked_kwargs(kwargs: Dict[str, "Mappable"]) -> Dict[str, unittest.mock.MagicMock]:
     """Create a mapping of mocks for given map arguments.
 
@@ -185,6 +202,8 @@ class OperatorPartial:
         from airflow.operators.dummy import DummyOperator
 
         validate_mapping_kwargs(self.operator_class, "apply", mapped_kwargs)
+        prevent_duplicates(self.kwargs, mapped_kwargs, fail_reason="mapping already partial")
+        ensure_xcomarg_return_value(mapped_kwargs)
 
         partial_kwargs = self.kwargs.copy()
         task_id = partial_kwargs.pop("task_id")
@@ -255,7 +274,6 @@ class MappedOperator(AbstractOperator):
     def __attrs_post_init__(self):
         from airflow.models.xcom_arg import XComArg
 
-        prevent_duplicates(self.partial_kwargs, self.mapped_kwargs, fail_reason="mapping already partial")
         self._validate_argument_count()
         if self.task_group:
             self.task_group.add(self)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -33,7 +33,6 @@ from airflow.models.baseoperator import BaseOperator, BaseOperatorMeta, chain, c
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
-from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.models.xcom_arg import XComArg
 from airflow.utils.context import Context
 from airflow.utils.edgemodifier import Label
@@ -757,8 +756,7 @@ def test_map_xcom_arg():
     """Test that dependencies are correct when mapping with an XComArg"""
     with DAG("test-dag", start_date=DEFAULT_DATE):
         task1 = BaseOperator(task_id="op1")
-        xcomarg = XComArg(task1, "test_key")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=xcomarg)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
         finish = MockOperator(task_id="finish")
 
         mapped >> finish
@@ -816,8 +814,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
     literal = [1, 2, {'a': 'b'}]
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
-        xcomarg = XComArg(task1, "test_key")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=xcomarg)
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
 
     dr = dag_maker.create_dagrun()
 
@@ -861,7 +858,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1, XCOM_RETURN_KEY))
+        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
 
     dr = dag_maker.create_dagrun()
 


### PR DESCRIPTION
We have not found a good way to support arbitrary XCom pushes, so this
is the best we can support for now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
