### PR TITLE
Support log download in task log view

### DIFF
--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -56,22 +56,8 @@ function scrollBottom() {
   $('html, body').animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
 }
 
-function downloadActiveLog() {
-  const tryNumber = $('#ti_log_try_index_list .active a').attr('href').replace(/\D/g,'');
-  const query = new URLSearchParams({
-    dag_id: dagId,
-    task_id: taskId,
-    execution_date: executionDate,
-    try_number: tryNumber,
-    metadata: 'null',
-    format: 'file'
-  });
-  window.location.href = `${logsWithMetadataUrl}?${query}`;
-}
-
 window.toggleWrapLogs = toggleWrap;
 window.scrollBottomLogs = scrollBottom;
-window.downloadActiveLog = downloadActiveLog;
 
 // Streaming log with auto-tailing.
 function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
@@ -154,6 +140,24 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
     ));
   });
 }
+
+function setDownloadUrl(tryNumber) {
+  if (!tryNumber) {
+    // default to the currently selected tab
+    tryNumber = $('#ti_log_try_index_list .active a').attr('href').replace(/\D/g, '');
+  }
+  const query = new URLSearchParams({
+    dag_id: dagId,
+    task_id: taskId,
+    execution_date: executionDate,
+    try_number: tryNumber,
+    metadata: 'null',
+    format: 'file'
+  });
+  const url = `${logsWithMetadataUrl}?${query}`;
+  $('#ti_log_download_active').attr('href', url);
+}
+
 $(document).ready(() => {
   // Lazily load all past task instance logs.
   // TODO: We only need to have recursive queries for
@@ -167,4 +171,10 @@ $(document).ready(() => {
     const autoTailing = i === TOTAL_ATTEMPTS;
     autoTailingLog(i, null, autoTailing);
   }
+
+  setDownloadUrl();
+  $('#ti_log_try_index_list a').click(function () {
+    const tryNumber = $(this).attr('href').replace(/\D/g, '');
+    setDownloadUrl(tryNumber);
+  });
 });

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -144,7 +144,7 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 function setDownloadUrl(tryNumber) {
   if (!tryNumber) {
     // default to the currently selected tab
-    tryNumber = $('#ti_log_try_index_list .active a').attr('href').replace(/\D/g, '');
+    tryNumber = $('#ti_log_try_number_list .active a').data('try-number');
   }
   const query = new URLSearchParams({
     dag_id: dagId,
@@ -173,8 +173,8 @@ $(document).ready(() => {
   }
 
   setDownloadUrl();
-  $('#ti_log_try_index_list a').click(function () {
-    const tryNumber = $(this).attr('href').replace(/\D/g, '');
+  $('#ti_log_try_number_list a').click(function () {
+    const tryNumber = $(this).data('try-number');
     setDownloadUrl(tryNumber);
   });
 });

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -152,7 +152,7 @@ function setDownloadUrl(tryNumber) {
     execution_date: executionDate,
     try_number: tryNumber,
     metadata: 'null',
-    format: 'file'
+    format: 'file',
   });
   const url = `${logsWithMetadataUrl}?${query}`;
   $('#ti_log_download_active').attr('href', url);

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -56,8 +56,22 @@ function scrollBottom() {
   $('html, body').animate({ scrollTop: $(document).height() }, ANIMATION_SPEED);
 }
 
+function downloadActiveLog() {
+  const tryNumber = $('#ti_log_try_index_list .active a').attr('href').replace(/\D/g,'');
+  const query = new URLSearchParams({
+    dag_id: dagId,
+    task_id: taskId,
+    execution_date: executionDate,
+    try_number: tryNumber,
+    metadata: 'null',
+    format: 'file'
+  });
+  window.location.href = `${logsWithMetadataUrl}?${query}`;
+}
+
 window.toggleWrapLogs = toggleWrap;
 window.scrollBottomLogs = scrollBottom;
+window.downloadActiveLog = downloadActiveLog;
 
 // Streaming log with auto-tailing.
 function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -54,7 +54,7 @@
     <div class="col-md-4 text-right">
       <a class="btn btn-default" onclick="scrollBottomLogs()">Jump To End</a>
       <a class="btn btn-default" onclick="toggleWrapLogs()">Toggle Wrap</a>
-      <a class="btn btn-default" onclick="downloadActiveLog()">Download</a>
+      <a class="btn btn-default" id="ti_log_download_active">Download</a>
     </div>
   </div>
   <div class="tab-content">

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -41,10 +41,10 @@
   <h4>{{ title }}</h4>
   <div class="row">
     <div class="col-md-8">
-      <ul id="ti_log_try_index_list" class="nav nav-pills" role="tablist">
+      <ul id="ti_log_try_number_list" class="nav nav-pills" role="tablist">
         {% for log in logs %}
           <li role="presentation" class="{{ 'active' if loop.last else '' }}">
-            <a href="#{{ loop.index }}" aria-controls="{{ loop.index }}" role="tab" data-toggle="tab">
+            <a href="#{{ loop.index }}" aria-controls="{{ loop.index }}" role="tab" data-toggle="tab" data-try-number="{{ loop.index }}">
               {{ loop.index }}
             </a>
           </li>

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -41,7 +41,7 @@
   <h4>{{ title }}</h4>
   <div class="row">
     <div class="col-md-8">
-      <ul class="nav nav-pills" role="tablist">
+      <ul id="ti_log_try_index_list" class="nav nav-pills" role="tablist">
         {% for log in logs %}
           <li role="presentation" class="{{ 'active' if loop.last else '' }}">
             <a href="#{{ loop.index }}" aria-controls="{{ loop.index }}" role="tab" data-toggle="tab">
@@ -54,6 +54,7 @@
     <div class="col-md-4 text-right">
       <a class="btn btn-default" onclick="scrollBottomLogs()">Jump To End</a>
       <a class="btn btn-default" onclick="toggleWrapLogs()">Toggle Wrap</a>
+      <a class="btn btn-default" onclick="downloadActiveLog()">Download</a>
     </div>
   </div>
   <div class="tab-content">


### PR DESCRIPTION
Closes #22174 

This PR adds a download button to the top-right of the task log view. On click, it downloads the visible log by redirecting the browser to the `logs_with_metadata_url` endpoint. Most query parameters in the request are taken from html meta tags, while the `try_number` is determined by checking the active "Log by attempts" tab to the left of the screen.


https://user-images.githubusercontent.com/11639738/162095529-eee56679-ff95-449a-9f30-3aada18b6a0c.mov



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
