### PR TITLE
Make sure build-prod-image works in the new Breeze2

### DIFF
--- a/dev/breeze/src/airflow_breeze/breeze.py
+++ b/dev/breeze/src/airflow_breeze/breeze.py
@@ -409,7 +409,6 @@ def build_prod_image(
     github_repository: Optional[str],
     platform: Optional[str],
     debian_version: Optional[str],
-    upgrade_to_newer_dependencies: str,
     prepare_buildx_cache: bool,
     skip_installing_airflow_providers_from_sources: bool,
     disable_pypi_when_building: bool,
@@ -418,6 +417,7 @@ def build_prod_image(
     install_from_docker_context_files: bool,
     image_tag: Optional[str],
     github_token: Optional[str],
+    upgrade_to_newer_dependencies: str = "false",
 ):
     """Builds docker Production image without entering the container."""
     if verbose:

--- a/dev/breeze/src/airflow_breeze/prod/prod_params.py
+++ b/dev/breeze/src/airflow_breeze/prod/prod_params.py
@@ -47,10 +47,10 @@ class ProdParams:
     install_docker_context_files: bool
     disable_pypi_when_building: bool
     disable_pip_cache: bool
-    upgrade_to_newer_dependencies: str
-    skip_installing_airflow_providers_from_sources: bool
-    cleanup_docker_context_files: bool
-    prepare_buildx_cache: bool
+    upgrade_to_newer_dependencies: str = "false"
+    skip_installing_airflow_providers_from_sources: bool = False
+    cleanup_docker_context_files: bool = False
+    prepare_buildx_cache: bool = False
     airflow_version: str = get_airflow_version()
     python_version: str = "3.7"
     airflow_branch_for_pypi_preloading: str = AIRFLOW_BRANCH


### PR DESCRIPTION
Some defaults were missing for manual build of PROD images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
