### PR TITLE
Celery worker liveness probe

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -225,6 +225,7 @@ spec:
                 {{- else}}
                 - sh
                 - -c
+                - exec /entrypoint
                 - celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
                 {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -213,6 +213,24 @@ spec:
             - name: KRB5CCNAME
               value:  {{ include "kerberos_ccache_path" . | quote }}
           {{- end }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.workers.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.workers.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.workers.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.workers.livenessProbe.periodSeconds }}
+            exec:
+              command:
+                {{- if .Values.workers.livenessProbe.command }}
+                {{ toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
+                {{- else}}
+                - celery
+                - --app
+                - airflow.executors.celery_executor.app
+                - inspect
+                - ping
+                - -d
+                - celery@${HOSTNAME}
+                {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}
         {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -225,8 +225,7 @@ spec:
                 {{- else}}
                 - sh
                 - -c
-                - exec /entrypoint
-                - celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
+                - exec /entrypoint celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
                 {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -221,7 +221,7 @@ spec:
             exec:
               command:
                 {{- if .Values.workers.livenessProbe.command }}
-                {{ toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
+                {{ toYaml .Values.workers.livenessProbe.command | nindent 16 }}
                 {{- else}}
                 - sh
                 - -c

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -225,7 +225,7 @@ spec:
                 {{- else}}
                 - sh
                 - -c
-                - exec /entrypoint celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
+                - exec /entrypoint python -m celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
                 {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -223,13 +223,9 @@ spec:
                 {{- if .Values.workers.livenessProbe.command }}
                 {{ toYaml .Values.workers.livenessProbe.command  | nindent 16 }}
                 {{- else}}
-                - celery
-                - --app
-                - airflow.executors.celery_executor.app
-                - inspect
-                - ping
-                - -d
-                - celery@${HOSTNAME}
+                - sh
+                - -c
+                - celery --app airflow.executors.celery_executor.app inspect ping -d celery@${HOSTNAME}
                 {{- end }}
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1124,6 +1124,19 @@
                         "periodSeconds": {
                             "description": "Webserver Liveness probe period seconds.",
                             "type": "integer"
+                        },
+                        "command": {
+                            "description": "Webserver command for livenessProbe",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
                         }
                     }
                 },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1104,6 +1104,29 @@
             "x-docsSection": "Workers",
             "additionalProperties": false,
             "properties": {
+                "livenessProbe": {
+                    "description": "Liveness probe configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "description": "Scheduler Liveness probe initial delay.",
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Scheduler Liveness probe timeout seconds.",
+                            "type": "integer"
+                        },
+                        "failureThreshold": {
+                            "description": "Scheduler Liveness probe failure threshold.",
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "description": "Webserver Liveness probe period seconds.",
+                            "type": "integer"
+                        }
+                    }
+                },
                 "replicas": {
                     "description": "Number of Airflow Celery workers in StatefulSet.",
                     "type": "integer",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1105,28 +1105,32 @@
             "additionalProperties": false,
             "properties": {
                 "livenessProbe": {
-                    "description": "Liveness probe configuration.",
+                    "description": "Liveness probe configuration for workers container.",
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
                         "initialDelaySeconds": {
-                            "description": "Scheduler Liveness probe initial delay.",
-                            "type": "integer"
+                            "description": "Number of seconds after the container has started before liveness probes are initiated.",
+                            "type": "integer",
+                            "default": 60
                         },
                         "timeoutSeconds": {
-                            "description": "Scheduler Liveness probe timeout seconds.",
-                            "type": "integer"
+                            "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
+                            "type": "integer",
+                            "default": 15
                         },
                         "failureThreshold": {
-                            "description": "Scheduler Liveness probe failure threshold.",
-                            "type": "integer"
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 5
                         },
                         "periodSeconds": {
-                            "description": "Webserver Liveness probe period seconds.",
-                            "type": "integer"
+                            "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 60
                         },
                         "command": {
-                            "description": "Webserver command for livenessProbe",
+                            "description": "Command for livenessProbe",
                             "type": [
                                 "array",
                                 "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -475,7 +475,7 @@ workers:
     # of local-path provisioner.
     fixPermissions: false
 
-  # If the celery stops heartbeating for 1.5 minutes (3*30s) kill the
+  # If the celery stops heartbeating for 5 minutes (5*60s) kill the
   # celery and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 60

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -474,13 +474,13 @@ workers:
     # This is currently only needed in kind, due to usage
     # of local-path provisioner.
     fixPermissions: false
-    
-  # If the celery stops heartbeating for 2.5 minutes (5*30s) kill the
+
+  # If the celery stops heartbeating for 1.5 minutes (3*30s) kill the
   # celery and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 30
     timeoutSeconds: 5
-    failureThreshold: 5
+    failureThreshold: 3
     periodSeconds: 30
 
   kerberosSidecar:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -478,10 +478,10 @@ workers:
   # If the celery stops heartbeating for 1.5 minutes (3*30s) kill the
   # celery and let Kubernetes restart it
   livenessProbe:
-    initialDelaySeconds: 30
-    timeoutSeconds: 5
-    failureThreshold: 3
-    periodSeconds: 30
+    initialDelaySeconds: 60
+    timeoutSeconds: 15
+    failureThreshold: 5
+    periodSeconds: 60
 
   kerberosSidecar:
     # Enable kerberos sidecar

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -474,6 +474,14 @@ workers:
     # This is currently only needed in kind, due to usage
     # of local-path provisioner.
     fixPermissions: false
+    
+  # If the celery stops heartbeating for 2.5 minutes (5*30s) kill the
+  # celery and let Kubernetes restart it
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 5
+    periodSeconds: 30
 
   kerberosSidecar:
     # Enable kerberos sidecar


### PR DESCRIPTION
### Airflow chart change

Adding celery worker liveness probe to determine whether worker is alive

Based on native `celery ping` command