### PR TITLE
Fix StatsD casing and helm chart StatsD comments

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -949,7 +949,7 @@ Bug Fixes
 * BugFix: TypeError in airflow.kubernetes.pod_launcher's monitor_pod (#14513)
 * Bugfix: Fix wrong output of tags and owners in dag detail API endpoint (#14490)
 * Fix logging error with task error when JSON logging is enabled (#14456)
-* Fix statsd metrics not sending when using daemon mode (#14454)
+* Fix StatsD metrics not sending when using daemon mode (#14454)
 * Gracefully handle missing start_date and end_date for DagRun (#14452)
 * BugFix: Serialize max_retry_delay as a timedelta (#14436)
 * Fix crash when user clicks on  "Task Instance Details" caused by start_date being None (#14416)
@@ -1109,7 +1109,7 @@ Improvements
 Doc only changes
 """"""""""""""""
 
-- Add Missing Statsd Metrics in Docs (#13708)
+- Add Missing StatsD Metrics in Docs (#13708)
 - Add Missing Email configs in Configuration doc (#13709)
 - Add quick start for Airflow on Docker (#13660)
 - Describe which Python versions are supported (#13259)
@@ -1170,7 +1170,7 @@ Bug Fixes
 - Scheduler should acknowledge active runs properly (#13803)
 - Include ``airflow/contrib/executors`` in the dist package
 - Pin Click version for Python 2.7 users
-- Ensure all statsd timers use millisecond values. (#10633)
+- Ensure all StatsD timers use millisecond values. (#10633)
 - [``kubernetes_generate_dag_yaml``] - Fix dag yaml generate function (#13816)
 - Fix ``airflow tasks clear`` cli command with ``--yes`` (#14188)
 - Fix permission error on non-POSIX filesystem (#13121) (#14383)
@@ -2253,7 +2253,7 @@ Bug Fixes
 - [AIRFLOW-5481] Allow Deleting Renamed DAGs (#6101)
 - [AIRFLOW-3857] spark_submit_hook cannot kill driver pod in Kubernetes (#4678)
 - [AIRFLOW-4391] Fix tooltip for None-State Tasks in 'Recent Tasks' (#5909)
-- [AIRFLOW-5554] Require statsd 3.3.0 minimum (#6185)
+- [AIRFLOW-5554] Require StatsD 3.3.0 minimum (#6185)
 - [AIRFLOW-5306] Fix the display of links when they contain special characters (#5904)
 - [AIRFLOW-3705] Fix PostgresHook get_conn to use conn_name_attr (#5841)
 - [AIRFLOW-5581] Cleanly shutdown KubernetesJobWatcher for safe Scheduler shutdown on SIGTERM (#6237)
@@ -2268,7 +2268,7 @@ Bug Fixes
 - [AIRFLOW-5342] Fix MSSQL breaking task_instance db migration (#6014)
 - [AIRFLOW-5556] Add separate config for timeout from scheduler dag processing (#6186)
 - [AIRFLOW-4858] Deprecate "Historical convenience functions" in airflow.configuration (#5495) (#6144)
-- [AIRFLOW-774] Fix long-broken DAG parsing Statsd metrics (#6157)
+- [AIRFLOW-774] Fix long-broken DAG parsing StatsD metrics (#6157)
 - [AIRFLOW-5419] Use ``sudo`` to kill cleared tasks when running with impersonation (#6026) (#6176)
 - [AIRFLOW-5537] Yamllint is not needed as dependency on host
 - [AIRFLOW-5536] Better handling of temporary output files
@@ -2913,7 +2913,7 @@ Bug fixes
 - [AIRFLOW-4037] Log response in SimpleHttpOperator even if the response check fails
 - [AIRFLOW-4044] The documentation of ``query_params`` in ``BigQueryOperator`` is wrong.  (#4876)
 - [AIRFLOW-4015] Make missing API endpoints available in classic mode
-- [AIRFLOW-3153] Send DAG processing stats to statsd (#4748)
+- [AIRFLOW-3153] Send DAG processing stats to StatsD (#4748)
 - [AIRFLOW-2966] Catch ApiException in the Kubernetes Executor (#4209)
 - [AIRFLOW-4129] Escape HTML in generated tooltips (#4950)
 - [AIRFLOW-4070] AirflowException -> log.warning for duplicate task dependencies (#4904)
@@ -3018,7 +3018,7 @@ Doc-only changes
 - [AIRFLOW-3996] Add view source link to included fragments
 - [AIRFLOW-3811] Automatic generation of API Reference in docs (#4788)
 - [AIRFLOW-3810] Remove duplicate autoclass directive (#4656)
-- [AIRFLOW-XXX] Mention that statsd must be installed to gather metrics (#5038)
+- [AIRFLOW-XXX] Mention that StatsD must be installed to gather metrics (#5038)
 - [AIRFLOW-XXX] Add contents to cli (#4825)
 - [AIRFLOW-XXX] fix check docs failure on CI (#4998)
 - [AIRFLOW-XXX] Fix syntax docs errors (#4789)
@@ -5168,7 +5168,7 @@ Airflow 1.7.1, 2016-05-19
 - [AIRFLOW-52] Fix bottlenecks when working with many tasks
 - Add columns to toggle extra detail in the connection list view.
 - Log the number of errors when importing DAGs
-- Log dagbag metrics duplicate messages in queue into Statsd (#1406)
+- Log dagbag metrics duplicate messages in queue into StatsD (#1406)
 - Clean up issue template (#1419)
 - correct missed arg.foreground to arg.daemon in cli
 - Reinstate imports for github enterprise auth

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -699,7 +699,7 @@
       default: ""
     - name: stat_name_handler
       description: |
-        A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+        A function that validate the StatsD stat name, apply changes to the stat name if necessary and return
         the transformed stat name.
 
         The function should have the following signature:
@@ -724,7 +724,7 @@
       default: ""
     - name: statsd_custom_client_path
       description: |
-        If you want to utilise your own custom Statsd client set the relevant
+        If you want to utilise your own custom StatsD client set the relevant
         module path below.
         Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
       version_added: 2.0.0
@@ -1894,7 +1894,7 @@
       default: "30"
     - name: pool_metrics_interval
       description: |
-        How often (in seconds) should pool usage stats be sent to statsd (if statsd_on is enabled)
+        How often (in seconds) should pool usage stats be sent to StatsD (if statsd_on is enabled)
       version_added: 2.0.0
       type: float
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -377,7 +377,7 @@ statsd_prefix = airflow
 # start with the elements of the list (e.g: "scheduler,executor,dagrun")
 statsd_allow_list =
 
-# A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+# A function that validate the StatsD stat name, apply changes to the stat name if necessary and return
 # the transformed stat name.
 #
 # The function should have the following signature:
@@ -390,7 +390,7 @@ statsd_datadog_enabled = False
 # List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
 statsd_datadog_tags =
 
-# If you want to utilise your own custom Statsd client set the relevant
+# If you want to utilise your own custom StatsD client set the relevant
 # module path below.
 # Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
 # statsd_custom_client_path =
@@ -952,7 +952,7 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs. Setting to 0 will disable printing stats
 print_stats_interval = 30
 
-# How often (in seconds) should pool usage stats be sent to statsd (if statsd_on is enabled)
+# How often (in seconds) should pool usage stats be sent to StatsD (if statsd_on is enabled)
 pool_metrics_interval = 5.0
 
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -45,7 +45,7 @@ class TimerProtocol(Protocol):
         ...
 
     def stop(self, send=True):
-        """Stop, and (by default) submit the timer to statsd"""
+        """Stop, and (by default) submit the timer to StatsD"""
         ...
 
 
@@ -75,7 +75,7 @@ class StatsLogger(Protocol):
 
 class Timer:
     """
-    Timer that records duration, and optional sends to statsd backend.
+    Timer that records duration, and optional sends to StatsD backend.
 
     This class lets us have an accurate timer with the logic in one place (so
     that we don't use datetime math for duration -- it is error prone).
@@ -182,7 +182,7 @@ ALLOWED_CHARACTERS = set(string.ascii_letters + string.digits + '_.-')
 
 
 def stat_name_default_handler(stat_name, max_length=250) -> str:
-    """A function that validate the statsd stat name, apply changes to the stat name
+    """A function that validate the StatsD stat name, apply changes to the stat name
     if necessary and return the transformed stat name.
     """
     if not isinstance(stat_name, str):
@@ -244,7 +244,7 @@ class AllowListValidator:
 
 
 class SafeStatsdLogger:
-    """Statsd Logger"""
+    """StatsD Logger"""
 
     def __init__(self, statsd_client, allow_list_validator=AllowListValidator()):
         self.statsd = statsd_client
@@ -362,7 +362,7 @@ class _Stats(type):
 
     @classmethod
     def get_statsd_logger(cls):
-        """Returns logger for statsd"""
+        """Returns logger for StatsD"""
         # no need to check for the scheduler/statsd_on -> this method is only called when it is set
         # and previously it would crash with None is callable if it was called without it.
         from statsd import StatsClient
@@ -372,11 +372,11 @@ class _Stats(type):
         if stats_class:
             if not issubclass(stats_class, StatsClient):
                 raise AirflowConfigException(
-                    "Your custom Statsd client must extend the statsd.StatsClient in order to ensure "
+                    "Your custom StatsD client must extend the statsd.StatsClient in order to ensure "
                     "backwards compatibility."
                 )
             else:
-                log.info("Successfully loaded custom Statsd client")
+                log.info("Successfully loaded custom StatsD client")
 
         else:
             stats_class = StatsClient
@@ -391,7 +391,7 @@ class _Stats(type):
 
     @classmethod
     def get_dogstatsd_logger(cls):
-        """Get DataDog statsd logger"""
+        """Get DataDog StatsD logger"""
         from datadog import DogStatsd
 
         dogstatsd = DogStatsd(

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -486,7 +486,7 @@ Create the name of the scheduler service account to use
 {{- end -}}
 
 {{/*
-Create the name of the statsd service account to use
+Create the name of the StatsD service account to use
 */}}
 {{- define "statsd.serviceAccountName" -}}
 {{- if .Values.statsd.serviceAccount.create -}}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -15,7 +15,7 @@
         "Triggerer",
         "Flower",
         "Redis",
-        "Statsd",
+        "StatsD",
         "Jobs",
         "Kubernetes",
         "Ingress",
@@ -531,21 +531,21 @@
                     }
                 },
                 "statsd": {
-                    "description": "Configuration of the statsd image.",
+                    "description": "Configuration of the StatsD image.",
                     "type": "object",
                     "properties": {
                         "repository": {
-                            "description": "The statsd image repository.",
+                            "description": "The StatsD image repository.",
                             "type": "string",
                             "default": "apache/airflow"
                         },
                         "tag": {
-                            "description": "The statsd image tag.",
+                            "description": "The StatsD image tag.",
                             "type": "string",
                             "default": "airflow-statsd-exporter-2021.04.28-v0.17.0"
                         },
                         "pullPolicy": {
-                            "description": "The statsd image pull policy.",
+                            "description": "The StatsD image pull policy.",
                             "type": "string",
                             "enum": [
                                 "Always",
@@ -3166,7 +3166,7 @@
         "statsd": {
             "description": "StatsD settings.",
             "type": "object",
-            "x-docsSection": "Statsd",
+            "x-docsSection": "StatsD",
             "additionalProperties": false,
             "properties": {
                 "enabled": {
@@ -3285,7 +3285,7 @@
                     "default": []
                 },
                 "securityContext": {
-                    "description": "Security context for the statsd pod. If not set, the values from `securityContext` will be used.",
+                    "description": "Security context for the StatsD pod. If not set, `statsd.uid` will be used.",
                     "type": "object",
                     "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
                     "default": {},

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1118,7 +1118,7 @@ flower:
 
   podAnnotations: {}
 
-# Statsd settings
+# StatsD settings
 statsd:
   enabled: true
 
@@ -1133,7 +1133,8 @@ statsd:
     # Annotations to add to worker kubernetes service account.
     annotations: {}
 
-  # When not set, the values defined in the global securityContext will be used
+  uid: 65534
+  # When not set, `statsd.uid` will be used
   securityContext: {}
   #  runAsUser: 65534
   #  fsGroup: 0
@@ -1152,17 +1153,15 @@ statsd:
   service:
     extraAnnotations: {}
 
-  # Select certain nodes for statsd pods.
+  # Select certain nodes for StatsD pods.
   nodeSelector: {}
   affinity: {}
   tolerations: []
 
   priorityClassName: ~
 
-  # Additional mappings for statsd exporter.
+  # Additional mappings for StatsD exporter.
   extraMappings: []
-
-  uid: 65534
 
 # PgBouncer settings
 pgbouncer:

--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -58,7 +58,7 @@ to the stat name if necessary, and returns the transformed stat name. The functi
     def my_custom_stat_name_handler(stat_name: str) -> str:
         return stat_name.lower()[:32]
 
-If you want to use a custom Statsd client instead of the default one provided by Airflow, the following key must be added
+If you want to use a custom StatsD client instead of the default one provided by Airflow, the following key must be added
 to the configuration file alongside the module path of your custom StatsD client. This module must be available on
 your :envvar:`PYTHONPATH`.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -367,7 +367,6 @@ Standarization
 StatefulSet
 StatefulSets
 StatsD
-Statsd
 StorageClass
 StoredInfoType
 Stringified

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -117,7 +117,7 @@ class TestStats(unittest.TestCase):
         ), pytest.raises(
             AirflowConfigException,
             match=re.escape(
-                'Your custom Statsd client must extend the statsd.'
+                'Your custom StatsD client must extend the statsd.'
                 'StatsClient in order to ensure backwards compatibility.'
             ),
         ):


### PR DESCRIPTION
This snowballed a bit, but this fixes the wording on a helm chart StatsD param to indicate it uses the local `uid` instead of the global securitycontext and then a bunch of StatsD casing fixes.