### PR TITLE
Add summary of runs to dag details

### DIFF
--- a/airflow/www/static/js/tree/details/content/Dag.jsx
+++ b/airflow/www/static/js/tree/details/content/Dag.jsx
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-/* global moment */
-
 import React from 'react';
 import {
   Table,
@@ -27,7 +25,6 @@ import {
   Td,
   Tag,
   Text,
-  Code,
   Link,
   Button,
   Flex,
@@ -48,9 +45,7 @@ const Dag = () => {
   const { data: { dagRuns = [] } } = useTreeData();
   if (!dag || !taskData) return null;
   const { tasks = [], totalEntries = '' } = taskData;
-  const {
-    description, tags, fileloc, owners, catchup, startDate, timezone, dagRunTimeout,
-  } = dag;
+  const { description, tags } = dag;
 
   // Build a key/value object of operator counts, the name is hidden inside of t.classRef.className
   const operators = {};
@@ -155,12 +150,6 @@ const Dag = () => {
           </Tr>
           )}
           <Tr>
-            <Td>Start Date</Td>
-            <Td>
-              <Time dateTime={startDate} />
-            </Td>
-          </Tr>
-          <Tr>
             <Td>Total Tasks</Td>
             <Td>{totalEntries}</Td>
           </Tr>
@@ -187,28 +176,6 @@ const Dag = () => {
             </Td>
           </Tr>
           )}
-          <Tr>
-            <Td>Catchup</Td>
-            <Td>{catchup ? 'True' : 'False'}</Td>
-          </Tr>
-          <Tr>
-            <Td>Owners</Td>
-            <Td>{owners.map((o) => <Text key={o} mr={1}>{o}</Text>)}</Td>
-          </Tr>
-          <Tr>
-            <Td>Relative File Location</Td>
-            <Td><Code colorScheme="blackAlpha" maxWidth="450px" fontSize="12px">{fileloc}</Code></Td>
-          </Tr>
-          {dagRunTimeout && (
-          <Tr>
-            <Td>DAG Run Timeout</Td>
-            <Td>{formatDuration(moment.duration(dagRunTimeout.days, 'd').add(dagRunTimeout.seconds, 's'))}</Td>
-          </Tr>
-          )}
-          <Tr>
-            <Td>DAG Timezone</Td>
-            <Td>{timezone}</Td>
-          </Tr>
         </Tbody>
       </Table>
     </>

--- a/airflow/www/static/js/tree/details/content/Dag.jsx
+++ b/airflow/www/static/js/tree/details/content/Dag.jsx
@@ -45,7 +45,7 @@ const dagDetailsUrl = getMetaValue('dag_details_url');
 const Dag = () => {
   const { data: dag } = useDag(dagId);
   const { data: taskData } = useTasks(dagId);
-  const { data: { groups = {}, dagRuns = [] } } = useTreeData();
+  const { data: { dagRuns = [] } } = useTreeData();
   if (!dag || !taskData) return null;
   const { tasks = [], totalEntries = '' } = taskData;
   const {
@@ -63,13 +63,8 @@ const Dag = () => {
   });
 
   const durations = [];
-  const runs = dagRuns.map((dagRun) => {
-    const duration = getDuration(dagRun.startDate, dagRun.endDate);
-    durations.push(duration);
-    return {
-      ...dagRun,
-      duration,
-    };
+  dagRuns.forEach((dagRun) => {
+    durations.push(getDuration(dagRun.startDate, dagRun.endDate));
   });
 
   // calculate dag run bar heights relative to max

--- a/airflow/www/static/js/tree/details/content/Dag.jsx
+++ b/airflow/www/static/js/tree/details/content/Dag.jsx
@@ -35,7 +35,7 @@ import {
 import { mean } from 'lodash';
 
 import { getDuration, formatDuration } from '../../../datetime_utils';
-import { getMetaValue } from '../../../utils';
+import { finalStatesMap, getMetaValue } from '../../../utils';
 import { useDag, useTasks, useTreeData } from '../../api';
 import Time from '../../Time';
 
@@ -62,9 +62,31 @@ const Dag = () => {
     }
   });
 
+  const numMap = finalStatesMap();
   const durations = [];
   dagRuns.forEach((dagRun) => {
     durations.push(getDuration(dagRun.startDate, dagRun.endDate));
+    const stateKey = dagRun.state == null ? 'no_status' : dagRun.state;
+    if (numMap.has(stateKey)) numMap.set(stateKey, numMap.get(stateKey) + 1);
+  });
+
+  const stateSummary = [];
+  numMap.forEach((key, val) => {
+    if (key > 0) {
+      stateSummary.push(
+        // eslint-disable-next-line react/no-array-index-key
+        <Tr key={val}>
+          <Td>
+            Total
+            {' '}
+            {val}
+          </Td>
+          <Td>
+            {key}
+          </Td>
+        </Tr>,
+      );
+    }
   });
 
   // calculate dag run bar heights relative to max
@@ -79,13 +101,25 @@ const Dag = () => {
       </Button>
       {durations.length > 0 && (
         <>
-          <Text my={3}>DAG Runs Summary</Text>
+          <Text mt={4} mb={2}>DAG Runs Summary</Text>
           <Table variant="striped">
             <Tbody>
               <Tr>
                 <Td>Total Runs Displayed</Td>
                 <Td>
                   {durations.length}
+                </Td>
+              </Tr>
+              <Tr>
+                <Td>First Run Start</Td>
+                <Td>
+                  <Time dateTime={dagRuns[0].startDate} />
+                </Td>
+              </Tr>
+              <Tr>
+                <Td>Last Run Start</Td>
+                <Td>
+                  <Time dateTime={dagRuns[dagRuns.length - 1].startDate} />
                 </Td>
               </Tr>
               <Tr>
@@ -106,11 +140,12 @@ const Dag = () => {
                   {formatDuration(min)}
                 </Td>
               </Tr>
+              {stateSummary}
             </Tbody>
           </Table>
         </>
       )}
-      <Text my={3}>DAG Summary</Text>
+      <Text mt={4} mb={2}>DAG Summary</Text>
       <Table variant="striped">
         <Tbody>
           {description && (

--- a/airflow/www/static/js/tree/details/content/Dag.jsx
+++ b/airflow/www/static/js/tree/details/content/Dag.jsx
@@ -24,10 +24,10 @@ import {
   Tr,
   Td,
   Tag,
-  Text,
   Link,
   Button,
   Flex,
+  Heading,
 } from '@chakra-ui/react';
 import { mean } from 'lodash';
 
@@ -96,7 +96,7 @@ const Dag = () => {
       </Button>
       {durations.length > 0 && (
         <>
-          <Text mt={4} mb={2}>DAG Runs Summary</Text>
+          <Heading size="md" mt={4} mb={2}>DAG Runs Summary</Heading>
           <Table variant="striped">
             <Tbody>
               <Tr>
@@ -140,7 +140,7 @@ const Dag = () => {
           </Table>
         </>
       )}
-      <Text mt={4} mb={2}>DAG Summary</Text>
+      <Heading size="md" mt={4} mb={2}>DAG Summary</Heading>
       <Table variant="striped">
         <Tbody>
           {description && (


### PR DESCRIPTION
The default details panel of DAG details was fairly basic. This PR adds a summary of the dag runs currently displayed by the Grid view to the DAG details. I also removed a few less-important fields that are redundant with the Dag Details that the panel already links to.

<img width="950" alt="Screen Shot 2022-04-06 at 12 10 12 AM" src="https://user-images.githubusercontent.com/4600967/161894081-e15c4dbf-4ccf-4be4-8f44-a0dc007af571.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
