### PR TITLE
Fix mocking the right method in secret backend test

### DIFF
--- a/tests/secrets/test_secrets.py
+++ b/tests/secrets/test_secrets.py
@@ -94,10 +94,10 @@ class TestConnectionsFromSecrets(unittest.TestCase):
     )
     @mock.patch(
         "airflow.providers.amazon.aws.secrets.systems_manager."
-        "SystemsManagerParameterStoreBackend.get_conn_uri"
+        "SystemsManagerParameterStoreBackend.get_connection"
     )
-    def test_backend_fallback_to_env_var(self, mock_get_uri):
-        mock_get_uri.return_value = None
+    def test_backend_fallback_to_env_var(self, mock_get_connection):
+        mock_get_connection.return_value = None
 
         backends = ensure_secrets_loaded()
         backend_classes = [backend.__class__.__name__ for backend in backends]
@@ -106,7 +106,7 @@ class TestConnectionsFromSecrets(unittest.TestCase):
         conn = Connection.get_connection_from_secrets(conn_id="test_mysql")
 
         # Assert that SystemsManagerParameterStoreBackend.get_conn_uri was called
-        mock_get_uri.assert_called_once_with(conn_id='test_mysql')
+        mock_get_connection.assert_called_once_with(conn_id='test_mysql')
 
         assert 'mysql://airflow:airflow@host:5432/airflow' == conn.get_uri()
 


### PR DESCRIPTION
The #22348 introduced a change on how connections are retrieved
from secret backends, but one of the tests has not been
changed to follow.

This fixes failing main.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
