### PR TITLE
make operator's execution_timeout configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -364,8 +364,8 @@
     - name: default_task_execution_timeout
       description: |
         The default task execution_timeout value for the operators. Expected positive integer value to
-        be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
-        means that the operators are never timed out.
+        be passed into timedelta as seconds. If not specified, then the value is considered as None,
+        meaning that the operators are never timed out by default.
       version_added: 2.3.0
       type: integer
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -366,7 +366,7 @@
         The default task execution_timeout value for the operators. Expected positive integer value to
         be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
         means that the operators are never timed out.
-      version_added: 2.3.1
+      version_added: 2.3.0
       type: integer
       example: ~
       default: ""

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -361,9 +361,9 @@
       type: string
       example: ~
       default: "downstream"
-    - name: default_execution_timeout
+    - name: default_task_execution_timeout
       description: |
-        The default execution_timeout value for the operators. Expected positive integer value to
+        The default task execution_timeout value for the operators. Expected positive integer value to
         be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
         means that the operators are never timed out.
       version_added: 2.3.1

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -363,7 +363,7 @@
       default: "downstream"
     - name: default_task_execution_timeout
       description: |
-        The default task execution_timeout value for the operators. Expected positive integer value to
+        The default task execution_timeout value for the operators. Expected an integer value to
         be passed into timedelta as seconds. If not specified, then the value is considered as None,
         meaning that the operators are never timed out by default.
       version_added: 2.3.0

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -361,6 +361,15 @@
       type: string
       example: ~
       default: "downstream"
+    - name: default_execution_timeout
+      description: |
+        The default execution_timeout value for the operators. Expected positive integer value to
+        be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
+        means that the operators are never timed out.
+      version_added: 2.3.1
+      type: integer
+      example: ~
+      default: ""
     - name: min_serialized_dag_update_interval
       description: |
         Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -211,8 +211,8 @@ default_task_retries = 0
 default_task_weight_rule = downstream
 
 # The default task execution_timeout value for the operators. Expected positive integer value to
-# be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
-# means that the operators are never timed out.
+# be passed into timedelta as seconds. If not specified, then the value is considered as None,
+# meaning that the operators are never timed out by default.
 default_task_execution_timeout =
 
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -210,6 +210,11 @@ default_task_retries = 0
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
 
+# The default execution_timeout value for the operators. Expected positive integer value to
+# be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
+# means that the operators are never timed out.
+default_execution_timeout =
+
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -210,10 +210,10 @@ default_task_retries = 0
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
 
-# The default execution_timeout value for the operators. Expected positive integer value to
+# The default task execution_timeout value for the operators. Expected positive integer value to
 # be passed into timedelta as seconds. The missing and the non-positive values are considered as None,
 # means that the operators are never timed out.
-default_execution_timeout =
+default_task_execution_timeout =
 
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -210,7 +210,7 @@ default_task_retries = 0
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
 
-# The default task execution_timeout value for the operators. Expected positive integer value to
+# The default task execution_timeout value for the operators. Expected an integer value to
 # be passed into timedelta as seconds. If not specified, then the value is considered as None,
 # meaning that the operators are never timed out by default.
 default_task_execution_timeout =

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -642,9 +642,10 @@ class AirflowConfigParser(ConfigParser):
 
             try:
                 return datetime.timedelta(seconds=int_val)
-            except OverflowError:
+            except OverflowError as err:
                 raise AirflowConfigException(
                     f'Failed to convert value to timedelta in `seconds`. '
+                    f'{err}. '
                     f'Please check "{key}" key in "{section}" section. Current value: "{val}".'
                 )
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -632,14 +632,6 @@ class AirflowConfigParser(ConfigParser):
                     f'Current value: "{val}".'
                 )
 
-            # the given value must be positive.
-            if int_val <= 0:
-                raise AirflowConfigException(
-                    f'Failed to convert value to timedelta in `seconds`. '
-                    f'Value must be greater than zero. '
-                    f'Please check "{key}" key in "{section}" section. Current value: "{val}".'
-                )
-
             try:
                 return datetime.timedelta(seconds=int_val)
             except OverflowError as err:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -634,7 +634,11 @@ class AirflowConfigParser(ConfigParser):
 
             # the given value must be positive. Otherwise fallback value is returned.
             if int_val <= 0:
-                return fallback
+                raise AirflowConfigException(
+                    f'Failed to convert value to timedelta in `seconds`. '
+                    f'Value must be greater than zero. '
+                    f'Please check "{key}" key in "{section}" section. Current value: "{val}".'
+                )
 
             try:
                 return datetime.timedelta(seconds=int_val)

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -632,7 +632,7 @@ class AirflowConfigParser(ConfigParser):
                     f'Current value: "{val}".'
                 )
 
-            # the given value must be positive. Otherwise fallback value is returned.
+            # the given value must be positive.
             if int_val <= 0:
                 raise AirflowConfigException(
                     f'Failed to convert value to timedelta in `seconds`. '

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -612,7 +612,7 @@ class AirflowConfigParser(ConfigParser):
     def gettimedelta(self, section, key, fallback=None, **kwargs) -> Optional[datetime.timedelta]:
         """
         Gets the config value for the given section and key, and converts it into datetime.timedelta object.
-        If the key is missing or set to a non-positive value, then it is considered as `None`.
+        If the key is missing, then it is considered as `None`.
 
         :param section: the section from the config
         :param key: the key defined in the given section

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import functools
 import json
 import logging
@@ -607,6 +608,43 @@ class AirflowConfigParser(ConfigParser):
             return json.loads(data)
         except JSONDecodeError as e:
             raise AirflowConfigException(f'Unable to parse [{section}] {key!r} as valid json') from e
+
+    def gettimedelta(self, section, key, fallback=None, **kwargs) -> Optional[datetime.timedelta]:
+        """
+        Gets the config value for the given section and key, and converts it into datetime.timedelta object.
+        If the key is missing or set to a non-positive value, then it is considered as `None`.
+
+        :param section: the section from the config
+        :param key: the key defined in the given section
+        :param fallback: fallback value when no config value is given, defaults to None
+        :raises AirflowConfigException: raised because ValueError or OverflowError
+        :return: datetime.timedelta(seconds=<config_value>) or None
+        """
+        val = self.get(section, key, fallback=fallback, **kwargs)
+
+        if val:
+            # the given value must be convertible to integer
+            try:
+                int_val = int(val)
+            except ValueError:
+                raise AirflowConfigException(
+                    f'Failed to convert value to int. Please check "{key}" key in "{section}" section. '
+                    f'Current value: "{val}".'
+                )
+
+            # the given value must be positive. Otherwise fallback value is returned.
+            if int_val <= 0:
+                return fallback
+
+            try:
+                return datetime.timedelta(seconds=int_val)
+            except OverflowError:
+                raise AirflowConfigException(
+                    f'Failed to convert value to timedelta in `seconds`. '
+                    f'Please check "{key}" key in "{section}" section. Current value: "{val}".'
+                )
+
+        return fallback
 
     def read(self, filenames, encoding=None):
         super().read(filenames=filenames, encoding=encoding)

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -67,7 +67,9 @@ DEFAULT_WEIGHT_RULE: WeightRule = WeightRule(
     conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
 )
 DEFAULT_TRIGGER_RULE: TriggerRule = TriggerRule.ALL_SUCCESS
-DEFAULT_EXECUTION_TIMEOUT: datetime.timedelta = conf.gettimedelta("core", "default_execution_timeout")
+DEFAULT_TASK_EXECUTION_TIMEOUT: datetime.timedelta = conf.gettimedelta(
+    "core", "default_task_execution_timeout"
+)
 
 
 class AbstractOperator(LoggingMixin, DAGNode):

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -67,6 +67,7 @@ DEFAULT_WEIGHT_RULE: WeightRule = WeightRule(
     conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
 )
 DEFAULT_TRIGGER_RULE: TriggerRule = TriggerRule.ALL_SUCCESS
+DEFAULT_EXECUTION_TIMEOUT: datetime.timedelta = conf.gettimedelta("core", "default_execution_timeout")
 
 
 class AbstractOperator(LoggingMixin, DAGNode):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -59,13 +59,13 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models.abstractoperator import (
-    DEFAULT_EXECUTION_TIMEOUT,
     DEFAULT_OWNER,
     DEFAULT_POOL_SLOTS,
     DEFAULT_PRIORITY_WEIGHT,
     DEFAULT_QUEUE,
     DEFAULT_RETRIES,
     DEFAULT_RETRY_DELAY,
+    DEFAULT_TASK_EXECUTION_TIMEOUT,
     DEFAULT_TRIGGER_RULE,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
@@ -202,7 +202,7 @@ def partial(
     queue: str = DEFAULT_QUEUE,
     pool: Optional[str] = None,
     pool_slots: int = DEFAULT_POOL_SLOTS,
-    execution_timeout: Optional[timedelta] = DEFAULT_EXECUTION_TIMEOUT,
+    execution_timeout: Optional[timedelta] = DEFAULT_TASK_EXECUTION_TIMEOUT,
     retry_delay: Union[timedelta, float] = DEFAULT_RETRY_DELAY,
     retry_exponential_backoff: bool = False,
     priority_weight: int = DEFAULT_PRIORITY_WEIGHT,
@@ -707,7 +707,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         pool: Optional[str] = None,
         pool_slots: int = DEFAULT_POOL_SLOTS,
         sla: Optional[timedelta] = None,
-        execution_timeout: Optional[timedelta] = DEFAULT_EXECUTION_TIMEOUT,
+        execution_timeout: Optional[timedelta] = DEFAULT_TASK_EXECUTION_TIMEOUT,
         on_execute_callback: Optional[TaskStateChangeCallback] = None,
         on_failure_callback: Optional[TaskStateChangeCallback] = None,
         on_success_callback: Optional[TaskStateChangeCallback] = None,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -59,6 +59,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.lineage import apply_lineage, prepare_lineage
 from airflow.models.abstractoperator import (
+    DEFAULT_EXECUTION_TIMEOUT,
     DEFAULT_OWNER,
     DEFAULT_POOL_SLOTS,
     DEFAULT_PRIORITY_WEIGHT,
@@ -201,7 +202,7 @@ def partial(
     queue: str = DEFAULT_QUEUE,
     pool: Optional[str] = None,
     pool_slots: int = DEFAULT_POOL_SLOTS,
-    execution_timeout: Optional[timedelta] = None,
+    execution_timeout: Optional[timedelta] = DEFAULT_EXECUTION_TIMEOUT,
     retry_delay: Union[timedelta, float] = DEFAULT_RETRY_DELAY,
     retry_exponential_backoff: bool = False,
     priority_weight: int = DEFAULT_PRIORITY_WEIGHT,
@@ -706,7 +707,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         pool: Optional[str] = None,
         pool_slots: int = DEFAULT_POOL_SLOTS,
         sla: Optional[timedelta] = None,
-        execution_timeout: Optional[timedelta] = None,
+        execution_timeout: Optional[timedelta] = DEFAULT_EXECUTION_TIMEOUT,
         on_execute_callback: Optional[TaskStateChangeCallback] = None,
         on_failure_callback: Optional[TaskStateChangeCallback] = None,
         on_success_callback: Optional[TaskStateChangeCallback] = None,

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -851,14 +851,14 @@ key2 = 300.99
 # too large value for C int
 key3 = 999999999999999
 
-# Equals to None
+[valid]
+# negative value
 key4 = -1
 
 # zero
 key5 = 0
 
-[valid]
-# valid seconds
+# positive value
 key6 = 300
 
 [default]
@@ -894,26 +894,10 @@ key7 =
         ):
             test_conf.gettimedelta("invalid", "key3")
 
-        with pytest.raises(
-            AirflowConfigException,
-            match=re.escape(
-                'Failed to convert value to timedelta in `seconds`. '
-                'Value must be greater than zero. '
-                'Please check "key4" key in "invalid" section. Current value: "-1".'
-            ),
-        ):
-            test_conf.gettimedelta("invalid", "key4")
-
-        with pytest.raises(
-            AirflowConfigException,
-            match=re.escape(
-                'Failed to convert value to timedelta in `seconds`. '
-                'Value must be greater than zero. '
-                'Please check "key5" key in "invalid" section. Current value: "0".'
-            ),
-        ):
-            test_conf.gettimedelta("invalid", "key5")
-
+        assert isinstance(test_conf.gettimedelta('valid', 'key4'), datetime.timedelta)
+        assert test_conf.gettimedelta('valid', 'key4') == datetime.timedelta(seconds=-1)
+        assert isinstance(test_conf.gettimedelta('valid', 'key5'), datetime.timedelta)
+        assert test_conf.gettimedelta('valid', 'key5') == datetime.timedelta(seconds=0)
         assert isinstance(test_conf.gettimedelta('valid', 'key6'), datetime.timedelta)
         assert test_conf.gettimedelta('valid', 'key6') == datetime.timedelta(seconds=300)
         assert isinstance(test_conf.gettimedelta('default', 'key7'), type(None))

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -851,13 +851,13 @@ key2 = 300.99
 # too large value for C int
 key3 = 999999999999999
 
-[valid]
 # Equals to None
 key4 = -1
 
 # zero
 key5 = 0
 
+[valid]
 # valid seconds
 key6 = 300
 
@@ -893,10 +893,26 @@ key7 =
         ):
             test_conf.gettimedelta("invalid", "key3")
 
-        assert isinstance(test_conf.gettimedelta('valid', 'key4'), type(None))
-        assert test_conf.gettimedelta('valid', 'key4') is None
-        assert isinstance(test_conf.gettimedelta('valid', 'key5'), type(None))
-        assert test_conf.gettimedelta('valid', 'key5') is None
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Failed to convert value to timedelta in `seconds`. '
+                'Value must be greater than zero. '
+                'Please check "key4" key in "invalid" section. Current value: "-1".'
+            ),
+        ):
+            test_conf.gettimedelta("invalid", "key4")
+
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Failed to convert value to timedelta in `seconds`. '
+                'Value must be greater than zero. '
+                'Please check "key5" key in "invalid" section. Current value: "0".'
+            ),
+        ):
+            test_conf.gettimedelta("invalid", "key5")
+
         assert isinstance(test_conf.gettimedelta('valid', 'key6'), datetime.timedelta)
         assert test_conf.gettimedelta('valid', 'key6') == datetime.timedelta(seconds=300)
         assert isinstance(test_conf.gettimedelta('default', 'key7'), type(None))

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import copy
+import datetime
 import io
 import os
 import re
@@ -837,3 +838,66 @@ notacommand = OK
         else:
             assert 'sql_alchemy_conn' in conf_maintain_cmds['core']
             assert conf_maintain_cmds['core']['sql_alchemy_conn'] == conf_conn
+
+    def test_gettimedelta(self):
+        test_config = '''
+[invalid]
+# non-integer value
+key1 = str
+
+# fractional value
+key2 = 300.99
+
+# too large value for C int
+key3 = 999999999999999
+
+[valid]
+# Equals to None
+key4 = -1
+
+# zero
+key5 = 0
+
+# valid seconds
+key6 = 300
+
+[default]
+# Equals to None
+key7 =
+'''
+        test_conf = AirflowConfigParser(default_config=test_config)
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Failed to convert value to int. Please check "key1" key in "invalid" section. '
+                'Current value: "str".'
+            ),
+        ):
+            test_conf.gettimedelta("invalid", "key1")
+
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Failed to convert value to int. Please check "key2" key in "invalid" section. '
+                'Current value: "300.99".'
+            ),
+        ):
+            test_conf.gettimedelta("invalid", "key2")
+
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Failed to convert value to timedelta in `seconds`. '
+                'Please check "key3" key in "invalid" section. Current value: "999999999999999".'
+            ),
+        ):
+            test_conf.gettimedelta("invalid", "key3")
+
+        assert isinstance(test_conf.gettimedelta('valid', 'key4'), type(None))
+        assert test_conf.gettimedelta('valid', 'key4') is None
+        assert isinstance(test_conf.gettimedelta('valid', 'key5'), type(None))
+        assert test_conf.gettimedelta('valid', 'key5') is None
+        assert isinstance(test_conf.gettimedelta('valid', 'key6'), datetime.timedelta)
+        assert test_conf.gettimedelta('valid', 'key6') == datetime.timedelta(seconds=300)
+        assert isinstance(test_conf.gettimedelta('default', 'key7'), type(None))
+        assert test_conf.gettimedelta('default', 'key7') is None

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -888,6 +888,7 @@ key7 =
             AirflowConfigException,
             match=re.escape(
                 'Failed to convert value to timedelta in `seconds`. '
+                'Python int too large to convert to C int. '
                 'Please check "key3" key in "invalid" section. Current value: "999999999999999".'
             ),
         ):


### PR DESCRIPTION
This PR aims to make the execution_timeout attribute to be configurable globally via airflow.cfg.

* The default value is still `None`. Users are expected to
define an integer value to be passed into timedelta object
to set the timeout in terms of seconds by default, via configuration.
* Added `gettimedelta` method in configuration to be used in abstractoperator
to get timedelta or None type object. The method raises exceptions
for the values that are; 
  * not convertible to integer
  * too large to be converted to C int.
* Sample config cases are added into unit tests.

Closes #18578