### PR TITLE
support for continue backfill on failures

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -337,6 +337,11 @@ ARG_RERUN_FAILED_TASKS = Arg(
     ),
     action="store_true",
 )
+ARG_CONTINUE_ON_FAILURES = Arg(
+    ("--continue-on-failures",),
+    help=("if set, the backfill will keep going even if some of the tasks failed"),
+    action="store_true",
+)
 ARG_RUN_BACKWARDS = Arg(
     (
         "-B",
@@ -1111,6 +1116,7 @@ DAGS_COMMANDS = (
             ARG_LOCAL,
             ARG_DONOT_PICKLE,
             ARG_YES,
+            ARG_CONTINUE_ON_FAILURES,
             ARG_BF_IGNORE_DEPENDENCIES,
             ARG_BF_IGNORE_FIRST_DEPENDS_ON_PAST,
             ARG_SUBDIR,

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -118,6 +118,7 @@ def dag_backfill(args, dag=None):
                 conf=run_conf,
                 rerun_failed_tasks=args.rerun_failed_tasks,
                 run_backwards=args.run_backwards,
+                continue_on_failures=args.continue_on_failures,
             )
         except ValueError as vr:
             print(str(vr))

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -115,6 +115,7 @@ class BackfillJob(BaseJob):
         rerun_failed_tasks=False,
         run_backwards=False,
         run_at_least_once=False,
+        continue_on_failures=False,
         *args,
         **kwargs,
     ):
@@ -153,6 +154,7 @@ class BackfillJob(BaseJob):
         self.rerun_failed_tasks = rerun_failed_tasks
         self.run_backwards = run_backwards
         self.run_at_least_once = run_at_least_once
+        self.continue_on_failures = continue_on_failures
         super().__init__(*args, **kwargs)
 
     def _update_counters(self, ti_status, session=None):
@@ -812,7 +814,8 @@ class BackfillJob(BaseJob):
                 remaining_dates = ti_status.total_runs - len(ti_status.executed_dag_run_dates)
                 err = self._collect_errors(ti_status=ti_status, session=session)
                 if err:
-                    raise BackfillUnfinished(err, ti_status)
+                    if not self.continue_on_failures or ti_status.deadlocked:
+                        raise BackfillUnfinished(err, ti_status)
 
                 if remaining_dates > 0:
                     self.log.info(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2210,6 +2210,7 @@ class DAG(LoggingMixin):
         rerun_failed_tasks=False,
         run_backwards=False,
         run_at_least_once=False,
+        continue_on_failures=False,
     ):
         """
         Runs the DAG.
@@ -2259,6 +2260,7 @@ class DAG(LoggingMixin):
             rerun_failed_tasks=rerun_failed_tasks,
             run_backwards=run_backwards,
             run_at_least_once=run_at_least_once,
+            continue_on_failures=continue_on_failures,
         )
         job.run()
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -100,6 +100,7 @@ class TestCliDags(unittest.TestCase):
             rerun_failed_tasks=False,
             run_backwards=False,
             verbose=False,
+            continue_on_failures=False,
         )
         mock_run.reset_mock()
         dag = self.dagbag.get_dag('example_bash_operator')
@@ -171,6 +172,7 @@ class TestCliDags(unittest.TestCase):
             rerun_failed_tasks=False,
             run_backwards=False,
             verbose=False,
+            continue_on_failures=False,
         )
         mock_run.reset_mock()
 
@@ -278,6 +280,7 @@ class TestCliDags(unittest.TestCase):
             rerun_failed_tasks=False,
             run_backwards=False,
             verbose=False,
+            continue_on_failures=False,
         )
 
     @mock.patch("airflow.cli.commands.dag_command.DAG.run")
@@ -317,6 +320,7 @@ class TestCliDags(unittest.TestCase):
             rerun_failed_tasks=False,
             run_backwards=True,
             verbose=False,
+            continue_on_failures=False,
         )
 
     def test_next_execution(self):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add a new CLI flag to support continue backfill on single task failure. When running large multi-year backfills (>1000 task runs), it's common for a one or couple date partitions to fail due to edge-cases in data distributions. In this case, we would like to continue the rest of the backfills and leave these one off anomalies for later manual inspections and recoveries.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
