### PR TITLE
PostgresToGoogleCloudStorageOperator - BigQuery schema type for time zone naive fields

### DIFF
--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -78,10 +78,10 @@ class PostgresToGCSOperator(BaseSQLToGCSOperator):
     ui_color = '#a0e08c'
 
     type_map = {
-        1114: 'TIMESTAMP',
+        1114: 'DATETIME',
         1184: 'TIMESTAMP',
-        1082: 'TIMESTAMP',
-        1083: 'TIMESTAMP',
+        1082: 'DATE',
+        1083: 'TIME',
         1005: 'INTEGER',
         1007: 'INTEGER',
         1016: 'INTEGER',
@@ -131,13 +131,27 @@ class PostgresToGCSOperator(BaseSQLToGCSOperator):
     def convert_type(self, value, schema_type):
         """
         Takes a value from Postgres, and converts it to a value that's safe for
-        JSON/Google Cloud Storage/BigQuery. Dates are converted to UTC seconds.
-        Decimals are converted to floats. Times are converted to seconds.
+        JSON/Google Cloud Storage/BigQuery. Time zone aware DateTime are converted to UTC seconds,
+        unaware DateTime, Date and Time are iso formatted.
+        Decimals are converted to floats.
         """
-        if isinstance(value, (datetime.datetime, datetime.date)):
+        if isinstance(value, datetime.datetime):
+            if value.tzinfo is None:
+                return value.isoformat()
             return pendulum.parse(value.isoformat()).float_timestamp
+        if isinstance(value, datetime.date):
+            return value.isoformat()
         if isinstance(value, datetime.time):
             formatted_time = time.strptime(str(value), "%H:%M:%S")
+            if value.tzinfo is None:
+                return str(
+                    datetime.timedelta(
+                        hours=formatted_time.tm_hour,
+                        minutes=formatted_time.tm_min,
+                        seconds=formatted_time.tm_sec,
+                    )
+                )
+
             return int(
                 datetime.timedelta(
                     hours=formatted_time.tm_hour, minutes=formatted_time.tm_min, seconds=formatted_time.tm_sec


### PR DESCRIPTION
Fixes #11547

The idea here is to use `DATETIME`, `DATE`. and `TIME` fields in bigquery when the postgres columns is defined timezone naive.(`timestamp`, `date`, `time` <=> to `timestamp without timezone`, `date without timezone` and `time without timezone`)

I had to modify the `convert_type` function as BigQuery cannot import data for `DATETIME`, `DATE`. and `TIME` fields from a timestamp.

I also added some tests for that function. (Similar to what we have in `airflow/providers/google/cloud/transfers/mysql_to_gcs.py`)

![screen2](https://user-images.githubusercontent.com/14861206/160213323-5af0f401-05b5-4b71-a87f-44fd4f176515.png)
![screen1](https://user-images.githubusercontent.com/14861206/160213326-ed91d0cc-4447-4791-adf2-926897642b2c.png)

