### PR TITLE
Docs: `remote_log_conn_id` can also be used to write logs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -496,7 +496,8 @@
     - name: remote_log_conn_id
       description: |
         Users must supply an Airflow connection id that provides access to the storage
-        location. Note: This is only used for reading logs, not writing logs
+        location. Depending on your remote logging service, this may only be used for
+        reading logs, not writing them.
       version_added: 2.0.0
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -281,7 +281,8 @@ base_log_folder = {AIRFLOW_HOME}/logs
 remote_logging = False
 
 # Users must supply an Airflow connection id that provides access to the storage
-# location. Note: This is only used for reading logs, not writing logs
+# location. Depending on your remote logging service, this may only be used for
+# reading logs, not writing them.
 remote_log_conn_id =
 
 # Path to Google Credential JSON file. If omitted, authorization based on `the Application Default


### PR DESCRIPTION
Soften the language for `remote_log_conn_id` because some remote services do use it to write (s3).

Related: #20499