### PR TITLE
Deprecate use of prefx `extra__<conn type>__` in connections

### DIFF
--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -40,7 +40,7 @@ class AsanaHook(BaseHook):
     conn_type = "asana"
     hook_name = "Asana"
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 
@@ -79,8 +79,8 @@ class AsanaHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__asana__workspace": StringField(lazy_gettext("Workspace"), widget=BS3TextFieldWidget()),
-            "extra__asana__project": StringField(lazy_gettext("Project"), widget=BS3TextFieldWidget()),
+            "workspace": StringField(lazy_gettext("Workspace"), widget=BS3TextFieldWidget()),
+            "project": StringField(lazy_gettext("Project"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -42,7 +42,8 @@ class AsanaHook(BaseHook):
 
     def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.connection = self.get_connection(conn_id)
+        self.asana_conn_id = conn_id
+        self.connection = self.get_connection(self.asana_conn_id)
         extras = self.connection.extra_dejson
         self.workspace = self._get_field(extras, "workspace", None) or None
         self.project = self._get_field(extras, "project", None) or None

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -40,6 +40,10 @@ class AsanaHook(BaseHook):
     conn_type = "asana"
     hook_name = "Asana"
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.asana_conn_id = conn_id

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -68,7 +68,7 @@ class KubernetesHook(BaseHook):
     conn_type = 'kubernetes'
     hook_name = 'Kubernetes Cluster Connection'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -68,6 +68,10 @@ class KubernetesHook(BaseHook):
     conn_type = 'kubernetes'
     hook_name = 'Kubernetes Cluster Connection'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -76,19 +76,13 @@ class KubernetesHook(BaseHook):
         from wtforms import BooleanField, StringField
 
         return {
-            "extra__kubernetes__in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
-            "extra__kubernetes__kube_config_path": StringField(
-                lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
-            ),
-            "extra__kubernetes__kube_config": StringField(
+            "in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
+            "kube_config_path": StringField(lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()),
+            "kube_config": StringField(
                 lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
             ),
-            "extra__kubernetes__namespace": StringField(
-                lazy_gettext('Namespace'), widget=BS3TextFieldWidget()
-            ),
-            "extra__kubernetes__cluster_context": StringField(
-                lazy_gettext('Cluster context'), widget=BS3TextFieldWidget()
-            ),
+            "namespace": StringField(lazy_gettext('Namespace'), widget=BS3TextFieldWidget()),
+            "cluster_context": StringField(lazy_gettext('Cluster context'), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -175,22 +175,14 @@ class GoogleBaseHook(BaseHook):
         from wtforms.validators import NumberRange
 
         return {
-            "extra__google_cloud_platform__project": StringField(
-                lazy_gettext('Project Id'), widget=BS3TextFieldWidget()
-            ),
-            "extra__google_cloud_platform__key_path": StringField(
-                lazy_gettext('Keyfile Path'), widget=BS3TextFieldWidget()
-            ),
-            "extra__google_cloud_platform__keyfile_dict": PasswordField(
-                lazy_gettext('Keyfile JSON'), widget=BS3PasswordFieldWidget()
-            ),
-            "extra__google_cloud_platform__scope": StringField(
-                lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
-            ),
-            "extra__google_cloud_platform__key_secret_name": StringField(
+            "project": StringField(lazy_gettext('Project Id'), widget=BS3TextFieldWidget()),
+            "key_path": StringField(lazy_gettext('Keyfile Path'), widget=BS3TextFieldWidget()),
+            "keyfile_dict": PasswordField(lazy_gettext('Keyfile JSON'), widget=BS3PasswordFieldWidget()),
+            "scope": StringField(lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()),
+            "key_secret_name": StringField(
                 lazy_gettext('Keyfile Secret Name (in GCP Secret Manager)'), widget=BS3TextFieldWidget()
             ),
-            "extra__google_cloud_platform__num_retries": IntegerField(
+            "num_retries": IntegerField(
                 lazy_gettext('Number of Retries'),
                 validators=[NumberRange(min=0)],
                 widget=BS3TextFieldWidget(),
@@ -300,9 +292,17 @@ class GoogleBaseHook(BaseHook):
         to the hook page, which allow admins to specify service_account,
         key_path, etc. They get formatted as shown below.
         """
-        long_f = f'extra__google_cloud_platform__{f}'
+        long_f = f'extra__{self.conn_type}__{f}'
         if hasattr(self, 'extras') and long_f in self.extras:
+            conn_id = getattr(self, self.conn_name_attr)
+            warnings.warn(
+                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {f}. "
+                f"Please update your connection prior to the next major release for this provider.",
+                DeprecationWarning,
+            )
             return self.extras[long_f]
+        elif hasattr(self, 'extras') and f in self.extras:
+            return self.extras[f]
         else:
             return default
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -289,16 +289,16 @@ class GoogleBaseHook(BaseHook):
         authed_http = google_auth_httplib2.AuthorizedHttp(credentials, http=http)
         return authed_http
 
-    def _get_field(self, f: str, default: Any = None) -> Any:
+    def _get_field(self, f: str, default: Any = None, strict=False) -> Any:
         """
         Fetches a field from extras, and returns it. This is some Airflow
         magic. The google_cloud_platform hook type adds custom UI elements
         to the hook page, which allow admins to specify service_account,
         key_path, etc. They get formatted as shown below.
         """
-        long_f = f'extra__{self.conn_type}__{f}'
+        long_f = f'extra__google_cloud_platform__{f}'
+        conn_id = getattr(self, self.conn_name_attr)
         if hasattr(self, 'extras') and long_f in self.extras:
-            conn_id = getattr(self, self.conn_name_attr)
             warnings.warn(
                 f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {f}. "
                 f"Please update your connection prior to the next major release for this provider.",
@@ -307,6 +307,8 @@ class GoogleBaseHook(BaseHook):
             return self.extras[long_f]
         elif hasattr(self, 'extras') and f in self.extras:
             return self.extras[f]
+        elif strict is True:
+            raise ValueError(f"Field {f!r} not found in connection {conn_id!r}")
         else:
             return default
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -166,7 +166,7 @@ class GoogleBaseHook(BaseHook):
     conn_type = 'google_cloud_platform'
     hook_name = 'Google Cloud'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -166,6 +166,10 @@ class GoogleBaseHook(BaseHook):
     conn_type = 'google_cloud_platform'
     hook_name = 'Google Cloud'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -51,7 +51,7 @@ class GrpcHook(BaseHook):
     conn_type = 'grpc'
     hook_name = 'GRPC Connection'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -51,6 +51,10 @@ class GrpcHook(BaseHook):
     conn_type = 'grpc'
     hook_name = 'GRPC Connection'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -39,6 +39,10 @@ class JdbcHook(DbApiHook):
     hook_name = 'JDBC Connection'
     supports_autocommit = True
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -39,7 +39,7 @@ class JdbcHook(DbApiHook):
     hook_name = 'JDBC Connection'
     supports_autocommit = True
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -75,6 +75,10 @@ class AzureDataExplorerHook(BaseHook):
     conn_type = 'azure_data_explorer'
     hook_name = 'Azure Data Explorer'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -75,7 +75,7 @@ class AzureDataExplorerHook(BaseHook):
     conn_type = 'azure_data_explorer'
     hook_name = 'Azure Data Explorer'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -187,9 +187,8 @@ class AzureDataExplorerHook(BaseHook):
         """Fetches a field from extras, and returns it."""
         long_f = f'extra__{self.conn_type}__{field_name}'
         if long_f in extras:
-            conn_id = getattr(self, self.conn_name_attr)
             warnings.warn(
-                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {field_name}. "
+                f"Extra param {long_f!r} in conn {self.conn_id!r} has been renamed to {field_name}. "
                 f"Please update your connection prior to the next major release for this provider.",
                 DeprecationWarning,
             )

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -39,7 +39,7 @@ class AzureBaseHook(BaseHook):
     conn_type = 'azure'
     hook_name = 'Azure'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -39,6 +39,10 @@ class AzureBaseHook(BaseHook):
     conn_type = 'azure'
     hook_name = 'Azure'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -91,7 +91,7 @@ class AzureBaseHook(BaseHook):
         conn = self.get_connection(self.conn_id)
         extras = conn.extra_dejson
         tenant = self._get_field(extras, 'tenantId')
-        subscription_id = self._get_field('subscriptionId')
+        subscription_id = self._get_field(extras, 'subscriptionId')
         key_path = self._get_field(extras, 'key_path')
         if key_path:
             if not key_path.endswith('.json'):

--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -43,7 +43,7 @@ class AzureBatchHook(BaseHook):
     conn_type = 'azure_batch'
     hook_name = 'Azure Batch Service'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -43,6 +43,10 @@ class AzureBatchHook(BaseHook):
     conn_type = 'azure_batch'
     hook_name = 'Azure Batch Service'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -367,9 +367,8 @@ class AzureBatchHook(BaseHook):
         """Fetches a field from extras, and returns it."""
         long_f = f'extra__{self.conn_type}__{field_name}'
         if long_f in extras:
-            conn_id = getattr(self, self.conn_name_attr)
             warnings.warn(
-                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {field_name}. "
+                f"Extra param {long_f!r} in conn {self.conn_id!r} has been renamed to {field_name}. "
                 f"Please update your connection prior to the next major release for this provider.",
                 DeprecationWarning,
             )

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -101,9 +101,8 @@ class AzureContainerVolumeHook(BaseHook):
         """Fetches a field from extras, and returns it."""
         long_f = f'extra__{self.conn_type}__{field_name}'
         if long_f in extras:
-            conn_id = getattr(self, self.conn_name_attr)
             warnings.warn(
-                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {field_name}. "
+                f"Extra param {long_f!r} in conn {self.conn_id!r} has been renamed to {field_name}. "
                 f"Please update your connection prior to the next major release for this provider.",
                 DeprecationWarning,
             )

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -37,7 +37,7 @@ class AzureContainerVolumeHook(BaseHook):
     conn_type = 'azure_container_volume'
     hook_name = 'Azure Container Volume'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -37,6 +37,10 @@ class AzureContainerVolumeHook(BaseHook):
     conn_type = 'azure_container_volume'
     hook_name = 'Azure Container Volume'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     def __init__(self, azure_container_volume_conn_id: str = 'azure_container_volume_default') -> None:
         super().__init__()
         self.conn_id = azure_container_volume_conn_id

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -58,10 +58,10 @@ class AzureCosmosDBHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_cosmos__database_name": StringField(
+            "database_name": StringField(
                 lazy_gettext('Cosmos Database Name (optional)'), widget=BS3TextFieldWidget()
             ),
-            "extra__azure_cosmos__collection_name": StringField(
+            "collection_name": StringField(
                 lazy_gettext('Cosmos Collection Name (optional)'), widget=BS3TextFieldWidget()
             ),
         }

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -50,7 +50,7 @@ class AzureCosmosDBHook(BaseHook):
     conn_type = 'azure_cosmos'
     hook_name = 'Azure CosmosDB'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -50,6 +50,10 @@ class AzureCosmosDBHook(BaseHook):
     conn_type = 'azure_cosmos'
     hook_name = 'Azure CosmosDB'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -123,7 +123,7 @@ class AzureDataFactoryHook(BaseHook):
     default_conn_name: str = 'azure_data_factory_default'
     hook_name: str = 'Azure Data Factory'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -163,7 +163,7 @@ class AzureDataFactoryHook(BaseHook):
         extras = conn.extra_dejson
         tenant = self._get_field(extras, 'tenantId')
 
-        subscription_id = self._get_field('subscriptionId')
+        subscription_id = self._get_field(extras, 'subscriptionId')
         if not subscription_id:
             raise ValueError("A Subscription ID is required to connect to Azure Data Factory.")
 
@@ -912,9 +912,8 @@ class AzureDataFactoryHook(BaseHook):
         """Fetches a field from extras, and returns it."""
         long_f = f'extra__{self.conn_type}__{field_name}'
         if long_f in extras:
-            conn_id = getattr(self, self.conn_name_attr)
             warnings.warn(
-                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {field_name}. "
+                f"Extra param {long_f!r} in conn {self.conn_id!r} has been renamed to {field_name}. "
                 f"Please update your connection prior to the next major release for this provider.",
                 DeprecationWarning,
             )

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -123,6 +123,10 @@ class AzureDataFactoryHook(BaseHook):
     default_conn_name: str = 'azure_data_factory_default'
     hook_name: str = 'Azure Data Factory'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -49,6 +49,10 @@ class AzureDataLakeHook(BaseHook):
     conn_type = 'azure_data_lake'
     hook_name = 'Azure Data Lake'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -49,7 +49,7 @@ class AzureDataLakeHook(BaseHook):
     conn_type = 'azure_data_lake'
     hook_name = 'Azure Data Lake'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -39,7 +39,7 @@ class AzureFileShareHook(BaseHook):
     conn_type = 'azure_fileshare'
     hook_name = 'Azure FileShare'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -39,6 +39,10 @@ class AzureFileShareHook(BaseHook):
     conn_type = 'azure_fileshare'
     hook_name = 'Azure FileShare'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     def __init__(self, azure_fileshare_conn_id: str = 'azure_fileshare_default') -> None:
         super().__init__()
         self.conn_id = azure_fileshare_conn_id

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -58,6 +58,10 @@ class WasbHook(BaseHook):
     conn_type = 'wasb'
     hook_name = 'Azure Blob Storage'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -58,7 +58,7 @@ class WasbHook(BaseHook):
     conn_type = 'wasb'
     hook_name = 'Azure Blob Storage'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -71,6 +71,10 @@ class SalesforceHook(BaseHook):
     conn_type = "salesforce"
     hook_name = "Salesforce"
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     def __init__(
         self,
         salesforce_conn_id: str = default_conn_name,

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -71,7 +71,7 @@ class SalesforceHook(BaseHook):
     conn_type = "salesforce"
     hook_name = "Salesforce"
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -84,7 +84,7 @@ class SnowflakeHook(DbApiHook):
     hook_name = 'Snowflake'
     supports_autocommit = True
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -84,6 +84,10 @@ class SnowflakeHook(DbApiHook):
     hook_name = 'Snowflake'
     supports_autocommit = True
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -37,6 +37,10 @@ class YandexCloudBaseHook(BaseHook):
     conn_type = 'yandexcloud'
     hook_name = 'Yandex Cloud'
 
+    __EXTRA_PREFIX_DEPRECATED = True
+    """This attribute lets the webserver know whether the hook has been updated to handle the
+     deprecation of the `extra__...` prefix in custom fields."""
+
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -37,7 +37,7 @@ class YandexCloudBaseHook(BaseHook):
     conn_type = 'yandexcloud'
     hook_name = 'Yandex Cloud'
 
-    __EXTRA_PREFIX_DEPRECATED = True
+    _EXTRA_PREFIX_DEPRECATED = True
     """This attribute lets the webserver know whether the hook has been updated to handle the
      deprecation of the `extra__...` prefix in custom fields."""
 

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -45,33 +45,33 @@ class YandexCloudBaseHook(BaseHook):
         from wtforms import PasswordField, StringField
 
         return {
-            "extra__yandexcloud__service_account_json": PasswordField(
+            "service_account_json": PasswordField(
                 lazy_gettext('Service account auth JSON'),
                 widget=BS3PasswordFieldWidget(),
                 description='Service account auth JSON. Looks like '
                 '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
                 'Will be used instead of OAuth token and SA JSON file path field if specified.',
             ),
-            "extra__yandexcloud__service_account_json_path": StringField(
+            "service_account_json_path": StringField(
                 lazy_gettext('Service account auth JSON file path'),
                 widget=BS3TextFieldWidget(),
                 description='Service account auth JSON file path. File content looks like '
                 '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
                 'Will be used instead of OAuth token if specified.',
             ),
-            "extra__yandexcloud__oauth": PasswordField(
+            "oauth": PasswordField(
                 lazy_gettext('OAuth Token'),
                 widget=BS3PasswordFieldWidget(),
                 description='User account OAuth token. '
                 'Either this or service account JSON must be specified.',
             ),
-            "extra__yandexcloud__folder_id": StringField(
+            "folder_id": StringField(
                 lazy_gettext('Default folder ID'),
                 widget=BS3TextFieldWidget(),
                 description='Optional. This folder will be used '
                 'to create all new clusters and nodes by default',
             ),
-            "extra__yandexcloud__public_ssh_key": StringField(
+            "public_ssh_key": StringField(
                 lazy_gettext('Public SSH key'),
                 widget=BS3TextFieldWidget(),
                 description='Optional. This key will be placed to all created Compute nodes'
@@ -146,8 +146,16 @@ class YandexCloudBaseHook(BaseHook):
 
     def _get_field(self, field_name: str, default: Any = None) -> Any:
         """Fetches a field from extras, and returns it."""
-        long_f = f'extra__yandexcloud__{field_name}'
+        long_f = f'extra__{self.conn_type}__{field_name}'
         if hasattr(self, 'extras') and long_f in self.extras:
+            conn_id = getattr(self, self.conn_name_attr)
+            warnings.warn(
+                f"Extra param {long_f!r} in conn {conn_id!r} has been renamed to {field_name}. "
+                f"Please update your connection prior to the next major release for this provider.",
+                DeprecationWarning,
+            )
             return self.extras[long_f]
+        elif hasattr(self, 'extras') and field_name in self.extras:
+            return self.extras[field_name]
         else:
             return default

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -725,16 +725,17 @@ class ProvidersManager(LoggingMixin):
             connection_testable=hasattr(hook_class, 'test_connection'),
         )
 
-    def _add_widgets(self, package_name: str, hook_class: type, widgets: Dict[str, Any]):
+    def _add_widgets(self, package_name: str, hook_class: BaseHook, widgets: Dict[str, Any]):
         for field_name, field in widgets.items():
             if not field_name.startswith("extra__"):
                 log.warning(
-                    "The field %s from class %s does not start with 'extra__'. Ignoring it.",
+                    f"Custom field %s from hook %s starts with 'extra__'. Please rename it.",
                     field_name,
                     hook_class.__name__,
                 )
                 continue
-            if field_name in self._connection_form_widgets:
+            field_name_with_prefix = f"extra__{hook_class.conn_type}__{field_name}"
+            if field_name_with_prefix in self._connection_form_widgets:
                 log.warning(
                     "The field %s from class %s has already been added by another provider. Ignoring it.",
                     field_name,
@@ -742,7 +743,7 @@ class ProvidersManager(LoggingMixin):
                 )
                 # In case of inherited hooks this might be happening several times
                 continue
-            self._connection_form_widgets[field_name] = ConnectionFormWidgetInfo(
+            self._connection_form_widgets[field_name_with_prefix] = ConnectionFormWidgetInfo(
                 hook_class.__name__, package_name, field
             )
 

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -726,15 +726,16 @@ class ProvidersManager(LoggingMixin):
         )
 
     def _add_widgets(self, package_name: str, hook_class: BaseHook, widgets: Dict[str, Any]):
+        field_prefix = f"extra__{hook_class.conn_type}__"
         for field_name, field in widgets.items():
-            if not field_name.startswith("extra__"):
+            if field_name.startswith("extra__"):
                 log.warning(
                     f"Custom field %s from hook %s starts with 'extra__'. Please rename it.",
                     field_name,
                     hook_class.__name__,
                 )
                 continue
-            field_name_with_prefix = f"extra__{hook_class.conn_type}__{field_name}"
+            field_name_with_prefix = f"{field_prefix}{field_name}"
             if field_name_with_prefix in self._connection_form_widgets:
                 log.warning(
                     "The field %s from class %s has already been added by another provider. Ignoring it.",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3939,10 +3939,11 @@ class ConnectionModelView(AirflowModelView):
                     category="error",
                 )
 
+        extra_prefix = f"extra__{conn_type}__"
         custom_fields = {
-            key: form.data[key]
+            key.replace(extra_prefix, ''): form.data[key]
             for key in self.extra_fields
-            if key in form.data and key.startswith(f"extra__{conn_type}__")
+            if key in form.data and key.startswith(extra_prefix)
         }
 
         extra.update(custom_fields)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3961,7 +3961,7 @@ class ConnectionModelView(AirflowModelView):
                 warnings.warn(f"Connection type {conn_type!r} not recognized by providers manager.")
                 return True
             hook_class = import_string(hook_info.hook_class_name)
-            is_deprecated = getattr(hook_class, '__EXTRA_PREFIX_DEPRECATED', False) is True
+            is_deprecated = getattr(hook_class, '_EXTRA_PREFIX_DEPRECATED', False) is True
             return is_deprecated
 
         def strip_prefix(val):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3999,6 +3999,8 @@ class ConnectionModelView(AirflowModelView):
 
     def prefill_form(self, form, pk):
         """Prefill the form."""
+        conn_type = form.data['conn_type']
+        extra_prefix = f"extra__{conn_type}__"
         try:
             extra = form.data.get('extra')
             if extra is None:
@@ -4012,10 +4014,12 @@ class ConnectionModelView(AirflowModelView):
             logging.warning('extra field for %s is not a dictionary', form.data.get('conn_id', '<unknown>'))
             return
 
-        for field in self.extra_fields:
-            value = extra_dictionary.get(field, '')
+        for field_name_with_prefix in self.extra_fields:
+            value = extra_dictionary.get(field_name_with_prefix.replace(extra_prefix, ''), '')
+            if not value:
+                value = extra_dictionary.get(field_name_with_prefix, '')
             if value:
-                field = getattr(form, field)
+                field = getattr(form, field_name_with_prefix)
                 field.data = value
 
 

--- a/tests/providers/google/cloud/utils/base_gcp_mock.py
+++ b/tests/providers/google/cloud/utils/base_gcp_mock.py
@@ -30,7 +30,7 @@ def mock_base_gcp_hook_default_project_id(
     impersonation_chain=None,
 ):
     self.extras = {'extra__google_cloud_platform__project': GCP_PROJECT_ID_HOOK_UNIT_TEST}
-    self._conn = gcp_conn_id
+    self.gcp_conn_id = gcp_conn_id
     self.delegate_to = delegate_to
     self.impersonation_chain = impersonation_chain
     self._client = None

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -159,7 +159,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         }
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == key_path
 
         with pytest.raises(
@@ -174,7 +174,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == key_path
 
         assert_gcp_credential_file_in_env(self.instance)
@@ -190,7 +190,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         mock_file_handler.write = string_file.write
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == file_name
             assert file_content == string_file.getvalue()
 
@@ -202,7 +202,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == key_path
 
         assert_gcp_credential_file_in_env(self.instance)
@@ -214,7 +214,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             raise Exception()
 
         with pytest.raises(Exception):
@@ -228,7 +228,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == key_path
 
         assert_gcp_credential_file_in_env(self.instance)
@@ -240,7 +240,7 @@ class TestProvideGcpCredentialFile(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(_):
+        def assert_gcp_credential_file_in_env(self):
             raise Exception()
 
         with pytest.raises(Exception):
@@ -510,7 +510,7 @@ class TestGoogleBaseHook(unittest.TestCase):
         self.instance.extras = {'extra__google_cloud_platform__key_path': key_path}
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(hook_instance):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == key_path
 
         assert_gcp_credential_file_in_env(self.instance)
@@ -526,7 +526,7 @@ class TestGoogleBaseHook(unittest.TestCase):
         mock_file_handler.write = string_file.write
 
         @hook.GoogleBaseHook.provide_gcp_credential_file
-        def assert_gcp_credential_file_in_env(hook_instance):
+        def assert_gcp_credential_file_in_env(self):
             assert os.environ[CREDENTIALS] == file_name
             assert file_content == string_file.getvalue()
 

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -76,7 +76,7 @@ def test_process_form_extras():
     cmv.process_form(form=mock_form, is_created=True)
 
     assert json.loads(mock_form.extra.data) == {
-        "extra__test__custom_field": "custom_field_val",
+        "custom_field": "custom_field_val",
         "param1": "param1_val",
     }
 
@@ -105,9 +105,9 @@ def test_process_form_extras():
     cmv.extra_fields = ["extra__test3__custom_field"]  # Custom field
     cmv.process_form(form=mock_form, is_created=True)
 
-    assert json.loads(mock_form.extra.data) == {"extra__test3__custom_field": "custom_field_val3"}
+    assert json.loads(mock_form.extra.data) == {"custom_field": "custom_field_val3"}
 
-    # Testing parameters set in both extra and custom fields (cunnection updates).
+    # Testing parameters set in both extra and custom fields (connection updates).
     mock_form = mock.Mock()
     mock_form.data = {
         "conn_type": "test4",
@@ -120,7 +120,7 @@ def test_process_form_extras():
     cmv.extra_fields = ["extra__test4__custom_field"]  # Custom field
     cmv.process_form(form=mock_form, is_created=True)
 
-    assert json.loads(mock_form.extra.data) == {"extra__test4__custom_field": "custom_field_val4"}
+    assert json.loads(mock_form.extra.data) == {"custom_field": "custom_field_val4"}
 
 
 def test_duplicate_connection(admin_client):


### PR DESCRIPTION
We namespaced custom connection fields (which are stored in the `extra` json field) with prefix `extra__<conn type>__` in order to keep them unique in a global dictionary of fields.

This made it ugly and clunky to use these fields when you deal with the `extra` field directly, e.g. when using an external secrets backend or storing connections in env vars.

With a slight change in logic, we can keep this namespacing (which ensures that different connections can have fields with the same name and different labels) and strip the prefix prior to saving (and add it back on read) so that the `extra` JSON doesn't have the prefix.

That's the easy part.  What was a little more challenging (or at least tedious) was to preserve backward compatibility, so users will be warned when their extras still have the deprecated prefix, but it will continue to work.
