### PR TITLE
Find Pod Before Cleanup In KubernetesPodOperator Execution

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -439,25 +439,24 @@ class KubernetesPodOperator(BaseOperator):
                 with _suppress(Exception):
                     for event in self.pod_manager.read_pod_events(pod).items:
                         self.log.error("Pod Event: %s - %s", event.reason, event.message)
-            if remote_pod is not None:
-                with _suppress(Exception):
-                    self.process_pod_deletion(pod)
+            with _suppress(Exception):
+                self.process_pod_deletion(remote_pod)
             error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)
             error_message = "\n" + error_message if error_message else ""
             raise AirflowException(
                 f'Pod {pod and pod.metadata.name} returned a failure:{error_message}\n{remote_pod}'
             )
         else:
-            if remote_pod is not None:
-                with _suppress(Exception):
-                    self.process_pod_deletion(pod)
+            with _suppress(Exception):
+                self.process_pod_deletion(remote_pod)
 
     def process_pod_deletion(self, pod):
-        if self.is_delete_operator_pod:
-            self.log.info("Deleting pod: %s", pod.metadata.name)
-            self.pod_manager.delete_pod(pod)
-        else:
-            self.log.info("skipping deleting pod: %s", pod.metadata.name)
+        if pod is not None:
+            if self.is_delete_operator_pod:
+                self.log.info("Deleting pod: %s", pod.metadata.name)
+                self.pod_manager.delete_pod(pod)
+            else:
+                self.log.info("skipping deleting pod: %s", pod.metadata.name)
 
     def _build_find_pod_label_selector(self, context: Optional[dict] = None, *, exclude_checked=True) -> str:
         labels = self._get_ti_pod_labels(context, include_try_number=False)

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -400,7 +400,7 @@ class KubernetesPodOperator(BaseOperator):
                 pod_request_obj=self.pod_request_obj,
                 context=context,
             )
-            # finding remote pod to ensure it exists
+            # get remote pod for use in cleanup methods
             remote_pod = self.find_pod(self.pod.metadata.namespace, context=context)
             self.await_pod_start(pod=self.pod)
 

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -87,7 +87,7 @@ def get_container_termination_message(pod: V1Pod, container_name: str):
         container_statuses = pod.status.container_statuses
         container_status = next(iter([x for x in container_statuses if x.name == container_name]), None)
         return container_status.state.terminated.message if container_status else None
-    except AttributeError:
+    except (AttributeError, TypeError):
         return None
 
 

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -660,7 +660,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             do_xcom_push=False,
         )
         # THEN
-        await_pod_completion_mock.return_value = None
+        await_pod_completion_mock.side_effect = AirflowException
         context = create_context(k)
         with pytest.raises(AirflowException):
             k.execute(context)

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -266,7 +266,10 @@ class TestKubernetesPodOperator:
         assert pod.spec.containers[0].image_pull_policy == "Always"
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.delete_pod")
-    def test_pod_delete_even_on_launcher_error(self, delete_pod_mock):
+    @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.find_pod")
+    def test_pod_delete_even_on_launcher_error(self, find_pod_mock, delete_pod_mock):
+        remote_pod_mock = MagicMock()
+        find_pod_mock.return_value = remote_pod_mock
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -285,6 +288,30 @@ class TestKubernetesPodOperator:
             context = create_context(k)
             k.execute(context=context)
         assert delete_pod_mock.called
+
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.delete_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.find_pod")
+    def test_pod_not_deleting_non_existing_pod(self, find_pod_mock, delete_pod_mock):
+
+        find_pod_mock.return_value = None
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context="default",
+            is_delete_operator_pod=True,
+        )
+        self.create_mock.side_effect = AirflowException("fake failure")
+        with pytest.raises(AirflowException):
+            context = create_context(k)
+            k.execute(context=context)
+        delete_pod_mock.assert_not_called()
 
     @pytest.mark.parametrize('randomize', [True, False])
     def test_provided_pod_name(self, randomize):
@@ -790,7 +817,6 @@ class TestKubernetesPodOperator:
             task_id="task",
         )
         self.run_pod(k)
-        k.client.list_namespaced_pod.assert_called_once()
         _, kwargs = k.client.list_namespaced_pod.call_args
         assert 'already_checked!=True' in kwargs['label_selector']
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -268,8 +268,6 @@ class TestKubernetesPodOperator:
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.delete_pod")
     @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.find_pod")
     def test_pod_delete_even_on_launcher_error(self, find_pod_mock, delete_pod_mock):
-        remote_pod_mock = MagicMock()
-        find_pod_mock.return_value = remote_pod_mock
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",


### PR DESCRIPTION
<!--

closes: #21169

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

As outlined in [this issue](https://github.com/apache/airflow/issues/21169), running multiple KubernetesPodOperators with  `random_name_suffix=False` and `is_delete_pod_operator=True` leads to
1. First task creating a pod (with name `'my_pod'` for example)
2. Second task attempting to create a pod with the same name and failing because a pod with name `'my_pod'` already exists
3. Second tasks deletes pod with name `'my_pod'`, which is the pod from the first task.

Ideally the second tasks shouldn't delete the pod from the first task, so I added a check to make sure a task's pod exists with the `find_pod` method before calling the `cleanup` function (which handles the deletion of the pod).

### Validation
To reproduce the issue and validate this change I ran two dag runs of the following DAG at the same time.
```python
from datetime import timedelta
from airflow import models
from airflow import utils
from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator

dag = models.DAG(
    'kubernetes_change_validation',
    start_date=utils.dates.days_ago(2),
    max_active_runs=3,
    dagrun_timeout=timedelta(minutes=5),
    schedule_interval='@daily'
)

test_kubernetes_pod= KubernetesPodOperator(
    namespace='my_namespace',
    image="busybox",
    cmds=['sh', '-c', 'sleep 600'],
    name="test_kubernetes_pod",
    in_cluster=True,
    task_id="test_kubernetes_pod",
    get_logs=True,
    random_name_suffix=False,
    dag=dag,
    is_delete_operator_pod=True
)
```


