### PR TITLE
Fix passing string to upgrade-to-newer-dependencies

### DIFF
--- a/dev/breeze/src/airflow_breeze/breeze.py
+++ b/dev/breeze/src/airflow_breeze/breeze.py
@@ -302,7 +302,7 @@ def build_ci_image(
     build_cache: Optional[str],
     platform: Optional[str],
     debian_version: Optional[str],
-    upgrade_to_newer_dependencies: Optional[str],
+    upgrade_to_newer_dependencies: str = "false",
 ):
     """Builds docker CI image without entering the container."""
 
@@ -331,7 +331,7 @@ def build_ci_image(
         docker_cache=build_cache,
         platform=platform,
         debian_version=debian_version,
-        upgrade_newer_dependencies=upgrade_to_newer_dependencies,
+        upgrade_to_newer_dependencies=upgrade_to_newer_dependencies,
     )
 
 
@@ -409,7 +409,7 @@ def build_prod_image(
     github_repository: Optional[str],
     platform: Optional[str],
     debian_version: Optional[str],
-    upgrade_to_newer_dependencies: bool,
+    upgrade_to_newer_dependencies: str,
     prepare_buildx_cache: bool,
     skip_installing_airflow_providers_from_sources: bool,
     disable_pypi_when_building: bool,
@@ -454,7 +454,7 @@ def build_prod_image(
         github_repository=github_repository,
         platform=platform,
         debian_version=debian_version,
-        upgrade_newer_dependencies=upgrade_to_newer_dependencies,
+        upgrade_to_newer_dependencies=upgrade_to_newer_dependencies,
         prepare_buildx_cache=prepare_buildx_cache,
         skip_installing_airflow_providers_from_sources=skip_installing_airflow_providers_from_sources,
         disable_pypi_when_building=disable_pypi_when_building,

--- a/dev/breeze/src/airflow_breeze/ci/build_params.py
+++ b/dev/breeze/src/airflow_breeze/ci/build_params.py
@@ -27,7 +27,7 @@ from airflow_breeze.utils.run_utils import run_command
 @dataclass
 class BuildParams:
     # To construct ci_image_name
-    upgrade_newer_dependencies: bool = False
+    upgrade_to_newer_dependencies: str = "false"
     python_version: str = "3.7"
     airflow_branch: str = AIRFLOW_BRANCH
     build_id: int = 0
@@ -121,10 +121,3 @@ class BuildParams:
     @property
     def airflow_version(self):
         return get_airflow_version()
-
-    @property
-    def upgrade_to_newer_dependencies(self) -> str:
-        upgrade_to_newer_dependencies = 'false'
-        if self.upgrade_newer_dependencies:
-            upgrade_to_newer_dependencies = 'true'
-        return upgrade_to_newer_dependencies

--- a/dev/breeze/src/airflow_breeze/prod/prod_params.py
+++ b/dev/breeze/src/airflow_breeze/prod/prod_params.py
@@ -47,7 +47,7 @@ class ProdParams:
     install_docker_context_files: bool
     disable_pypi_when_building: bool
     disable_pip_cache: bool
-    upgrade_newer_dependencies: bool
+    upgrade_to_newer_dependencies: str
     skip_installing_airflow_providers_from_sources: bool
     cleanup_docker_context_files: bool
     prepare_buildx_cache: bool
@@ -363,13 +363,6 @@ class ProdParams:
         if self.install_docker_context_files:
             install_from_docker_context_files = 'true'
         return install_from_docker_context_files
-
-    @property
-    def upgrade_to_newer_dependencies(self) -> str:
-        upgrade_to_newer_dependencies = 'false'
-        if self.upgrade_newer_dependencies:
-            upgrade_to_newer_dependencies = 'true'
-        return upgrade_to_newer_dependencies
 
     @property
     def airflow_extras(self):

--- a/dev/breeze/tests/test_prod_image.py
+++ b/dev/breeze/tests/test_prod_image.py
@@ -32,7 +32,7 @@ default_params = {
     'install_docker_context_files': False,
     'disable_pypi_when_building': False,
     'disable_pip_cache': False,
-    'upgrade_newer_dependencies': False,
+    'upgrade_to_newer_dependencies': False,
     'skip_installing_airflow_providers_from_sources': False,
     'cleanup_docker_context_files': False,
     'prepare_buildx_cache': False,


### PR DESCRIPTION
This change fixes passing upgrade-to-newer-dependencies
parameter as string. The previous fix (#22597) did not actually
fix handling of the parameter passed and "false" passed as string
was considered as "true" :)

This should speed UP most CI builds immensely.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
