### PR TITLE
Run inclusive language check on CHANGELOG

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -406,8 +406,7 @@ repos:
           ^tests/providers/apache/cassandra/hooks/test_cassandra\.py$|
           ^docs/apache-airflow-providers-apache-cassandra/connections/cassandra\.rst$|
           ^docs/apache-airflow-providers-apache-hive/commits\.rst$|
-          git|
-          ^CHANGELOG\.txt$
+          git
       - id: base-operator
         language: pygrep
         name: Check BaseOperator[Link] core imports

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1612,7 +1612,7 @@ Doc only changes
 - Add note extra links only render on when using RBAC webserver  (#8788)
 - Remove unused Airflow import from docs (#9274)
 - Add PR/issue note in Contribution Workflow Example (#9177)
-- Don't use the term "whitelist" - language matters (#9174)
+- Use inclusive language - language matters (#9174)
 - Add docs to change Colors on the Webserver (#9607)
 - Change 'initiate' to 'initialize' in installation.rst (#9619)
 - Replace old Variables View Screenshot with new (#9620)


### PR DESCRIPTION
We should run our inclusive language check on our changelog. We only
have a single failure when we do, ironically from when we put the
check in place.