### PR TITLE
retry on very specific eni provision failures

### DIFF
--- a/airflow/providers/amazon/aws/exceptions.py
+++ b/airflow/providers/amazon/aws/exceptions.py
@@ -21,6 +21,17 @@
 import warnings
 
 
+class EcsTaskFailToStart(Exception):
+    """Raise when ECS tasks fail to start AFTER processing the request."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+    def __reduce__(self):
+        return EcsTaskFailToStart, (self.message)
+
+
 class EcsOperatorError(Exception):
     """Raise when ECS cannot handle the request."""
 

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -30,7 +30,7 @@ from botocore.waiter import Waiter
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, XCom
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError
+from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.typing_compat import Protocol, runtime_checkable
@@ -44,6 +44,16 @@ def should_retry(exception: Exception):
             quota_reason in failure['reason']
             for quota_reason in ['RESOURCE:MEMORY', 'RESOURCE:CPU']
             for failure in exception.failures
+        )
+    return False
+
+
+def should_retry_eni(exception: Exception):
+    """Check if exception is related to ENI (Elastic Network Interfaces)."""
+    if isinstance(exception, EcsTaskFailToStart):
+        return any(
+            eni_reason in exception.message
+            for eni_reason in ['network interface provisioning']
         )
     return False
 
@@ -287,6 +297,23 @@ class EcsOperator(BaseOperator):
         if self.reattach:
             self._try_reattach_task(context)
 
+        self._start_wait_check_task(context)
+
+        self.log.info('ECS Task has been successfully executed')
+
+        if self.reattach:
+            # Clear the XCom value storing the ECS task ARN if the task has completed
+            # as we can't reattach it anymore
+            self._xcom_del(session, self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id))
+
+        if self.do_xcom_push and self.task_log_fetcher:
+            return self.task_log_fetcher.get_last_log_message()
+
+        return None
+
+    @AwsBaseHook.retry(should_retry_eni)
+    def _start_wait_check_task(self, context):
+
         if not self.arn:
             self._start_task(context)
 
@@ -305,18 +332,6 @@ class EcsOperator(BaseOperator):
             self._wait_for_task_ended()
 
         self._check_success_task()
-
-        self.log.info('ECS Task has been successfully executed')
-
-        if self.reattach:
-            # Clear the XCom value storing the ECS task ARN if the task has completed
-            # as we can't reattach it anymore
-            self._xcom_del(session, self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id))
-
-        if self.do_xcom_push and self.task_log_fetcher:
-            return self.task_log_fetcher.get_last_log_message()
-
-        return None
 
     def _xcom_del(self, session, task_id):
         session.query(XCom).filter(XCom.dag_id == self.dag_id, XCom.task_id == task_id).delete()
@@ -438,7 +453,7 @@ class EcsOperator(BaseOperator):
         for task in response['tasks']:
 
             if task.get('stopCode', '') == 'TaskFailedToStart':
-                raise AirflowException(f"The task failed to start due to: {task.get('stoppedReason', '')}")
+                raise EcsTaskFailToStart(f"The task failed to start due to: {task.get('stoppedReason', '')}")
 
             # This is a `stoppedReason` that indicates a task has not
             # successfully finished, but there is no other indication of failure

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -51,10 +51,7 @@ def should_retry(exception: Exception):
 def should_retry_eni(exception: Exception):
     """Check if exception is related to ENI (Elastic Network Interfaces)."""
     if isinstance(exception, EcsTaskFailToStart):
-        return any(
-            eni_reason in exception.message
-            for eni_reason in ['network interface provisioning']
-        )
+        return any(eni_reason in exception.message for eni_reason in ['network interface provisioning'])
     return False
 
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -568,7 +568,8 @@ class TestShouldRetryEni(unittest.TestCase):
         self.assertTrue(
             should_retry_eni(
                 EcsTaskFailToStart(
-                    "The task failed to start due to: Timeout waiting for network interface provisioning to complete."
+                    "The task failed to start due to: "
+                    "Timeout waiting for network interface provisioning to complete."
                 )
             )
         )
@@ -577,7 +578,9 @@ class TestShouldRetryEni(unittest.TestCase):
         self.assertFalse(
             should_retry_eni(
                 EcsTaskFailToStart(
-                    "The task failed to start due to: CannotPullContainerError: ref pull has been retried 5 time(s): failed to resolve reference"
+                    "The task failed to start due to: "
+                    "CannotPullContainerError: "
+                    "ref pull has been retried 5 time(s): failed to resolve reference"
                 )
             )
         )

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -29,7 +29,12 @@ from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
-from airflow.providers.amazon.aws.operators.ecs import EcsOperator, EcsTaskLogFetcher, should_retry, should_retry_eni
+from airflow.providers.amazon.aws.operators.ecs import (
+    EcsOperator,
+    EcsTaskLogFetcher,
+    should_retry,
+    should_retry_eni,
+)
 
 # fmt: off
 RESPONSE_WITHOUT_FAILURES = {
@@ -560,10 +565,22 @@ class TestShouldRetry(unittest.TestCase):
 
 class TestShouldRetryEni(unittest.TestCase):
     def test_return_true_on_valid_reason(self):
-        self.assertTrue(should_retry_eni(EcsTaskFailToStart("The task failed to start due to: Timeout waiting for network interface provisioning to complete.")))
+        self.assertTrue(
+            should_retry_eni(
+                EcsTaskFailToStart(
+                    "The task failed to start due to: Timeout waiting for network interface provisioning to complete."
+                )
+            )
+        )
 
     def test_return_false_on_invalid_reason(self):
-        self.assertFalse(should_retry_eni(EcsTaskFailToStart("The task failed to start due to: CannotPullContainerError: ref pull has been retried 5 time(s): failed to resolve reference")))
+        self.assertFalse(
+            should_retry_eni(
+                EcsTaskFailToStart(
+                    "The task failed to start due to: CannotPullContainerError: ref pull has been retried 5 time(s): failed to resolve reference"
+                )
+            )
+        )
 
 
 class TestEcsTaskLogFetcher(unittest.TestCase):

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -28,8 +28,8 @@ from botocore.exceptions import ClientError
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.exceptions import EcsOperatorError
-from airflow.providers.amazon.aws.operators.ecs import EcsOperator, EcsTaskLogFetcher, should_retry
+from airflow.providers.amazon.aws.exceptions import EcsOperatorError, EcsTaskFailToStart
+from airflow.providers.amazon.aws.operators.ecs import EcsOperator, EcsTaskLogFetcher, should_retry, should_retry_eni
 
 # fmt: off
 RESPONSE_WITHOUT_FAILURES = {
@@ -261,7 +261,7 @@ class TestEcsOperator(unittest.TestCase):
             ]
         }
 
-        with pytest.raises(Exception) as ctx:
+        with pytest.raises(EcsTaskFailToStart) as ctx:
             self.ecs._check_success_task()
 
         assert str(ctx.value) == "The task failed to start due to: Task failed to start"
@@ -556,6 +556,14 @@ class TestShouldRetry(unittest.TestCase):
 
     def test_return_false_on_invalid_reason(self):
         self.assertFalse(should_retry(EcsOperatorError([{'reason': 'CLUSTER_NOT_FOUND'}], 'Foo')))
+
+
+class TestShouldRetryEni(unittest.TestCase):
+    def test_return_true_on_valid_reason(self):
+        self.assertTrue(should_retry_eni(EcsTaskFailToStart("The task failed to start due to: Timeout waiting for network interface provisioning to complete.")))
+
+    def test_return_false_on_invalid_reason(self):
+        self.assertFalse(should_retry_eni(EcsTaskFailToStart("The task failed to start due to: CannotPullContainerError: ref pull has been retried 5 time(s): failed to resolve reference")))
 
 
 class TestEcsTaskLogFetcher(unittest.TestCase):


### PR DESCRIPTION
In an old PR https://github.com/apache/airflow/pull/14263 we tried to add a "retry" mechanism for triggering new ECS task but it didn't work as expected according to my explanation in https://github.com/apache/airflow/pull/16150. 

The TL;DR version is: 

* The immediate API response after sending out the `run_task` request to aws is not reliable. To make sure our task is really running in good health, we have to wait and send out another `describe_tasks` request.


This explanation still holds today. Since people start using Fargate nowadays, this issue becomes more and more acute. On a good day, 0.15% Fargate tasks could fail to start due to ENI (AWS Elastic Network Interface) provision failures. However on a bad day, it could rise to 1~2%.

Per recommendations from the AWS support team, we should consider the "triggering an ECS task, waiting for it to be provisioned, checking for its status" steps a single routine that can be retried as a whole.

This PR is largely based on the framework established in https://github.com/apache/airflow/pull/14263.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
