### PR TITLE
DatabricksSqlOperator - switch to databricks-sql-connector 2.x

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -33,7 +33,24 @@ USER_AGENT_STRING = f'airflow-{__version__}'
 
 
 class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
-    """Hook to interact with Databricks SQL."""
+    """
+    Hook to interact with Databricks SQL.
+
+    :param databricks_conn_id: Reference to the
+        :ref:`Databricks connection <howto/connection:databricks>`.
+    :param http_path: Optional string specifying HTTP path of Databricks SQL Endpoint or cluster.
+        If not specified, it should be either specified in the Databricks connection's extra parameters,
+        or ``sql_endpoint_name`` must be specified.
+    :param sql_endpoint_name: Optional name of Databricks SQL Endpoint. If not specified, ``http_path``
+        must be provided as described above.
+    :param session_configuration: An optional dictionary of Spark session parameters. Defaults to None.
+        If not specified, it could be specified in the Databricks connection's extra parameters.
+    :param http_headers: An optional list of (k, v) pairs that will be set as HTTP headers
+        on every request
+    :param catalog: An optional initial catalog to use. Requires DBR version 9.0+
+    :param schema: An optional initial schema to use. Requires DBR version 9.0+
+    :param kwargs: Additional parameters internal to Databricks SQL Connector parameters
+    """
 
     hook_name = 'Databricks SQL'
 
@@ -48,24 +65,6 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         schema: Optional[str] = None,
         **kwargs,
     ) -> None:
-        """
-        Initializes DatabricksSqlHook
-
-        :param databricks_conn_id: Reference to the
-            :ref:`Databricks connection <howto/connection:databricks>`.
-        :param http_path: Optional string specifying HTTP path of Databricks SQL Endpoint or cluster.
-            If not specified, it should be either specified in the Databricks connection's extra parameters,
-            or ``sql_endpoint_name`` must be specified.
-        :param sql_endpoint_name: Optional name of Databricks SQL Endpoint. If not specified, ``http_path``
-            must be provided as described above.
-        :param session_configuration: An optional dictionary of Spark session parameters. Defaults to None.
-            If not specified, it could be specified in the Databricks connection's extra parameters.
-        :param http_headers: An optional list of (k, v) pairs that will be set as HTTP headers
-            on every request
-        :param catalog: An optional initial catalog to use. Requires DBR version 9.0+
-        :param schema: An optional initial schema to use. Requires DBR version 9.0+
-        :param kwargs: Additional parameters internal to Databricks SQL Connector parameters
-        """
         super().__init__(databricks_conn_id)
         self._sql_conn = None
         self._token: Optional[str] = None

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -18,7 +18,7 @@
 import re
 from contextlib import closing
 from copy import copy
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from databricks import sql  # type: ignore[attr-defined]
 from databricks.sql.client import Connection  # type: ignore[attr-defined]
@@ -42,6 +42,9 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         be provided as described above.
     :param session_configuration: An optional dictionary of Spark session parameters. Defaults to None.
         If not specified, it could be specified in the Databricks connection's extra parameters.
+    :param metadata: An optional list of (k, v) pairs that will be set as Http headers on every request
+    :param catalog: An optional initial catalog to use. Requires DBR version 9.0+
+    :param schema: An optional initial schema to use. Requires DBR version 9.0+
     """
 
     hook_name = 'Databricks SQL'
@@ -52,6 +55,9 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         http_path: Optional[str] = None,
         sql_endpoint_name: Optional[str] = None,
         session_configuration: Optional[Dict[str, str]] = None,
+        metadata: Optional[List[Tuple[str, str]]] = None,
+        catalog: Optional[str] = None,
+        schema: Optional[str] = None,
     ) -> None:
         super().__init__(databricks_conn_id)
         self._sql_conn = None
@@ -60,6 +66,9 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         self._sql_endpoint_name = sql_endpoint_name
         self.supports_autocommit = True
         self.session_config = session_configuration
+        self.metadata = metadata
+        self.catalog = catalog
+        self.schema = schema
 
     def _get_extra_config(self) -> Dict[str, Optional[Any]]:
         extra_params = copy(self.databricks_conn.extra_dejson)

--- a/docs/apache-airflow-providers-databricks/index.rst
+++ b/docs/apache-airflow-providers-databricks/index.rst
@@ -81,7 +81,6 @@ PIP package                   Version required
 ============================  ===================
 ``apache-airflow``            ``>=2.1.0``
 ``databricks-sql-connector``  ``>=2.0.0, <3.0.0``
->>>>>>> DatabricksSqlOperator - switch to databricks-sql-connector 2.x
 ``requests``                  ``>=2.26.0, <3``
 ============================  ===================
 

--- a/docs/apache-airflow-providers-databricks/index.rst
+++ b/docs/apache-airflow-providers-databricks/index.rst
@@ -80,7 +80,8 @@ PIP requirements
 PIP package                   Version required
 ============================  ===================
 ``apache-airflow``            ``>=2.1.0``
-``databricks-sql-connector``  ``>=1.0.2, <2.0.0``
+``databricks-sql-connector``  ``>=2.0.0, <3.0.0``
+>>>>>>> DatabricksSqlOperator - switch to databricks-sql-connector 2.x
 ``requests``                  ``>=2.26.0, <3``
 ============================  ===================
 

--- a/docs/apache-airflow-providers-databricks/operators/copy_into.rst
+++ b/docs/apache-airflow-providers-databricks/operators/copy_into.rst
@@ -49,25 +49,29 @@ Operator loads data from a specified location into a table using a configured en
      - Optional HTTP path for Databricks SQL endpoint or Databricks cluster. If not specified, it should be provided in Databricks connection, or the ``sql_endpoint_name`` parameter must be set.
    * - session_configuration: dict[str,str]
      - optional dict specifying Spark configuration parameters that will be set for the session.
-   * - metadata: list[tuple[str, str]]
-     - Optional list of (k, v) pairs that will be set as Http headers on every request
-   * - files: Optional[List[str]]
+   * - http_headers: list[tuple[str, str]]
+     - Optional list of (k, v) pairs that will be set as HTTP headers on every request
+   * - client_parameters: dict[str,str]
+     - optional additional parameters internal to Databricks SQL Connector parameters
+   * - files: list[str]]
      - optional list of files to import. Can't be specified together with ``pattern``.
-   * - pattern: Optional[str]
+   * - pattern: str
      - optional regex string to match file names to import. Can't be specified together with ``files``.
-   * - expression_list: Optional[str]
+   * - expression_list: str
      - optional string that will be used in the ``SELECT`` expression.
-   * - credential: Optional[Dict[str, str]]
+   * - credential: dict[str, str]
      - optional credential configuration for authentication against a specified location
-   * - encryption: Optional[Dict[str, str]]
+   * - encryption: dict[str, str]
      - optional encryption configuration for a specified location
-   * - format_options: Optional[Dict[str, str]]
+   * - storage_credential: str
+     - optional Unity Catalog storage credential name for the target table
+   * - format_options: dict[str, str]
      - optional dictionary with options specific for a given file format.
-   * - force_copy: Optional[bool]
-     - optional bool to control forcing of data import (could be also specified in ``copy_options``).
-   * - copy_options: Optional[Dict[str, str]]
+   * - force_copy: bool
+     - optional boolean parameter to control forcing of data import (could be also specified in ``copy_options``).
+   * - copy_options: dict[str, str]
      - optional dictionary of copy options. Right now only ``force`` option is supported.
-   * - validate: Optional[Union[bool, int]]
+   * - validate: union[bool, int]]
      - optional validation configuration. ``True`` forces validation of all rows, positive number - only N first rows. (requires Preview channel)
 
 Examples

--- a/docs/apache-airflow-providers-databricks/operators/copy_into.rst
+++ b/docs/apache-airflow-providers-databricks/operators/copy_into.rst
@@ -29,50 +29,14 @@ command.
 Using the Operator
 ------------------
 
-Operator loads data from a specified location into a table using a configured endpoint.
+Operator loads data from a specified location into a table using a configured endpoint.  The only required parameters are:
 
-.. list-table::
-   :widths: 15 25
-   :header-rows: 1
+* ``table_name`` - string with the table name
+* ``file_location`` - string with the URI of data to load
+* ``file_format`` - string specifying the file format of data to load. Supported formats are ``CSV``, ``JSON``, ``AVRO``, ``ORC``, ``PARQUET``, ``TEXT``, ``BINARYFILE``.
+* One of ``sql_endpoint_name`` (name of Databricks SQL endpoint to use) or ``http_path`` (HTTP path for Databricks SQL endpoint or Databricks cluster).
 
-   * - Parameter
-     - Input
-   * - table_name: str
-     - Required name of the table.
-   * - file_location: str
-     - Required location of files to import.
-   * - file_format: str
-     - Required file format. Supported formats are ``CSV``, ``JSON``, ``AVRO``, ``ORC``, ``PARQUET``, ``TEXT``, ``BINARYFILE``.
-   * - sql_endpoint_name: str
-     - Optional name of Databricks SQL endpoint to use. If not specified, ``http_path`` should be provided.
-   * - http_path: str
-     - Optional HTTP path for Databricks SQL endpoint or Databricks cluster. If not specified, it should be provided in Databricks connection, or the ``sql_endpoint_name`` parameter must be set.
-   * - session_configuration: dict[str,str]
-     - optional dict specifying Spark configuration parameters that will be set for the session.
-   * - http_headers: list[tuple[str, str]]
-     - Optional list of (k, v) pairs that will be set as HTTP headers on every request
-   * - client_parameters: dict[str,str]
-     - optional additional parameters internal to Databricks SQL Connector parameters
-   * - files: list[str]]
-     - optional list of files to import. Can't be specified together with ``pattern``.
-   * - pattern: str
-     - optional regex string to match file names to import. Can't be specified together with ``files``.
-   * - expression_list: str
-     - optional string that will be used in the ``SELECT`` expression.
-   * - credential: dict[str, str]
-     - optional credential configuration for authentication against a specified location
-   * - encryption: dict[str, str]
-     - optional encryption configuration for a specified location
-   * - storage_credential: str
-     - optional Unity Catalog storage credential name for the target table
-   * - format_options: dict[str, str]
-     - optional dictionary with options specific for a given file format.
-   * - force_copy: bool
-     - optional boolean parameter to control forcing of data import (could be also specified in ``copy_options``).
-   * - copy_options: dict[str, str]
-     - optional dictionary of copy options. Right now only ``force`` option is supported.
-   * - validate: union[bool, int]]
-     - optional validation configuration. ``True`` forces validation of all rows, positive number - only N first rows. (requires Preview channel)
+Other parameters are optional and could be found in the class documentation.
 
 Examples
 --------

--- a/docs/apache-airflow-providers-databricks/operators/copy_into.rst
+++ b/docs/apache-airflow-providers-databricks/operators/copy_into.rst
@@ -49,6 +49,8 @@ Operator loads data from a specified location into a table using a configured en
      - Optional HTTP path for Databricks SQL endpoint or Databricks cluster. If not specified, it should be provided in Databricks connection, or the ``sql_endpoint_name`` parameter must be set.
    * - session_configuration: dict[str,str]
      - optional dict specifying Spark configuration parameters that will be set for the session.
+   * - metadata: list[tuple[str, str]]
+     - Optional list of (k, v) pairs that will be set as Http headers on every request
    * - files: Optional[List[str]]
      - optional list of files to import. Can't be specified together with ``pattern``.
    * - pattern: Optional[str]

--- a/docs/apache-airflow-providers-databricks/operators/sql.rst
+++ b/docs/apache-airflow-providers-databricks/operators/sql.rst
@@ -29,44 +29,17 @@ on a `Databricks SQL endpoint  <https://docs.databricks.com/sql/admin/sql-endpoi
 Using the Operator
 ------------------
 
-Operator executes given SQL queries against configured endpoint.  There are 3 ways of specifying SQL queries:
+Operator executes given SQL queries against configured endpoint. The only required parameters are:
 
-1. Simple string with SQL statement.
-2. List of strings representing SQL statements.
-3. Name of the file with SQL queries. File must have ``.sql`` extension. Each query should finish with ``;<new_line>``
+* ``sql`` - SQL queries to execute. There are 3 ways of specifying SQL queries:
 
-.. list-table::
-   :widths: 15 25
-   :header-rows: 1
+  1. Simple string with SQL statement.
+  2. List of strings representing SQL statements.
+  3. Name of the file with SQL queries. File must have ``.sql`` extension. Each query should finish with ``;<new_line>``
 
-   * - Parameter
-     - Input
-   * - sql: str or list[str]
-     - Required parameter specifying a queries to execute.
-   * - sql_endpoint_name: str
-     - Optional name of Databricks SQL endpoint to use. If not specified, ``http_path`` should be provided.
-   * - http_path: str
-     - Optional HTTP path for Databricks SQL endpoint or Databricks cluster. If not specified, it should be provided in Databricks connection, or the ``sql_endpoint_name`` parameter must be set.
-   * - parameters: dict[str, any]
-     - Optional parameters that will be used to substitute variable(s) in SQL query.
-   * - session_configuration: dict[str,str]
-     - optional dict specifying Spark configuration parameters that will be set for the session.
-   * - http_headers: list[tuple[str, str]]
-     - Optional list of (k, v) pairs that will be set as HTTP headers on every request
-   * - client_parameters: dict[str,str]
-     - optional additional parameters internal to Databricks SQL Connector parameters
-   * - catalog: str
-     - Optional initial catalog to use. Requires DBR version 9.0+
-   * - schema: str
-     - Optional initial schema to use. Requires DBR version 9.0+
-   * - output_path: str
-     - Optional path to the file to which results will be written.
-   * - output_format: str
-     - Name of the format which will be used to write results.  Supported values are (case-insensitive): ``JSON`` (array of JSON objects), ``JSONL`` (each row as JSON object on a separate line), ``CSV`` (default).
-   * - csv_params: dict[str, any]
-     - Optional dictionary with parameters to customize Python CSV writer.
-   * - do_xcom_push: bool
-     - whether we should push query results (last query if multiple queries are provided) to xcom. Default: false
+* One of ``sql_endpoint_name`` (name of Databricks SQL endpoint to use) or ``http_path`` (HTTP path for Databricks SQL endpoint or Databricks cluster).
+
+Other parameters are optional and could be found in the class documentation.
 
 Examples
 --------

--- a/docs/apache-airflow-providers-databricks/operators/sql.rst
+++ b/docs/apache-airflow-providers-databricks/operators/sql.rst
@@ -51,6 +51,12 @@ Operator executes given SQL queries against configured endpoint.  There are 3 wa
      - Optional parameters that will be used to substitute variable(s) in SQL query.
    * - session_configuration: dict[str,str]
      - optional dict specifying Spark configuration parameters that will be set for the session.
+   * - metadata: list[tuple[str, str]]
+     - Optional list of (k, v) pairs that will be set as Http headers on every request
+   * - catalog: str
+     - Optional initial catalog to use. Requires DBR version 9.0+
+   * - schema: str
+     - Optional initial schema to use. Requires DBR version 9.0+
    * - output_path: str
      - Optional path to the file to which results will be written.
    * - output_format: str

--- a/docs/apache-airflow-providers-databricks/operators/sql.rst
+++ b/docs/apache-airflow-providers-databricks/operators/sql.rst
@@ -51,8 +51,10 @@ Operator executes given SQL queries against configured endpoint.  There are 3 wa
      - Optional parameters that will be used to substitute variable(s) in SQL query.
    * - session_configuration: dict[str,str]
      - optional dict specifying Spark configuration parameters that will be set for the session.
-   * - metadata: list[tuple[str, str]]
-     - Optional list of (k, v) pairs that will be set as Http headers on every request
+   * - http_headers: list[tuple[str, str]]
+     - Optional list of (k, v) pairs that will be set as HTTP headers on every request
+   * - client_parameters: dict[str,str]
+     - optional additional parameters internal to Databricks SQL Connector parameters
    * - catalog: str
      - Optional initial catalog to use. Requires DBR version 9.0+
    * - schema: str
@@ -63,7 +65,7 @@ Operator executes given SQL queries against configured endpoint.  There are 3 wa
      - Name of the format which will be used to write results.  Supported values are (case-insensitive): ``JSON`` (array of JSON objects), ``JSONL`` (each row as JSON object on a separate line), ``CSV`` (default).
    * - csv_params: dict[str, any]
      - Optional dictionary with parameters to customize Python CSV writer.
-   * - do_xcom_push: boolean
+   * - do_xcom_push: bool
      - whether we should push query results (last query if multiple queries are provided) to xcom. Default: false
 
 Examples

--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ dask = [
 ]
 databricks = [
     'requests>=2.26.0, <3',
-    'databricks-sql-connector>=1.0.2, <2.0.0',
+    'databricks-sql-connector>=2.0.0, <3.0.0',
 ]
 datadog = [
     'datadog>=0.14.0',

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -53,7 +53,13 @@ class TestDatabricksSqlOperator(unittest.TestCase):
 
         assert results == mock_results
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, http_path=None, session_configuration=None, sql_endpoint_name=None
+            DEFAULT_CONN_ID,
+            http_path=None,
+            session_configuration=None,
+            sql_endpoint_name=None,
+            metadata=None,
+            catalog=None,
+            schema=None,
         )
         db_mock.run.assert_called_once_with(sql, parameters=None)
 
@@ -78,7 +84,13 @@ class TestDatabricksSqlOperator(unittest.TestCase):
 
         assert results == ["id,value", "1,value1"]
         db_mock_class.assert_called_once_with(
-            DEFAULT_CONN_ID, http_path=None, session_configuration=None, sql_endpoint_name=None
+            DEFAULT_CONN_ID,
+            http_path=None,
+            session_configuration=None,
+            sql_endpoint_name=None,
+            metadata=None,
+            catalog=None,
+            schema=None,
         )
         db_mock.run.assert_called_once_with(sql, parameters=None)
 

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -57,7 +57,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
             http_path=None,
             session_configuration=None,
             sql_endpoint_name=None,
-            metadata=None,
+            http_headers=None,
             catalog=None,
             schema=None,
         )
@@ -88,7 +88,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
             http_path=None,
             session_configuration=None,
             sql_endpoint_name=None,
-            metadata=None,
+            http_headers=None,
             catalog=None,
             schema=None,
         )
@@ -151,6 +151,25 @@ COPY_OPTIONS ('force' = 'true')
         assert (
             op._create_sql_query()
             == f"""COPY INTO test
+FROM (SELECT {expression} FROM '{COPY_FILE_LOCATION}' WITH (CREDENTIAL (AZURE_SAS_TOKEN = 'abc') ))
+FILEFORMAT = CSV
+""".strip()
+        )
+
+    def test_copy_with_target_credential(self):
+        expression = "col1, col2"
+        op = DatabricksCopyIntoOperator(
+            file_location=COPY_FILE_LOCATION,
+            file_format='CSV',
+            table_name='test',
+            task_id=TASK_ID,
+            expression_list=expression,
+            storage_credential='abc',
+            credential={'AZURE_SAS_TOKEN': 'abc'},
+        )
+        assert (
+            op._create_sql_query()
+            == f"""COPY INTO test WITH (CREDENTIAL abc)
 FROM (SELECT {expression} FROM '{COPY_FILE_LOCATION}' WITH (CREDENTIAL (AZURE_SAS_TOKEN = 'abc') ))
 FILEFORMAT = CSV
 """.strip()


### PR DESCRIPTION
Switch to `databricks-sql-connector` 2.x in Databricks SQL Operators:
* Allow to specify default catalog & schema
* Allow to pass additional parameters to underlying `Connection` object
* Allow to pass additional HTTP headers

Also, allow to pass Unity Catalog storage credential for destination table in the `DatabricksCopyIntoOperator`