### PR TITLE
Add dag-processor cli command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1865,6 +1865,21 @@ airflow_commands: List[CLICommand] = [
         ),
     ),
     ActionCommand(
+        name='dag-processor',
+        help="Start a standalone Dag Processor instance",
+        func=lazy_load_command('airflow.cli.commands.dag_processor_command.dag_processor'),
+        args=(
+            ARG_PID,
+            ARG_DAEMON,
+            ARG_SUBDIR,
+            ARG_NUM_RUNS,
+            ARG_DO_PICKLE,
+            ARG_STDOUT,
+            ARG_STDERR,
+            ARG_LOG_FILE,
+        ),
+    ),
+    ActionCommand(
         name='version',
         help="Show the version",
         func=lazy_load_command('airflow.cli.commands.version_command.version'),

--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""DagProcessor command"""
+import logging
+from datetime import timedelta
+
+import daemon
+from daemon.pidfile import TimeoutPIDLockFile
+
+from airflow import settings
+from airflow.configuration import conf
+from airflow.dag_processing.manager import DagFileProcessorManager
+from airflow.utils import cli as cli_utils
+from airflow.utils.cli import setup_locations, setup_logging
+
+log = logging.getLogger(__name__)
+
+
+def _create_dag_processor_manager(args) -> DagFileProcessorManager:
+    """Creates DagFileProcessorProcess instance."""
+    processor_timeout_seconds: int = conf.getint('core', 'dag_file_processor_timeout')
+    processor_timeout = timedelta(seconds=processor_timeout_seconds)
+    return DagFileProcessorManager(
+        dag_directory=settings.DAGS_FOLDER,
+        max_runs=args.num_runs,
+        processor_timeout=processor_timeout,
+        dag_ids=[],
+        pickle_dags=args.do_pickle,
+    )
+
+
+@cli_utils.action_cli
+def dag_processor(args):
+    """Starts Airflow Dag Processor Job"""
+    if not conf.getboolean("scheduler", "standalone_dag_processor"):
+        raise SystemExit('The option [scheduler/standalone_dag_processor] must be True.')
+
+    sql_conn: str = conf.get('core', 'sql_alchemy_conn').lower()
+    if sql_conn.startswith('sqlite'):
+        raise SystemExit('Standalone DagProcessor is not supported when using sqlite.')
+
+    manager = _create_dag_processor_manager(args)
+
+    if args.daemon:
+        pid, stdout, stderr, log_file = setup_locations(
+            "dag-processor", args.pid, args.stdout, args.stderr, args.log_file
+        )
+        handle = setup_logging(log_file)
+        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+            ctx = daemon.DaemonContext(
+                pidfile=TimeoutPIDLockFile(pid, -1),
+                files_preserve=[handle],
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+            )
+            with ctx:
+                try:
+                    manager.register_exit_signals()
+                finally:
+                    manager.terminate()
+                    manager.end()
+    else:
+        manager.register_exit_signals()
+        manager.start()

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -242,9 +242,9 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
             dag_directory=dag_directory,
             max_runs=max_runs,
             processor_timeout=processor_timeout,
-            signal_conn=signal_conn,
             dag_ids=dag_ids,
             pickle_dags=pickle_dags,
+            signal_conn=signal_conn,
             async_mode=async_mode,
         )
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -128,7 +128,7 @@ class SchedulerJob(BaseJob):
         self._scheduler_idle_sleep_time = scheduler_idle_sleep_time
         # How many seconds do we wait for tasks to heartbeat before mark them as zombies.
         self._zombie_threshold_secs = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
-
+        self._standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         self.do_pickle = do_pickle
         super().__init__(*args, **kwargs)
 
@@ -599,7 +599,7 @@ class SchedulerJob(BaseJob):
     @provide_session
     def _process_executor_events(self, session: Session = None) -> int:
         """Respond to executor events."""
-        if not self.processor_agent:
+        if not self._standalone_dag_processor and not self.processor_agent:
             raise ValueError("Processor agent is not started.")
         ti_primary_key_to_try_number_map: Dict[Tuple[str, str, str, int], int] = {}
         event_buffer = self.executor.get_event_buffer()
@@ -722,21 +722,22 @@ class SchedulerJob(BaseJob):
 
         processor_timeout_seconds: int = conf.getint('core', 'dag_file_processor_timeout')
         processor_timeout = timedelta(seconds=processor_timeout_seconds)
-        self.processor_agent = DagFileProcessorAgent(
-            dag_directory=self.subdir,
-            max_runs=self.num_times_parse_dags,
-            processor_timeout=processor_timeout,
-            dag_ids=[],
-            pickle_dags=pickle_dags,
-            async_mode=async_mode,
-        )
+        if not self._standalone_dag_processor:
+            self.processor_agent = DagFileProcessorAgent(
+                dag_directory=self.subdir,
+                max_runs=self.num_times_parse_dags,
+                processor_timeout=processor_timeout,
+                dag_ids=[],
+                pickle_dags=pickle_dags,
+                async_mode=async_mode,
+            )
 
         try:
             self.executor.job_id = self.id
-            if conf.getboolean("scheduler", "standalone_dag_processor"):
+            if self._standalone_dag_processor:
                 self.log.debug("Using DatabaseCallbackSink as callback sink.")
                 self.executor.callback_sink = DatabaseCallbackSink()
-            else:
+            elif self.processor_agent:
                 self.log.debug("Using PipeCallbackSink as callback sink.")
                 self.executor.callback_sink = PipeCallbackSink(
                     get_sink_pipe=self.processor_agent.get_callbacks_pipe
@@ -746,23 +747,25 @@ class SchedulerJob(BaseJob):
 
             self.register_signals()
 
-            self.processor_agent.start()
+            if not self._standalone_dag_processor and self.processor_agent:
+                self.processor_agent.start()
 
             execute_start_time = timezone.utcnow()
 
             self._run_scheduler_loop()
 
-            # Stop any processors
-            self.processor_agent.terminate()
+            if not self._standalone_dag_processor and self.processor_agent:
+                # Stop any processors
+                self.processor_agent.terminate()
 
-            # Verify that all files were processed, and if so, deactivate DAGs that
-            # haven't been touched by the scheduler as they likely have been
-            # deleted.
-            if self.processor_agent.all_files_processed:
-                self.log.info(
-                    "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
-                )
-                models.DAG.deactivate_stale_dags(execute_start_time)
+                # Verify that all files were processed, and if so, deactivate DAGs that
+                # haven't been touched by the scheduler as they likely have been
+                # deleted.
+                if self.processor_agent.all_files_processed:
+                    self.log.info(
+                        "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
+                    )
+                    models.DAG.deactivate_stale_dags(execute_start_time)
 
             settings.Session.remove()  # type: ignore
         except Exception:
@@ -773,10 +776,11 @@ class SchedulerJob(BaseJob):
                 self.executor.end()
             except Exception:
                 self.log.exception("Exception when executing Executor.end")
-            try:
-                self.processor_agent.end()
-            except Exception:
-                self.log.exception("Exception when executing DagFileProcessorAgent.end")
+            if not self._standalone_dag_processor and self.processor_agent:
+                try:
+                    self.processor_agent.end()
+                except Exception:
+                    self.log.exception("Exception when executing DagFileProcessorAgent.end")
             self.log.info("Exited execute loop")
 
     def _run_scheduler_loop(self) -> None:
@@ -796,7 +800,7 @@ class SchedulerJob(BaseJob):
 
         :rtype: None
         """
-        if not self.processor_agent:
+        if not self._standalone_dag_processor and not self.processor_agent:
             raise ValueError("Processor agent is not started.")
         is_unit_test: bool = conf.getboolean('core', 'unit_test_mode')
 
@@ -828,7 +832,7 @@ class SchedulerJob(BaseJob):
         for loop_count in itertools.count(start=1):
             with Stats.timer() as timer:
 
-                if self.using_sqlite:
+                if not self._standalone_dag_processor and self.using_sqlite and self.processor_agent:
                     self.processor_agent.run_single_parsing_loop()
                     # For the sqlite case w/ 1 thread, wait until the processor
                     # is finished to avoid concurrent access to the DB.
@@ -841,8 +845,8 @@ class SchedulerJob(BaseJob):
                     self.executor.heartbeat()
                     session.expunge_all()
                     num_finished_events = self._process_executor_events(session=session)
-
-                self.processor_agent.heartbeat()
+                if not self._standalone_dag_processor and self.processor_agent:
+                    self.processor_agent.heartbeat()
 
                 # Heartbeat the scheduler periodically
                 self.heartbeat(only_if_necessary=True)
@@ -866,7 +870,7 @@ class SchedulerJob(BaseJob):
                     loop_count,
                 )
                 break
-            if self.processor_agent.done:
+            if not self._standalone_dag_processor and self.processor_agent and self.processor_agent.done:
                 self.log.info(
                     "Exiting scheduler loop as requested DAG parse count (%d) has been reached after %d"
                     " scheduler loops",

--- a/tests/cli/commands/test_dag_processor_command.py
+++ b/tests/cli/commands/test_dag_processor_command.py
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from unittest import mock
+
+import pytest
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import dag_processor_command
+from airflow.configuration import conf
+from tests.test_utils.config import conf_vars
+
+
+class TestDagProcessorCommand(unittest.TestCase):
+    """
+    Tests the CLI interface and that it correctly calls the DagProcessor
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @conf_vars(
+        {
+            ('scheduler', 'standalone_dag_processor'): 'True',
+            ('core', 'load_examples'): 'False',
+        }
+    )
+    @mock.patch("airflow.cli.commands.dag_processor_command.DagFileProcessorManager")
+    @pytest.mark.skipif(
+        conf.get('core', 'sql_alchemy_conn').lower().startswith('sqlite'),
+        reason="Standalone Dag Processor doesn't support sqlite.",
+    )
+    def test_start_manager(
+        self,
+        mock_dag_manager,
+    ):
+        """Ensure that DagFileProcessorManager is started"""
+        args = self.parser.parse_args(['dag-processor'])
+        dag_processor_command.dag_processor(args)
+        mock_dag_manager.return_value.start.assert_called()

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -757,12 +757,7 @@ class TestDagFileProcessorManager:
         )
 
         with create_session() as session:
-            results = self.run_processor_manager_one_loop(manager, parent_pipe)
-
-        assert results[0] == callback3
-        assert results[1] == callback2
-        assert results[2] == callback1
-        with create_session() as session:
+            self.run_processor_manager_one_loop(manager, parent_pipe)
             assert session.query(DbCallbackRequest).count() == 0
 
     @conf_vars(
@@ -798,13 +793,11 @@ class TestDagFileProcessorManager:
         )
 
         with create_session() as session:
-            results = self.run_processor_manager_one_loop(manager, parent_pipe)
-            assert (len(results)) == 2
+            self.run_processor_manager_one_loop(manager, parent_pipe)
             assert session.query(DbCallbackRequest).count() == 3
 
         with create_session() as session:
-            results = self.run_processor_manager_one_loop(manager, parent_pipe)
-            assert (len(results)) == 2
+            self.run_processor_manager_one_loop(manager, parent_pipe)
             assert session.query(DbCallbackRequest).count() == 1
 
     @conf_vars(


### PR DESCRIPTION
This change introduces new cli command: 'dag-processor' which runs DagProcessorManager as a standalone process.

Part of AIP-43
https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-43+DAG+Processor+separation