### PR TITLE
Fix location of --push directive for prod images

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -601,7 +601,6 @@ function build_images::build_prod_images() {
     elif [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         docker_prod_directive=(
             "--cache-from=${AIRFLOW_PROD_IMAGE}:cache"
-            "--push"
         )
     else
         echo
@@ -616,6 +615,7 @@ function build_images::build_prod_images() {
         # Cache for prod image contains also build stage for buildx when mode=max specified!
         docker_prod_directive+=(
             "--cache-to=type=registry,ref=${AIRFLOW_PROD_IMAGE}:cache,mode=max"
+            "--push"
         )
         if [[ ${PLATFORM} =~ .*,.* ]]; then
             echo


### PR DESCRIPTION
Previous #22127 had `--push` added in a wrong place.
It should only be added when cache is being built and it
was added always, with resulted in authentication error as
login has not been performed before the --push.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
