### PR TITLE
Support DAGRun type reset through the backfill command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -298,6 +298,11 @@ ARG_BF_IGNORE_DEPENDENCIES = Arg(
     ),
     action="store_true",
 )
+ARG_BF_RESET_RUN_TYPE = Arg(
+    ("-r", "--reset-run-type"),
+    help=("Set DAGRun type from 'backfill' to 'scheduled' for finished DAG runs only (successful/failed)"),
+    action="store_true",
+)
 ARG_BF_IGNORE_FIRST_DEPENDS_ON_PAST = Arg(
     ("-I", "--ignore-first-depends-on-past"),
     help=(
@@ -1118,6 +1123,7 @@ DAGS_COMMANDS = (
             ARG_YES,
             ARG_CONTINUE_ON_FAILURES,
             ARG_BF_IGNORE_DEPENDENCIES,
+            ARG_BF_RESET_RUN_TYPE,
             ARG_BF_IGNORE_FIRST_DEPENDS_ON_PAST,
             ARG_SUBDIR,
             ARG_POOL,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -217,6 +217,11 @@ class DagRun(Base, LoggingMixin):
             if state == State.QUEUED:
                 self.queued_at = timezone.utcnow()
 
+    @provide_session
+    def reset_run_type(self, session: Session = None):
+        self.run_type = DagRunType.SCHEDULED
+        session.merge(self)
+
     @declared_attr
     def state(self):
         return synonym('_state', descriptor=property(self.get_state, self.set_state))

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -113,6 +113,17 @@ class TestDagRun:
         dr0 = session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.execution_date == now).first()
         assert dr0.state == DagRunState.QUEUED
 
+    def test_reset_dagrun_type(self, session):
+        now = timezone.utcnow()
+        dag_id = 'test_reset_dagrun_type'
+        dag = DAG(dag_id=dag_id, start_date=now)
+        dag_run = self.create_dag_run(dag, execution_date=now, is_backfill=True, session=session)
+        assert dag_run.run_type == DagRunType.BACKFILL_JOB
+        dag_run.reset_run_type()
+
+        dr = session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.execution_date == now).first()
+        assert dr.run_type == DagRunType.SCHEDULED
+
     def test_dagrun_find(self, session):
         now = timezone.utcnow()
 


### PR DESCRIPTION
Support resetting dagrun type so users can trigger task reruns from the web ui through the scheduler.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
