### PR TITLE
Remove extraneous treeData fields

### DIFF
--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -37,6 +37,7 @@ import ClearRun from './ClearRun';
 import { useTreeData } from '../../../api';
 import { appendSearchParams, getMetaValue } from '../../../../utils';
 
+const dagId = getMetaValue('dag_id');
 const graphUrl = getMetaValue('graph_url');
 const dagRunDetailsUrl = getMetaValue('dagrun_details_url');
 
@@ -46,7 +47,6 @@ const DagRun = ({ runId }) => {
   if (!run) return null;
   const {
     executionDate,
-    dagId,
     state,
     runType,
     duration,

--- a/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
@@ -29,8 +29,8 @@ import { getDuration, formatDuration } from '../../../../datetime_utils';
 import { SimpleStatus } from '../../../StatusBox';
 import Time from '../../../Time';
 
-const Details = ({ instance, task }) => {
-  const isGroup = !!task.children;
+const Details = ({ instance, group, operator }) => {
+  const isGroup = !!group.children;
   const groupSummary = [];
   const mapSummary = [];
 
@@ -38,16 +38,21 @@ const Details = ({ instance, task }) => {
     taskId,
     runId,
     duration,
-    operator,
     startDate,
     endDate,
     state,
     mappedStates,
   } = instance;
 
+  const {
+    isMapped,
+    children,
+    tooltip,
+  } = group;
+
   if (isGroup) {
     const numMap = finalStatesMap();
-    task.children.forEach((child) => {
+    children.forEach((child) => {
       const taskInstance = child.instances.find((ti) => ti.runId === runId);
       if (taskInstance) {
         const stateKey = taskInstance.state == null ? 'no_status' : taskInstance.state;
@@ -68,7 +73,7 @@ const Details = ({ instance, task }) => {
     });
   }
 
-  if (task.isMapped && mappedStates) {
+  if (isMapped && mappedStates) {
     const numMap = finalStatesMap();
     mappedStates.forEach((s) => {
       const stateKey = s || 'no_status';
@@ -94,8 +99,8 @@ const Details = ({ instance, task }) => {
   return (
     <Flex flexWrap="wrap" justifyContent="space-between">
       <Box>
-        {task.tooltip && (
-          <Text>{task.tooltip}</Text>
+        {tooltip && (
+          <Text>{tooltip}</Text>
         )}
         <Flex alignItems="center">
           <Text as="strong">Status:</Text>
@@ -109,7 +114,7 @@ const Details = ({ instance, task }) => {
             {groupSummary}
           </>
         )}
-        {task.isMapped && (
+        {isMapped && (
           <>
             <br />
             <Text as="strong">

--- a/airflow/www/static/js/tree/details/content/taskInstance/Nav.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Nav.jsx
@@ -27,6 +27,7 @@ import {
 
 import { getMetaValue, appendSearchParams } from '../../../../utils';
 
+const dagId = getMetaValue('dag_id');
 const isK8sExecutor = getMetaValue('k8s_or_k8scelery_executor') === 'True';
 const numRuns = getMetaValue('num_runs');
 const baseDate = getMetaValue('base_date');
@@ -40,14 +41,9 @@ const gridUrlNoRoot = getMetaValue('grid_url_no_root');
 
 const LinkButton = ({ children, ...rest }) => (<Button as={Link} variant="ghost" colorScheme="blue" {...rest}>{children}</Button>);
 
-const Nav = ({ instance, isMapped }) => {
-  const {
-    taskId,
-    dagId,
-    operator,
-    executionDate,
-  } = instance;
-
+const Nav = ({
+  taskId, executionDate, operator, isMapped,
+}) => {
   const params = new URLSearchParams({
     task_id: taskId,
     execution_date: executionDate,

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
@@ -72,7 +72,7 @@ const MarkFailed = ({
       setAffectedTasks(data);
       onOpen();
     } catch (e) {
-      console.log(e);
+      console.error(e);
     }
   };
 

--- a/airflow/www/static/js/tree/treeDataUtils.js
+++ b/airflow/www/static/js/tree/treeDataUtils.js
@@ -19,7 +19,7 @@
 
 import camelcaseKeys from 'camelcase-keys';
 
-export const areActiveRuns = (runs) => runs.filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
+export const areActiveRuns = (runs = []) => runs.filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
 
 export const formatData = (data, emptyData) => {
   if (!data || !Object.keys(data).length) {

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -114,15 +114,12 @@ def get_mapped_summary(parent_instance, task_instances):
         else parent_instance.try_number
     )
     return {
-        'dag_id': parent_instance.dag_id,
         'task_id': parent_instance.task_id,
         'run_id': parent_instance.run_id,
         'state': group_state,
         'start_date': group_start_date,
         'end_date': group_end_date,
         'mapped_states': mapped_states,
-        'operator': parent_instance.operator,
-        'execution_date': datetime_to_string(parent_instance.execution_date),
         'try_number': try_count,
     }
 
@@ -143,15 +140,12 @@ def encode_ti(
     )
     return {
         'task_id': task_instance.task_id,
-        'dag_id': task_instance.dag_id,
         'run_id': task_instance.run_id,
         'map_index': task_instance.map_index,
         'state': task_instance.state,
         'duration': task_instance.duration,
         'start_date': datetime_to_string(task_instance.start_date),
         'end_date': datetime_to_string(task_instance.end_date),
-        'operator': task_instance.operator,
-        'execution_date': datetime_to_string(task_instance.execution_date),
         'try_number': try_count,
     }
 
@@ -161,7 +155,6 @@ def encode_dag_run(dag_run: Optional[models.DagRun]) -> Optional[Dict[str, Any]]
         return None
 
     return {
-        'dag_id': dag_run.dag_id,
         'run_id': dag_run.run_id,
         'start_date': datetime_to_string(dag_run.start_date),
         'end_date': datetime_to_string(dag_run.end_date),


### PR DESCRIPTION
The `treeData` object that is used to render the Grid view can get large very fast. One way to reduce that, and parse the data faster, is to remove extraneous fields. `dagId` `executionDate` and `operator` could all be inferred from existing data in the react app.

Follow-up: https://github.com/apache/airflow/pull/22765

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
