### PR TITLE
Temporarily disable task_fail pre-upgrade duplicates check

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1158,7 +1158,7 @@ def _check_migration_errors(session: Session = NEW_SESSION) -> Iterable[str]:
     :rtype: list[str]
     """
     check_functions: Tuple[Callable[..., Iterable[str]], ...] = (
-        check_task_fail_for_duplicates,
+        # todo: check task fail for duplicates
         check_conn_id_duplicates,
         check_conn_type_null,
         check_run_id_null,


### PR DESCRIPTION
I am reworking it to actually move the rows but for now we can disable it.
