### PR TITLE
Log traceback only on DEBUG for KPO logs read interruption

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -214,10 +214,11 @@ class PodManager(LoggingMixin):
                 for line in logs:
                     timestamp, message = self.parse_log_line(line.decode('utf-8'))
                     self.log.info(message)
-            except BaseHTTPError:
+            except BaseHTTPError as e:
                 self.log.warning(
-                    "Reading of logs was interrupted, likely due to a connection issue. "
-                    "Will retry momentarily.",
+                    "Reading of logs interrupted with error %r; will retry. "
+                    "Set log level to DEBUG for traceback.",
+                    e,
                 )
                 self.log.debug(
                     "Traceback for interrupted logs read for pod %r",

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -214,9 +214,13 @@ class PodManager(LoggingMixin):
                 for line in logs:
                     timestamp, message = self.parse_log_line(line.decode('utf-8'))
                     self.log.info(message)
-            except BaseHTTPError:  # Catches errors like ProtocolError(TimeoutError).
+            except BaseHTTPError:
                 self.log.warning(
-                    'Failed to read logs for pod %s',
+                    "Reading of logs was interrupted, likely due to a connection issue. "
+                    "Will retry momentarily.",
+                )
+                self.log.debug(
+                    "Traceback for interrupted logs read for pod %r",
                     pod.metadata.name,
                     exc_info=True,
                 )


### PR DESCRIPTION
Logging the traceback after every disconnect is a little overly scary when this is an expected occurrence for long-running pods, and this can create false alarm for users.  Here we reduce noise a bit while allowing users to troubleshoot if desired by changing the log level to debug.
