### PR TITLE
Do not use native obj Jinja2 env to render error emails

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -115,7 +115,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
         dag = self.get_dag()
         if dag:
-            return dag.get_template_env()
+            return dag.get_template_env(force_string=True)
         return SandboxedEnvironment(cache_size=0)
 
     def prepare_template(self) -> None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1260,7 +1260,7 @@ class DAG(LoggingMixin):
         for t in self.tasks:
             t.resolve_template_files()
 
-    def get_template_env(self) -> jinja2.Environment:
+    def get_template_env(self, force_string=False) -> jinja2.Environment:
         """Build a Jinja2 environment."""
         # Collect directories to search for template files
         searchpath = [self.folder]
@@ -1278,7 +1278,10 @@ class DAG(LoggingMixin):
             jinja_env_options.update(self.jinja_environment_kwargs)
         env: jinja2.Environment
         if self.render_template_as_native_obj:
-            env = airflow.templates.NativeEnvironment(**jinja_env_options)
+            if force_string:
+                env = airflow.templates.SandboxedEnvironment(**jinja_env_options)
+            else:
+                env = airflow.templates.NativeEnvironment(**jinja_env_options)
         else:
             env = airflow.templates.SandboxedEnvironment(**jinja_env_options)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1277,11 +1277,9 @@ class DAG(LoggingMixin):
         if self.jinja_environment_kwargs:
             jinja_env_options.update(self.jinja_environment_kwargs)
         env: jinja2.Environment
-        if self.render_template_as_native_obj:
-            if force_string:
-                env = airflow.templates.SandboxedEnvironment(**jinja_env_options)
-            else:
-                env = airflow.templates.NativeEnvironment(**jinja_env_options)
+        use_native_env = self.render_template_as_native_obj and not force_string
+        if use_native_env:
+            env = airflow.templates.NativeEnvironment(**jinja_env_options)
         else:
             env = airflow.templates.SandboxedEnvironment(**jinja_env_options)
 

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -288,7 +288,7 @@ def render_template(template: Any, context: MutableMapping[str, Any], *, native:
         import jinja2.nativetypes
 
         return jinja2.nativetypes.native_concat(nodes)
-    return "".join((str(n) for n in nodes))
+    return "".join(nodes)
 
 
 def render_template_to_string(template: "jinja2.Template", context: MutableMapping[str, Any]) -> str:

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -288,7 +288,7 @@ def render_template(template: Any, context: MutableMapping[str, Any], *, native:
         import jinja2.nativetypes
 
         return jinja2.nativetypes.native_concat(nodes)
-    return "".join(nodes)
+    return "".join((str(n) for n in nodes))
 
 
 def render_template_to_string(template: "jinja2.Template", context: MutableMapping[str, Any]) -> str:


### PR DESCRIPTION
https://github.com/apache/airflow/issues/22152

I added a flag **force_string** to make sure returning will be string,
Testing code still in progress.
Need more discussion.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
