### PR TITLE
Refine 'task not mapped' warning

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -179,9 +179,15 @@ class OperatorPartial:
 
     def __del__(self):
         if not self._expand_called:
-            warnings.warn(f"{self!r} was never mapped!")
+            try:
+                task_id = repr(self.kwargs["task_id"])
+            except KeyError:
+                task_id = f"at {hex(id(self))}"
+            warnings.warn(f"Task {task_id} was never mapped!")
 
     def expand(self, **mapped_kwargs: "Mappable") -> "MappedOperator":
+        self._expand_called = True
+
         from airflow.operators.dummy import DummyOperator
 
         validate_mapping_kwargs(self.operator_class, "expand", mapped_kwargs)
@@ -218,7 +224,6 @@ class OperatorPartial:
             start_date=start_date,
             end_date=end_date,
         )
-        self._expand_called = True
         return op
 
 


### PR DESCRIPTION
This plus #22677 close #22665.

Previously, we only count 'expand' as "called" when the function ends
successfully. This however means the "not called" warning would be
emitted if the 'expand' call is made, but ends with an exception.

Although it is not strictly accurate to count a task as mapped without
'expand' being completed, the behavior described above emits a
disturbing, superfulous warning that the user already knows about on a
DAG-parsing error, which should be much more common than edge cases when
'expand' does not finish, but the DAG-parsing process does not fail
(e.g. if the user wraps task creation in a try-except block), so this
should be a reasonable tradeoff.

This also simplifies the warning being emitted when 'expand' is indeed
never called, to only show the object's task_id or Python object ID,
instead of the entire task object representation. This should make the
message more concise and easier to understand.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
