### PR TITLE
Allow searching/filtering Browse Task Instances view by map_index

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4701,6 +4701,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         'dag_id',
         'task_id',
         'run_id',
+        'map_index',
         'execution_date',
         'operator',
         'start_date',


### PR DESCRIPTION
We displayed the column already, but it's not possible to search on it.

(It's also not currently possible to find _unmapped_ tasks as FAB doesn't give the ability to say "is None", but that's an existing issue)

![image](https://user-images.githubusercontent.com/34150/157449409-e4e90681-5102-40f8-9c36-1a2dfb15ea2d.png)
