### PR TITLE
Prepare for Python 3.10 adding

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1270,7 +1270,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1485,7 +1485,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1560,7 +1560,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1642,7 +1642,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1693,7 +1693,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1903,7 +1903,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -1987,7 +1987,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.
@@ -2402,7 +2402,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.10
 
   --platform PLATFORM
           Builds image for the platform specified.

--- a/breeze-complete
+++ b/breeze-complete
@@ -22,7 +22,7 @@
 # the ./scripts/ci/libraries/_initialization.sh and it is verified
 # Those cannot be made read-only as the breeze-complete must be re-sourceable
 
-_breeze_allowed_python_major_minor_versions="3.7 3.8 3.9"
+_breeze_allowed_python_major_minor_versions="3.7 3.8 3.9 3.10"
 _breeze_allowed_debian_versions="bullseye buster"
 _breeze_allowed_backends="sqlite mysql postgres mssql"
 _breeze_allowed_integrations="cassandra kerberos mongo openldap pinot rabbitmq redis statsd trino all"

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -32,7 +32,7 @@ DEFAULT_PYTHON_MAJOR_MINOR_VERSION = '3.7'
 DEFAULT_BACKEND = 'sqlite'
 
 # Checked before putting in build cache
-ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS = ['3.6', '3.7', '3.8', '3.9']
+ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS = ['3.7', '3.8', '3.9', '3.10']
 ALLOWED_BACKENDS = ['sqlite', 'mysql', 'postgres', 'mssql']
 ALLOWED_STATIC_CHECKS = [
     "all",
@@ -213,8 +213,8 @@ SQLITE_URL = "sqlite:////root/airflow/airflow.db"
 PYTHONDONTWRITEBYTECODE = True
 
 PRODUCTION_IMAGE = False
-ALL_PYTHON_MAJOR_MINOR_VERSIONS = ['3.6', '3.7', '3.8', '3.9']
-CURRENT_PYTHON_MAJOR_MINOR_VERSIONS = ['3.6', '3.7', '3.8', '3.9']
+ALL_PYTHON_MAJOR_MINOR_VERSIONS = ['3.7', '3.8', '3.9', '3.10']
+CURRENT_PYTHON_MAJOR_MINOR_VERSIONS = ['3.7', '3.8', '3.9', '3.10']
 CURRENT_POSTGRES_VERSIONS = ['10', '11', '12', '13']
 CURRENT_MYSQL_VERSIONS = ['5.7', '8']
 CURRENT_MSSQL_VERSIONS = ['2017-latest', '2019-latest']

--- a/dev/breeze/src/airflow_ci/find_newer_dependencies.py
+++ b/dev/breeze/src/airflow_ci/find_newer_dependencies.py
@@ -37,7 +37,7 @@ option_branch = click.option(
 
 option_python = click.option(
     "--python",
-    type=click.Choice(["3.7", "3.8", "3.9"]),
+    type=click.Choice(["3.7", "3.8", "3.9", "3.10"]),
     default="3.7",
     help="Python version used",
 )

--- a/dev/breeze/tests/test_cache.py
+++ b/dev/breeze/tests/test_cache.py
@@ -35,8 +35,8 @@ AIRFLOW_SOURCES = Path(__file__).parent.parent.parent.parent
     [
         ("backend", "mysql", (True, ['sqlite', 'mysql', 'postgres', 'mssql']), None),
         ("backend", "xxx", (False, ['sqlite', 'mysql', 'postgres', 'mssql']), None),
-        ("python_major_minor_version", "3.8", (True, ['3.6', '3.7', '3.8', '3.9']), None),
-        ("python_major_minor_version", "3.5", (False, ['3.6', '3.7', '3.8', '3.9']), None),
+        ("python_major_minor_version", "3.8", (True, ['3.7', '3.8', '3.9', '3.10']), None),
+        ("python_major_minor_version", "3.5", (False, ['3.7', '3.8', '3.9', '3.10']), None),
         ("missing", "value", None, AttributeError),
     ],
 )

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -117,7 +117,7 @@ function initialization::initialize_base_variables() {
     export PRODUCTION_IMAGE="false"
 
     # All supported major/minor versions of python in all versions of Airflow
-    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9")
+    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9" "3.10")
     export ALL_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported major/minor versions of python


### PR DESCRIPTION
We need to merge this change to `main` first before we
enable Python 3.10 in order to make sure our build-image
workflow is ready to build 3.10 images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
