### PR TITLE
Cleanup dup code now that k8s provider requires 2.3.0+

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -23,11 +23,7 @@ from kubernetes.client import ApiClient, models as k8s
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.models.xcom import XCom
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
-    KubernetesPodOperator,
-    _prune_dict,
-    _suppress,
-)
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator, _suppress
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 
@@ -858,32 +854,3 @@ def test__suppress():
             raise ValueError("failure")
 
         mock_error.assert_called_once_with("failure", exc_info=True)
-
-
-@pytest.mark.parametrize(
-    'mode, expected',
-    [
-        (
-            'strict',
-            {
-                'b': '',
-                'c': {'b': '', 'c': 'hi', 'd': ['', 0, '1']},
-                'd': ['', 0, '1'],
-                'e': ['', 0, {'b': '', 'c': 'hi', 'd': ['', 0, '1']}, ['', 0, '1'], ['']],
-            },
-        ),
-        (
-            'truthy',
-            {
-                'c': {'c': 'hi', 'd': ['1']},
-                'd': ['1'],
-                'e': [{'c': 'hi', 'd': ['1']}, ['1']],
-            },
-        ),
-    ],
-)
-def test__prune_dict(mode, expected):
-    l1 = ['', 0, '1', None]
-    d1 = {'a': None, 'b': '', 'c': 'hi', 'd': l1}
-    d2 = {'a': None, 'b': '', 'c': d1, 'd': l1, 'e': [None, '', 0, d1, l1, ['']]}
-    assert _prune_dict(d2, mode=mode) == expected


### PR DESCRIPTION
The kubernetes provider now requires core 2.3.0+, so we can safely dedup this code 🎉