### PR TITLE
Don't show irrelevant/duplicated/"internal" Task attrs in UI

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -18,7 +18,21 @@
 
 import datetime
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Collection, Dict, Iterable, List, Optional, Set, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Collection,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Type,
+    Union,
+)
 
 from sqlalchemy.orm import Session
 
@@ -82,6 +96,25 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
     owner: str
     task_id: str
+
+    HIDE_ATTRS_FROM_UI: ClassVar[FrozenSet[str]] = frozenset(
+        (
+            'log',
+            'dag',  # We show dag_id, don't need to show this too
+            'node_id',  # Duplicates task_id
+            'task_group',  # Doesn't have a useful repr, no point showing in UI
+            'inherits_from_dummy_operator',  # impl detail
+            # For compatibility with TG, for operators these are just the current task, no point showing
+            'roots',
+            'leaves',
+            # These lists are already shown via *_task_ids
+            'upstream_list',
+            'downstream_list',
+            # Not useful, implementation detail, already shown elsewhere
+            'global_operator_extra_link_dict',
+            'operator_extra_link_dict',
+        )
+    )
 
     def get_dag(self) -> "Optional[DAG]":
         raise NotImplementedError()

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -278,6 +278,13 @@ class MappedOperator(AbstractOperator):
     is_mapped: ClassVar[bool] = True
     subdag: None = None  # Since we don't support SubDagOperator, this is always None.
 
+    HIDE_ATTRS_FROM_UI: ClassVar[FrozenSet[str]] = AbstractOperator.HIDE_ATTRS_FROM_UI | frozenset(
+        (
+            'parse_time_mapped_ti_count',
+            'operator_class',
+        )
+    )
+
     def __repr__(self):
         return f"<Mapped({self._task_type}): {self.task_id}>"
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1614,12 +1614,21 @@ class Airflow(AirflowBaseView):
             ti_attrs = sorted((name, attr) for name, attr in all_ti_attrs if not callable(attr))
 
         attr_renderers = wwwutils.get_attr_renderer()
+
+        attrs_to_skip = getattr(task, 'HIDE_ATTRS_FROM_UI', set())
+
+        def include_task_attrs(attr_name):
+            return not (
+                attr_name == 'HIDE_ATTRS_FROM_UI'
+                or attr_name.startswith("_")
+                or attr_name in attr_renderers
+                or attr_name in attrs_to_skip
+            )
+
         task_attrs = [
             (attr_name, attr)
             for attr_name, attr in (
-                (attr_name, getattr(task, attr_name))
-                for attr_name in dir(task)
-                if not attr_name.startswith("_") and attr_name not in attr_renderers
+                (attr_name, getattr(task, attr_name)) for attr_name in filter(include_task_attrs, dir(task))
             )
             if not callable(attr)
         ]


### PR DESCRIPTION
For example, showing `Log Logger <airflow.models.mappedoperator.MappedOperator (INFO)>` isn't useful.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).