### PR TITLE
Skip some tests for Databricks from running on Python 3.10

### DIFF
--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -34,6 +34,9 @@ versions:
 additional-dependencies:
   - apache-airflow>=2.1.0
 
+excluded-python-versions:
+  - "3.10"
+
 integrations:
   - integration-name: Databricks
     external-doc-url: https://databricks.com/

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -24,7 +24,7 @@ from unittest import mock
 import pytest
 from databricks.sql.types import Row
 
-from airflow import AirflowException
+from airflow import PY310, AirflowException
 from airflow.providers.databricks.operators.databricks_sql import (
     DatabricksCopyIntoOperator,
     DatabricksSqlOperator,
@@ -83,6 +83,12 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         db_mock.run.assert_called_once_with(sql, parameters=None)
 
 
+@pytest.mark.skipif(
+    PY310,
+    reason="Databricks SQL tests not run on Python 3.10 because there is direct Iterable import from"
+    " collections in the databricks SQL library, where it should be imported from collections.abc."
+    " This could be removed when https://github.com/apache/airflow/issues/22220 is solved",
+)
 class TestDatabricksSqlCopyIntoOperator(unittest.TestCase):
     def test_copy_with_files(self):
         op = DatabricksCopyIntoOperator(


### PR DESCRIPTION
This is a temporary measure until the Databricks SQL library
is released in Python 3.10 - compatible version.

Related to: #22220

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
