### PR TITLE
Fix: Add extra headers to all livy API requests instead of only to post_batch

### DIFF
--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -181,7 +181,7 @@ class LivyHook(HttpHook, LoggingMixin):
         self._validate_session_id(session_id)
 
         self.log.debug("Fetching info for batch session %d", session_id)
-        response = self.run_method(endpoint=f'/batches/{session_id}')
+        response = self.run_method(endpoint=f'/batches/{session_id}', headers=self.extra_headers)
 
         try:
             response.raise_for_status()
@@ -208,7 +208,8 @@ class LivyHook(HttpHook, LoggingMixin):
         self._validate_session_id(session_id)
 
         self.log.debug("Fetching info for batch session %d", session_id)
-        response = self.run_method(endpoint=f'/batches/{session_id}/state', retry_args=retry_args)
+        response = self.run_method(endpoint=f'/batches/{session_id}/state', retry_args=retry_args,
+                                   headers=self.extra_headers)
 
         try:
             response.raise_for_status()
@@ -234,7 +235,7 @@ class LivyHook(HttpHook, LoggingMixin):
         self._validate_session_id(session_id)
 
         self.log.info("Deleting batch session %d", session_id)
-        response = self.run_method(method='DELETE', endpoint=f'/batches/{session_id}')
+        response = self.run_method(method='DELETE', endpoint=f'/batches/{session_id}', headers=self.extra_headers)
 
         try:
             response.raise_for_status()
@@ -258,7 +259,7 @@ class LivyHook(HttpHook, LoggingMixin):
         """
         self._validate_session_id(session_id)
         log_params = {'from': log_start_position, 'size': log_batch_size}
-        response = self.run_method(endpoint=f'/batches/{session_id}/log', data=log_params)
+        response = self.run_method(endpoint=f'/batches/{session_id}/log', data=log_params, headers=self.extra_headers)
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:

--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -208,8 +208,9 @@ class LivyHook(HttpHook, LoggingMixin):
         self._validate_session_id(session_id)
 
         self.log.debug("Fetching info for batch session %d", session_id)
-        response = self.run_method(endpoint=f'/batches/{session_id}/state', retry_args=retry_args,
-                                   headers=self.extra_headers)
+        response = self.run_method(
+            endpoint=f'/batches/{session_id}/state', retry_args=retry_args, headers=self.extra_headers
+        )
 
         try:
             response.raise_for_status()
@@ -235,7 +236,9 @@ class LivyHook(HttpHook, LoggingMixin):
         self._validate_session_id(session_id)
 
         self.log.info("Deleting batch session %d", session_id)
-        response = self.run_method(method='DELETE', endpoint=f'/batches/{session_id}', headers=self.extra_headers)
+        response = self.run_method(
+            method='DELETE', endpoint=f'/batches/{session_id}', headers=self.extra_headers
+        )
 
         try:
             response.raise_for_status()
@@ -259,7 +262,9 @@ class LivyHook(HttpHook, LoggingMixin):
         """
         self._validate_session_id(session_id)
         log_params = {'from': log_start_position, 'size': log_batch_size}
-        response = self.run_method(endpoint=f'/batches/{session_id}/log', data=log_params, headers=self.extra_headers)
+        response = self.run_method(
+            endpoint=f'/batches/{session_id}/log', data=log_params, headers=self.extra_headers
+        )
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
Currently, in the Apache Livy Hook, the `extra_headers` field (from the connection) is only passed to the post_batch request.
This makes certain functionality of the hook such as `poll_for_termination` not usable in combination with authentication proxy's such as Apache Knox. This PR adds the `extra_headers` field to all Livy requests.