### PR TITLE
Correctly handle task_id mangling during unmapping

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -309,7 +309,8 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
 
         dag = partial_kwargs.pop("dag", DagContext.get_current_dag())
         task_group = partial_kwargs.pop("task_group", TaskGroupContext.get_current_task_group(dag))
-        task_id = get_unique_task_id(partial_kwargs.pop("task_id"), dag, task_group)
+        user_supplied_task_id = partial_kwargs.pop("task_id")
+        task_id = get_unique_task_id(user_supplied_task_id, dag, task_group)
         params = partial_kwargs.pop("params", None)
 
         # Logic here should be kept in sync with BaseOperatorMeta.partial().
@@ -334,6 +335,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         _MappedOperator = cast(Any, DecoratedMappedOperator)
         operator = _MappedOperator(
             operator_class=self.operator_class,
+            user_supplied_task_id=user_supplied_task_id,
             mapped_kwargs={},
             partial_kwargs=partial_kwargs,
             task_id=task_id,
@@ -420,7 +422,7 @@ class DecoratedMappedOperator(MappedOperator):
         return {
             "dag": self.dag,
             "task_group": self.task_group,
-            "task_id": self.task_id,
+            "task_id": self.user_supplied_task_id,
             "op_kwargs": op_kwargs,
             "multiple_outputs": self.multiple_outputs,
             "python_callable": self.python_callable,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -217,6 +217,7 @@ def partial(
     from airflow.utils.task_group import TaskGroupContext
 
     validate_mapping_kwargs(operator_class, "partial", kwargs)
+    user_supplied_task_id = task_id
 
     dag = dag or DagContext.get_current_dag()
     if dag:
@@ -281,7 +282,11 @@ def partial(
     partial_kwargs["executor_config"] = partial_kwargs["executor_config"] or {}
     partial_kwargs["resources"] = coerce_resources(partial_kwargs["resources"])
 
-    return OperatorPartial(operator_class=operator_class, kwargs=partial_kwargs)
+    return OperatorPartial(
+        operator_class=operator_class,
+        user_supplied_task_id=user_supplied_task_id,
+        kwargs=partial_kwargs,
+    )
 
 
 class BaseOperatorMeta(abc.ABCMeta):

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -161,6 +161,7 @@ class OperatorPartial:
     """
 
     operator_class: Type["BaseOperator"]
+    user_supplied_task_id: str
     kwargs: Dict[str, Any]
 
     _expand_called: bool = False  # Set when expand() is called to ease user debugging.
@@ -197,6 +198,7 @@ class OperatorPartial:
 
         op = MappedOperator(
             operator_class=self.operator_class,
+            user_supplied_task_id=self.user_supplied_task_id,
             mapped_kwargs=mapped_kwargs,
             partial_kwargs=partial_kwargs,
             task_id=task_id,
@@ -224,6 +226,7 @@ class MappedOperator(AbstractOperator):
     """Object representing a mapped operator in a DAG."""
 
     operator_class: Union[Type["BaseOperator"], str]
+    user_supplied_task_id: str  # This is the task_id supplied by the user.
     mapped_kwargs: Dict[str, "Mappable"]
     partial_kwargs: Dict[str, Any]
 
@@ -434,7 +437,7 @@ class MappedOperator(AbstractOperator):
 
     def _get_unmap_kwargs(self) -> Dict[str, Any]:
         return {
-            "task_id": self.task_id,
+            "task_id": self.user_supplied_task_id,
             "dag": self.dag,
             "task_group": self.task_group,
             "params": self.params,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -681,6 +681,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 mapped_kwargs={},
                 partial_kwargs={},
                 task_id=encoded_op["task_id"],
+                user_supplied_task_id=encoded_op["user_supplied_task_id"],
                 params={},
                 deps=MappedOperator.deps_for(BaseOperator),
                 operator_extra_links=BaseOperator.operator_extra_links,

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1589,6 +1589,7 @@ def test_mapped_operator_serde():
         'template_ext': ['.sh', '.bash'],
         'ui_color': '#f0ede4',
         'ui_fgcolor': '#000',
+        'user_supplied_task_id': 'a',
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)
@@ -1622,6 +1623,7 @@ def test_mapped_operator_xcomarg_serde():
         'operator_extra_links': [],
         'ui_color': '#fff',
         'ui_fgcolor': '#000',
+        'user_supplied_task_id': 'task_2',
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)
@@ -1697,6 +1699,7 @@ def test_mapped_decorator_serde():
         'task_id': 'x',
         'template_ext': [],
         'template_fields': ['op_args', 'op_kwargs'],
+        'user_supplied_task_id': 'x',
     }
 
     deserialized = SerializedBaseOperator.deserialize_operator(serialized)


### PR DESCRIPTION
Fix #22340.

Since BaseOperator modifies task_id according to the task group hierarchy, we can't use MappedOperator's task_id (which is already task-group-prefixed) directly when creating the unmapped BaseOperator. Instead, we need to keep a reference to the "original" task_id value as supplied by the user, and pass it into BaseOperator.