### PR TITLE
update smart sensor docs and minor fix on is_smart_sensor_compatible()

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -164,9 +164,8 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
             self.on_retry_callback,
             self.on_failure_callback,
         ]
-        for status in check_list:
-            if status:
-                return False
+        if any(check_list):
+            return False
 
         operator = self.__class__.__name__
         return operator in self.sensors_support_sensor_service

--- a/docs/apache-airflow/concepts/smart-sensors.rst
+++ b/docs/apache-airflow/concepts/smart-sensors.rst
@@ -85,6 +85,8 @@ It is transparent to the individual users. Existing DAGs don't need to be change
 enabling/disabling the smart sensor. Rotating centralized smart sensor tasks will not
 cause any user’s sensor task failure.
 
+*   Callback arguments(``on_success_callback``, ``on_failure_callback``, and ``on_retry_callback``) on sensor operator are not compatible with smart sensor. If any callback arguments is provided, that sensor task will not be executed on smart sensor.
+
 Support new operators in the smart sensor service
 -------------------------------------------------
 

--- a/docs/apache-airflow/concepts/smart-sensors.rst
+++ b/docs/apache-airflow/concepts/smart-sensors.rst
@@ -85,7 +85,7 @@ It is transparent to the individual users. Existing DAGs don't need to be change
 enabling/disabling the smart sensor. Rotating centralized smart sensor tasks will not
 cause any user’s sensor task failure.
 
-*   Callback arguments(``on_success_callback``, ``on_failure_callback``, and ``on_retry_callback``) on sensor operator are not compatible with smart sensor. If any callback arguments is provided, that sensor task will not be executed on smart sensor.
+*   Using callback arguments (``on_success_callback``, ``on_failure_callback``, and ``on_retry_callback``) on a sensor task is not compatible with the smart sensor mode. If any callback arguments are provided, the sensor task will not be executed when the smart sensor mode is enabled.
 
 Support new operators in the smart sensor service
 -------------------------------------------------


### PR DESCRIPTION
Even though smart sensor feature was deprecated and planned to be removed on version 2.4, the fact that sensor tasks with any callback arguments are not compatible with smart sensor, has to be noticed on the official docs.