### PR TITLE
Fix Localexecutor's parallelism option

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -349,7 +349,7 @@ class LocalExecutor(BaseExecutor):
         self.workers_active = 0
         self.impl = (
             LocalExecutor.UnlimitedParallelism(self)
-            if self.parallelism == 0
+            if self.parallelism <= 0
             else LocalExecutor.LimitedParallelism(self)
         )
 

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -203,6 +203,8 @@ class LocalExecutor(BaseExecutor):
 
     def __init__(self, parallelism: int = PARALLELISM):
         super().__init__(parallelism=parallelism)
+        if self.parallelism < 0:
+            raise AirflowException("parallelism must be bigger than or equal to 0")
         self.manager: Optional[SyncManager] = None
         self.result_queue: Optional['Queue[TaskInstanceStateType]'] = None
         self.workers: List[QueuedLocalWorker] = []
@@ -349,7 +351,7 @@ class LocalExecutor(BaseExecutor):
         self.workers_active = 0
         self.impl = (
             LocalExecutor.UnlimitedParallelism(self)
-            if self.parallelism <= 0
+            if self.parallelism == 0
             else LocalExecutor.LimitedParallelism(self)
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

LocalExecutor's worker is created by number of parallelism if LimitedParallelism.
if self.parallelism is negative number, airflow doesn't raise error but all tasks are stucking in scheduled because worker doesn't generate.

```python
# class LimitedParallelism
        def start(self) -> None:
            """Starts limited parallelism implementation."""
            if not self.executor.manager:
                raise AirflowException(NOT_STARTED_MESSAGE)
            self.queue = self.executor.manager.Queue()
            if not self.executor.result_queue:
                raise AirflowException(NOT_STARTED_MESSAGE)
            self.executor.workers = [
                QueuedLocalWorker(self.queue, self.executor.result_queue)
                for _ in range(self.executor.parallelism)
            ]

            self.executor.workers_used = len(self.executor.workers)

            for worker in self.executor.workers:
                worker.start()
```

so if self.parallelism is negative number, it should be UnlimitedParallelism that doesn't effected by parallelism option.

```python
self.impl = (
            LocalExecutor.UnlimitedParallelism(self)
            if self.parallelism <= 0
            else LocalExecutor.LimitedParallelism(self)
        )

```
<br/>

**code changed**
it'll raise exception in init scope when parallelism less than 0

```python

class LocalExecutor(BaseExecutor):
    """
    LocalExecutor executes tasks locally in parallel.
    It uses the multiprocessing Python library and queues to parallelize the execution
    of tasks.

    :param parallelism: how many parallel processes are run in the executor
    """

    def __init__(self, parallelism: int = PARALLELISM):
        super().__init__(parallelism=parallelism)
        if self.parallelism < 0:
            raise AirflowException("parallelism must be bigger than or equal to 0")
        self.manager: Optional[SyncManager] = None
        self.result_queue: Optional['Queue[TaskInstanceStateType]'] = None
        self.workers: List[QueuedLocalWorker] = []
        self.workers_used: int = 0
        self.workers_active: int = 0
        self.impl: Optional[
            Union['LocalExecutor.UnlimitedParallelism', 'LocalExecutor.LimitedParallelism']
        ] = None

```


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
