### PR TITLE
Update ``GKEDeleteClusterOperator`, ``GKECreateClusterOperator`` docstrings

### DIFF
--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -61,7 +61,7 @@ class GKEDeleteClusterOperator(BaseOperator):
 
     :param project_id: The Google Developers Console [project ID or project number]
     :param name: The name of the resource to delete, in this case cluster name
-    :param location: The name of the Google Compute Engine zone or region in which the cluster
+    :param location: The name of the Google Kubernetes Engine zone or region in which the cluster
         resides.
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
     :param api_version: The api version to use
@@ -155,7 +155,7 @@ class GKECreateClusterOperator(BaseOperator):
         :ref:`howto/operator:GKECreateClusterOperator`
 
     :param project_id: The Google Developers Console [project ID or project number]
-    :param location: The name of the Google Compute Engine  or region in which the cluster
+    :param location: The name of the Google Kubernetes Engine zone or region in which the cluster
         resides.
     :param body: The Cluster definition to create, can be protobuf or python dict, if
         dict it must match protobuf message Cluster


### PR DESCRIPTION
updated misleading docstrings to use Kubernetes rather than Compute as this takes Kubernetes engine zone as location parameters

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
