### PR TITLE
Add template support for external_task_ids.

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -77,7 +77,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         or DAG does not exist (default value: False).
     """
 
-    template_fields = ['external_dag_id', 'external_task_id']
+    template_fields = ['external_dag_id', 'external_task_id', 'external_task_ids']
     ui_color = '#19647e'
 
     @property
@@ -116,20 +116,21 @@ class ExternalTaskSensor(BaseSensorOperator):
                 'be provided to ExternalTaskSensor; not both.'
             )
 
-        has_invalid_state = not (total_states <= set(State.task_states))
+        if external_task_id is not None:
+            external_task_ids = [external_task_id]
 
-        if (external_task_ids or external_task_id) and has_invalid_state:
-            raise ValueError(
-                f'Valid values for `allowed_states` and `failed_states` '
-                f'when `external_task_id` or `external_task_ids` is not `None`: {State.task_states}'
-            )
-        elif external_task_ids:
+        if external_task_ids:
+            if not total_states <= set(State.task_states):
+                raise ValueError(
+                    f'Valid values for `allowed_states` and `failed_states` '
+                    f'when `external_task_id` or `external_task_ids` is not `None`: {State.task_states}'
+                )
             if len(external_task_ids) > len(set(external_task_ids)):
                 raise ValueError('Duplicate task_ids passed in external_task_ids parameter')
-        elif has_invalid_state:
+        elif not total_states <= set(State.dag_states):
             raise ValueError(
                 f'Valid values for `allowed_states` and `failed_states` '
-                f'when `external_task_id` is `None`: {State.task_states}'
+                f'when `external_task_id` is `None`: {State.dag_states}'
             )
 
         if execution_delta is not None and execution_date_fn is not None:
@@ -157,9 +158,6 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         dttm_filter = dttm if isinstance(dttm, list) else [dttm]
         serialized_dttm_filter = ','.join(dt.isoformat() for dt in dttm_filter)
-
-        if self.external_task_ids is None and self.external_task_id is not None:
-            self.external_task_ids = [self.external_task_id]
 
         self.log.info(
             'Poking for tasks %s in dag %s on %s ... ',

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -134,13 +134,34 @@ class TestExternalTaskSensor(unittest.TestCase):
                 "unit_test_dag failed."
             )
 
-    def test_external_task_sensor_external_task_ids_param(self):
+    def test_external_task_sensor_external_task_id_param(self):
         """Test external_task_ids is set properly when external_task_id is passed as a template"""
         self.test_time_sensor()
         op = ExternalTaskSensor(
             task_id='test_external_task_sensor_check',
             external_dag_id='{{ params.dag_id }}',
             external_task_id='{{ params.task_id }}',
+            params={
+                'dag_id': TEST_DAG_ID,
+                'task_id': TEST_TASK_ID,
+            },
+            dag=self.dag,
+        )
+
+        with self.assertLogs(op.log, level=logging.INFO) as cm:
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            assert (
+                f"INFO:airflow.task.operators:Poking for tasks ['{TEST_TASK_ID}'] "
+                f"in dag unit_test_dag on {DEFAULT_DATE.isoformat()} ... " in cm.output
+            )
+
+    def test_external_task_sensor_external_task_ids_param(self):
+        """Test external_task_ids rendering when a template is passed."""
+        self.test_time_sensor()
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id='{{ params.dag_id }}',
+            external_task_ids=['{{ params.task_id }}'],
             params={
                 'dag_id': TEST_DAG_ID,
                 'task_id': TEST_TASK_ID,
@@ -442,7 +463,7 @@ def test_external_task_sensor_templated(dag_maker, app):
 
     assert instance.task.external_dag_id == f"dag_{DEFAULT_DATE.date()}"
     assert instance.task.external_task_id == f"task_{DEFAULT_DATE.date()}"
-    assert instance.task.external_task_ids is None
+    assert instance.task.external_task_ids == [f"task_{DEFAULT_DATE.date()}"]
 
     # Verify that the operator link uses the rendered value of ``external_dag_id``.
     app.config['SERVER_NAME'] = ""

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -134,6 +134,27 @@ class TestExternalTaskSensor(unittest.TestCase):
                 "unit_test_dag failed."
             )
 
+    def test_external_task_sensor_external_task_ids_param(self):
+        """Test external_task_ids is set properly when external_task_id is passed as a template"""
+        self.test_time_sensor()
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id='{{ params.dag_id }}',
+            external_task_id='{{ params.task_id }}',
+            params={
+                'dag_id': TEST_DAG_ID,
+                'task_id': TEST_TASK_ID,
+            },
+            dag=self.dag,
+        )
+
+        with self.assertLogs(op.log, level=logging.INFO) as cm:
+            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            assert (
+                f"INFO:airflow.task.operators:Poking for tasks ['{TEST_TASK_ID}'] "
+                f"in dag unit_test_dag on {DEFAULT_DATE.isoformat()} ... " in cm.output
+            )
+
     def test_external_task_sensor_failed_states_as_success_mulitple_task_ids(self):
         self.test_time_sensor(task_id=TEST_TASK_ID)
         self.test_time_sensor(task_id=TEST_TASK_ID_ALTERNATE)
@@ -421,6 +442,7 @@ def test_external_task_sensor_templated(dag_maker, app):
 
     assert instance.task.external_dag_id == f"dag_{DEFAULT_DATE.date()}"
     assert instance.task.external_task_id == f"task_{DEFAULT_DATE.date()}"
+    assert instance.task.external_task_ids is None
 
     # Verify that the operator link uses the rendered value of ``external_dag_id``.
     app.config['SERVER_NAME'] = ""


### PR DESCRIPTION
When `external_task_id` is passed as a template directly setting it as a list `external_task_ids` will result in logging and using unrendered value. Set the `external_task_ids` with value from `external_task_id` if `external_task_ids` was None initially so that the rendered value from `external_task_id` is used.

closes: #22782
related: #22782
