### PR TITLE
Soften the wording in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -118,7 +118,7 @@ body:
         <details><summary>x.log</summary> lots of stuff </details>
   - type: checkboxes
     attributes:
-      label: Are you will ing to submit PR?
+      label: Are you willing to submit PR?
       description: >
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.

--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -51,7 +51,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: What you expected to happen
+      label: What you think should happen instead
       description: What do you think went wrong?
       placeholder: >
         Please explain why you think the behaviour is erroneous. It is extremely helpful if you copy&paste
@@ -118,7 +118,7 @@ body:
         <details><summary>x.log</summary> lots of stuff </details>
   - type: checkboxes
     attributes:
-      label: Are you willing to submit PR?
+      label: Are you will ing to submit PR?
       description: >
         This is absolutely not required, but we are happy to guide you in the contribution process
         especially if you already have a good understanding of how to implement the fix.

--- a/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
@@ -19,7 +19,7 @@ body:
       # yamllint enable rule:line-length
   - type: textarea
     attributes:
-      label: Describe the issue with documentation
+      label: What do you see as an issue?
       description: Please describe the issue with documentation you have.
       placeholder: >
         Please include links to the documentation that has the problem and possibly screenshots showing
@@ -27,7 +27,7 @@ body:
         audience of the documentation. Please explain why you think the docs are wrong.
   - type: textarea
     attributes:
-      label: How to solve the problem
+      label: Solving the problem
       description: How do you think the problem can be solved?
       placeholder: >
         Please explain how you think the documentation could be fixed. Ideally specify where a new or missing

--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -90,7 +90,7 @@ body:
         Please provide the context in which the problem occurred and explain what happened
   - type: textarea
     attributes:
-      label: What you expected to happen
+      label: What you think should happen instead
       description: What do you think went wrong?
       placeholder: >
         Please explain why you think the behaviour is erroneous. It is extremely helpful if you copy&paste

--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -168,7 +168,7 @@ body:
         Please provide the context in which the problem occurred and explain what happened
   - type: textarea
     attributes:
-      label: What you expected to happen
+      label: What you think should happen instead
       description: What do you think went wrong?
       placeholder: >
         Please explain why you think the behaviour is erroneous. It is extremely helpful if you copy&paste

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,7 +25,7 @@ body:
   - type: textarea
     attributes:
       label: Use case/motivation
-      description: What do you want to happen?
+      description: What would you like to happen?
       placeholder: >
           Rather than telling us how you might implement this feature, try to take a
           step back and describe what you are trying to achieve.


### PR DESCRIPTION
Maybe this is my non-native English, but I often feel a bit strange
when reading the issues raised by our users whe they start the
description with:

* "I expected this and that"

For me - this comes from the "What you expected to happen" heading
we have and I have a feeling this might lead to bad wording of the
issues which can lead to unnecessary tensions. "Expectation" is
a bit too strong of a word for the Open-Source project because there
might be many reasons why the "expectation" is not fulfilled and
the user might not be aware, so they might "Expect" something in
a sense of "demanding" it, when there are good reasons things are
how they are.

In most cases people do not read the description or hint we
provided - they stop short by reading the header and base their
answer on the header.

I personally perceive that when you start "I expected this and this",
it feels like "This is obvious it should be like this".

I think changing the heading to "What you think should happen"
might be much better and has much less of the "demand" in it.
Eventually it might lead to people understanding better that what
they raise here is more of a "wish" rather than "expectation" and
that this presents their personal thinking rather than "general
expectation".

Making sure in the heading wording that the raised issue is a bit
"softer" might also set the tone for the follow-up conversation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
