### PR TITLE
Airflow file sensor by prefix for azure data lake storage

### DIFF
--- a/airflow/contrib/sensors/DataLake_PrefixFile_Sensor.py
+++ b/airflow/contrib/sensors/DataLake_PrefixFile_Sensor.py
@@ -49,5 +49,6 @@ class DataLakePrefixSensor(BaseSensorOperator):
         hook = AzureDataLakeHook(azure_data_lake_conn_id=self.azure_data_lake_conn_id)
         return len(hook.list(self.DataLake_path + "/" + self.prefix)) > 0
 
+
         # return TRUE => 1 ou more file detected
         # return FALSE => No file detected

--- a/airflow/contrib/sensors/DataLake_PrefixFile_Sensor.py
+++ b/airflow/contrib/sensors/DataLake_PrefixFile_Sensor.py
@@ -1,0 +1,53 @@
+from airflow.contrib.hooks.azure_data_lake_hook import AzureDataLakeHook
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+# File detector by prefix sensor for azure data lake storage
+
+class DataLakePrefixSensor(BaseSensorOperator):
+
+    """
+    Interacts with Azure Data Lake:
+
+    Client ID and client secret should be in user and password parameters.
+    Tenant and account name should be extra field as
+    {"tenant": "<TENANT>", "account_name": "ACCOUNT_NAME"}.
+
+    :param azure_data_lake_conn_id: Reference to the Azure Data Lake connection
+
+    DataLake_path : directory of the file
+
+    prefix : file name
+
+    """
+
+    @apply_defaults
+    def __init__(
+        self,
+        DataLake_path,
+        prefix,
+        azure_data_lake_conn_id="azure_data_lake_default",
+        check_options=None,
+        *args,
+        **kwargs
+    ):
+        super(DataLakePrefixSensor, self).__init__(*args, **kwargs)
+        if check_options is None:
+            check_options = {}
+        self.azure_data_lake_conn_id = azure_data_lake_conn_id
+        self.DataLake_path = DataLake_path
+        self.prefix = prefix
+        self.check_options = check_options
+
+    def poke(self, context):
+        self.log.info(
+            "Poking for prefix: %s in Data Lake path: %s",
+            self.prefix,
+            self.DataLake_path,
+        )
+        hook = AzureDataLakeHook(azure_data_lake_conn_id=self.azure_data_lake_conn_id)
+        return len(hook.list(self.DataLake_path + "/" + self.prefix)) > 0
+
+        # return TRUE => 1 ou more file detected
+        # return FALSE => No file detected


### PR DESCRIPTION
Hi, 

I noticed there was no airflow file sensor suitable for Azure Data Lake Storage. Hence, I created one. That could be realy useful for people who store data in Data Lake. 

My sensor is adaptable with the prefix of the file's name and any directory path

hope this contribution will help someone. 

Regards, Ashraf ZAMAN

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
