### PR TITLE
Fixes ScheduleInterval api spec

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3348,7 +3348,7 @@ components:
         Schedule interval. Defines how often DAG runs, this object gets added to your latest task instance's
         execution_date to figure out the next schedule.
       readOnly: true
-      oneOf:
+      anyOf:
         - $ref: '#/components/schemas/TimeDelta'
         - $ref: '#/components/schemas/RelativeDelta'
         - $ref: '#/components/schemas/CronExpression'


### PR DESCRIPTION
In the schedule interval, the data can actually match more than one schema and the `__type` should decide which type of the interval it actually matches. 

Fixes https://github.com/apache/airflow-client-go/issues/20

Verified by generating a go-client. https://github.com/senthilkumarkj/airflow-client-go/commit/ecb428a82ac51802432cbd61b6028c3aecd94850 The client now uses `__type` to unmarshal.

