### PR TITLE
Improve StatusBox rendering in Grid view

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -87,6 +87,7 @@
     "framer-motion": "^4",
     "jquery": ">=3.5.0",
     "jshint": "^2.13.4",
+    "lodash": "^4.17.21",
     "moment-timezone": "^0.5.28",
     "nvd3": "^1.8.6",
     "react": "^17.0.2",

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -20,6 +20,7 @@
 /* global stateColors */
 
 import React from 'react';
+import { isEqual } from 'lodash';
 import {
   Flex,
   Box,
@@ -30,7 +31,7 @@ import { callModal } from '../dag';
 import InstanceTooltip from './InstanceTooltip';
 
 const StatusBox = ({
-  group, instance, containerRef, extraLinks = [], ...rest
+  group, instance, containerRef, extraLinks = [],
 }) => {
   const {
     executionDate, taskId, tryNumber = 0, operator, runId,
@@ -68,7 +69,6 @@ const StatusBox = ({
         zIndex={1}
         onMouseEnter={onMouseOver}
         onMouseLeave={onMouseLeave}
-        {...rest}
       >
         <Box
           width="10px"
@@ -82,4 +82,16 @@ const StatusBox = ({
   );
 };
 
-export default StatusBox;
+// The default equality function is a shallow comparison and json objects will return false
+// This custom compare function allows us to do a deeper comparison
+const compareProps = (
+  prevProps,
+  nextProps,
+) => (
+  isEqual(prevProps.group, nextProps.group)
+  && isEqual(prevProps.instance, nextProps.instance)
+  && prevProps.extraLinks === nextProps.extraLinks
+  && prevProps.containerRef === nextProps.containerRef
+);
+
+export default React.memo(StatusBox, compareProps);

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -20,6 +20,7 @@
 /* global stateColors, moment */
 
 import React from 'react';
+import { isEqual } from 'lodash';
 import {
   Flex,
   Box,
@@ -115,7 +116,7 @@ const compareProps = (
   prevProps,
   nextProps,
 ) => (
-  JSON.stringify(prevProps.run) === JSON.stringify(nextProps.run)
+  isEqual(prevProps.run, nextProps.run)
   && prevProps.max === nextProps.max
   && prevProps.index === nextProps.index
   && prevProps.totalRuns === nextProps.totalRuns

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -120,7 +120,7 @@ const Row = (props) => {
           backgroundColor="white"
           borderBottom={0}
         >
-          <Collapse in={isFullyOpen}>
+          <Collapse in={isFullyOpen} unmountOnExit>
             <TaskName
               onToggle={memoizedToggle}
               isGroup={isGroup}
@@ -133,7 +133,7 @@ const Row = (props) => {
         </Td>
         <Td width={0} p={0} borderBottom={0} />
         <Td p={0} align="right" _groupHover={{ backgroundColor: 'rgba(113, 128, 150, 0.1)' }} transition="background-color 0.2s" borderBottom={0}>
-          <Collapse in={isFullyOpen}>
+          <Collapse in={isFullyOpen} unmountOnExit>
             <TaskInstances dagRunIds={dagRunIds} task={task} containerRef={containerRef} />
           </Collapse>
         </Td>

--- a/airflow/www/static/js/tree/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.test.jsx
@@ -127,13 +127,15 @@ describe('Test renderTaskRows', () => {
 
     const groupName = getByText('group_1');
 
-    expect(getAllByTestId('task-instance')).toHaveLength(2);
+    expect(getAllByTestId('task-instance')).toHaveLength(1);
     expect(groupName).toBeInTheDocument();
     expect(getByTestId('closed-group')).toBeInTheDocument();
 
     fireEvent.click(groupName);
 
     expect(getByTestId('open-group')).toBeInTheDocument();
+    // task instances are only rendered when their group is expanded
+    expect(getAllByTestId('task-instance')).toHaveLength(2);
   });
 
   test('Still renders names if there are no instances', () => {


### PR DESCRIPTION
Use `React.memo` and a custom equality function to eliminate unnecessary rerenders of the `StatusBox` component. Also use `unmountOnExit` for the `Collapse` component to avoid rendering unexpanded groups.

StatusBox is the colored square that indicates a Task Instance.





First row is during autorefresh of a dag run. Second row is expanding/collapsing groups.
Before | After
---|---
<img width="269" alt="Screen Shot 2022-03-10 at 2 39 13 PM" src="https://user-images.githubusercontent.com/4600967/157767703-e16824fd-9958-4af3-918a-f4cbbd6165b1.png"> | <img width="177" alt="Screen Shot 2022-03-10 at 2 42 38 PM" src="https://user-images.githubusercontent.com/4600967/157767731-25af3c16-b573-481f-8ec0-9d1294b0ba7b.png">
![Mar-10-2022 17-35-07](https://user-images.githubusercontent.com/4600967/157767788-2ef2ff9a-1d3e-4ceb-b82e-4d79bb561912.gif) | ![Mar-10-2022 17-34-50](https://user-images.githubusercontent.com/4600967/157767803-5e355179-2fa0-4f90-9f9b-296d9d96eb24.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
