### PR TITLE
Fix SQLALchemy warning about conflicting relationships

### DIFF
--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -72,6 +72,7 @@ class RenderedTaskInstanceFields(Base):
             RenderedTaskInstanceFields.dag_id == foreign(DagRun.dag_id),
             RenderedTaskInstanceFields.run_id == foreign(DagRun.run_id),
         )""",
+        viewonly=True,
     )
 
     execution_date = association_proxy("dag_run", "execution_date")


### PR DESCRIPTION
Running airflow commands print out warnings about conflicting relationships.

```
SAWarning: relationship 'DagRun.serialized_dag' will copy column serialized_dag.dag_id
 to column dag_run.dag_id, which conflicts with relationship(s): 'RenderedTaskInstanceFields.dag_run'
 (copies rendered_task_instance_fields.dag_id to dag_run.dag_id). If this is not the intention,
 consider if these relationships should be linked with back_populates, or if viewonly=True
should be applied to one or more if they are read-only. For the less common case that foreign
key constraints are partially overlapping, the orm.foreign() annotation can be used to
isolate the columns that should be written towards.   The 'overlaps' parameter may be used to remove
 this warning. (Background on this error at: http://sqlalche.me/e/14/qzyx)
/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/relationships.py:3463 SAWarning:
relationship 'SerializedDagModel.dag_runs' will copy column serialized_dag.dag_id to
column dag_run.dag_id, which conflicts with relationship(s): 'RenderedTaskInstanceFields.dag_run'
(copies rendered_task_instance_fields.dag_id to dag_run.dag_id). If this is not the intention,
 consider if these relationships should be linked with back_populates, or if viewonly=True
 should be applied to one or more if they are read-only. For the less common case that foreign
key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate
the columns that should be written towards.   The 'overlaps' parameter may be used to remove this warning.
 (Background on this error at: http://sqlalche.me/e/14/qzyx)
```
Since the RenderedTaskInstanceFields.dag_run is only used in loading up the execution_date, we mark it as
viewonly which fixes the above warning
