### PR TITLE
Fix mistakenly added install_requires for all providers

### DIFF
--- a/dev/provider_packages/SETUP_TEMPLATE.cfg.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.cfg.jinja2
@@ -67,9 +67,6 @@ python_requires = ~=3.7
 packages = find:
 setup_requires = {{ SETUP_REQUIREMENTS }}
 install_requires = {{ INSTALL_REQUIREMENTS }}
-    gitpython
-    wheel
-
 
 [options.entry_points]
 apache_airflow_provider=


### PR DESCRIPTION
The TroveClassifiers change #22226 - by mistake - added the
gitpython and wheel for all providers.

This could have been avoided (and noticed) if we split the change
from doc generation. So as a learning I separate a fix to only
fix the problem.

Fix #22380

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
