### PR TITLE
Disable connection pool for celery worker

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -100,6 +100,8 @@ def _run_worker(options, skip_serve_logs):
 @cli_utils.action_cli
 def worker(args):
     """Starts Airflow Celery worker"""
+    # Disable connection pool so that celery worker does not hold an unnecessary db connection
+    settings.reconfigure_orm(disable_connection_pool=True)
     if not settings.validate_session():
         raise SystemExit("Worker exiting, database connection precheck failed.")
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

so that it does not hold an unnecessary connection 

before the change, running `airflow celery worker`

![image](https://user-images.githubusercontent.com/8662365/159777149-e9726814-27ba-4001-905b-f31b8fec07d3.png)


after the change, running `airflow celery worker`

![image](https://user-images.githubusercontent.com/8662365/159777162-e176c8e1-6b02-4d1a-8c5d-0e7768f559b5.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
