### PR TITLE
Fix very strange (likely a bug) error in mypy

### DIFF
--- a/dev/breeze/src/airflow_ci/find_newer_dependencies.py
+++ b/dev/breeze/src/airflow_ci/find_newer_dependencies.py
@@ -139,4 +139,4 @@ def main(constraints_branch: str, python: str, timezone: str, updated_on_or_afte
 
 
 if __name__ == '__main__':
-    main()
+    main()  # type: ignore[misc]


### PR DESCRIPTION
Mypy Started to return a strange error in one of the scripts:

```
dev/breeze/src/airflow_ci/find_newer_dependencies.py:142: error: <nothing> not
callable  [misc]
        main()
        ^
```

This is likely a bug.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
