### PR TITLE
Upgrade `moto` library to version 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -619,9 +619,7 @@ devel_only = [
     'jira',
     'jsondiff',
     'mongomock',
-    # Moto3 is limited for unknown reason
-    # TODO: attempt to remove the limitation
-    'moto~=2.2,>=2.2.12',
+    'moto~=3.0,>=3.0.3',
     'parameterized',
     'paramiko',
     'pipdeptree',

--- a/setup.py
+++ b/setup.py
@@ -619,7 +619,7 @@ devel_only = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto~=3.0,>=3.0.3',
+    'moto>=3.0.3',
     'parameterized',
     'paramiko',
     'pipdeptree',

--- a/tests/providers/amazon/aws/hooks/test_kinesis.py
+++ b/tests/providers/amazon/aws/hooks/test_kinesis.py
@@ -58,7 +58,7 @@ class TestFirehoseHook:
         )
 
         stream_arn = response['DeliveryStreamARN']
-        assert stream_arn == "arn:aws:firehose:us-east-1:123456789012:/delivery_stream/test_airflow"
+        assert stream_arn == "arn:aws:firehose:us-east-1:123456789012:deliverystream/test_airflow"
 
         records = [{"Data": str(uuid.uuid4())} for _ in range(100)]
 


### PR DESCRIPTION
Some of the RDS functionality was added to `moto` recently.
Therefore, there are needed to upgrade version of the library