### PR TITLE
Use f-strings in PoolSlotsAvailableDep

### DIFF
--- a/airflow/ti_deps/deps/pool_slots_available_dep.py
+++ b/airflow/ti_deps/deps/pool_slots_available_dep.py
@@ -46,7 +46,7 @@ class PoolSlotsAvailableDep(BaseTIDep):
         pools = session.query(Pool).filter(Pool.pool == pool_name).all()
         if not pools:
             yield self._failing_status(
-                reason=("Tasks using non-existent pool '%s' will not be scheduled", pool_name)
+                reason=f"Tasks using non-existent pool '{pool_name}' will not be scheduled"
             )
             return
         else:
@@ -59,14 +59,10 @@ class PoolSlotsAvailableDep(BaseTIDep):
 
         if open_slots <= (ti.pool_slots - 1):
             yield self._failing_status(
-                reason=(
-                    "Not scheduling since there are %s open slots in pool %s and require %s pool slots",
-                    open_slots,
-                    pool_name,
-                    ti.pool_slots,
-                )
+                reason=f"Not scheduling since there are {open_slots} open slots in pool {pool_name} "
+                f"and require {ti.pool_slots} pool slots"
             )
         else:
             yield self._passing_status(
-                reason=("There are enough open slots in %s to execute the task", pool_name)
+                reason=f"There are enough open slots in {pool_name} to execute the task",
             )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Use f-strings in `PoolSlotsAvailableDep`, as are used in every other dep. This way the message is properly rendered in the UI.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
