### PR TITLE
Remove task group mapping for now

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -681,25 +681,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped = False
 
-    def __new__(
-        cls,
-        dag: Optional['DAG'] = None,
-        task_group: Optional["TaskGroup"] = None,
-        _airflow_from_mapped: bool = False,  # Whether called from a MappedOperator.
-        **kwargs,
-    ):
-        # If we are creating a new Task _and_ we are in the context of a MappedTaskGroup, then we should only
-        # create mapped operators.
-        from airflow.models.dag import DagContext
-        from airflow.utils.task_group import MappedTaskGroup, TaskGroupContext
-
-        dag = dag or DagContext.get_current_dag()
-        task_group = task_group or TaskGroupContext.get_current_task_group(dag)
-
-        if not _airflow_from_mapped and isinstance(task_group, MappedTaskGroup):
-            return cls.partial(dag=dag, task_group=task_group, **kwargs).expand()
-        return super().__new__(cls)
-
     def __init__(
         self,
         task_id: str,

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -299,7 +299,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         provide a way to record an DAG node's all downstream nodes instead.
         """
         from airflow.models.mappedoperator import MappedOperator
-        from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+        from airflow.utils.task_group import TaskGroup
 
         def _walk_group(group: TaskGroup) -> Iterable[Tuple[str, DAGNode]]:
             """Recursively walk children in a task group.
@@ -318,7 +318,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         for key, child in _walk_group(tg):
             if key == self.node_id:
                 continue
-            if not isinstance(child, (MappedOperator, MappedTaskGroup)):
+            if not isinstance(child, MappedOperator):
                 continue
             if self.node_id in child.upstream_task_ids:
                 yield child

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -51,7 +51,7 @@ from airflow.utils.code_utils import get_python_source
 from airflow.utils.docs import get_docs_url
 from airflow.utils.module_loading import as_importable_string, import_string
 from airflow.utils.operator_resources import Resources
-from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+from airflow.utils.task_group import TaskGroup
 
 if TYPE_CHECKING:
     from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
@@ -1120,14 +1120,6 @@ class SerializedTaskGroup(TaskGroup, BaseSerialization):
             "upstream_task_ids": cls._serialize(sorted(task_group.upstream_task_ids)),
             "downstream_task_ids": cls._serialize(sorted(task_group.downstream_task_ids)),
         }
-
-        if isinstance(task_group, MappedTaskGroup):
-            if task_group.mapped_arg:
-                serialize_group['mapped_arg'] = cls._serialize(task_group.mapped_arg)
-            if task_group.mapped_kwargs:
-                serialize_group['mapped_arg'] = cls._serialize(task_group.mapped_kwargs)
-            if task_group.partial_kwargs:
-                serialize_group['mapped_arg'] = cls._serialize(task_group.partial_kwargs)
 
         return serialize_group
 

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -21,16 +21,14 @@ import pytest
 
 from airflow.decorators import dag, task_group as task_group_decorator
 from airflow.models import DAG
-from airflow.models.mappedoperator import MappedOperator
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
-from airflow.utils.task_group import MappedTaskGroup, TaskGroup
+from airflow.utils.task_group import TaskGroup
 from airflow.www.views import dag_edges, task_group_to_dict
 from tests.models import DEFAULT_DATE
-from tests.test_utils.mock_operators import MockOperator
 
 EXPECTED_JSON = {
     'id': None,
@@ -1039,54 +1037,6 @@ def test_pass_taskgroup_output_to_task():
     wrap()
 
 
-def test_map() -> None:
-    with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
-        start = MockOperator(task_id="start")
-        end = MockOperator(task_id="end")
-        literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").expand(literal) as process_one:
-            one = MockOperator(task_id='one')
-            two = MockOperator(task_id='two')
-            three = MockOperator(task_id='three')
-
-            one >> two >> three
-
-        start >> process_one >> end
-
-    # check the mapped operators are attached to the task broup
-    assert isinstance(process_one, MappedTaskGroup)
-    assert process_one.has_task(one)
-    assert process_one.mapped_arg is literal
-
-    assert isinstance(one, MappedOperator)
-    assert start.downstream_list == [one]
-    assert one in dag.tasks
-    # At parse time there should only be two tasks!
-    assert len(dag.tasks) == 5
-
-    assert end.upstream_list == [three]
-    assert three.downstream_list == [end]
-
-
-def test_nested_map() -> None:
-    with DAG("test-dag", start_date=DEFAULT_DATE):
-        start = MockOperator(task_id="start")
-        end = MockOperator(task_id="end")
-        literal = ['a', 'b', 'c']
-        with TaskGroup("process_one").expand(literal) as process_one:
-            one = MockOperator(task_id='one')
-
-            with TaskGroup("process_two").expand(literal) as process_one_two:
-                two = MockOperator(task_id='two')
-                three = MockOperator(task_id='three')
-                two >> three
-
-            four = MockOperator(task_id='four')
-            one >> process_one_two >> four
-
-        start >> process_one >> end
-
-
 def test_decorator_unknown_args():
     """Test that unknown args passed to the decorator cause an error at parse time"""
     with pytest.raises(TypeError):
@@ -1120,40 +1070,6 @@ def test_decorator_multiple_use_task():
         "tg.t__2",
         "t__1",  # End node.
     ]
-
-
-def test_decorator_partial_unmapped():
-    @task_group_decorator
-    def tg():
-        ...
-
-    with pytest.warns(UserWarning, match='was never mapped'):
-        with DAG("test-dag", start_date=DEFAULT_DATE):
-            tg.partial()
-
-
-def test_decorator_map():
-    @task_group_decorator
-    def my_task_group(my_arg_1: str, unmapped: bool):
-        assert unmapped is True
-        assert isinstance(my_arg_1, object)
-        task_1 = DummyOperator(task_id="task_1")
-        task_2 = BashOperator(task_id="task_2", bash_command='echo "${my_arg_1}"', env={'my_arg_1': my_arg_1})
-        task_3 = DummyOperator(task_id="task_3")
-        task_1 >> [task_2, task_3]
-
-        return task_1, task_2, task_3
-
-    with DAG("test-dag", start_date=DEFAULT_DATE) as dag:
-        lines = ["foo", "bar", "baz"]
-
-        (task_1, task_2, task_3) = my_task_group.partial(unmapped=True).expand(my_arg_1=lines)
-
-    assert task_1 in dag.tasks
-
-    tg = dag.task_group.get_child_by_label("my_task_group")
-    assert isinstance(tg, MappedTaskGroup)
-    assert "my_arg_1" in tg.mapped_kwargs
 
 
 def test_topological_sort1():


### PR DESCRIPTION
Too many things to cover just to properly implement operator-level mapping. Let's leave this out of 2.3. We can do this later.