### PR TITLE
support dag serialization with custom ti_deps rules

### DIFF
--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -95,6 +95,7 @@ class TestPluginsCommand(unittest.TestCase):
                         'label': 'The Apache Software Foundation',
                     },
                 ],
+                'ti_deps': ['<TIDep(CustomTestTriggerRule)>'],
             }
         ]
         get_listener_manager().clear()

--- a/tests/plugins/test_plugin.py
+++ b/tests/plugins/test_plugin.py
@@ -28,6 +28,7 @@ from airflow.models.baseoperator import BaseOperator
 # This is the class you derive to create a plugin
 from airflow.plugins_manager import AirflowPlugin
 from airflow.sensors.base import BaseSensorOperator
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.timetables.interval import CronDataIntervalTimetable
 from tests.listeners import empty_listener
 from tests.test_utils.mock_operators import (
@@ -106,6 +107,10 @@ class CustomCronDataIntervalTimetable(CronDataIntervalTimetable):
     pass
 
 
+class CustomTestTriggerRule(BaseTIDep):
+    pass
+
+
 # Defining the plugin class
 class AirflowTestPlugin(AirflowPlugin):
     name = "test_plugin"
@@ -124,6 +129,7 @@ class AirflowTestPlugin(AirflowPlugin):
     operator_extra_links = [GoogleLink(), AirflowLink2(), CustomOpLink(), CustomBaseIndexOpLink(1)]
     timetables = [CustomCronDataIntervalTimetable]
     listeners = [empty_listener]
+    ti_deps = [CustomTestTriggerRule()]
 
 
 class MockPluginA(AirflowPlugin):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add a new config to support custom task instance dependency rules.

We have been running this patch internally for more than a year and the cost of serializing custom deps has been negligible. In fact, I think we could probably just change the default behavior to serialize all deps by default :)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
