### PR TITLE
missing quotes

### DIFF
--- a/docs/helm-chart/quick-start.rst
+++ b/docs/helm-chart/quick-start.rst
@@ -66,7 +66,7 @@ Use the following code to install the chart with Example DAGs:
   export NAMESPACE=example-namespace
   helm install $RELEASE_NAME apache-airflow/airflow \
     --namespace $NAMESPACE \
-    --set 'env[0].name=AIRFLOW__CORE__LOAD_EXAMPLES,env[0].value=True'
+    --set 'env[0].name=AIRFLOW__CORE__LOAD_EXAMPLES,env[0].value="True"'
 
 It may take a few minutes. Confirm the pods are up:
 

--- a/docs/helm-chart/quick-start.rst
+++ b/docs/helm-chart/quick-start.rst
@@ -66,7 +66,8 @@ Use the following code to install the chart with Example DAGs:
   export NAMESPACE=example-namespace
   helm install $RELEASE_NAME apache-airflow/airflow \
     --namespace $NAMESPACE \
-    --set 'env[0].name=AIRFLOW__CORE__LOAD_EXAMPLES,env[0].value="True"'
+    --set-string "env[0].name=AIRFLOW__CORE__LOAD_EXAMPLES" \
+    --set-string "env[0].value=True" 
 
 It may take a few minutes. Confirm the pods are up:
 

--- a/docs/helm-chart/quick-start.rst
+++ b/docs/helm-chart/quick-start.rst
@@ -67,7 +67,7 @@ Use the following code to install the chart with Example DAGs:
   helm install $RELEASE_NAME apache-airflow/airflow \
     --namespace $NAMESPACE \
     --set-string "env[0].name=AIRFLOW__CORE__LOAD_EXAMPLES" \
-    --set-string "env[0].value=True" 
+    --set-string "env[0].value=True"
 
 It may take a few minutes. Confirm the pods are up:
 


### PR DESCRIPTION
Missing quotes throws the following error:
```
airflow:
- env.0.value: Invalid type. Expected: string, given: boolean
```
