### PR TITLE
Add vertical scrolling to grid view

### DIFF
--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -22,7 +22,6 @@
 import React from 'react';
 import { isEqual } from 'lodash';
 import {
-  Flex,
   Box,
   Tooltip,
 } from '@chakra-ui/react';

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -39,7 +39,7 @@ const StatusBox = ({
   const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId);
 
   // Fetch the corresponding column element and set its background color when hovering
-  const onMouseOver = () => {
+  const onMouseEnter = () => {
     [...containerRef.current.getElementsByClassName(`js-${runId}`)]
       .forEach((e) => { e.style.backgroundColor = 'rgba(113, 128, 150, 0.1)'; });
   };
@@ -57,27 +57,19 @@ const StatusBox = ({
       placement="top"
       openDelay={400}
     >
-      <Flex
-        p="1px"
-        my="1px"
-        mx="2px"
-        justifyContent="center"
-        alignItems="center"
+      <Box
+        width="10px"
+        height="10px"
+        backgroundColor={stateColors[instance.state] || 'white'}
+        borderRadius="2px"
+        borderWidth={instance.state ? 0 : 1}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
         onClick={onClick}
+        zIndex={1}
         cursor={!group.children && 'pointer'}
         data-testid="task-instance"
-        zIndex={1}
-        onMouseEnter={onMouseOver}
-        onMouseLeave={onMouseLeave}
-      >
-        <Box
-          width="10px"
-          height="10px"
-          backgroundColor={stateColors[instance.state] || 'white'}
-          borderRadius="2px"
-          borderWidth={instance.state ? 0 : 1}
-        />
-      </Flex>
+      />
     </Tooltip>
   );
 };

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -29,6 +29,9 @@ import {
 import { callModal } from '../dag';
 import InstanceTooltip from './InstanceTooltip';
 
+export const boxSize = 10;
+export const boxSizePx = `${boxSize}px`;
+
 const StatusBox = ({
   group, instance, containerRef, extraLinks = [],
 }) => {
@@ -57,8 +60,8 @@ const StatusBox = ({
       openDelay={400}
     >
       <Box
-        width="10px"
-        height="10px"
+        width={boxSizePx}
+        height={boxSizePx}
         backgroundColor={stateColors[instance.state] || 'white'}
         borderRadius="2px"
         borderWidth={instance.state ? 0 : 1}

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -37,6 +37,7 @@ import DagRuns from './dagRuns';
 const Tree = () => {
   const containerRef = useRef();
   const scrollRef = useRef();
+  const tableRef = useRef();
   const { data: { groups = {}, dagRuns = [] }, isRefreshOn, onToggleRefresh } = useTreeData();
   const dagRunIds = dagRuns.map((dr) => dr.runId);
 
@@ -47,6 +48,8 @@ const Tree = () => {
       runsContainer.scrollBy(runsContainer.clientWidth, 0);
     }
   }, []);
+
+  const tableWidth = tableRef && tableRef.current ? tableRef.current.offsetWidth : '100%';
 
   return (
     <Box position="relative" ref={containerRef}>
@@ -62,11 +65,15 @@ const Tree = () => {
       <Box px="24px">
         <Box position="relative" width="100%" overflowX="auto" ref={scrollRef}>
           <Table>
-            <Thead>
-              <DagRuns containerRef={containerRef} />
+            <Thead display="block" pr="10px">
+              <DagRuns containerRef={containerRef} tableWidth={tableWidth} />
             </Thead>
-            <Tbody>
-              {renderTaskRows({ task: groups, containerRef, dagRunIds })}
+            {/* eslint-disable-next-line max-len */}
+            {/* TODO: don't use hardcoded values. 665px is roughly the normal total header and footer heights */}
+            <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" overflow="auto" ref={tableRef} pr="10px">
+              {renderTaskRows({
+                task: groups, containerRef, dagRunIds, tableWidth,
+              })}
             </Tbody>
           </Table>
         </Box>

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -49,6 +49,7 @@ const Tree = () => {
     if (runsContainer && runsContainer.scrollWidth > runsContainer.clientWidth) {
       runsContainer.scrollBy(runsContainer.clientWidth, 0);
     }
+    // only run when the tableWidth changes
   }, [tableWidth]);
 
   return (

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -41,15 +41,15 @@ const Tree = () => {
   const { data: { groups = {}, dagRuns = [] }, isRefreshOn, onToggleRefresh } = useTreeData();
   const dagRunIds = dagRuns.map((dr) => dr.runId);
 
+  const tableWidth = tableRef && tableRef.current ? tableRef.current.offsetWidth : '100%';
+
   useEffect(() => {
     // Set initial scroll to far right if it is scrollable
     const runsContainer = scrollRef.current;
     if (runsContainer && runsContainer.scrollWidth > runsContainer.clientWidth) {
       runsContainer.scrollBy(runsContainer.clientWidth, 0);
     }
-  }, []);
-
-  const tableWidth = tableRef && tableRef.current ? tableRef.current.offsetWidth : '100%';
+  }, [tableWidth]);
 
   return (
     <Box position="relative" ref={containerRef}>
@@ -63,14 +63,14 @@ const Tree = () => {
       <Text transform="rotate(-90deg)" position="absolute" left="-6px" top="130px">Runs</Text>
       <Text transform="rotate(-90deg)" position="absolute" left="-6px" top="190px">Tasks</Text>
       <Box px="24px">
-        <Box position="relative" width="100%" overflowX="auto" ref={scrollRef}>
+        <Box position="relative" width="100%" overflow="auto" ref={scrollRef}>
           <Table>
-            <Thead display="block" pr="10px">
+            <Thead display="block" pr="10px" position="sticky" top={0} zIndex={3} bg="white">
               <DagRuns containerRef={containerRef} tableWidth={tableWidth} />
             </Thead>
             {/* eslint-disable-next-line max-len */}
             {/* TODO: don't use hardcoded values. 665px is roughly the normal total header and footer heights */}
-            <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" overflow="auto" ref={tableRef} pr="10px">
+            <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
               {renderTaskRows({
                 task: groups, containerRef, dagRunIds, tableWidth,
               })}

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -65,7 +65,7 @@ const Tree = () => {
       <Box px="24px">
         <Box position="relative" width="100%" overflow="auto" ref={scrollRef}>
           <Table>
-            <Thead display="block" pr="10px" position="sticky" top={0} zIndex={3} bg="white">
+            <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">
               <DagRuns containerRef={containerRef} tableWidth={tableWidth} />
             </Thead>
             {/* eslint-disable-next-line max-len */}

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -26,7 +26,6 @@ import {
   FormControl,
   FormLabel,
   Spinner,
-  Text,
   Thead,
 } from '@chakra-ui/react';
 

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -61,23 +61,18 @@ const Tree = () => {
         </FormLabel>
         <Switch id="auto-refresh" onChange={onToggleRefresh} isChecked={isRefreshOn} size="lg" />
       </FormControl>
-      <Text transform="rotate(-90deg)" position="absolute" left="-6px" top="130px">Runs</Text>
-      <Text transform="rotate(-90deg)" position="absolute" left="-6px" top="190px">Tasks</Text>
-      <Box px="24px">
-        <Box position="relative" width="100%" overflow="auto" ref={scrollRef}>
-          <Table>
-            <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">
-              <DagRuns containerRef={containerRef} tableWidth={tableWidth} />
-            </Thead>
-            {/* eslint-disable-next-line max-len */}
-            {/* TODO: don't use hardcoded values. 665px is roughly the normal total header and footer heights */}
-            <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
-              {renderTaskRows({
-                task: groups, containerRef, dagRunIds, tableWidth,
-              })}
-            </Tbody>
-          </Table>
-        </Box>
+      <Box position="relative" width="100%" overflow="auto" ref={scrollRef} px="24px">
+        <Table>
+          <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">
+            <DagRuns containerRef={containerRef} tableWidth={tableWidth} />
+          </Thead>
+          {/* TODO: remove hardcoded values. 665px is roughly the total heade+footer height */}
+          <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
+            {renderTaskRows({
+              task: groups, containerRef, dagRunIds, tableWidth,
+            })}
+          </Tbody>
+        </Table>
       </Box>
     </Box>
   );

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -38,29 +38,39 @@ const BAR_HEIGHT = 100;
 const DagRunBar = ({
   run, max, index, totalRuns, containerRef,
 }) => {
-  let highlightHeight = '100%';
-  if (containerRef && containerRef.current) {
-    const table = containerRef.current.getElementsByTagName('tbody')[0];
-    highlightHeight = table.offsetHeight + BAR_HEIGHT;
-  }
+  // Fetch the corresponding column element and set its background color when hovering
+  const onMouseEnter = () => {
+    [...containerRef.current.getElementsByClassName(`js-${run.runId}`)]
+      .forEach((e) => { e.style.backgroundColor = 'rgba(113, 128, 150, 0.1)'; });
+  };
+  const onMouseLeave = () => {
+    [...containerRef.current.getElementsByClassName(`js-${run.runId}`)]
+      .forEach((e) => { e.style.backgroundColor = null; });
+  };
+
   return (
-    <Box position="relative">
+    <Box
+      className={`js-${run.runId}`}
+      transition="background-color 0.2s"
+      px="1px"
+      pb="2px"
+      position="relative"
+    >
       <Flex
         height={BAR_HEIGHT}
         alignItems="flex-end"
         justifyContent="center"
-        mb="2px"
-        // py="2px"
         px="2px"
-        mx="1px"
         cursor="pointer"
         width="14px"
         zIndex={1}
         onClick={() => {
-          callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
+          callModalDag({
+            execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId,
+          });
         }}
-        position="relative"
-        data-peer
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
       >
         <Tooltip
           label={<DagRunTooltip dagRun={run} />}
@@ -88,16 +98,6 @@ const DagRunBar = ({
           </Flex>
         </Tooltip>
       </Flex>
-      <Box
-        position="absolute"
-        width="100%"
-        top="1px"
-        height={highlightHeight}
-        className={`js-${run.runId}`}
-        _peerHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}
-        zIndex={0}
-        transition="background-color 0.2s"
-      />
       {index < totalRuns - 3 && index % 10 === 0 && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -36,7 +36,7 @@ const DurationTick = ({ children, ...rest }) => (
   </Text>
 );
 
-const DagRuns = ({ containerRef }) => {
+const DagRuns = ({ containerRef, tableWidth }) => {
   const { data: { dagRuns = [] } } = useTreeData();
   const durations = [];
   const runs = dagRuns.map((dagRun) => {
@@ -66,6 +66,7 @@ const DagRuns = ({ containerRef }) => {
         backgroundColor="white"
         zIndex={2}
         borderBottom={0}
+        width={`${tableWidth - (runs.length * 16)}px`}
       >
         {!!runs.length && (
         <>
@@ -87,7 +88,7 @@ const DagRuns = ({ containerRef }) => {
         <Box position="absolute" bottom="50px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
         <Box position="absolute" bottom="4px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
       </Td>
-      <Td p={0} width="16px" align="right" verticalAlign="bottom" borderBottom={0}>
+      <Td p={0} align="right" verticalAlign="bottom" borderBottom={0} width={`${runs.length * 16}px`}>
         <Flex justifyContent="flex-end">
           {runs.map((run, i) => (
             <DagRunBar

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -87,6 +87,8 @@ const DagRuns = ({ containerRef, tableWidth }) => {
         <Box position="absolute" bottom="100px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
         <Box position="absolute" bottom="50px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
         <Box position="absolute" bottom="4px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
+        <Text transform="rotate(-90deg)" position="absolute" left="-27px" top="110px">Runs</Text>
+        <Text transform="rotate(-90deg)" position="absolute" left="-27px" top="170px">Tasks</Text>
       </Td>
       <Td p={0} align="right" verticalAlign="bottom" borderBottom={0} width={`${runs.length * 16}px`}>
         <Flex justifyContent="flex-end">

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -38,7 +38,7 @@ import { getMetaValue } from '../utils';
 const dagId = getMetaValue('dag_id');
 
 const renderTaskRows = ({
-  task, containerRef, level = 0, isParentOpen, dagRunIds,
+  task, containerRef, level = 0, isParentOpen, dagRunIds, tableWidth,
 }) => task.children.map((t) => (
   <Row
     key={t.id}
@@ -48,6 +48,7 @@ const renderTaskRows = ({
     prevTaskId={task.id}
     isParentOpen={isParentOpen}
     dagRunIds={dagRunIds}
+    tableWidth={tableWidth}
   />
 ));
 
@@ -73,7 +74,7 @@ const TaskInstances = ({ task, containerRef, dagRunIds }) => (
 
 const Row = (props) => {
   const {
-    task, containerRef, level, prevTaskId, isParentOpen = true, dagRunIds,
+    task, containerRef, level, prevTaskId, isParentOpen = true, dagRunIds, tableWidth,
   } = props;
   const isGroup = !!task.children;
 
@@ -119,6 +120,7 @@ const Row = (props) => {
           left={0}
           backgroundColor="white"
           borderBottom={0}
+          width={`${tableWidth - (dagRunIds.length * 16)}px`}
         >
           <Collapse in={isFullyOpen} unmountOnExit>
             <TaskName
@@ -132,7 +134,7 @@ const Row = (props) => {
           </Collapse>
         </Td>
         <Td width={0} p={0} borderBottom={0} />
-        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0}>
+        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0} width={`${dagRunIds.length * 16}px`}>
           <Collapse in={isFullyOpen} unmountOnExit>
             <TaskInstances dagRunIds={dagRunIds} task={task} containerRef={containerRef} />
           </Collapse>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -57,17 +57,26 @@ const TaskInstances = ({ task, containerRef, dagRunIds }) => (
     {dagRunIds.map((runId) => {
       // Check if an instance exists for the run, or return an empty box
       const instance = task.instances.find((gi) => gi.runId === runId);
-      return instance
-        ? (
-          <StatusBox
-            key={`${runId}-${task.id}`}
-            instance={instance}
-            containerRef={containerRef}
-            extraLinks={task.extraLinks}
-            group={task}
-          />
-        )
-        : <Box key={`${runId}-${task.id}`} width="18px" data-testid="blank-task" />;
+      return (
+        <Box
+          py="4px"
+          px="3px"
+          className={`js-${runId}`}
+          transition="background-color 0.2s"
+          key={`${runId}-${task.id}`}
+        >
+          {instance
+            ? (
+              <StatusBox
+                instance={instance}
+                containerRef={containerRef}
+                extraLinks={task.extraLinks}
+                group={task}
+              />
+            )
+            : <Box width="18px" data-testid="blank-task" />}
+        </Box>
+      );
     })}
   </Flex>
 );
@@ -121,7 +130,7 @@ const Row = (props) => {
           backgroundColor="white"
           borderBottom={0}
           width={`${tableWidth - (dagRunIds.length * 16)}px`}
-          zIndex={2}
+          zIndex={1}
         >
           <Collapse in={isFullyOpen} unmountOnExit>
             <TaskName

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -121,6 +121,7 @@ const Row = (props) => {
           backgroundColor="white"
           borderBottom={0}
           width={`${tableWidth - (dagRunIds.length * 16)}px`}
+          zIndex={2}
         >
           <Collapse in={isFullyOpen} unmountOnExit>
             <TaskName

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -29,10 +29,14 @@ import {
   Collapse,
 } from '@chakra-ui/react';
 
-import StatusBox from './StatusBox';
+import StatusBox, { boxSize, boxSizePx } from './StatusBox';
 import TaskName from './TaskName';
 
 import { getMetaValue } from '../utils';
+
+const boxPadding = 3;
+const boxPaddingPx = `${boxPadding}px`;
+const columnWidth = boxSize + 2 * boxPadding;
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
@@ -60,7 +64,7 @@ const TaskInstances = ({ task, containerRef, dagRunIds }) => (
       return (
         <Box
           py="4px"
-          px="3px"
+          px={boxPaddingPx}
           className={`js-${runId}`}
           transition="background-color 0.2s"
           key={`${runId}-${task.id}`}
@@ -74,7 +78,7 @@ const TaskInstances = ({ task, containerRef, dagRunIds }) => (
                 group={task}
               />
             )
-            : <Box width="18px" data-testid="blank-task" />}
+            : <Box width={boxSizePx} data-testid="blank-task" />}
         </Box>
       );
     })}
@@ -129,7 +133,7 @@ const Row = (props) => {
           left={0}
           backgroundColor="white"
           borderBottom={0}
-          width={`${tableWidth - (dagRunIds.length * 16)}px`}
+          width={`${tableWidth - (dagRunIds.length * columnWidth)}px`}
           zIndex={1}
         >
           <Collapse in={isFullyOpen} unmountOnExit>
@@ -144,7 +148,14 @@ const Row = (props) => {
           </Collapse>
         </Td>
         <Td width={0} p={0} borderBottom={0} />
-        <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0} width={`${dagRunIds.length * 16}px`}>
+        <Td
+          p={0}
+          align="right"
+          _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }}
+          transition="background-color 0.2s"
+          borderBottom={0}
+          width={`${dagRunIds.length * columnWidth}px`}
+        >
           <Collapse in={isFullyOpen} unmountOnExit>
             <TaskInstances dagRunIds={dagRunIds} task={task} containerRef={containerRef} />
           </Collapse>


### PR DESCRIPTION
After a few dozen tasks, the grid becomes too long to be able to see a task and the dag runs at the same time. This PR allows the table body the scroll vertically while keeping the table head fixed.

By default, the page will load with the scroll set to the top and right. (1st task and most recent dag run)

Note: Right now, it is a little hacky to determine the max height to set for a table before scrolling kicks in. I am open to suggestions.

Note2: I had to rework the hover state quite a bit to get it to work with both horizontal and vertical scrolling and the zindexes of each.

Vertical scrolling:
![Mar-09-2022 17-37-52](https://user-images.githubusercontent.com/4600967/157550633-1ace554f-72aa-47c1-8fc0-f77d1b03dd06.gif)

Vertical and horizontal scrolling on Mac+Chrome (demoed with a shorter maxHeight):
![Mar-09-2022 19-26-17](https://user-images.githubusercontent.com/4600967/157563474-3df7df9d-902c-4cb8-9111-4cef60b7b0bd.gif)

Vertical and horizontal scrolling on WIndows+Edge
![Mar-10-2022 09-50-19](https://user-images.githubusercontent.com/4600967/157687174-74f7edf9-066f-4846-bdff-6e6958fca96b.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
