### PR TITLE
Make ElasticSearch Provider compatible for Airflow<2.3

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -134,7 +134,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             data_interval_end=data_interval_end,
             execution_date=execution_date,
             try_number=try_number,
-            map_index=ti.map_index,
+            map_index=getattr(ti, "map_index", ""),
         )
 
     @staticmethod


### PR DESCRIPTION
`ti.map_index` is not released yet and even once it is released in 2.3, we still want this provider to be backwards compatible, this fixes it.

We already do the same for `run_id`

https://github.com/apache/airflow/blob/f366af7832bf83ad8c030a651cb169971527ae8f/airflow/providers/elasticsearch/log/es_task_handler.py#L132

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
