### PR TITLE
Correctly fetch logs for mapped task instances

### DIFF
--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -25,6 +25,7 @@ import { formatDateTime } from './datetime_utils';
 const executionDate = getMetaValue('execution_date');
 const dagId = getMetaValue('dag_id');
 const taskId = getMetaValue('task_id');
+const mapIndex = getMetaValue('map_index');
 const logsWithMetadataUrl = getMetaValue('logs_with_metadata_url');
 const DELAY = parseInt(getMetaValue('delay'), 10);
 const AUTO_TAILING_OFFSET = parseInt(getMetaValue('auto_tailing_offset'), 10);
@@ -60,8 +61,9 @@ window.scrollBottomLogs = scrollBottom;
 
 // Streaming log with auto-tailing.
 function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
-  console.debug(`Auto-tailing log for dag_id: ${dagId}, task_id: ${taskId}, \
-   execution_date: ${executionDate}, try_number: ${tryNumber}, metadata: ${JSON.stringify(metadata)}`);
+  console.debug(`Auto-tailing log for dag_id: ${dagId}, task_id: ${taskId}, `
+   + `execution_date: ${executionDate}, map_index: ${mapIndex}, try_number: ${tryNumber}, `
+   + `metadata: ${JSON.stringify(metadata)}`);
 
   return Promise.resolve(
     $.ajax({
@@ -69,6 +71,7 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
       data: {
         dag_id: dagId,
         task_id: taskId,
+        map_index: mapIndex,
         execution_date: executionDate,
         try_number: tryNumber,
         metadata: JSON.stringify(metadata),

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -23,6 +23,7 @@
 {% block head_meta %}
   {{ super() }}
   <meta name="task_id" content="{{ task_id }}">
+  <meta name="map_index" content="{{ map_index }}">
   <meta name="execution_date" content="{{ execution_date }}">
   <meta name="logs_with_metadata_url" content="{{ url_for('Airflow.get_logs_with_metadata') }}">
   {# Time interval to wait before next log fetching. Default 2s. #}


### PR DESCRIPTION
We weren't passing the map_index param down to the server