### PR TITLE
Make code snippet appear again

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -556,7 +556,6 @@ Setting up Debug
 - Add a ``__main__`` block at the end of your DAG file to make it runnable. It will run a ``back_fill`` job:
 
   .. code-block:: python
-    ...
 
     if __name__ == "__main__":
         dag.clear()
@@ -1355,7 +1354,7 @@ Setting up Debug
 - Add a ``__main__`` block at the end of your DAG file to make it runnable. It will run a ``back_fill`` job:
 
   .. code-block:: python
-    ...
+
 
     if __name__ == "__main__":
         dag.clear()


### PR DESCRIPTION
Due to some erroneous extra dots, the reStructuredText got mangled and the code snippet was no longer visible.

Situation before:

![before](https://user-images.githubusercontent.com/59344/157739944-542c03fa-9b2e-4077-998e-86742ade55b6.PNG)

Situation when this pull request is applied:

![after](https://user-images.githubusercontent.com/59344/157740175-ef94708f-b5e4-4ebd-919c-3588380d421f.PNG)

