### PR TITLE
Add map_index support to all task instance-related views

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -53,6 +53,7 @@ let taskId = '';
 let executionDate = '';
 let subdagId = '';
 let dagRunId = '';
+let mapIndex = undefined;
 const showExternalLogRedirect = getMetaValue('show_external_log_redirect') === 'True';
 
 const buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce((obj, elm) => {
@@ -79,12 +80,14 @@ function updateModalUrls() {
     dag_id: dagId,
     task_id: taskId,
     execution_date: executionDate,
+    map_index: mapIndex,
   });
 
   updateButtonUrl(buttons.rendered, {
     dag_id: dagId,
     task_id: taskId,
     execution_date: executionDate,
+    map_index: mapIndex,
   });
 
   if (buttons.rendered_k8s) {
@@ -92,12 +95,14 @@ function updateModalUrls() {
       dag_id: dagId,
       task_id: taskId,
       execution_date: executionDate,
+      map_index: mapIndex,
     });
   }
 
   updateButtonUrl(buttons.ti, {
     _flt_3_dag_id: dagId,
     _flt_3_task_id: taskId,
+    _flt_3_map_index: mapIndex,
     _oc_TaskInstanceModelView: executionDate,
   });
 
@@ -105,6 +110,7 @@ function updateModalUrls() {
     dag_id: dagId,
     task_id: taskId,
     execution_date: executionDate,
+    map_index: mapIndex,
   });
 }
 
@@ -115,7 +121,7 @@ document.addEventListener('click', (event) => {
   }
 });
 
-export function callModal(t, d, extraLinks, tryNumbers, sd, drID) {
+export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
   taskId = t;
   const location = String(window.location);
   $('#btn_filter').on('click', () => {
@@ -124,8 +130,10 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID) {
   subdagId = sd;
   executionDate = d;
   dagRunId = drID;
+  mapIndex = mi;
   $('#dag_run_id').text(drID);
   $('#task_id').text(t);
+  $('#map_index').text(mapIndex);
   $('#execution_date').text(formatDateTime(d));
   $('#taskInstanceModal').modal({});
   $('#taskInstanceModal').css('margin-top', '0');
@@ -156,6 +164,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID) {
     }?dag_id=${encodeURIComponent(dagId)
     }&task_id=${encodeURIComponent(taskId)
     }&execution_date=${encodeURIComponent(executionDate)
+    }&map_index=${mapIndex
     }&metadata=null`
       + '&format=file';
 
@@ -175,6 +184,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID) {
       }?dag_id=${encodeURIComponent(dagId)
       }&task_id=${encodeURIComponent(taskId)
       }&execution_date=${encodeURIComponent(executionDate)
+      }&map_index=${mapIndex
       }&try_number=${index}`;
       $('#redir_log_try_index').append(`<li role="presentation" style="display:inline">
       <a href="${redirLogUrl}"> ${showLabel} </a>
@@ -190,6 +200,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID) {
       }?task_id=${encodeURIComponent(taskId)
       }&dag_id=${encodeURIComponent(dagId)
       }&execution_date=${encodeURIComponent(executionDate)
+      }&map_index=${mapIndex
       }&link_name=${encodeURIComponent(link)}`;
       const externalLink = $('<a href="#" class="btn btn-primary disabled"></a>');
       const linkTooltip = $('<span class="tool-tip" data-toggle="tooltip" style="padding-right: 2px; padding-left: 3px" data-placement="top" '

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -182,7 +182,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
     }
 
     $('#try_index').append(`<li role="presentation" style="display:inline">
-      <a href="${logsWithMetadataUrl}?${query}"> ${showLabel} </a>
+      <a href="${logsWithMetadataUrl}?${query}&format=file"> ${showLabel} </a>
       </li>`);
 
     if (index !== 0 || showExternalLogRedirect) {

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -135,12 +135,18 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
   mapIndex = mi;
   $('#dag_run_id').text(drID);
   $('#task_id').text(t);
-  $('#map_index').text(mapIndex);
   $('#execution_date').text(formatDateTime(d));
   $('#taskInstanceModal').modal({});
   $('#taskInstanceModal').css('margin-top', '0');
   $('#extra_links').prev('hr').hide();
   $('#extra_links').empty().hide();
+  if (mi >= 0) {
+    $('#modal_map_index').show();
+    $('#map_index, #modal_map_index .value').text(mi);
+  } else {
+    $('#modal_map_index').hide();
+    $('#map_index, #modal_map_index .value').text('');
+  }
   if (sd) {
     $('#div_btn_subdag').show();
     subdagId = `${dagId}.${t}`;

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -142,10 +142,10 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
   $('#extra_links').empty().hide();
   if (mi >= 0) {
     $('#modal_map_index').show();
-    $('#map_index, #modal_map_index .value').text(mi);
+    $('#modal_map_index .value').text(mi);
   } else {
     $('#modal_map_index').hide();
-    $('#map_index, #modal_map_index .value').text('');
+    $('#modal_map_index .value').text('');
   }
   if (sd) {
     $('#div_btn_subdag').show();
@@ -272,6 +272,9 @@ $('form[data-action]').on('submit', function submit(e) {
     if (form.task_id) {
       form.task_id.value = taskId;
     }
+    if (form.map_index) {
+      form.map_index.value = mapIndex === undefined ? '' : mapIndex;
+    }
     form.action = $(this).data('action');
     form.submit();
   }
@@ -291,6 +294,9 @@ $('form button[data-action]').on('click', function onClick() {
     form.origin.value = window.location;
     if (form.task_id) {
       form.task_id.value = taskId;
+    }
+    if (form.map_index) {
+      form.map_index.value = mapIndex === undefined ? '' : mapIndex;
     }
     form.action = $(this).data('action');
     form.submit();

--- a/airflow/www/static/js/gantt.js
+++ b/airflow/www/static/js/gantt.js
@@ -204,7 +204,7 @@ d3.gantt = () => {
       .on('mouseover', tip.show)
       .on('mouseout', tip.hide)
       .on('click', (d) => {
-        callModal(d.task_id, d.execution_date, d.extraLinks, undefined, undefined, d.run_id);
+        callModal(d.task_id, d.execution_date, d.extraLinks, undefined, undefined, d.run_id, d.map_index);
       })
       .attr('class', (d) => d.state || 'null')
       .attr('y', 0)

--- a/airflow/www/static/js/gantt.js
+++ b/airflow/www/static/js/gantt.js
@@ -204,6 +204,7 @@ d3.gantt = () => {
       .on('mouseover', tip.show)
       .on('mouseout', tip.hide)
       .on('click', (d) => {
+        // eslint-disable-next-line max-len
         callModal(d.task_id, d.execution_date, d.extraLinks, undefined, undefined, d.run_id, d.map_index);
       })
       .attr('class', (d) => d.state || 'null')

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -172,8 +172,8 @@ function draw() {
       const task = tasks[nodeId];
       const tryNumber = taskInstances[nodeId].try_number || 0;
 
-      if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true, dagRunId);
-      else callModal(nodeId, executionDate, task.extra_links, tryNumber, undefined, dagRunId);
+      if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true, dagRunId, task.map_index);
+      else callModal(nodeId, executionDate, task.extra_links, tryNumber, undefined, dagRunId, task.map_index);
     }
   });
 

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -172,8 +172,15 @@ function draw() {
       const task = tasks[nodeId];
       const tryNumber = taskInstances[nodeId].try_number || 0;
 
-      if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true, dagRunId, task.map_index);
-      else callModal(nodeId, executionDate, task.extra_links, tryNumber, undefined, dagRunId, task.map_index);
+      callModal(
+        nodeId,
+        executionDate,
+        task.extra_links,
+        tryNumber,
+        task.task_tupe === 'SubDagOperator',
+        dagRunId,
+        task.map_index,
+      );
     }
   });
 

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -38,7 +38,7 @@ const StatusBox = ({
   const {
     executionDate, taskId, tryNumber = 0, operator, runId, mapIndex,
   } = instance;
-  const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId, mapIndex);
+  const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator', runId, mapIndex);
 
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -36,9 +36,9 @@ const StatusBox = ({
   group, instance, containerRef, extraLinks = [],
 }) => {
   const {
-    executionDate, taskId, tryNumber = 0, operator, runId,
+    executionDate, taskId, tryNumber = 0, operator, runId, mapIndex,
   } = instance;
-  const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId);
+  const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator' || undefined, runId, mapIndex);
 
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -232,6 +232,7 @@
             <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
             <input type="hidden" name="task_id">
             <input type="hidden" name="dag_run_id">
+            <input type="hidden" name="map_index">
             <input type="hidden" name="origin" value="{{ request.base_url }}">
             <div class="row">
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -180,6 +180,7 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           <h4 class="modal-title" id="taskInstanceModalLabel">
             <span class="text-muted">Task Instance:</span> <span id="task_id"></span>
+            <span id="modal_map_index"><br><span class="text-muted">Map Index:</span> <span class="value"></span></span>
             <br><span class="text-muted">at:</span> <span id="execution_date"></span>
           </h4>
         </div>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -27,7 +27,7 @@
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
-    {% if map_index is defined and map_index != -1 %}
+    {% if map_index is defined and map_index < 0 %}
       <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
     {% endif %}
   </h4>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -27,6 +27,9 @@
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
+    {% if map_index and map_index != -1 %}
+      <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
+    {% endif %}
   </h4>
   <ul class="nav nav-pills">
     {% macro ti_url(endpoint) -%}

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -27,7 +27,7 @@
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
-    {% if map_index and map_index != -1 %}
+    {% if map_index is defined and map_index != -1 %}
       <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
     {% endif %}
   </h4>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -29,21 +29,28 @@
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
   </h4>
   <ul class="nav nav-pills">
-    <li><a href="{{ url_for('Airflow.task', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
+    {% macro ti_url(endpoint) -%}
+      {% if map_index >= 0 -%}
+        {{ url_for(endpoint, dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}
+      {%- else -%}
+        {{ url_for(endpoint, dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}
+      {%- endif -%}
+    {% endmacro -%}
+    <li><a href="{{ ti_url('Airflow.task') }}">
         <span class="material-icons" aria-hidden="true">details</span>
       Task Instance Details</a></li>
-    <li><a href="{{ url_for('Airflow.rendered_templates', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
+    <li><a href="{{ ti_url('Airflow.rendered_templates') }}">
         <span class="material-icons" aria-hidden="true">code</span>
       Rendered Template</a></li>
     {% if k8s_or_k8scelery_executor %}
-      <li><a href="{{ url_for('Airflow.rendered_k8s', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
+      <li><a href="{{ ti_url('Airflow.rendered_k8s') }}">
         {{ icon('kubernetes') }}
         K8s Pod Spec</a></li>
     {% endif %}
-    <li><a href="{{ url_for('Airflow.log', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
+    <li><a href="{{ ti_url('Airflow.log') }}">
         <span class="material-icons" aria-hidden="true">reorder</span>
       Log</a></li>
-    <li><a href="{{ url_for('Airflow.xcom', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
+    <li><a href="{{ ti_url('Airflow.xcom') }}">
         <span class="material-icons" aria-hidden="true">sync_alt</span>
       XCom</a></li>
   </ul>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -29,21 +29,21 @@
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
   </h4>
   <ul class="nav nav-pills">
-    <li><a href="{{ url_for('Airflow.task', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
+    <li><a href="{{ url_for('Airflow.task', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
         <span class="material-icons" aria-hidden="true">details</span>
       Task Instance Details</a></li>
-    <li><a href="{{ url_for('Airflow.rendered_templates', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
+    <li><a href="{{ url_for('Airflow.rendered_templates', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
         <span class="material-icons" aria-hidden="true">code</span>
       Rendered Template</a></li>
     {% if k8s_or_k8scelery_executor %}
-      <li><a href="{{ url_for('Airflow.rendered_k8s', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
+      <li><a href="{{ url_for('Airflow.rendered_k8s', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
         {{ icon('kubernetes') }}
         K8s Pod Spec</a></li>
     {% endif %}
-    <li><a href="{{ url_for('Airflow.log', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
+    <li><a href="{{ url_for('Airflow.log', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
         <span class="material-icons" aria-hidden="true">reorder</span>
       Log</a></li>
-    <li><a href="{{ url_for('Airflow.xcom', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">
+    <li><a href="{{ url_for('Airflow.xcom', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index) }}">
         <span class="material-icons" aria-hidden="true">sync_alt</span>
       XCom</a></li>
   </ul>

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -135,6 +135,7 @@ def encode_ti(
         'task_id': task_instance.task_id,
         'dag_id': task_instance.dag_id,
         'run_id': task_instance.run_id,
+        'map_index': task_instance.map_index,
         'state': task_instance.state,
         'duration': task_instance.duration,
         'start_date': datetime_to_string(task_instance.start_date),

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -445,6 +445,13 @@ def dag_run_link(attr):
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 
+def format_map_index(value: int) -> str:
+    """Format map index for list columns in model view."""
+    if value < 0:
+        return Markup("&nbsp;")
+    return str(value)
+
+
 def pygment_html_render(s, lexer=lexers.TextLexer):
     """Highlight text using a given Lexer"""
     return highlight(s, lexer(), HtmlFormatter(linenos=True))

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -349,7 +349,13 @@ def task_instance_link(attr):
     dag_id = attr.get('dag_id')
     task_id = attr.get('task_id')
     execution_date = attr.get('dag_run.execution_date') or attr.get('execution_date') or timezone.utcnow()
-    url = url_for('Airflow.task', dag_id=dag_id, task_id=task_id, execution_date=execution_date.isoformat())
+    url = url_for(
+        'Airflow.task',
+        dag_id=dag_id,
+        task_id=task_id,
+        execution_date=execution_date.isoformat(),
+        map_index=attr.get('map_index', -1),
+    )
     url_root = url_for(
         'Airflow.graph', dag_id=dag_id, root=task_id, execution_date=execution_date.isoformat()
     )

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -452,8 +452,9 @@ def dag_run_link(attr):
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 
-def format_map_index(value: int) -> str:
+def format_map_index(attr: dict) -> str:
     """Format map index for list columns in model view."""
+    value = attr['map_index']
     if value < 0:
         return Markup("&nbsp;")
     return str(value)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1716,8 +1716,9 @@ class Airflow(AirflowBaseView):
         dag_id = request.form.get('dag_id')
         task_id = request.form.get('task_id')
         dag_run_id = request.form.get('dag_run_id')
+        map_index = request.args.get('map_index', -1, type=int)
         origin = get_safe_url(request.form.get('origin'))
-        dag = current_app.dag_bag.get_dag(dag_id)
+        dag: DAG = current_app.dag_bag.get_dag(dag_id)
         task = dag.get_task(task_id)
 
         ignore_all_deps = request.form.get('ignore_all_deps') == "true"
@@ -1731,7 +1732,7 @@ class Airflow(AirflowBaseView):
             return redirect(origin)
 
         dag_run = dag.get_dagrun(run_id=dag_run_id)
-        ti = dag_run.get_task_instance(task_id=task.task_id)
+        ti = dag_run.get_task_instance(task_id=task.task_id, map_index=map_index)
         if not ti:
             flash(
                 "Could not queue task instance for execution, task instance is missing",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1335,12 +1335,13 @@ class Airflow(AirflowBaseView):
         dttm = timezone.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
         root = request.args.get('root', '')
+        map_index = request.args.get('map_index', -1, type=int)
         logging.info("Retrieving rendered templates.")
 
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
         task = dag.get_task(task_id)
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
-        ti = dag_run.get_task_instance(task_id=task.task_id, session=session)
+        ti = dag_run.get_task_instance(task_id=task.task_id, map_index=map_index, session=session)
 
         pod_spec = None
         try:
@@ -1368,6 +1369,7 @@ class Airflow(AirflowBaseView):
             dag=dag,
             task_id=task_id,
             execution_date=execution_date,
+            map_index=map_index,
             form=form,
             root=root,
             title=title,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1558,6 +1558,7 @@ class Airflow(AirflowBaseView):
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
         dttm = timezone.parse(execution_date)
+        map_index = request.args.get('map_index', -1, type=int)
         form = DateTimeForm(data={'execution_date': dttm})
         root = request.args.get('root', '')
         dag = current_app.dag_bag.get_dag(dag_id)
@@ -1582,6 +1583,7 @@ class Airflow(AirflowBaseView):
                 DagRun.execution_date == dttm,
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.task_id == task_id,
+                TaskInstance.map_index == map_index,
             )
             .one_or_none()
         )
@@ -1646,6 +1648,7 @@ class Airflow(AirflowBaseView):
             failed_dep_reasons=failed_dep_reasons or no_failed_deps_result,
             task_id=task_id,
             execution_date=execution_date,
+            map_index=map_index,
             special_attrs_rendered=special_attrs_rendered,
             form=form,
             root=root,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3277,6 +3277,7 @@ class Airflow(AirflowBaseView):
         """
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
+        map_index = request.args.get('map_index', -1, type=int)
         execution_date = request.args.get('execution_date')
         link_name = request.args.get('link_name')
         dttm = timezone.parse(execution_date)
@@ -3296,11 +3297,7 @@ class Airflow(AirflowBaseView):
 
         ti = (
             session.query(TaskInstance)
-            .filter(
-                models.TaskInstance.dag_id == dag_id,
-                models.TaskInstance.task_id == task_id,
-                models.TaskInstance.execution_date == dttm,
-            )
+            .filter_by(dag_id=dag_id, task_id=task_id, execution_date=dttm, map_index=map_index)
             .options(joinedload(TaskInstance.dag_run))
             .first()
         )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1578,13 +1578,7 @@ class Airflow(AirflowBaseView):
                 joinedload(TaskInstance.queued_by_job, innerjoin=False),
                 joinedload(TaskInstance.trigger, innerjoin=False),
             )
-            .join(TaskInstance.dag_run)
-            .filter(
-                DagRun.execution_date == dttm,
-                TaskInstance.dag_id == dag_id,
-                TaskInstance.task_id == task_id,
-                TaskInstance.map_index == map_index,
-            )
+            .filter_by(execution_date=dttm, dag_id=dag_id, task_id=task_id, map_index=map_index)
             .one_or_none()
         )
         if ti is None:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1521,15 +1521,12 @@ class Airflow(AirflowBaseView):
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
         dttm = timezone.parse(execution_date)
+        map_index = request.args.get('map_index', -1, type=int)
         try_number = request.args.get('try_number', 1)
 
         ti = (
             session.query(models.TaskInstance)
-            .filter(
-                models.TaskInstance.dag_id == dag_id,
-                models.TaskInstance.task_id == task_id,
-                models.TaskInstance.execution_date == dttm,
-            )
+            .filter_by(dag_id=dag_id, task_id=task_id, execution_date=dttm, map_index=map_index)
             .first()
         )
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1471,6 +1471,7 @@ class Airflow(AirflowBaseView):
         """Retrieve log."""
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
+        map_index = request.args.get('map_index', -1, type=int)
         execution_date = request.args.get('execution_date')
         dttm = timezone.parse(execution_date) if execution_date else None
         form = DateTimeForm(data={'execution_date': dttm})
@@ -1478,11 +1479,7 @@ class Airflow(AirflowBaseView):
 
         ti = (
             session.query(models.TaskInstance)
-            .filter(
-                models.TaskInstance.dag_id == dag_id,
-                models.TaskInstance.task_id == task_id,
-                models.TaskInstance.execution_date == dttm,
-            )
+            .filter_by(dag_id=dag_id, task_id=task_id, execution_date=dttm, map_index=map_index)
             .first()
         )
 
@@ -1502,6 +1499,7 @@ class Airflow(AirflowBaseView):
             dag_id=dag_id,
             task_id=task_id,
             execution_date=execution_date,
+            map_index=map_index,
             form=form,
             root=root,
             wrapped=conf.getboolean('webserver', 'default_wrap'),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1390,6 +1390,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
         execution_date = request.args.get('execution_date')
+        map_index = request.args.get('map_index', -1, type=int)
         try_number = request.args.get('try_number', type=int)
         metadata = request.args.get('metadata')
         metadata = json.loads(metadata)
@@ -1422,11 +1423,7 @@ class Airflow(AirflowBaseView):
 
         ti = (
             session.query(models.TaskInstance)
-            .filter(
-                models.TaskInstance.dag_id == dag_id,
-                models.TaskInstance.task_id == task_id,
-                models.TaskInstance.execution_date == execution_date,
-            )
+            .filter_by(dag_id=dag_id, task_id=task_id, execution_date=execution_date, map_index=map_index)
             .first()
         )
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1235,6 +1235,7 @@ class Airflow(AirflowBaseView):
         """Get rendered Dag."""
         dag_id = request.args.get('dag_id')
         task_id = request.args.get('task_id')
+        map_index = request.args.get('map_index', -1, type=int)
         execution_date = request.args.get('execution_date')
         dttm = timezone.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
@@ -1251,10 +1252,10 @@ class Airflow(AirflowBaseView):
             # make sense in this situation, but "works" prior to AIP-39. This
             # "fakes" a temporary DagRun-TaskInstance association (not saved to
             # database) for presentation only.
-            ti = TaskInstance(task)
+            ti = TaskInstance(task, map_index=map_index)
             ti.dag_run = DagRun(dag_id=dag_id, execution_date=dttm)
         else:
-            ti = dag_run.get_task_instance(task_id=task.task_id, session=session)
+            ti = dag_run.get_task_instance(task_id=task.task_id, map_index=map_index, session=session)
             ti.refresh_from_task(task)
 
         try:
@@ -1309,6 +1310,7 @@ class Airflow(AirflowBaseView):
             dag=dag,
             task_id=task_id,
             execution_date=execution_date,
+            map_index=map_index,
             form=form,
             root=root,
             title=title,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3637,6 +3637,7 @@ class SlaMissModelView(AirflowModelView):
         'execution_date': wwwutils.datetime_f('execution_date'),
         'timestamp': wwwutils.datetime_f('timestamp'),
         'dag_id': wwwutils.dag_link,
+        'map_index': wwwutils.format_map_index,
     }
 
 
@@ -3663,7 +3664,7 @@ class XComModelView(AirflowModelView):
     ]
 
     search_columns = ['key', 'value', 'timestamp', 'dag_id', 'task_id', 'run_id']
-    list_columns = ['key', 'value', 'timestamp', 'dag_id', 'task_id', 'run_id']
+    list_columns = ['key', 'value', 'timestamp', 'dag_id', 'task_id', 'run_id', 'map_index']
     base_order = ('dag_run_id', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]
@@ -3672,6 +3673,7 @@ class XComModelView(AirflowModelView):
         'task_id': wwwutils.task_instance_link,
         'timestamp': wwwutils.datetime_f('timestamp'),
         'dag_id': wwwutils.dag_link,
+        'map_index': wwwutils.format_map_index,
     }
 
     @action('muldelete', 'Delete', "Are you sure you want to delete selected records?", single=False)
@@ -4628,6 +4630,7 @@ class TaskRescheduleModelView(AirflowModelView):
         'run_id',
         'dag_run.execution_date',
         'task_id',
+        'map_index',
         'try_number',
         'start_date',
         'end_date',
@@ -4669,6 +4672,7 @@ class TaskRescheduleModelView(AirflowModelView):
         'dag_run.execution_date': wwwutils.datetime_f('dag_run.execution_date'),
         'reschedule_date': wwwutils.datetime_f('reschedule_date'),
         'duration': duration_f,
+        'map_index': wwwutils.format_map_index,
     }
 
 
@@ -4814,18 +4818,11 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
             return td_format(timedelta(seconds=duration))
         return None
 
-    def format_map_index(self):
-        """Only show indices of mapped tasks"""
-        map_index = self.get('map_index')
-        if map_index < 0:
-            return Markup("&nbsp;")
-        return None
-
     formatters_columns = {
         'log_url': log_url_formatter,
         'task_id': wwwutils.task_instance_link,
         'run_id': wwwutils.dag_run_link,
-        'map_index': format_map_index,
+        'map_index': wwwutils.format_map_index,
         'hostname': wwwutils.nobr_f('hostname'),
         'state': wwwutils.state_f,
         'dag_run.execution_date': wwwutils.datetime_f('dag_run.execution_date'),


### PR DESCRIPTION
This makes multiple ti-related views take an additional parameter `map_index` (optional, defaults to -1 if not given for unmapped tasks). But I’m not really sure how to actually _pass_ the argument in those. Also `map_index` is added to `list_columns` for views to models with that field.

Some oddities not handled in this PR that need to be fixed later:

* `/success` and `/failed` set state to a task (and potentially its upstreams/downstreams). It feels a bit weird to be able to set the state to only one mapped task? Also upstream/downstream makes less sense if any of those are mapped. So I’m currently leaving these views alone (i.e. setting success/failed to a mapped task sets the state of all mapped tis). We can perhaps add some UI components to optionally do more fine-grained state modification.
* `SlamissModelView` is currently unchanged awaiting #22184.
* `LogModelView` is currently unchanged awaiting #22274.