### PR TITLE
Reduce verbosity of provider import failure logs & make configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -539,6 +539,15 @@
       type: string
       example: ~
       default: "INFO"
+    - name: provider_import_error_level
+      description: |
+        Logging level for provider import failures.  Intended mainly for Airflow developers.
+
+        Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
+      version_added: 2.3.0
+      type: string
+      example: ~
+      default: ~
     - name: celery_logging_level
       description: |
         Logging level for celery. If not set, it uses the value of logging_level

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -306,6 +306,11 @@ encrypt_s3_logs = False
 # Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
 logging_level = INFO
 
+# Logging level for provider import failures.  Intended mainly for Airflow developers.
+#
+# Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.
+# provider_import_error_level =
+
 # Logging level for celery. If not set, it uses the value of logging_level
 #
 # Supported values: ``CRITICAL``, ``ERROR``, ``WARNING``, ``INFO``, ``DEBUG``.


### PR DESCRIPTION
When running airflow from sources we might not have all deps installed so provider imports fail.

Currently the traceback is logged at warning level which is too much; it obliterates your history.

Instead we make optional the simple reporting of an import failure in a provider, and additionally we move the traceback to DEBUG only (not configurable).
