### PR TITLE
Fix the docstrings

### DIFF
--- a/airflow/providers/google/cloud/hooks/pubsub.py
+++ b/airflow/providers/google/cloud/hooks/pubsub.py
@@ -115,7 +115,7 @@ class PubSubHook(GoogleBaseHook):
             include the ``projects/{project}/topics/`` prefix.
         :param messages: messages to publish; if the data field in a
             message is set, it should be a bytestring (utf-8 encoded)
-            http://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
+            https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#pubsubmessage
         :param project_id: Optional, the Google Cloud project ID in which to publish.
             If set to None or missing, the default project_id from the Google Cloud connection is used.
         """
@@ -489,7 +489,7 @@ class PubSubHook(GoogleBaseHook):
         :return: A list of Pub/Sub ReceivedMessage objects each containing
             an ``ackId`` property and a ``message`` property, which includes
             the base64-encoded message content. See
-            https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull#ReceivedMessage
+            https://cloud.google.com/pubsub/docs/reference/rpc/google.pubsub.v1#google.pubsub.v1.ReceivedMessage
         """
         subscriber = self.subscriber_client
         # E501


### PR DESCRIPTION
I think PubSubHook is using gRPC but not REST.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
