### PR TITLE
Use variable for vote end date for helm chart release email

### DIFF
--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -273,6 +273,11 @@ cat <<EOF
 EOF
 ```
 
+```shell
+export VOTE_END_TIME=$(date --utc -d "now + 72 hours + 10 minutes" +'%Y-%m-%d %H:%M')
+export TIME_DATE_URL="to?iso=$(date --utc -d "now + 72 hours + 10 minutes" +'%Y%m%dT%H%M')&p0=136&font=cursive"
+```
+
 Body:
 
 ```shell
@@ -303,9 +308,9 @@ gpg:                using RSA key E1A1E984F55B8F280BD9CBA20BB7163892A2E48E
 gpg: Good signature from "Jed Cunningham <jedcunningham@apache.org>" [ultimate]
 plugin: Chart SHA verified. sha256:b33eac716e0416a18af89fb4fa1043fcfcf24f9f903cda3912729815213525df
 
-The vote will be open for at least 72 hours (2021-05-19 01:30 UTC) or until the necessary number of votes are reached.
+The vote will be open for at least 72 hours ($VOTE_END_TIME UTC) or until the necessary number of votes is reached.
 
-https://www.timeanddate.com/countdown/to?iso=20210519T0230&p0=136&font=cursive
+https://www.timeanddate.com/countdown/$TIME_DATE_URL
 
 Please vote accordingly:
 
@@ -324,14 +329,17 @@ java -jar $PATH_TO_RAT/apache-rat-0.13/apache-rat-0.13.jar chart -E .rat-exclude
 
 Please note that the version number excludes the \`rcX\` string, so it's now
 simply ${VERSION_WITHOUT_RC}. This will allow us to rename the artifact without modifying
-the artifact checksums when we actually release.
+the artifact checksums when we actually release it.
+
+The status of testing the Helm Chart by the community is kept here:
+<TODO COPY LINK TO THE ISSUE CREATED>
 
 Thanks,
 <your name>
 EOF
 ```
 
-Note, you need to update the `helm gpg verify` output and the end of the voting period in the body.
+Note, you need to update the `helm gpg verify` output and verify the end of the voting period in the body.
 
 # Verify the release candidate by PMCs
 


### PR DESCRIPTION
The current URL is auto escaped in zsh with backslashes and instead of manually editing this
url, I propose to automate it with environment variables that are not auto escaped by zsh

Also, added a link to the created issue for testing the release in the email body