### PR TITLE
Update limits of dependencies after dask test disabling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -163,10 +163,7 @@ install_requires =
     tabulate>=0.7.5
     tenacity>=6.2.0
     termcolor>=1.1.0
-    # typing-extensions can be removed under two scenarios: dropping support for python 3.7
-    # or bumping the minimum version of airflow for providers to 2.2.* which would allow the use of airflow.typing_compat
-    # Kubernetes Tests also rely on typing-extensions < 4.0.0  - fixing the tests should allow to remove the upperbound
-    typing-extensions>=3.7.4,<4.0.0
+    typing-extensions>=3.7.4
     unicodecsv>=0.14.1
     # Werkzeug is known to cause breaking changes and it is very closely tied with FlaskAppBuilder and other
     # Flask dependencies and the limit to 1.* line should be reviewed when we upgrade Flask and remove

--- a/setup.py
+++ b/setup.py
@@ -639,6 +639,9 @@ devel_only = [
     'pytest-xdist',
     'python-jose',
     'pywinrm',
+    # The Responses 0.19.0 released on 07.03.2022 break our S3 tests. This limitation should be
+    # Removed when https://github.com/getsentry/responses/issues/511 is solved.
+    'responses<0.19.0',
     'qds-sdk>=1.9.6',
     'pytest-httpx',
     'requests_mock',


### PR DESCRIPTION
Some of the tests failed previously with typing extensions above 4.
This PR attempts to relax the limit and check if the problems
still appear.

Also new tests (S3) started to fail when a new `responses` library
version has been released today.

So this change also add limits to the responses library in order
to make sure the tests pass.

Issue https://github.com/getsentry/responses/issues/511 has been
opened to raise it to `responses` library maintainers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
