### PR TITLE
Reduce rerendering of DagRunBar

### DIFF
--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -109,4 +109,17 @@ const DagRunBar = ({
   );
 };
 
-export default DagRunBar;
+// The default equality function is a shallow comparison and json objects will return false
+// This custom compare function allows us to do a deeper comparison
+const compareProps = (
+  prevProps,
+  nextProps,
+) => (
+  JSON.stringify(prevProps.run) === JSON.stringify(nextProps.run)
+  && prevProps.max === nextProps.max
+  && prevProps.index === nextProps.index
+  && prevProps.totalRuns === nextProps.totalRuns
+  && prevProps.containerRef === nextProps.containerRef
+);
+
+export default React.memo(DagRunBar, compareProps);


### PR DESCRIPTION
Use `React.memo` and a custom equality function to eliminate unnecessary rerenders of the `DagRunBar` component

DagRunBar is the individual bar of the duration chart at the top of the Grid view (my local scheduler is broken):
<img width="211" alt="Screen Shot 2022-03-10 at 2 03 36 PM" src="https://user-images.githubusercontent.com/4600967/157736335-75c16ce8-f630-47ea-bd7f-2451656fe765.png">

Below is a debug console.log while autorefreshing a run of `example_task_group`.
5 turns to 8 initial renders is because there were more runs.
Subsequent renders are from the active dag run bar updating with new data.
Before | After
---|---
<img width="392" alt="Screen Shot 2022-03-10 at 1 32 43 PM" src="https://user-images.githubusercontent.com/4600967/157736414-0fd306fc-9379-47b5-956a-302bd5d5f672.png"> | <img width="211" alt="Screen Shot 2022-03-10 at 1 50 32 PM" src="https://user-images.githubusercontent.com/4600967/157736425-26521062-ff59-40a4-8bda-307208a40dac.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
