### PR TITLE
extra condition to check returned object not None

### DIFF
--- a/airflow/providers/jenkins/operators/jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/operators/jenkins_job_trigger.py
@@ -158,7 +158,11 @@ class JenkinsJobTriggerOperator(BaseOperator):
             )
             if location_answer is not None:
                 json_response = json.loads(location_answer['body'])
-                if 'executable' in json_response and 'number' in json_response['executable']:
+                if (
+                    'executable' in json_response
+                    and json_response['executable'] is not None
+                    and 'number' in json_response['executable']
+                ):
                     build_number = json_response['executable']['number']
                     self.log.info('Job executed on Jenkins side with the build number %s', build_number)
                     return build_number


### PR DESCRIPTION
This PR will add an extra condition to the JenkinsJobTriggerOperator to prevent a bug which happens when iterating over `executable` key in the returned response from jenkins server when polling for the newly created job.

closes: #22606
related: #22606