### PR TITLE
Fix imports of vendored cgroupspy

### DIFF
--- a/airflow/_vendor/cgroupspy/controllers.py
+++ b/airflow/_vendor/cgroupspy/controllers.py
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 import os
 import errno
-from cgroupspy.contenttypes import DeviceAccess, DeviceThrottle
+from airflow._vendor.cgroupspy.contenttypes import DeviceAccess, DeviceThrottle
 
 from .interfaces import BaseFileInterface, FlagFile, BitFieldFile, IntegerFile, SplitValueFile, DictOrFlagFile
 from .interfaces import MultiLineIntegerFile, CommaDashSetFile, DictFile, IntegerListFile, TypedFile

--- a/airflow/_vendor/cgroupspy/interfaces.py
+++ b/airflow/_vendor/cgroupspy/interfaces.py
@@ -25,7 +25,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 from collections import Iterable
-from cgroupspy.contenttypes import BaseContentType
+from airflow._vendor.cgroupspy.contenttypes import BaseContentType
 
 
 class BaseFileInterface(object):


### PR DESCRIPTION
This commit applies import fixes to vendored cgroupspy library
so that the library uses the vendored version internally.

This commit will need to be re-applied if we upgrade the
vendored cgroupspy library.

This is part of the effort needed to implement Python 3.10
compatibility: #22050

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
