### PR TITLE
Set Grid view data as camelCase in webserver

### DIFF
--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -23,7 +23,7 @@ import { useQuery } from 'react-query';
 
 import { getMetaValue } from '../../utils';
 import { useAutoRefresh } from '../context/autorefresh';
-import { formatData, areActiveRuns } from '../treeDataUtils';
+import { areActiveRuns } from '../treeDataUtils';
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
@@ -37,7 +37,7 @@ const useTreeData = () => {
     dagRuns: [],
     groups: {},
   };
-  const initialData = formatData(treeData, emptyData);
+  const initialData = treeData || emptyData;
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   return useQuery('treeData', async () => {
     try {
@@ -45,8 +45,7 @@ const useTreeData = () => {
       const base = baseDate ? `&base_date=${baseDate}` : '';
       const resp = await fetch(`${treeDataUrl}?dag_id=${dagId}&num_runs=${numRuns}${root}${base}`);
       if (resp) {
-        let newData = await resp.json();
-        newData = formatData(newData);
+        const newData = await resp.json();
         // turn off auto refresh if there are no active runs
         if (!areActiveRuns(newData.dagRuns)) stopRefresh();
         return newData;

--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -37,7 +37,7 @@ const useTreeData = () => {
     dagRuns: [],
     groups: {},
   };
-  const initialData = treeData || emptyData;
+  const initialData = treeData && treeData.groups && treeData.dagRuns ? treeData : emptyData;
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   return useQuery('treeData', async () => {
     try {

--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -23,7 +23,7 @@ import { useQuery } from 'react-query';
 
 import { getMetaValue } from '../../utils';
 import { useAutoRefresh } from '../context/autorefresh';
-import { areActiveRuns } from '../treeDataUtils';
+import { parseJSON, areActiveRuns } from '../treeDataUtils';
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
@@ -32,14 +32,12 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const baseDate = getMetaValue('base_date');
 
-const data = JSON.parse(treeData);
-
 const useTreeData = () => {
   const emptyData = {
     dagRuns: [],
     groups: {},
   };
-  const initialData = data && data.groups && data.dagRuns ? data : emptyData;
+  const initialData = parseJSON(treeData, emptyData);
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   return useQuery('treeData', async () => {
     try {

--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -32,12 +32,14 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const baseDate = getMetaValue('base_date');
 
+const data = JSON.parse(treeData);
+
 const useTreeData = () => {
   const emptyData = {
     dagRuns: [],
     groups: {},
   };
-  const initialData = treeData && treeData.groups && treeData.dagRuns ? treeData : emptyData;
+  const initialData = data && data.groups && data.dagRuns ? data : emptyData;
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   return useQuery('treeData', async () => {
     try {

--- a/airflow/www/static/js/tree/api/useTreeData.test.jsx
+++ b/airflow/www/static/js/tree/api/useTreeData.test.jsx
@@ -26,17 +26,16 @@ import { AutoRefreshProvider } from '../context/autorefresh';
 
 const pendingTreeData = {
   groups: {},
-  dag_runs: [
+  dagRuns: [
     {
-      dag_id: 'example_python_operator',
-      run_id: 'manual__2021-11-08T21:14:17.170046+00:00',
-      start_date: null,
-      end_date: null,
+      dagId: 'example_python_operator',
+      runId: 'manual__2021-11-08T21:14:17.170046+00:00',
+      startDate: null,
+      endDate: null,
       state: 'queued',
-      execution_date: '2021-11-08T21:14:17.170046+00:00',
-      data_interval_start: '2021-11-08T21:14:17.170046+00:00',
-      data_interval_end: '2021-11-08T21:14:17.170046+00:00',
-      run_type: 'manual',
+      dataIntervalStart: '2021-11-08T21:14:17.170046+00:00',
+      dataIntervalEnd: '2021-11-08T21:14:17.170046+00:00',
+      runType: 'manual',
     },
   ],
 };
@@ -59,14 +58,13 @@ describe('Test useTreeData hook', () => {
   });
 
   test('data is valid camelcase json', () => {
-    global.treeData = JSON.stringify(pendingTreeData);
+    global.treeData = pendingTreeData;
 
     const { result } = renderHook(() => useTreeData(), { wrapper: Wrapper });
     const { data } = result.current;
 
     expect(typeof data === 'object').toBe(true);
     expect(data.dagRuns).toBeDefined();
-    expect(data.dag_runs).toBeUndefined();
   });
 
   test('Can handle no treeData', () => {

--- a/airflow/www/static/js/tree/api/useTreeData.test.jsx
+++ b/airflow/www/static/js/tree/api/useTreeData.test.jsx
@@ -24,22 +24,6 @@ import { AutoRefreshProvider } from '../context/autorefresh';
 
 /* global describe, test, expect, jest, beforeAll */
 
-const pendingTreeData = {
-  groups: {},
-  dagRuns: [
-    {
-      dagId: 'example_python_operator',
-      runId: 'manual__2021-11-08T21:14:17.170046+00:00',
-      startDate: null,
-      endDate: null,
-      state: 'queued',
-      dataIntervalStart: '2021-11-08T21:14:17.170046+00:00',
-      dataIntervalEnd: '2021-11-08T21:14:17.170046+00:00',
-      runType: 'manual',
-    },
-  ],
-};
-
 const Wrapper = ({ children }) => {
   const queryClient = new QueryClient();
   return (
@@ -55,16 +39,6 @@ describe('Test useTreeData hook', () => {
   beforeAll(() => {
     global.autoRefreshInterval = 5;
     global.fetch = jest.fn();
-  });
-
-  test('data is valid camelcase json', () => {
-    global.treeData = pendingTreeData;
-
-    const { result } = renderHook(() => useTreeData(), { wrapper: Wrapper });
-    const { data } = result.current;
-
-    expect(typeof data === 'object').toBe(true);
-    expect(data.dagRuns).toBeDefined();
   });
 
   test('Can handle no treeData', () => {

--- a/airflow/www/static/js/tree/context/autorefresh.jsx
+++ b/airflow/www/static/js/tree/context/autorefresh.jsx
@@ -21,7 +21,7 @@
 
 import React, { useContext, useState, useEffect } from 'react';
 import { getMetaValue } from '../../utils';
-import { formatData, areActiveRuns } from '../treeDataUtils';
+import { areActiveRuns } from '../treeDataUtils';
 
 const autoRefreshKey = 'disabledAutoRefresh';
 
@@ -31,13 +31,7 @@ const isRefreshDisabled = JSON.parse(localStorage.getItem(autoRefreshKey));
 const AutoRefreshContext = React.createContext(null);
 
 export const AutoRefreshProvider = ({ children }) => {
-  let dagRuns = [];
-  try {
-    const data = JSON.parse(treeData);
-    if (data.dag_runs) dagRuns = formatData(data.dag_runs);
-  } catch {
-    dagRuns = [];
-  }
+  const dagRuns = (treeData && treeData.dagRuns) || [];
   const [isPaused, setIsPaused] = useState(initialIsPaused);
   const isActive = areActiveRuns(dagRuns);
   const isRefreshAllowed = !(isPaused || isRefreshDisabled);

--- a/airflow/www/static/js/tree/context/autorefresh.jsx
+++ b/airflow/www/static/js/tree/context/autorefresh.jsx
@@ -27,11 +27,12 @@ const autoRefreshKey = 'disabledAutoRefresh';
 
 const initialIsPaused = getMetaValue('is_paused') === 'True';
 const isRefreshDisabled = JSON.parse(localStorage.getItem(autoRefreshKey));
+const data = JSON.parse(treeData);
 
 const AutoRefreshContext = React.createContext(null);
 
 export const AutoRefreshProvider = ({ children }) => {
-  const dagRuns = (treeData && treeData.dagRuns) || [];
+  const dagRuns = (data && data.dagRuns) || [];
   const [isPaused, setIsPaused] = useState(initialIsPaused);
   const isActive = areActiveRuns(dagRuns);
   const isRefreshAllowed = !(isPaused || isRefreshDisabled);

--- a/airflow/www/static/js/tree/context/autorefresh.jsx
+++ b/airflow/www/static/js/tree/context/autorefresh.jsx
@@ -21,18 +21,21 @@
 
 import React, { useContext, useState, useEffect } from 'react';
 import { getMetaValue } from '../../utils';
-import { areActiveRuns } from '../treeDataUtils';
+import { parseJSON, areActiveRuns } from '../treeDataUtils';
 
 const autoRefreshKey = 'disabledAutoRefresh';
 
 const initialIsPaused = getMetaValue('is_paused') === 'True';
 const isRefreshDisabled = JSON.parse(localStorage.getItem(autoRefreshKey));
-const data = JSON.parse(treeData);
 
 const AutoRefreshContext = React.createContext(null);
 
 export const AutoRefreshProvider = ({ children }) => {
-  const dagRuns = (data && data.dagRuns) || [];
+  const emptyData = {
+    dagRuns: [],
+    groups: {},
+  };
+  const { dagRuns } = parseJSON(treeData, emptyData);
   const [isPaused, setIsPaused] = useState(initialIsPaused);
   const isActive = areActiveRuns(dagRuns);
   const isRefreshAllowed = !(isPaused || isRefreshDisabled);

--- a/airflow/www/static/js/tree/dagRuns/index.test.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.test.jsx
@@ -84,10 +84,10 @@ describe('Test DagRuns', () => {
   ];
 
   test('Durations and manual run arrow render correctly, but without any date ticks', () => {
-    global.treeData = JSON.stringify({
+    global.treeData = {
       groups: {},
       dagRuns,
-    });
+    };
     const { queryAllByTestId, getByText, queryByText } = render(
       <DagRuns />, { wrapper: Wrapper },
     );
@@ -100,7 +100,7 @@ describe('Test DagRuns', () => {
   });
 
   test('Top date ticks appear when there are 4 or more runs', () => {
-    global.treeData = JSON.stringify({
+    global.treeData = {
       groups: {},
       dagRuns: [
         ...dagRuns,
@@ -125,7 +125,7 @@ describe('Test DagRuns', () => {
           endDate: '2021-11-09T00:22:18.607167+00:00',
         },
       ],
-    });
+    };
     const { getByText } = render(
       <DagRuns />, { wrapper: Wrapper },
     );

--- a/airflow/www/static/js/tree/dagRuns/index.test.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.test.jsx
@@ -84,10 +84,10 @@ describe('Test DagRuns', () => {
   ];
 
   test('Durations and manual run arrow render correctly, but without any date ticks', () => {
-    global.treeData = {
+    global.treeData = JSON.stringify({
       groups: {},
       dagRuns,
-    };
+    });
     const { queryAllByTestId, getByText, queryByText } = render(
       <DagRuns />, { wrapper: Wrapper },
     );
@@ -100,7 +100,7 @@ describe('Test DagRuns', () => {
   });
 
   test('Top date ticks appear when there are 4 or more runs', () => {
-    global.treeData = {
+    global.treeData = JSON.stringify({
       groups: {},
       dagRuns: [
         ...dagRuns,
@@ -125,7 +125,7 @@ describe('Test DagRuns', () => {
           endDate: '2021-11-09T00:22:18.607167+00:00',
         },
       ],
-    };
+    });
     const { getByText } = render(
       <DagRuns />, { wrapper: Wrapper },
     );
@@ -133,10 +133,10 @@ describe('Test DagRuns', () => {
   });
 
   test('Handles empty data correctly', () => {
-    global.treeData = {
+    global.treeData = JSON.stringify({
       groups: {},
       dagRuns: [],
-    };
+    });
     const { queryByTestId } = render(
       <DagRuns />, { wrapper: Wrapper },
     );
@@ -144,7 +144,7 @@ describe('Test DagRuns', () => {
   });
 
   test('Handles no data correctly', () => {
-    global.treeData = {};
+    global.treeData = JSON.stringify({});
     const { queryByTestId } = render(
       <DagRuns />, { wrapper: Wrapper },
     );

--- a/airflow/www/static/js/tree/treeDataUtils.js
+++ b/airflow/www/static/js/tree/treeDataUtils.js
@@ -17,18 +17,5 @@
  * under the License.
  */
 
-import camelcaseKeys from 'camelcase-keys';
-
+// eslint-disable-next-line import/prefer-default-export
 export const areActiveRuns = (runs = []) => runs.filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
-
-export const formatData = (data, emptyData) => {
-  if (!data || !Object.keys(data).length) {
-    return emptyData;
-  }
-  let formattedData = data;
-  // Convert to json if needed
-  if (typeof data === 'string') formattedData = JSON.parse(data);
-  // change from pascal to camelcase
-  formattedData = camelcaseKeys(formattedData, { deep: true });
-  return formattedData;
-};

--- a/airflow/www/static/js/tree/treeDataUtils.js
+++ b/airflow/www/static/js/tree/treeDataUtils.js
@@ -17,5 +17,13 @@
  * under the License.
  */
 
-// eslint-disable-next-line import/prefer-default-export
 export const areActiveRuns = (runs = []) => runs.filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
+
+export const parseJSON = (data, emptyData = {}) => {
+  if (!data) return emptyData;
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    return emptyData;
+  }
+};

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -78,8 +78,7 @@
 {% block tail_js %}
   {{ super() }}
   <script>
-    // Data is already json, there is no need to convert it
-    const treeData = {{ data }};
+    const treeData = {{ data|tojson }};
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
   </script>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -78,7 +78,8 @@
 {% block tail_js %}
   {{ super() }}
   <script>
-    const treeData = {{ data|tojson }};
+    // Data is already json, there is no need to convert it
+    const treeData = {{ data }};
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
   </script>

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -75,7 +75,7 @@ def get_instance_with_map(task_instance, session):
     return get_mapped_summary(task_instance, mapped_instances)
 
 
-def get_mapped_summary(parent_instance, task_instances):
+def get_mapped_summary(parent_instance, task_instances, camel_case=False):
     priority = [
         TaskInstanceState.FAILED,
         TaskInstanceState.UPSTREAM_FAILED,
@@ -113,6 +113,17 @@ def get_mapped_summary(parent_instance, task_instances):
         if parent_instance.prev_attempted_tries != 0
         else parent_instance.try_number
     )
+    if camel_case:
+        return {
+            'taskId': parent_instance.task_id,
+            'runId': parent_instance.run_id,
+            'state': group_state,
+            'startDate': group_start_date,
+            'endDate': group_end_date,
+            'mappedStates': mapped_states,
+            'tryNumber': try_count,
+        }
+
     return {
         'task_id': parent_instance.task_id,
         'run_id': parent_instance.run_id,
@@ -131,7 +142,9 @@ def encode_ti(
         return None
 
     if is_mapped:
-        return get_mapped_summary(task_instance, task_instances=get_mapped_instances(task_instance, session))
+        return get_mapped_summary(
+            task_instance, task_instances=get_mapped_instances(task_instance, session), camel_case=True
+        )
 
     try_count = (
         task_instance.prev_attempted_tries
@@ -139,14 +152,14 @@ def encode_ti(
         else task_instance.try_number
     )
     return {
-        'task_id': task_instance.task_id,
-        'run_id': task_instance.run_id,
-        'map_index': task_instance.map_index,
+        'taskId': task_instance.task_id,
+        'runId': task_instance.run_id,
+        'mapIndex': task_instance.map_index,
         'state': task_instance.state,
         'duration': task_instance.duration,
-        'start_date': datetime_to_string(task_instance.start_date),
-        'end_date': datetime_to_string(task_instance.end_date),
-        'try_number': try_count,
+        'startDate': datetime_to_string(task_instance.start_date),
+        'endDate': datetime_to_string(task_instance.end_date),
+        'tryNumber': try_count,
     }
 
 
@@ -155,15 +168,15 @@ def encode_dag_run(dag_run: Optional[models.DagRun]) -> Optional[Dict[str, Any]]
         return None
 
     return {
-        'run_id': dag_run.run_id,
-        'start_date': datetime_to_string(dag_run.start_date),
-        'end_date': datetime_to_string(dag_run.end_date),
+        'runId': dag_run.run_id,
+        'startDate': datetime_to_string(dag_run.start_date),
+        'endDate': datetime_to_string(dag_run.end_date),
         'state': dag_run.state,
-        'execution_date': datetime_to_string(dag_run.execution_date),
-        'data_interval_start': datetime_to_string(dag_run.data_interval_start),
-        'data_interval_end': datetime_to_string(dag_run.data_interval_end),
-        'run_type': dag_run.run_type,
-        'last_scheduling_decision': datetime_to_string(dag_run.last_scheduling_decision),
+        'executionDate': datetime_to_string(dag_run.execution_date),
+        'dataIntervalStart': datetime_to_string(dag_run.data_interval_start),
+        'dataIntervalEnd': datetime_to_string(dag_run.data_interval_end),
+        'runType': dag_run.run_type,
+        'lastSchedulingDecision': datetime_to_string(dag_run.last_scheduling_decision),
     }
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -243,8 +243,8 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
                 if ti.task_id == task_item_or_group.task_id
             ],
             'label': task_item_or_group.label,
-            'extra_links': task_item_or_group.extra_links,
-            'is_mapped': task_item_or_group.is_mapped,
+            'extraLinks': task_item_or_group.extra_links,
+            'isMapped': task_item_or_group.is_mapped,
         }
 
     # Task Group
@@ -276,12 +276,10 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
         child_instances = [item for sublist in child_instances for item in sublist]
 
         children_start_dates = [
-            item['start_date'] for item in child_instances if item['run_id'] == dag_run.run_id
+            item['startDate'] for item in child_instances if item['runId'] == dag_run.run_id
         ]
-        children_end_dates = [
-            item['end_date'] for item in child_instances if item['run_id'] == dag_run.run_id
-        ]
-        children_states = [item['state'] for item in child_instances if item['run_id'] == dag_run.run_id]
+        children_end_dates = [item['endDate'] for item in child_instances if item['runId'] == dag_run.run_id]
+        children_states = [item['state'] for item in child_instances if item['runId'] == dag_run.run_id]
 
         group_state = None
         for state in priority:
@@ -296,11 +294,11 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
         )
 
         return {
-            'task_id': task_group.group_id,
-            'run_id': dag_run.run_id,
+            'taskId': task_group.group_id,
+            'runId': dag_run.run_id,
             'state': group_state,
-            'start_date': group_start_date,
-            'end_date': group_end_date,
+            'startDate': group_start_date,
+            'endDate': group_end_date,
         }
 
     group_summaries = [get_summary(dr, children) for dr in dag_runs]
@@ -2556,7 +2554,7 @@ class Airflow(AirflowBaseView):
 
         data = {
             'groups': task_group_to_tree(dag.task_group, dag, dag_runs, tis, session),
-            'dag_runs': encoded_runs,
+            'dagRuns': encoded_runs,
         }
 
         # avoid spaces to reduce payload size
@@ -3426,7 +3424,7 @@ class Airflow(AirflowBaseView):
             tis = dag.get_task_instances(start_date=min_date, end_date=base_date, session=session)
             data = {
                 'groups': task_group_to_tree(dag.task_group, dag, dag_runs, tis, session),
-                'dag_runs': encoded_runs,
+                'dagRuns': encoded_runs,
             }
 
         # avoid spaces to reduce payload size


### PR DESCRIPTION
The UI was parsing and formatting the data for Grid view. On DAGs with many runs and/or many instances this could be add a significant amount of loading time for the UI. Instead, the webserver can send the data already as camelCased json and avoid these extra steps.

Why not just use pascal_case in the UI? javascript is usually more camelCase friendly and our linting is already configured for that. Mixing the two is also just asking for syntax errors. Also, we already pass camelCase json to the UI in the Gantt view.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
