### PR TITLE
Pass custom headers through in SES email backend

### DIFF
--- a/airflow/providers/amazon/aws/utils/emailer.py
+++ b/airflow/providers/amazon/aws/utils/emailer.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Airflow module for email backend using AWS SES"""
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from airflow.providers.amazon.aws.hooks.ses import SesHook
 
@@ -32,6 +32,7 @@ def send_email(
     mime_charset: str = 'utf-8',
     conn_id: str = 'aws_default',
     from_email: Optional[str] = None,
+    custom_headers: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> None:
     """Email backend for SES."""
@@ -48,4 +49,5 @@ def send_email(
         bcc=bcc,
         mime_subtype=mime_subtype,
         mime_charset=mime_charset,
+        custom_headers=custom_headers
     )

--- a/airflow/providers/amazon/aws/utils/emailer.py
+++ b/airflow/providers/amazon/aws/utils/emailer.py
@@ -49,5 +49,5 @@ def send_email(
         bcc=bcc,
         mime_subtype=mime_subtype,
         mime_charset=mime_charset,
-        custom_headers=custom_headers
+        custom_headers=custom_headers,
     )

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -32,7 +32,7 @@ class TestSendEmailSes(TestCase):
             html_content="content",
             from_email="From Test <from@test.com>",
             custom_headers={
-                'X-Test-Header': 'test-val'
+                "X-Test-Header": "test-val"
             }
         )
 
@@ -47,7 +47,7 @@ class TestSendEmailSes(TestCase):
             mime_charset="utf-8",
             mime_subtype="mixed",
             custom_headers={
-                'X-Test-Header': 'test-val'
+                "X-Test-Header": "test-val"
             }
         )
 

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -31,9 +31,7 @@ class TestSendEmailSes(TestCase):
             subject="subject",
             html_content="content",
             from_email="From Test <from@test.com>",
-            custom_headers={
-                "X-Test-Header": "test-val"
-            }
+            custom_headers={"X-Test-Header": "test-val"},
         )
 
         mock_hook.return_value.send_email.assert_called_once_with(
@@ -46,9 +44,7 @@ class TestSendEmailSes(TestCase):
             files=None,
             mime_charset="utf-8",
             mime_subtype="mixed",
-            custom_headers={
-                "X-Test-Header": "test-val"
-            }
+            custom_headers={"X-Test-Header": "test-val"},
         )
 
     @mock.patch("airflow.providers.amazon.aws.utils.emailer.SesHook")

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -31,6 +31,9 @@ class TestSendEmailSes(TestCase):
             subject="subject",
             html_content="content",
             from_email="From Test <from@test.com>",
+            custom_headers={
+                'X-Test-Header': 'test-val'
+            }
         )
 
         mock_hook.return_value.send_email.assert_called_once_with(
@@ -43,6 +46,9 @@ class TestSendEmailSes(TestCase):
             files=None,
             mime_charset="utf-8",
             mime_subtype="mixed",
+            custom_headers={
+                'X-Test-Header': 'test-val'
+            }
         )
 
     @mock.patch("airflow.providers.amazon.aws.utils.emailer.SesHook")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I noticed while looking through the source that the SES email provider was not passing through the custom headers.  This was fixed for SMTP in #19009 but SES appears to have been missed.
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
