### PR TITLE
List Mapped Instances in Task Details Panel

### DIFF
--- a/airflow/www/package.json
+++ b/airflow/www/package.json
@@ -95,6 +95,7 @@
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
     "react-query": "^3.34.16",
+    "react-table": "^7.7.0",
     "redoc": "^2.0.0-rc.63",
     "url-search-params-polyfill": "^8.1.0"
   },

--- a/airflow/www/static/js/tree/Table.jsx
+++ b/airflow/www/static/js/tree/Table.jsx
@@ -45,7 +45,7 @@ import {
 } from 'react-icons/ti';
 
 const Table = ({
-  data, columns, manualPagination, pageSize = 25, setSortBy,
+  data, columns, manualPagination, pageSize = 25, setSortBy, isLoading = false,
 }) => {
   const { totalEntries, offset, setOffset } = manualPagination || {};
   const oddColor = useColorModeValue('gray.50', 'gray.900');
@@ -120,7 +120,7 @@ const Table = ({
           </Tr>
         </Thead>
         <Tbody {...getTableBodyProps()}>
-          {!data.length && (
+          {!data.length && !isLoading && (
           <Tr>
             <Td colSpan={2}>No Data found.</Td>
           </Tr>

--- a/airflow/www/static/js/tree/Table.jsx
+++ b/airflow/www/static/js/tree/Table.jsx
@@ -1,0 +1,168 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Custom wrapper of react-table using Chakra UI components
+*/
+
+import React, { useEffect } from 'react';
+import {
+  Flex,
+  Table as ChakraTable,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  IconButton,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import {
+  useTable, useSortBy, usePagination,
+} from 'react-table';
+import {
+  MdKeyboardArrowLeft, MdKeyboardArrowRight,
+} from 'react-icons/md';
+import {
+  TiArrowUnsorted, TiArrowSortedDown, TiArrowSortedUp,
+} from 'react-icons/ti';
+
+const Table = ({
+  data, columns, manualPagination, pageSize = 25, setSortBy,
+}) => {
+  const { totalEntries, offset, setOffset } = manualPagination || {};
+  const oddColor = useColorModeValue('gray.50', 'gray.900');
+  const hoverColor = useColorModeValue('gray.100', 'gray.700');
+
+  const pageCount = totalEntries ? (Math.ceil(totalEntries / pageSize) || 1) : data.length;
+
+  const lowerCount = (offset || 0) + 1;
+  const upperCount = lowerCount + data.length - 1;
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    allColumns,
+    prepareRow,
+    page,
+    canPreviousPage,
+    canNextPage,
+    nextPage,
+    previousPage,
+    state: { pageIndex, sortBy },
+  } = useTable(
+    {
+      columns,
+      data,
+      pageCount,
+      manualPagination: !!manualPagination,
+      manualSortBy: !!setSortBy,
+      initialState: {
+        pageIndex: offset ? offset / pageSize : 0,
+        pageSize,
+      },
+    },
+    useSortBy,
+    usePagination,
+  );
+
+  const handleNext = () => {
+    nextPage();
+    if (setOffset) setOffset((pageIndex + 1) * pageSize);
+  };
+
+  const handlePrevious = () => {
+    previousPage();
+    if (setOffset) setOffset((pageIndex - 1 || 0) * pageSize);
+  };
+
+  useEffect(() => {
+    if (setSortBy) setSortBy(sortBy);
+  }, [sortBy, setSortBy]);
+
+  return (
+    <>
+      <ChakraTable {...getTableProps()}>
+        <Thead>
+          <Tr>
+            {allColumns.map((column) => (
+              <Th
+                {...column.getHeaderProps(column.getSortByToggleProps())}
+              >
+                {column.render('Header')}
+                {column.isSorted && (
+                  column.isSortedDesc ? (
+                    <TiArrowSortedDown aria-label="sorted descending" style={{ display: 'inline' }} size="1em" />
+                  ) : (
+                    <TiArrowSortedUp aria-label="sorted ascending" style={{ display: 'inline' }} size="1em" />
+                  )
+                )}
+                {(!column.isSorted && column.canSort) && (<TiArrowUnsorted aria-label="unsorted" style={{ display: 'inline' }} size="1em" />)}
+              </Th>
+            ))}
+          </Tr>
+        </Thead>
+        <Tbody {...getTableBodyProps()}>
+          {!data.length && (
+          <Tr>
+            <Td colSpan={2}>No Data found.</Td>
+          </Tr>
+          )}
+          {page.map((row) => {
+            prepareRow(row);
+            return (
+              <Tr
+                {...row.getRowProps()}
+                _odd={{ backgroundColor: oddColor }}
+                _hover={{ backgroundColor: hoverColor }}
+              >
+                {row.cells.map((cell) => (
+                  <Td
+                    {...cell.getCellProps()}
+                    py={3}
+                  >
+                    {cell.render('Cell')}
+                  </Td>
+                ))}
+              </Tr>
+            );
+          })}
+        </Tbody>
+      </ChakraTable>
+      <Flex alignItems="center" justifyContent="flex-start" my={4}>
+        <IconButton variant="ghost" onClick={handlePrevious} disabled={!canPreviousPage} aria-label="Previous Page">
+          <MdKeyboardArrowLeft />
+        </IconButton>
+        <IconButton variant="ghost" onClick={handleNext} disabled={!canNextPage} aria-label="Next Page">
+          <MdKeyboardArrowRight />
+        </IconButton>
+        <Text>
+          {lowerCount}
+          -
+          {upperCount}
+          {' of '}
+          {totalEntries}
+        </Text>
+      </Flex>
+    </>
+  );
+};
+
+export default Table;

--- a/airflow/www/static/js/tree/Table.jsx
+++ b/airflow/www/static/js/tree/Table.jsx
@@ -147,12 +147,20 @@ const Table = ({
         </Tbody>
       </ChakraTable>
       <Flex alignItems="center" justifyContent="flex-start" my={4}>
-        <IconButton variant="ghost" onClick={handlePrevious} disabled={!canPreviousPage} aria-label="Previous Page">
-          <MdKeyboardArrowLeft />
-        </IconButton>
-        <IconButton variant="ghost" onClick={handleNext} disabled={!canNextPage} aria-label="Next Page">
-          <MdKeyboardArrowRight />
-        </IconButton>
+        <IconButton
+          variant="ghost"
+          onClick={handlePrevious}
+          disabled={!canPreviousPage}
+          aria-label="Previous Page"
+          icon={<MdKeyboardArrowLeft />}
+        />
+        <IconButton
+          variant="ghost"
+          onClick={handleNext}
+          disabled={!canNextPage}
+          aria-label="Next Page"
+          icon={<MdKeyboardArrowRight />}
+        />
         <Text>
           {lowerCount}
           -

--- a/airflow/www/static/js/tree/api/index.js
+++ b/airflow/www/static/js/tree/api/index.js
@@ -33,6 +33,7 @@ import useMarkSuccessTask from './useMarkSuccessTask';
 import useExtraLinks from './useExtraLinks';
 import useConfirmMarkTask from './useConfirmMarkTask';
 import useTreeData from './useTreeData';
+import useMappedInstances from './useMappedInstances';
 
 axios.interceptors.response.use(
   (res) => (res.data ? camelcaseKeys(res.data, { deep: true }) : res),
@@ -54,4 +55,5 @@ export {
   useExtraLinks,
   useConfirmMarkTask,
   useTreeData,
+  useMappedInstances,
 };

--- a/airflow/www/static/js/tree/api/useMappedInstances.js
+++ b/airflow/www/static/js/tree/api/useMappedInstances.js
@@ -17,17 +17,26 @@
  * under the License.
  */
 
+/* global autoRefreshInterval */
+
 import axios from 'axios';
 import { useQuery } from 'react-query';
+
+import { useAutoRefresh } from '../context/autorefresh';
 
 export default function useMappedInstances({
   dagId, runId, taskId, limit, offset, order,
 }) {
   const orderParam = order && order !== 'map_index' ? { order_by: order } : {};
+  const { isRefreshOn } = useAutoRefresh();
   return useQuery(
     ['mappedInstances', dagId, runId, taskId, offset, order],
     () => axios.get(`/api/v1/dags/${dagId}/dagRuns/${runId}/taskInstances/${taskId}/listMapped`, {
       params: { offset, limit, ...orderParam },
     }),
+    {
+      keepPreviousData: true,
+      refetchInterval: isRefreshOn && autoRefreshInterval * 1000,
+    },
   );
 }

--- a/airflow/www/static/js/tree/api/useMappedInstances.js
+++ b/airflow/www/static/js/tree/api/useMappedInstances.js
@@ -1,0 +1,33 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios from 'axios';
+import { useQuery } from 'react-query';
+
+export default function useMappedInstances({
+  dagId, runId, taskId, limit, offset, order,
+}) {
+  const orderParam = order && order !== 'map_index' ? { order_by: order } : {};
+  return useQuery(
+    ['mappedInstances', dagId, runId, taskId, offset, order],
+    () => axios.get(`/api/v1/dags/${dagId}/dagRuns/${runId}/taskInstances/${taskId}/listMapped`, {
+      params: { offset, limit, ...orderParam },
+    }),
+  );
+}

--- a/airflow/www/static/js/tree/api/useMappedInstances.js
+++ b/airflow/www/static/js/tree/api/useMappedInstances.js
@@ -22,16 +22,20 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
 
+import { getMetaValue } from '../../utils';
 import { useAutoRefresh } from '../context/autorefresh';
+
+const mappedInstancesUrl = getMetaValue('mapped_instances_api');
 
 export default function useMappedInstances({
   dagId, runId, taskId, limit, offset, order,
 }) {
+  const url = mappedInstancesUrl.replace('_DAG_RUN_ID_', runId).replace('_TASK_ID_', taskId);
   const orderParam = order && order !== 'map_index' ? { order_by: order } : {};
   const { isRefreshOn } = useAutoRefresh();
   return useQuery(
     ['mappedInstances', dagId, runId, taskId, offset, order],
-    () => axios.get(`/api/v1/dags/${dagId}/dagRuns/${runId}/taskInstances/${taskId}/listMapped`, {
+    () => axios.get(url, {
       params: { offset, limit, ...orderParam },
     }),
     {

--- a/airflow/www/static/js/tree/details/content/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/MappedInstances.jsx
@@ -1,0 +1,136 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useMemo } from 'react';
+import {
+  Flex,
+  Text,
+  Box,
+  Link,
+  Button,
+} from '@chakra-ui/react';
+import { snakeCase } from 'lodash';
+
+import { formatDateTime, formatDuration } from '../../../datetime_utils';
+import { useMappedInstances } from '../../api';
+import { SimpleStatus } from '../../StatusBox';
+import Table from '../../Table';
+
+const MappedInstances = ({
+  dagId, runId, taskId,
+}) => {
+  const limit = 25;
+  const [offset, setOffset] = useState(0);
+  const [sortBy, setSortBy] = useState([]);
+
+  const sort = sortBy[0];
+
+  const order = sort && (sort.id === 'state' || sort.id === 'mapIndex') ? `${sort.desc ? '-' : ''}${snakeCase(sort.id)}` : '';
+
+  const {
+    data: { taskInstances, totalEntries } = { taskInstances: [], totalEntries: 0 },
+  } = useMappedInstances({
+    dagId, runId, taskId, limit, offset, order,
+  });
+
+  const data = useMemo(
+    () => taskInstances.map((mi) => {
+      const params = new URLSearchParams({
+        dag_id: dagId,
+        task_id: mi.taskId,
+        execution_date: mi.executionDate,
+        map_index: mi.mapIndex,
+      }).toString();
+      const logLink = `/log?${params}`;
+      const detailsLink = `/task?${params}`;
+      return {
+        ...mi,
+        state: (
+          <Flex alignItems="center">
+            <SimpleStatus state={mi.state} mx={2} />
+            {mi.state || 'no status'}
+          </Flex>
+        ),
+        duration: formatDuration(mi.duration),
+        startDate: formatDateTime(mi.startDate),
+        endDate: formatDateTime(mi.endDate),
+        links: (
+          <Flex alignItems="center">
+            <Button as={Link} variant="outline" mr={1} colorScheme="blue" href={logLink}>Log</Button>
+            <Button as={Link} variant="outline" colorScheme="blue" href={detailsLink}>More Details</Button>
+          </Flex>
+        ),
+      };
+    }),
+    [dagId, taskInstances],
+  );
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: 'Map Index',
+        accessor: 'mapIndex',
+      },
+      {
+        Header: 'State',
+        accessor: 'state',
+      },
+      {
+        Header: 'Duration',
+        accessor: 'duration',
+        disableSortBy: true,
+      },
+      {
+        Header: 'Start Date',
+        accessor: 'startDate',
+        disableSortBy: true,
+      },
+      {
+        Header: 'End Date',
+        accessor: 'endDate',
+        disableSortBy: true,
+      },
+      {
+        disableSortBy: true,
+        accessor: 'links',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <Box>
+      <br />
+      <Text as="strong">Mapped Instances</Text>
+      <Table
+        data={data}
+        columns={columns}
+        manualPagination={{
+          offset,
+          setOffset,
+          totalEntries,
+        }}
+        pageSize={limit}
+        setSortBy={setSortBy}
+      />
+    </Box>
+  );
+};
+
+export default MappedInstances;

--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -126,16 +126,20 @@ const DagRun = ({ runId }) => {
         <Time dateTime={dataIntervalEnd} />
       </Text>
       <br />
+      {startDate && (
       <Text>
         Started:
         {' '}
         <Time dateTime={startDate} />
       </Text>
+      )}
+      {endDate && (
       <Text>
         Ended:
         {' '}
         <Time dateTime={endDate} />
       </Text>
+      )}
     </Box>
   );
 };

--- a/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
@@ -89,6 +89,7 @@ const Details = ({ instance, task }) => {
   }
 
   const taskIdTitle = isGroup ? 'Task Group Id: ' : 'Task Id: ';
+  const isStateFinal = ['success', 'failed', 'upstream_failed', 'skipped'].includes(state);
 
   return (
     <Flex flexWrap="wrap" justifyContent="space-between">
@@ -144,16 +145,20 @@ const Details = ({ instance, task }) => {
         </Text>
       </Box>
       <Box>
+        {startDate && (
         <Text>
           Started:
           {' '}
           <Time dateTime={startDate} />
         </Text>
+        )}
+        {endDate && isStateFinal && (
         <Text>
           Ended:
           {' '}
           <Time dateTime={endDate} />
         </Text>
+        )}
       </Box>
     </Flex>
   );

--- a/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
@@ -27,10 +27,15 @@ import {
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
 
-import { formatDateTime, formatDuration } from '../../../datetime_utils';
-import { useMappedInstances } from '../../api';
-import { SimpleStatus } from '../../StatusBox';
-import Table from '../../Table';
+import { getMetaValue } from '../../../../utils';
+import { formatDateTime, formatDuration } from '../../../../datetime_utils';
+import { useMappedInstances } from '../../../api';
+import { SimpleStatus } from '../../../StatusBox';
+import Table from '../../../Table';
+
+const renderedTemplatesUrl = getMetaValue('rendered_templates_url');
+const logUrl = getMetaValue('log_url');
+const taskUrl = getMetaValue('task_url');
 
 const MappedInstances = ({
   dagId, runId, taskId,
@@ -57,8 +62,9 @@ const MappedInstances = ({
         execution_date: mi.executionDate,
         map_index: mi.mapIndex,
       }).toString();
-      const logLink = `/log?${params}`;
-      const detailsLink = `/task?${params}`;
+      const detailsLink = `${taskUrl}&${params}`;
+      const renderedLink = `${renderedTemplatesUrl}&${params}`;
+      const logLink = `${logUrl}&${params}`;
       return {
         ...mi,
         state: (
@@ -67,11 +73,12 @@ const MappedInstances = ({
             {mi.state || 'no status'}
           </Flex>
         ),
-        duration: formatDuration(mi.duration),
-        startDate: formatDateTime(mi.startDate),
-        endDate: formatDateTime(mi.endDate),
+        duration: mi.duration && formatDuration(mi.duration),
+        startDate: mi.startDate && formatDateTime(mi.startDate),
+        endDate: mi.endDate && formatDateTime(mi.endDate),
         links: (
           <Flex alignItems="center">
+            <Button as={Link} variant="outline" mr={1} colorScheme="blue" href={renderedLink}>Rendered</Button>
             <Button as={Link} variant="outline" mr={1} colorScheme="blue" href={logLink}>Log</Button>
             <Button as={Link} variant="outline" colorScheme="blue" href={detailsLink}>More Details</Button>
           </Flex>

--- a/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
@@ -57,6 +57,7 @@ const MappedInstances = ({
 
   const {
     data: { taskInstances, totalEntries } = { taskInstances: [], totalEntries: 0 },
+    isLoading,
   } = useMappedInstances({
     dagId, runId, taskId, limit, offset, order,
   });
@@ -142,6 +143,7 @@ const MappedInstances = ({
         }}
         pageSize={limit}
         setSortBy={setSortBy}
+        isLoading={isLoading}
       />
     </Box>
   );

--- a/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
@@ -23,9 +23,12 @@ import {
   Text,
   Box,
   Link,
-  Button,
+  IconButton,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
+import { FaMicroscope } from 'react-icons/fa';
+import { GiLog } from 'react-icons/gi';
+import { HiTemplate } from 'react-icons/hi';
 
 import { getMetaValue } from '../../../../utils';
 import { formatDateTime, formatDuration } from '../../../../datetime_utils';
@@ -36,6 +39,10 @@ import Table from '../../../Table';
 const renderedTemplatesUrl = getMetaValue('rendered_templates_url');
 const logUrl = getMetaValue('log_url');
 const taskUrl = getMetaValue('task_url');
+
+const IconLink = (props) => (
+  <IconButton as={Link} variant="outline" colorScheme="blue" {...props} />
+);
 
 const MappedInstances = ({
   dagId, runId, taskId,
@@ -78,9 +85,9 @@ const MappedInstances = ({
         endDate: mi.endDate && formatDateTime(mi.endDate),
         links: (
           <Flex alignItems="center">
-            <Button as={Link} variant="outline" mr={1} colorScheme="blue" href={renderedLink}>Rendered</Button>
-            <Button as={Link} variant="outline" mr={1} colorScheme="blue" href={logLink}>Log</Button>
-            <Button as={Link} variant="outline" colorScheme="blue" href={detailsLink}>More Details</Button>
+            <IconLink mr={1} title="Rendered Templates" aria-label="Rendered Templates" icon={<HiTemplate />} href={renderedLink} />
+            <IconLink mr={1} title="Log" aria-label="Log" icon={<GiLog />} href={logLink} />
+            <IconLink title="Details" aria-label="Details" icon={<FaMicroscope />} href={detailsLink} />
           </Flex>
         ),
       };

--- a/airflow/www/static/js/tree/details/content/taskInstance/Nav.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Nav.jsx
@@ -44,7 +44,6 @@ const Nav = ({ instance, isMapped }) => {
   const {
     taskId,
     dagId,
-    runId,
     operator,
     executionDate,
   } = instance;
@@ -62,12 +61,6 @@ const Nav = ({ instance, isMapped }) => {
     _flt_3_task_id: taskId,
     _oc_TaskInstanceModelView: 'dag_run.execution_date',
   });
-  const mapParams = new URLSearchParams({
-    _flt_3_dag_id: dagId,
-    _flt_3_task_id: taskId,
-    _flt_3_run_id: runId,
-    _oc_TaskInstanceModelView: 'map_index',
-  });
   const subDagParams = new URLSearchParams({
     execution_date: executionDate,
   }).toString();
@@ -79,7 +72,6 @@ const Nav = ({ instance, isMapped }) => {
   }).toString();
 
   const allInstancesLink = `${taskInstancesUrl}?${listParams.toString()}`;
-  const mappedInstancesLink = `${taskInstancesUrl}?${mapParams.toString()}`;
 
   const filterUpstreamLink = appendSearchParams(gridUrlNoRoot, filterParams);
   const subDagLink = appendSearchParams(gridUrl.replace(dagId, `${dagId}.${taskId}`), subDagParams);
@@ -102,9 +94,6 @@ const Nav = ({ instance, isMapped }) => {
           )}
           <LinkButton href={logLink}>Log</LinkButton>
         </>
-        )}
-        {isMapped && (
-        <LinkButton href={mappedInstancesLink} title="Show the mapped instances for this DAG run">Mapped Instances</LinkButton>
         )}
         <LinkButton href={allInstancesLink} title="View all instances across all DAG runs">All Instances</LinkButton>
         <LinkButton href={filterUpstreamLink}>Filter Upstream</LinkButton>

--- a/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
@@ -35,7 +35,7 @@ import TaskNav from './Nav';
 import Details from './Details';
 
 import { useTreeData } from '../../../api';
-import MappedInstances from '../MappedInstances';
+import MappedInstances from './MappedInstances';
 
 const getTask = ({ taskId, runId, task }) => {
   if (task.id === taskId) return task;

--- a/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
@@ -35,6 +35,7 @@ import TaskNav from './Nav';
 import Details from './Details';
 
 import { useTreeData } from '../../../api';
+import MappedInstances from '../MappedInstances';
 
 const getTask = ({ taskId, runId, task }) => {
   if (task.id === taskId) return task;
@@ -100,6 +101,9 @@ const TaskInstance = ({ taskId, runId }) => {
         executionDate={executionDate}
         extraLinks={task.extraLinks}
       />
+      {task.isMapped && (
+        <MappedInstances dagId={dagId} runId={runId} taskId={taskId} />
+      )}
     </Box>
   );
 };

--- a/airflow/www/static/js/tree/details/index.jsx
+++ b/airflow/www/static/js/tree/details/index.jsx
@@ -30,28 +30,21 @@ import DagRunContent from './content/dagRun';
 import DagContent from './content/Dag';
 import { useSelection } from '../context/selection';
 
-const Details = ({ isRefreshOn, onToggleRefresh }) => {
+const Details = () => {
   const { selected } = useSelection();
   return (
-    <Flex borderLeftWidth="1px" flexDirection="column" p={3} flexGrow={1} maxWidth="600px">
+    <Flex borderLeftWidth="1px" flexDirection="column" pl={3} mr={3} flexGrow={1} maxWidth="750px">
       <Header />
       <Divider my={2} />
-      <Box minWidth="500px">
-        {/* TODO: get full instance data from the API */}
+      <Box minWidth="750px">
         {!selected.runId && !selected.taskId && <DagContent />}
         {selected.runId && !selected.taskId && (
-          <DagRunContent
-            runId={selected.runId}
-            isRefreshOn={isRefreshOn}
-            onToggleRefresh={onToggleRefresh}
-          />
+          <DagRunContent runId={selected.runId} />
         )}
         {selected.taskId && (
         <TaskInstanceContent
           runId={selected.runId}
           taskId={selected.taskId}
-          isRefreshOn={isRefreshOn}
-          onToggleRefresh={onToggleRefresh}
         />
         )}
       </Box>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -67,6 +67,7 @@
   <meta name="task_instances_url" content="{{ url_for('TaskInstanceModelView.list') }}">
   <meta name="dag_details_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_endpoint_get_dag_details', dag_id=dag.dag_id) }}">
   <meta name="tasks_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_endpoint_get_tasks', dag_id=dag.dag_id) }}">
+  <meta name="mapped_instances_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_mapped_task_instances', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_') }}">
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">
   <meta name="csrf_token" content="{{ csrf_token() }}">

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -9838,6 +9838,11 @@ react-style-singleton@^2.1.0:
     invariant "^2.2.4"
     tslib "^1.0.0"
 
+react-table@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
+  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
+
 react-tabs@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.2.2.tgz#07bdc3cdb17bdffedd02627f32a93cd4b3d6e4d0"


### PR DESCRIPTION
Add a table of mapped instances to the details of a mapped task in the grid view.

Supports server-side pagination and sorting.
Auto-refreshes with the rest of the page.

<img width="1135" alt="Screen Shot 2022-04-01 at 11 54 49 AM" src="https://user-images.githubusercontent.com/4600967/161299715-81d2f15c-0b05-4205-9062-f1c26fd1862e.png">

![Apr-01-2022 12-00-04](https://user-images.githubusercontent.com/4600967/161299975-4da95972-812c-4239-8da5-f8d6ae13cbea.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
