### PR TITLE
Add the new Airflow Trove Classifier to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: System :: Monitoring
+    Framework :: Apache Airflow
 project_urls =
     Documentation=https://airflow.apache.org/docs/
     Bug Tracker=https://github.com/apache/airflow/issues


### PR DESCRIPTION
We have new Trove Classifiers in PyPI for Apache Airflow:

https://github.com/pypa/trove-classifiers/pull/87

This PR adds it for Airflow. The next release of Providers will
add the classifiers for providers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
