### PR TITLE
Fix PYTHONPATH Environment Variable Name in logging-tasks.rst

### DIFF
--- a/docs/apache-airflow/logging-monitoring/logging-tasks.rst
+++ b/docs/apache-airflow/logging-monitoring/logging-tasks.rst
@@ -90,7 +90,7 @@ Follow the steps below to enable custom logging config class:
 
     .. code-block:: bash
 
-        export PYTHON_PATH=~/airflow/
+        export PYTHONPATH=~/airflow/
 
 #. Create a directory to store the config file e.g. ``~/airflow/config``
 #. Create file called ``~/airflow/config/log_config.py`` with following the contents:


### PR DESCRIPTION
Fix PYTHONPATH Environment Variable name

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
