### PR TITLE
Removes limitations from Dask dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -165,7 +165,8 @@ install_requires =
     termcolor>=1.1.0
     # typing-extensions can be removed under two scenarios: dropping support for python 3.7
     # or bumping the minimum version of airflow for providers to 2.2.* which would allow the use of airflow.typing_compat
-    typing-extensions>=3.7.4
+    # Kubernetes Tests also rely on typing-extensions < 4.0.0  - fixing the tests should allow to remove the upperbound
+    typing-extensions>=3.7.4,<4.0.0
     unicodecsv>=0.14.1
     # Werkzeug is known to cause breaking changes and it is very closely tied with FlaskAppBuilder and other
     # Flask dependencies and the limit to 1.* line should be reviewed when we upgrade Flask and remove

--- a/setup.py
+++ b/setup.py
@@ -251,10 +251,9 @@ cloudant = [
 dask = [
     # Dask support is limited, we need Dask team to upgrade support for dask if we were to continue
     # Supporting it in the future
-    # TODO: upgrade libraries used or maybe deprecate and drop DASK support
-    'cloudpickle>=1.4.1, <1.5.0',
-    'dask>=2.9.0, <2021.6.1',  # dask 2021.6.1 does not work with `distributed`
-    'distributed>=2.11.1, <2.20',
+    'cloudpickle>=1.4.1',
+    'dask>=2.9.0',
+    'distributed>=2.11.1',
 ]
 databricks = [
     'requests>=2.26.0, <3',


### PR DESCRIPTION
Dask dependencies were holding us back - when it comes to upgrading
somoe of the packages (for example apache-beam and looker - in google
provider). This PR removes the limitations but with a twist.

* Dask tests stop working. We reach out to the Dask Team to fix them
  but since a very old version of `distributed` library was used
  the Dask team is called for help to fix those

* The typing-extensions library was limited by `distributed` but it
  seems that version 4.0.0+ breaks kubernetes tests

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
