### PR TITLE
Fix mypy errors resulting from typing updates in marshmallow

### DIFF
--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -198,7 +198,7 @@ def _import_users(users_list: List[Dict[str, Any]]):
         UserSchema(many=True).load(users_list)
     except ValidationError as e:
         msg = []
-        for row_num, failure in e.messages.items():
+        for row_num, failure in e.normalized_messages().items():
             msg.append(f'[Item {row_num}]')
             for key, value in failure.items():
                 msg.append(f'\t{key}: {value}')


### PR DESCRIPTION
Marshmallow library has now better typing and mypy detected
a potential problem with messages not always being dict in
ValidationError. Switched to normalized_messages to fix it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
