### PR TITLE
Show tasks in grid view based on topological sort.

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1728,7 +1728,7 @@ class DAG(LoggingMixin):
                 else:
                     yield node
 
-        return tuple(*nested_topo(self.task_group))
+        return tuple(nested_topo(self.task_group))
 
     @provide_session
     def set_dag_runs_state(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -26,7 +26,6 @@ import re
 import sys
 import traceback
 import warnings
-from collections import OrderedDict
 from datetime import datetime, timedelta
 from inspect import signature
 from typing import (
@@ -1718,54 +1717,18 @@ class DAG(LoggingMixin):
         Sorts tasks in topographical order, such that a task comes after any of its
         upstream dependencies.
 
-        Heavily inspired by:
-        http://blog.jupo.org/2012/04/06/topological-sorting-acyclic-directed-graphs/
-
-        :param include_subdag_tasks: whether to include tasks in subdags, default to False
-        :return: list of tasks in topological order
+        Deprecated in favour of ``task_group.topological_sort``
         """
-        from airflow.operators.subdag import SubDagOperator  # Avoid circular import
+        from airflow.utils.task_group import TaskGroup
 
-        # convert into an OrderedDict to speedup lookup while keeping order the same
-        graph_unsorted = OrderedDict((task.task_id, task) for task in self.tasks)
-
-        graph_sorted: List[Operator] = []
-
-        # special case
-        if len(self.tasks) == 0:
-            return tuple(graph_sorted)
-
-        # Run until the unsorted graph is empty.
-        while graph_unsorted:
-            # Go through each of the node/edges pairs in the unsorted
-            # graph. If a set of edges doesn't contain any nodes that
-            # haven't been resolved, that is, that are still in the
-            # unsorted graph, remove the pair from the unsorted graph,
-            # and append it to the sorted graph. Note here that by using
-            # using the items() method for iterating, a copy of the
-            # unsorted graph is used, allowing us to modify the unsorted
-            # graph as we move through it. We also keep a flag for
-            # checking that graph is acyclic, which is true if any
-            # nodes are resolved during each pass through the graph. If
-            # not, we need to exit as the graph therefore can't be
-            # sorted.
-            acyclic = False
-            for node in list(graph_unsorted.values()):
-                for edge in node.upstream_list:
-                    if edge.node_id in graph_unsorted:
-                        break
-                # no edges in upstream tasks
+        def nested_topo(group):
+            for node in group.topological_sort(_include_subdag_tasks=include_subdag_tasks):
+                if isinstance(node, TaskGroup):
+                    yield from nested_topo(node)
                 else:
-                    acyclic = True
-                    del graph_unsorted[node.task_id]
-                    graph_sorted.append(node)
-                    if include_subdag_tasks and isinstance(node, SubDagOperator):
-                        graph_sorted.extend(node.subdag.topological_sort(include_subdag_tasks=True))
+                    yield node
 
-            if not acyclic:
-                raise AirflowException(f"A cyclic dependency occurred in dag: {self.dag_id}")
-
-        return tuple(graph_sorted)
+        return list(nested_topo(self.task_group))
 
     @provide_session
     def set_dag_runs_state(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1717,7 +1717,7 @@ class DAG(LoggingMixin):
         Sorts tasks in topographical order, such that a task comes after any of its
         upstream dependencies.
 
-        Deprecated in favour of ``task_group.topological_sort``
+        Deprecated in place of ``task_group.topological_sort``
         """
         from airflow.utils.task_group import TaskGroup
 
@@ -1728,7 +1728,7 @@ class DAG(LoggingMixin):
                 else:
                     yield node
 
-        return list(nested_topo(self.task_group))
+        return tuple(*nested_topo(self.task_group))
 
     @provide_session
     def set_dag_runs_state(

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -147,6 +147,13 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         return self.dag is not None
 
     @property
+    def dag_id(self) -> str:
+        """Returns dag id if it has one or an adhoc/meaningless ID"""
+        if self.dag:
+            return self.dag.dag_id
+        return "_in_memory_dag_"
+
+    @property
     def log(self) -> "Logger":
         raise NotImplementedError()
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -24,7 +24,7 @@ import re
 import weakref
 from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
-from airflow.exceptions import AirflowException, DuplicateTaskIdFound
+from airflow.exceptions import AirflowDagCycleException, AirflowException, DuplicateTaskIdFound
 from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.utils.helpers import validate_group_key
@@ -400,6 +400,69 @@ class TaskGroup(DAGNode):
         if self.task_group:
             self.task_group._remove(self)
         return MappedTaskGroup(group_id=self._group_id, dag=self.dag, mapped_arg=arg)
+
+    def topological_sort(self, _include_subdag_tasks: bool = False):
+        """
+        Sorts children in topographical order, such that a task comes after any of its
+        upstream dependencies.
+
+        Heavily inspired by:
+        http://blog.jupo.org/2012/04/06/topological-sorting-acyclic-directed-graphs/
+
+        :return: list of tasks in topological order
+        """
+        from airflow.operators.subdag import SubDagOperator  # Avoid circular import
+
+        graph_unsorted = copy.copy(self.children)
+
+        graph_sorted: List[DAGNode] = []
+
+        # special case
+        if len(self.children) == 0:
+            return tuple(graph_sorted)
+
+        # Run until the unsorted graph is empty.
+        while graph_unsorted:
+            # Go through each of the node/edges pairs in the unsorted
+            # graph. If a set of edges doesn't contain any nodes that
+            # haven't been resolved, that is, that are still in the
+            # unsorted graph, remove the pair from the unsorted graph,
+            # and append it to the sorted graph. Note here that by using
+            # using the items() method for iterating, a copy of the
+            # unsorted graph is used, allowing us to modify the unsorted
+            # graph as we move through it. We also keep a flag for
+            # checking that graph is acyclic, which is true if any
+            # nodes are resolved during each pass through the graph. If
+            # not, we need to exit as the graph therefore can't be
+            # sorted.
+            acyclic = False
+            for node in list(graph_unsorted.values()):
+                for edge in node.upstream_list:
+                    if edge.node_id in graph_unsorted:
+                        break
+                    # Check for task's group is a child (or grand child) of this TG,
+                    tg = edge.task_group
+                    while tg:
+                        if tg.node_id in graph_unsorted:
+                            break
+                        tg = tg.task_group
+
+                    if tg:
+                        # We are already going to visit that TG
+                        break
+                else:
+                    acyclic = True
+                    del graph_unsorted[node.node_id]
+                    graph_sorted.append(node)
+                    if _include_subdag_tasks and isinstance(node, SubDagOperator):
+                        graph_sorted.extend(
+                            node.subdag.task_group.topological_sort(_include_subdag_tasks=True)
+                        )
+
+            if not acyclic:
+                raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
+
+        return tuple(graph_sorted)
 
 
 class MappedTaskGroup(TaskGroup):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -251,7 +251,7 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
     task_group = task_item_or_group
 
     children = [
-        task_group_to_tree(child, dag, dag_runs, tis, session) for child in task_group.children.values()
+        task_group_to_tree(child, dag, dag_runs, tis, session) for child in task_group.topological_sort()
     ]
 
     def get_summary(dag_run, children):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -255,69 +255,6 @@ class TestDag(unittest.TestCase):
         assert self._occur_before('a_child', 'b_parent', topological_list)
         assert self._occur_before('b_child', 'b_parent', topological_list)
 
-    def test_dag_topological_sort1(self):
-        dag = DAG('dag', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
-        # A -> B
-        # A -> C -> D
-        # ordered: B, D, C, A or D, B, C, A or D, C, B, A
-        with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='D')
-            op1.set_upstream([op2, op3])
-            op3.set_upstream(op4)
-
-        topological_list = dag.topological_sort()
-        logging.info(topological_list)
-
-        tasks = [op2, op3, op4]
-        assert topological_list[0] in tasks
-        tasks.remove(topological_list[0])
-        assert topological_list[1] in tasks
-        tasks.remove(topological_list[1])
-        assert topological_list[2] in tasks
-        tasks.remove(topological_list[2])
-        assert topological_list[3] == op1
-
-    def test_dag_topological_sort2(self):
-        dag = DAG('dag', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
-        # C -> (A u B) -> D
-        # C -> E
-        # ordered: E | D, A | B, C
-        with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='D')
-            op5 = DummyOperator(task_id='E')
-            op1.set_downstream(op3)
-            op2.set_downstream(op3)
-            op1.set_upstream(op4)
-            op2.set_upstream(op4)
-            op5.set_downstream(op3)
-
-        topological_list = dag.topological_sort()
-        logging.info(topological_list)
-
-        set1 = [op4, op5]
-        assert topological_list[0] in set1
-        set1.remove(topological_list[0])
-
-        set2 = [op1, op2]
-        set2.extend(set1)
-        assert topological_list[1] in set2
-        set2.remove(topological_list[1])
-
-        assert topological_list[2] in set2
-        set2.remove(topological_list[2])
-
-        assert topological_list[3] in set2
-
-        assert topological_list[4] == op3
-
     def test_dag_topological_sort_dag_without_tasks(self):
         dag = DAG('dag', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1771,5 +1771,5 @@ def test_mapped_task_group_serde():
         ],
     }
 
-    with DAG("test", start_date=execution_date):
-        SerializedTaskGroup.deserialize_task_group(serialized, None, dag.task_dict)
+    with DAG("test", start_date=execution_date) as new_dag:
+        SerializedTaskGroup.deserialize_task_group(serialized, None, dag.task_dict, new_dag)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1196,6 +1196,7 @@ class TestStringifiedDAGs:
         assert serialized_dag.task_group.children.keys() == dag.task_group.children.keys()
 
         def check_task_group(node):
+            assert node.dag is serialized_dag
             try:
                 children = node.children.values()
             except AttributeError:


### PR DESCRIPTION
This takes the existing topological sort that existed on a DAG and moves
it down to TaskGroup.

In order to do this (and not have duplicated sort) the existing sort on
DAG is re-implemented on top of the new method.

This also surfaced a tiny bug in deserialize_task_group where the
SerializedTaskGroup did not have `dag` set -- it didn't cause any
problems until now but was needed to call `upstream_list` on a
SerializedTaskGroup object.

Fixes https://github.com/apache/airflow/issues/22731