### PR TITLE
Suppress import errors for providers from sources

### DIFF
--- a/airflow/api_connexion/endpoints/provider_endpoint.py
+++ b/airflow/api_connexion/endpoints/provider_endpoint.py
@@ -34,9 +34,9 @@ def _remove_rst_syntax(value: str) -> str:
 
 def _provider_mapper(provider: ProviderInfo) -> Provider:
     return Provider(
-        package_name=provider[1]["package-name"],
-        description=_remove_rst_syntax(provider[1]["description"]),
-        version=provider[0],
+        package_name=provider.data["package-name"],
+        description=_remove_rst_syntax(provider.data["description"]),
+        version=provider.version,
     )
 
 

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -304,7 +304,7 @@ class AirflowInfo:
 
     @property
     def _providers_info(self):
-        return [(p.provider_info['package-name'], p.version) for p in ProvidersManager().providers.values()]
+        return [(p.data['package-name'], p.version) for p in ProvidersManager().providers.values()]
 
     def show(self, output: str, console: Optional[AirflowConsole] = None) -> None:
         """Shows information about Airflow instance"""

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -55,9 +55,9 @@ def providers_list(args):
         data=list(ProvidersManager().providers.values()),
         output=args.output,
         mapper=lambda x: {
-            "package_name": x[1]["package-name"],
-            "description": _remove_rst_syntax(x[1]["description"]),
-            "version": x[0],
+            "package_name": x.provider_info["package-name"],
+            "description": _remove_rst_syntax(x.provider_info["description"]),
+            "version": x.version,
         },
     )
 

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -34,7 +34,7 @@ def provider_get(args):
     providers = ProvidersManager().providers
     if args.provider_name in providers:
         provider_version = providers[args.provider_name].version
-        provider_info = providers[args.provider_name].provider_info
+        provider_info = providers[args.provider_name].data
         if args.full:
             provider_info["description"] = _remove_rst_syntax(provider_info["description"])
             AirflowConsole().print_as(
@@ -55,8 +55,8 @@ def providers_list(args):
         data=list(ProvidersManager().providers.values()),
         output=args.output,
         mapper=lambda x: {
-            "package_name": x.provider_info["package-name"],
-            "description": _remove_rst_syntax(x.provider_info["description"]),
+            "package_name": x.data["package-name"],
+            "description": _remove_rst_syntax(x.data["description"]),
             "version": x.version,
         },
     )

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -32,6 +32,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Literal,
     MutableMapping,
     NamedTuple,
     Optional,
@@ -141,11 +142,18 @@ def _check_builtin_provider_prefix(provider_package: str, class_name: str) -> bo
 
 @dataclass
 class ProviderInfo:
-    """Provider information"""
+    """
+    Provider information
+
+    :param version: version string
+    :param provider_info: information about the provider
+    :param source_or_package: whether the provider is source files or PyPI package. When installed from
+        sources we suppress provider import errors.
+    """
 
     version: str
     provider_info: Dict
-    package_or_source: str
+    package_or_source: Union[Literal['source'], Literal['package']]
 
     def __post_init__(self):
         if not self.package_or_source in ('source', 'package'):

--- a/tests/api_connexion/endpoints/test_provider_endpoint.py
+++ b/tests/api_connexion/endpoints/test_provider_endpoint.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import pytest
 
+from airflow.providers_manager import ProviderInfo
 from airflow.security import permissions
 from tests.test_utils.api_connexion_utils import create_user, delete_user
 
@@ -27,7 +28,7 @@ MOCK_PROVIDERS = OrderedDict(
     [
         (
             'apache-airflow-providers-amazon',
-            (
+            ProviderInfo(
                 '1.0.0',
                 {
                     'package-name': 'apache-airflow-providers-amazon',
@@ -35,11 +36,12 @@ MOCK_PROVIDERS = OrderedDict(
                     'description': '`Amazon Web Services (AWS) <https://aws.amazon.com/>`__.\n',
                     'versions': ['1.0.0'],
                 },
+                'package',
             ),
         ),
         (
             'apache-airflow-providers-apache-cassandra',
-            (
+            ProviderInfo(
                 '1.0.0',
                 {
                     'package-name': 'apache-airflow-providers-apache-cassandra',
@@ -47,6 +49,7 @@ MOCK_PROVIDERS = OrderedDict(
                     'description': '`Apache Cassandra <http://cassandra.apache.org/>`__.\n',
                     'versions': ['1.0.0'],
                 },
+                'package',
             ),
         ),
     ]


### PR DESCRIPTION
When we are running airflow locally with providers installed from sources, often many providers will be discovered which we haven't installed the deps for.  This generally results in a very large amount of traceback logging, which has a very negative effect on usefulness of terminal output.  Here we suppress this error logging for providers that are installed from sources.
