### PR TITLE
limit sphinx-jinja

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ doc = [
     'sphinx-argparse>=0.1.13',
     'sphinx-autoapi>=1.8.0',
     'sphinx-copybutton',
-    'sphinx-jinja>=1.1',
+    'sphinx-jinja>=1.1, <2.0',
     'sphinx-rtd-theme>=0.1.6',
     'sphinxcontrib-httpdomain>=1.7.0',
     'sphinxcontrib-redoc>=1.6.0',

--- a/setup.py
+++ b/setup.py
@@ -275,6 +275,8 @@ doc = [
     'sphinx-argparse>=0.1.13',
     'sphinx-autoapi>=1.8.0',
     'sphinx-copybutton',
+    # we can remove the upper limit when we will apply the fix as explained in the change log:
+    # https://github.com/tardyp/sphinx-jinja/blob/d4f3ba9aa2b6a1217dfd90c676475d516e69b306/ChangeLog#L8-L16
     'sphinx-jinja>=1.1, <2.0',
     'sphinx-rtd-theme>=0.1.6',
     'sphinxcontrib-httpdomain>=1.7.0',


### PR DESCRIPTION
`sphinx-jinja` release new major version  which fails our doc build
https://pypi.org/project/sphinx-jinja/#history
causing PRs to fail on doc build:
https://github.com/apache/airflow/pull/22099

we can remove the limit when we will apply the fix needed as explained in the change log
https://github.com/tardyp/sphinx-jinja/blob/master/ChangeLog#L3


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
