### PR TITLE
DiscordWebhookOperator - add webhook_endpoint to templated fields

### DIFF
--- a/airflow/providers/discord/operators/discord_webhook.py
+++ b/airflow/providers/discord/operators/discord_webhook.py
@@ -40,7 +40,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
                          default webhook endpoint in the extra field in the form of
                          {"webhook_endpoint": "webhooks/{webhook.id}/{webhook.token}"}
     :param webhook_endpoint: Discord webhook endpoint in the form of
-                             "webhooks/{webhook.id}/{webhook.token}"
+                             "webhooks/{webhook.id}/{webhook.token}" (templated)
     :param message: The message you want to send to your Discord channel
                     (max 2000 characters). (templated)
     :param username: Override the default username of the webhook. (templated)
@@ -49,7 +49,7 @@ class DiscordWebhookOperator(SimpleHttpOperator):
     :param proxy: Proxy to use to make the Discord webhook call
     """
 
-    template_fields: Sequence[str] = ('username', 'message')
+    template_fields: Sequence[str] = ('username', 'message', 'webhook_endpoint')
 
     def __init__(
         self,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Added webhook_endpoint to templated fields in DiscordWebhookOperator.

User might want to leverage templates for that field. In my case I wanted to use token saved in password field of a connection to avoid leaking the token to logs:
```python
send_discord_message_task = DiscordWebhookOperator(
        task_id="send_discord_message",
        http_conn_id="discord_webhook",
        webhook_endpoint="webhooks/{{ conn.discord_webhook.login }}/{{ conn.discord_webhook.password }}",
        message="...",
)
```
It's possible to overwrite templated fields later but this seems like a good default.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
