### PR TITLE
Fix extra links for grid view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -238,7 +238,7 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
                 if ti.task_id == task_item_or_group.task_id
             ],
             'label': task_item_or_group.label,
-            'extra_links': [],
+            'extra_links': task_item_or_group.extra_links,
             'is_mapped': task_item_or_group.is_mapped,
         }
 


### PR DESCRIPTION
In #21740, I had removed extra_links during some debug/development and forgot to add it back in.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
