### PR TITLE
Use logger to print message during task execution.

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -56,6 +56,8 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
 
+log = logging.getLogger(__name__)
+
 CreateIfNecessary = Union[Literal[False], Literal["db"], Literal["memory"]]
 
 
@@ -364,7 +366,7 @@ def task_run(args, dag=None):
 
     hostname = get_hostname()
 
-    print(f"Running {ti} on host {hostname}")
+    log.info("Running %s on host %s", ti, hostname)
 
     if args.interactive:
         _run_task_by_selected_method(args, dag, ti)


### PR DESCRIPTION
By default messages written to stdout by Celery worker are redirected to logger with WARNING level https://github.com/celery/celery/blob/7d4658eedef4b9d87974e1a59e26c2da77b1f961/celery/app/defaults.py#L327.

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/1017130/159712215-60bf5717-3ca8-4c36-9e54-fbeb5a9037b5.png">

Therefore message "Running <TaskInstance: *.* * [queued]> on host *" is written with WARNING level, however it doesn't indicate any warning, this message should be INFO level.

closes: #22487

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
