### PR TITLE
Fixed permissions error in Docker image by adding read permission to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -468,7 +468,7 @@ COPY --chown=airflow:0 scripts/in_container/prod/clean-logs.sh /clean-logs
 # See https://github.com/apache/airflow/issues/9248
 # Set default groups for airflow and root user
 
-RUN chmod a+x /entrypoint /clean-logs \
+RUN chmod a+rx /entrypoint /clean-logs \
     && chmod g=u /etc/passwd \
     && chmod g+w "${AIRFLOW_USER_HOME_DIR}/.local" \
     && usermod -g 0 airflow -G 0


### PR DESCRIPTION
When I build the docker image, Airflow fails to start. The logs show repeated "permission denied" errors. This is caused by the entrypoint script having execute *but not* read permissions. This PR adds read permissions to the entrypoint in the docker image.

Others might not get this error if they have relatively open umask, because in that case read permissions are already present. This makes it explicit.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
