### PR TITLE
Fix starting standalone dag processor when running as a daemon

### DIFF
--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -71,6 +71,7 @@ def dag_processor(args):
             with ctx:
                 try:
                     manager.register_exit_signals()
+                    manager.start()
                 finally:
                     manager.terminate()
                     manager.end()

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -527,7 +527,7 @@ class DagFileProcessorManager(LoggingMixin):
         self._refresh_dag_dir()
         self.prepare_file_path_queue()
         max_callbacks_per_loop = conf.getint("scheduler", "max_callbacks_per_loop")
-
+        standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
         if self._async_mode:
             # If we're in async mode, we can start up straight away. If we're
             # in sync mode we need to be told to start a "loop"
@@ -578,7 +578,7 @@ class DagFileProcessorManager(LoggingMixin):
                 self.waitables.pop(sentinel)
                 self._processors.pop(processor.file_path)
 
-            if conf.getboolean("scheduler", "standalone_dag_processor"):
+            if standalone_dag_processor:
                 self._fetch_callbacks(max_callbacks_per_loop)
             self._deactivate_stale_dags()
             self._refresh_dag_dir()


### PR DESCRIPTION
Also move reading [scheduler]standalone_dag_processor outside of the loop

See
https://github.com/apache/airflow/pull/22305#discussion_r841004257

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
