### PR TITLE
Remove extraneous json parsing in Calendar and Grid

### DIFF
--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -63,9 +63,6 @@ const dateFormat = 'YYYY-MM-DD';
 document.addEventListener('DOMContentLoaded', () => {
   $('span.status_square').tooltip({ html: true });
 
-  // JSON.parse is faster for large payloads than an object literal
-  const rootData = JSON.parse(calendarData);
-
   const dayTip = d3.tip()
     .attr('class', 'tooltip d3-tip')
     .html((toolTipHtml) => toolTipHtml);
@@ -93,12 +90,12 @@ document.addEventListener('DOMContentLoaded', () => {
       .key((dr) => moment.utc(dr.date, dateFormat).month())
       .key((dr) => moment.utc(dr.date, dateFormat).date())
       .key((dr) => dr.state)
-      .map(rootData.dag_states);
+      .map(calendarData.dag_states);
 
     // Make sure we have one year displayed for each year between the start and end dates.
     // This also ensures we do not have show an empty calendar view when no dag runs exist.
-    const startYear = moment.utc(rootData.start_date, dateFormat).year();
-    const endYear = moment.utc(rootData.end_date, dateFormat).year();
+    const startYear = moment.utc(calendarData.start_date, dateFormat).year();
+    const endYear = moment.utc(calendarData.end_date, dateFormat).year();
     for (let y = startYear; y <= endYear; y += 1) {
       dagStates[y] = dagStates[y] || {};
     }

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -51,6 +51,6 @@
       statesColors["{{state}}"] = "{{state_color_mapping[state]}}";
     {% endfor %}
 
-    const calendarData = {{ data|tojson }};
+    const calendarData = {{ data }};
   </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -78,7 +78,8 @@
 {% block tail_js %}
   {{ super() }}
   <script>
-    const treeData = {{ data|tojson }};
+    // Data is already json, there is no need to convert it
+    const treeData = {{ data }};
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
   </script>


### PR DESCRIPTION
Both `/grid` and `/calendar` use `htmlsafe_json_dumps()` in the webserver before passing data to the UI. The data is already json and doesn't need to be parsed again. In fact, `{{ data }}` was already a json object while `{{ data|tojson }}` was converting it back to a string which required calling `JSON.parse({{ data|tojson }})`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
