### PR TITLE
Switch azure provider to azure-keyvault-secrets

### DIFF
--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -106,7 +106,7 @@ class TestPythonPackages:
             'azure.cosmos',
             'azure.datalake.store',
             'azure.identity',
-            'azure.keyvault',
+            'azure.keyvault.secrets',
             'azure.kusto.data',
             'azure.mgmt.containerinstance',
             'azure.mgmt.datalake.store',

--- a/docs/apache-airflow-providers-microsoft-azure/index.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/index.rst
@@ -86,7 +86,7 @@ PIP package                       Version required
 ``azure-cosmos``                  ``>=4.0.0``
 ``azure-datalake-store``          ``>=0.0.45``
 ``azure-identity``                ``>=1.3.1``
-``azure-keyvault``                ``>=4.1.0``
+``azure-keyvault-secrets``        ``>=4.1.0,<5.0``
 ``azure-kusto-data``              ``>=0.0.43,<0.1``
 ``azure-mgmt-containerinstance``  ``>=1.5.0,<2.0``
 ``azure-mgmt-datafactory``        ``>=1.0.0,<2.0``

--- a/setup.py
+++ b/setup.py
@@ -218,7 +218,7 @@ azure = [
     'azure-cosmos>=4.0.0',
     'azure-datalake-store>=0.0.45',
     'azure-identity>=1.3.1',
-    'azure-keyvault>=4.1.0',
+    'azure-keyvault-secrets>=4.1.0,<5.0',
     'azure-kusto-data>=0.0.43,<0.1',
     # Azure integration uses old librarires and the limits below reflect that
     # TODO: upgrade to newer versions of all the below libraries


### PR DESCRIPTION
The only dependency actually used in the `microsoft-azure` provider appears to be `azure-keyvault-secrets`.  This merge updates the provider to depend only on that package and not the full `azure-keyvault` metapackage.  This has the potential added benefits of allowing that package to be constrained more specifically and also removing dependence on a metapackage that is causing problem for packagers (on conda-forge in specific).

closes #22551

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
