### PR TITLE
Add `securityContext` support to Redis

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -22,6 +22,7 @@
 {{- $nodeSelector := or .Values.redis.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.redis.affinity .Values.affinity }}
 {{- $tolerations := or .Values.redis.tolerations .Values.tolerations }}
+{{- $securityContext := include "localSecurityContext" .Values.redis }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
@@ -63,6 +64,7 @@ spec:
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
       serviceAccountName: {{ include "redis.serviceAccountName" . }}
+      securityContext: {{ $securityContext | nindent 8 }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3774,6 +3774,24 @@
                             }
                         }
                     }
+                },
+                "uid": {
+                    "description": "Redis run as user parameter.",
+                    "type": "integer",
+                    "default": 999
+                },
+                "securityContext": {
+                    "description": "Security context for the Redis pod. If not set, `redis.uid` will be used.",
+                    "type": "object",
+                    "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext",
+                    "default": {},
+                    "examples": [
+                        {
+                            "runAsUser": 999,
+                            "runAsGroup": 0,
+                            "fsGroup": 0
+                        }
+                    ]
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1297,6 +1297,13 @@ redis:
     # Annotations to add to worker kubernetes service account.
     annotations: {}
 
+  uid: 999
+  # If not set, `redis.uid` will be used
+  securityContext: {}
+  #  runAsUser: 999
+  #  fsGroup: 0
+  #  runAsGroup: 0
+
   persistence:
     # Enable persistent volumes
     enabled: true


### PR DESCRIPTION
This is an alternative to #22182.

This allows users to set `securityContext` on the Redis pod.

cc @pgvishnuram