### PR TITLE
Stop crashing when empty logs are received from kubernetes client

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -269,7 +269,11 @@ class PodManager(LoggingMixin):
         """
         split_at = line.find(' ')
         if split_at == -1:
-            raise Exception(f'Log not in "{{timestamp}} {{log}}" format. Got: {line}')
+            self.log.error(
+                f"Error parsing timestamp (no timestamp in message '${line}'). "
+                "Will continue execution but won't update timestamp"
+            )
+            return None, line
         timestamp = line[:split_at]
         message = line[split_at + 1 :].rstrip()
         try:

--- a/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_manager.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import logging
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -234,8 +235,11 @@ class TestPodManager:
         assert timestamp == pendulum.parse(real_timestamp)
         assert line == log_message
 
-        with pytest.raises(Exception):
+    def test_parse_invalid_log_line(self, caplog):
+        with caplog.at_level(logging.INFO):
             self.pod_manager.parse_log_line('2020-10-08T14:16:17.793417674ZInvalidmessage\n')
+        assert "Invalidmessage" in caplog.text
+        assert "no timestamp in message" in caplog.text
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.run_pod_async")
     def test_start_pod_retries_on_409_error(self, mock_run_pod_async):


### PR DESCRIPTION
It seems that in some circumstances, the K8S client might return
empty logs even if "timestamps" options is specified.

That should not happen in general, but apparently it does in
some cases and leads to task being killed.

Rather than killing the tasks we should log it as an error
(on top of trying to find out why and preventing it from
happening - also to be able to gather more information and
diagnosis on when it happens).

Related to: #21605

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
