### PR TITLE
PowerShell Remoting fail on non-zero exitcode

### DIFF
--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -148,7 +148,7 @@ class PsrpOperator(BaseOperator):
 
         rc = ps.runspace_pool.host.rc
         if rc:
-            raise AirflowException("Process exited with non-zero status code: %d", rc)
+            raise AirflowException(f"Process exited with non-zero status code: {rc}")
 
         if not self.do_xcom_push:
             return None

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -146,6 +146,10 @@ class PsrpOperator(BaseOperator):
         if ps.had_errors:
             raise AirflowException("Process failed")
 
+        rc = ps.runspace_pool.host.rc
+        if rc:
+            raise AirflowException("Process exited with non-zero status code: %d", rc)
+
         if not self.do_xcom_push:
             return None
 

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call, patch
 
 from parameterized import parameterized
+from pypsrp.host import PSHost
 from pypsrp.messages import MessageType
 from pypsrp.powershell import PSInvocationState
 from pytest import raises
@@ -180,8 +181,10 @@ class TestPsrpHook(TestCase):
         assert_log(INFO, DUMMY_STACKTRACE[1])
 
         assert call('Invocation state: %s', 'Completed') in logger.info.mock_calls
-
-        assert runspace_pool.call_args == call(ws_man.return_value, connection_name='foo')
+        args, kwargs = runspace_pool.call_args
+        assert args == (ws_man.return_value,)
+        assert kwargs["connection_name"] == "foo"
+        assert isinstance(kwargs["host"], PSHost)
 
     def test_invoke_cmdlet(self, *mocks):
         with PsrpHook(CONNECTION_ID) as hook:

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -60,13 +60,20 @@ class TestPsrpOperator(TestCase):
                     ExecuteParameter("powershell", call.add_script("foo"), None),
                     ExecuteParameter("cmdlet", call.add_cmdlet("foo"), {"bar": "baz"}),
                 ],
-                [False, True],
+                [
+                    (False, 0),
+                    (False, None),
+                    (True, None),
+                    (False, 1),
+                    (True, 1),
+                ],
                 [False, True],
             )
         )
     )
     @patch(f"{PsrpOperator.__module__}.PsrpHook")
-    def test_execute(self, parameter, had_errors, do_xcom_push, hook_impl):
+    def test_execute(self, parameter, result, do_xcom_push, hook_impl):
+        had_errors, rc = result
         kwargs = {parameter.name: "foo"}
         if parameter.expected_parameters:
             kwargs["parameters"] = parameter.expected_parameters
@@ -78,12 +85,19 @@ class TestPsrpOperator(TestCase):
             do_xcom_push=do_xcom_push,
             **kwargs,
         )
-        ps = Mock(spec=PowerShell, output=[json.dumps("<output>")], had_errors=had_errors)
+        runspace_pool = Mock()
+        runspace_pool.host.rc = rc
+        ps = Mock(
+            spec=PowerShell,
+            output=[json.dumps("<output>")],
+            had_errors=had_errors,
+            runspace_pool=runspace_pool,
+        )
         hook_impl.configure_mock(
             **{"return_value.__enter__.return_value.invoke.return_value.__enter__.return_value": ps}
         )
-        if had_errors:
-            exception_msg = "Process failed"
+        if had_errors or rc:
+            exception_msg = "Process failed" if had_errors else "Process exited with non-zero status code: %d"
             with pytest.raises(AirflowException, match=exception_msg):
                 op.execute(None)
         else:

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -97,7 +97,7 @@ class TestPsrpOperator(TestCase):
             **{"return_value.__enter__.return_value.invoke.return_value.__enter__.return_value": ps}
         )
         if had_errors or rc:
-            exception_msg = "Process failed" if had_errors else "Process exited with non-zero status code: %d"
+            exception_msg = "Process failed" if had_errors else "Process exited with non-zero status code: 1"
             with pytest.raises(AirflowException, match=exception_msg):
                 op.execute(None)
         else:


### PR DESCRIPTION
This adds a host configuration to the runspace pool such that the exit code of the PowerShell session is captured.

If a non-zero exit code is returned, the task now fails.

See https://github.com/jborean93/pypsrp/issues/146.