### PR TITLE
Fail with error when extending image with pip run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -486,7 +486,13 @@ ENV DUMB_INIT_SETSID="1" \
     PS1="(airflow)" \
     AIRFLOW_VERSION=${AIRFLOW_VERSION} \
     AIRFLOW__CORE__LOAD_EXAMPLES="false" \
-    PIP_USER="true"
+    PIP_USER="true" \
+    PATH="/root/bin:${PATH}"
+
+# Add protection against running pip as root user
+RUN mkdir -pv /root/bin
+COPY scripts/docker/pip /root/bin/pip
+RUN chmod u+x /root/bin/pip
 
 WORKDIR ${AIRFLOW_HOME}
 

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -115,7 +115,9 @@ for more complex cases which might involve either extending or customizing the i
 Adding new ``apt`` package
 ..........................
 
-The following example adds ``vim`` to the airflow image.
+The following example adds ``vim`` to the airflow image. When adding packages via ``apt`` you should
+switch to ``root`` user for the time of installation, but do not forget to switch back to the
+``airflow`` user after installation is complete.
 
 .. exampleinclude:: docker-examples/extending/add-apt-packages/Dockerfile
     :language: Dockerfile
@@ -126,7 +128,9 @@ The following example adds ``vim`` to the airflow image.
 Adding a new ``PyPI`` package
 .............................
 
-The following example adds ``lxml`` python package from PyPI to the image.
+The following example adds ``lxml`` python package from PyPI to the image. When adding packages via
+``pip`` you need to use ``airflow`` user rather than ``root``. Attempts to install ``pip`` packages
+with root, when you using typical ``pip install`` command will fail with appropriate error message.
 
 .. exampleinclude:: docker-examples/extending/add-pypi-packages/Dockerfile
     :language: Dockerfile

--- a/scripts/docker/pip
+++ b/scripts/docker/pip
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+COLOR_RED=$'\e[31m'
+COLOR_RESET=$'\e[0m'
+COLOR_YELLOW=$'\e[33m'
+
+if [[ $(id -u) == "0" ]]; then
+    echo
+    echo "${COLOR_RED}You are running pip as root. Please use 'airflow' user to run pip!${COLOR_RESET}"
+    echo
+    echo "${COLOR_YELLOW}See: https://airflow.apache.org/docs/docker-stack/build.html#adding-a-new-pypi-package${COLOR_RESET}"
+    echo
+    exit 1
+fi
+exec "${HOME}"/.local/bin/pip "${@}"


### PR DESCRIPTION
The production docker image installs airflow with --user
flag for `airflow` user and all subsequent image extension
should be done using `airflow` user. It is very easy however,
to run `pip` as root user when you switched temporarily to the
root user for `apt` installation.

This PR makes the accidental `root` user run `pip` fail with
error and redirection to the documentation where it is explained
to the users that they should use `airflow` user for `pip` with
examples.

Fixes: #22250

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
