### PR TITLE
add allow_manual DAG argument to prevent scheduled DAGs from being triggered manually

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -298,3 +298,7 @@ class TaskDeferred(BaseException):
 
 class TaskDeferralError(AirflowException):
     """Raised when a task failed during deferral for some reason."""
+
+
+class DAGDisallowManual(AirflowException):
+    """Raised when a user tries to trigger a manual run for a DAG that has allow_manual set to False."""

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -98,6 +98,7 @@
           }
         },
         "catchup": { "type": "boolean" },
+        "allow_manual": { "type": "boolean" },
         "is_subdag": { "type": "boolean" },
         "fileloc": { "type" : "string"},
         "orientation": { "type" : "string"},

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1123,6 +1123,21 @@ class TestDag(unittest.TestCase):
         dag.clear()
         self._clean_up(dag_id)
 
+    def test_disable_manual_dag_trigger(self):
+        """
+        Tests manually scheduling a dag with allow_manual set to False
+        """
+        dag_id = "test_disable_manual_dag_trigger"
+        dag = DAG(dag_id=dag_id, allow_manual=False)
+        dag.add_task(BaseOperator(task_id="faketastic", owner='Also fake', start_date=TEST_DATE))
+
+        with pytest.raises(AirflowException):
+            dag.create_dagrun(
+                run_type=DagRunType.MANUAL,
+                execution_date=TEST_DATE,
+                state=State.RUNNING,
+            )
+
     @patch('airflow.models.dag.Stats')
     def test_dag_handle_callback_crash(self, mock_stats):
         """


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We have couple very critical DAGs that absolutely cannot be triggered manually ;) 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
