### PR TITLE
Move S3ToRedshiftOperator documentation to transfer dir

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
@@ -15,13 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Ignore missing args provided by default_args
-# type: ignore[call-arg]
-
-"""
-This is an example dag for using `S3ToRedshiftOperator` to copy a S3 key into a Redshift table.
-"""
-
 from datetime import datetime
 from os import getenv
 
@@ -32,24 +25,22 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
 
-# [START howto_operator_s3_to_redshift_env_variables]
-S3_BUCKET = getenv("S3_BUCKET", "test-bucket")
-S3_KEY = getenv("S3_KEY", "key")
-REDSHIFT_TABLE = getenv("REDSHIFT_TABLE", "test_table")
-# [END howto_operator_s3_to_redshift_env_variables]
+S3_BUCKET_NAME = getenv("S3_BUCKET_NAME", "s3_bucket_name")
+S3_KEY = getenv("S3_KEY", "s3_filename")
+REDSHIFT_TABLE = getenv("REDSHIFT_TABLE", "redshift_table")
 
 
 @task(task_id='setup__add_sample_data_to_s3')
-def add_sample_data_to_s3():
+def task_add_sample_data_to_s3():
     s3_hook = S3Hook()
-    s3_hook.load_string("0,Airflow", f'{S3_KEY}/{REDSHIFT_TABLE}', S3_BUCKET, replace=True)
+    s3_hook.load_string("0,Airflow", f'{S3_KEY}/{REDSHIFT_TABLE}', S3_BUCKET_NAME, replace=True)
 
 
 @task(task_id='teardown__remove_sample_data_from_s3')
-def remove_sample_data_from_s3():
+def task_remove_sample_data_from_s3():
     s3_hook = S3Hook()
-    if s3_hook.check_for_key(f'{S3_KEY}/{REDSHIFT_TABLE}', S3_BUCKET):
-        s3_hook.delete_objects(S3_BUCKET, f'{S3_KEY}/{REDSHIFT_TABLE}')
+    if s3_hook.check_for_key(f'{S3_KEY}/{REDSHIFT_TABLE}', S3_BUCKET_NAME):
+        s3_hook.delete_objects(S3_BUCKET_NAME, f'{S3_KEY}/{REDSHIFT_TABLE}')
 
 
 with DAG(
@@ -59,28 +50,28 @@ with DAG(
     catchup=False,
     tags=['example'],
 ) as dag:
-    add_sample_data_to_s3 = add_sample_data_to_s3()
+    add_sample_data_to_s3 = task_add_sample_data_to_s3()
 
     setup__task_create_table = RedshiftSQLOperator(
         sql=f'CREATE TABLE IF NOT EXISTS {REDSHIFT_TABLE}(Id int, Name varchar)',
         task_id='setup__create_table',
     )
-    # [START howto_operator_s3_to_redshift_task_1]
+    # [START howto_transfer_s3_to_redshift]
     task_transfer_s3_to_redshift = S3ToRedshiftOperator(
-        s3_bucket=S3_BUCKET,
+        s3_bucket=S3_BUCKET_NAME,
         s3_key=S3_KEY,
-        schema="PUBLIC",
+        schema='PUBLIC',
         table=REDSHIFT_TABLE,
         copy_options=['csv'],
         task_id='transfer_s3_to_redshift',
     )
-    # [END howto_operator_s3_to_redshift_task_1]
+    # [END howto_transfer_s3_to_redshift]
     teardown__task_drop_table = RedshiftSQLOperator(
         sql=f'DROP TABLE IF EXISTS {REDSHIFT_TABLE}',
         task_id='teardown__drop_table',
     )
 
-    remove_sample_data_from_s3 = remove_sample_data_from_s3()
+    remove_sample_data_from_s3 = task_remove_sample_data_from_s3()
 
     chain(
         [add_sample_data_to_s3, setup__task_create_table],

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -464,7 +464,7 @@ transfers:
     python-module: airflow.providers.amazon.aws.transfers.redshift_to_s3
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: Amazon Redshift
-    how-to-guide: /docs/apache-airflow-providers-amazon/operators/s3_to_redshift.rst
+    how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/s3_to_redshift.rst
     python-module: airflow.providers.amazon.aws.transfers.s3_to_redshift
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: SSH File Transfer Protocol (SFTP)

--- a/docs/apache-airflow-providers-amazon/operators/transfer/s3_to_redshift.rst
+++ b/docs/apache-airflow-providers-amazon/operators/transfer/s3_to_redshift.rst
@@ -18,58 +18,37 @@
 
 .. _howto/operator:S3ToRedshiftOperator:
 
-S3 To Redshift Transfer Operator
-================================
+Amazon Redshift to S3 Transfer Operator
+=======================================
 
-Overview
---------
+Use the S3ToRedshiftOperator transfer to copy the data from a Amazon S3 file into an Amazon Redshift table.
 
-The ``S3ToRedshiftOperator`` copies data from a S3 Bucket into a Redshift table.
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
 
-The example dag provided showcases the
+.. include:: ../_partials/prerequisite_tasks.rst
+
+S3 To Redshift
+^^^^^^^^^^^^^^
+
+This operator loads data from S3 to an existing Amazon Redshift table.
+
+To get more information about operator visit:
 :class:`~airflow.providers.amazon.aws.transfers.s3_to_redshift.S3ToRedshiftOperator`
-in action.
 
- - example_s3_to_redshift.py
-
-example_s3_to_redshift.py
--------------------------
-
-Purpose
-"""""""
-
-This is a basic example dag for using ``S3ToRedshiftOperator`` to copies data from a S3 Bucket into a Redshift table.
-
-Environment variables
-"""""""""""""""""""""
-
-This example relies on the following variables, which can be passed via OS environment variables.
+Example usage:
 
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
     :language: python
-    :start-after: [START howto_operator_s3_to_redshift_env_variables]
-    :end-before: [END howto_operator_s3_to_redshift_env_variables]
-
-You need to set at least the ``S3_BUCKET``.
-
-Copy S3 key into Redshift table
-"""""""""""""""""""""""""""""""
-
-In the following code we are copying the S3 key ``s3://{S3_BUCKET}/{S3_KEY}`` into the Redshift table
-``PUBLIC.{REDSHIFT_TABLE}``.
-
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
-    :language: python
-    :start-after: [START howto_operator_s3_to_redshift_task_1]
-    :end-before: [END howto_operator_s3_to_redshift_task_1]
+    :dedent: 4
+    :start-after: [START howto_transfer_s3_to_redshift]
+    :end-before: [END howto_transfer_s3_to_redshift]
 
 You can find more information to the ``COPY`` command used
 `here <https://docs.aws.amazon.com/us_en/redshift/latest/dg/copy-parameters-data-source-s3.html>`__.
 
 Reference
----------
-
-For further information, look at:
+^^^^^^^^^
 
 * `AWS COPY from Amazon S3 Documentation <https://docs.aws.amazon.com/us_en/redshift/latest/dg/copy-parameters-data-source-s3.html>`__
 * `AWS boto3 Library Documentation for S3 <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html>`__

--- a/docs/apache-airflow-providers-amazon/redirects.txt
+++ b/docs/apache-airflow-providers-amazon/redirects.txt
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+operators/s3_to_redshift.rst operators/transfer/s3_to_redshift.rst


### PR DESCRIPTION
Move `S3ToRedshiftOperator` documentation to `transfer` directory

I also did some clean up in the documentation