### PR TITLE
Use timetable to generate planned days for current year

### DIFF
--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -162,7 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
         .attr('width', swatchesWidth / numSwatches)
         .attr('height', cellSize)
         .attr('class', 'day')
-        .attr('fill', (v) => d3.interpolateHsl(startColor, endColor)(v / numSwatches));
+        .attr('fill', (v) => (startColor.startsWith('url') ? startColor : d3.interpolateHsl(startColor, endColor)(v / numSwatches)));
       legendXOffset -= legendSwatchesPadding;
 
       if (leftState !== undefined) {
@@ -179,6 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     drawLegend('no_status');
+    drawLegend('planned');
     drawLegend('running');
     drawLegend('failed', 'success', 10, 100);
 

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -265,12 +265,17 @@ document.addEventListener('DOMContentLoaded', () => {
       .attr('height', cellSize)
       .attr('class', 'day')
       .attr('fill', (data) => {
-        const runningCount = (data.dagStates.running || [{ count: 0 }])[0].count;
+        const getCount = (state) => (data.dagStates[state] || [{ count: 0 }])[0].count;
+        const runningCount = getCount('running');
         if (runningCount > 0) return statesColors.running;
 
-        const successCount = (data.dagStates.success || [{ count: 0 }])[0].count;
-        const failedCount = (data.dagStates.failed || [{ count: 0 }])[0].count;
-        if (successCount + failedCount === 0) return statesColors.no_status;
+        const successCount = getCount('success');
+        const failedCount = getCount('failed');
+        if (successCount + failedCount === 0) {
+          const plannedCount = getCount('planned');
+          if (plannedCount > 0) return statesColors.planned;
+          return statesColors.no_status;
+        }
 
         let ratioFailures;
         if (failedCount === 0) ratioFailures = 0;

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -32,7 +32,11 @@
   <hr>
   <div id="svg_container">
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
-    <svg id="calendar-svg"></svg>
+    <svg id="calendar-svg">
+      <pattern id="calendar-svg-greydot" patternUnits="userSpaceOnUse" width="16" height="16">
+        <circle cx="8" cy="8" r="1.5" fill="#ddd"></circle>
+      </pattern>
+    </svg>
   </div>
 {% endblock %}
 
@@ -44,6 +48,7 @@
   <script>
     const statesColors = {};
     statesColors["no_status"] = "white";
+    statesColors["planned"] = "url(#calendar-svg-greydot)";
     {% for state in ['failed', 'success', 'running'] %}
       statesColors["{{state}}"] = "{{state_color_mapping[state]}}";
     {% endfor %}

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -34,7 +34,7 @@
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
     <svg id="calendar-svg">
       <pattern id="calendar-svg-greydot" patternUnits="userSpaceOnUse" width="16" height="16">
-        <circle cx="8" cy="8" r="1.5" fill="#ddd"></circle>
+        <circle cx="8" cy="8" r="2" fill="#a3a3a3"></circle>
       </pattern>
     </svg>
   </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -109,6 +109,7 @@ from airflow.providers_manager import ProvidersManager
 from airflow.security import permissions
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS
+from airflow.timetables.base import DataInterval, TimeRestriction
 from airflow.utils import json as utils_json, timezone, yaml
 from airflow.utils.dates import infer_time_unit, scale_time_units
 from airflow.utils.docs import get_doc_url_for_provider, get_docs_url
@@ -2548,6 +2549,8 @@ class Airflow(AirflowBaseView):
             session.query(
                 (_convert_to_date(session, DagRun.execution_date)).label('date'),
                 DagRun.state,
+                func.max(DagRun.data_interval_start).label('data_interval_start'),
+                func.max(DagRun.data_interval_end).label('data_interval_end'),
                 func.count('*').label('count'),
             )
             .filter(DagRun.dag_id == dag.dag_id)
@@ -2556,7 +2559,7 @@ class Airflow(AirflowBaseView):
             .all()
         )
 
-        dag_states = [
+        data_dag_states = [
             {
                 # DATE() in SQLite and MySQL behave differently:
                 # SQLite returns a string, MySQL returns a date.
@@ -2567,10 +2570,39 @@ class Airflow(AirflowBaseView):
             for dr in dag_states
         ]
 
+        if dag_states:
+            last_automated_data_interval = DataInterval(
+                dag_states[-1].data_interval_start, dag_states[-1].data_interval_end
+            )
+
+            year = last_automated_data_interval.end.year
+            restriction = TimeRestriction(dag.start_date, dag.end_date, False)
+            dates = collections.Counter()
+
+            while True:
+                info = dag.timetable.next_dagrun_info(
+                    last_automated_data_interval=last_automated_data_interval, restriction=restriction
+                )
+                if info is None:
+                    break
+
+                if info.logical_date.year != year:
+                    break
+
+                last_automated_data_interval = info.data_interval
+                dates[info.logical_date] += 1
+
+            data_dag_states.extend(
+                {'date': date.isoformat(), 'state': 'planned', 'count': count}
+                for (date, count) in dates.items()
+            )
+
+        now = DateTime.utcnow()
+
         data = {
-            'dag_states': dag_states,
+            'dag_states': data_dag_states,
             'start_date': (dag.start_date or DateTime.utcnow()).date().isoformat(),
-            'end_date': (dag.end_date or DateTime.utcnow()).date().isoformat(),
+            'end_date': (dag.end_date or now).date().isoformat(),
         }
 
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None))


### PR DESCRIPTION
This adds a new state "planned" to the calendar view which shows days where it is expected that we'll have a dag run.

The state is rendered as a grey dot to avoid confusion with existing states.

<img width="777" alt="Screenshot 2022-03-07 at 17 19 51" src="https://user-images.githubusercontent.com/26405/157075050-2bbe776e-ded6-4567-b002-841e82fcea54.png">
