### PR TITLE
Add support for Alibaba-Cloud EMR cluster template (#21957)

### DIFF
--- a/airflow/providers/alibaba/cloud/hooks/aliyun_emr_hook.py
+++ b/airflow/providers/alibaba/cloud/hooks/aliyun_emr_hook.py
@@ -1,0 +1,105 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=invalid-name
+
+
+import json
+
+from aliyunsdkcore.auth.credentials import AccessKeyCredential
+from aliyunsdkcore.client import AcsClient
+from aliyunsdkcore.request import CommonRequest
+
+from airflow.hooks.base_hook import BaseHook
+
+
+class AliyunEmrHook(BaseHook):
+    def __init__(self, conn_id='oss_default', region=None):
+        self.conn_id = conn_id
+        self.region = region
+        self.conn = self.get_connection(conn_id)
+        self.client = self.get_client()
+
+    def create_cluster_from_template(self, template_id, cluster_name):
+        request = CommonRequest()
+        request.set_accept_format('json')
+        request.set_domain("emr-vpc." + self.region + ".aliyuncs.com")
+        request.set_method('POST')
+        request.set_protocol_type('https')
+        request.set_version('2016-04-08')
+        request.set_action_name('CreateClusterWithTemplate')
+        request.add_query_param('TemplateBizId', template_id)
+        request.add_query_param('ClusterName', cluster_name)
+        request.set_accept_format('json')
+        response = json.loads(str(self.client.do_action_with_exception(request), encoding='utf-8'))
+        self.log.info(response)
+        return response['ClusterId']
+
+    def tear_down_cluster(self, cluster_id):
+        request = CommonRequest()
+        request.set_accept_format('json')
+        request.set_domain("emr-vpc." + self.region + ".aliyuncs.com")
+        request.set_method('POST')
+        request.set_protocol_type('https')  # https | http
+        request.set_version('2016-04-08')
+        request.set_action_name('ReleaseCluster')
+        request.add_query_param('RegionId', self.region)
+        request.add_query_param('Id', cluster_id)
+        response = json.loads(str(self.client.do_action(request), encoding='utf-8'))
+        self.log.info(response)
+
+    def get_cluster_info(self, cluster_id):
+        request = CommonRequest()
+        request.set_accept_format('json')
+        request.set_domain("emr-vpc." + self.region + ".aliyuncs.com")
+        request.set_method('POST')
+        request.set_protocol_type('https')  # https | http
+        request.set_version('2016-04-08')
+        request.set_action_name('DescribeClusterV2')
+        request.add_query_param('RegionId', self.region)
+        request.add_query_param('Id', cluster_id)
+        response = json.loads(str(self.client.do_action(request), encoding='utf-8'))
+        return response
+
+    def get_client(self):
+        # self.log.info('trying to establish connection...')
+
+        extra_config = self.conn.extra_dejson
+        auth_type = extra_config.get('auth_type', None)
+        if not auth_type:
+            raise Exception("No auth_type specified in extra_config. ")
+
+        if auth_type == 'AK':
+            access_key_id = extra_config.get('access_key_id', None)
+            access_key_secret = extra_config.get('access_key_secret', None)
+            region = extra_config.get('region', None)
+            if not access_key_id:
+                raise Exception("No access_key_id is specified for connection: " + self.conn_id)
+            if not access_key_secret:
+                raise Exception("No access_key_secret is specified for connection: " + self.conn_id)
+            if not self.region:
+                if not region:
+                    raise Exception("No region is specified for connection: " + self.conn_id)
+                self.region = region
+
+        else:
+            raise Exception("Unsupported auth_type: " + auth_type)
+
+        credentials = AccessKeyCredential(access_key_id, access_key_secret)
+        self.client = AcsClient(region_id=self.region, credential=credentials)
+        return self.client

--- a/airflow/providers/alibaba/cloud/operators/aliyun_emr_operator.py
+++ b/airflow/providers/alibaba/cloud/operators/aliyun_emr_operator.py
@@ -1,0 +1,108 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from time import gmtime, sleep, strftime
+
+
+from airflow.models import BaseOperator
+from airflow.providers.alibaba.cloud.hooks.aliyun_emr_hook import AliyunEmrHook
+from airflow.utils.decorators import apply_defaults
+from airflow.utils.trigger_rule import TriggerRule
+
+
+class CreateClusterFromTemplateOperator(BaseOperator):
+
+    # template_fields = ('to', 'subject', 'html_content')
+    # template_ext = ('.html',)
+    # ui_color = '#e6faf9'
+
+    @apply_defaults
+    def __init__(self, template_id, xcom_cluster_id_key='xcom_cluster_id', *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        timestamp = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
+        self.cluster_name = f'cluster-created-by-airflow_{timestamp}'
+        self.template_id = template_id
+        self.xcom_cluster_id_key = xcom_cluster_id_key
+        self.aliyun_emr_hook = AliyunEmrHook()
+        self.cluster_id = None
+        self.cluster_type = None
+
+    def execute(self, context):
+        # create cluster from template
+        self.cluster_id = self.aliyun_emr_hook.create_cluster_from_template(
+            self.template_id, self.cluster_name
+        )
+        # put cluster_id into xcom channel
+        ti = context['ti']
+        ti.xcom_push(key=self.xcom_cluster_id_key, value=self.cluster_id)
+        self.log.info(f"xcom_task_key: {self.xcom_cluster_id_key}")
+        # check cluster status
+        self.log.info('Checking cluster status...')
+        retry = True
+        while True:
+            try:
+                response = self.aliyun_emr_hook.get_cluster_info(self.cluster_id)
+                status = response['ClusterInfo']['Status']
+                self.log.info(f'Cluster status: {status}')
+                if status == 'IDLE':
+                    self.log.info('Cluster setup done!')
+                    self.cluster_type = response['ClusterInfo']['SoftwareInfo']['ClusterType']
+                    break
+            except AttributeError as error:
+                self.log.error(error)
+                break
+            except Exception as exception:
+                self.log.error(exception)
+                if retry == True:
+                    retry == False
+                    continue
+                break
+            sleep(10)
+        sleep(30)
+        self.log.info(f"cluster {self.cluster_id} is created")
+
+    def on_kill(self):
+        self.log.info("Cluster creating process get stopped externally, releasing cluster...")
+        self.aliyun_emr_hook.tear_down_cluster(self.cluster_id)
+
+
+class TearDownClusterOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+        self,
+        create_cluster_task_id,
+        xcom_cluster_id_key='xcom_cluster_id',
+        trigger_rule=TriggerRule.ALL_DONE,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.xcom_cluster_id_key = xcom_cluster_id_key
+        self.create_cluster_task_id = create_cluster_task_id
+        self.trigger_rule = trigger_rule
+        self.aliyun_emr_hook = AliyunEmrHook()
+
+    def execute(self, context):
+        self.log.info('tearing down cluster...')
+        ti = context['ti']
+        self.log.info(f"create_cluster_task_id: {self.create_cluster_task_id}")
+        self.log.info(f"xcom_task_key: {self.xcom_cluster_id_key}")
+        cluster_id = ti.xcom_pull(task_ids=self.create_cluster_task_id, key=self.xcom_cluster_id_key)
+        self.log.info('ready to tear down cluster with id: ')
+        self.log.info(cluster_id)
+        self.aliyun_emr_hook.tear_down_cluster(cluster_id)
+        self.log.info("Cluster successfully torn down...")

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -39,6 +39,9 @@ operators:
   - integration-name: Alibaba Cloud OSS
     python-modules:
       - airflow.providers.alibaba.cloud.operators.oss
+  - integration-name: Alibaba Cloud EMR
+    python-modules:
+      - airflow.providers.alibaba.cloud.operators.aliyun_emr_operator
 
 sensors:
   - integration-name: Alibaba Cloud OSS
@@ -49,6 +52,9 @@ hooks:
   - integration-name: Alibaba Cloud OSS
     python-modules:
       - airflow.providers.alibaba.cloud.hooks.oss
+  - integration-name: Alibaba Cloud EMR
+    python-modules:
+      - airflow.providers.alibaba.cloud.hooks.aliyun_emr_hook
 
 hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
   - airflow.providers.alibaba.cloud.hooks.oss.OSSHook


### PR DESCRIPTION
- Alibaba Cloud EMR is an all-in-one enterprise-ready big data platform that provides cluster, job, and data management services based on open-source ecosystems, such as Hadoop, Spark, Kafka, Flink, and Storm.
- This pr adds support for [Alibaba-Cloud EMR](https://www.alibabacloud.com/product/emapreduce) cluster template in alibaba provider so that users could use airflow operator to create / tear down EMR cluster automatically. 
- This pr closes: #21957
- related: #17200