### PR TITLE
Remove the overhead of handling WASB append logging.

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -264,6 +264,7 @@ class WasbHook(BaseHook):
         string_data: str,
         container_name: str,
         blob_name: str,
+        blob_type:str = 'BlockBlob',
         create_container: bool = False,
         **kwargs,
     ) -> None:
@@ -273,15 +274,18 @@ class WasbHook(BaseHook):
         :param string_data: String to load.
         :param container_name: Name of the container.
         :param blob_name: Name of the blob.
+        :param blob_type: The type of the blob. This can be either ``BlockBlob``,
+            ``PageBlob`` or ``AppendBlob``. The default value is ``BlockBlob``.
         :param create_container: Attempt to create the target container prior to uploading the blob. This is
             useful if the target container may not exist yet. Defaults to False.
-        :param kwargs: Optional keyword arguments that ``BlobClient.upload()`` takes.
+        :param kwargs: Optional keyword arguments that ``BlobClient.upload_blob()`` takes.
         """
         # Reorder the argument order from airflow.providers.amazon.aws.hooks.s3.load_string.
         self.upload(
             container_name=container_name,
             blob_name=blob_name,
             data=string_data,
+            blob_type=blob_type,
             create_container=create_container,
             **kwargs,
         )

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -176,11 +176,12 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         :param append: if False, any existing log file is overwritten. If True,
             the new log is appended to any existing logs.
         """
-        if append and self.wasb_log_exists(remote_log_location):
-            old_log = self.wasb_read(remote_log_location)
-            log = '\n'.join([old_log, log]) if old_log else log
+        blob_type='BlockBlob'
 
+        if append:
+            blob_type='AppendBlob'
+        
         try:
-            self.hook.load_string(log, self.wasb_container, remote_log_location, overwrite=True)
+            self.hook.load_string(log, self.wasb_container, remote_log_location, blob_type=blob_type, overwrite=blob_type is 'BlockBlob')
         except AzureHttpError:
             self.log.exception('Could not write logs to %s', remote_log_location)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -176,10 +176,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         :param append: if False, any existing log file is overwritten. If True,
             the new log is appended to any existing logs.
         """
-        blob_type='BlockBlob'
-
-        if append:
-            blob_type='AppendBlob'
+        blob_type='AppendBlob' if append else 'BlockBlob'
         
         try:
             self.hook.load_string(log, self.wasb_container, remote_log_location, blob_type=blob_type, overwrite=blob_type is 'BlockBlob')

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -207,12 +207,14 @@ class TestWasbHook:
         )
 
     @pytest.mark.parametrize(argnames="create_container", argvalues=[True, False])
+    @pytest.mark.parametrize(argnames="blob_type", argvalues=['AppendBlob', 'BlockBlob'])
     @mock.patch.object(WasbHook, 'upload')
-    def test_load_string(self, mock_upload, create_container):
+    def test_load_string(self, mock_upload, create_container,blob_type):
         hook = WasbHook(wasb_conn_id=self.shared_key_conn_id)
         hook.load_string('big string', 'container', 'blob', create_container, max_connections=1)
         mock_upload.assert_called_once_with(
             container_name='container',
+            blob_type=blob_type,
             blob_name='blob',
             data='big string',
             create_container=create_container,

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -135,32 +135,26 @@ class TestWasbTaskHandler:
             )
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
-    @mock.patch.object(WasbTaskHandler, "wasb_read")
-    @mock.patch.object(WasbTaskHandler, "wasb_log_exists")
     def test_write_log(self, mock_log_exists, mock_wasb_read, mock_hook):
-        mock_log_exists.return_value = True
-        mock_wasb_read.return_value = ""
         self.wasb_task_handler.wasb_write('text', self.remote_log_location)
         mock_hook.return_value.load_string.assert_called_once_with(
-            "text", self.container_name, self.remote_log_location, overwrite=True
+            "text", self.container_name, self.remote_log_location, blob_type='AppendBlob', overwrite=False
         )
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
-    @mock.patch.object(WasbTaskHandler, "wasb_read")
-    @mock.patch.object(WasbTaskHandler, "wasb_log_exists")
     def test_write_on_existing_log(self, mock_log_exists, mock_wasb_read, mock_hook):
         mock_log_exists.return_value = True
         mock_wasb_read.return_value = "old log"
         self.wasb_task_handler.wasb_write('text', self.remote_log_location)
         mock_hook.return_value.load_string.assert_called_once_with(
-            "old log\ntext", self.container_name, self.remote_log_location, overwrite=True
+            "old log\ntext", self.container_name, self.remote_log_location, blob_type='AppendBlob', overwrite=False
         )
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
     def test_write_when_append_is_false(self, mock_hook):
         self.wasb_task_handler.wasb_write('text', self.remote_log_location, False)
         mock_hook.return_value.load_string.assert_called_once_with(
-            "text", self.container_name, self.remote_log_location, overwrite=True
+            "text", self.container_name, self.remote_log_location, blob_type='BlockBlob', overwrite=True
         )
 
     def test_write_raises(self):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Python SDK for Azure Storage Blob works with AppendBlob blob types.
From the official documentation:
![image](https://user-images.githubusercontent.com/16648593/159816613-af8e1029-1343-4bd6-b5d5-27066028c528.png)

This implementation reduces the round-trips made to the storage account which otherwise would handle the following calls.
wasb_log_exists, wasb_read then wasb_write.

Generally found that too many requests to the storage account slightly degrades the performance - especially if running in a container. Plus each call logs too much detail to the log which fills up the volume mounted to store logs locally. This fix is one part of improving logging performance. The other part can be done in our local setup to minimize verbosity for the azure sdks.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
