### PR TITLE
Show import error for 'airflow dags list' CLI command

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -315,6 +315,12 @@ def dag_next_execution(args):
 def dag_list_dags(args):
     """Displays dags with or without stats at the command line"""
     dagbag = DagBag(process_subdir(args.subdir))
+    if dagbag.import_errors:
+        from rich import print as rich_print
+
+        rich_print("[red][bold]Error:[bold] The following dags failed to load [red]")
+        for filename, stacktrace in dagbag.import_errors.items():
+            rich_print(f"[red][bold]Broken DAG: {filename}: {stacktrace}[bold][red]")
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=lambda d: d.dag_id),
         output=args.output,

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -318,9 +318,9 @@ def dag_list_dags(args):
     if dagbag.import_errors:
         from rich import print as rich_print
 
-        rich_print("[red][bold]Error:[bold] The following dags failed to load [red]")
+        rich_print("[red][bold]Error:[/bold] The following dags failed to load")
         for filename, stacktrace in dagbag.import_errors.items():
-            rich_print(f"[red][bold]Broken DAG: {filename}: {stacktrace}[bold][red]")
+            rich_print(f"[red][bold]Broken DAG {filename}:[/bold] {stacktrace}")
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=lambda d: d.dag_id),
         output=args.output,

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -318,9 +318,11 @@ def dag_list_dags(args):
     if dagbag.import_errors:
         from rich import print as rich_print
 
-        rich_print("[red][bold]Error:[/bold] The following dags failed to load", file=sys.stderr)
-        for filename, stacktrace in dagbag.import_errors.items():
-            rich_print(f"[red][bold]Broken DAG {filename}:[/bold] {stacktrace}", file=sys.stderr)
+        rich_print(
+            "[red][bold]Error:[/bold] Failed to load all files. "
+            "For details, run airflow dags list-import-errors",
+            file=sys.stderr,
+        )
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=lambda d: d.dag_id),
         output=args.output,

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -320,7 +320,7 @@ def dag_list_dags(args):
 
         rich_print(
             "[red][bold]Error:[/bold] Failed to load all files. "
-            "For details, run airflow dags list-import-errors",
+            "For details, run `airflow dags list-import-errors`",
             file=sys.stderr,
         )
     AirflowConsole().print_as(

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -318,9 +318,9 @@ def dag_list_dags(args):
     if dagbag.import_errors:
         from rich import print as rich_print
 
-        rich_print("[red][bold]Error:[/bold] The following dags failed to load")
+        rich_print("[red][bold]Error:[/bold] The following dags failed to load", file=sys.stderr)
         for filename, stacktrace in dagbag.import_errors.items():
-            rich_print(f"[red][bold]Broken DAG {filename}:[/bold] {stacktrace}")
+            rich_print(f"[red][bold]Broken DAG {filename}:[/bold] {stacktrace}", file=sys.stderr)
     AirflowConsole().print_as(
         data=sorted(dagbag.dags.values(), key=lambda d: d.dag_id),
         output=args.output,

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -408,6 +408,15 @@ class TestCliDags(unittest.TestCase):
         assert "- dag_id:" in out
 
     @conf_vars({('core', 'load_examples'): 'false'})
+    def test_cli_list_dags_prints_import_errors(self):
+        dag_path = os.path.join(TEST_DAGS_FOLDER, 'test_invalid_cron.py')
+        args = self.parser.parse_args(['dags', 'list', '--output', 'yaml', '--subdir', dag_path])
+        with contextlib.redirect_stderr(io.StringIO()) as temp_stdout:
+            dag_command.dag_list_dags(args)
+            out = temp_stdout.getvalue()
+        assert "Failed to load all files." in out
+
+    @conf_vars({('core', 'load_examples'): 'false'})
     def test_cli_list_import_errors(self):
         dag_path = os.path.join(TEST_DAGS_FOLDER, 'test_invalid_cron.py')
         args = self.parser.parse_args(['dags', 'list', '--output', 'yaml', '--subdir', dag_path])

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -411,9 +411,9 @@ class TestCliDags(unittest.TestCase):
     def test_cli_list_dags_prints_import_errors(self):
         dag_path = os.path.join(TEST_DAGS_FOLDER, 'test_invalid_cron.py')
         args = self.parser.parse_args(['dags', 'list', '--output', 'yaml', '--subdir', dag_path])
-        with contextlib.redirect_stderr(io.StringIO()) as temp_stdout:
+        with contextlib.redirect_stderr(io.StringIO()) as temp_stderr:
             dag_command.dag_list_dags(args)
-            out = temp_stdout.getvalue()
+            out = temp_stderr.getvalue()
         assert "Failed to load all files." in out
 
     @conf_vars({('core', 'load_examples'): 'false'})


### PR DESCRIPTION
When there's an import error in a dag, the dag doesn't show up in the list of dags
and there's no indication that there's an import error.
This PR fixes that

