### PR TITLE
Don't validate that Params are JSON when NOTSET

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -62,7 +62,8 @@ class Param:
         from jsonschema.exceptions import ValidationError
 
         try:
-            json.dumps(value)
+            if value is not NOTSET:
+                json.dumps(value)
         except Exception:
             warnings.warn(
                 "The use of non-json-serializable params is deprecated and will be removed in "

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -38,12 +38,25 @@ class Param:
     CLASS_IDENTIFIER = '__class'
 
     def __init__(self, default: Any = NOTSET, description: Optional[str] = None, **kwargs):
+        if default is not NOTSET:
+            self._warn_if_not_json(default)
         self.value = default
         self.description = description
         self.schema = kwargs.pop('schema') if 'schema' in kwargs else kwargs
 
     def __copy__(self) -> "Param":
         return Param(self.value, self.description, schema=self.schema)
+
+    @staticmethod
+    def _warn_if_not_json(value):
+        try:
+            json.dumps(value)
+        except Exception:
+            warnings.warn(
+                "The use of non-json-serializable params is deprecated and will be removed in "
+                "a future release",
+                DeprecationWarning,
+            )
 
     def resolve(self, value: Any = NOTSET, suppress_exception: bool = False) -> Any:
         """
@@ -61,15 +74,8 @@ class Param:
         from jsonschema import FormatChecker
         from jsonschema.exceptions import ValidationError
 
-        try:
-            if value is not NOTSET:
-                json.dumps(value)
-        except Exception:
-            warnings.warn(
-                "The use of non-json-serializable params is deprecated and will be removed in "
-                "a future release",
-                DeprecationWarning,
-            )
+        if value is not NOTSET:
+            self._warn_if_not_json(value)
         final_val = value if value is not NOTSET else self.value
         if isinstance(final_val, ArgNotSet):
             if suppress_exception:

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -292,5 +292,5 @@ class TestDagParamRuntime:
             p = Param(default=default)
         p.resolve()  # when resolved with NOTSET, should not warn.
         p.resolve(value={'a': 1})  # when resolved with JSON-serializable, should not warn.
-        with pytest.warns(DeprecationWarning, match='The use of non-json-serializable params is deprecated'):
+        with pytest.warns(DeprecationWarning, match=warning_msg):
             p.resolve(value={1, 2, 3})  # when resolved with not JSON-serializable, should warn.

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -274,23 +274,21 @@ class TestDagParamRuntime:
         assert ti.xcom_pull() == 'test'
 
     @pytest.mark.parametrize(
-        'default, context_manager',
+        'default, should_warn',
         [
             pytest.param(
                 {0, 1, 2},
-                pytest.warns(
-                    DeprecationWarning, match='The use of non-json-serializable params is deprecated'
-                ),
+                True,
                 id='default-non-JSON-serializable',
             ),
-            pytest.param(None, nullcontext(), id='default-None'),  # Param init should not warn
-            pytest.param(
-                {"b": 1}, nullcontext(), id='default-JSON-serializable'
-            ),  # Param init should not warn
+            pytest.param(None, False, id='default-None'),  # Param init should not warn
+            pytest.param({"b": 1}, False, id='default-JSON-serializable'),  # Param init should not warn
         ],
     )
-    def test_param_json_warning(self, default, context_manager):
-        with context_manager:
+    def test_param_json_warning(self, default, should_warn):
+        warning_msg = 'The use of non-json-serializable params is deprecated'
+        cm = pytest.warns(DeprecationWarning, match=warning_msg) if should_warn else nullcontext()
+        with cm:
             p = Param(default=default)
         p.resolve()  # when resolved with NOTSET, should not warn.
         p.resolve(value={'a': 1})  # when resolved with JSON-serializable, should not warn.

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -276,11 +276,7 @@ class TestDagParamRuntime:
     @pytest.mark.parametrize(
         'default, should_warn',
         [
-            pytest.param(
-                {0, 1, 2},
-                True,
-                id='default-non-JSON-serializable',
-            ),
+            pytest.param({0, 1, 2}, True, id='default-non-JSON-serializable'),
             pytest.param(None, False, id='default-None'),  # Param init should not warn
             pytest.param({"b": 1}, False, id='default-JSON-serializable'),  # Param init should not warn
         ],

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -293,4 +293,4 @@ class TestDagParamRuntime:
         p.resolve()  # when resolved with NOTSET, should not warn.
         p.resolve(value={'a': 1})  # when resolved with JSON-serializable, should not warn.
         with pytest.warns(DeprecationWarning, match='The use of non-json-serializable params is deprecated'):
-            p.resolve(value={1, 2, 3})  # when resolved with JSON-serializable, should warn.
+            p.resolve(value={1, 2, 3})  # when resolved with not JSON-serializable, should warn.


### PR DESCRIPTION
If params are NOTSET, then JSON validation will of course fail.
