### PR TITLE
Make `defer` more tolerant of signature differences in subclasses

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1485,18 +1485,34 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def defer(
         self,
         *,
-        trigger: BaseTrigger,
-        method_name: str,
+        trigger: Optional[BaseTrigger] = None,
+        method_name: Optional[str] = None,
         kwargs: Optional[Dict[str, Any]] = None,
         timeout: Optional[timedelta] = None,
+        **defer_kwargs,
     ):
         """
-        Marks this Operator as being "deferred" - that is, suspending its
+        Marks this Operator as being "deferred" -- that is, suspending its
         execution until the provided trigger fires an event.
 
         This is achieved by raising a special exception (TaskDeferred)
         which is caught in the main _execute_task wrapper.
+
+        :param trigger: the trigger class to defer with
+        :param method_name: the operator method to resume to
+        :param kwargs: kwargs to pass back to operator when resuming at ``method_name``
+        :param timeout: max time to be in deferred state for this deferral
+        :param defer_kwargs: additional kwargs to use (only makes sense for subclasses that
+            override this ``defer`` method.
+        :return: None
+        :rtype: NoneType
         """
+        if not trigger or not method_name:
+            raise ValueError(
+                "Params ``trigger`` and ``method_name`` are required.  We only "
+                "make them optional in the base class so that subclasses can "
+                "implement more freely customize ``defer``."
+            )
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
 
     @classmethod


### PR DESCRIPTION
*note* not 100% sure we need to change the signature in this way, but please read on to see what this is about.

The base `defer` method takes params trigger, method, kwargs, and timeout, and builds a TaskDeferred exception.

In practice, building the trigger instance can be cumbersome.  And sometimes you want to reuse your deferral logic in multiple places in your operator.  In this case it's convenient to implement `defer` with different arguments and let it handle the construction of the trigger instance.  By making the `defer` signature a little more flexible, we enable subclasses to make `defer` more powerful without technically having signature inconsistencies between the base class method and the subclass implementation.

So for example, in a KPO async operator we want to defer in two places -- once, initially after we start the pod, and possibly later if we only resumed execution to get the latest logs.  

So it would be convenient in the first instance to simply call `self.defer()` and later call `self.defer(last_log_time='2021-01-01 01:02:03')`.

But currently the signature forces us to create the trigger instance in the call to `defer` which is very ugly.

See here the first call:

```python
        self.defer(
            trigger=WaitContainerTrigger(
                kubernetes_conn_id=None,
                hook_params={
                    "cluster_context": self.cluster_context,
                    "config_file": self.config_file,
                    "in_cluster": self.in_cluster,
                },
                pod_name=self.pod.metadata.name,
                container_name=self.BASE_CONTAINER_NAME,
                pod_namespace=self.pod.metadata.namespace,
                pending_phase_timeout=self.startup_timeout_seconds,
                poll_interval=self.poll_interval,
                logging_interval=self.logging_interval,
                last_log_time=None,
            ),
            method_name=self.trigger_reentry.__name__,
        )
```

And here the second:

```python
        self.defer(
            trigger=WaitContainerTrigger(
                kubernetes_conn_id=None,
                hook_params={
                    "cluster_context": self.cluster_context,
                    "config_file": self.config_file,
                    "in_cluster": self.in_cluster,
                },
                pod_name=self.pod.metadata.name,
                container_name=self.BASE_CONTAINER_NAME,
                pod_namespace=self.pod.metadata.namespace,
                pending_phase_timeout=self.startup_timeout_seconds,
                poll_interval=self.poll_interval,
                logging_interval=self.logging_interval,
                last_log_time='2021-01-01 01:02:03',
            ),
            method_name=self.trigger_reentry.__name__,
        )
```

By abstracting away (into defer) the trigger creation logic our calls can be much cleaner.

Here's what my defer would look like:

```python
    def defer(self, last_log_time=None, **kwargs):  # kwargs here are not used -- it's only for "compatibility" with base class
        """Defers to WaitContainerTrigger optionally with last log time."""
        if kwargs:
            raise ValueError(
                f"Received keyword arguments {list(kwargs.keys())} but "
                f"they are not used in this implementation of `defer`."
            )
        super().defer(
            trigger=WaitContainerTrigger(
                kubernetes_conn_id=None,
                hook_params={
                    "cluster_context": self.cluster_context,
                    "config_file": self.config_file,
                    "in_cluster": self.in_cluster,
                },
                pod_name=self.pod.metadata.name,
                container_name=self.BASE_CONTAINER_NAME,
                pod_namespace=self.pod.metadata.namespace,
                pending_phase_timeout=self.startup_timeout_seconds,
                poll_interval=self.poll_interval,
                logging_interval=self.logging_interval,
                last_log_time=last_log_time,
            ),
            method_name=self.trigger_reentry.__name__,
        )
```
