### PR TITLE
Serialize mapped operator expansion kwargs logic

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -357,6 +357,10 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
             multiple_outputs=self.multiple_outputs,
             python_callable=self.function,
             mapped_op_kwargs=map_kwargs,
+            # Different from classic operators, kwargs passed to a taskflow
+            # task's expand() contribute to the op_kwargs operator argument, not
+            # the operator arguments themselves, and should expand against it.
+            expansion_kwargs_attr="mapped_op_kwargs",
         )
         return XComArg(operator=operator)
 
@@ -403,15 +407,6 @@ class DecoratedMappedOperator(MappedOperator):
         # Not using super(..., self) to work around pyupgrade bug.
         super(DecoratedMappedOperator, DecoratedMappedOperator).__attrs_post_init__(self)
         XComArg.apply_upstream_relationship(self, self.mapped_op_kwargs)
-
-    def _get_expansion_kwargs(self) -> Dict[str, "Mappable"]:
-        """The kwargs to calculate expansion length against.
-
-        Different from classic operators, a decorated (taskflow) operator's
-        ``map()`` contributes to the ``op_kwargs`` operator argument (not the
-        operator arguments themselves), and should therefore expand against it.
-        """
-        return self.mapped_op_kwargs
 
     def _get_unmap_kwargs(self) -> Dict[str, Any]:
         partial_kwargs = self.partial_kwargs.copy()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -796,6 +796,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 task_group=None,
                 start_date=None,
                 end_date=None,
+                expansion_kwargs_attr=encoded_op["_expansion_kwargs_attr"],
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op['task_id'])

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1589,6 +1589,7 @@ def test_mapped_operator_serde():
         'ui_color': '#f0ede4',
         'ui_fgcolor': '#000',
         'user_supplied_task_id': 'a',
+        '_expansion_kwargs_attr': 'mapped_kwargs',
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)
@@ -1633,6 +1634,7 @@ def test_mapped_operator_xcomarg_serde():
         'ui_color': '#fff',
         'ui_fgcolor': '#000',
         'user_supplied_task_id': 'task_2',
+        '_expansion_kwargs_attr': 'mapped_kwargs',
     }
 
     op = SerializedBaseOperator.deserialize_operator(serialized)
@@ -1720,6 +1722,7 @@ def test_mapped_decorator_serde():
         'template_fields': ['op_args', 'op_kwargs'],
         'template_fields_renderers': {"op_args": "py", "op_kwargs": "py"},
         'user_supplied_task_id': 'x',
+        '_expansion_kwargs_attr': 'mapped_op_kwargs',
     }
 
     deserialized = SerializedBaseOperator.deserialize_operator(serialized)


### PR DESCRIPTION
This is needed because we need to be able to access the correct expansion kwargs from the serialized mapped operator in the scheduler.