### PR TITLE
Fix python 3.10 support in vendored in cgroupspy

### DIFF
--- a/airflow/_vendor/cgroupspy/interfaces.py
+++ b/airflow/_vendor/cgroupspy/interfaces.py
@@ -24,7 +24,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-from collections import Iterable
+from collections.abc import Iterable
 from airflow._vendor.cgroupspy.contenttypes import BaseContentType
 
 


### PR DESCRIPTION
The cgrouppspy is not Python 3.10 compliant due to Iterable
being imported directly from collections.

This is captured in https://github.com/cloudsigma/cgroupspy/issues/13

We fix it in our vendored-in version of cgroupspy until
hopefully new version of it is released.

This is part of the effort needed to implement Python 3.10
compatibility: https://github.com/apache/airflow/pull/22050

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
