### PR TITLE
Fix failing main after merging SFTP hook test connection

### DIFF
--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -674,14 +674,14 @@ class TestConnection(unittest.TestCase):
     @mock.patch.dict(
         'os.environ',
         {
-            'AIRFLOW_CONN_TEST_URI_HOOK_METHOD_MISSING': 'ftp://',
+            'AIRFLOW_CONN_TEST_URI_HOOK_METHOD_MISSING': 'grpc://',
         },
     )
     def test_connection_test_hook_method_missing(self):
-        conn = Connection(conn_id='test_uri_hook_method_mising', conn_type='ftp')
+        conn = Connection(conn_id='test_uri_hook_method_missing', conn_type='grpc')
         res = conn.test_connection()
         assert res[0] is False
-        assert res[1] == "Hook FTPHook doesn't implement or inherit test_connection method"
+        assert res[1] == "Hook GrpcHook doesn't implement or inherit test_connection method"
 
     def test_extra_warnings_non_json(self):
         with pytest.warns(DeprecationWarning, match='non-JSON'):


### PR DESCRIPTION
The #21997 implemented test_connection method in FTP hook, but
we were using FTP hook to actually test .... what happens
when the test_connection method was missing :)

Unfortunately the test for it was not run because the "core"
tests are skipped in case only provider change :(.

This PR switches the test_connection missing test to use GRPC hook
(it does not have the test_connection method) and moves the whole
test_connection.py to "always" category of tests that are
always executed - there are more tests there that have some
assumptions on the existing connections and having the tests
executed "always" makes sense to avoid similar problems in the
future.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
