### PR TITLE
Add pip_install_options to PythonVirtualenvOperator

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -310,6 +310,8 @@ class PythonVirtualenvOperator(PythonOperator):
     :param system_site_packages: Whether to include
         system_site_packages in your virtualenv.
         See virtualenv documentation for more information.
+    :param pip_install_options: a list of pip install options when installing requirements
+        See 'pip install -h' for available options
     :param op_args: A list of positional arguments to pass to python_callable.
     :param op_kwargs: A dict of keyword arguments to pass to python_callable.
     :param string_args: Strings that are present in the global var virtualenv_string_args,
@@ -367,6 +369,7 @@ class PythonVirtualenvOperator(PythonOperator):
         python_version: Optional[Union[str, int, float]] = None,
         use_dill: bool = False,
         system_site_packages: bool = True,
+        pip_install_options: Optional[List[str]] = None,
         op_args: Optional[Collection[Any]] = None,
         op_kwargs: Optional[Mapping[str, Any]] = None,
         string_args: Optional[Iterable[str]] = None,
@@ -409,6 +412,7 @@ class PythonVirtualenvOperator(PythonOperator):
         self.python_version = python_version
         self.use_dill = use_dill
         self.system_site_packages = system_site_packages
+        self.pip_install_options = pip_install_options
         self.pickling_library = dill if self.use_dill else pickle
 
     def execute(self, context: Context) -> Any:
@@ -447,6 +451,7 @@ class PythonVirtualenvOperator(PythonOperator):
                 python_bin=f'python{self.python_version}' if self.python_version else None,
                 system_site_packages=self.system_site_packages,
                 requirements_file_path=requirements_file_name,
+                pip_install_options=self.pip_install_options,
             )
 
             self._write_args(input_filename)

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -36,13 +36,17 @@ def _generate_virtualenv_cmd(tmp_dir: str, python_bin: str, system_site_packages
     return cmd
 
 
-def _generate_pip_install_cmd_from_file(tmp_dir: str, requirements_file_path: str) -> List[str]:
-    cmd = [f'{tmp_dir}/bin/pip', 'install', '-r']
+def _generate_pip_install_cmd_from_file(
+    tmp_dir: str, requirements_file_path: str, pip_install_options: List[str]
+) -> List[str]:
+    cmd = [f'{tmp_dir}/bin/pip', 'install'] + pip_install_options + ['-r']
     return cmd + [requirements_file_path]
 
 
-def _generate_pip_install_cmd_from_list(tmp_dir: str, requirements: List[str]) -> List[str]:
-    cmd = [f'{tmp_dir}/bin/pip', 'install']
+def _generate_pip_install_cmd_from_list(
+    tmp_dir: str, requirements: List[str], pip_install_options: List[str]
+) -> List[str]:
+    cmd = [f'{tmp_dir}/bin/pip', 'install'] + pip_install_options
     return cmd + requirements
 
 
@@ -82,6 +86,7 @@ def prepare_virtualenv(
     system_site_packages: bool,
     requirements: Optional[List[str]] = None,
     requirements_file_path: Optional[str] = None,
+    pip_install_options: Optional[List[str]] = None,
 ) -> str:
     """Creates a virtual environment and installs the additional python packages.
 
@@ -94,6 +99,9 @@ def prepare_virtualenv(
     :return: Path to a binary file with Python in a virtual environment.
     :rtype: str
     """
+    if pip_install_options is None:
+        pip_install_options = []
+
     virtualenv_cmd = _generate_virtualenv_cmd(venv_directory, python_bin, system_site_packages)
     execute_in_subprocess(virtualenv_cmd)
 
@@ -102,9 +110,11 @@ def prepare_virtualenv(
 
     pip_cmd = None
     if requirements is not None and len(requirements) != 0:
-        pip_cmd = _generate_pip_install_cmd_from_list(venv_directory, requirements)
+        pip_cmd = _generate_pip_install_cmd_from_list(venv_directory, requirements, pip_install_options)
     if requirements_file_path is not None and requirements_file_path:
-        pip_cmd = _generate_pip_install_cmd_from_file(venv_directory, requirements_file_path)
+        pip_cmd = _generate_pip_install_cmd_from_file(
+            venv_directory, requirements_file_path, pip_install_options
+        )
 
     if pip_cmd:
         execute_in_subprocess(pip_cmd)

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -45,6 +45,25 @@ class TestPrepareVirtualenv(unittest.TestCase):
         )
 
     @mock.patch('airflow.utils.python_virtualenv.execute_in_subprocess')
+    def test_pip_install_options(self, mock_execute_in_subprocess):
+        pip_install_options = ['--no-deps']
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV",
+            python_bin="pythonVER",
+            system_site_packages=True,
+            requirements=['apache-beam[gcp]'],
+            pip_install_options=pip_install_options,
+        )
+
+        assert "/VENV/bin/python" == python_bin
+        mock_execute_in_subprocess.assert_any_call(
+            [sys.executable, '-m', 'virtualenv', '/VENV', '--system-site-packages', '--python=pythonVER']
+        )
+        mock_execute_in_subprocess.assert_called_with(
+            ['/VENV/bin/pip', 'install'] + pip_install_options + ['apache-beam[gcp]']
+        )
+
+    @mock.patch('airflow.utils.python_virtualenv.execute_in_subprocess')
     def test_should_create_virtualenv_with_extra_packages(self, mock_execute_in_subprocess):
         python_bin = prepare_virtualenv(
             venv_directory="/VENV",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This gives the users more power to control how packages are installed in the virtual env. For example, users can choose to add `[--no-deps]` so that the virtualenv does not update the underlying deps, which can conflict with airflow deps, or upgrade them to the latest version.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
