### PR TITLE
Remove references to `rbac = True` from docs

### DIFF
--- a/docs/apache-airflow/plugins.rst
+++ b/docs/apache-airflow/plugins.rst
@@ -247,16 +247,6 @@ definitions in Airflow.
 
 .. seealso:: :doc:`/howto/define_extra_link`
 
-Note on role based views
-------------------------
-
-Airflow 1.10 introduced role based views using FlaskAppBuilder. You can configure which UI is used by setting
-``rbac = True``. To support plugin views and links for both versions of the UI and maintain backwards compatibility,
-the fields ``appbuilder_views`` and ``appbuilder_menu_items`` were added to the ``AirflowTestPlugin`` class.
-
-``appbuilder_views`` supports both views-with-menu and views-without-menu - to add a view with menu link, add a "name"
-key in view's package dictionary, otherwise the view is added to flask appbuilder without menu item.
-
 Exclude views from CSRF protection
 ----------------------------------
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -96,16 +96,9 @@ Please use command line interface ``airflow users create`` to create accounts, o
 Other Methods
 '''''''''''''
 
-Since the Airflow 2.0, the default UI is the Flask App Builder RBAC. A ``webserver_config.py`` configuration file
+Since Airflow 2.0, the default UI is the Flask App Builder RBAC. A ``webserver_config.py`` configuration file
 is automatically generated and can be used to configure the Airflow to support authentication
 methods like OAuth, OpenID, LDAP, REMOTE_USER.
-
-For previous versions from Airflow, the ``$AIRFLOW_HOME/airflow.cfg`` following entry needs to be set to enable
-the Flask App Builder RBAC UI.
-
-.. code-block:: ini
-
-    rbac = True
 
 The default authentication option described in the :ref:`Web Authentication <web-authentication>` section is related
 with the following entry in the ``$AIRFLOW_HOME/webserver_config.py``.


### PR DESCRIPTION
Removing `rbac = True` paragraphs from the docs.
This is Airflow 1.10 info which is not relevant for Airflow 2 documentation.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
