### PR TITLE
Improve Grid view selection rerenders

### DIFF
--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global stateColors, window */
+/* global stateColors */
 
 import React from 'react';
 import { isEqual } from 'lodash';
@@ -56,9 +56,8 @@ const StatusBox = ({
   const onMouseEnter = () => {
     [...containerRef.current.getElementsByClassName(`js-${runId}`)]
       .forEach((e) => {
-        const bg = window.getComputedStyle(e).backgroundColor;
         // Don't apply hover if it is already selected
-        if (bg !== 'rgb(190, 227, 248)') e.style.backgroundColor = hoverBlue;
+        if (e.getAttribute('data-selected') === 'false') e.style.backgroundColor = hoverBlue;
       });
   };
   const onMouseLeave = () => {

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global stateColors */
+/* global stateColors, window */
 
 import React from 'react';
 import { isEqual } from 'lodash';
@@ -29,7 +29,6 @@ import {
 
 import InstanceTooltip from './InstanceTooltip';
 import { useContainerRef } from './context/containerRef';
-import { useSelection } from './context/selection';
 
 export const boxSize = 10;
 export const boxSizePx = `${boxSize}px`;
@@ -46,20 +45,21 @@ export const SimpleStatus = ({ state, ...rest }) => (
 );
 
 const StatusBox = ({
-  group, instance,
+  group, instance, onSelect,
 }) => {
   const containerRef = useContainerRef();
-  const { selected, onSelect } = useSelection();
   const { runId, taskId } = instance;
   const { colors } = useTheme();
   const hoverBlue = `${colors.blue[100]}50`;
 
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {
-    if (selected.runId !== runId) {
-      [...containerRef.current.getElementsByClassName(`js-${runId}`)]
-        .forEach((e) => { e.style.backgroundColor = hoverBlue; });
-    }
+    [...containerRef.current.getElementsByClassName(`js-${runId}`)]
+      .forEach((e) => {
+        const bg = window.getComputedStyle(e).backgroundColor;
+        // Don't apply hover if it is already selected
+        if (bg !== 'rgb(190, 227, 248)') e.style.backgroundColor = hoverBlue;
+      });
   };
   const onMouseLeave = () => {
     [...containerRef.current.getElementsByClassName(`js-${runId}`)]
@@ -103,7 +103,6 @@ const compareProps = (
 ) => (
   isEqual(prevProps.group, nextProps.group)
   && isEqual(prevProps.instance, nextProps.instance)
-  && prevProps.extraLinks === nextProps.extraLinks
 );
 
 export default React.memo(StatusBox, compareProps);

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -72,7 +72,7 @@ const Tree = () => {
       const runsContainer = scrollRef.current;
       // Set initial scroll to top right if it is scrollable
       if (runsContainer && runsContainer.scrollWidth > runsContainer.clientWidth) {
-        runsContainer.scrollBy(runsContainer.clientWidth, 0);
+        runsContainer.scrollBy(tableRef.current.offsetWidth, 0);
       }
     }
   }, [tableRef, isOpen]);

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -59,6 +59,7 @@ const DagRunBar = ({
   return (
     <Box
       className={`js-${run.runId}`}
+      data-selected={isSelected}
       bg={isSelected && 'blue.100'}
       transition="background-color 0.2s"
       px="1px"

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -33,23 +33,20 @@ import { MdPlayArrow } from 'react-icons/md';
 
 import DagRunTooltip from './Tooltip';
 import { useContainerRef } from '../context/containerRef';
-import { useSelection } from '../context/selection';
 import Time from '../Time';
 
 const BAR_HEIGHT = 100;
 
 const DagRunBar = ({
-  run, max, index, totalRuns,
+  run, max, index, totalRuns, isSelected, onSelect,
 }) => {
   const containerRef = useContainerRef();
-  const { selected, onSelect } = useSelection();
   const { colors } = useTheme();
   const hoverBlue = `${colors.blue[100]}50`;
-  const isSelected = run.runId === selected.runId;
 
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {
-    if (selected.runId !== run.runId) {
+    if (!isSelected) {
       [...containerRef.current.getElementsByClassName(`js-${run.runId}`)]
         .forEach((e) => { e.style.backgroundColor = hoverBlue; });
     }
@@ -128,6 +125,7 @@ const compareProps = (
   && prevProps.max === nextProps.max
   && prevProps.index === nextProps.index
   && prevProps.totalRuns === nextProps.totalRuns
+  && prevProps.isSelected === nextProps.isSelected
 );
 
 export default React.memo(DagRunBar, compareProps);

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -29,6 +29,7 @@ import {
 import { useTreeData } from '../api';
 import DagRunBar from './Bar';
 import { getDuration, formatDuration } from '../../datetime_utils';
+import { useSelection } from '../context/selection';
 
 const DurationTick = ({ children, ...rest }) => (
   <Text fontSize={10} color="gray.400" right={1} position="absolute" whiteSpace="nowrap" {...rest}>
@@ -38,6 +39,7 @@ const DurationTick = ({ children, ...rest }) => (
 
 const DagRuns = ({ tableWidth }) => {
   const { data: { dagRuns = [] } } = useTreeData();
+  const { selected, onSelect } = useSelection();
   const durations = [];
   const runs = dagRuns.map((dagRun) => {
     const duration = getDuration(dagRun.startDate, dagRun.endDate);
@@ -99,6 +101,8 @@ const DagRuns = ({ tableWidth }) => {
               max={max}
               index={i}
               totalRuns={runs.length}
+              isSelected={run.runId === selected.runId}
+              onSelect={onSelect}
             />
           ))}
         </Flex>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -56,7 +56,7 @@ const renderTaskRows = ({
 ));
 
 const TaskInstances = ({
-  task, dagRunIds, selectedRunId,
+  task, dagRunIds, selectedRunId, onSelect,
 }) => (
   <Flex justifyContent="flex-end">
     {dagRunIds.map((runId) => {
@@ -75,8 +75,8 @@ const TaskInstances = ({
             ? (
               <StatusBox
                 instance={instance}
-                extraLinks={task.extraLinks}
                 group={task}
+                onSelect={onSelect}
               />
             )
             : <Box width={boxSizePx} data-testid="blank-task" />}
@@ -96,7 +96,7 @@ const Row = (props) => {
     tableWidth,
   } = props;
   const { colors } = useTheme();
-  const { selected } = useSelection();
+  const { selected, onSelect } = useSelection();
 
   const hoverBlue = `${colors.blue[100]}50`;
   const isGroup = !!task.children;
@@ -171,6 +171,7 @@ const Row = (props) => {
               dagRunIds={dagRunIds}
               task={task}
               selectedRunId={selected.runId}
+              onSelect={onSelect}
             />
           </Collapse>
         </Td>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -62,14 +62,16 @@ const TaskInstances = ({
     {dagRunIds.map((runId) => {
       // Check if an instance exists for the run, or return an empty box
       const instance = task.instances.find((gi) => gi.runId === runId);
+      const isSelected = selectedRunId === runId;
       return (
         <Box
           py="4px"
           px={boxPaddingPx}
           className={`js-${runId}`}
+          data-selected={isSelected}
           transition="background-color 0.2s"
           key={`${runId}-${task.id}`}
-          bg={selectedRunId === runId && 'blue.100'}
+          bg={isSelected && 'blue.100'}
         >
           {instance
             ? (


### PR DESCRIPTION
When creating a context provider for what task instance or dag run was selected, it broke some of the memoization and too many components were rerendering whenever a user clicked on a new instance. To fix this, the `useSelection` hook is moved outside of the memoized components.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
