### PR TITLE
Add autodetect arg in BQCreateExternalTable Operator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -965,7 +965,8 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         contains the schema for the table. (templated)
     :param source_format: File format of the data.
     :param autodetect: Try to detect schema and format options automatically.
-        Any option specified explicitly will be honored.
+        The schema_fields and schema_object options will be honored when specified explicitly.
+        https://cloud.google.com/bigquery/docs/schema-detect#schema_auto-detection_for_external_data_sources
     :param compression: [Optional] The compression type of the data source.
         Possible values include GZIP and NONE.
         The default value is NONE.
@@ -1060,6 +1061,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
                 skip_leading_rows,
                 field_delimiter,
                 max_bad_records,
+                autodetect,
                 quote_character,
                 allow_quoted_newlines,
                 allow_jagged_rows,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -964,6 +964,8 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
     :param schema_object: If set, a GCS object path pointing to a .json file that
         contains the schema for the table. (templated)
     :param source_format: File format of the data.
+    :param autodetect: Try to detect schema and format options automatically.
+        Any option specified explicitly will be honored.
     :param compression: [Optional] The compression type of the data source.
         Possible values include GZIP and NONE.
         The default value is NONE.
@@ -1028,6 +1030,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         schema_fields: Optional[List] = None,
         schema_object: Optional[str] = None,
         source_format: Optional[str] = None,
+        autodetect: bool = False,
         compression: Optional[str] = None,
         skip_leading_rows: Optional[int] = None,
         field_delimiter: Optional[str] = None,
@@ -1116,6 +1119,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         self.bigquery_conn_id = bigquery_conn_id
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
+        self.autodetect = autodetect
 
         self.src_fmt_configs = src_fmt_configs or {}
         self.labels = labels
@@ -1153,6 +1157,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             schema_fields=schema_fields,
             source_uris=source_uris,
             source_format=self.source_format,
+            autodetect=self.autodetect,
             compression=self.compression,
             skip_leading_rows=self.skip_leading_rows,
             field_delimiter=self.field_delimiter,

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -193,6 +193,9 @@ Or you may point the operator to a Google Cloud Storage object name where the sc
     :start-after: [START howto_operator_bigquery_create_table_schema_json]
     :end-before: [END howto_operator_bigquery_create_table_schema_json]
 
+To use BigQuery `schema auto-detection <https://cloud.google.com/bigquery/docs/schema-detect#schema_auto-detection_for_external_data_sources>`__,
+set the ``autodetect`` flag instead of providing explicit schema information.
+
 .. _howto/operator:BigQueryGetDataOperator:
 
 Fetch data from table

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -197,6 +197,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             bucket=TEST_GCS_BUCKET,
             source_objects=TEST_GCS_DATA,
             source_format=TEST_SOURCE_FORMAT,
+            autodetect=True,
         )
 
         operator.execute(None)
@@ -205,7 +206,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             schema_fields=[],
             source_uris=[f'gs://{TEST_GCS_BUCKET}/{source_object}' for source_object in TEST_GCS_DATA],
             source_format=TEST_SOURCE_FORMAT,
-            autodetect=False,
+            autodetect=True,
             compression='NONE',
             skip_leading_rows=0,
             field_delimiter=',',

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -205,6 +205,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             schema_fields=[],
             source_uris=[f'gs://{TEST_GCS_BUCKET}/{source_object}' for source_object in TEST_GCS_DATA],
             source_format=TEST_SOURCE_FORMAT,
+            autodetect=False,
             compression='NONE',
             skip_leading_rows=0,
             field_delimiter=',',


### PR DESCRIPTION
Closes #22129

This PR adds an `autodetect` flag (with a backward compatible default value) to the BigQueryCreateExternalTableOperator constructor. If `schema_fields` and `schema_object` are blank, and the `autodetect` flag is set to `True`, BigQuery will attempt to auto-detect the input data schema.

Todo:
- [x] update code
- [x] update documentation
- [x] update unit tests
- [x] check manually

### Documentation updates

Added the following line to the Google provider package docs.

<img width="1118" alt="update" src="https://user-images.githubusercontent.com/11639738/161474266-09588d7e-6608-4025-955f-65446562479d.png">

### Manual checks

I uploaded a CSV file containing the following to a Google Cloud Storage bucket in the `us-east1` region.
```csv
name,age
Bill,42
Sally,15
```

I then ran a test DAG to create an external table based on the above CSV file. I enable BigQuery schema auto-detection by setting the `autodetect` flag to `True`.

```py
BigQueryCreateExternalTableOperator(
    task_id="test",
    bucket="***",
    source_objects=["test.csv"],
    destination_project_dataset_table = "***",
    source_format = "CSV",
    autodetect = True,
    skip_leading_rows=1,
    location = "us-east1",
)
```

The table is created with the correct field names and types. The table configuration also shows that schema auto-detection was enabled.

<img width="417" alt="Screen Shot 2022-04-04 at 13 31 03" src="https://user-images.githubusercontent.com/11639738/161474282-0f4e7924-6417-418e-b8b0-d0b96abeffe7.png">

<img width="417" alt="Screen Shot 2022-04-04 at 13 29 29" src="https://user-images.githubusercontent.com/11639738/161474275-4fb9ba81-5008-40ba-9f9d-1173d64a03f3.png">


