### PR TITLE
Remove Snowflake limits

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -18,7 +18,7 @@
 import os
 from contextlib import closing
 from io import StringIO
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -262,7 +262,7 @@ class SnowflakeHook(DbApiHook):
         self,
         sql: Union[str, list],
         autocommit: bool = False,
-        parameters: Optional[Union[dict, Iterable]] = None,
+        parameters: Optional[Union[Sequence[Any], Dict[Any, Any]]] = None,
         handler: Optional[Callable] = None,
     ):
         """
@@ -290,7 +290,8 @@ class SnowflakeHook(DbApiHook):
                 sql = [sql_string for sql_string, _ in split_statements_tuple if sql_string]
 
             self.log.debug("Executing %d statements against Snowflake DB", len(sql))
-            with closing(conn.cursor(DictCursor)) as cur:
+            # SnowflakeCursor does not extend ContextManager, so we have to ignore mypy error here
+            with closing(conn.cursor(DictCursor)) as cur:  # type: ignore[type-var]
 
                 for sql_statement in sql:
 

--- a/setup.py
+++ b/setup.py
@@ -510,13 +510,8 @@ slack = [
     'slack_sdk>=3.0.0',
 ]
 snowflake = [
-    # Snowflake connector 2.7.2 requires pyarrow >=6.0.0 but apache-beam requires < 6.0.0
-    # We should remove the limitation when apache-beam upgrades pyarrow
-    'snowflake-connector-python>=2.4.1,<2.7.2',
-    # The snowflake-alchemy 1.2.5 introduces a hard dependency on sqlalchemy>=1.4.0, but they didn't define
-    # this requirements in setup.py, so pip cannot figure out the correct set of dependencies.
-    # See: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/234
-    'snowflake-sqlalchemy>=1.1.0,!=1.2.5',
+    'snowflake-connector-python>=2.4.1',
+    'snowflake-sqlalchemy>=1.1.0',
 ]
 spark = [
     'pyspark',


### PR DESCRIPTION
The limits of snowflake can be removed as the conditions for
all limits are fulfilled now.

This is the last thing to remove before we can enable Python 3.10

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
