### PR TITLE
 Raise exception if src file does not exist while using LocalFilesystemToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/local_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/local_to_gcs.py
@@ -109,6 +109,13 @@ class LocalFilesystemToGCSOperator(BaseOperator):
         )
 
         filepaths = self.src if isinstance(self.src, list) else glob(self.src)
+        if len(filepaths) < 1:
+            raise ValueError("'src' parameter references filepath. Please specify the src file")
+        else:
+            for file in filepaths:
+                if not os.path.exists(file):
+                    raise ValueError("File %s does not exists", file)
+
         if os.path.basename(self.dst):  # path to a file
             if len(filepaths) > 1:  # multiple file upload
                 raise ValueError(


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/22705

This PR provides an exception if the src file does not exist while copying file from src to dest using the LocalFilesystemToGCSOperator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
