### PR TITLE
Changed self-destruct log level to ERROR instead of WARNING

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -195,7 +195,7 @@ class LocalTaskJob(BaseJob):
             fqdn = get_hostname()
             same_hostname = fqdn == ti.hostname
             if not same_hostname:
-                self.log.warning(
+                self.log.error(
                     "The recorded hostname %s does not match this instance's hostname %s",
                     ti.hostname,
                     fqdn,


### PR DESCRIPTION
The log level was set to `warning` but it raises and `AirflowException`. I believe it should be `error` level. Code snippet:

```python
if ti.state == State.RUNNING:
            fqdn = get_hostname()
            same_hostname = fqdn == ti.hostname
            if not same_hostname:
    -->          self.log.warning(
                    "The recorded hostname %s does not match this instance's hostname %s",
                    ti.hostname,
                    fqdn,
                )
                raise AirflowException("Hostname of job runner does not match")
```

The warning message misleads the actual error (in my case, it was due to Azure dynamic DNS changing the hostname). If it was an error (as it raises an exception), my team would have found the culprit earlier.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
