### PR TITLE
bump moto version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -617,7 +617,7 @@ devel_only = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto>=3.0.3',
+    'moto>=3.0.7',
     'parameterized',
     'paramiko',
     'pipdeptree',
@@ -640,9 +640,6 @@ devel_only = [
     'pytest-xdist',
     'python-jose',
     'pywinrm',
-    # The Responses 0.19.0 released on 07.03.2022 break our S3 tests. This limitation should be
-    # Removed when https://github.com/getsentry/responses/issues/511 is solved.
-    'responses<0.19.0',
     'qds-sdk>=1.9.6',
     'pytest-httpx',
     'requests_mock',


### PR DESCRIPTION
We had to pin `responses` due to issue with moto lib https://github.com/apache/airflow/pull/22046

`moto` fixed the problem https://github.com/spulec/moto/issues/4913 in 3.0.7 so we can just bump `moto` and drop the `responses` limit.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
