### PR TITLE
Update secrets backends to use get_conn_value instead of get_conn_uri

### DIFF
--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -20,6 +20,7 @@
 import ast
 import json
 import sys
+import warnings
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -173,9 +174,9 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         return connection
 
-    def get_conn_uri(self, conn_id: str):
+    def get_conn_value(self, conn_id: str):
         """
-        Get Connection Value
+        Get serialized representation of Connection
 
         :param conn_id: connection id
         """
@@ -198,6 +199,21 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                 connection = self.get_uri_from_secret(secret)
 
             return connection
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Return URI representation of Connection conn_id
+
+        :param conn_id: the connection id
+        :return: deserialized Connection
+        """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"in a future release.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -211,25 +211,20 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
-        Return URI representation of Connection conn_id
+        Return URI representation of Connection conn_id.
+
+        As of Airflow version 2.3.0 this method is deprecated.
 
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        message = (
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release."
-        )
-        if _parse_version(airflow_version) < _parse_version('2.3.0'):
-            message += (
-                "\nIf you are not calling this method directly, you can make it go away by upgrading "
-                "to Airflow 2.3.0, which no longer calls this method."
+        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+            warnings.warn(
+                f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        warnings.warn(
-            message,
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -26,7 +26,6 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import boto3
-from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -41,7 +40,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return VersionInfo.parse(val)
+    return val.split('.')
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -208,7 +208,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :return: deserialized Connection
         """
         warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             f"in a future release.",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -220,7 +220,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-                "in a future release.",
+                "in a future release.  Please use method `get_conn_value` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -40,7 +40,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(val.split('.'))
+    return tuple(int(x) for x in val.split('.'))
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -26,7 +26,7 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import boto3
-from semver import parse as semver_parse
+from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -41,7 +41,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return semver_parse(val)
+    return VersionInfo.parse(val)
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -218,7 +218,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+        if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.",

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -40,7 +40,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return val.split('.')
+    return tuple(val.split('.'))
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -25,6 +25,9 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import boto3
+from semver import parse as parse_version
+
+from airflow.version import version as airflow_version
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -207,10 +210,18 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
+        message = (
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            f"in a future release.",
-            PendingDeprecationWarning,
+            "in a future release."
+        )
+        if parse_version(airflow_version) < parse_version('2.3.0'):
+            message += (
+                "\nIf you are not calling this method directly, you can make it go away by upgrading "
+                "to Airflow 2.3.0, which no longer calls this method."
+            )
+        warnings.warn(
+            message,
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -19,13 +19,14 @@
 
 import ast
 import json
+import re
 import sys
 import warnings
 from typing import Optional
 from urllib.parse import urlencode
 
 import boto3
-from semver import parse as parse_version
+from semver import parse as semver_parse
 
 from airflow.version import version as airflow_version
 
@@ -36,6 +37,11 @@ else:
 
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def _parse_version(val):
+    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
+    return semver_parse(val)
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
@@ -214,7 +220,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             "in a future release."
         )
-        if parse_version(airflow_version) < parse_version('2.3.0'):
+        if _parse_version(airflow_version) < _parse_version('2.3.0'):
             message += (
                 "\nIf you are not calling this method directly, you can make it go away by upgrading "
                 "to Airflow 2.3.0, which no longer calls this method."

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -36,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return val.split('.')
+    return tuple(val.split('.'))
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -22,7 +22,7 @@ import warnings
 from typing import Optional
 
 import boto3
-from semver import parse as semver_parse
+from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -37,7 +37,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return semver_parse(val)
+    return VersionInfo.parse(val)
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -116,7 +116,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+        if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.",

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -17,6 +17,7 @@
 # under the License.
 """Objects relating to sourcing connections from AWS SSM Parameter Store"""
 import sys
+import warnings
 from typing import Optional
 
 import boto3
@@ -86,7 +87,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         session = boto3.Session(profile_name=self.profile_name)
         return session.client("ssm", **self.kwargs)
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_value(self, conn_id: str) -> Optional[str]:
         """
         Get param value
 
@@ -96,6 +97,21 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
             return None
 
         return self._get_secret(self.connections_prefix, conn_id)
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Return URI representation of Connection conn_id
+
+        :param conn_id: the connection id
+        :return: deserialized Connection
+        """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"in a future release.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -16,12 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections from AWS SSM Parameter Store"""
+import re
 import sys
 import warnings
 from typing import Optional
 
 import boto3
-from semver import parse as parse_version
+from semver import parse as semver_parse
 
 from airflow.version import version as airflow_version
 
@@ -32,6 +33,11 @@ else:
 
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def _parse_version(val):
+    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
+    return semver_parse(val)
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
@@ -112,7 +118,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             "in a future release."
         )
-        if parse_version(airflow_version) < parse_version('2.3.0'):
+        if _parse_version(airflow_version) < _parse_version('2.3.0'):
             message += (
                 "\nIf you are not calling this method directly, you can make it go away by upgrading "
                 "to Airflow 2.3.0, which no longer calls this method."

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -118,7 +118,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-                "in a future release.",
+                "in a future release.  Please use method `get_conn_value` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -36,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(val.split('.'))
+    return tuple(int(x) for x in val.split('.'))
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -106,7 +106,7 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         :return: deserialized Connection
         """
         warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             f"in a future release.",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -109,25 +109,20 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
-        Return URI representation of Connection conn_id
+        Return URI representation of Connection conn_id.
+
+        As of Airflow version 2.3.0 this method is deprecated.
 
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        message = (
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release."
-        )
-        if _parse_version(airflow_version) < _parse_version('2.3.0'):
-            message += (
-                "\nIf you are not calling this method directly, you can make it go away by upgrading "
-                "to Airflow 2.3.0, which no longer calls this method."
+        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+            warnings.warn(
+                f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        warnings.warn(
-            message,
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -21,6 +21,9 @@ import warnings
 from typing import Optional
 
 import boto3
+from semver import parse as parse_version
+
+from airflow.version import version as airflow_version
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -105,10 +108,18 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
+        message = (
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            f"in a future release.",
-            PendingDeprecationWarning,
+            "in a future release."
+        )
+        if parse_version(airflow_version) < parse_version('2.3.0'):
+            message += (
+                "\nIf you are not calling this method directly, you can make it go away by upgrading "
+                "to Airflow 2.3.0, which no longer calls this method."
+            )
+        warnings.warn(
+            message,
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -22,7 +22,6 @@ import warnings
 from typing import Optional
 
 import boto3
-from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -37,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return VersionInfo.parse(val)
+    return val.split('.')
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -21,12 +21,14 @@ import warnings
 from typing import Optional
 
 from google.auth.exceptions import DefaultCredentialsError
+from semver import parse as parse_version
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
 from airflow.providers.google.cloud.utils.credentials_provider import get_credentials_and_project_id
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.version import version as airflow_version
 
 log = logging.getLogger(__name__)
 
@@ -140,10 +142,18 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
+        message = (
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            f"in a future release.",
-            PendingDeprecationWarning,
+            "in a future release."
+        )
+        if parse_version(airflow_version) < parse_version('2.3.0'):
+            message += (
+                "\nIf you are not calling this method directly, you can make it go away by upgrading "
+                "to Airflow 2.3.0, which no longer calls this method."
+            )
+        warnings.warn(
+            message,
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -141,7 +141,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         :return: deserialized Connection
         """
         warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             f"in a future release.",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -22,7 +22,7 @@ import warnings
 from typing import Optional
 
 from google.auth.exceptions import DefaultCredentialsError
-from semver import parse as semver_parse
+from semver import VersionInfo
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -38,7 +38,7 @@ SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return semver_parse(val)
+    return VersionInfo.parse(val)
 
 
 class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -22,7 +22,6 @@ import warnings
 from typing import Optional
 
 from google.auth.exceptions import DefaultCredentialsError
-from semver import VersionInfo
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -38,7 +37,7 @@ SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return VersionInfo.parse(val)
+    return val.split('.')
 
 
 class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -152,7 +152,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-                "in a future release.",
+                "in a future release.  Please use method `get_conn_value` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -17,6 +17,7 @@
 
 """Objects relating to sourcing connections from Google Cloud Secrets Manager"""
 import logging
+import warnings
 from typing import Optional
 
 from google.auth.exceptions import DefaultCredentialsError
@@ -121,9 +122,9 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         prefix = self.connections_prefix + self.sep
         return _SecretManagerClient.is_valid_secret_name(prefix)
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_value(self, conn_id: str) -> Optional[str]:
         """
-        Get secret value from the SecretManager.
+        Get serialized representation of Connection
 
         :param conn_id: connection id
         """
@@ -131,6 +132,21 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
             return None
 
         return self._get_secret(self.connections_prefix, conn_id)
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Return URI representation of Connection conn_id
+
+        :param conn_id: the connection id
+        :return: deserialized Connection
+        """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"in a future release.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:
         """

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -37,7 +37,7 @@ SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return val.split('.')
+    return tuple(val.split('.'))
 
 
 class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -37,7 +37,7 @@ SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(val.split('.'))
+    return tuple(int(x) for x in val.split('.'))
 
 
 class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -17,11 +17,12 @@
 
 """Objects relating to sourcing connections from Google Cloud Secrets Manager"""
 import logging
+import re
 import warnings
 from typing import Optional
 
 from google.auth.exceptions import DefaultCredentialsError
-from semver import parse as parse_version
+from semver import parse as semver_parse
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -33,6 +34,11 @@ from airflow.version import version as airflow_version
 log = logging.getLogger(__name__)
 
 SECRET_ID_PATTERN = r"^[a-zA-Z0-9-_]*$"
+
+
+def _parse_version(val):
+    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
+    return semver_parse(val)
 
 
 class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
@@ -146,7 +152,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             "in a future release."
         )
-        if parse_version(airflow_version) < parse_version('2.3.0'):
+        if _parse_version(airflow_version) < _parse_version('2.3.0'):
             message += (
                 "\nIf you are not calling this method directly, you can make it go away by upgrading "
                 "to Airflow 2.3.0, which no longer calls this method."

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -150,7 +150,7 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+        if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.",

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -143,25 +143,20 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
-        Return URI representation of Connection conn_id
+        Return URI representation of Connection conn_id.
+
+        As of Airflow version 2.3.0 this method is deprecated.
 
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        message = (
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release."
-        )
-        if _parse_version(airflow_version) < _parse_version('2.3.0'):
-            message += (
-                "\nIf you are not calling this method directly, you can make it go away by upgrading "
-                "to Airflow 2.3.0, which no longer calls this method."
+        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+            warnings.warn(
+                f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        warnings.warn(
-            message,
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -16,20 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections & variables from Hashicorp Vault"""
-import re
 import warnings
 from typing import TYPE_CHECKING, Optional
-
-from semver import parse as semver_parse
 
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
-
-
-def _parse_version(val):
-    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return semver_parse(val)
 
 
 class VaultBackend(BaseSecretsBackend, LoggingMixin):
@@ -191,7 +183,6 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
             stacklevel=2,
         )
         response = self.get_response(conn_id)
-
         return response.get("conn_uri") if response else None
 
     # Make sure connection is imported this way for type checking, otherwise when importing

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -167,7 +167,7 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         secret_path = self.build_path(self.connections_path, conn_id)
         return self.vault_client.get_secret(secret_path=secret_path)
 
-    def get_conn_value(self, conn_id: str) -> Optional[str]:
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
         Get serialized representation of connection
 
@@ -175,6 +175,13 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: The connection uri retrieved from the secret
         """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+            "in a future release.  Since VaultBackend implements `get_connection`, `get_conn_uri` "
+            "is not used.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         response = self.get_response(conn_id)
 
         return response.get("conn_uri") if response else None
@@ -183,21 +190,6 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     # the backend it will get a circular dependency and fail
     if TYPE_CHECKING:
         from airflow.models.connection import Connection
-
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
-        """
-        Return URI representation of Connection conn_id
-
-        :param conn_id: the connection id
-        :return: deserialized Connection
-        """
-        warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
-            f"in a future release.",
-            PendingDeprecationWarning,
-            stacklevel=2,
-        )
-        return self.get_conn_value(conn_id)
 
     def get_connection(self, conn_id: str) -> 'Optional[Connection]':
         """

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -16,12 +16,20 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections & variables from Hashicorp Vault"""
+import re
 import warnings
 from typing import TYPE_CHECKING, Optional
+
+from semver import parse as semver_parse
 
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def _parse_version(val):
+    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
+    return semver_parse(val)
 
 
 class VaultBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -175,10 +175,12 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         :rtype: str
         :return: The connection uri retrieved from the secret
         """
+
+        # Since VaultBackend implements `get_connection`, `get_conn_uri` is not used. So we
+        # don't need to implement (or direct users to use) method `get_conn_value` instead
         warnings.warn(
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release.  Since VaultBackend implements `get_connection`, `get_conn_uri` "
-            "is not used.",
+            "in a future release.",
             PendingDeprecationWarning,
             stacklevel=2,
         )

--- a/airflow/providers/hashicorp/secrets/vault.py
+++ b/airflow/providers/hashicorp/secrets/vault.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections & variables from Hashicorp Vault"""
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 from airflow.providers.hashicorp._internal_client.vault_client import _VaultClient
@@ -166,9 +167,9 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
         secret_path = self.build_path(self.connections_path, conn_id)
         return self.vault_client.get_secret(secret_path=secret_path)
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_value(self, conn_id: str) -> Optional[str]:
         """
-        Get secret value from Vault. Store the secret in the form of URI
+        Get serialized representation of connection
 
         :param conn_id: The connection id
         :rtype: str
@@ -182,6 +183,21 @@ class VaultBackend(BaseSecretsBackend, LoggingMixin):
     # the backend it will get a circular dependency and fail
     if TYPE_CHECKING:
         from airflow.models.connection import Connection
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Return URI representation of Connection conn_id
+
+        :param conn_id: the connection id
+        :return: deserialized Connection
+        """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"in a future release.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_conn_value(conn_id)
 
     def get_connection(self, conn_id: str) -> 'Optional[Connection]':
         """

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -36,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(val.split('.'))
+    return tuple(int(x) for x in val.split('.'))
 
 
 class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -22,7 +22,7 @@ from typing import Optional
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from semver import parse as semver_parse
+from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -37,7 +37,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return semver_parse(val)
+    return VersionInfo.parse(val)
 
 
 class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import re
 import sys
 import warnings
 from typing import Optional
@@ -21,7 +22,7 @@ from typing import Optional
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from semver import parse as parse_version
+from semver import parse as semver_parse
 
 from airflow.version import version as airflow_version
 
@@ -32,6 +33,11 @@ else:
 
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def _parse_version(val):
+    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
+    return semver_parse(val)
 
 
 class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
@@ -126,7 +132,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             "in a future release."
         )
-        if parse_version(airflow_version) < parse_version('2.3.0'):
+        if _parse_version(airflow_version) < _parse_version('2.3.0'):
             message += (
                 "\nIf you are not calling this method directly, you can make it go away by upgrading "
                 "to Airflow 2.3.0, which no longer calls this method."

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -120,7 +120,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :return: deserialized Connection
         """
         warnings.warn(
-            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
             f"in a future release.",
             PendingDeprecationWarning,
             stacklevel=2,

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -123,25 +123,20 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
 
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
         """
-        Return URI representation of Connection conn_id
+        Return URI representation of Connection conn_id.
+
+        As of Airflow version 2.3.0 this method is deprecated.
 
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        message = (
-            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            "in a future release."
-        )
-        if _parse_version(airflow_version) < _parse_version('2.3.0'):
-            message += (
-                "\nIf you are not calling this method directly, you can make it go away by upgrading "
-                "to Airflow 2.3.0, which no longer calls this method."
+        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+            warnings.warn(
+                f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        warnings.warn(
-            message,
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import sys
+import warnings
 from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -100,9 +101,9 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         client = SecretClient(vault_url=self.vault_url, credential=credential, **self.kwargs)
         return client
 
-    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+    def get_conn_value(self, conn_id: str) -> Optional[str]:
         """
-        Get an Airflow Connection URI from an Azure Key Vault secret
+        Get a serialized representation of Airflow Connection from an Azure Key Vault secret
 
         :param conn_id: The Airflow connection id to retrieve
         """
@@ -110,6 +111,21 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
             return None
 
         return self._get_secret(self.connections_prefix, conn_id)
+
+    def get_conn_uri(self, conn_id: str) -> Optional[str]:
+        """
+        Return URI representation of Connection conn_id
+
+        :param conn_id: the connection id
+        :return: deserialized Connection
+        """
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_value` is deprecated and will be removed "
+            f"in a future release.",
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_conn_value(conn_id)
 
     def get_variable(self, key: str) -> Optional[str]:
         """

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -22,7 +22,6 @@ from typing import Optional
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
-from semver import VersionInfo
 
 from airflow.version import version as airflow_version
 
@@ -37,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return VersionInfo.parse(val)
+    return val.split('.')
 
 
 class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -36,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 def _parse_version(val):
     val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return val.split('.')
+    return tuple(val.split('.'))
 
 
 class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -130,7 +130,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        if _parse_version(airflow_version) >= _parse_version('2.3.0'):
+        if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
                 "in a future release.",

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -21,6 +21,9 @@ from typing import Optional
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
+from semver import parse as parse_version
+
+from airflow.version import version as airflow_version
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -119,10 +122,18 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param conn_id: the connection id
         :return: deserialized Connection
         """
-        warnings.warn(
+        message = (
             f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-            f"in a future release.",
-            PendingDeprecationWarning,
+            "in a future release."
+        )
+        if parse_version(airflow_version) < parse_version('2.3.0'):
+            message += (
+                "\nIf you are not calling this method directly, you can make it go away by upgrading "
+                "to Airflow 2.3.0, which no longer calls this method."
+            )
+        warnings.warn(
+            message,
+            DeprecationWarning,
             stacklevel=2,
         )
         return self.get_conn_value(conn_id)

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -132,7 +132,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         if _parse_version(airflow_version) >= (2, 3):
             warnings.warn(
                 f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-                "in a future release.",
+                "in a future release.  Please use method `get_conn_value` instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/docs/apache-airflow/security/secrets/secrets-backend/index.rst
+++ b/docs/apache-airflow/security/secrets/secrets-backend/index.rst
@@ -99,7 +99,7 @@ Roll your own secrets backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A secrets backend is a subclass of :py:class:`airflow.secrets.BaseSecretsBackend` and must implement either
-:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connection` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_uri`.
+:py:meth:`~airflow.secrets.BaseSecretsBackend.get_connection` or :py:meth:`~airflow.secrets.BaseSecretsBackend.get_conn_value`.
 
 After writing your backend class, provide the fully qualified class name in the ``backend`` key in the ``[secrets]``
 section of ``airflow.cfg``.
@@ -107,20 +107,13 @@ section of ``airflow.cfg``.
 Additional arguments to your SecretsBackend can be configured in ``airflow.cfg`` by supplying a JSON string to ``backend_kwargs``, which will be passed to the ``__init__`` of your SecretsBackend.
 See :ref:`Configuration <secrets_backend_configuration>` for more details, and :ref:`SSM Parameter Store <ssm_parameter_store_secrets>` for an example.
 
-.. note::
-
-    If you are rolling your own secrets backend, you don't strictly need to use airflow's URI format. But
-    doing so makes it easier to switch between environment variables, the metastore, and your secrets backend.
 
 Adapt to non-Airflow compatible secret formats for connections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The default implementation of Secret backend requires use of an Airflow-specific format of storing
 secrets for connections. Currently most community provided implementations require the connections to
-be stored as URIs (with the possibility of adding more friendly formats in the future)
-:doc:`apache-airflow-providers:core-extensions/secrets-backends`. However some organizations may prefer
-to keep the credentials (passwords/tokens etc) in other formats --
-for example when you want the same credentials to be used across multiple clients, or when you want to
-use built-in mechanism of rotating the credentials that do not work well with the Airflow-specific format.
+be stored as JSON or the Airflow Connection URI format (see
+:doc:`apache-airflow-providers:core-extensions/secrets-backends`). However some organizations may need to store the credentials (passwords/tokens etc) in some other way, for example if the same creds store needs to be used for multiple data platforms, or if you are using a service with a built-in mechanism of rotating the credentials that does not work with the Airflow-specific format.
 In this case you will need to roll your own secret backend as described in the previous chapter,
-possibly extending existing secret backend and adapt it to the scheme used by your organization.
+possibly extending an existing secrets backend and adapting it to the scheme used by your organization.

--- a/docs/apache-airflow/security/secrets/secrets-backend/index.rst
+++ b/docs/apache-airflow/security/secrets/secrets-backend/index.rst
@@ -114,6 +114,6 @@ Adapt to non-Airflow compatible secret formats for connections
 The default implementation of Secret backend requires use of an Airflow-specific format of storing
 secrets for connections. Currently most community provided implementations require the connections to
 be stored as JSON or the Airflow Connection URI format (see
-:doc:`apache-airflow-providers:core-extensions/secrets-backends`). However some organizations may need to store the credentials (passwords/tokens etc) in some other way, for example if the same creds store needs to be used for multiple data platforms, or if you are using a service with a built-in mechanism of rotating the credentials that does not work with the Airflow-specific format.
+:doc:`apache-airflow-providers:core-extensions/secrets-backends`). However some organizations may need to store the credentials (passwords/tokens etc) in some other way, for example if the same credentials store needs to be used for multiple data platforms, or if you are using a service with a built-in mechanism of rotating the credentials that does not work with the Airflow-specific format.
 In this case you will need to roll your own secret backend as described in the previous chapter,
 possibly extending an existing secrets backend and adapting it to the scheme used by your organization.

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -23,9 +23,9 @@ from airflow.providers.amazon.aws.secrets.secrets_manager import SecretsManagerB
 
 
 class TestSecretsManagerBackend(TestCase):
-    @mock.patch("airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend.get_conn_uri")
-    def test_aws_secrets_manager_get_connections(self, mock_get_uri):
-        mock_get_uri.return_value = "scheme://user:pass@host:100"
+    @mock.patch("airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend.get_conn_value")
+    def test_aws_secrets_manager_get_connections(self, mock_get_value):
+        mock_get_value.return_value = "scheme://user:pass@host:100"
         conn_list = SecretsManagerBackend().get_connections("fake_conn")
         conn = conn_list[0]
         assert conn.host == 'host'

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -27,10 +27,10 @@ from tests.test_utils.config import conf_vars
 class TestSsmSecrets(TestCase):
     @mock.patch(
         "airflow.providers.amazon.aws.secrets.systems_manager."
-        "SystemsManagerParameterStoreBackend.get_conn_uri"
+        "SystemsManagerParameterStoreBackend.get_conn_value"
     )
-    def test_aws_ssm_get_connections(self, mock_get_uri):
-        mock_get_uri.return_value = "scheme://user:pass@host:100"
+    def test_aws_ssm_get_connections(self, mock_get_value):
+        mock_get_value.return_value = "scheme://user:pass@host:100"
         conn_list = SystemsManagerParameterStoreBackend().get_connections("fake_conn")
         conn = conn_list[0]
         assert conn.host == 'host'

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -108,10 +108,10 @@ class TestCloudSecretManagerBackend(TestCase):
         mock_client.secret_version_path.assert_called_once_with(PROJECT_ID, secret_id, "latest")
 
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
-    @mock.patch(MODULE_NAME + ".CloudSecretManagerBackend.get_conn_uri")
-    def test_get_connections(self, mock_get_uri, mock_get_creds):
+    @mock.patch(MODULE_NAME + ".CloudSecretManagerBackend.get_conn_value")
+    def test_get_connections(self, mock_get_value, mock_get_creds):
         mock_get_creds.return_value = CREDENTIALS, PROJECT_ID
-        mock_get_uri.return_value = CONN_URI
+        mock_get_value.return_value = CONN_URI
         conns = CloudSecretManagerBackend().get_connections(conn_id=CONN_ID)
         assert isinstance(conns, list)
         assert isinstance(conns[0], Connection)

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -24,9 +24,9 @@ from airflow.providers.microsoft.azure.secrets.key_vault import AzureKeyVaultBac
 
 
 class TestAzureKeyVaultBackend(TestCase):
-    @mock.patch('airflow.providers.microsoft.azure.secrets.key_vault.AzureKeyVaultBackend.get_conn_uri')
-    def test_get_connections(self, mock_get_uri):
-        mock_get_uri.return_value = 'scheme://user:pass@host:100'
+    @mock.patch('airflow.providers.microsoft.azure.secrets.key_vault.AzureKeyVaultBackend.get_conn_value')
+    def test_get_connections(self, mock_get_value):
+        mock_get_value.return_value = 'scheme://user:pass@host:100'
         conn_list = AzureKeyVaultBackend().get_connections('fake_conn')
         conn = conn_list[0]
         assert conn.host == 'host'


### PR DESCRIPTION
In #19857 we enabled storing connections as JSON instead of URI and renamed get_conn_uri to get_conn_value to be consistent with this change.  The method get_conn_uri is now deprecated and should warn when used.

This PR updates secrets backends in providers to implement the new method, while retaining support for the old method for backcompat.  We cannot remove the old methods until min airflow version is updated to 2.3 for the provider.

For users of Airflow versions older than 2.3 we suppress the deprecation warning since it's only from 2.3 onward that the warning makes sense (below 2.3, get_conn_uri is called; in 2.3 we call get_conn_value instead).