### PR TITLE
enable optional subPath for dags volume mount

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -419,6 +419,9 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{ define "airflow_dags_mount" -}}
 - name: dags
   mountPath: {{ (printf "%s/dags" .Values.airflowHome) }}
+  {{ if .Values.dags.persistence.subPath -}}
+  subPath: {{ .Values.dags.persistence.subPath }}
+  {{- end }}
   readOnly: {{ .Values.dags.gitSync.enabled | ternary "True" "False" }}
 {{- end -}}
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4142,6 +4142,14 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "subPath": {
+                            "description": "Subpath within the PVC where dags are located.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1515,6 +1515,8 @@ dags:
     accessMode: ReadWriteOnce
     ## the name of an existing PVC to use
     existingClaim:
+    ## optional subpath for dag volume mount
+    subPath: ~
   gitSync:
     enabled: false
 

--- a/tests/charts/test_airflow_common.py
+++ b/tests/charts/test_airflow_common.py
@@ -33,18 +33,45 @@ class TestAirflowCommon:
 
     @parameterized.expand(
         [
-            ({"gitSync": {"enabled": True}}, True),
-            ({"persistence": {"enabled": True}}, False),
+            (
+                {"gitSync": {"enabled": True}},
+                {
+                    "mountPath": "/opt/airflow/dags",
+                    "name": "dags",
+                    "readOnly": True,
+                },
+            ),
+            (
+                {"persistence": {"enabled": True}},
+                {
+                    "mountPath": "/opt/airflow/dags",
+                    "name": "dags",
+                    "readOnly": False,
+                },
+            ),
             (
                 {
                     "gitSync": {"enabled": True},
                     "persistence": {"enabled": True},
                 },
-                True,
+                {
+                    "mountPath": "/opt/airflow/dags",
+                    "name": "dags",
+                    "readOnly": True,
+                },
+            ),
+            (
+                {"persistence": {"enabled": True, "subPath": "test/dags"}},
+                {
+                    "subPath": "test/dags",
+                    "mountPath": "/opt/airflow/dags",
+                    "name": "dags",
+                    "readOnly": False,
+                },
             ),
         ]
     )
-    def test_dags_mount(self, dag_values, expected_read_only):
+    def test_dags_mount(self, dag_values, expected_mount):
         docs = render_chart(
             values={
                 "dags": dag_values,
@@ -59,11 +86,6 @@ class TestAirflowCommon:
 
         assert 3 == len(docs)
         for doc in docs:
-            expected_mount = {
-                "mountPath": "/opt/airflow/dags",
-                "name": "dags",
-                "readOnly": expected_read_only,
-            }
             assert expected_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", doc)
 
     def test_annotations(self):

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -518,11 +518,3 @@ class SchedulerTest(unittest.TestCase):
                 "memory": "2Gi",
             },
         } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
-
-    def test_dags_persistence_subpath(self):
-        docs = render_chart(
-            values={"dags": {"persistence": {"enabled": True, "subPath": "test/dags"}}},
-            show_only=["templates/scheduler/scheduler-deployment.yaml"],
-        )
-
-        assert "dags" in jmespath.search("spec.template.spec.containers[0].volumeMounts[*].name", docs[0])

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -518,3 +518,11 @@ class SchedulerTest(unittest.TestCase):
                 "memory": "2Gi",
             },
         } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
+
+    def test_dags_persistence_subpath(self):
+        docs = render_chart(
+            values={"dags": {"persistence": {"enabled": True, "subPath": "test/dags"}}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert "dags" in jmespath.search("spec.template.spec.containers[0].volumeMounts[*].name", docs[0])


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Users may have their DAGs on a volume that includes other things and as such want to use a `subPath` on the Volume Mount. This is similar to how the `gitSync` Volume Mount is setup.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
