### PR TITLE
Add back celery intersphinx mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -604,7 +604,7 @@ intersphinx_mapping = {
     pkg_name: (f"{THIRD_PARTY_INDEXES[pkg_name]}/", (f'{INVENTORY_CACHE_DIR}/{pkg_name}/objects.inv',))
     for pkg_name in [
         'boto3',
-        # 'celery', # Temporarily remove celery as it disappeared from Internet
+        'celery',
         'docker',
         'hdfs',
         'jinja2',

--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -17,7 +17,7 @@
 
 THIRD_PARTY_INDEXES = {
     'boto3': 'https://boto3.amazonaws.com/v1/documentation/api/latest',
-    'celery': 'https://docs.celeryproject.org/en/stable',
+    'celery': 'https://docs.celeryq.dev/en/stable/',
     'docker': 'https://docker-py.readthedocs.io/en/stable',
     'hdfs': 'https://hdfscli.readthedocs.io/en/latest',
     'jinja2': 'https://jinja.palletsprojects.com/en/2.11.x',


### PR DESCRIPTION
We had disabled this previously in (#22254) but now the website is up on a different domain as listed in https://github.com/celery/celeryproject/issues/51#issuecomment-1072248499

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
