### PR TITLE
Require SQLAlchemy 1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -158,7 +158,7 @@ install_requires =
     # as string and fail to be converted back to datetime. It was supposed to be fixed in
     # https://github.com/sqlalchemy/sqlalchemy/issues/6366 (released in 1.4.12) but apparently our case
     # is different. Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660 to track it
-    sqlalchemy>=1.3.18,<1.4.10
+    sqlalchemy>=1.4,<1.4.10
     sqlalchemy_jsonfield>=1.0
     tabulate>=0.7.5
     tenacity>=6.2.0


### PR DESCRIPTION
Some of the exceptions have moved between 1.3 and 1.4 (`sqlalchemy.orm.exc import MultipleResultsFound` becomes `from sqlalchemy.exc import MultipleResultsFound`)

Since we only ever test with the "latest" version we should update the requirement to be tighter to ease upgrades. If we don't do this, we'll have to expand our unit tests to check against SQLA 1.3 and 1.4.

(Without this the UI/API will fail to start)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).