### PR TITLE
Fix failing Breeze2 tests after adding 3.6 version in main

### DIFF
--- a/dev/breeze/tests/test_cache.py
+++ b/dev/breeze/tests/test_cache.py
@@ -35,8 +35,8 @@ AIRFLOW_SOURCES = Path(__file__).parent.parent.parent.parent
     [
         ("backend", "mysql", (True, ['sqlite', 'mysql', 'postgres', 'mssql']), None),
         ("backend", "xxx", (False, ['sqlite', 'mysql', 'postgres', 'mssql']), None),
-        ("python_major_minor_version", "3.8", (True, ['3.7', '3.8', '3.9', '3.10']), None),
-        ("python_major_minor_version", "3.5", (False, ['3.7', '3.8', '3.9', '3.10']), None),
+        ("python_major_minor_version", "3.8", (True, ['3.7', '3.8', '3.9', '3.10', "3.6"]), None),
+        ("python_major_minor_version", "3.5", (False, ['3.7', '3.8', '3.9', '3.10', "3.6"]), None),
         ("missing", "value", None, AttributeError),
     ],
 )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
