### PR TITLE
Fix `email_on_failure` with `render_template_as_native_obj`

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -106,7 +106,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def node_id(self) -> str:
         return self.task_id
 
-    def get_template_env(self) -> "jinja2.Environment":
+    def get_template_env(self, force_sandboxed: bool = False) -> "jinja2.Environment":
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
         # This is imported locally since Jinja2 is heavy and we don't need it
         # for most of the functionalities. It is imported by get_template_env()
@@ -115,7 +115,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
         dag = self.get_dag()
         if dag:
-            return dag.get_template_env()
+            return dag.get_template_env(force_sandboxed=force_sandboxed)
         return SandboxedEnvironment(cache_size=0)
 
     def prepare_template(self) -> None:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -106,7 +106,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def node_id(self) -> str:
         return self.task_id
 
-    def get_template_env(self, force_sandboxed: bool = False) -> "jinja2.Environment":
+    def get_template_env(self, *, force_sandboxed: bool = False) -> "jinja2.Environment":
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
         # This is imported locally since Jinja2 is heavy and we don't need it
         # for most of the functionalities. It is imported by get_template_env()

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -106,7 +106,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def node_id(self) -> str:
         return self.task_id
 
-    def get_template_env(self, *, force_sandboxed: bool = False) -> "jinja2.Environment":
+    def get_template_env(self) -> "jinja2.Environment":
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
         # This is imported locally since Jinja2 is heavy and we don't need it
         # for most of the functionalities. It is imported by get_template_env()
@@ -115,7 +115,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
         dag = self.get_dag()
         if dag:
-            return dag.get_template_env(force_sandboxed=force_sandboxed)
+            return dag.get_template_env(force_sandboxed=False)
         return SandboxedEnvironment(cache_size=0)
 
     def prepare_template(self) -> None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1260,7 +1260,7 @@ class DAG(LoggingMixin):
         for t in self.tasks:
             t.resolve_template_files()
 
-    def get_template_env(self) -> jinja2.Environment:
+    def get_template_env(self, force_sandboxed: bool = False) -> jinja2.Environment:
         """Build a Jinja2 environment."""
         # Collect directories to search for template files
         searchpath = [self.folder]
@@ -1277,7 +1277,7 @@ class DAG(LoggingMixin):
         if self.jinja_environment_kwargs:
             jinja_env_options.update(self.jinja_environment_kwargs)
         env: jinja2.Environment
-        if self.render_template_as_native_obj:
+        if self.render_template_as_native_obj and not force_sandboxed:
             env = airflow.templates.NativeEnvironment(**jinja_env_options)
         else:
             env = airflow.templates.SandboxedEnvironment(**jinja_env_options)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1260,7 +1260,7 @@ class DAG(LoggingMixin):
         for t in self.tasks:
             t.resolve_template_files()
 
-    def get_template_env(self, force_sandboxed: bool = False) -> jinja2.Environment:
+    def get_template_env(self, *, force_sandboxed: bool = False) -> jinja2.Environment:
         """Build a Jinja2 environment."""
         # Collect directories to search for template files
         searchpath = [self.folder]

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -100,6 +100,7 @@ from airflow.models.xcom import XCOM_RETURN_KEY, XCom
 from airflow.plugins_manager import integrate_macros_plugins
 from airflow.sentry import Sentry
 from airflow.stats import Stats
+from airflow.templates import SandboxedEnvironment
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.timetables.base import DataInterval
@@ -2196,7 +2197,14 @@ class TaskInstance(Base, LoggingMixin):
             html_content_err = jinja_env.from_string(default_html_content_err).render(**default_context)
 
         else:
-            jinja_env = self.task.dag.get_template_env(force_sandboxed=True)
+            # Use the DAG's get_template_env() to set force_sandboxed. Don't add
+            # the flag to the function on task object -- that function can be
+            # overridden, and adding a flag breaks backward compatibility.
+            dag = self.task.get_dag()
+            if dag:
+                jinja_env = dag.get_template_env(force_sandboxed=True)
+            else:
+                jinja_env = SandboxedEnvironment(cache_size=0)
             jinja_context = self.get_template_context()
             context_merge(jinja_context, additional_context)
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2196,7 +2196,7 @@ class TaskInstance(Base, LoggingMixin):
             html_content_err = jinja_env.from_string(default_html_content_err).render(**default_context)
 
         else:
-            jinja_env = self.task.get_template_env()
+            jinja_env = self.task.get_template_env(force_sandboxed=True)
             jinja_context = self.get_template_context()
             context_merge(jinja_context, additional_context)
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2196,7 +2196,7 @@ class TaskInstance(Base, LoggingMixin):
             html_content_err = jinja_env.from_string(default_html_content_err).render(**default_context)
 
         else:
-            jinja_env = self.task.get_template_env(force_sandboxed=True)
+            jinja_env = self.task.dag.get_template_env(force_sandboxed=True)
             jinja_context = self.get_template_context()
             context_merge(jinja_context, additional_context)
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -476,6 +476,7 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand(
         [
+            (False, True, SandboxedEnvironment),
             (False, False, SandboxedEnvironment),
             (True, False, NativeEnvironment),
             (True, True, SandboxedEnvironment),

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -51,6 +51,7 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.subdag import SubDagOperator
 from airflow.security import permissions
+from airflow.templates import NativeEnvironment, SandboxedEnvironment
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.utils import timezone
@@ -472,6 +473,18 @@ class TestDag(unittest.TestCase):
         dag = DAG("test-dag", template_undefined=jinja2.Undefined)
         jinja_env = dag.get_template_env()
         assert jinja_env.undefined is jinja2.Undefined
+
+    @parameterized.expand(
+        [
+            (False, False, SandboxedEnvironment),
+            (True, False, NativeEnvironment),
+            (True, True, SandboxedEnvironment),
+        ],
+    )
+    def test_template_env(self, use_native_obj, force_sandboxed, expected_env):
+        dag = DAG("test-dag", render_template_as_native_obj=use_native_obj)
+        jinja_env = dag.get_template_env(force_sandboxed=force_sandboxed)
+        assert isinstance(jinja_env, expected_env)
 
     def test_resolve_template_files_value(self):
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1311,9 +1311,10 @@ class TestTaskInstance:
 
         assert params["override"] is False
 
+    @pytest.mark.parametrize("use_native_obj", [True, False])
     @patch('airflow.models.taskinstance.send_email')
-    def test_email_alert(self, mock_send_email, dag_maker):
-        with dag_maker(dag_id='test_failure_email'):
+    def test_email_alert(self, mock_send_email, dag_maker, use_native_obj):
+        with dag_maker(dag_id='test_failure_email', render_template_as_native_obj=use_native_obj):
             task = BashOperator(task_id='test_email_alert', bash_command='exit 1', email='to')
         ti = dag_maker.create_dagrun(execution_date=timezone.utcnow()).task_instances[0]
         ti.task = task


### PR DESCRIPTION
Co-authored-by: andyhuang <andyhuang@mirrormedia.mg>

Closes: #22152
Alternative of #22218, refactored to only change behavior when generating emails and including test coverage.

cc @andyfcx