### PR TITLE
retry commit on MySQL deadlocks during backfill

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional,
 
 import attr
 import pendulum
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm.session import Session, make_transient
 from tabulate import tabulate
 
@@ -486,6 +487,13 @@ class BackfillJob(BaseJob):
                         ti.queued_by_job_id = self.id
                         ti.queued_dttm = timezone.utcnow()
                         session.merge(ti)
+                        try:
+                            session.commit()
+                        except OperationalError:
+                            self.log.exception("Failed to commit task state change due to operational error")
+                            session.rollback()
+                            # early exit so the outer loop can retry
+                            return
 
                         cfg_path = None
                         if self.executor_class in (
@@ -505,7 +513,6 @@ class BackfillJob(BaseJob):
                         )
                         ti_status.running[key] = ti
                         ti_status.to_run.pop(key)
-                    session.commit()
                     return
 
                 if ti.state == TaskInstanceState.UPSTREAM_FAILED:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Without this patch, backfill runs will crash randomly in the middle whenever deadlock happens for MySQL < 8, requiring a lot of manual hand holding to complete a single backfill run end to end.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
