### PR TITLE
Include Helm Chart 1.5.0 in airflow_helmchart_bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -28,7 +28,8 @@ body:
         What Apache Airflow Helm Chart version are you using?
       multiple: false
       options:
-        - "1.4.0 (latest released)"
+        - "1.5.0 (latest released)"
+        - "1.4.0"
         - "1.3.0"
         - "1.2.0"
         - "1.1.0"


### PR DESCRIPTION
Update `.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml` with Helm Chart 1.5.0.