### PR TITLE
Add timeout parameter to `DockerOperator`

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -18,6 +18,7 @@
 from typing import Any, Dict, Optional
 
 from docker import APIClient
+from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from docker.errors import APIError
 
 from airflow.exceptions import AirflowException
@@ -55,6 +56,7 @@ class DockerHook(BaseHook, LoggingMixin):
         base_url: Optional[str] = None,
         version: Optional[str] = None,
         tls: Optional[str] = None,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
     ) -> None:
         super().__init__()
         if not base_url:
@@ -76,6 +78,7 @@ class DockerHook(BaseHook, LoggingMixin):
         self.__base_url = base_url
         self.__version = version
         self.__tls = tls
+        self.__timeout = timeout
         if conn.port:
             self.__registry = f"{conn.host}:{conn.port}"
         else:
@@ -86,7 +89,9 @@ class DockerHook(BaseHook, LoggingMixin):
         self.__reauth = extra_options.get('reauth') != 'no'
 
     def get_conn(self) -> APIClient:
-        client = APIClient(base_url=self.__base_url, version=self.__version, tls=self.__tls)
+        client = APIClient(
+            base_url=self.__base_url, version=self.__version, tls=self.__tls, timeout=self.__timeout
+        )
         self.__login(client)
         return client
 

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -24,6 +24,7 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Union
 
 from docker import APIClient, tls
+from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from docker.errors import APIError
 from docker.types import Mount
 
@@ -181,6 +182,7 @@ class DockerOperator(BaseOperator):
         extra_hosts: Optional[Dict[str, str]] = None,
         retrieve_output: bool = False,
         retrieve_output_path: Optional[str] = None,
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -224,6 +226,7 @@ class DockerOperator(BaseOperator):
         self.container = None
         self.retrieve_output = retrieve_output
         self.retrieve_output_path = retrieve_output_path
+        self.timeout = timeout
 
     def get_hook(self) -> DockerHook:
         """
@@ -236,6 +239,7 @@ class DockerOperator(BaseOperator):
             base_url=self.docker_url,
             version=self.api_version,
             tls=self.__get_tls_config(),
+            timeout=self.timeout,
         )
 
     def _run_image(self) -> Optional[Union[List[str], str]]:
@@ -387,7 +391,9 @@ class DockerOperator(BaseOperator):
             return self.get_hook().get_conn()
         else:
             tls_config = self.__get_tls_config()
-            return APIClient(base_url=self.docker_url, version=self.api_version, tls=tls_config)
+            return APIClient(
+                base_url=self.docker_url, version=self.api_version, tls=tls_config, timeout=self.timeout
+            )
 
     @staticmethod
     def format_command(command: Union[str, List[str]]) -> Union[List[str], str]:

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -69,10 +69,14 @@ class TestDockerHook(unittest.TestCase):
             base_url='https://index.docker.io/v1/',
             version='1.23',
             tls='someconfig',
+            timeout=100,
         )
         hook.get_conn()
         docker_client_mock.assert_called_once_with(
-            base_url='https://index.docker.io/v1/', version='1.23', tls='someconfig'
+            base_url='https://index.docker.io/v1/',
+            version='1.23',
+            tls='someconfig',
+            timeout=100,
         )
 
     def test_get_conn_with_standard_config(self, _):

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -21,8 +21,8 @@ from unittest import mock
 from unittest.mock import call
 
 import pytest
-from docker.errors import APIError
 from docker.constants import DEFAULT_TIMEOUT_SECONDS
+from docker.errors import APIError
 
 from airflow.exceptions import AirflowException
 

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -22,6 +22,7 @@ from unittest.mock import call
 
 import pytest
 from docker.errors import APIError
+from docker.constants import DEFAULT_TIMEOUT_SECONDS
 
 from airflow.exceptions import AirflowException
 
@@ -91,7 +92,7 @@ class TestDockerOperator(unittest.TestCase):
         operator.execute(None)
 
         self.client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
+            base_url='unix://var/run/docker.sock', tls=None, version='1.19', timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
         self.client_mock.create_container.assert_called_once_with(
@@ -157,7 +158,7 @@ class TestDockerOperator(unittest.TestCase):
         operator.execute(None)
 
         self.client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
+            base_url='unix://var/run/docker.sock', tls=None, version='1.19', timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
         self.client_mock.create_container.assert_called_once_with(
@@ -230,7 +231,7 @@ class TestDockerOperator(unittest.TestCase):
                 "and mounting temporary volume from host is not supported" in captured.output[0]
             )
         self.client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
+            base_url='unix://var/run/docker.sock', tls=None, version='1.19', timeout=DEFAULT_TIMEOUT_SECONDS
         )
         self.client_mock.create_container.assert_has_calls(
             [
@@ -340,7 +341,7 @@ class TestDockerOperator(unittest.TestCase):
         )
 
         self.client_class_mock.assert_called_once_with(
-            base_url='https://127.0.0.1:2376', tls=tls_mock, version=None
+            base_url='https://127.0.0.1:2376', tls=tls_mock, version=None, timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
     def test_execute_unicode_logs(self):

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 from docker import APIClient, types
+from docker.constants import DEFAULT_TIMEOUT_SECONDS
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -96,7 +97,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
 
         client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
+            base_url='unix://var/run/docker.sock', tls=None, version='1.19', timeout=DEFAULT_TIMEOUT_SECONDS
         )
 
         client_mock.service_logs.assert_called_once_with(


### PR DESCRIPTION
Included the timeout support in APIClient of Docker in DockerOperator and Hook under Docker provider. 
closes: #22115
related:  #22115
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
