### PR TITLE
Fix typo in the Pull Request "build image" if.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -166,7 +166,7 @@ jobs:
       fail-fast: true
     if: |
       needs.build-info.outputs.image-build == 'true' &&
-      github.event.pull_request.repo.head.full_name != 'apache/airflow'
+      github.event.pull_request.head.repo.full_name != 'apache/airflow'
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn)[0] }}
       BACKEND: sqlite
@@ -254,7 +254,7 @@ jobs:
       fail-fast: true
     if: |
       needs.build-info.outputs.image-build == 'true' &&
-      github.event.pull_request.repo.head.full_name != 'apache/airflow'
+      github.event.pull_request.head.repo.full_name != 'apache/airflow'
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn)[0] }}
       BACKEND: sqlite


### PR DESCRIPTION
In case Pull request is run in the "apache/airflow" repository,
image building happens in the ci.yml workflow as of #22542.

However there was a typo in the build-image workflow that made the
images build in both - BuildImage and CI workflow.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
