### PR TITLE
Print configuration on scheduler startup.

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -18,9 +18,9 @@
 #
 """Utilities module for cli"""
 import functools
+import io
 import json
 import logging
-import io
 import os
 import re
 import socket
@@ -33,10 +33,14 @@ from contextlib import redirect_stdout
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar, cast
 
+import pygments
+from pygments.lexers.configs import IniLexer
+
 from airflow import settings
 from airflow.configuration import AirflowConfigParser, conf
 from airflow.exceptions import AirflowException
 from airflow.utils import cli_action_loggers
+from airflow.utils.code_utils import get_terminal_formatter
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.platform import getuser, is_terminal_support_colors
 from airflow.utils.session import provide_session
@@ -278,8 +282,9 @@ def sigconf_handler(sig, frame):
     """
     Print configuration and source including default values.
     """
-    config = get_config_with_source(include_default=True)
-    print(config)
+    config = get_config_with_source(include_default=True, include_colors=False)
+    log = logging.getLogger(__name__)
+    log.info(config)
 
 
 def sigquit_handler(sig, frame):
@@ -341,19 +346,30 @@ def suppress_logs_and_warning(f: T) -> T:
     return cast(T, _wrapper)
 
 
-def get_config_with_source(include_default=False):
+def get_config_with_source(include_default=False, include_colors=True):
     """
     Return configuration along with source for each option.
     """
-    parser = AirflowConfigParser(strict=False, interpolation=None)
     config_dict = conf.as_dict(display_source=True)
 
     with io.StringIO() as buf, redirect_stdout(buf):
         for section, options in config_dict.items():
-            print(f"[{section}]")
-            for key, (value, source) in options.items():
-                if not include_default and source == "default":
-                    continue
-                print(f"{key} = {value} [{source}]")
-            print()
-        return buf.getvalue()
+            if not include_default:
+                options = {
+                    key: (value, source) for key, (value, source) in options.items() if source != "default"
+                }
+
+            # Print the section only when there are options after filtering
+            if options:
+                print(f"[{section}]")
+                for key, (value, source) in options.items():
+                    if not include_default and source == "default":
+                        continue
+                    print(f"{key} = {value} [{source}]")
+                print()
+        code = buf.getvalue()
+
+        if include_colors:
+            code = pygments.highlight(code=code, formatter=get_terminal_formatter(), lexer=IniLexer())
+
+        return code

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -37,7 +37,7 @@ import pygments
 from pygments.lexers.configs import IniLexer
 
 from airflow import settings
-from airflow.configuration import AirflowConfigParser, conf
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.utils import cli_action_loggers
 from airflow.utils.code_utils import get_terminal_formatter
@@ -279,9 +279,7 @@ def sigint_handler(sig, frame):
 
 
 def sigconf_handler(sig, frame):
-    """
-    Print configuration and source including default values.
-    """
+    """Print configuration and source including default values."""
     config = get_config_with_source(include_default=True)
     log = logging.getLogger(__name__)
     log.info(config)
@@ -346,10 +344,8 @@ def suppress_logs_and_warning(f: T) -> T:
     return cast(T, _wrapper)
 
 
-def get_config_with_source(include_default=False):
-    """
-    Return configuration along with source for each option.
-    """
+def get_config_with_source(include_default: bool = False) -> str:
+    """Return configuration along with source for each option."""
     config_dict = conf.as_dict(display_source=True)
 
     with io.StringIO() as buf, redirect_stdout(buf):
@@ -363,8 +359,6 @@ def get_config_with_source(include_default=False):
             if options:
                 print(f"[{section}]")
                 for key, (value, source) in options.items():
-                    if not include_default and source == "default":
-                        continue
                     print(f"{key} = {value} [{source}]")
                 print()
         code = buf.getvalue()

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -282,7 +282,7 @@ def sigconf_handler(sig, frame):
     """
     Print configuration and source including default values.
     """
-    config = get_config_with_source(include_default=True, include_colors=False)
+    config = get_config_with_source(include_default=True)
     log = logging.getLogger(__name__)
     log.info(config)
 
@@ -346,7 +346,7 @@ def suppress_logs_and_warning(f: T) -> T:
     return cast(T, _wrapper)
 
 
-def get_config_with_source(include_default=False, include_colors=True):
+def get_config_with_source(include_default=False):
     """
     Return configuration along with source for each option.
     """
@@ -369,7 +369,7 @@ def get_config_with_source(include_default=False, include_colors=True):
                 print()
         code = buf.getvalue()
 
-        if include_colors:
+        if is_terminal_support_colors():
             code = pygments.highlight(code=code, formatter=get_terminal_formatter(), lexer=IniLexer())
 
         return code

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -126,6 +126,10 @@ the example below.
     work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
     should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.
 
+    During startup Airflow scheduler prints configuration options whose values are different from default
+    values along with source from which the value was loaded i.e. airflow.cfg, environment variable, etc.
+    You can print all configuration options by sending ``SIGUSR1`` signal to the scheduler.
+
     The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token
     generated using the secret key has a short expiry time though - make sure that time on ALL the machines
     that you run airflow components on is synchronized (for example using ntpd) otherwise you might get

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -126,8 +126,8 @@ the example below.
     work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
     should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.
 
-    During startup Airflow scheduler prints configuration options whose values are different from default
-    values along with source from which the value was loaded i.e. airflow.cfg, environment variable, etc.
+    During startup the scheduler prints configuration options whose values differ from the default
+    values along with the source from which the value was loaded (i.e. airflow.cfg, environment variable, etc).
     You can print all configuration options by sending ``SIGUSR1`` signal to the scheduler.
 
     The webserver key is also used to authorize requests to Celery workers when logs are retrieved. The token

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -91,7 +91,7 @@ class TestSchedulerCommand(unittest.TestCase):
             finally:
                 mock_process().terminate.assert_called()
 
-    @mock.patch.dict(os.environ, {}, clear=True)
+    @mock.patch.dict(os.environ, {'AIRFLOW__CORE__PARALLELISM': '35'}, clear=True)
     @mock.patch("airflow.cli.commands.scheduler_command.SchedulerJob")
     @mock.patch("airflow.cli.commands.scheduler_command.Process")
     def test_scheduler_print_config(self, mock_process, mock_scheduler_job):
@@ -100,4 +100,7 @@ class TestSchedulerCommand(unittest.TestCase):
             with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
                 scheduler_command.scheduler(args)
                 output = temp_stdout.getvalue()
-                assert "sql_alchemy_conn = < hidden >" in output
+                assert "sql_alchemy_conn = < hidden > [cmd]" in output
+                assert "max_active_tasks_per_dag = 16 [airflow.cfg]" in output
+                assert "parallelism = < hidden > [env var]" in output
+                assert "max_active_runs_per_dag = 16 [default]" not in output

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -102,11 +102,6 @@ class TestSchedulerCommand(unittest.TestCase):
                 scheduler_command.scheduler(args)
                 output = temp_stdout.getvalue()
 
-                # Filter out ansi escape
-                # https://stackoverflow.com/a/14693789/2610955
-                ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
-                output = ansi_escape.sub('', output)
-
                 assert "sql_alchemy_conn = < hidden > [cmd]" in output
                 assert "max_active_tasks_per_dag = 16 [airflow.cfg]" in output
                 assert "parallelism = < hidden > [env var]" in output

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -18,7 +18,6 @@
 import contextlib
 import io
 import os
-import re
 import unittest
 from unittest import mock
 

--- a/tests/cli/commands/test_scheduler_command.py
+++ b/tests/cli/commands/test_scheduler_command.py
@@ -18,6 +18,7 @@
 import contextlib
 import io
 import os
+import re
 import unittest
 from unittest import mock
 
@@ -100,6 +101,12 @@ class TestSchedulerCommand(unittest.TestCase):
             with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
                 scheduler_command.scheduler(args)
                 output = temp_stdout.getvalue()
+
+                # Filter out ansi escape
+                # https://stackoverflow.com/a/14693789/2610955
+                ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+                output = ansi_escape.sub('', output)
+
                 assert "sql_alchemy_conn = < hidden > [cmd]" in output
                 assert "max_active_tasks_per_dag = 16 [airflow.cfg]" in output
                 assert "parallelism = < hidden > [env var]" in output


### PR DESCRIPTION
This PR prints the configuration used during scheduler startup. The sensitive values are masked so that they are not captured by mistake in log files.

closes: #22141
related: #22141

