### PR TITLE
Remove json parse for gantt chart

### DIFF
--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -76,9 +76,8 @@
   {{ super() }}
   <script src="{{ url_for_asset('d3.min.js') }}"></script>
   <script src="{{ url_for_asset('d3-tip.js') }}"></script>
-  <script src="{{ url_for_asset('gantt.js') }}"></script>
   <script>
-    // Loading data via <meta> wasn't loading extra_links in a task
-    const data = JSON.parse('{{ data|tojson }}');
+    const data = {{ data|tojson }};
   </script>
+  <script src="{{ url_for_asset('gantt.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
I added `JSON.parse()` to the data in the gantt view when migrating the js over to its own file. But, if we load the page a little differently, we don't actually need to do that. Saving potential issues is JSON.parse fails.

Maybe related: https://github.com/apache/airflow/issues/22702

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
