### PR TITLE
Fix blank graph view for mapped DAG with no runs

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -87,10 +87,16 @@ let innerSvg = d3.select('#graph-svg g');
 // returns true if at least one node is changed
 const updateNodeLabels = (node, instances) => {
   let haveLabelsChanged = false;
-  const label = tasks[node.id] && tasks[node.id].is_mapped
-    ? `${node.id} [${(instances[node.id].mapped_states && instances[node.id].mapped_states.length) || ' '}]`
-    : node.value.label;
+  let { label } = node.value;
+  // Check if there is a count of mapped instances
+  if (tasks[node.id] && tasks[node.id].is_mapped) {
+    const count = instances[node.id]
+      && instances[node.id].mapped_states
+      ? instances[node.id].mapped_states.length
+      : ' ';
 
+    label = `${node.id} [${count}]`;
+  }
   if (g.node(node.id) && g.node(node.id).label !== label) {
     g.node(node.id).label = label;
     haveLabelsChanged = true;


### PR DESCRIPTION
The app graph view was crashing when a  DAG contained a mapped task but had no runs. The fix includes an extra check to decide if we should add a number count inside the node or not.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
