### PR TITLE
Reset warnings.showwarning on interpreter shutdown

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -120,7 +120,20 @@ def custom_show_warning(message, category, filename, lineno, file=None, line=Non
     write_console.print(msg, soft_wrap=True)
 
 
-warnings.showwarning = custom_show_warning
+def replace_showwarning(replacement):
+    """Replace ``warnings.showwarning``, returning the original.
+
+    This is useful since we want to "reset" the ``showwarning`` hook on exit to
+    avoid lazy-loading issues. If a warning is emitted after Python cleaned up
+    the import system, we would no longer be able to import ``rich``.
+    """
+    original = warnings.showwarning
+    warnings.showwarning = replacement
+    return original
+
+
+original_show_warning = replace_showwarning(custom_show_warning)
+atexit.register(functools.partial(replace_showwarning, original_show_warning))
 
 
 def task_policy(task) -> None:


### PR DESCRIPTION
First part of #22665.

Since our custom showwarning hook lazy-imports Rich, it may not be able to execute correctly if a warning is emitted after the interpreter has already cleaned up the import system. This adds an atexit hook to restore the original showwarning hook, so that warnings emitted after the clean-up phase are logged plainly without using additional modules.