### PR TITLE
Remove dag parsing from `airflow db init` command

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -644,13 +644,6 @@ def initdb(session: Session = NEW_SESSION):
 
     with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
 
-        dagbag = DagBag()
-        # Save DAGs in the ORM
-        dagbag.sync_to_db(session=session)
-
-        # Deactivate the unknown ones
-        DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
-
         from flask_appbuilder.models.sqla import Base
 
         Base.metadata.create_all(settings.engine)
@@ -1283,6 +1276,17 @@ def resetdb(session: Session = NEW_SESSION):
         drop_flask_models(connection)
 
     initdb(session=session)
+
+
+@provide_session
+def bootstrap_dagbag(session: Session = NEW_SESSION):
+
+    dagbag = DagBag()
+    # Save DAGs in the ORM
+    dagbag.sync_to_db(session=session)
+
+    # Deactivate the unknown ones
+    DAG.deactivate_unknown_dags(dagbag.dags.keys(), session=session)
 
 
 @provide_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,6 +169,7 @@ def initial_db_init():
     from airflow.utils import db
 
     db.resetdb()
+    db.bootstrap_dagbag()
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
When running `airflow db init`, Airflow will parse all of the DAGs in the configured dag folder sequentially in a single process. When there are a large number of DAGs present this can _significantly_ slow down the time it takes for the `db init` command to run. 

In my opinion, initializing the DB and populating it with data are separate tasks and shouldn't be combined into a single function. The background DAG processor is also much faster at parsing files and populating the DB due to using multiprocessing. 

I propose splitting the bootstrapping of the DagBag out into a separate function (so as to not introduce any changes to the test setup / teardown process) and removing it from the `db init` and `db reset` commands.

Additionally, removing this PR might be required for AIP-43 anyways

Let me know if there's anything I'm missing here, or if there's an explanation for parsing DAGs here which I may have missed. 



