### PR TITLE
Update FAB to latest released from 3.4 line (3.4.5)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ install_requires =
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/www/fab_security` with their upstream counterparts. In particular, make sure any breaking changes,
     # for example any new methods, are accounted for.
-    flask-appbuilder==3.4.4
+    flask-appbuilder==3.4.5
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
     # Strict upper-bound on the latest release of flask-session,


### PR DESCRIPTION
We checked that the changes introduced between 3.4.4 and 3.4.5
do not require from us to change the vendored-in security manager.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
