### PR TITLE
 Disable SLAs for mapped operators

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -45,7 +45,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm.session import Session
 
 from airflow.compat.functools import cache, cached_property
-from airflow.exceptions import UnmappableOperator
+from airflow.exceptions import AirflowException, UnmappableOperator
 from airflow.models.abstractoperator import (
     DEFAULT_OWNER,
     DEFAULT_POOL_SLOTS,
@@ -295,6 +295,11 @@ class MappedOperator(AbstractOperator):
         for k, v in self.partial_kwargs.items():
             if k in self.template_fields:
                 XComArg.apply_upstream_relationship(self, v)
+        if self.partial_kwargs.get('sla') is not None:
+            raise AirflowException(
+                f"SLAs are unsupported with mapped tasks. Please set `sla=None` for task "
+                f"{self.task_id!r}."
+            )
 
     @classmethod
     @cache


### PR DESCRIPTION
When trying to update SLA logic to handle mapped operators we discovered some odd behavior and decided to defer adding support for SLAs with mapped tasks.