### PR TITLE
Fix /rendered-templates for mapped operator

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -344,6 +344,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             operator_extra_links=self.operator_class.operator_extra_links,
             template_ext=self.operator_class.template_ext,
             template_fields=self.operator_class.template_fields,
+            template_fields_renderers=self.operator_class.template_fields_renderers,
             ui_color=self.operator_class.ui_color,
             ui_fgcolor=self.operator_class.ui_fgcolor,
             is_dummy=False,

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -68,7 +68,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
     :meta private:
     """
 
-    operator_class: Union[str, Type["BaseOperator"]]
+    operator_class: Union[Type["BaseOperator"], Dict[str, Any]]
 
     weight_rule: str
     priority_weight: int

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -347,9 +347,9 @@ class BaseOperatorMeta(abc.ABCMeta):
             if len(args) > 0:
                 raise AirflowException("Use keyword arguments when initializing operators")
 
-            mapped_validation_only = kwargs.pop(
-                "_airflow_mapped_validation_only",
-                getattr(self, "_BaseOperator__mapped_validation", False),
+            instantiated_from_mapped = kwargs.pop(
+                "_airflow_from_mapped",
+                getattr(self, "_BaseOperator__from_mapped", False),
             )
 
             dag: Optional[DAG] = kwargs.get('dag') or DagContext.get_current_dag()
@@ -386,14 +386,14 @@ class BaseOperatorMeta(abc.ABCMeta):
 
             if not hasattr(self, '_BaseOperator__init_kwargs'):
                 self._BaseOperator__init_kwargs = {}
-            self._BaseOperator__mapped_validation = mapped_validation_only
+            self._BaseOperator__from_mapped = instantiated_from_mapped
 
             result = func(self, **kwargs, default_args=default_args)
 
             # Store the args passed to init -- we need them to support task.map serialzation!
             self._BaseOperator__init_kwargs.update(kwargs)  # type: ignore
 
-            if not mapped_validation_only:
+            if not instantiated_from_mapped:
                 # Set upstream task defined by XComArgs passed to template fields of the operator.
                 self.set_xcomargs_dependencies()
                 # Mark instance as instantiated.
@@ -678,14 +678,14 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # logic (default implementation is 'pass' i.e. no validation whatsoever).
     mapped_arguments_validated_by_init: ClassVar[bool] = False
 
-    # Set to True for an operator instantiated only for mapping validation.
-    __mapped_validation = False
+    # Set to True for an operator instantiated by a mapped operator.
+    __from_mapped = False
 
     def __new__(
         cls,
         dag: Optional['DAG'] = None,
         task_group: Optional["TaskGroup"] = None,
-        _airflow_mapped_validation_only: bool = False,  # Whether called to validate a MappedOperator.
+        _airflow_from_mapped: bool = False,  # Whether called from a MappedOperator.
         **kwargs,
     ):
         # If we are creating a new Task _and_ we are in the context of a MappedTaskGroup, then we should only
@@ -696,7 +696,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         dag = dag or DagContext.get_current_dag()
         task_group = task_group or TaskGroupContext.get_current_task_group(dag)
 
-        if not _airflow_mapped_validation_only and isinstance(task_group, MappedTaskGroup):
+        if not _airflow_from_mapped and isinstance(task_group, MappedTaskGroup):
             return cls.partial(dag=dag, task_group=task_group, **kwargs).expand()
         return super().__new__(cls)
 
@@ -777,7 +777,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             self.task_id = task_group.child_id(task_id)
         else:
             self.task_id = task_id
-        if not self.__mapped_validation and task_group:
+        if not self.__from_mapped and task_group:
             task_group.add(self)
 
         self.owner = owner
@@ -998,7 +998,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     def __setattr__(self, key, value):
         super().__setattr__(key, value)
-        if self.__mapped_validation or self._lock_for_execution:
+        if self.__from_mapped or self._lock_for_execution:
             return  # Skip any custom behavior for validation and during execute.
         if key in self.__init_kwargs:
             self.__init_kwargs[key] = value
@@ -1052,8 +1052,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         elif self.has_dag() and self.dag is not dag:
             raise AirflowException(f"The DAG assigned to {self} can not be changed.")
 
-        if self.__mapped_validation:
-            pass  # Don't add task to DAG for validation.
+        if self.__from_mapped:
+            pass  # Don't add to DAG -- the mapped task takes the place.
         elif self.task_id not in dag.task_dict:
             dag.add_task(self)
         elif self.task_id in dag.task_dict and dag.task_dict[self.task_id] is not self:
@@ -1445,7 +1445,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     'label',
                     '_BaseOperator__instantiated',
                     '_BaseOperator__init_kwargs',
-                    '_BaseOperator__mapped_validation',
+                    '_BaseOperator__from_mapped',
                 }
                 | {  # Class level defaults need to be added to this list
                     'start_date',
@@ -1503,7 +1503,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def validate_mapped_arguments(cls, **kwargs: Any) -> None:
         """Validate arguments when this operator is being mapped."""
         if cls.mapped_arguments_validated_by_init:
-            cls(**kwargs, _airflow_mapped_validation_only=True)
+            cls(**kwargs, _airflow_from_mapped=True)
 
     def unmap(self) -> "BaseOperator":
         """:meta private:"""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -451,12 +451,8 @@ class MappedOperator(AbstractOperator):
 
     def unmap(self) -> "BaseOperator":
         """Get the "normal" Operator after applying the current mapping."""
-        dag = self.dag
-        if not dag:
-            raise RuntimeError("Cannot unmap a task without a DAG")
-        dag._remove_task(self.task_id)
         if isinstance(self.operator_class, type):
-            return self.operator_class(**self._get_unmap_kwargs())
+            return self.operator_class(**self._get_unmap_kwargs(), _airflow_from_mapped=True)
 
         # After a mapped operator is serialized, there's no real way to actually
         # unmap it since we've lost access to the underlying operator class.
@@ -464,7 +460,7 @@ class MappedOperator(AbstractOperator):
         # mapped operator to a new SerializedBaseOperator instance.
         from airflow.serialization.serialized_objects import SerializedBaseOperator
 
-        op = SerializedBaseOperator(task_id=self.task_id)
+        op = SerializedBaseOperator(task_id=self.task_id, _airflow_from_mapped=True)
         SerializedBaseOperator.populate_operator(op, self.operator_class)
         return op
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -226,7 +226,13 @@ class OperatorPartial:
 class MappedOperator(AbstractOperator):
     """Object representing a mapped operator in a DAG."""
 
+    # This attribute serves double purpose. For a "normal" operator instance
+    # loaded from DAG, this holds the underlying non-mapped operator class that
+    # can be used to create an unmapped operator for execution. For an operator
+    # recreated from a serialized DAG, however, this holds the serialized data
+    # that can be used to unmap this into a SerializedBaseOperator.
     operator_class: Union[Type["BaseOperator"], Dict[str, Any]]
+
     user_supplied_task_id: str  # This is the task_id supplied by the user.
     mapped_kwargs: Dict[str, "Mappable"]
     partial_kwargs: Dict[str, Any]

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -207,6 +207,7 @@ class OperatorPartial:
             operator_extra_links=self.operator_class.operator_extra_links,
             template_ext=self.operator_class.template_ext,
             template_fields=self.operator_class.template_fields,
+            template_fields_renderers=self.operator_class.template_fields_renderers,
             ui_color=self.operator_class.ui_color,
             ui_fgcolor=self.operator_class.ui_fgcolor,
             is_dummy=issubclass(self.operator_class, DummyOperator),
@@ -237,6 +238,7 @@ class MappedOperator(AbstractOperator):
     operator_extra_links: Collection["BaseOperatorLink"]
     template_ext: Collection[str]
     template_fields: Collection[str]
+    template_fields_renderers: Dict[str, str]
     ui_color: str
     ui_fgcolor: str
     _is_dummy: bool

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2051,6 +2051,7 @@ class TaskInstance(Base, LoggingMixin):
             for field_name, rendered_value in rendered_task_instance_fields.items():
                 setattr(self.task, field_name, rendered_value)
             self.task = task
+            return
         try:
             self.render_templates()
         except (TemplateAssertionError, UndefinedError) as e:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -687,6 +687,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 operator_extra_links=BaseOperator.operator_extra_links,
                 template_ext=BaseOperator.template_ext,
                 template_fields=BaseOperator.template_fields,
+                template_fields_renderers=BaseOperator.template_fields_renderers,
                 ui_color=BaseOperator.ui_color,
                 ui_fgcolor=BaseOperator.ui_fgcolor,
                 is_dummy=False,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -671,36 +671,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         return serialize_op
 
     @classmethod
-    def deserialize_operator(cls, encoded_op: Dict[str, Any]) -> Union[BaseOperator, MappedOperator]:
-        """Deserializes an operator from a JSON object."""
-        op: Union[BaseOperator, MappedOperator]
-        if encoded_op.get("_is_mapped", False):
-            # Most of these will be loaded later, these are just some stand-ins.
-            op = MappedOperator(
-                operator_class=f"{encoded_op['_task_module']}.{encoded_op['_task_type']}",
-                mapped_kwargs={},
-                partial_kwargs={},
-                task_id=encoded_op["task_id"],
-                user_supplied_task_id=encoded_op["user_supplied_task_id"],
-                params={},
-                deps=MappedOperator.deps_for(BaseOperator),
-                operator_extra_links=BaseOperator.operator_extra_links,
-                template_ext=BaseOperator.template_ext,
-                template_fields=BaseOperator.template_fields,
-                template_fields_renderers=BaseOperator.template_fields_renderers,
-                ui_color=BaseOperator.ui_color,
-                ui_fgcolor=BaseOperator.ui_fgcolor,
-                is_dummy=False,
-                task_module=encoded_op["_task_module"],
-                task_type=encoded_op["_task_type"],
-                dag=None,
-                task_group=None,
-                start_date=None,
-                end_date=None,
-            )
-        else:
-            op = SerializedBaseOperator(task_id=encoded_op['task_id'])
-
+    def populate_operator(cls, op: Operator, encoded_op: Dict[str, Any]) -> None:
         if "label" not in encoded_op:
             # Handle deserialization of old data before the introduction of TaskGroup
             encoded_op["label"] = encoded_op["task_id"]
@@ -797,6 +768,39 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Used to determine if an Operator is inherited from DummyOperator
         setattr(op, "_is_dummy", bool(encoded_op.get("_is_dummy", False)))
 
+    @classmethod
+    def deserialize_operator(cls, encoded_op: Dict[str, Any]) -> Operator:
+        """Deserializes an operator from a JSON object."""
+        op: Operator
+        if encoded_op.get("_is_mapped", False):
+            # Most of these will be loaded later, these are just some stand-ins.
+            op_data = {k: v for k, v in encoded_op.items() if k in BaseOperator.get_serialized_fields()}
+            op = MappedOperator(
+                operator_class=op_data,
+                mapped_kwargs={},
+                partial_kwargs={},
+                task_id=encoded_op["task_id"],
+                user_supplied_task_id=encoded_op["user_supplied_task_id"],
+                params={},
+                deps=MappedOperator.deps_for(BaseOperator),
+                operator_extra_links=BaseOperator.operator_extra_links,
+                template_ext=BaseOperator.template_ext,
+                template_fields=BaseOperator.template_fields,
+                template_fields_renderers=BaseOperator.template_fields_renderers,
+                ui_color=BaseOperator.ui_color,
+                ui_fgcolor=BaseOperator.ui_fgcolor,
+                is_dummy=False,
+                task_module=encoded_op["_task_module"],
+                task_type=encoded_op["_task_type"],
+                dag=None,
+                task_group=None,
+                start_date=None,
+                end_date=None,
+            )
+        else:
+            op = SerializedBaseOperator(task_id=encoded_op['task_id'])
+
+        cls.populate_operator(op, encoded_op)
         return op
 
     @classmethod

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1244,7 +1244,7 @@ class Airflow(AirflowBaseView):
         logging.info("Retrieving rendered templates.")
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
-        task = dag.get_task(task_id).prepare_for_execution()
+        raw_task = dag.get_task(task_id).prepare_for_execution()
 
         ti: TaskInstance
         if dag_run is None:
@@ -1253,11 +1253,11 @@ class Airflow(AirflowBaseView):
             # make sense in this situation, but "works" prior to AIP-39. This
             # "fakes" a temporary DagRun-TaskInstance association (not saved to
             # database) for presentation only.
-            ti = TaskInstance(task, map_index=map_index)
+            ti = TaskInstance(raw_task, map_index=map_index)
             ti.dag_run = DagRun(dag_id=dag_id, execution_date=dttm)
         else:
-            ti = dag_run.get_task_instance(task_id=task.task_id, map_index=map_index, session=session)
-            ti.refresh_from_task(task)
+            ti = dag_run.get_task_instance(task_id=task_id, map_index=map_index, session=session)
+            ti.refresh_from_task(raw_task)
 
         try:
             ti.get_rendered_template_fields(session=session)
@@ -1268,8 +1268,13 @@ class Airflow(AirflowBaseView):
             flash(msg, "error")
         except Exception as e:
             flash("Error rendering template: " + str(e), "error")
-        else:
-            task = ti.task
+
+        # Ensure we are rendering the unmapped operator. Unmapping should be
+        # done automatically if template fields are rendered successfully; this
+        # only matters if get_rendered_template_fields() raised an exception.
+        # The following rendering won't show useful values in this case anyway,
+        # but we'll display some quasi-meaingful field names.
+        task = ti.task.unmap()
 
         title = "Rendered Template"
         html_dict = {}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1246,6 +1246,7 @@ class Airflow(AirflowBaseView):
         dag_run = dag.get_dagrun(execution_date=dttm, session=session)
         task = dag.get_task(task_id).prepare_for_execution()
 
+        ti: TaskInstance
         if dag_run is None:
             # No DAG run matching given logical date. This usually means this
             # DAG has never been run. Task instance rendering does not really

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1597,7 +1597,16 @@ def test_mapped_operator_serde():
     assert isinstance(op, MappedOperator)
     assert op.deps is MappedOperator.deps_for(BaseOperator)
 
-    assert op.operator_class == "airflow.operators.bash.BashOperator"
+    assert op.operator_class == {
+        '_task_type': 'BashOperator',
+        'downstream_task_ids': [],
+        'task_id': 'a',
+        'template_ext': ['.sh', '.bash'],
+        'template_fields': ['bash_command', 'env'],
+        'template_fields_renderers': {'bash_command': 'bash', 'env': 'json'},
+        'ui_color': '#f0ede4',
+        'ui_fgcolor': '#000',
+    }
     assert op.mapped_kwargs['bash_command'] == literal
     assert op.partial_kwargs['executor_config'] == {'dict': {'sub': 'value'}}
 
@@ -1640,6 +1649,16 @@ def test_mapped_operator_xcomarg_serde():
     xcom_arg = serialized_dag.task_dict['task_2'].mapped_kwargs['arg2']
     assert isinstance(xcom_arg, XComArg)
     assert xcom_arg.operator is serialized_dag.task_dict['op1']
+
+
+def test_mapped_operator_deserialized_unmap():
+    """Unmap a deserialized mapped operator should be similar to deserializing an non-mapped operator."""
+    normal = BashOperator(task_id='a', bash_command=[1, 2], executor_config={"a": "b"})
+    mapped = BashOperator.partial(task_id='a', executor_config={"a": "b"}).expand(bash_command=[1, 2])
+
+    serialize = SerializedBaseOperator._serialize
+    deserialize = SerializedBaseOperator.deserialize_operator
+    assert deserialize(serialize(mapped)).unmap() == deserialize(serialize(normal))
 
 
 def test_task_resources_serde():

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1587,6 +1587,7 @@ def test_mapped_operator_serde():
         'operator_extra_links': [],
         'template_fields': ['bash_command', 'env'],
         'template_ext': ['.sh', '.bash'],
+        'template_fields_renderers': {'bash_command': 'bash', 'env': 'json'},
         'ui_color': '#f0ede4',
         'ui_fgcolor': '#000',
         'user_supplied_task_id': 'a',
@@ -1620,6 +1621,7 @@ def test_mapped_operator_xcomarg_serde():
         'task_id': 'task_2',
         'template_fields': ['arg1', 'arg2'],
         'template_ext': [],
+        'template_fields_renderers': {},
         'operator_extra_links': [],
         'ui_color': '#fff',
         'ui_fgcolor': '#000',
@@ -1699,6 +1701,7 @@ def test_mapped_decorator_serde():
         'task_id': 'x',
         'template_ext': [],
         'template_fields': ['op_args', 'op_kwargs'],
+        'template_fields_renderers': {"op_args": "py", "op_kwargs": "py"},
         'user_supplied_task_id': 'x',
     }
 


### PR DESCRIPTION
There are a few things that needed fixing:

1. `template_fields_renderers` needed to be serialised for MappedOperator so the web view can render the fields correctly.
2. A bug was accidentally introduced in #21641 that caused `render_templates()` to always be called by `TaskInstance.get_rendered_template_fields()`. This is now fixed.
3. To allow templated fields to be rendered on the correct operator instance (the _unmapped_ one), `unmap()` needs to support serialised operators. This is conceptually impossible, but can be approximated by unmapping into a `SerializedBaseOperator` and copy all the attributes from `MappedOperator` to it. This is good enough for cases where task instance fields are pre-rendered, since `RenderedTaskInstanceFields` would be able to re-populate the real attributes; for fields not yet rendered (i.e. from a DAG that’s never run), `/rendered-templates` has always been inaccurate, so it’s not that big a deal to not able to correctly populate all the fields (and it’s impossible anyway).
4. Another consequence on supporting `unmap()` is that we need to get rid of its side effect of replacing the mapped task with an unmapped one in the DAG, because the webserver won’t be able to recover from this replacement and would lose all operator-mapping information if we do that. Fortunately, I believe the task replacement is not needed in the first place, and can be avoided entirely without consequences. Furthermore, we already have a mechanism for unmapping a task without adding it to the DAG (the task validation API); we just need to rename the argument and attribute to reflect its broader usage.

Note the clicking on the _Rendered_ button still **does not work** after this PR, because the button is currently missing a correct `map_index` argument. We need to tweak the modal to be able to display a mapped task correctly. cc @bbovenzi 