### PR TITLE
Reduce rerendering of TaskName component

### DIFF
--- a/airflow/www/static/js/tree/TaskName.jsx
+++ b/airflow/www/static/js/tree/TaskName.jsx
@@ -1,0 +1,64 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import {
+  Box,
+  Text,
+  Flex,
+} from '@chakra-ui/react';
+import { FiChevronUp, FiChevronDown } from 'react-icons/fi';
+
+const TaskName = ({
+  isGroup = false, isMapped = false, onToggle, isOpen, level, taskName,
+}) => (
+  <Box _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s">
+    <Flex
+      as={isGroup ? 'button' : 'div'}
+      onClick={onToggle}
+      color={level > 4 && 'white'}
+      aria-label={taskName}
+      title={taskName}
+      mr={4}
+      width="100%"
+      backgroundColor={`rgba(203, 213, 224, ${0.25 * level})`}
+      alignItems="center"
+    >
+      <Text
+        display="inline"
+        fontSize="12px"
+        ml={level * 4 + 4}
+        isTruncated
+      >
+        {taskName}
+        {isMapped && (
+          ' [ ]'
+        )}
+      </Text>
+      {isGroup && (
+        isOpen ? <FiChevronDown data-testid="open-group" /> : <FiChevronUp data-testid="closed-group" />
+      )}
+    </Flex>
+  </Box>
+);
+
+// Only rerender the component if props change
+const MemoizedTaskName = React.memo(TaskName);
+
+export default MemoizedTaskName;

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -19,19 +19,18 @@
 
 /* global localStorage */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   Tr,
   Td,
   Box,
-  Text,
   Flex,
   useDisclosure,
   Collapse,
 } from '@chakra-ui/react';
-import { FiChevronUp, FiChevronDown } from 'react-icons/fi';
 
 import StatusBox from './StatusBox';
+import TaskName from './TaskName';
 
 import { getMetaValue } from '../utils';
 
@@ -51,39 +50,6 @@ const renderTaskRows = ({
     dagRunIds={dagRunIds}
   />
 ));
-
-const TaskName = ({
-  isGroup = false, isMapped = false, onToggle, isOpen, level, taskName,
-}) => (
-  <Box _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s">
-    <Flex
-      as={isGroup ? 'button' : 'div'}
-      onClick={() => isGroup && onToggle()}
-      color={level > 4 && 'white'}
-      aria-label={taskName}
-      title={taskName}
-      mr={4}
-      width="100%"
-      backgroundColor={`rgba(203, 213, 224, ${0.25 * level})`}
-      alignItems="center"
-    >
-      <Text
-        display="inline"
-        fontSize="12px"
-        ml={level * 4 + 4}
-        isTruncated
-      >
-        {taskName}
-        {isMapped && (
-          ' [ ]'
-        )}
-      </Text>
-      {isGroup && (
-        isOpen ? <FiChevronDown data-testid="open-group" /> : <FiChevronUp data-testid="closed-group" />
-      )}
-    </Flex>
-  </Box>
-);
 
 const TaskInstances = ({ task, containerRef, dagRunIds }) => (
   <Flex justifyContent="flex-end">
@@ -124,6 +90,12 @@ const Row = (props) => {
   };
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isGroupId, onClose, onOpen });
 
+  // assure the function is the same across renders
+  const memoizedToggle = useCallback(
+    () => isGroup && onToggle(),
+    [onToggle, isGroup],
+  );
+
   const parentTasks = task.id.split('.');
   parentTasks.splice(-1);
 
@@ -150,7 +122,7 @@ const Row = (props) => {
         >
           <Collapse in={isFullyOpen}>
             <TaskName
-              onToggle={onToggle}
+              onToggle={memoizedToggle}
               isGroup={isGroup}
               isMapped={task.isMapped}
               taskName={taskName}


### PR DESCRIPTION
Use `React.memo` and `React.useCallback` to eliminate unnecessary rerenders of the `TaskName` component

TaskName is the component for the leftmost column of Grid view and it was rerendering on every change to autorefresh.
<img width="173" alt="Screen Shot 2022-03-10 at 1 42 30 PM" src="https://user-images.githubusercontent.com/4600967/157732787-1bea0b21-0aa4-43f3-be23-8401cb874398.png">


Below is a debug console.log while autorefreshing a run of `example_task_group` that has 12 task/task groups:
Before | After
---|---
<img width="396" alt="Screen Shot 2022-03-10 at 1 16 02 PM" src="https://user-images.githubusercontent.com/4600967/157729898-632a5e66-e4d0-46e4-aaf8-d8e4d8a83491.png"> | <img width="389" alt="Screen Shot 2022-03-10 at 1 16 29 PM" src="https://user-images.githubusercontent.com/4600967/157729916-e51ae8e3-3288-46c4-bc20-104fe959f619.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
