### PR TITLE
Only hide rendered button for mapped summaries

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -183,10 +183,8 @@ export function callModal({
   }
 
   if (isMapped || mapIndex >= 0) {
-    $('#btn_rendered').hide();
     $('#mapped_instances').show();
   } else {
-    $('#btn_rendered').show();
     $('#mapped_instances').hide();
   }
 
@@ -198,7 +196,9 @@ export function callModal({
     });
     $('#btn_mapped').show();
     $('#mapped_dropdown').css('display', 'inline-block');
+    $('#btn_rendered').hide();
   } else {
+    $('#btn_rendered').show();
     $('#btn_mapped').hide();
     $('#mapped_dropdown').hide();
   }


### PR DESCRIPTION
With https://github.com/apache/airflow/pull/22396 and https://github.com/apache/airflow/pull/22578. Rendered template links should now work for individual mapped task instances. Now, we will only hide them when the modal is showing a summary of all mapped instances.

<img width="513" alt="Screen Shot 2022-03-30 at 3 07 38 PM" src="https://user-images.githubusercontent.com/4600967/160911939-7127a730-60ae-4ae7-9441-02e498e163c1.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
