### PR TITLE
Switched cgroupspy to vendored version

### DIFF
--- a/airflow/task/task_runner/cgroup_task_runner.py
+++ b/airflow/task/task_runner/cgroup_task_runner.py
@@ -23,8 +23,8 @@ import os
 import uuid
 
 import psutil
-from cgroupspy import trees
 
+from airflow._vendor.cgroupspy import trees
 from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 from airflow.utils.operator_resources import Resources
 from airflow.utils.platform import getuser

--- a/setup.py
+++ b/setup.py
@@ -242,8 +242,13 @@ celery = [
     'celery>=5.2.3',
     'flower>=1.0.0',
 ]
-cgroups = [
-    'cgroupspy>=0.1.4',
+cgroups = [  # type:ignore
+    # Cgroups are now vendored in `airflow/_vendor/cgroupspy` for Python 3.10 compatibility
+    # The vendored code can be removed once cgroupspy released a new version after fixing
+    # the incompatibility https://github.com/cloudsigma/cgroupspy/issues/13 (hopefully >0.2.1 will
+    # be good for that. We should also be able to remove type:ignore above, as MyPy can't derive the type
+    # when this line is commented out
+    # 'cgroupspy>0.2.1',
 ]
 cloudant = [
     'cloudant>=2.0',


### PR DESCRIPTION
This is part of the effort needed to implement Python 3.10
compatibility: #22050

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
