### PR TITLE
Update regexp classifying changes for providers

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -596,8 +596,8 @@ function get_count_cli_files() {
 function get_count_providers_files() {
     start_end::group_start "Count providers files"
     local pattern_array=(
-        "^airflow/providers"
-        "^tests/providers"
+        "^airflow/providers/"
+        "^tests/providers/"
     )
     show_changed_files
     COUNT_PROVIDERS_CHANGED_FILES=$(count_changed_files)


### PR DESCRIPTION
The regexp we had classified airflow/providers_manager as
provider change which prevented the test running when only that
file was modified. This change fixes the regexp to only
count files in "providers" subdirectories as provider changes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
