### PR TITLE
Pass explicit overrides in `DbtCloudJobRunOperator` to `DbtCloudHook`

### DIFF
--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -116,6 +116,8 @@ class DbtCloudRunJobOperator(BaseOperator):
             account_id=self.account_id,
             job_id=self.job_id,
             cause=self.trigger_reason,
+            steps_override=self.steps_override,
+            schema_override=self.schema_override,
             additional_run_config=self.additional_run_config,
         )
         self.run_id = trigger_job_response.json()["data"]["id"]

--- a/tests/providers/dbt/cloud/operators/test_dbt_cloud.py
+++ b/tests/providers/dbt/cloud/operators/test_dbt_cloud.py
@@ -87,6 +87,9 @@ class TestDbtCloudRunJobOperator:
             "job_id": JOB_ID,
             "check_interval": 1,
             "timeout": 3,
+            "steps_override": ["dbt run --select my_first_dbt_model"],
+            "schema_override": "another_schema",
+            "additional_run_config": {"threads_override": 8},
         }
 
     @patch.object(DbtCloudHook, "trigger_job_run", return_value=MagicMock(**DEFAULT_ACCOUNT_JOB_RUN_RESPONSE))
@@ -119,6 +122,9 @@ class TestDbtCloudRunJobOperator:
         assert operator.check_interval == self.config["check_interval"]
         assert operator.timeout == self.config["timeout"]
         assert operator.wait_for_termination
+        assert operator.steps_override == self.config["steps_override"]
+        assert operator.schema_override == self.config["schema_override"]
+        assert operator.additional_run_config == self.config["additional_run_config"]
 
         with patch.object(DbtCloudHook, "get_job_run") as mock_get_job_run:
             mock_get_job_run.return_value.json.return_value = {
@@ -148,7 +154,9 @@ class TestDbtCloudRunJobOperator:
                 account_id=account_id,
                 job_id=JOB_ID,
                 cause=f"Triggered via Apache Airflow by task {TASK_ID!r} in the {self.dag.dag_id} DAG.",
-                additional_run_config={},
+                steps_override=self.config["steps_override"],
+                schema_override=self.config["schema_override"],
+                additional_run_config=self.config["additional_run_config"],
             )
 
             if job_run_status in DbtCloudJobRunStatus.TERMINAL_STATUSES.value:
@@ -183,6 +191,9 @@ class TestDbtCloudRunJobOperator:
         assert operator.check_interval == self.config["check_interval"]
         assert operator.timeout == self.config["timeout"]
         assert not operator.wait_for_termination
+        assert operator.steps_override == self.config["steps_override"]
+        assert operator.schema_override == self.config["schema_override"]
+        assert operator.additional_run_config == self.config["additional_run_config"]
 
         with patch.object(DbtCloudHook, "get_job_run") as mock_get_job_run:
             operator.execute(context=self.mock_context)
@@ -191,7 +202,9 @@ class TestDbtCloudRunJobOperator:
                 account_id=account_id,
                 job_id=JOB_ID,
                 cause=f"Triggered via Apache Airflow by task {TASK_ID!r} in the {self.dag.dag_id} DAG.",
-                additional_run_config={},
+                steps_override=self.config["steps_override"],
+                schema_override=self.config["schema_override"],
+                additional_run_config=self.config["additional_run_config"],
             )
 
             mock_get_job_run.assert_not_called()
@@ -226,7 +239,9 @@ class TestDbtCloudRunJobOperator:
                 account_id=account_id,
                 job_id=JOB_ID,
                 cause=custom_trigger_reason,
-                additional_run_config={},
+                steps_override=self.config["steps_override"],
+                schema_override=self.config["schema_override"],
+                additional_run_config=self.config["additional_run_config"],
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
The `steps_override` and `schema_override` args were not being passed to the underlying `DbtCloudHook` call within the `DbtCloudJobRunOperator` when triggering a job. Users would need to pass these override configurations in the available `additional_run_config` parameter as a workaround.

This PR allows users to explicit pass `steps_override` and/or `schema_override` values directly when triggering a dbt Cloud job.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
