### PR TITLE
Fixing task status for non-running and non-committed tasks 

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -469,11 +469,9 @@ def set_dag_run_state_to_failed(
         tasks.append(task)
 
     # Mark non-finished tasks as SKIPPED.
-    task_ids = [task.task_id for task in dag.tasks]
     tis = session.query(TaskInstance).filter(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id == run_id,
-        TaskInstance.task_id.in_(task_ids),
         TaskInstance.state.not_in(State.finished),
         TaskInstance.state.not_in(State.running),
     )

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -468,7 +468,22 @@ def set_dag_run_state_to_failed(
         task.dag = dag
         tasks.append(task)
 
-    return set_state(tasks=tasks, run_id=run_id, state=State.FAILED, commit=commit, session=session)
+    # Mark non-finished tasks as SKIPPED.
+    task_ids = [task.task_id for task in dag.tasks]
+    tis = session.query(TaskInstance).filter(
+        TaskInstance.dag_id == dag.dag_id,
+        TaskInstance.run_id == run_id,
+        TaskInstance.task_id.in_(task_ids),
+        TaskInstance.state.not_in(State.finished),
+        TaskInstance.state.not_in(State.running),
+    )
+
+    tis = [ti for ti in tis]
+    if commit:
+        for ti in tis:
+            ti.set_state(State.SKIPPED)
+
+    return tis + set_state(tasks=tasks, run_id=run_id, state=State.FAILED, commit=commit, session=session)
 
 
 def __set_dag_run_state_to_running_or_queued(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2113,7 +2113,7 @@ class Airflow(AirflowBaseView):
 
             response = self.render_template(
                 'airflow/confirm.html',
-                message="Here's the list of task instances you are about to mark as failed",
+                message="Here's the list of task instances you are about to mark as failed or skipped",
                 details=details,
             )
 

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -514,8 +514,13 @@ class TestMarkDAGRun:
         self._set_default_task_instance_states(dr)
 
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
-        # Only running task should be altered.
-        expected = self._get_num_tasks_with_starting_state(State.RUNNING, inclusion=True)
+        # Only non-completed tasks should be altered.
+        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
+            State.SUCCESS, inclusion=True
+        )
+        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -561,8 +566,13 @@ class TestMarkDAGRun:
         self._set_default_task_instance_states(dr)
 
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
-        # Only running task should be altered.
-        expected = self._get_num_tasks_with_starting_state(State.RUNNING, inclusion=True)
+        # Only non-completed tasks should be altered.
+        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
+            State.SUCCESS, inclusion=True
+        )
+        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -609,8 +619,13 @@ class TestMarkDAGRun:
 
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
 
-        # Only running task should be altered.
-        expected = self._get_num_tasks_with_starting_state(State.RUNNING, inclusion=True)
+        # Only non-completed tasks should be altered.
+        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
+            State.SUCCESS, inclusion=True
+        )
+        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -655,15 +670,20 @@ class TestMarkDAGRun:
 
         will_be_altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=False)
 
-        # Only the running task should be altered.
-        expected = self._get_num_tasks_with_starting_state(State.RUNNING, inclusion=True)
+        # Only the non-completed tasks should be altered.
+        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
+            State.SUCCESS, inclusion=True
+        )
+        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
         assert len(will_be_altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.RUNNING)
         self._verify_task_instance_states_remain_default(dr)
 
         will_be_altered = set_dag_run_state_to_success(dag=self.dag1, run_id=dr.run_id, commit=False)
 
-        # All except the SUCCESS task should be altered.
+        # Only the non-completed tasks should be altered.
         expected = self._get_num_tasks_with_starting_state(State.SUCCESS, inclusion=False)
         assert len(will_be_altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.RUNNING)

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -450,6 +450,20 @@ class TestMarkDAGRun:
 
         return len([s for s in states if compare(s, state)])
 
+    def _get_num_tasks_with_non_completed_state(self):
+        """
+        Return the non completed tasks.
+        :return: number of tasks in non completed state (SUCCESS, FAILED, SKIPPED, UPSTREAM_FAILED)
+        """
+        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
+            State.SUCCESS, inclusion=True
+        )
+        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
+        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
+
+        return expected
+
     def _set_default_task_instance_states(self, dr):
         for task_id, state in self.INITIAL_TASK_STATES.items():
             dr.get_task_instance(task_id).set_state(state)
@@ -515,12 +529,7 @@ class TestMarkDAGRun:
 
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
         # Only non-completed tasks should be altered.
-        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
-            State.SUCCESS, inclusion=True
-        )
-        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
+        expected = self._get_num_tasks_with_non_completed_state()
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -567,12 +576,7 @@ class TestMarkDAGRun:
 
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
         # Only non-completed tasks should be altered.
-        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
-            State.SUCCESS, inclusion=True
-        )
-        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
+        expected = self._get_num_tasks_with_non_completed_state()
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -620,12 +624,7 @@ class TestMarkDAGRun:
         altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=True)
 
         # Only non-completed tasks should be altered.
-        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
-            State.SUCCESS, inclusion=True
-        )
-        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
+        expected = self._get_num_tasks_with_non_completed_state()
         assert len(altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.FAILED)
         assert dr.get_task_instance('run_after_loop').state == State.FAILED
@@ -671,19 +670,14 @@ class TestMarkDAGRun:
         will_be_altered = set_dag_run_state_to_failed(dag=self.dag1, run_id=dr.run_id, commit=False)
 
         # Only the non-completed tasks should be altered.
-        expected = len(self.INITIAL_TASK_STATES.values()) - self._get_num_tasks_with_starting_state(
-            State.SUCCESS, inclusion=True
-        )
-        expected = expected - self._get_num_tasks_with_starting_state(State.FAILED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.SKIPPED, inclusion=True)
-        expected = expected - self._get_num_tasks_with_starting_state(State.UPSTREAM_FAILED, inclusion=True)
+        expected = self._get_num_tasks_with_non_completed_state()
         assert len(will_be_altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.RUNNING)
         self._verify_task_instance_states_remain_default(dr)
 
         will_be_altered = set_dag_run_state_to_success(dag=self.dag1, run_id=dr.run_id, commit=False)
 
-        # Only the non-completed tasks should be altered.
+        # All except the SUCCESS task should be altered.
         expected = self._get_num_tasks_with_starting_state(State.SUCCESS, inclusion=False)
         assert len(will_be_altered) == expected
         self._verify_dag_run_state(self.dag1, date, State.RUNNING)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fixing task status for non-running and non-committed tasks
---
This change fixes a bug in the scheduler where the DAG was set back to Running state after being marked Failed if there were scheduled tasks. 

After this change when a DAG run is marked failed the behaviour will be as follows:
- mark all running tasks failed
- mark all non-finished tasks as skipped
- mark the DagRun as failed
 
Closes: https://github.com/apache/airflow/issues/21908


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
