### PR TITLE
fix AttributeError

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -283,7 +283,7 @@ class KubernetesPodOperator(BaseOperator):
             return {}
 
         ti = context['ti']
-        run_id = getattr(ti, 'run_id') or context['run_id']
+        run_id = getattr(ti, 'run_id', context['run_id'])
 
         labels = {'dag_id': ti.dag_id, 'task_id': ti.task_id, 'run_id': run_id}
 


### PR DESCRIPTION
`getattr` doesn't return `None` in case of attribute absence, it throws `AttributeError`. Thats why previous construction with `or` didn't work and third argument in `getattr` should be used instead.