### PR TITLE
Add max line length setting to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,7 @@ charset = utf-8
 
 [*.py]
 indent_size = 4
+max_line_length = 110
 
 [*.sh]
 indent_size = 4
@@ -44,6 +45,7 @@ indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2
+max_line_length = 110
 
 [*.{htm,html}]
 indent_size = 2


### PR DESCRIPTION
Right now, there is no explicit settings for max line width, so often error` is only detected when pre-commit hook is executed.  Adding explicit setting helps to mitigate this issue earlier.

P.S. I'm not sure if we need to add such settings for `.sh` and `.sql` files as well...
