### PR TITLE
Masking extras in GET /connections/<connection> endpoint

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -43,6 +43,8 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
         'private_key',
         'secret',
         'token',
+        'keyfile_dict',
+        'service_account',
     }
 )
 """Names of fields (Connection extra, Variable key name etc.) that are deemed sensitive"""

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -141,7 +141,7 @@ class TestGetConnection(TestConnectionEndpoint):
             conn_id='test-connection-id',
             conn_type='mysql',
             description='test description',
-            extra="{\"nonsensitive\": \"just_a_value\", \"api_token\": \"***\"}",
+            extra={"nonsensitive": "just_a_value", "api_token": "secretvalue"},
         )
         session.add(connection_model)
         session.commit()
@@ -150,7 +150,7 @@ class TestGetConnection(TestConnectionEndpoint):
             "/api/v1/connections/test-connection-id", environ_overrides={'REMOTE_USER': "test"}
         )
 
-        assert response.json['extra'] == "{'nonsensitive': 'just_a_value', 'api_token': '***'}"
+        assert response.json['extra'] == '{"nonsensitive": "just_a_value", "api_token": "***"}'
 
     def test_should_respond_404(self):
         response = self.client.get(

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -136,6 +136,22 @@ class TestGetConnection(TestConnectionEndpoint):
             'extra': "{'param': 'value'}",
         }
 
+    def test_should_mask_sensitive_values_in_extra(self, session):
+        connection_model = Connection(
+            conn_id='test-connection-id',
+            conn_type='mysql',
+            description='test description',
+            extra="{\"nonsensitive\": \"just_a_value\", \"api_token\": \"***\"}",
+        )
+        session.add(connection_model)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/connections/test-connection-id", environ_overrides={'REMOTE_USER': "test"}
+        )
+
+        assert response.json['extra'] == "{'nonsensitive': 'just_a_value', 'api_token': '***'}"
+
     def test_should_respond_404(self):
         response = self.client.get(
             "/api/v1/connections/invalid-connection", environ_overrides={'REMOTE_USER': "test"}


### PR DESCRIPTION
Applying secrets masking when reading the `extras` field of a connection via the REST API.

Users can still update the extras with the `patch` or `post` endpoints, but when reading them they will be recursively redacted.

Also adding some commonly used sensitive `extras` keys to the default sensitive values so that they will be properly redacted.
