### PR TITLE
Consider mapped upstream in TriggerRuleDep

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -837,7 +837,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 f"'{dag.dag_id if dag else ''}.{task_id}'; received '{trigger_rule}'."
             )
 
-        self.trigger_rule = trigger_rule
+        self.trigger_rule = TriggerRule(trigger_rule)
         self.depends_on_past: bool = depends_on_past
         self.ignore_first_depends_on_past = ignore_first_depends_on_past
         self.wait_for_downstream = wait_for_downstream

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -103,7 +103,9 @@ class BaseXCom(Base, LoggingMixin):
         self.value = self.orm_deserialize_value()
 
     def __repr__(self):
-        return f'<XCom "{self.key}" ({self.task_id} @ {self.run_id})>'
+        if self.map_index < 0:
+            return f'<XCom "{self.key}" ({self.task_id} @ {self.run_id})>'
+        return f'<XCom "{self.key}" ({self.task_id}[{self.map_index}] @ {self.run_id})>'
 
     @overload
     @classmethod

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -981,3 +981,45 @@ def test_mapped_task_upstream_failed(dag_maker, session):
     tis, _ = dr.update_state(execute_callbacks=False, session=session)
     assert tis == []
     assert dr.state == DagRunState.FAILED
+
+
+def test_mapped_task_all_finish_before_downstream(dag_maker, session):
+    with dag_maker(session=session) as dag:
+
+        @dag.task
+        def make_list():
+            return [1, 2]
+
+        @dag.task
+        def double(value):
+            return value * 2
+
+        @dag.task
+        def consumer(value):
+            print(value)
+
+        consumer(value=double.expand(value=make_list()))
+
+    dr: DagRun = dag_maker.create_dagrun()
+
+    def _task_ids(tis):
+        return [ti.task_id for ti in tis]
+
+    # The first task is always make_list.
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert _task_ids(decision.schedulable_tis) == ["make_list"]
+
+    # After make_list is run, double is expanded.
+    decision.schedulable_tis[0].run(verbose=False, session=session)
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert _task_ids(decision.schedulable_tis) == ["double", "double"]
+
+    # Running just one of the mapped tis does not make downstream schedulable.
+    decision.schedulable_tis[0].run(verbose=False, session=session)
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert _task_ids(decision.schedulable_tis) == ["double"]
+
+    # Downstream is schedulable after all mapped tis are run.
+    decision.schedulable_tis[0].run(verbose=False, session=session)
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert _task_ids(decision.schedulable_tis) == ["consumer"]

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -41,7 +41,7 @@ def get_task_instance(session, dag_maker):
                 task_id='test_task', trigger_rule=trigger_rule, start_date=datetime(2015, 1, 1)
             )
             if upstream_task_ids:
-                task.upstream_task_ids.update(upstream_task_ids)
+                [DummyOperator(task_id=task_id) for task_id in upstream_task_ids] >> task
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
@@ -662,10 +662,10 @@ class TestTriggerRuleDep:
 
         # check handling with cases that tasks are triggered from backfill with no finished tasks
         finished_tis = DepContext().ensure_finished_tis(ti_op2.dag_run, session)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op2) == (1, 0, 0, 0, 1)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op2) == (1, 0, 0, 0, 1)
         finished_tis = dr.get_task_instances(state=State.finished, session=session)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op4) == (1, 0, 1, 0, 2)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, ti=ti_op5) == (2, 0, 1, 0, 3)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op4) == (1, 0, 1, 0, 2)
+        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op5) == (2, 0, 1, 0, 3)
 
         dr.update_state()
         assert State.SUCCESS == dr.state


### PR DESCRIPTION
This is needed to ensure all mapped upstream task instances are depended on by a downstream, instead of just one of them signifying the entire task as "done".

~Does not work yet. This depends on correct task-unmapping behaviour implemented in #22396. I also want to add some more asserts to make sure the downstream can pull all the values from the mapped upstream, but that depends on #22609.~ Ready!