### PR TITLE
Rename 'S3' hook name to 'Amazon S3'

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -104,7 +104,7 @@ class S3Hook(AwsBaseHook):
     """
 
     conn_type = 's3'
-    hook_name = 'S3'
+    hook_name = 'Amazon S3'
 
     def __init__(self, *args, **kwargs) -> None:
         kwargs['client_type'] = 's3'


### PR DESCRIPTION
PR to produce more intuitive and organized name for Amazon S3 hook. This will align better with other naming of Amazon hooks.

## Fixes for request at https://github.com/apache/airflow/issues/21987 to make the hook naming consistent with other AWS hooks

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
