### PR TITLE
Enhance `db upgrade` args

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1359,8 +1359,21 @@ DB_COMMANDS = (
     ActionCommand(
         name='upgrade',
         help="Upgrade the metadata database to latest version",
+        description=(
+            "Upgrade the schema of the metadata database. "
+            "To print but not execute commands, use option `--sql-only`. "
+            "If using options `--from-revision` or `--from-version`, you must also use `--sql-only`, "
+            "because if actually *running* migrations, we should only migrate from the *current* revision."
+        ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
-        args=(ARG_VERSION_RANGE, ARG_REVISION_RANGE),
+        args=(
+            ARG_DB_REVISION,
+            ARG_DB_VERSION,
+            ARG_DB_SQL,
+            ARG_YES,
+            ARG_DB_FROM_REVISION,
+            ARG_DB_FROM_VERSION,
+        ),
     ),
     ActionCommand(
         name='downgrade',

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -528,14 +528,14 @@ ARG_DB_UG_REVISION = Arg(
         "-r",
         "--revision",
     ),
-    help="(Optional) The airflow revision to upgrade to. Note: must provide either `--revision` or `--version`.",
+    help="(Optional) If provided, only run migrations up to and including this revision.",
 )
 ARG_DB_DG_VERSION = Arg(
     (
         "-n",
         "--version",
     ),
-    help="The airflow version to downgrade to. Note: must provide either `--revision` or `--version`.",
+    help="(Optional) If provided, only run migrations up to this version.",
 )
 ARG_DB_FROM_VERSION = Arg(
     ("--from-version",),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -516,7 +516,21 @@ ARG_MIGRATION_TIMEOUT = Arg(
     type=int,
     default=60,
 )
-ARG_DB_VERSION = Arg(
+ARG_DB_UG_VERSION = Arg(
+    (
+        "-n",
+        "--version",
+    ),
+    help="(Optional) The airflow version to upgrade to. Note: must provide either `--revision` or `--version`.",
+)
+ARG_DB_UG_REVISION = Arg(
+    (
+        "-r",
+        "--revision",
+    ),
+    help="(Optional) The airflow revision to upgrade to. Note: must provide either `--revision` or `--version`.",
+)
+ARG_DB_DG_VERSION = Arg(
     (
         "-n",
         "--version",
@@ -525,9 +539,9 @@ ARG_DB_VERSION = Arg(
 )
 ARG_DB_FROM_VERSION = Arg(
     ("--from-version",),
-    help="(Optional) If generating sql, may supply a _from_ version",
+    help="(Optional) If generating sql, may supply a *from* version",
 )
-ARG_DB_REVISION = Arg(
+ARG_DB_DG_REVISION = Arg(
     (
         "-r",
         "--revision",
@@ -536,7 +550,7 @@ ARG_DB_REVISION = Arg(
 )
 ARG_DB_FROM_REVISION = Arg(
     ("--from-revision",),
-    help="(Optional) If generating sql, may supply a _from_ revision",
+    help="(Optional) If generating sql, may supply a *from* revision",
 )
 ARG_DB_SQL_ONLY = Arg(
     ("-s", "--show-sql-only"),
@@ -1362,13 +1376,13 @@ DB_COMMANDS = (
         description=(
             "Upgrade the schema of the metadata database. "
             "To print but not execute commands, use option ``--show-sql-only``. "
-            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--shouw-sql-only``, "
+            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--show-sql-only``, "
             "because if actually *running* migrations, we should only migrate from the *current* revision."
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
         args=(
-            ARG_DB_REVISION,
-            ARG_DB_VERSION,
+            ARG_DB_UG_REVISION,
+            ARG_DB_UG_VERSION,
             ARG_DB_SQL_ONLY,
             ARG_DB_FROM_REVISION,
             ARG_DB_FROM_VERSION,
@@ -1386,8 +1400,8 @@ DB_COMMANDS = (
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.downgrade'),
         args=(
-            ARG_DB_REVISION,
-            ARG_DB_VERSION,
+            ARG_DB_DG_REVISION,
+            ARG_DB_DG_VERSION,
             ARG_DB_SQL_ONLY,
             ARG_YES,
             ARG_DB_FROM_REVISION,

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -516,36 +516,24 @@ ARG_MIGRATION_TIMEOUT = Arg(
     type=int,
     default=60,
 )
-ARG_DB_UG_VERSION = Arg(
-    (
-        "-n",
-        "--version",
-    ),
+ARG_DB_VERSION__UPGRADE = Arg(
+    ("-n", "--version"),
     help="(Optional) The airflow version to upgrade to. Note: must provide either `--revision` or `--version`.",
 )
-ARG_DB_UG_REVISION = Arg(
-    (
-        "-r",
-        "--revision",
-    ),
+ARG_DB_REVISION__UPGRADE = Arg(
+    ("-r", "--revision"),
     help="(Optional) If provided, only run migrations up to and including this revision.",
 )
-ARG_DB_DG_VERSION = Arg(
-    (
-        "-n",
-        "--version",
-    ),
+ARG_DB_VERSION__DOWNGRADE = Arg(
+    ("-n", "--version"),
     help="(Optional) If provided, only run migrations up to this version.",
 )
 ARG_DB_FROM_VERSION = Arg(
     ("--from-version",),
     help="(Optional) If generating sql, may supply a *from* version",
 )
-ARG_DB_DG_REVISION = Arg(
-    (
-        "-r",
-        "--revision",
-    ),
+ARG_DB_REVISION__DOWNGRADE = Arg(
+    ("-r", "--revision"),
     help="The airflow revision to downgrade to. Note: must provide either `--revision` or `--version`.",
 )
 ARG_DB_FROM_REVISION = Arg(
@@ -1381,8 +1369,8 @@ DB_COMMANDS = (
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
         args=(
-            ARG_DB_UG_REVISION,
-            ARG_DB_UG_VERSION,
+            ARG_DB_REVISION__UPGRADE,
+            ARG_DB_VERSION__UPGRADE,
             ARG_DB_SQL_ONLY,
             ARG_DB_FROM_REVISION,
             ARG_DB_FROM_VERSION,
@@ -1400,8 +1388,8 @@ DB_COMMANDS = (
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.downgrade'),
         args=(
-            ARG_DB_DG_REVISION,
-            ARG_DB_DG_VERSION,
+            ARG_DB_REVISION__DOWNGRADE,
+            ARG_DB_VERSION__DOWNGRADE,
             ARG_DB_SQL_ONLY,
             ARG_YES,
             ARG_DB_FROM_REVISION,

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1362,7 +1362,7 @@ DB_COMMANDS = (
         description=(
             "Upgrade the schema of the metadata database. "
             "To print but not execute commands, use option `--sql-only`. "
-            "If using options `--from-revision` or `--from-version`, you must also use `--sql-only`, "
+            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--sql-only``, "
             "because if actually *running* migrations, we should only migrate from the *current* revision."
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1370,7 +1370,6 @@ DB_COMMANDS = (
             ARG_DB_REVISION,
             ARG_DB_VERSION,
             ARG_DB_SQL,
-            ARG_YES,
             ARG_DB_FROM_REVISION,
             ARG_DB_FROM_VERSION,
         ),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -518,7 +518,10 @@ ARG_MIGRATION_TIMEOUT = Arg(
 )
 ARG_DB_VERSION__UPGRADE = Arg(
     ("-n", "--version"),
-    help="(Optional) The airflow version to upgrade to. Note: must provide either `--revision` or `--version`.",
+    help=(
+        "(Optional) The airflow version to upgrade to. Note: must provide either "
+        "`--revision` or `--version`."
+    ),
 )
 ARG_DB_REVISION__UPGRADE = Arg(
     ("-r", "--revision"),
@@ -1364,8 +1367,9 @@ DB_COMMANDS = (
         description=(
             "Upgrade the schema of the metadata database. "
             "To print but not execute commands, use option ``--show-sql-only``. "
-            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--show-sql-only``, "
-            "because if actually *running* migrations, we should only migrate from the *current* revision."
+            "If using options ``--from-revision`` or ``--from-version``, you must also use "
+            "``--show-sql-only``, because if actually *running* migrations, we should only "
+            "migrate from the *current* revision."
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
         args=(

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -538,8 +538,8 @@ ARG_DB_FROM_REVISION = Arg(
     ("--from-revision",),
     help="(Optional) If generating sql, may supply a _from_ revision",
 )
-ARG_DB_SQL = Arg(
-    ("-s", "--sql-only"),
+ARG_DB_SQL_ONLY = Arg(
+    ("-s", "--show-sql-only"),
     help="Don't actually run migrations; just print out sql scripts for offline migration. "
     "Required if using either `--from-version` or `--from-version`.",
     action="store_true",
@@ -1361,15 +1361,15 @@ DB_COMMANDS = (
         help="Upgrade the metadata database to latest version",
         description=(
             "Upgrade the schema of the metadata database. "
-            "To print but not execute commands, use option `--sql-only`. "
-            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--sql-only``, "
+            "To print but not execute commands, use option ``--show-sql-only``. "
+            "If using options ``--from-revision`` or ``--from-version``, you must also use ``--shouw-sql-only``, "
             "because if actually *running* migrations, we should only migrate from the *current* revision."
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.upgradedb'),
         args=(
             ARG_DB_REVISION,
             ARG_DB_VERSION,
-            ARG_DB_SQL,
+            ARG_DB_SQL_ONLY,
             ARG_DB_FROM_REVISION,
             ARG_DB_FROM_VERSION,
         ),
@@ -1380,15 +1380,15 @@ DB_COMMANDS = (
         description=(
             "Downgrade the schema of the metadata database. "
             "You must provide either `--revision` or `--version`. "
-            "To print but not execute commands, use option `--sql-only`. "
-            "If using options `--from-revision` or `--from-version`, you must also use `--sql-only`, "
+            "To print but not execute commands, use option `--show-sql-only`. "
+            "If using options `--from-revision` or `--from-version`, you must also use `--show-sql-only`, "
             "because if actually *running* migrations, we should only migrate from the *current* revision."
         ),
         func=lazy_load_command('airflow.cli.commands.db_command.downgrade'),
         args=(
             ARG_DB_REVISION,
             ARG_DB_VERSION,
-            ARG_DB_SQL,
+            ARG_DB_SQL_ONLY,
             ARG_YES,
             ARG_DB_FROM_REVISION,
             ARG_DB_FROM_VERSION,

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -161,7 +161,6 @@ def connections_add(args):
     # Check that the conn_id and conn_uri args were passed to the command:
     missing_args = []
     invalid_args = []
-    print(args.__class__)
     if args.conn_uri:
         if not _valid_uri(args.conn_uri):
             raise SystemExit(f'The URI provided to --conn-uri is invalid: {args.conn_uri}')

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -161,6 +161,7 @@ def connections_add(args):
     # Check that the conn_id and conn_uri args were passed to the command:
     missing_args = []
     invalid_args = []
+    print(args.__class__)
     if args.conn_uri:
         if not _valid_uri(args.conn_uri):
             raise SystemExit(f'The URI provided to --conn-uri is invalid: {args.conn_uri}')

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -17,7 +17,6 @@
 """Database sub-commands"""
 import os
 import textwrap
-import typing
 from tempfile import NamedTemporaryFile
 
 from packaging.version import parse as parse_version
@@ -54,8 +53,10 @@ def upgradedb(args):
         raise SystemExit("Cannot supply both `--revision` and `--version`.")
     if args.from_version and args.from_revision:
         raise SystemExit("Cannot supply both `--from-revision` and `--from-version`")
-    if (args.from_revision or args.from_version) and not args.sql_only:
-        raise SystemExit("Args `--from-revision` and `--from-version` may only be used with `--sql-only`")
+    if (args.from_revision or args.from_version) and not args.show_sql_only:
+        raise SystemExit(
+            "Args `--from-revision` and `--from-version` may only be used with `--show-sql-only`"
+        )
     revision = None
     from_revision = None
     if args.from_revision:
@@ -74,13 +75,13 @@ def upgradedb(args):
     elif args.revision:
         revision = args.revision
 
-    if not args.sql_only:
+    if not args.show_sql_only:
         print("Performing upgrade with database " + repr(settings.engine.url))
     else:
         print("Generating sql for upgrade -- upgrade commands will *not* be submitted.")
 
-    db.upgradedb(to_revision=revision, from_revision=from_revision, sql=args.sql_only)
-    if not args.sql_only:
+    db.upgradedb(to_revision=revision, from_revision=from_revision, show_sql_only=args.show_sql_only)
+    if not args.show_sql_only:
         print("Upgrades done")
 
 
@@ -91,8 +92,10 @@ def downgrade(args):
         raise SystemExit("Cannot supply both `revision` and `version`.")
     if args.from_version and args.from_revision:
         raise SystemExit("`--from-revision` may not be combined with `--from-version`")
-    if (args.from_revision or args.from_version) and not args.sql_only:
-        raise SystemExit("Args `--from-revision` and `--from-version` may only be used with `--sql-only`")
+    if (args.from_revision or args.from_version) and not args.show_sql_only:
+        raise SystemExit(
+            "Args `--from-revision` and `--from-version` may only be used with `--show-sql-only`"
+        )
     if not (args.version or args.revision):
         raise SystemExit("Must provide either revision or version.")
     from_revision = None
@@ -108,12 +111,12 @@ def downgrade(args):
             raise SystemExit(f"Downgrading to version {args.version} is not supported.")
     elif args.revision:
         revision = args.revision
-    if not args.sql_only:
+    if not args.show_sql_only:
         print("Performing downgrade with database " + repr(settings.engine.url))
     else:
         print("Generating sql for downgrade -- downgrade commands will *not* be submitted.")
 
-    if args.sql_only or (
+    if args.show_sql_only or (
         args.yes
         or input(
             "\nWarning: About to reverse schema migrations for the airflow metastore. "
@@ -122,8 +125,8 @@ def downgrade(args):
         ).upper()
         == "Y"
     ):
-        db.downgrade(to_revision=revision, from_revision=from_revision, sql=args.sql_only)
-        if not args.sql_only:
+        db.downgrade(to_revision=revision, from_revision=from_revision, show_sql_only=args.show_sql_only)
+        if not args.show_sql_only:
             print("Downgrade complete")
     else:
         raise SystemExit("Cancelled")

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -20,6 +20,8 @@ import textwrap
 import typing
 from tempfile import NamedTemporaryFile
 
+from packaging.version import parse as parse_version
+
 from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils import cli as cli_utils, db
@@ -62,6 +64,8 @@ def upgradedb(args):
     if args.from_revision:
         from_revision = args.from_revision
     elif args.from_version:
+        if parse_version(args.from_version) < parse_version('2.0.0'):
+            raise SystemExit("From version must be greater than 2.0.0")
         from_revision = REVISION_HEADS_MAP.get(args.from_version)
         if not from_revision:
             raise SystemExit(f"Unknown version {args.from_version!r} supplied as `--from-version`.")

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -63,7 +63,7 @@ def upgradedb(args):
         from_revision = args.from_revision
     elif args.from_version:
         if parse_version(args.from_version) < parse_version('2.0.0'):
-            raise SystemExit("From version must be greater or equal to than 2.0.0")
+            raise SystemExit("--from-version must be greater or equal to than 2.0.0")
         from_revision = REVISION_HEADS_MAP.get(args.from_version)
         if not from_revision:
             raise SystemExit(f"Unknown version {args.from_version!r} supplied as `--from-version`.")

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -19,7 +19,6 @@ import os
 import textwrap
 import typing
 from tempfile import NamedTemporaryFile
-from typing import Dict, List, Optional
 
 from airflow import settings
 from airflow.exceptions import AirflowException
@@ -29,7 +28,7 @@ from airflow.utils.db_cleanup import config_dict, run_cleanup
 from airflow.utils.process_utils import execute_interactive
 
 if typing.TYPE_CHECKING:
-    from argparse import Namespace
+    pass
 
 
 def initdb(args):
@@ -52,8 +51,34 @@ def resetdb(args):
 def upgradedb(args):
     """Upgrades the metadata database"""
     print("DB: " + repr(settings.engine.url))
-    db.upgradedb(version_range=args.range, revision_range=args.revision_range)
-    print("Upgrades done")
+    if args.revision and args.version:
+        raise SystemExit("Cannot supply both `revision` and `version`.")
+    if args.from_version and args.from_revision:
+        raise SystemExit("`--from-revision` may not be combined with `--from-version`")
+    if (args.from_revision or args.from_version) and not args.sql_only:
+        raise SystemExit("Args `--from-revision` and `--from-version` may only be used with `--sql-only`")
+    revision = None
+    from_revision = None
+    if args.from_revision:
+        from_revision = args.from_revision
+    elif args.from_version:
+        from_revision = REVISION_HEADS_MAP.get(args.from_version)
+        if not from_revision:
+            raise SystemExit(f"Unknown version {args.from_version!r} supplied as `--from-version`.")
+    if args.version:
+        revision = REVISION_HEADS_MAP.get(args.version)
+        if not revision:
+            raise SystemExit(f"Upgrading to version {args.version} is not supported.")
+    elif args.revision:
+        revision = args.revision
+    if not args.sql_only:
+        print("Performing upgrade with database " + repr(settings.engine.url))
+    else:
+        print("Generating sql for upgrade -- upgrade commands will *not* be submitted.")
+
+    db.upgradedb(to_revision=revision, from_revision=from_revision, sql=args.sql_only)
+    if not args.sql_only:
+        print("Upgrades done")
 
 
 @cli_utils.action_cli(check_db=False)
@@ -95,49 +120,6 @@ def downgrade(args):
         == "Y"
     ):
         db.downgrade(to_revision=revision, from_revision=from_revision, sql=args.sql_only)
-        if not args.sql_only:
-            print("Downgrade complete")
-    else:
-        raise SystemExit("Cancelled")
-
-
-@cli_utils.action_cli(check_db=False)
-def upgrade2(args):
-    """Upgrades the metadata database"""
-    if args.revision and args.version:
-        raise SystemExit("Cannot supply both `revision` and `version`.")
-    if args.from_version and args.from_revision:
-        raise SystemExit("`--from-revision` may not be combined with `--from-version`")
-    if (args.from_revision or args.from_version) and not args.sql_only:
-        raise SystemExit("Args `--from-revision` and `--from-version` may only be used with `--sql-only`")
-    from_revision = None
-    if args.from_revision:
-        from_revision = args.from_revision
-    elif args.from_version:
-        from_revision = REVISION_HEADS_MAP.get(args.from_version)
-        if not from_revision:
-            raise SystemExit(f"Unknown version {args.version!r} supplied as `--from-version`.")
-    if args.version:
-        revision = REVISION_HEADS_MAP.get(args.version)
-        if not revision:
-            raise SystemExit(f"Downgrading to version {args.version} is not supported.")
-    elif args.revision:
-        revision = args.revision
-    if not args.sql_only:
-        print("Performing downgrade with database " + repr(settings.engine.url))
-    else:
-        print("Generating sql for downgrade -- downgrade commands will *not* be submitted.")
-
-    if args.sql_only or (
-        args.yes
-        or input(
-            "\nWarning: About to reverse schema migrations for the airflow metastore. "
-            "Please ensure you have backed up your database before any upgrade or "
-            "downgrade operation. Proceed? (y/n)\n"
-        ).upper()
-        == "Y"
-    ):
-        db.upgradedb(to_revision=revision, from_revision=from_revision, sql=args.sql_only)
         if not args.sql_only:
             print("Downgrade complete")
     else:

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -29,9 +29,6 @@ from airflow.utils.db import REVISION_HEADS_MAP
 from airflow.utils.db_cleanup import config_dict, run_cleanup
 from airflow.utils.process_utils import execute_interactive
 
-if typing.TYPE_CHECKING:
-    pass
-
 
 def initdb(args):
     """Initializes the metadata database"""
@@ -54,9 +51,9 @@ def upgradedb(args):
     """Upgrades the metadata database"""
     print("DB: " + repr(settings.engine.url))
     if args.revision and args.version:
-        raise SystemExit("Cannot supply both `revision` and `version`.")
+        raise SystemExit("Cannot supply both `--revision` and `--version`.")
     if args.from_version and args.from_revision:
-        raise SystemExit("`--from-revision` may not be combined with `--from-version`")
+        raise SystemExit("Cannot supply both `--from-revision` and `--from-version`")
     if (args.from_revision or args.from_version) and not args.sql_only:
         raise SystemExit("Args `--from-revision` and `--from-version` may only be used with `--sql-only`")
     revision = None
@@ -65,16 +62,18 @@ def upgradedb(args):
         from_revision = args.from_revision
     elif args.from_version:
         if parse_version(args.from_version) < parse_version('2.0.0'):
-            raise SystemExit("From version must be greater than 2.0.0")
+            raise SystemExit("From version must be greater or equal to than 2.0.0")
         from_revision = REVISION_HEADS_MAP.get(args.from_version)
         if not from_revision:
             raise SystemExit(f"Unknown version {args.from_version!r} supplied as `--from-version`.")
+
     if args.version:
         revision = REVISION_HEADS_MAP.get(args.version)
         if not revision:
             raise SystemExit(f"Upgrading to version {args.version} is not supported.")
     elif args.revision:
         revision = args.revision
+
     if not args.sql_only:
         print("Performing upgrade with database " + repr(settings.engine.url))
     else:

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1125,8 +1125,10 @@ def upgradedb(
 ):
     """
 
-    :param to_revision: Optional Alembic revision ID to upgrade *to*.  If omitted, upgrades to latest revision.
-    :param from_revision: Optional Alembic revision ID to upgrade *from*.  Not compatible with ``sql_only=False``.
+    :param to_revision: Optional Alembic revision ID to upgrade *to*.
+        If omitted, upgrades to latest revision.
+    :param from_revision: Optional Alembic revision ID to upgrade *from*.
+        Not compatible with ``sql_only=False``.
     :param sql: if True, migration statements will be printed but not executed.
     :param session: sqlalchemy session with connection to Airflow metadata database
     :return: None
@@ -1143,8 +1145,6 @@ def upgradedb(
     config = _get_alembic_config()
 
     if sql:
-        # _validate_version_for_offline_migration(from_version)  # only for offline migration
-        # if no changes between revisions, raise: list(script.revision_map.iterate_revisions(to_revision, from_revision))
         if not from_revision:
             from_revision = _get_current_revision(session)
 

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1163,7 +1163,7 @@ def upgradedb(
         _revisions_above_min_for_offline(config=config, revisions=[from_revision, to_revision])
 
         _offline_migration(command.upgrade, config, f"{from_revision}:{to_revision}")
-        return
+        return  # only running sql; our job is done
 
     errors_seen = False
     for err in _check_migration_errors(session=session):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1074,7 +1074,6 @@ def print_happy_cat(message):
     print("""(='_' )""".center(size))
     print("""(,(") (")""".center(size))
     print("""^^^""".center(size))
-    return
 
 
 def _revision_greater(config, this_rev, base_rev):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1074,6 +1074,7 @@ def print_happy_cat(message):
     print("""(='_' )""".center(size))
     print("""(,(") (")""".center(size))
     print("""^^^""".center(size))
+    return
 
 
 def _revision_greater(config, this_rev, base_rev):
@@ -1104,8 +1105,6 @@ def _revisions_above_min_for_offline(config, revisions):
     # Check if there is history between the revisions and the start revision
     # This ensures that the revisions are above `min_revision`
     for rev in revisions:
-        if not rev:
-            raise ValueError('unexpected')
         if not _revision_greater(config, rev, min_revision):
             raise ValueError(
                 f"Error while checking history for revision range {min_revision}:{rev}. "
@@ -1147,9 +1146,6 @@ def upgradedb(
     if show_sql_only:
         if not from_revision:
             from_revision = _get_current_revision(session)
-
-        if not from_revision and to_revision:
-            raise Exception('unexpected')
 
         if to_revision == from_revision:
             print_happy_cat("No migrations to apply; nothing to do.")

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1135,7 +1135,7 @@ def upgradedb(
     :rtype: None
     """
     if from_revision and not sql:
-        raise Exception("`from_revision` only supported with `sql_only=True`.")
+        raise AirflowException("`from_revision` only supported with `sql_only=True`.")
 
     # alembic adds significant import time, so we import it lazily
     if not settings.SQL_ALCHEMY_CONN:

--- a/docs/apache-airflow/usage-cli.rst
+++ b/docs/apache-airflow/usage-cli.rst
@@ -254,8 +254,8 @@ Downgrading Airflow
 
 You can downgrade to a particular Airflow version with the ``db downgrade`` command.  Alternatively you may provide an Alembic revision id to downgrade to.
 
-If you want to preview the commands but not execute them, use option ``--sql-only``.
+If you want to preview the commands but not execute them, use option ``--show-sql-only``.
 
-Options ``--from-revision`` and ``--from-version`` may only be used in conjunction with the ``--sql-only`` option, because when actually *running* migrations we should always downgrade from current revision.
+Options ``--from-revision`` and ``--from-version`` may only be used in conjunction with the ``--show-sql-only`` option, because when actually *running* migrations we should always downgrade from current revision.
 
 For a mapping between Airflow version and Alembic revision see :doc:`/migrations-ref`.

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -99,11 +99,6 @@ class TestCliDb:
         with pytest.raises(SystemExit, match=pattern):
             db_command.upgradedb(self.parser.parse_args(['db', 'upgrade', *args]))
 
-    @mock.patch("airflow.cli.commands.db_command.db.upgradedb")
-    def test_no_changes(self, mock_upgradedb, args, pattern):
-        """test that when from rev and to rev are same, throw error or something"""
-        raise Exception()
-
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
     @mock.patch("airflow.cli.commands.db_command.NamedTemporaryFile")
     @mock.patch(

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -99,6 +99,11 @@ class TestCliDb:
         with pytest.raises(SystemExit, match=pattern):
             db_command.upgradedb(self.parser.parse_args(['db', 'upgrade', *args]))
 
+    @mock.patch("airflow.cli.commands.db_command.db.upgradedb")
+    def test_no_changes(self, mock_upgradedb, args, pattern):
+        """test that when from rev and to rev are same, throw error or something"""
+        raise Exception()
+
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
     @mock.patch("airflow.cli.commands.db_command.NamedTemporaryFile")
     @mock.patch(

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 
 import pendulum
 import pytest
+from pytest import param
 from sqlalchemy.engine.url import make_url
 
 from airflow.cli import cli_parser
@@ -88,10 +89,22 @@ class TestCliDb:
     @pytest.mark.parametrize(
         'args, pattern',
         [
-            (['--version', '2.1.25'], 'not supported'),
-            (['--revision', 'abc', '--from-revision', 'abc123'], 'used with `--sql-only`'),
-            (['--revision', 'abc', '--from-version', '2.0.2'], 'used with `--sql-only`'),
-            (['--revision', 'abc', '--from-version', '2.1.25', '--sql-only'], 'Unknown version'),
+            param(['--version', '2.1.25'], 'not supported', id='bad version'),
+            param(
+                ['--revision', 'abc', '--from-revision', 'abc123'],
+                'used with `--sql-only`',
+                id='requires offline',
+            ),
+            param(
+                ['--revision', 'abc', '--from-version', '2.0.2'],
+                'used with `--sql-only`',
+                id='requires offline',
+            ),
+            param(
+                ['--revision', 'abc', '--from-version', '2.1.25', '--sql-only'],
+                'Unknown version',
+                id='bad version',
+            ),
         ],
     )
     @mock.patch("airflow.cli.commands.db_command.db.upgradedb")

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -122,16 +122,6 @@ class TestDb:
 
     @pytest.mark.parametrize(
         'from_revision, to_revision',
-        [('be2bfac3da23', 'e959f08ac86c'), ("ccde3e26fe78", "2e42bb497a22")],
-    )
-    def test_offline_upgrade_version(self, from_revision, to_revision):
-        with mock.patch('airflow.utils.db.settings.engine.dialect'):
-            with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb(to_revision=to_revision, from_revision=from_revision, show_sql_only=True)
-        mock_alembic_upgrade.assert_called_once_with(mock.ANY, f"{from_revision}:{to_revision}", sql=True)
-
-    @pytest.mark.parametrize(
-        'from_revision, to_revision',
         [('be2bfac3da23', 'e959f08ac86c'), ('ccde3e26fe78', '2e42bb497a22')],
     )
     def test_offline_upgrade_wrong_order(self, from_revision, to_revision):
@@ -146,7 +136,7 @@ class TestDb:
             ('e959f08ac86c', 'e959f08ac86c'),
         ],
     )
-    def test_offline_upgrade_version(self, from_revision, to_revision):
+    def test_offline_upgrade_revision_nothing(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade'):
                 with redirect_stdout(io.StringIO()) as temp_stdout:
@@ -156,10 +146,7 @@ class TestDb:
 
     @pytest.mark.parametrize(
         'from_revision, to_revision',
-        [
-            ("90d1635d7b86", "54bebd308c5f"),
-            ("e959f08ac86c", "587bdf053233"),
-        ],
+        [("90d1635d7b86", "54bebd308c5f"), ("e959f08ac86c", "587bdf053233")],
     )
     def test_offline_upgrade_revision(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -17,7 +17,9 @@
 # under the License.
 
 import inspect
+import io
 import re
+from contextlib import redirect_stdout
 from unittest import mock
 
 import pytest
@@ -116,103 +118,71 @@ class TestDb:
     @mock.patch('alembic.command')
     def test_upgradedb(self, mock_alembic_command):
         upgradedb()
-        mock_alembic_command.upgrade.assert_called_once_with(mock.ANY, 'heads')
+        mock_alembic_command.upgrade.assert_called_once_with(mock.ANY, revision='heads')
 
     @pytest.mark.parametrize(
-        'version, revision',
-        [('2.0.0:2.2.3', "e959f08ac86c:be2bfac3da23"), ("2.0.2:2.1.4", "2e42bb497a22:ccde3e26fe78")],
+        'to_revision, from_revision',
+        [('be2bfac3da23', 'e959f08ac86c'), ("ccde3e26fe78", "2e42bb497a22")],
     )
-    def test_offline_upgrade_version(self, version, revision):
+    def test_offline_upgrade_version(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb(version_range=version)
-        mock_alembic_upgrade.assert_called_once_with(mock.ANY, revision, sql=True)
+                upgradedb(to_revision, from_revision, sql=True)
+        mock_alembic_upgrade.assert_called_once_with(mock.ANY, f"{from_revision}:{to_revision}", sql=True)
 
     @pytest.mark.parametrize(
-        'version, revision',
-        [('2.2.3:2.0.0', "be2bfac3da23:e959f08ac86c"), ("2.1.4:2.0.2", "ccde3e26fe78:2e42bb497a22")],
+        'to_revision, from_revision',
+        [('e959f08ac86c', 'be2bfac3da23'), ("2e42bb497a22", "ccde3e26fe78")],
     )
-    def test_offline_upgrade_fails_for_migration_incorrect_versions(self, version, revision):
+    def test_offline_upgrade_version(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
-            with pytest.raises(AirflowException) as e:
-                upgradedb(version)
-        assert e.exconly() == (
-            f"airflow.exceptions.AirflowException: "
-            f"Error while checking history for revision range {revision}. "
-            f"Check that the supplied airflow version is in the format 'old_version:new_version'."
-        )
+            with mock.patch('alembic.command.upgrade'):
+                with pytest.raises(ValueError, match='to.* revision .* older than .*from'):
+                    upgradedb(to_revision, from_revision, sql=True)
 
     @pytest.mark.parametrize(
-        'version, error',
+        'to_revision, from_revision',
         [
-            ('2.2.3', 'Please provide Airflow version range with the format "old_version:new_version"'),
-            ("2.1.2:2.1.5", "Please provide valid Airflow versions above 2.0.0."),
+            ('e959f08ac86c', 'e959f08ac86c'),
         ],
     )
-    def test_offline_upgrade_fails_for_migration_single_versions_or_not_existing_head(self, version, error):
-        with pytest.raises(AirflowException) as e:
-            upgradedb(version)
-        assert e.exconly() == (f"airflow.exceptions.AirflowException: {error}")
+    def test_offline_upgrade_version(self, from_revision, to_revision):
+        with mock.patch('airflow.utils.db.settings.engine.dialect'):
+            with mock.patch('alembic.command.upgrade'):
+                with redirect_stdout(io.StringIO()) as temp_stdout:
+                    upgradedb(to_revision, from_revision, sql=True)
+                stdout = temp_stdout.getvalue()
+                assert 'nothing to do' in stdout
 
-    @pytest.mark.parametrize('revision', ['90d1635d7b86:54bebd308c5f', "e959f08ac86c:587bdf053233"])
-    def test_offline_upgrade_revision(self, revision):
+    @pytest.mark.parametrize(
+        'from_revision, to_revision',
+        [
+            ("90d1635d7b86", "54bebd308c5f"),
+            ("e959f08ac86c", "587bdf053233"),
+        ],
+    )
+    def test_offline_upgrade_revision(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb(revision_range=revision)
-        mock_alembic_upgrade.assert_called_once_with(mock.ANY, revision, sql=True)
+                upgradedb(from_revision=from_revision, to_revision=to_revision, sql=True)
+        mock_alembic_upgrade.assert_called_once_with(mock.ANY, f"{from_revision}:{to_revision}", sql=True)
 
     def test_offline_upgrade_fails_for_migration_less_than_2_0_0_head(self):
-        rev_2_0_0_head = 'e959f08ac86c'
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
-            with pytest.raises(AirflowException) as e:
-                upgradedb(revision_range='e1a11ece99cc:54bebd308c5f')
-        revision = f"{rev_2_0_0_head}:e1a11ece99cc"
-        assert e.exconly() == (
-            f"airflow.exceptions.AirflowException: "
-            f"Error while checking history for revision range {revision}. "
-            f"Check that {revision.split(':')[1]} is a valid revision. "
-            f"Supported revision for offline migration is from {rev_2_0_0_head} "
-            f"which is airflow 2.0.0 head"
-        )
+            with pytest.raises(ValueError, match='Check that e1a11ece99cc is a valid revision'):
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
 
     def test_sqlite_offline_upgrade_raises_with_revision(self):
         with mock.patch('airflow.utils.db.settings.engine.dialect') as dialect:
             dialect.name = 'sqlite'
-            with pytest.raises(AirflowException) as e:
-                upgradedb(revision_range='e1a11ece99cc:54bebd308c5f')
-        assert e.exconly() == (
-            "airflow.exceptions.AirflowException: SQLite is not supported for offline migration."
-        )
-
-    def test_sqlite_offline_upgrade_raises_with_version(self):
-        with mock.patch('airflow.utils.db.settings.engine.dialect') as dialect:
-            dialect.name = 'sqlite'
-            with pytest.raises(AirflowException) as e:
-                upgradedb(revision_range='2.0.0:2.2.3')
-        assert e.exconly() == (
-            "airflow.exceptions.AirflowException: SQLite is not supported for offline migration."
-        )
+            with pytest.raises(AirflowException, match='Offline migration not supported for SQLite') as e:
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
 
     def test_offline_upgrade_fails_for_migration_less_than_2_2_0_head_for_mssql(self):
-        rev_2_2_0_head = '7b2661a43ba3'
         with mock.patch('airflow.utils.db.settings.engine.dialect') as dialect:
             dialect.name = 'mssql'
-            with pytest.raises(AirflowException) as e:
-                upgradedb(revision_range='e1a11ece99cc:54bebd308c5f')
-        revision = f"{rev_2_2_0_head}:e1a11ece99cc"
-        assert e.exconly() == (
-            f"airflow.exceptions.AirflowException: "
-            f"Error while checking history for revision range {revision}. "
-            f"Check that {revision.split(':')[1]} is a valid revision. "
-            f"Supported revision for offline migration is from {rev_2_2_0_head} "
-            f"which is airflow 2.2.0 head"
-        )
-
-    def test_versions_without_migration_donot_raise(self):
-        with mock.patch('airflow.utils.db.settings.engine.dialect'):
-            with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb("2.1.1:2.1.2")
-        mock_alembic_upgrade.assert_not_called()
+            with pytest.raises(ValueError, match='Check that .* is a valid .* For dialect \'mssql\''):
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
 
     @mock.patch('airflow.utils.db._offline_migration')
     def test_downgrade_sql_no_from(self, mock_om):

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -127,7 +127,7 @@ class TestDb:
     def test_offline_upgrade_version(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb(to_revision=to_revision, from_revision=from_revision, sql=True)
+                upgradedb(to_revision=to_revision, from_revision=from_revision, show_sql_only=True)
         mock_alembic_upgrade.assert_called_once_with(mock.ANY, f"{from_revision}:{to_revision}", sql=True)
 
     @pytest.mark.parametrize(
@@ -138,7 +138,7 @@ class TestDb:
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade'):
                 with pytest.raises(ValueError, match='to.* revision .* older than .*from'):
-                    upgradedb(from_revision=from_revision, to_revision=to_revision, sql=True)
+                    upgradedb(from_revision=from_revision, to_revision=to_revision, show_sql_only=True)
 
     @pytest.mark.parametrize(
         'to_revision, from_revision',
@@ -150,7 +150,7 @@ class TestDb:
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade'):
                 with redirect_stdout(io.StringIO()) as temp_stdout:
-                    upgradedb(to_revision=to_revision, from_revision=from_revision, sql=True)
+                    upgradedb(to_revision=to_revision, from_revision=from_revision, show_sql_only=True)
                 stdout = temp_stdout.getvalue()
                 assert 'nothing to do' in stdout
 
@@ -164,35 +164,35 @@ class TestDb:
     def test_offline_upgrade_revision(self, from_revision, to_revision):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with mock.patch('alembic.command.upgrade') as mock_alembic_upgrade:
-                upgradedb(from_revision=from_revision, to_revision=to_revision, sql=True)
+                upgradedb(from_revision=from_revision, to_revision=to_revision, show_sql_only=True)
         mock_alembic_upgrade.assert_called_once_with(mock.ANY, f"{from_revision}:{to_revision}", sql=True)
 
     def test_offline_upgrade_fails_for_migration_less_than_2_0_0_head(self):
         with mock.patch('airflow.utils.db.settings.engine.dialect'):
             with pytest.raises(ValueError, match='Check that e1a11ece99cc is a valid revision'):
-                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', show_sql_only=True)
 
     def test_sqlite_offline_upgrade_raises_with_revision(self):
         with mock.patch('airflow.utils.db.settings.engine.dialect') as dialect:
             dialect.name = 'sqlite'
             with pytest.raises(AirflowException, match='Offline migration not supported for SQLite'):
-                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', show_sql_only=True)
 
     def test_offline_upgrade_fails_for_migration_less_than_2_2_0_head_for_mssql(self):
         with mock.patch('airflow.utils.db.settings.engine.dialect') as dialect:
             dialect.name = 'mssql'
             with pytest.raises(ValueError, match='Check that .* is a valid .* For dialect \'mssql\''):
-                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', sql=True)
+                upgradedb(from_revision='e1a11ece99cc', to_revision='54bebd308c5f', show_sql_only=True)
 
     @mock.patch('airflow.utils.db._offline_migration')
     def test_downgrade_sql_no_from(self, mock_om):
-        downgrade(to_revision='abc', sql=True, from_revision=None)
+        downgrade(to_revision='abc', show_sql_only=True, from_revision=None)
         actual = mock_om.call_args[1]['revision']
         assert re.match(r'[a-z0-9]+:abc', actual) is not None
 
     @mock.patch('airflow.utils.db._offline_migration')
     def test_downgrade_sql_with_from(self, mock_om):
-        downgrade(to_revision='abc', sql=True, from_revision='123')
+        downgrade(to_revision='abc', show_sql_only=True, from_revision='123')
         actual = mock_om.call_args[1]['revision']
         assert actual == '123:abc'
 


### PR DESCRIPTION
Make `db upgrade` args more like `db downgrade`.

```
usage: airflow db upgrade [-h] [--from-revision FROM_REVISION] [--from-version FROM_VERSION] [-r REVISION]
                          [-s] [-n VERSION]

Upgrade the schema of the metadata database. To print but not execute commands, use option ``--show-sql-only``. If using options ``--from-revision`` or ``--from-version``, you must also use ``--show-sql-only``, because if actually *running* migrations, we should only migrate from the *current* revision.

optional arguments:
  -h, --help            show this help message and exit
  --from-revision FROM_REVISION
                        (Optional) If generating sql, may supply a *from* revision
  --from-version FROM_VERSION
                        (Optional) If generating sql, may supply a *from* version
  -r REVISION, --revision REVISION
                        (Optional) The airflow revision to upgrade to. Note: must provide either `--revision` or `--version`.
  -s, --show-sql-only   Don't actually run migrations; just print out sql scripts for offline migration. Required if using either `--from-version` or `--from-version`.
  -n VERSION, --version VERSION
                        (Optional) The airflow version to upgrade to. Note: must provide either `--revision` or `--version`.
```