### PR TITLE
Switch oss hook tests in alibaba-provider to use Mocks (17617)

### DIFF
--- a/tests/providers/alibaba/cloud/utils/oss_mock.py
+++ b/tests/providers/alibaba/cloud/utils/oss_mock.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+
+from airflow.models import Connection
+
+OSS_PROJECT_ID_HOOK_UNIT_TEST = 'example-project'
+
+
+def mock_oss_hook_default_project_id(self, oss_conn_id='mock_oss_default', region='mock_region'):
+    self.oss_conn_id = oss_conn_id
+    self.oss_conn = Connection(
+        extra=json.dumps(
+            {
+                'auth_type': 'AK',
+                'access_key_id': 'mock_access_key_id',
+                'access_key_secret': 'mock_access_key_secret',
+            }
+        )
+    )
+    self.region = region


### PR DESCRIPTION
- At present, unit tests of oss hook in alibaba-provider use real OSS(remote object storage service), which is not a good practice for unit test and could cause stability issues. Furthermore, most of test cases for OSSHook object are absent.
- This pr refactors the previous oss hook unit tests and uses unittest.mock to get rid of communications with real OSS.
- This pr also adds test cases to cover all functions for OSSHook object. 
- related: #17617