### PR TITLE
Pause autorefresh if scheduler isn't running

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -35,6 +35,7 @@ const executionDate = getMetaValue('execution_date');
 const dagRunId = getMetaValue('dag_run_id');
 const arrange = getMetaValue('arrange');
 const taskInstancesUrl = getMetaValue('task_instances_url');
+const isSchedulerRunning = getMetaValue('is_scheduler_running');
 
 // This maps the actual taskId to the current graph node id that contains the task
 // (because tasks may be grouped into a group node)
@@ -450,7 +451,7 @@ $('#auto_refresh').change(() => {
 function initRefresh() {
   const isDisabled = localStorage.getItem('disableAutoRefresh');
   const isFinal = checkRunState();
-  $('#auto_refresh').prop('checked', !(isDisabled || isFinal));
+  $('#auto_refresh').prop('checked', !(isDisabled || isFinal) && isSchedulerRunning === 'True');
   startOrStopRefresh();
   d3.select('#refresh_button').on('click', () => handleRefresh());
 }

--- a/airflow/www/static/js/tree/useTreeData.js
+++ b/airflow/www/static/js/tree/useTreeData.js
@@ -32,6 +32,7 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const isPaused = getMetaValue('is_paused');
 const baseDate = getMetaValue('base_date');
+const isSchedulerRunning = getMetaValue('is_scheduler_running');
 
 const autoRefreshKey = 'disabledAutoRefresh';
 
@@ -55,7 +56,14 @@ const formatData = (data) => {
 const useTreeData = () => {
   const initialData = formatData(treeData);
 
-  const defaultIsOpen = isPaused !== 'True' && !JSON.parse(localStorage.getItem(autoRefreshKey)) && areActiveRuns(initialData.dagRuns);
+  const isRefreshDisabled = JSON.parse(localStorage.getItem(autoRefreshKey));
+  const defaultIsOpen = (
+    isPaused !== 'True'
+    && !isRefreshDisabled
+    && areActiveRuns(initialData.dagRuns)
+    && isSchedulerRunning === 'True'
+  );
+
   const { isOpen: isRefreshOn, onToggle, onClose } = useDisclosure({ defaultIsOpen });
 
   const onToggleRefresh = () => {

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -28,6 +28,13 @@
   {% endif%}
 {% endblock %}
 
+{% block head_meta %}
+  {{ super() }}
+  {% if scheduler_job is defined and scheduler_job.is_alive() %}
+    <meta name="is_scheduler_running" content="True">
+  {% endif %}
+{% endblock %}
+
 {% block head_css %}
   {{ super() }}
 

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -30,7 +30,7 @@
 
 {% block head_meta %}
   {{ super() }}
-  {% if scheduler_job is defined and scheduler_job.is_alive() %}
+  {% if scheduler_job is defined and (scheduler_job and scheduler_job.is_alive()) %}
     <meta name="is_scheduler_running" content="True">
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
If the scheduler is not running we show a banner to the user, but autorefresh in Grid and Graph can remain active. This is a lot of unnecessary API calls. Therefore, this PR adds an additional check to see if the scheduler is running before turning on autorefresh on page load.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
