### PR TITLE
Update modal buttons for mapped task instances

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -463,3 +463,8 @@ label[for="timezone-other"],
 .tooltip.d3-tip {
   z-index: 1070;
 }
+
+.menu-scroll {
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -54,6 +54,9 @@ let executionDate = '';
 let subdagId = '';
 let dagRunId = '';
 let mapIndex;
+let runId;
+let showBack = false;
+let mapLength = 0;
 const showExternalLogRedirect = getMetaValue('show_external_log_redirect') === 'True';
 
 const buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce((obj, elm) => {
@@ -109,6 +112,13 @@ function updateModalUrls() {
     _oc_TaskInstanceModelView: executionDate,
   });
 
+  updateButtonUrl(buttons.mapped, {
+    _flt_3_dag_id: dagId,
+    _flt_3_task_id: taskId,
+    _flt_3_run_id: runId,
+    _oc_TaskInstanceModelView: executionDate,
+  });
+
   updateButtonUrl(buttons.log, {
     dag_id: dagId,
     task_id: taskId,
@@ -124,7 +134,17 @@ document.addEventListener('click', (event) => {
   }
 });
 
-export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
+export function callModal({
+  taskId: t,
+  executionDate: d,
+  extraLinks,
+  tryNumber,
+  isSubDag,
+  dagRunId: drID,
+  mapIndex: mi,
+  isMapped = false,
+  mappedLength = 0,
+}) {
   taskId = t;
   const location = String(window.location);
   $('#btn_filter').on('click', () => {
@@ -133,6 +153,17 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
   executionDate = d;
   dagRunId = drID;
   mapIndex = mi;
+  if (isMapped) {
+    mapLength = mappedLength;
+    runId = drID;
+  } else {
+    runId = undefined;
+  }
+  if (showBack) {
+    $('#btn_back').show();
+  } else {
+    $('#btn_back').hide();
+  }
   $('#dag_run_id').text(drID);
   $('#task_id').text(t);
   $('#execution_date').text(formatDateTime(d));
@@ -147,7 +178,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
     $('#modal_map_index').hide();
     $('#modal_map_index .value').text('');
   }
-  if (sd) {
+  if (isSubDag) {
     $('#div_btn_subdag').show();
     subdagId = `${dagId}.${t}`;
   } else {
@@ -155,9 +186,30 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
     subdagId = undefined;
   }
 
+  if (isMapped || mapIndex >= 0) {
+    $('#btn_rendered').hide();
+    $('#mapped_instances').show();
+  } else {
+    $('#btn_rendered').show();
+    $('#mapped_instances').hide();
+  }
+
+  if (isMapped) {
+    $('#mapped_dropdown #dropdown-label').text(`Mapped Instances [${mappedLength}]`);
+    $('#mapped_dropdown .dropdown-menu').empty();
+    [...Array(mappedLength)].forEach((_, i) => {
+      $('#mapped_dropdown .dropdown-menu').append(`<li><a href="#" class="map_index_item" data-mapIndex="${i}">${i}</a></li>`);
+    });
+    $('#btn_mapped').show();
+    $('#mapped_dropdown').css('display', 'inline-block');
+  } else {
+    $('#btn_mapped').hide();
+    $('#mapped_dropdown').hide();
+  }
+
   $('#dag_dl_logs').hide();
   $('#dag_redir_logs').hide();
-  if (tryNumbers > 0) {
+  if (tryNumber > 0 && !isMapped) {
     $('#dag_dl_logs').show();
     if (showExternalLogRedirect) {
       $('#dag_redir_logs').show();
@@ -168,7 +220,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
 
   $('#try_index > li').remove();
   $('#redir_log_try_index > li').remove();
-  const startIndex = (tryNumbers > 2 ? 0 : 1);
+  const startIndex = (tryNumber > 2 ? 0 : 1);
 
   const query = new URLSearchParams({
     dag_id: dagId,
@@ -179,7 +231,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
   if (mi !== undefined) {
     query.set('map_index', mi);
   }
-  for (let index = startIndex; index < tryNumbers; index += 1) {
+  for (let index = startIndex; index < tryNumber; index += 1) {
     let showLabel = index;
     if (index !== 0) {
       query.set('try_number', index);
@@ -239,6 +291,31 @@ export function callModal(t, d, extraLinks, tryNumbers, sd, drID, mi) {
     extraLinksSpan.find('[data-toggle="tooltip"]').tooltip();
   }
 }
+
+// Switch the modal from a mapped task summary to a specific mapped task instance
+$(document).on('click', '.map_index_item', function mapItem() {
+  const mi = $(this).attr('data-mapIndex');
+  showBack = true;
+  callModal({
+    taskId,
+    executionDate,
+    dagRunId,
+    mapIndex: mi,
+  });
+});
+
+// Switch from a mapped task instance back to a mapped task summary
+$(document).on('click', '#btn_back', () => {
+  showBack = false;
+  callModal({
+    taskId,
+    executionDate,
+    dagRunId,
+    mapIndex: -1,
+    isMapped: true,
+    mappedLength: mapLength,
+  });
+});
 
 export function callModalDag(dag) {
   $('#dagModal').modal({});

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -54,7 +54,6 @@ let executionDate = '';
 let subdagId = '';
 let dagRunId = '';
 let mapIndex;
-let runId;
 let showBack = false;
 let mapLength = 0;
 const showExternalLogRedirect = getMetaValue('show_external_log_redirect') === 'True';
@@ -115,7 +114,7 @@ function updateModalUrls() {
   updateButtonUrl(buttons.mapped, {
     _flt_3_dag_id: dagId,
     _flt_3_task_id: taskId,
-    _flt_3_run_id: runId,
+    _flt_3_run_id: dagRunId,
     _oc_TaskInstanceModelView: executionDate,
   });
 
@@ -155,9 +154,6 @@ export function callModal({
   mapIndex = mi;
   if (isMapped) {
     mapLength = mappedLength;
-    runId = drID;
-  } else {
-    runId = undefined;
   }
   if (showBack) {
     $('#btn_back').show();

--- a/airflow/www/static/js/gantt.js
+++ b/airflow/www/static/js/gantt.js
@@ -204,8 +204,13 @@ d3.gantt = () => {
       .on('mouseover', tip.show)
       .on('mouseout', tip.hide)
       .on('click', (d) => {
-        // eslint-disable-next-line max-len
-        callModal(d.task_id, d.execution_date, d.extraLinks, undefined, undefined, d.run_id, d.map_index);
+        callModal({
+          taskId: d.task_id,
+          executionDate: d.execution_date,
+          extraLinks: d.extraLinks,
+          dagRunId: d.run_id,
+          mapIndex: d.map_index,
+        });
       })
       .attr('class', (d) => d.state || 'null')
       .attr('y', 0)

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -177,16 +177,20 @@ function draw() {
       // A task node
       const task = tasks[nodeId];
       const tryNumber = taskInstances[nodeId].try_number || 0;
+      let mappedLength = 0;
+      if (task.is_mapped) mappedLength = taskInstances[nodeId].mapped_states.length;
 
-      callModal(
-        nodeId,
+      callModal({
+        taskId: nodeId,
         executionDate,
-        task.extra_links,
+        extraLinks: task.extra_links,
         tryNumber,
-        task.task_type === 'SubDagOperator',
+        isSubDag: task.task_type === 'SubDagOperator',
         dagRunId,
-        task.map_index,
-      );
+        mapIndex: task.map_index,
+        isMapped: task.is_mapped,
+        mappedLength,
+      });
     }
   });
 

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -183,7 +183,7 @@ function draw() {
         executionDate,
         task.extra_links,
         tryNumber,
-        task.task_tupe === 'SubDagOperator',
+        task.task_type === 'SubDagOperator',
         dagRunId,
         task.map_index,
       );

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -38,7 +38,15 @@ const StatusBox = ({
   const {
     executionDate, taskId, tryNumber = 0, operator, runId, mapIndex,
   } = instance;
-  const onClick = () => executionDate && callModal(taskId, executionDate, extraLinks, tryNumber, operator === 'SubDagOperator', runId, mapIndex);
+  const onClick = () => executionDate && callModal({
+    taskId,
+    executionDate,
+    extraLinks,
+    tryNumber,
+    isSubDag: operator === 'SubDagOperator',
+    dagRunId: runId,
+    mapIndex,
+  });
 
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -205,10 +205,10 @@
           <a id="btn_log" class="btn btn-sm" data-base-url="{{ url_for('Airflow.log') }}">
             Log
           </a>
-          <a id="btn_ti" class="btn btn-sm" data-base-url="{{ url_for('TaskInstanceModelView.list') }}">
+          <a id="btn_ti" class="btn btn-sm" data-base-url="{{ url_for('TaskInstanceModelView.list') }}" title="View all instances across all DAG runs">
             All Instances
           </a>
-          <button id="btn_filter" type="button" class="btn btn-sm" title="Filter on this task and upstream ">
+          <button id="btn_filter" type="button" class="btn btn-sm" title="Filter on this task and upstream">
             Filter Upstream
           </button>
           <hr>
@@ -217,6 +217,22 @@
             <ul class="nav nav-pills" role="tablist" id="try_index" style="display:inline">
             </ul>
             <hr>
+          </div>
+          <div id="mapped_instances">
+            <button id="btn_back" style="display: none;" type="button" class="btn btn-sm" title="Go back to the mapped task summary page">
+              Back to Mapped Summary
+            </button>
+            <a id="btn_mapped" style="display: none;" class="btn btn-sm" data-base-url="{{ url_for('TaskInstanceModelView.list') }}" title="Show the mapped instances for this DAG run">
+              All Mapped Instances
+            </a>
+            <div class="dropdown" id="mapped_dropdown">
+              <button class="btn btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
+                <span id="dropdown-label" title="Select Mapped Instance"></span>
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu menu-scroll"></ul>
+            </div>
+            <hr style="margin-bottom: 8px;">
           </div>
           {% if external_log_name is defined %}
             <div id="dag_redir_logs">

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -27,7 +27,7 @@
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
     <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
-    {% if map_index is defined and map_index < 0 %}
+    {% if map_index is defined and map_index >= 0 %}
       <span class="text-muted">Map Index:</span> <span>{{ map_index }}</span>
     {% endif %}
   </h4>


### PR DESCRIPTION
Right now in graph view, a user can click on a mapped task and see a summary in a modal. But they cannot see an individual mapped task. This PR fixes that with:

- Adds a new "All Mapped Instances" button to the `/taskinstance/list`, but filtered to just that DAG run
- Adds a dropdown to select a mapped instance by `map_index` and update the modal
- Adds a back button to return the modal back to the task summary

Related: #22409

Also, updates `callModal` to use object props to avoid having to specifically order arguments or passing `undefined`

<img width="607" alt="Screen Shot 2022-03-28 at 4 37 03 PM" src="https://user-images.githubusercontent.com/4600967/160493818-63463b14-e41b-41d7-a2a6-9dd628647a12.png">

![Mar-28-2022 16-39-08](https://user-images.githubusercontent.com/4600967/160493805-6c776a46-3923-4b61-88af-3156289edde6.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
