### PR TITLE
Set queued_dttm when submitting task to directly to executor

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1716,7 +1716,8 @@ class Airflow(AirflowBaseView):
         ]
     )
     @action_logging
-    def run(self):
+    @provide_session
+    def run(self, session=None):
         """Runs Task Instance."""
         dag_id = request.form.get('dag_id')
         task_id = request.form.get('task_id')
@@ -1771,6 +1772,8 @@ class Airflow(AirflowBaseView):
             ignore_ti_state=ignore_ti_state,
         )
         executor.heartbeat()
+        ti.queued_dttm = timezone.utcnow()
+        session.merge(ti)
         flash(f"Sent {ti} to the message queue, it should start any moment now.")
         return redirect(origin)
 


### PR DESCRIPTION
Re: https://github.com/apache/airflow/issues/22160

If a task is in a non-running state and is submitted directly to the executor, it will be created with a null `queued_dttm` which can cause the scheduler to crashloop when trying to adopt the task (more details in the linked issue)

This updates the `/run` form to also set the `queued_dttm` on the task when it is submitted. 
