### PR TITLE
Fix RedshiftDataOperator and update doc

### DIFF
--- a/docs/apache-airflow-providers-amazon/operators/redshift_data.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_data.rst
@@ -15,38 +15,37 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/operator:RedshiftDataOperator:
-
-RedshiftDataOperator
-====================
-
-.. contents::
-  :depth: 1
-  :local:
-
-Overview
---------
+Amazon Redshift Data Operators
+==============================
 
 Use the :class:`RedshiftDataOperator <airflow.providers.amazon.aws.operators.redshift_data>` to execute
 statements against an Amazon Redshift cluster.
 
-This differs from RedshiftSQLOperator in that it allows users to query and retrieve data via the AWS API and avoid the necessity of a Postgres connection.
+This differs from `RedshiftSQLOperator` in that it allows users to query and retrieve data via the AWS API and avoid the necessity of a Postgres connection.
 
-example_redshift_data_execute_sql.py
-------------------------------------
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
 
-Purpose
-"""""""
+.. include:: _partials/prerequisite_tasks.rst
+
+Amazon Redshift Data
+^^^^^^^^^^^^^^^^^^^^
+
+.. _howto/operator:RedshiftDataOperator:
+
+Execute a statement on an Amazon Redshift Cluster
+"""""""""""""""""""""""""""""""""""""""""""""""""
 
 This is a basic example DAG for using :class:`RedshiftDataOperator <airflow.providers.amazon.aws.operators.redshift_data>`
 to execute statements against an Amazon Redshift cluster.
 
-List tables in database
-"""""""""""""""""""""""
-
-In the following code we list the tables in the provided database.
-
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_redshift_data_execute_sql.py
     :language: python
+    :dedent: 4
     :start-after: [START howto_redshift_data]
     :end-before: [END howto_redshift_data]
+
+Reference
+^^^^^^^^^
+
+ * `AWS boto3 Library Documentation for Amazon Redshift Data <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/redshift-data.html>`__

--- a/docs/apache-airflow-providers-amazon/operators/redshift_data.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_data.rst
@@ -21,7 +21,7 @@ Amazon Redshift Data Operators
 Use the :class:`RedshiftDataOperator <airflow.providers.amazon.aws.operators.redshift_data>` to execute
 statements against an Amazon Redshift cluster.
 
-This differs from `RedshiftSQLOperator` in that it allows users to query and retrieve data via the AWS API and avoid the necessity of a Postgres connection.
+This differs from ``RedshiftSQLOperator`` in that it allows users to query and retrieve data via the AWS API and avoid the necessity of a Postgres connection.
 
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^

--- a/tests/providers/amazon/aws/operators/test_redshift_data.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_data.py
@@ -40,38 +40,42 @@ class TestRedshiftDataOperator:
         )
         operator.execute(None)
         mock_conn.execute_statement.assert_called_once_with(
-            ClusterIdentifier=None,
             Database=DATABASE,
-            DbUser=None,
             Sql=SQL,
-            Parameters=None,
-            SecretArn=None,
-            StatementName=None,
             WithEvent=False,
         )
         mock_conn.describe_statement.assert_not_called()
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook.conn")
-    def test_execute(self, mock_conn):
+    def test_execute_with_all_parameters(self, mock_conn):
+        cluster_identifier = "cluster_identifier"
+        db_user = "db_user"
+        secret_arn = "secret_arn"
+        statement_name = "statement_name"
         parameters = [{"name": "id", "value": "1"}]
         mock_conn.execute_statement.return_value = {'Id': STATEMENT_ID}
         mock_conn.describe_statement.return_value = {"Status": "FINISHED"}
+
         operator = RedshiftDataOperator(
             aws_conn_id=CONN_ID,
             task_id=TASK_ID,
             sql=SQL,
-            parameters=parameters,
             database=DATABASE,
+            cluster_identifier=cluster_identifier,
+            db_user=db_user,
+            secret_arn=secret_arn,
+            statement_name=statement_name,
+            parameters=parameters,
         )
         operator.execute(None)
         mock_conn.execute_statement.assert_called_once_with(
-            ClusterIdentifier=None,
             Database=DATABASE,
-            DbUser=None,
             Sql=SQL,
+            ClusterIdentifier=cluster_identifier,
+            DbUser=db_user,
+            SecretArn=secret_arn,
+            StatementName=statement_name,
             Parameters=parameters,
-            SecretArn=None,
-            StatementName=None,
             WithEvent=False,
         )
         mock_conn.describe_statement.assert_called_once_with(


### PR DESCRIPTION
While testing `RedshiftDataOperator` operator as part of #22063 verification process I found out some bugs. The bugs are, for all optional parameters as part of `RedshiftDataOperator`, they should not be passed down to the boto3 client if no value is specified. Otherwise, such error message are thrown

`Invalid type for parameter Parameters, value: None, type: <class 'NoneType'>, valid types: <class 'list'>, <class 'tuple'>.`

I also updated the doc and sample dag for `RedshiftDataOperator`