### PR TITLE
KubernetesPodOperator should patch "already checked" always

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -404,14 +404,14 @@ class KubernetesPodOperator(BaseOperator):
 
     def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod):
         pod_phase = remote_pod.status.phase if hasattr(remote_pod, 'status') else None
+        if not self.is_delete_operator_pod:
+            with _suppress(Exception):
+                self.patch_already_checked(pod)
         if pod_phase != PodPhase.SUCCEEDED:
             if self.log_events_on_failure:
                 with _suppress(Exception):
                     for event in self.pod_manager.read_pod_events(pod).items:
                         self.log.error("Pod Event: %s - %s", event.reason, event.message)
-            if not self.is_delete_operator_pod:
-                with _suppress(Exception):
-                    self.patch_already_checked(pod)
             with _suppress(Exception):
                 self.process_pod_deletion(pod)
             error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -22,6 +22,7 @@ import shutil
 import sys
 import textwrap
 import unittest
+from copy import copy
 from unittest import mock
 from unittest.mock import ANY, MagicMock
 
@@ -167,8 +168,10 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         )
         context = create_context(k)
         k.execute(context)
+        expected_pod = copy(self.expected_pod)
+        expected_pod['metadata']['labels']['already_checked'] = 'True'
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        assert self.expected_pod == actual_pod
+        assert expected_pod == actual_pod
 
     def test_working_pod(self):
         k = KubernetesPodOperator(
@@ -404,14 +407,16 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k.execute(context=context)
             mock_logger.info.assert_any_call('retrieved from mount')
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-            self.expected_pod['spec']['containers'][0]['args'] = args
-            self.expected_pod['spec']['containers'][0]['volumeMounts'] = [
+            expected_pod = copy(self.expected_pod)
+            expected_pod['spec']['containers'][0]['args'] = args
+            expected_pod['spec']['containers'][0]['volumeMounts'] = [
                 {'name': 'test-volume', 'mountPath': '/tmp/test_volume', 'readOnly': False}
             ]
-            self.expected_pod['spec']['volumes'] = [
+            expected_pod['spec']['volumes'] = [
                 {'name': 'test-volume', 'persistentVolumeClaim': {'claimName': 'test-volume'}}
             ]
-            assert self.expected_pod == actual_pod
+            # expected_pod['metadata']['labels']['already_checked'] = 'True'
+            assert expected_pod == actual_pod
 
     def test_run_as_user_root(self):
         security_context = {
@@ -760,6 +765,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             'kubernetes_pod_operator': 'True',
             'task_id': mock.ANY,
             'try_number': '1',
+            'already_checked': 'True',
         }
         assert k.pod.spec.containers[0].env == [k8s.V1EnvVar(name="env_name", value="value")]
         assert result == {"hello": "world"}
@@ -982,19 +988,23 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         client = kube_client.get_kube_client(in_cluster=False)
         name = "test"
         namespace = "default"
-        k = KubernetesPodOperator(
-            namespace='default',
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["exit 1"],
-            labels={"foo": "bar"},
-            name="test",
-            task_id=name,
-            in_cluster=False,
-            do_xcom_push=False,
-            is_delete_operator_pod=False,
-            termination_grace_period=0,
-        )
+
+        def get_op():
+            return KubernetesPodOperator(
+                namespace='default',
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["exit 1"],
+                labels={"foo": "bar"},
+                name="test",
+                task_id=name,
+                in_cluster=False,
+                do_xcom_push=False,
+                is_delete_operator_pod=False,
+                termination_grace_period=0,
+            )
+
+        k = get_op()
 
         context = create_context(k)
 
@@ -1004,9 +1014,14 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ) as await_pod_completion_mock:
             pod_mock = MagicMock()
 
-            # we don't want failure because we don't want the pod to be patched as "already_checked"
             pod_mock.status.phase = 'Succeeded'
             await_pod_completion_mock.return_value = pod_mock
+
+            # we want to simulate that there was a worker failure and the airflow operator process
+            # was killed without running the cleanup process.  in this case the pod will not be marked as
+            # already checked
+            k.cleanup = MagicMock()
+
             k.execute(context)
             name = k.pod.metadata.name
             pod = client.read_namespaced_pod(name=name, namespace=namespace)
@@ -1014,7 +1029,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 pod = client.read_namespaced_pod(name=name, namespace=namespace)
             assert 'already_checked' not in pod.metadata.labels
 
-        # should not call `create_pod`, because there's a pod there it should find
+        # create a new version of the same operator instance to remove the monkey patching in first
+        # part of the test
+        k = get_op()
+
+        # `create_pod` should not be called because there's a pod there it should find
         # should use the found pod and patch as "already_checked" (in failure block)
         with mock.patch(
             "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.create_pod"
@@ -1024,6 +1043,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             pod = client.read_namespaced_pod(name=name, namespace=namespace)
             assert pod.metadata.labels["already_checked"] == "True"
             create_mock.assert_not_called()
+
+        # recreate op just to ensure we're not relying on any statefulness
+        k = get_op()
 
         # `create_pod` should be called because though there's still a pod to be found,
         # it will be `already_checked`

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -402,6 +402,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 task_id="task" + self.get_current_task_name(),
                 in_cluster=False,
                 do_xcom_push=False,
+                is_delete_operator_pod=False,
             )
             context = create_context(k)
             k.execute(context=context)
@@ -415,7 +416,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             expected_pod['spec']['volumes'] = [
                 {'name': 'test-volume', 'persistentVolumeClaim': {'claimName': 'test-volume'}}
             ]
-            # expected_pod['metadata']['labels']['already_checked'] = 'True'
+            expected_pod['metadata']['labels']['already_checked'] = 'True'
             assert expected_pod == actual_pod
 
     def test_run_as_user_root(self):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -402,22 +402,19 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 task_id="task" + self.get_current_task_name(),
                 in_cluster=False,
                 do_xcom_push=False,
-                is_delete_operator_pod=False,
             )
             context = create_context(k)
             k.execute(context=context)
             mock_logger.info.assert_any_call('retrieved from mount')
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-            expected_pod = copy(self.expected_pod)
-            expected_pod['spec']['containers'][0]['args'] = args
-            expected_pod['spec']['containers'][0]['volumeMounts'] = [
+            self.expected_pod['spec']['containers'][0]['args'] = args
+            self.expected_pod['spec']['containers'][0]['volumeMounts'] = [
                 {'name': 'test-volume', 'mountPath': '/tmp/test_volume', 'readOnly': False}
             ]
-            expected_pod['spec']['volumes'] = [
+            self.expected_pod['spec']['volumes'] = [
                 {'name': 'test-volume', 'persistentVolumeClaim': {'claimName': 'test-volume'}}
             ]
-            expected_pod['metadata']['labels']['already_checked'] = 'True'
-            assert expected_pod == actual_pod
+            assert self.expected_pod == actual_pod
 
     def test_run_as_user_root(self):
         security_context = {

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -18,6 +18,7 @@
 import json
 import sys
 import unittest
+from copy import copy
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -301,14 +302,16 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k.execute(context=context)
             mock_logger.info.assert_any_call('retrieved from mount')
             actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-            self.expected_pod['spec']['containers'][0]['args'] = args
-            self.expected_pod['spec']['containers'][0]['volumeMounts'] = [
+            expected_pod = copy(self.expected_pod)
+            expected_pod['spec']['containers'][0]['args'] = args
+            expected_pod['spec']['containers'][0]['volumeMounts'] = [
                 {'name': 'test-volume', 'mountPath': '/tmp/test_volume', 'readOnly': False}
             ]
-            self.expected_pod['spec']['volumes'] = [
+            expected_pod['spec']['volumes'] = [
                 {'name': 'test-volume', 'persistentVolumeClaim': {'claimName': 'test-volume'}}
             ]
-            assert self.expected_pod == actual_pod
+            expected_pod['metadata']['labels']['already_checked'] = 'True'
+            assert expected_pod == actual_pod
 
     def test_run_as_user_root(self):
         security_context = {


### PR DESCRIPTION
When not configured to delete pods, at end of task execution the current behavior is to patch the pod as "already checked", but only if pod not successful.  We should also patch when successful so it isn't "reattached" to after a task clear.
