### PR TITLE
Add provide_bucket_name to S3Hook.delete_objects

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -381,7 +381,7 @@ class S3DeleteObjectsOperator(BaseOperator):
 
         keys = self.keys or s3_hook.list_keys(bucket_name=self.bucket, prefix=self.prefix)
         if keys:
-            s3_hook.delete_objects(bucket=self.bucket, keys=keys)
+            s3_hook.delete_objects(bucket_name=self.bucket, keys=keys)
 
 
 class S3FileTransformOperator(BaseOperator):

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -383,9 +383,16 @@ class TestAwsS3Hook:
         # The behaviour of delete changed in recent version of s3 mock libraries.
         # It will succeed idempotently
         hook = S3Hook()
-        hook.delete_objects(bucket=s3_bucket, keys=['key-1'])
+        hook.delete_objects(bucket_name=s3_bucket, keys=['key-1'])
 
     def test_delete_objects_one_key(self, mocked_s3_res, s3_bucket):
+        key = 'key-1'
+        mocked_s3_res.Object(s3_bucket, key).put(Body=b'Data')
+        hook = S3Hook()
+        hook.delete_objects(bucket_name=s3_bucket, keys=[key])
+        assert [o.key for o in mocked_s3_res.Bucket(s3_bucket).objects.all()] == []
+
+    def test_delete_objects_bucket_param(self, mocked_s3_res, s3_bucket):
         key = 'key-1'
         mocked_s3_res.Object(s3_bucket, key).put(Body=b'Data')
         hook = S3Hook()
@@ -402,7 +409,7 @@ class TestAwsS3Hook:
 
         assert sum(1 for _ in mocked_s3_res.Bucket(s3_bucket).objects.all()) == num_keys_to_remove
         hook = S3Hook()
-        hook.delete_objects(bucket=s3_bucket, keys=keys)
+        hook.delete_objects(bucket_name=s3_bucket, keys=keys)
         assert [o.key for o in mocked_s3_res.Bucket(s3_bucket).objects.all()] == []
 
     def test_unify_bucket_name_and_key(self):


### PR DESCRIPTION
* Add `provide_bucket` name to `S3Hook.delete_objects`.
* Unify `delete_objects` bucket parameter name. (Remove in next major version)
* Cache bucket name from connection schema.