### PR TITLE
Deprecate connection extra prefix

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3911,6 +3911,7 @@ class ConnectionModelView(AirflowModelView):
         """Process form data."""
         conn_type = form.data['conn_type']
         conn_id = form.data["conn_id"]
+        extra_prefix = f"extra__{conn_type}__"
 
         # The extra value is the combination of custom fields for this conn_type and the Extra field.
         # The extra form field with all extra values (including custom fields) is in the form being processed
@@ -3919,9 +3920,10 @@ class ConnectionModelView(AirflowModelView):
 
         extra_field = form.data.get("extra")
 
+        raw_extra_dict = {}
         if extra_field:
             try:
-                extra.update(json.loads(extra_field))
+                raw_extra_dict = json.loads(extra_field)
             except (JSONDecodeError, TypeError):
                 flash(
                     Markup(
@@ -3935,11 +3937,56 @@ class ConnectionModelView(AirflowModelView):
                     category="error",
                 )
 
-        custom_fields = {
-            key: form.data[key]
-            for key in self.extra_fields
-            if key in form.data and key.startswith(f"extra__{conn_type}__")
-        }
+        def warn_of_deprecated_conn_extra(old, new):
+            try:
+                flash(
+                    Markup(
+                        f"Deprecation warning for connection <q>{conn_id}</q>:</p>"
+                        f"<p>The <em>Extra</em> connection field <q>{old}</q> has been renamed to <q>{new}</q>."
+                    ),
+                    category="warning",
+                )
+            except RuntimeError:
+                warnings.warn("Could not generate flash message; likely invoked via test.")
+
+        def hook_deprecates_extra_prefix():
+            from airflow.utils.module_loading import import_string
+
+            hook_info = ProvidersManager().hooks.get(conn_type, None)
+            if not hook_info:
+                warnings.warn(f"Connection type {conn_type!r} not recognized by providers manager.")
+                return True
+            hook_class = import_string(hook_info.hook_class_name)
+            is_deprecated = getattr(hook_class, '_EXTRA_PREFIX_DEPRECATED', False) is True
+            return is_deprecated
+
+        def strip_prefix(val):
+            return val.replace(extra_prefix, '')
+
+        prefix_is_deprecated = hook_deprecates_extra_prefix()
+
+        if prefix_is_deprecated:
+            for k, v in raw_extra_dict.items():
+                new_k = strip_prefix(k)
+                extra[new_k] = v
+                warn_of_deprecated_conn_extra(k, new_k)
+        else:
+            extra.update(raw_extra_dict)
+
+        del raw_extra_dict
+
+        if prefix_is_deprecated:
+            custom_fields = {
+                strip_prefix(key): form.data[key]
+                for key in self.extra_fields
+                if key in form.data and key.startswith(extra_prefix)
+            }
+        else:
+            custom_fields = {
+                key: form.data[key]
+                for key in self.extra_fields
+                if key in form.data and key.startswith(extra_prefix)
+            }
 
         extra.update(custom_fields)
 
@@ -3948,6 +3995,8 @@ class ConnectionModelView(AirflowModelView):
 
     def prefill_form(self, form, pk):
         """Prefill the form."""
+        conn_type = form.data['conn_type']
+        extra_prefix = f"extra__{conn_type}__"
         try:
             extra = form.data.get('extra')
             if extra is None:
@@ -3961,10 +4010,17 @@ class ConnectionModelView(AirflowModelView):
             logging.warning('extra field for %s is not a dictionary', form.data.get('conn_id', '<unknown>'))
             return
 
-        for field in self.extra_fields:
-            value = extra_dictionary.get(field, '')
+        for field_name_with_prefix in self.extra_fields:
+            field_name = field_name_with_prefix.replace(extra_prefix, '')
+
+            # first check for short name (i.e. for hooks not using deprecated extra prefix)
+            value = extra_dictionary.get(field_name, '')
+            if not value:
+                # did not find the short i.e. un-prefixed name
+                # check for the prefixed name for backcompat
+                value = extra_dictionary.get(field_name_with_prefix, '')
             if value:
-                field = getattr(form, field)
+                field = getattr(form, field_name_with_prefix)
                 field.data = value
 
 


### PR DESCRIPTION
Previously, connection "extra" fields which were added as custom fields in the
webserver connection form had to be named with prefix `extra__<conn_type>__`.
This was because custom fields are registered globally on the connection view model,
so the prefix was necessary to prevent collisions.

But the prefix is ugly and cumbersome in the `extra` field.  So now what we do is
add this prefix when defining the field internally in the model, and strip it when
saving the connection.

Notes:

* alternatively we could leave widget definitions with the prefix spelled out and then just strip it on save.  this would be slightly simpler but maybe tiny bit less intuitive for folks defining extra fields?
* it would be nice to avoid having to add this `_EXTRA_PREFIX_DEPRECATED` attribute on hooks as we update them but i'm not sure there's another way, since users may keep an old provider but upgrade airflow.

After this I'll have to update the providers one at a time so they all use a `_get_field` type of function to handle the backcompat for connections defined in the old way, and to add that indicator attribute so webserver will handle the saving correctly.