### PR TITLE
Add Notifications of build failures

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,3 +63,5 @@ github:
     - paolaperaza
     - petedejoy
     - gmcdonald
+  notifications:
+    jobs: jobs@airflow.apache.org


### PR DESCRIPTION
There is new feature to receive notifications about build failures
for git repos. It is supposed to only send info about changed
status -> failed/succeeded or succeeded-> failed transition.

Trying it out.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
