### PR TITLE
Add information on DAG pausing/deactivation/deletion

### DIFF
--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -745,3 +745,40 @@ the dependency graph.
 
 The dependency detector is configurable, so you can implement your own logic different than the defaults in
 :class:`~airflow.serialization.serialized_objects.DependencyDetector`
+
+DAG pausing, deactivation and deletion
+--------------------------------------
+
+The DAGs have several states when it comes to being "not running". DAGs can be paused, deactivated
+and finally all metadata for the DAG can be deleted.
+
+Dag can be paused via UI when it is present in the ``DAGS_FOLDER``, and scheduler stored it in
+the database, but the user chose to disable it via the UI. The "pause" and "unpause" actions are available
+via UI and API. Paused DAG is not scheduled by the Scheduler, but you can trigger them via UI for
+manual runs. In the UI, you can see Paused DAGs (in ``Paused`` tab). The DAGs that are un-paused
+can be found in the ``Active`` tab.
+
+Dag can be deactivated (do not confuse it with ``Active`` tag in the UI by removing them from the
+``DAGS_FOLDER``. When scheduler parses the ``DAGS_FOLDER`` and misses the DAG that it had seen
+before and stored in the database it will set is as deactivated. The metadata and history of the
+DAG` is kept for deactivated DAGs and when the DAG is re-added to the ``DAGS_FOLDER`` it will be again
+activated and history will be visible. You cannot activate/deactivate DAG via UI or API, this
+can only be done by removing files from the ``DAGS_FOLDER``. Once again - no data for historical runs of the
+DAG are lost when it is deactivated by the scheduler. Note that the ``Active`` tab in Airflow UI
+refers to DAGs that are not both ``Activated`` and ``Not paused`` so this might initially be a
+little confusing.
+
+You can't see the deactivated DAGs in the UI - you can sometimes see the historical runs, but when you try to
+see the information about those you will see the error that the DAG is missing.
+
+You can also delete the DAG metadata from the metadata database using UI or API, but it does not
+always result in disappearing of the DAG from the UI - which might be also initially a bit confusing.
+If the DAG is still in ``DAGS_FOLDER`` when you delete the metadata, the DAG will re-appear as
+Scheduler will parse the folder, only historical runs information for the DAG will be removed.
+
+This all means that if you want to actually delete a DAG and its all historical metadata, you need to do
+it in three steps:
+
+* pause the DAG
+* delete the historical metadata from the database, via UI or API
+* delete the DAG file from the ``DAGS_FOLDER`` and wait until it becomes inactive


### PR DESCRIPTION
Many of our users do not understand how DAG deactivation, deletion
works - it's quite straightforward for us, who understand how
scheduler, serialization and refresh works, but we have not really
documented everywhere what the differences are between pausing,
deactivation and actual deletion of the metadata.

It has been distributed in a few places (API documentation, comments
when you issued a "delete" UI action, but I found that there is no
single place where it is described.

This PR adds documentation in "DAG" page about it - explaining
what happens in those different states and instructing the user
to follow -> remove dag file -> wait for deactivation -> delete
pattern if they want to remove a DAG.

Related: #21864

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
