### PR TITLE
Fix bugs about timezone change

### DIFF
--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -163,7 +163,7 @@ function initializeUITimezone() {
   }
 
   $('a[data-timezone]').click((evt) => {
-    changeDisplayedTimezone($(evt.target).data('timezone'));
+    changeDisplayedTimezone($(evt.currentTarget).data('timezone'));
   });
 
   $('#timezone-other').typeahead({

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -41,7 +41,7 @@ function displayTime() {
     .html(`${now.format('HH:mm')} <strong>${formatTimezone(now)}</strong>`);
 }
 
-function changDisplayedTimezone(tz) {
+function changeDisplayedTimezone(tz) {
   localStorage.setItem('selected-timezone', tz);
   setDisplayedTimezone(tz);
   displayTime();
@@ -147,7 +147,7 @@ function initializeUITimezone() {
     setManualTimezone(manualTz);
   }
 
-  changDisplayedTimezone(selectedTz || Airflow.defaultUITimezone);
+  changeDisplayedTimezone(selectedTz || Airflow.defaultUITimezone);
 
   if (Airflow.serverTimezone !== 'UTC') {
     $('#timezone-server a').html(`${formatTimezone(Airflow.serverTimezone)} <span class="label label-primary">Server</span>`);
@@ -163,7 +163,7 @@ function initializeUITimezone() {
   }
 
   $('a[data-timezone]').click((evt) => {
-    changDisplayedTimezone($(evt.target).data('timezone'));
+    changeDisplayedTimezone($(evt.target).data('timezone'));
   });
 
   $('#timezone-other').typeahead({
@@ -179,7 +179,7 @@ function initializeUITimezone() {
       this.$element.val('');
 
       setManualTimezone(data.tzName);
-      changDisplayedTimezone(data.tzName);
+      changeDisplayedTimezone(data.tzName);
 
       // We need to delay the close event to not be in the form handler,
       // otherwise bootstrap ignores it, thinking it's caused by interaction on


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I found a bug that timezone information become `undefined` when clicking upper right clock to change timezone.
This is because the click event refers `evt.target` and I clicked `server` label shown in the following image.
This can be fixed by use `evt.currentTarget`. 

![image](https://user-images.githubusercontent.com/6898958/160087904-e94ad2fa-2976-49fe-843a-e46383e97295.png)

This image is the fact that `target: span.label.label-primary` is referred actually though`currentTarget: a` should be referred.
<img width="754" alt="image" src="https://user-images.githubusercontent.com/6898958/160088201-b57958e6-745c-4b78-935f-bd3ea2dc46af.png">

I also fixed typo `changDisplayedTimezone` -> `changeDisplayedTimezone` :)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
