### PR TITLE
More explicit mapped argument validation

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -49,7 +49,6 @@ from airflow.models.dag import DAG, DagContext
 from airflow.models.mappedoperator import (
     MappedOperator,
     ValidationSource,
-    create_mocked_kwargs,
     ensure_xcomarg_return_value,
     get_mappable_types,
     prevent_duplicates,
@@ -411,29 +410,23 @@ class DecoratedMappedOperator(MappedOperator):
         """
         return self.mapped_op_kwargs
 
-    def _create_unmapped_operator(self, *, mapped_kwargs: Dict[str, Any], real: bool) -> "BaseOperator":
-        assert not isinstance(self.operator_class, str)
+    def _get_unmap_kwargs(self) -> Dict[str, Any]:
         partial_kwargs = self.partial_kwargs.copy()
-        if real:
-            mapped_op_kwargs: Dict[str, Any] = self.mapped_op_kwargs
-        else:
-            mapped_op_kwargs = create_mocked_kwargs(self.mapped_op_kwargs)
         op_kwargs = _merge_kwargs(
             partial_kwargs.pop("op_kwargs"),
-            mapped_op_kwargs,
+            self.mapped_op_kwargs,
             fail_reason="mapping already partial",
         )
-        return self.operator_class(
-            dag=self.dag,
-            task_group=self.task_group,
-            task_id=self.task_id,
-            op_kwargs=op_kwargs,
-            multiple_outputs=self.multiple_outputs,
-            python_callable=self.python_callable,
-            _airflow_map_validation=not real,
+        return {
+            "dag": self.dag,
+            "task_group": self.task_group,
+            "task_id": self.task_id,
+            "op_kwargs": op_kwargs,
+            "multiple_outputs": self.multiple_outputs,
+            "python_callable": self.python_callable,
             **partial_kwargs,
-            **mapped_kwargs,
-        )
+            **self.mapped_kwargs,
+        }
 
     def _expand_mapped_field(self, key: str, content: Any, context: Context, *, session: Session) -> Any:
         if key != "op_kwargs" or not isinstance(content, collections.abc.Mapping):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -133,6 +133,8 @@ class PythonOperator(BaseOperator):
         'op_kwargs',
     )
 
+    mapped_arguments_validated_by_init = True
+
     def __init__(
         self,
         *,


### PR DESCRIPTION
Instead of always using MagicMock to validate mapped arguments, this implements a more sophisticated protocol that allows an operator to implement a `validate_mapped_arguments` to provide custom validation logic. If an operator just wants to use `__init__` for validation, however, they can set a flag `mapped_arguments_validated_by_init` to get the behavior easily. (This does *not* use MagicMock, however, since any custom validation logic should be able to handle those on its own).

The `validate_mapped_arguments` flag is currently only set on PythonOperator. It can likely be used on a lot more operators down the road.
