### PR TITLE
Don't set adoption timeout for already-started celery tasks

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -543,7 +543,8 @@ class CeleryExecutor(BaseExecutor):
 
             # Set the correct elements of the state dicts, then update this
             # like we just queried it.
-            self.adopted_task_timeouts[ti.key] = ti.queued_dttm + self.task_adoption_timeout
+            if state == celery_states.PENDING:
+                self.adopted_task_timeouts[ti.key] = ti.queued_dttm + self.task_adoption_timeout
             self.tasks[ti.key] = result
             self.running.add(ti.key)
             self.update_task_state(ti.key, state, info)


### PR DESCRIPTION
Re: https://github.com/apache/airflow/issues/22160

In some exceedingly rare cases, it's possible to have running tasks without a `queued_dttm`. This can cause a scheduler crashloop during task adoption as the executor tries to calculate the adoption timeout. 

https://github.com/apache/airflow/blob/9e6769206e124b65d31028a3b7b9047d51fd0be5/airflow/executors/celery_executor.py#L546

But this can be skipped, as if the task is running then the `adopted_task_timeouts` value is cleared almost immediately after it is set.
https://github.com/apache/airflow/blob/9e6769206e124b65d31028a3b7b9047d51fd0be5/airflow/executors/celery_executor.py#L549
https://github.com/apache/airflow/blob/9e6769206e124b65d31028a3b7b9047d51fd0be5/airflow/executors/celery_executor.py#L474-L476

So by not setting the `adoption_task_timeout` for a running task, we can avoid ever accessing the `queued_dttm` and thus avoid the scheduler crash. 