### PR TITLE
Fix wrong reference in tracking-user-activity.rst

### DIFF
--- a/docs/apache-airflow/logging-monitoring/tracking-user-activity.rst
+++ b/docs/apache-airflow/logging-monitoring/tracking-user-activity.rst
@@ -32,7 +32,7 @@ Edit ``airflow.cfg`` and set the ``webserver`` block to have an ``analytics_tool
   analytics_id = XXXXXXXXXXX
 
 .. note:: You can see view injected tracker html within Airflow's source code at
-  ``airflow/www/templates/appbuilder/baselayout.html``. The related global
+  ``airflow/www/templates/airflow/main.html``. The related global
   variables are set in ``airflow/www/templates/app.py``.
 
 .. note::


### PR DESCRIPTION
The path of the file was changed in https://github.com/apache/airflow/pull/7366


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
