### PR TITLE
WIP - Add shareProcessNamespace for sidecar

### DIFF
--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -78,6 +78,9 @@ spec:
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}
       {{- end }}
+      {{- if .Values.migrateDatabaseJob.shareProcessNamespace }}
+      shareProcessNamespace: {{ .Values.migrateDatabaseJob.shareProcessNamespace }}
+      {{- end }}
       containers:
         - name: run-airflow-migrations
           image: {{ template "airflow_image_for_migrations" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -787,6 +787,9 @@ migrateDatabaseJob:
   # In case you need to disable the helm hooks that create the jobs after install.
   # Disable this if you are using ArgoCD for example
   useHelmHooks: true
+  # In case you need to load a proxy sidecar, shareProcessNamespace will allow you to
+  # terminate the sidecar when the job is complete.
+  shareProcessNamespace: false
 
 # Airflow webserver settings
 webserver:


### PR DESCRIPTION
This change adds the ability to shareProcessNamespace for sidecars.
The purpose of this change is to have the ability to kill the sidecar when the job is complete.

Use case is in the case of database sidecar use with an external postgres, the proxy stays open after the job completes and prevents the rest of the application from starting.