### PR TITLE
Fix assert_queries_count margin to be 0 by default

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3843,7 +3843,7 @@ class TestSchedulerJobQueriesCount:
             self.scheduler_job.heartbeat = mock.MagicMock()
             self.scheduler_job.processor_agent = mock_agent
 
-            with assert_queries_count(expected_query_count):
+            with assert_queries_count(expected_query_count, margin=15):
                 with mock.patch.object(DagRun, 'next_dagruns_to_examine') as mock_dagruns:
                     mock_dagruns.return_value = dagruns
 
@@ -3923,7 +3923,7 @@ class TestSchedulerJobQueriesCount:
             for expected_query_count in expected_query_counts:
                 with create_session() as session:
                     try:
-                        with assert_queries_count(expected_query_count, message):
+                        with assert_queries_count(expected_query_count, message_fmt=message, margin=15):
                             self.scheduler_job._do_scheduling(session)
                     except AssertionError as e:
                         failures.append(str(e))

--- a/tests/test_utils/asserts.py
+++ b/tests/test_utils/asserts.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import logging
 import re
 import traceback
 from collections import Counter
 from contextlib import contextmanager
+from typing import Optional
 
 from sqlalchemy import event
 
@@ -71,13 +71,17 @@ count_queries = CountQueries
 
 
 @contextmanager
-def assert_queries_count(expected_count, message_fmt=None):
+def assert_queries_count(expected_count: int, message_fmt: Optional[str] = None, margin: int = 0):
+    """
+    Asserts that the number of queries is as expected with the margin applied
+    The margin is helpful in case of complex cases where we do not want to change it every time we
+    changed queries, but we want to catch cases where we spin out of control
+    :param expected_count: expected number of queries
+    :param message_fmt: message printed optionally if the number is exceeded
+    :param margin: margin to add to expected number of calls
+    """
     with count_queries() as result:
         yield None
-
-    # This is a margin we have for queries - we do not want to change it every time we
-    # changed queries, but we want to catch cases where we spin out of control
-    margin = 15
 
     count = sum(result.values())
     if count > expected_count + margin:

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -30,7 +30,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 
 
 def test_index(admin_client):
-    with assert_queries_count(11):
+    with assert_queries_count(12):
         resp = admin_client.get('/', follow_redirects=True)
     check_content_in_response('DAGs', resp)
 


### PR DESCRIPTION
The margin is really only needed for more complex queries. For
most normal queries we should look at the exact value (i.e.
margin should be 0 by default)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
