### PR TITLE
Fix deprecation warning due to using query.value

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1074,14 +1074,12 @@ class DAG(LoggingMixin):
     @provide_session
     def get_is_active(self, session=NEW_SESSION) -> Optional[None]:
         """Returns a boolean indicating whether this DAG is active"""
-        qry = session.query(DagModel).filter(DagModel.dag_id == self.dag_id)
-        return qry.value(DagModel.is_active)
+        return session.query(DagModel.is_active).filter(DagModel.dag_id == self.dag_id).scalar()
 
     @provide_session
     def get_is_paused(self, session=NEW_SESSION) -> Optional[None]:
         """Returns a boolean indicating whether this DAG is paused"""
-        qry = session.query(DagModel).filter(DagModel.dag_id == self.dag_id)
-        return qry.value(DagModel.is_paused)
+        return session.query(DagModel.is_paused).filter(DagModel.dag_id == self.dag_id).scalar()
 
     @property
     def is_paused(self):


### PR DESCRIPTION
When using sqlalchemy 1.4, there's a deprecation warning at the task logging:

SADeprecationWarning: Query.value() is deprecated and will be removed
in a future release.  Please use Query.with_entities() in combination
with Query.scalar() (deprecated since: 1.4)

This PR fixes it

