### PR TITLE
fix deprecation warning in test_default_views.py

### DIFF
--- a/tests/dags/test_default_views.py
+++ b/tests/dags/test_default_views.py
@@ -24,7 +24,7 @@ tree_dag = DAG(
     dag_id='test_tree_view',
     default_args=args,
     schedule_interval='0 0 * * *',
-    default_view='tree',
+    default_view='grid',
 )
 
 graph_dag = DAG(


### PR DESCRIPTION
```
    /opt/airflow/tests/dags/test_default_views.py:27: DeprecationWarning: `default_view` of 'tree' has been renamed to 'grid' -- please update your DAG
      default_view='tree'

```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
