### PR TITLE
Upgrade to FAB 4.0

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_setup_cfg_file.sh
+++ b/scripts/ci/pre_commit/pre_commit_setup_cfg_file.sh
@@ -33,7 +33,7 @@ readonly TMP_FILE
 TMP_OUTPUT=$(mktemp)
 readonly TMP_OUTPUT
 
-find  "licenses" -type f -exec echo "  " {} \; | LC_ALL=C sort >>"${TMP_FILE}"
+find  "licenses" -type f -exec echo "  " {} \; | LC_ALL=C sort | grep -v "LICENSES-ui.txt" >>"${TMP_FILE}"
 
 SETUP_CFG_FILE="${AIRFLOW_SOURCES}/setup.cfg"
 readonly SETUP_CFG_FILE

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,29 +102,25 @@ install_requires =
     # Flask and all related libraries are limited to below 2.0.0 because we expect it to introduce
     # Serious breaking changes. Flask 2.0 has been introduced in May 2021 and 2.0.2 version is available
     # now (Feb 2022): TODO: we should attempt to migrate to Flask 2 and all below flask libraries soon.
-    flask>=1.1.0, <2.0
+    flask>=2.0,<3
     # We are tightly coupled with FAB version because we vendored in part of FAB code related to security manager
     # This is done as part of preparation to removing FAB as dependency, but we are not ready for it yet
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/www/fab_security` with their upstream counterparts. In particular, make sure any breaking changes,
     # for example any new methods, are accounted for.
-    flask-appbuilder==3.4.5
-    flask-caching>=1.5.0, <2.0.0
-    flask-login>=0.3, <0.5
+    flask-appbuilder~=4.0.0
+    flask-caching>=1.5.0
+    flask-login>=0.3
     # Strict upper-bound on the latest release of flask-session,
     # as any schema changes will require a migration.
-    flask-session>=0.3.1, <=0.4.0
-    flask-wtf>=0.14.3, <0.15
+    flask-session>=0.3.1
+    flask-wtf>=0.14.3
     graphviz>=0.12
     gunicorn>=20.1.0
     httpx
     importlib_metadata>=1.7;python_version<"3.9"
     importlib_resources>=5.2;python_version<"3.9"
-    # Logging is broken with itsdangerous > 2 - likely due to changed serializing support
-    # https://itsdangerous.palletsprojects.com/en/2.0.x/changes/#version-2-0-0
-    # itsdangerous 2 has been released in May 2020
-    # TODO: we should attempt to upgrade to line 2 of itsdangerous
-    itsdangerous>=1.1.0, <2.0
+    itsdangerous>=1.1.0
     # Jinja2 3.1 will remove the 'autoescape' and 'with' extensions, which would
     # break Flask 1.x, so we limit this for future compatibility. Remove this
     # when bumping Flask to >=2.
@@ -167,10 +163,7 @@ install_requires =
     termcolor>=1.1.0
     typing-extensions>=3.7.4
     unicodecsv>=0.14.1
-    # Werkzeug is known to cause breaking changes and it is very closely tied with FlaskAppBuilder and other
-    # Flask dependencies and the limit to 1.* line should be reviewed when we upgrade Flask and remove
-    # FlaskAppBuilder.
-    werkzeug~=1.0, >=1.0.1
+    werkzeug>=1.0.1
 
 [options.packages.find]
 include =

--- a/setup.py
+++ b/setup.py
@@ -620,16 +620,6 @@ devel_only = [
     'flake8-colors',
     'flaky',
     'freezegun',
-    # Github3 version 3.1.2 requires PyJWT>=2.3.0 which clashes with Flask App Builder where PyJWT is <2.0.0
-    # Actually GitHub3.1.0 already introduced PyJWT>=2.3.0 but so far `pip` was able to resolve it without
-    # getting into a long backtracking loop and figure out that github3 3.0.0 version is the right version
-    # similarly limiting it to 3.1.2 causes pip not to enter the backtracking loop. Apparently when there
-    # are 3 versions with PyJWT>=2.3.0 (3.1.0, 3.1.1 an 3.1.2) pip enters into backtrack loop and fails
-    # to resolve that github3 3.0.0 is the right version to use.
-    # This limitation could be removed if PyJWT limitation < 2.0.0 is dropped from FAB or when
-    # pip resolution is improved to handle the case. The issue which describes this PIP behaviour
-    # and hopefully allowing to improve it is tracked in https://github.com/pypa/pip/issues/10924
-    'github3.py<3.1.0',
     'gitpython',
     'ipdb',
     'jira',


### PR DESCRIPTION
Flask Application Builder 4.0 unblocked many of our dependencies.
This PR updates to FAB 4.0 and related libraries.

Closes: #22397

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
