### PR TITLE
Use unmapped operator for template rendering

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -342,8 +342,6 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             params=params,
             deps=MappedOperator.deps_for(self.operator_class),
             operator_extra_links=self.operator_class.operator_extra_links,
-            template_ext=self.operator_class.template_ext,
-            template_fields=self.operator_class.template_fields,
             ui_color=self.operator_class.ui_color,
             ui_fgcolor=self.operator_class.ui_fgcolor,
             is_dummy=False,

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -125,29 +125,6 @@ class AbstractOperator(LoggingMixin, DAGNode):
         template is rendered, it should override this method to do so.
         """
 
-    def resolve_template_files(self) -> None:
-        """Getting the content of files for template_field / template_ext."""
-        if self.template_ext:
-            for field in self.template_fields:
-                content = getattr(self, field, None)
-                if content is None:
-                    continue
-                elif isinstance(content, str) and any(content.endswith(ext) for ext in self.template_ext):
-                    env = self.get_template_env()
-                    try:
-                        setattr(self, field, env.loader.get_source(env, content)[0])  # type: ignore
-                    except Exception:
-                        self.log.exception("Failed to resolve template field %r", field)
-                elif isinstance(content, list):
-                    env = self.get_template_env()
-                    for i, item in enumerate(content):
-                        if isinstance(item, str) and any(item.endswith(ext) for ext in self.template_ext):
-                            try:
-                                content[i] = env.loader.get_source(env, item)[0]  # type: ignore
-                            except Exception as e:
-                                self.log.exception(e)
-        self.prepare_template()
-
     def get_direct_relative_ids(self, upstream: bool = False) -> Set[str]:
         """Get direct relative IDs to the current task, upstream or downstream."""
         if upstream:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -75,10 +75,6 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
     # Defines the operator level extra links.
     operator_extra_links: Collection["BaseOperatorLink"]
-    # For derived classes to define which fields will get jinjaified.
-    template_fields: Collection[str]
-    # Defines which files extensions to look for in the templated fields.
-    template_ext: Collection[str]
 
     owner: str
     task_id: str
@@ -292,6 +288,9 @@ class AbstractOperator(LoggingMixin, DAGNode):
             )
             setattr(parent, attr_name, rendered_content)
 
+    def _looks_like_template_filepath(self, value: str) -> bool:
+        raise NotImplementedError()
+
     def _render_template_field(
         self,
         key: str,
@@ -337,7 +336,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
         from airflow.models.xcom_arg import XComArg
 
         if isinstance(value, str):
-            if any(value.endswith(ext) for ext in self.template_ext):  # A filepath.
+            if self._looks_like_template_filepath(value):
                 template = jinja_env.get_template(value)
             else:
                 template = jinja_env.from_string(value)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1258,7 +1258,7 @@ class DAG(LoggingMixin):
 
     def resolve_template_files(self):
         for t in self.tasks:
-            t.resolve_template_files()
+            t.unmap().resolve_template_files()
 
     def get_template_env(self) -> jinja2.Environment:
         """Build a Jinja2 environment."""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -305,6 +305,11 @@ class MappedOperator(AbstractOperator):
             return  # No need to validate deserialized operator.
         self.operator_class.validate_mapped_arguments(**self._get_unmap_kwargs())
 
+    def _looks_like_template_filepath(self, value: str) -> bool:
+        """Implementing Operator."""
+        assert not isinstance(self.operator_class, str)
+        return any(value.endswith(ext) for ext in self.operator_class.template_ext)
+
     @property
     def task_type(self) -> str:
         """Implementing Operator."""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -260,12 +260,14 @@ class MappedOperator(AbstractOperator):
             self.task_group.add(self)
         if self.dag:
             self.dag.add_task(self)
-        for k, v in self.mapped_kwargs.items():
-            if k in self.template_fields:
-                XComArg.apply_upstream_relationship(self, v)
-        for k, v in self.partial_kwargs.items():
-            if k in self.template_fields:
-                XComArg.apply_upstream_relationship(self, v)
+        if not isinstance(self.operator_class, str):
+            template_fields = self.operator_class.template_fields
+            for k, v in self.mapped_kwargs.items():
+                if k in template_fields:
+                    XComArg.apply_upstream_relationship(self, v)
+            for k, v in self.partial_kwargs.items():
+                if k in template_fields:
+                    XComArg.apply_upstream_relationship(self, v)
 
     @classmethod
     @cache

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -205,8 +205,6 @@ class OperatorPartial:
             params=params,
             deps=MappedOperator.deps_for(self.operator_class),
             operator_extra_links=self.operator_class.operator_extra_links,
-            template_ext=self.operator_class.template_ext,
-            template_fields=self.operator_class.template_fields,
             ui_color=self.operator_class.ui_color,
             ui_fgcolor=self.operator_class.ui_fgcolor,
             is_dummy=issubclass(self.operator_class, DummyOperator),
@@ -235,8 +233,6 @@ class MappedOperator(AbstractOperator):
     params: Optional[dict]
     deps: FrozenSet[BaseTIDep]
     operator_extra_links: Collection["BaseOperatorLink"]
-    template_ext: Collection[str]
-    template_fields: Collection[str]
     ui_color: str
     ui_fgcolor: str
     _is_dummy: bool

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -26,6 +26,7 @@ from sqlalchemy.orm import Session, relationship
 
 from airflow.configuration import conf
 from airflow.models.base import Base, StringID
+from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.serialization.helpers import serialize_template_field
 from airflow.settings import json
@@ -84,6 +85,8 @@ class RenderedTaskInstanceFields(Base):
         self.ti = ti
         if render_templates:
             ti.render_templates()
+        if not isinstance(ti.task, BaseOperator):
+            raise ValueError("can only store rendered fields from unmapped task")
         self.task = ti.task
         if os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", None):
             self.k8s_pod_yaml = ti.render_k8s_pod_yaml()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -659,11 +659,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Store all template_fields as they are if there are JSON Serializable
         # If not, store them as strings
-        if op.template_fields:
-            for template_field in op.template_fields:
-                value = getattr(op, template_field, None)
-                if not cls._is_excluded(value, template_field, op):
-                    serialize_op[template_field] = serialize_template_field(value)
+        for template_field in getattr(op, "template_fields", ()):
+            value = getattr(op, template_field, None)
+            if not cls._is_excluded(value, template_field, op):
+                serialize_op[template_field] = serialize_template_field(value)
 
         if op.params:
             serialize_op['params'] = cls._serialize_params_dict(op.params)
@@ -787,7 +786,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 setattr(op, k, None)
 
         # Set all the template_field to None that were not present in Serialized JSON
-        for field in op.template_fields:
+        for field in getattr(op, "template_fields", ()):
             if not hasattr(op, field):
                 setattr(op, field, None)
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -685,8 +685,6 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 params={},
                 deps=MappedOperator.deps_for(BaseOperator),
                 operator_extra_links=BaseOperator.operator_extra_links,
-                template_ext=BaseOperator.template_ext,
-                template_fields=BaseOperator.template_fields,
                 ui_color=BaseOperator.ui_color,
                 ui_fgcolor=BaseOperator.ui_fgcolor,
                 is_dummy=False,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1246,6 +1246,7 @@ class Airflow(AirflowBaseView):
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
         raw_task = dag.get_task(task_id).prepare_for_execution()
 
+        ti: TaskInstance
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this
             # DAG has never been run. Task instance rendering does not really
@@ -1560,12 +1561,12 @@ class Airflow(AirflowBaseView):
         map_index = request.args.get('map_index', -1, type=int)
         form = DateTimeForm(data={'execution_date': dttm})
         root = request.args.get('root', '')
-        dag = current_app.dag_bag.get_dag(dag_id)
+        dag: Optional[DAG] = current_app.dag_bag.get_dag(dag_id)
 
         if not dag or task_id not in dag.task_ids:
             flash(f"Task [{dag_id}.{task_id}] doesn't seem to exist at the moment", "error")
             return redirect(url_for('Airflow.index'))
-        task = copy.copy(dag.get_task(task_id))
+        task = copy.copy(dag.get_task(task_id)).unmap()
         task.resolve_template_files()
 
         ti: Optional[TaskInstance] = (

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1618,8 +1618,6 @@ def test_mapped_operator_xcomarg_serde():
         'mapped_kwargs': {'arg2': {'__type': 'xcomref', '__var': {'task_id': 'op1', 'key': 'return_value'}}},
         'partial_kwargs': {},
         'task_id': 'task_2',
-        'template_fields': ['arg1', 'arg2'],
-        'template_ext': [],
         'operator_extra_links': [],
         'ui_color': '#fff',
         'ui_fgcolor': '#000',
@@ -1697,8 +1695,6 @@ def test_mapped_decorator_serde():
         'ui_color': '#ffefeb',
         'ui_fgcolor': '#000',
         'task_id': 'x',
-        'template_ext': [],
-        'template_fields': ['op_args', 'op_kwargs'],
         'user_supplied_task_id': 'x',
     }
 


### PR DESCRIPTION
Currently the /rendered-templates view may fail to render a task if it cannot successfully call `get_rendered_template_fields`. However, instead of *adding* things to MappedOperator, I think we are currently not handling the operator-unmapping boundary correctly and are carrying too much information on the class to do what it shouldn't do.

Therefore, here I'm trying to *remove* things from MappedOperator and let the rendering code always use the unmapped operator. Let's see if this would work. I have a mind to remove some more fields if this turns out to be viable.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
