### PR TITLE
Final fix for image caching

### DIFF
--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -247,13 +247,7 @@ currently run build. They are built once per each build and pulled by each test 
   ghcr.io/apache/airflow/<BRANCH>/ci/python<X.Y>:<COMMIT_SHA>         - for CI images
   ghcr.io/apache/airflow/<BRANCH>/prod/python<X.Y>:<COMMIT_SHA>       - for production images
 
-
-The cache images (pushed when main merge succeeds) are kept with ``cache`` tag:
-
-.. code-block:: bash
-
-  ghcr.io/apache/airflow/<BRANCH>/ci/python<X.Y>:cache           - for CI images
-  ghcr.io/apache/airflow/<BRANCH>/prod/python<X.Y>:cache         - for production images
+Thoe image contain inlined cache.
 
 You can see all the current GitHub images at `<https://github.com/apache/airflow/packages>`_
 

--- a/dev/breeze/src/airflow_breeze/ci/build_params.py
+++ b/dev/breeze/src/airflow_breeze/ci/build_params.py
@@ -72,12 +72,6 @@ class BuildParams:
         return image
 
     @property
-    def airflow_ci_image_name_with_cache(self):
-        """Construct CI image link"""
-        image = f'{self.airflow_image_name}/{self.airflow_branch}/ci/python{self.python_version}:cache'
-        return image
-
-    @property
     def airflow_ci_image_name_with_tag(self):
         """Construct CI image link"""
         image = f'{self.airflow_image_name}/{self.airflow_branch}/ci/python{self.python_version}'
@@ -117,7 +111,7 @@ class BuildParams:
         docker_cache_ci_directive = []
         if self.docker_cache == "pulled":
             docker_cache_ci_directive.append("--cache-from")
-            docker_cache_ci_directive.append(self.airflow_ci_image_name_with_cache)
+            docker_cache_ci_directive.append(self.airflow_ci_image_name)
         elif self.docker_cache == "disabled":
             docker_cache_ci_directive.append("--no-cache")
         else:

--- a/dev/breeze/src/airflow_breeze/prod/prod_params.py
+++ b/dev/breeze/src/airflow_breeze/prod/prod_params.py
@@ -224,16 +224,14 @@ class ProdParams:
         docker_cache_prod_directive = []
 
         if self.docker_cache == "pulled":
-            docker_cache_prod_directive.append(f"--cache-from={self.airflow_prod_image_name}:cache")
+            docker_cache_prod_directive.append(f"--cache-from={self.airflow_prod_image_name}")
         elif self.docker_cache == "disabled":
             docker_cache_prod_directive.append("--no-cache")
         else:
             docker_cache_prod_directive = []
 
         if self.prepare_buildx_cache:
-            docker_cache_prod_directive.extend(
-                [f"--cache-to=type=registry,ref={self.airflow_prod_image_name}:cache,mode=max", "--push"]
-            )
+            docker_cache_prod_directive.extend([f"--cache-to=type=inline,mode=max", "--push"])
             if is_multi_platform(self.platform):
                 console.print("\nSkip loading docker image on multi-platform build")
             else:

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -434,7 +434,7 @@ function build_images::build_ci_image() {
         docker_ci_directive=()
     elif [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         docker_ci_directive=(
-            "--cache-from=${AIRFLOW_CI_IMAGE}:cache"
+            "--cache-from=${AIRFLOW_CI_IMAGE}"
         )
     else
         echo
@@ -446,7 +446,7 @@ function build_images::build_ci_image() {
         # we need to login to docker registry so that we can push cache there
         build_images::login_to_docker_registry
         docker_ci_directive+=(
-            "--cache-to=type=registry,ref=${AIRFLOW_CI_IMAGE}:cache,mode=max"
+            "--cache-to=type=inline,mode=max"
             "--push"
         )
     fi
@@ -590,7 +590,7 @@ function build_images::build_prod_images() {
         docker_prod_directive=()
     elif [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         docker_prod_directive=(
-            "--cache-from=${AIRFLOW_PROD_IMAGE}:cache"
+            "--cache-from=${AIRFLOW_PROD_IMAGE}"
         )
     else
         echo
@@ -604,7 +604,7 @@ function build_images::build_prod_images() {
         build_images::login_to_docker_registry
         # Cache for prod image contains also build stage for buildx when mode=max specified!
         docker_prod_directive+=(
-            "--cache-to=type=registry,ref=${AIRFLOW_PROD_IMAGE}:cache,mode=max"
+            "--cache-to=type=inline,mode=max"
             "--push"
         )
         if [[ ${PLATFORM} =~ .*,.* ]]; then


### PR DESCRIPTION
This is - I hope - final fix for our image caching. I fought with
it for quite a while and it turned out that I was fighting with
buidkit bug when preparing a multiplatform image.

I think I finally got it under control, the main problem was that
when we prepared multi-platform image, seems like the image that
was prepared "last" was overriding the cache that was prepared
by the other platform build. This cause numerous problems with
investigating it, because sometimes it looked like it worked,
when the "other" platform was faster to build and someties it
did not when it was slower. It almost drove me mad.

It looks like however, that the inline cache works better in
this case (and I got it repetetively working) so finally we might
go back to faster builds on CI and fast pull for ./breeze.

I also opened an issue at buildkit, hoping that they will be able
to fix it:

https://github.com/moby/buildkit/issues/2758

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
