### PR TITLE
Better handle Grid auto-refresh errors

### DIFF
--- a/airflow/www/static/js/tree/api/useTreeData.test.jsx
+++ b/airflow/www/static/js/tree/api/useTreeData.test.jsx
@@ -22,7 +22,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import useTreeData from './useTreeData';
 import { AutoRefreshProvider } from '../context/autorefresh';
 
-/* global describe, test, expect, jest, beforeAll */
+/* global describe, test, expect, beforeAll */
 
 const pendingTreeData = {
   groups: {},
@@ -55,7 +55,6 @@ const Wrapper = ({ children }) => {
 describe('Test useTreeData hook', () => {
   beforeAll(() => {
     global.autoRefreshInterval = 5;
-    global.fetch = jest.fn();
   });
 
   test('data is valid camelcase json', () => {


### PR DESCRIPTION
If there was an error during autorefresh in Grid view. The page would crash because we weren't handling the error well. `axios` handles errors better than fetch so I swapped that in and added a toast message to communicate to the user what failed.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
