### PR TITLE
Rename task-mapping trigger to 'expand'

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -290,18 +290,18 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         kwargs_left = kwargs.copy()
         for arg_name in self._mappable_function_argument_names:
             value = kwargs_left.pop(arg_name, NOTSET)
-            if func != "apply" or value is NOTSET or isinstance(value, get_mappable_types()):
+            if func != "expand" or value is NOTSET or isinstance(value, get_mappable_types()):
                 continue
             tname = type(value).__name__
-            raise ValueError(f"apply() got an unexpected type {tname!r} for keyword argument {arg_name!r}")
+            raise ValueError(f"expand() got an unexpected type {tname!r} for keyword argument {arg_name!r}")
         if len(kwargs_left) == 1:
             raise TypeError(f"{func}() got an unexpected keyword argument {next(iter(kwargs_left))!r}")
         elif kwargs_left:
             names = ", ".join(repr(n) for n in kwargs_left)
             raise TypeError(f"{func}() got unexpected keyword arguments {names}")
 
-    def apply(self, **map_kwargs: "Mappable") -> XComArg:
-        self._validate_arg_names("apply", map_kwargs)
+    def expand(self, **map_kwargs: "Mappable") -> XComArg:
+        self._validate_arg_names("expand", map_kwargs)
         prevent_duplicates(self.kwargs, map_kwargs, fail_reason="mapping already partial")
         ensure_xcomarg_return_value(map_kwargs)
 
@@ -452,7 +452,7 @@ class Task(Generic[Function]):
 
     function: Function
 
-    def apply(self, **kwargs: "Mappable") -> XComArg:
+    def expand(self, **kwargs: "Mappable") -> XComArg:
         ...
 
     def partial(self, **kwargs: Any) -> "Task[Function]":

--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -84,8 +84,8 @@ class TaskGroupDecorator(Generic[R]):
     def partial(self, **kwargs) -> "MappedTaskGroupDecorator[R]":
         return MappedTaskGroupDecorator(function=self.function, kwargs=self.kwargs).partial(**kwargs)
 
-    def apply(self, **kwargs) -> Union[R, TaskGroup]:
-        return MappedTaskGroupDecorator(function=self.function, kwargs=self.kwargs).apply(**kwargs)
+    def expand(self, **kwargs) -> Union[R, TaskGroup]:
+        return MappedTaskGroupDecorator(function=self.function, kwargs=self.kwargs).expand(**kwargs)
 
 
 @attr.define
@@ -116,7 +116,7 @@ class MappedTaskGroupDecorator(TaskGroupDecorator[R]):
         self.partial_kwargs.update(kwargs)
         return self
 
-    def apply(self, **kwargs) -> Union[R, TaskGroup]:
+    def expand(self, **kwargs) -> Union[R, TaskGroup]:
         if self.mapped_kwargs:
             raise RuntimeError("Already a mapped task group")
         self.mapped_kwargs = kwargs
@@ -150,7 +150,7 @@ class Group(Generic[F]):
     function: F
 
     # Return value should match F's return type, but that's impossible to declare.
-    def apply(self, **kwargs: "Mappable") -> Any:
+    def expand(self, **kwargs: "Mappable") -> Any:
         ...
 
     def partial(self, **kwargs: Any) -> "Group[F]":

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -267,7 +267,7 @@ def partial(
     partial_kwargs.setdefault("outlets", outlets)
     partial_kwargs.setdefault("resources", resources)
 
-    # Post-process arguments. Should be kept in sync with _TaskDecorator.apply().
+    # Post-process arguments. Should be kept in sync with _TaskDecorator.expand().
     if "task_concurrency" in kwargs:  # Reject deprecated option.
         raise TypeError("unexpected argument: task_concurrency")
     if partial_kwargs["wait_for_downstream"]:
@@ -692,7 +692,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         task_group = task_group or TaskGroupContext.get_current_task_group(dag)
 
         if not _airflow_mapped_validation_only and isinstance(task_group, MappedTaskGroup):
-            return cls.partial(dag=dag, task_group=task_group, **kwargs).apply()
+            return cls.partial(dag=dag, task_group=task_group, **kwargs).expand()
         return super().__new__(cls)
 
     def __init__(

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -94,7 +94,7 @@ def _get_default_mapped_partial() -> Dict[str, Any]:
     are defaults, they are automatically supplied on de-serialization, so we
     don't need to store them.
     """
-    default_partial_kwargs = BaseOperator.partial(task_id="_").apply().partial_kwargs
+    default_partial_kwargs = BaseOperator.partial(task_id="_").expand().partial_kwargs
     return BaseSerialization._serialize(default_partial_kwargs)[Encoding.VAR]
 
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -392,7 +392,7 @@ class TaskGroup(DAGNode):
 
         return DagAttributeTypes.TASK_GROUP, SerializedTaskGroup.serialize_task_group(self)
 
-    def apply(self, arg: Iterable) -> "MappedTaskGroup":
+    def expand(self, arg: Iterable) -> "MappedTaskGroup":
         if self.children:
             raise RuntimeError("Cannot map a TaskGroup that already has children")
         if not self.group_id:

--- a/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_mapped_task_instance_endpoint.py
@@ -86,7 +86,7 @@ class TestMappedTaskInstanceEndpoint:
         literal = [1, 2, {'a': 'b'}]
         with dag_maker(session=session, dag_id='mapped_tis', start_date=DEFAULT_DATETIME_1):
             task1 = BaseOperator(task_id="op1")
-            mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+            mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
 
         dr = dag_maker.create_dagrun(run_id='test_dagrun')
 
@@ -129,7 +129,7 @@ class TestMappedTaskInstanceEndpoint:
         literal = [1]
         with dag_maker(session=session, dag_id='mapped_tis', start_date=DEFAULT_DATETIME_1):
             task1 = BaseOperator(task_id="op1")
-            mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+            mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
 
         dr = dag_maker.create_dagrun(run_id='test_dagrun')
 

--- a/tests/dags/test_mapped_classic.py
+++ b/tests/dags/test_mapped_classic.py
@@ -31,4 +31,4 @@ def consumer(value):
 
 
 with DAG(dag_id='test_mapped_classic', start_date=days_ago(2)) as dag:
-    PythonOperator.partial(task_id='consumer', python_callable=consumer).apply(op_args=make_arg_lists())
+    PythonOperator.partial(task_id='consumer', python_callable=consumer).expand(op_args=make_arg_lists())

--- a/tests/dags/test_mapped_taskflow.py
+++ b/tests/dags/test_mapped_taskflow.py
@@ -28,4 +28,4 @@ with DAG(dag_id='test_mapped_taskflow', start_date=days_ago(2)) as dag:
     def consumer(value):
         print(repr(value))
 
-    consumer.apply(value=make_list())
+    consumer.expand(value=make_list())

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -92,7 +92,7 @@ class MockNamedTuple(NamedTuple):
 
 
 class TestBaseOperator:
-    def test_apply(self):
+    def test_expand(self):
         dummy = DummyClass(test_param=True)
         assert dummy.test_param
 
@@ -703,7 +703,7 @@ def test_task_mapping_with_dag():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         task1 = BaseOperator(task_id="op1")
         literal = ['a', 'b', 'c']
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=literal)
         finish = MockOperator(task_id="finish")
 
         task1 >> mapped >> finish
@@ -722,7 +722,7 @@ def test_task_mapping_without_dag_context():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         task1 = BaseOperator(task_id="op1")
     literal = ['a', 'b', 'c']
-    mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
+    mapped = MockOperator.partial(task_id='task_2').expand(arg2=literal)
 
     task1 >> mapped
 
@@ -739,7 +739,7 @@ def test_task_mapping_default_args():
     with DAG("test-dag", start_date=DEFAULT_DATE, default_args=default_args):
         task1 = BaseOperator(task_id="op1")
         literal = ['a', 'b', 'c']
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=literal)
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=literal)
 
         task1 >> mapped
 
@@ -749,14 +749,14 @@ def test_task_mapping_default_args():
 
 def test_map_unknown_arg_raises():
     with pytest.raises(TypeError, match=r"argument 'file'"):
-        BaseOperator.partial(task_id='a').apply(file=[1, 2, {'a': 'b'}])
+        BaseOperator.partial(task_id='a').expand(file=[1, 2, {'a': 'b'}])
 
 
 def test_map_xcom_arg():
     """Test that dependencies are correct when mapping with an XComArg"""
     with DAG("test-dag", start_date=DEFAULT_DATE):
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
         finish = MockOperator(task_id="finish")
 
         mapped >> finish
@@ -814,7 +814,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
     literal = [1, 2, {'a': 'b'}]
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
 
     dr = dag_maker.create_dagrun()
 
@@ -858,7 +858,7 @@ def test_expand_mapped_task_instance(dag_maker, session, num_existing_tis, expec
 def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
     with dag_maker(session=session):
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
 
     dr = dag_maker.create_dagrun()
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -910,7 +910,7 @@ def test_verify_integrity_task_start_date(Stats_incr, session, run_type, expecte
 def test_expand_mapped_task_instance(dag_maker, session):
     literal = [1, 2, {'a': 'b'}]
     with dag_maker(session=session):
-        mapped = MockOperator(task_id='task_2').apply(arg2=literal)
+        mapped = MockOperator(task_id='task_2').expand(arg2=literal)
 
     dr = dag_maker.create_dagrun()
     indices = (
@@ -926,7 +926,7 @@ def test_expand_mapped_task_instance(dag_maker, session):
 def test_ti_scheduling_mapped_zero_length(dag_maker, session):
     with dag_maker(session=session):
         task = BaseOperator(task_id='task_1')
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task))
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task))
 
     dr: DagRun = dag_maker.create_dagrun()
     ti1, _ = sorted(dr.task_instances, key=lambda ti: ti.task_id)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2312,7 +2312,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.apply(value=push_something())
+            pull_something.expand(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         with pytest.raises(UnmappableXComTypePushed) as ctx:
@@ -2335,7 +2335,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.apply(value=push_something())
+            pull_something.expand(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
         with pytest.raises(UnmappableXComLengthPushed) as ctx:
@@ -2364,7 +2364,7 @@ class TestTaskInstanceRecordTaskMapXComPush:
             def pull_something(value):
                 print(value)
 
-            pull_something.apply(value=push_something())
+            pull_something.expand(value=push_something())
 
         dag_run = dag_maker.create_dagrun()
         ti = next(ti for ti in dag_run.task_instances if ti.task_id == "push_something")
@@ -2396,7 +2396,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(value):
                 outputs.append(value)
 
-            show.apply(value=literal)
+            show.expand(value=literal)
 
         dag_run = dag_maker.create_dagrun()
         show_task = dag.get_task("show")
@@ -2428,7 +2428,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(value):
                 outputs.append(value)
 
-            show.apply(value=emit())
+            show.expand(value=emit())
 
         dag_run = dag_maker.create_dagrun()
         emit_ti = dag_run.get_task_instance("emit", session=session)
@@ -2461,7 +2461,7 @@ class TestMappedTaskInstanceReceiveValue:
             def show(number, letter):
                 outputs.append((number, letter))
 
-            show.apply(number=emit_numbers(), letter=emit_letters())
+            show.expand(number=emit_numbers(), letter=emit_letters())
 
         dag_run = dag_maker.create_dagrun()
         for task_id in ["emit_numbers", "emit_letters"]:
@@ -2500,7 +2500,7 @@ class TestMappedTaskInstanceReceiveValue:
                 outputs.append((a, b))
 
             emit_task = emit_numbers()
-            show.apply(a=emit_task, b=emit_task)
+            show.expand(a=emit_task, b=emit_task)
 
         dag_run = dag_maker.create_dagrun()
         ti = dag_run.get_task_instance("emit_numbers", session=session)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1556,7 +1556,7 @@ def test_kubernetes_optional():
 
 def test_mapped_operator_serde():
     literal = [1, 2, {'a': 'b'}]
-    real_op = BashOperator.partial(task_id='a', executor_config={'dict': {'sub': 'value'}}).apply(
+    real_op = BashOperator.partial(task_id='a', executor_config={'dict': {'sub': 'value'}}).expand(
         bash_command=literal
     )
 
@@ -1605,7 +1605,7 @@ def test_mapped_operator_xcomarg_serde():
 
     with DAG("test-dag", start_date=datetime(2020, 1, 1)) as dag:
         task1 = BaseOperator(task_id="op1")
-        mapped = MockOperator.partial(task_id='task_2').apply(arg2=XComArg(task1))
+        mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task1))
 
     serialized = SerializedBaseOperator._serialize(mapped)
     assert serialized == {
@@ -1670,7 +1670,7 @@ def test_mapped_decorator_serde():
         def x(arg1, arg2, arg3):
             print(arg1, arg2, arg3)
 
-        x.partial(arg1=[1, 2, {"a": "b"}]).apply(arg2={"a": 1, "b": 2}, arg3=XComArg(op1))
+        x.partial(arg1=[1, 2, {"a": "b"}]).expand(arg2={"a": 1, "b": 2}, arg3=XComArg(op1))
 
     original = dag.get_task("x")
 
@@ -1721,7 +1721,7 @@ def test_mapped_task_group_serde():
 
     literal = [1, 2, {'a': 'b'}]
     with DAG("test", start_date=execution_date) as dag:
-        with TaskGroup("process_one", dag=dag).apply(literal) as process_one:
+        with TaskGroup("process_one", dag=dag).expand(literal) as process_one:
             BaseOperator(task_id='one')
 
     serialized = SerializedTaskGroup.serialize_task_group(process_one)

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1044,7 +1044,7 @@ def test_map() -> None:
         start = MockOperator(task_id="start")
         end = MockOperator(task_id="end")
         literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").apply(literal) as process_one:
+        with TaskGroup("process_one").expand(literal) as process_one:
             one = MockOperator(task_id='one')
             two = MockOperator(task_id='two')
             three = MockOperator(task_id='three')
@@ -1073,10 +1073,10 @@ def test_nested_map() -> None:
         start = MockOperator(task_id="start")
         end = MockOperator(task_id="end")
         literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").apply(literal) as process_one:
+        with TaskGroup("process_one").expand(literal) as process_one:
             one = MockOperator(task_id='one')
 
-            with TaskGroup("process_two").apply(literal) as process_one_two:
+            with TaskGroup("process_two").expand(literal) as process_one_two:
                 two = MockOperator(task_id='two')
                 three = MockOperator(task_id='three')
                 two >> three
@@ -1147,7 +1147,7 @@ def test_decorator_map():
     with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
         lines = ["foo", "bar", "baz"]
 
-        (task_1, task_2, task_3) = my_task_group.partial(unmapped=True).apply(my_arg_1=lines)
+        (task_1, task_2, task_3) = my_task_group.partial(unmapped=True).expand(my_arg_1=lines)
 
     assert task_1 in dag.tasks
 


### PR DESCRIPTION
This seems to read much better than 'apply', and also convey the idea of a task being "fanned out" better.