### PR TITLE
Added autodetect arg to Create External Table Operator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -956,6 +956,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                            {"name": "salary", "type": "INTEGER", "mode": "NULLABLE"}]
 
         Should not be set when source_format is 'DATASTORE_BACKUP'.
+    :param autodetect: (Optional) If True will automatically detect schema of file.
     :param table_resource: Table resource as described in documentation:
         https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#Table
         If provided all other parameters are ignored. External schema from object will be resolved.
@@ -1024,6 +1025,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         destination_project_dataset_table: Optional[str] = None,
         table_resource: Optional[Dict[str, Any]] = None,
         schema_fields: Optional[List] = None,
+        autodetect: bool = True,
         schema_object: Optional[str] = None,
         source_format: Optional[str] = None,
         compression: Optional[str] = None,
@@ -1051,6 +1053,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                 destination_project_dataset_table,
                 schema_fields,
                 source_format,
+                autodetect,
                 compression,
                 skip_leading_rows,
                 field_delimiter,
@@ -1107,6 +1110,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         if table_resource and kwargs_passed:
             raise ValueError("You provided both `table_resource` and exclusive keywords arguments.")
 
+        self.autodetect = autodetect
         self.max_bad_records = max_bad_records
         self.quote_character = quote_character
         self.allow_quoted_newlines = allow_quoted_newlines
@@ -1161,6 +1165,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             src_fmt_configs=self.src_fmt_configs,
             labels=self.labels,
             encryption_configuration=self.encryption_configuration,
+            autodetect=self.autodetect
         )
 
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1165,7 +1165,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             src_fmt_configs=self.src_fmt_configs,
             labels=self.labels,
             encryption_configuration=self.encryption_configuration,
-            autodetect=self.autodetect
+            autodetect=self.autodetect,
         )
 
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -196,6 +196,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             bucket=TEST_GCS_BUCKET,
             source_objects=TEST_GCS_DATA,
             source_format=TEST_SOURCE_FORMAT,
+            autodetect = False,
         )
 
         operator.execute(None)
@@ -214,6 +215,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             src_fmt_configs={},
             labels=None,
             encryption_configuration=None,
+            autodetect = False,
         )
 
 


### PR DESCRIPTION
closes: #22129
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #22129
related: #22129 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Added autodetect argument to BigQueryCreateExternalTable Operator 
---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
