### PR TITLE
Add `list-import-errors` to `airflow dags` command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -932,6 +932,12 @@ DAGS_COMMANDS = (
         args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE),
     ),
     ActionCommand(
+        name='list-import-errors',
+        help="List all the DAGs that have import errors",
+        func=lazy_load_command('airflow.cli.commands.dag_command.dag_list_import_errors'),
+        args=(ARG_SUBDIR, ARG_OUTPUT, ARG_VERBOSE),
+    ),
+    ActionCommand(
         name='report',
         help='Show DagBag loading report',
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_report'),

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -329,6 +329,20 @@ def dag_list_dags(args):
 
 @cli_utils.action_cli
 @suppress_logs_and_warning
+def dag_list_import_errors(args):
+    """Displays dags with import errors on the command line"""
+    dagbag = DagBag(process_subdir(args.subdir))
+    data = []
+    for filename, errors in dagbag.import_errors.items():
+        data.append({"filepath": filename, "error": errors})
+    AirflowConsole().print_as(
+        data=data,
+        output=args.output,
+    )
+
+
+@cli_utils.action_cli
+@suppress_logs_and_warning
 def dag_report(args):
     """Displays dagbag stats at the command line"""
     dagbag = DagBag(process_subdir(args.subdir))


### PR DESCRIPTION
This will help users to see the dags with import error and enable scripts
process the output
