### PR TITLE
Fix `download_media` url in `GoogleDisplayVideo360SDFtoGCSOperator`

### DIFF
--- a/airflow/providers/google/marketing_platform/hooks/display_video.py
+++ b/airflow/providers/google/marketing_platform/hooks/display_video.py
@@ -27,7 +27,7 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 class GoogleDisplayVideo360Hook(GoogleBaseHook):
     """Hook for Google Display & Video 360."""
 
-    _conn = None  # type: Optional[Any]
+    _conn: Optional[Resource] = None
 
     def __init__(
         self,

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -692,7 +692,7 @@ class GoogleDisplayVideo360SDFtoGCSOperator(BaseOperator):
         operation_state = hook.get_sdf_download_operation(operation_name=self.operation_name)
 
         self.log.info("Creating file for upload...")
-        media = hook.download_media(resource_name=operation_state)
+        media = hook.download_media(resource_name=operation_state["response"]["resourceName"])
 
         self.log.info("Sending file to the Google Cloud Storage...")
         with tempfile.NamedTemporaryFile() as temp_file:

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -354,7 +354,6 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.tempfile")
     def test_execute(self, mock_temp, gcs_mock_hook, mock_hook):
         operation_name = "operation_name"
-        operation = {"key": "value"}
         operation = {"response": {"resourceName": "test_name"}}
         gzip = False
 
@@ -388,7 +387,9 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
 
         mock_hook.return_value.download_media.assert_called_once()
         mock_hook.return_value.download_media.assert_called_once_with(
-            resource_name=mock_hook.return_value.get_sdf_download_operation.return_value
+            resource_name=mock_hook.return_value.get_sdf_download_operation.return_value["response"][
+                "resourceName"
+            ]
         )
 
         mock_hook.return_value.download_content_from_request.assert_called_once()


### PR DESCRIPTION
Fixes: #14075

Following @sarahamilton closed PR and instructions reported in the issue #14075, here is a small change to fix the download url for `Google Display & Video 360` service.

Link to the API doc: https://developers.google.com/display-video/api/reference/rest/v1/media/download
Link to the underlying lib: https://github.com/googleapis/google-api-python-client/blob/main/googleapiclient/discovery.py

I was not able to create an account on `Google Display & Video 360` to test this. (no free trial, or 'fake' account for devs).
