### PR TITLE
Do not log the hook password even at DEBUG level

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -68,14 +68,13 @@ class BaseHook(LoggingMixin):
         conn = Connection.get_connection_from_secrets(conn_id)
         log.info("Using connection ID '%s' for task execution.", conn.conn_id)
         log.debug(
-            "Connection details for '%s':: Host: %s, Port: %s, Schema: %s, Login: %s, Password: %s, "
+            "Connection details for '%s':: Host: %s, Port: %s, Schema: %s, Login: %s, "
             "Extra: %s",
             conn.conn_id,
             conn.host,
             conn.port,
             conn.schema,
             conn.login,
-            redact(conn.password),
             redact(conn.extra_dejson),
         )
         return conn

--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.log.secrets_masker import redact
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection  # Avoid circular imports.

--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -67,16 +67,6 @@ class BaseHook(LoggingMixin):
 
         conn = Connection.get_connection_from_secrets(conn_id)
         log.info("Using connection ID '%s' for task execution.", conn.conn_id)
-        log.debug(
-            "Connection details for '%s':: Host: %s, Port: %s, Schema: %s, Login: %s, "
-            "Extra: %s",
-            conn.conn_id,
-            conn.host,
-            conn.port,
-            conn.schema,
-            conn.login,
-            redact(conn.extra_dejson),
-        )
         return conn
 
     @classmethod


### PR DESCRIPTION
The BaseHook currently logs connection details including password at the DEBUG level. While the password is redacted under normal conditions in task logs, there are edge cases where this can lead to a password leaking into logs, such as calling python code that uses a hook from a BashOperator.

The value of logging the password simply seems small relative to the consequences of leaking to logs even in edge cases. There remain plenty of ways to log the password if that is explicitly what you want to do, such as `airflow connection list`.