### PR TITLE
Support for sorting DAGs in the web UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -21,6 +21,37 @@
 {% from 'appbuilder/loading_dots.html' import loading_dots %}
 {% from 'airflow/_messages.html' import show_message %}
 
+{%- macro sortable_column(display_name, attribute_name) -%}
+
+{%- endmacro -%}
+{%- macro sortable_column(display_name, attribute_name) -%}
+   {% set curr_ordering_direction = (request.args.get('sorting_direction', 'desc')) %}
+   {% set new_ordering_direction = ('asc' if (curr_ordering_direction == 'desc' or request.args.get('sorting_key') != attribute_name) else 'desc') %}
+   <a href="{{ url_for('Airflow.index',
+                       status=request.args.get('status', 'all'),
+                       search=request.args.get('search', None),
+                       tags=request.args.get('tags', None),
+                       sorting_key=attribute_name,
+                       sorting_direction=new_ordering_direction
+                       ) }}"
+   class="js-tooltip"
+   role="tooltip"
+   title="Sort by {{ new_ordering_direction }} {{ attribute_name }}."
+   >
+    {{ display_name }}
+
+    <span class="material-icons" aria-hidden="true" aria-describedby="sorting-tip-{{ display_name }}">
+      {% if curr_ordering_direction == 'desc' and request.args.get('sorting_key') == attribute_name %}
+        expand_more
+      {% elif curr_ordering_direction == 'asc' and request.args.get('sorting_key') == attribute_name %}
+        expand_less
+      {% else %}
+        unfold_more
+      {% endif %}
+    </span>
+  </a>
+{%- endmacro -%}
+
 {% block page_title %}
   {% if search_query %}"{{ search_query }}" - {% endif %}DAGs - {{ appbuilder.app_name }}
 {% endblock %}
@@ -122,8 +153,8 @@
               <th width="12">
                 <span class="material-icons text-muted js-tooltip" title="Use this toggle to pause/unpause a DAG. The scheduler won't schedule new tasks instances for a paused DAG. Tasks already running at pause time won't be affected.">info</span>
               </th>
-              <th>DAG</th>
-              <th>Owner</th>
+              <th>{{ sortable_column("DAG", "dag_id") }}</th>
+              <th>{{ sortable_column("Owner", "owners") }}</th>
               <th>Runs
                 <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Status of all previous DAG runs.">info</span>
               </th>
@@ -131,7 +162,7 @@
               <th style="width:180px;">Last Run
                 <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Date/Time of the latest Dag Run.">info</span>
               </th>
-              <th style="width:180px;">Next Run
+              <th style="width:180px;">{{ sortable_column("Next Run", "next_dagrun") }}
                 <span class="material-icons text-muted js-tooltip" aria-hidden="true" title="Expected Date/Time of the next Dag Run.">info</span>
               </th>
               <th>Recent Tasks

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -22,9 +22,6 @@
 {% from 'airflow/_messages.html' import show_message %}
 
 {%- macro sortable_column(display_name, attribute_name) -%}
-
-{%- endmacro -%}
-{%- macro sortable_column(display_name, attribute_name) -%}
    {% set curr_ordering_direction = (request.args.get('sorting_direction', 'desc')) %}
    {% set new_ordering_direction = ('asc' if (request.args.get('sorting_key') != attribute_name or curr_ordering_direction == 'desc') else 'desc') %}
    <a href="{{ url_for('Airflow.index',

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -26,7 +26,7 @@
 {%- endmacro -%}
 {%- macro sortable_column(display_name, attribute_name) -%}
    {% set curr_ordering_direction = (request.args.get('sorting_direction', 'desc')) %}
-   {% set new_ordering_direction = ('asc' if (curr_ordering_direction == 'desc' or request.args.get('sorting_key') != attribute_name) else 'desc') %}
+   {% set new_ordering_direction = ('asc' if (request.args.get('sorting_key') != attribute_name or curr_ordering_direction == 'desc') else 'desc') %}
    <a href="{{ url_for('Airflow.index',
                        status=request.args.get('status', 'all'),
                        search=request.args.get('search', None),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -761,7 +761,7 @@ class Airflow(AirflowBaseView):
             sort_column = DagModel.__table__.c.get(arg_sorting_key)
             if sort_column is not None:
                 if arg_sorting_direction == 'desc':
-                    sort_column = desc(sort_column)
+                    sort_column = sort_column.desc()
                 current_dags = current_dags.order_by(sort_column)
 
             dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -86,6 +86,7 @@ from pygments.formatters import HtmlFormatter
 from sqlalchemy import Date, and_, desc, func, inspect, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.sql.expression import nullslast
 from wtforms import SelectField, validators
 from wtforms.validators import InputRequired
 
@@ -686,6 +687,8 @@ class Airflow(AirflowBaseView):
         arg_search_query = request.args.get('search')
         arg_tags_filter = request.args.getlist('tags')
         arg_status_filter = request.args.get('status')
+        arg_sorting_key = request.args.get('sorting_key', "dag_id")
+        arg_sorting_direction = request.args.get('sorting_direction', default='asc')
 
         if request.args.get('reset_tags') is not None:
             flask_session[FILTER_TAGS_COOKIE] = None
@@ -756,13 +759,12 @@ class Airflow(AirflowBaseView):
                 current_dags = all_dags
                 num_of_all_dags = all_dags_count
 
-            dags = (
-                current_dags.order_by(DagModel.dag_id)
-                .options(joinedload(DagModel.tags))
-                .offset(start)
-                .limit(dags_per_page)
-                .all()
+            sort_column = DagModel.__table__.c[arg_sorting_key]
+            current_dags = current_dags.order_by(
+                nullslast(desc(sort_column)) if arg_sorting_direction == "desc" else nullslast(sort_column)
             )
+
+            dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()
             user_permissions = g.user.perms
             all_dags_editable = (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG) in user_permissions
             can_create_dag_run = (
@@ -890,6 +892,8 @@ class Airflow(AirflowBaseView):
             status_count_active=status_count_active,
             status_count_paused=status_count_paused,
             tags_filter=arg_tags_filter,
+            sorting_key=arg_sorting_key,
+            sorting_direction=arg_sorting_direction,
         )
 
     @expose('/dag_stats', methods=['POST'])

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -86,7 +86,6 @@ from pygments.formatters import HtmlFormatter
 from sqlalchemy import Date, and_, desc, func, inspect, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy.sql.expression import nullslast
 from wtforms import SelectField, validators
 from wtforms.validators import InputRequired
 
@@ -761,7 +760,7 @@ class Airflow(AirflowBaseView):
 
             sort_column = DagModel.__table__.c[arg_sorting_key]
             current_dags = current_dags.order_by(
-                nullslast(desc(sort_column)) if arg_sorting_direction == "desc" else nullslast(sort_column)
+                sort_column.is_(None), desc(sort_column) if arg_sorting_direction == "desc" else sort_column
             )
 
             dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -760,10 +760,9 @@ class Airflow(AirflowBaseView):
 
             sort_column = DagModel.__table__.c.get(arg_sorting_key)
             if sort_column is not None:
-                nulls_last = sort_column.is_(None)
                 if arg_sorting_direction == 'desc':
                     sort_column = desc(sort_column)
-                current_dags = current_dags.order_by(nulls_last, sort_column)
+                current_dags = current_dags.order_by(sort_column)
 
             dags = current_dags.options(joinedload(DagModel.tags)).offset(start).limit(dags_per_page).all()
             user_permissions = g.user.perms

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -117,7 +117,7 @@ def client_single_dag(app, user_single_dag):
     )
 
 
-TEST_FILTER_DAG_IDS = ['filter_test_1', 'filter_test_2']
+TEST_FILTER_DAG_IDS = ['filter_test_1', 'filter_test_2', 'a_first_dag_id_asc']
 
 
 def _process_file(file_path, session):
@@ -251,3 +251,29 @@ def test_audit_log_view(user_client, working_dags):
     url = 'audit_log?dag_id=filter_test_1'
     resp = user_client.get(url, follow_redirects=True)
     check_content_in_response('Dag Audit Log', resp)
+
+
+def test_sorting_home_view(user_client, working_dags):
+    # No order specified should default to dag_id in ascending
+    url = "home?status=all"
+    resp = user_client.get(url, follow_redirects=True)
+    resp_html = resp.data.decode('utf-8')
+    first_index = resp_html.find('a_first_dag_id_asc')
+    second_index = resp_html.find('filter_test_1')
+    assert first_index < second_index
+
+    # Ascending order on dag_id
+    url = "home?status=all&sorting_key=dag_id&sorting_direction=asc"
+    resp = user_client.get(url, follow_redirects=True)
+    resp_html = resp.data.decode('utf-8')
+    first_index = resp_html.find('filter_test_1')
+    second_index = resp_html.find('filter_test_2')
+    assert first_index < second_index
+
+    # Descending order on dag_id
+    url = "home?status=all&sorting_key=dag_id&sorting_direction=desc"
+    resp = user_client.get(url, follow_redirects=True)
+    resp_html = resp.data.decode('utf-8')
+    first_index = resp_html.find('filter_test_1')
+    second_index = resp_html.find('filter_test_2')
+    assert first_index > second_index

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -253,27 +253,18 @@ def test_audit_log_view(user_client, working_dags):
     check_content_in_response('Dag Audit Log', resp)
 
 
-def test_sorting_home_view(user_client, working_dags):
-    # No order specified should default to dag_id in ascending
-    url = "home?status=all"
+@pytest.mark.parametrize(
+    "url, lower_key, greater_key",
+    [
+        ("home?status=all", "a_first_dag_id_asc", "filter_test_1"),
+        ("home?status=all&sorting_key=dag_id&sorting_direction=asc", "filter_test_1", "filter_test_2"),
+        ("home?status=all&sorting_key=dag_id&sorting_direction=desc", "filter_test_2", "filter_test_1"),
+    ],
+    ids=["no_order_provided", "ascending_order_on_dag_id", "descending_order_on_dag_id"],
+)
+def test_sorting_home_view(url, lower_key, greater_key, user_client, working_dags):
     resp = user_client.get(url, follow_redirects=True)
     resp_html = resp.data.decode('utf-8')
-    first_index = resp_html.find('a_first_dag_id_asc')
-    second_index = resp_html.find('filter_test_1')
-    assert first_index < second_index
-
-    # Ascending order on dag_id
-    url = "home?status=all&sorting_key=dag_id&sorting_direction=asc"
-    resp = user_client.get(url, follow_redirects=True)
-    resp_html = resp.data.decode('utf-8')
-    first_index = resp_html.find('filter_test_1')
-    second_index = resp_html.find('filter_test_2')
-    assert first_index < second_index
-
-    # Descending order on dag_id
-    url = "home?status=all&sorting_key=dag_id&sorting_direction=desc"
-    resp = user_client.get(url, follow_redirects=True)
-    resp_html = resp.data.decode('utf-8')
-    first_index = resp_html.find('filter_test_1')
-    second_index = resp_html.find('filter_test_2')
-    assert first_index > second_index
+    lower_index = resp_html.find(lower_key)
+    greater_index = resp_html.find(greater_key)
+    assert lower_index < greater_index


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/8459

Based on the closed PR https://github.com/apache/airflow/pull/11652/, add supports for sorting dag list in the home page.

Try to simplified the logic and added a small test to check that items appear in the correct order in the dom. (dag table)
![screen1](https://user-images.githubusercontent.com/14861206/161150820-8f7a44e7-96e0-404b-bf6d-7dc2846f637c.png)
![screen4](https://user-images.githubusercontent.com/14861206/161153808-7267415f-673b-4ede-9b9d-90adc9f444df.png)
![screen2](https://user-images.githubusercontent.com/14861206/161150819-4b35e23b-cdf3-4605-8891-c0c973a64f15.png)
![screen3](https://user-images.githubusercontent.com/14861206/161150818-4534999e-47e8-4ffb-a893-0c15767cea33.png)



