### PR TITLE
Disable foreign keys on sqlite when modifying dag_run

### DIFF
--- a/airflow/migrations/utils.py
+++ b/airflow/migrations/utils.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from collections import defaultdict
+from contextlib import contextmanager
 
 
 def get_mssql_table_constraints(conn, table_name):
@@ -41,9 +42,6 @@ def get_mssql_table_constraints(conn, table_name):
     for constraint, constraint_type, col_name in result:
         constraint_dict[constraint_type][constraint].append(col_name)
     return constraint_dict
-
-
-from contextlib import contextmanager
 
 
 @contextmanager

--- a/airflow/migrations/utils.py
+++ b/airflow/migrations/utils.py
@@ -41,3 +41,16 @@ def get_mssql_table_constraints(conn, table_name):
     for constraint, constraint_type, col_name in result:
         constraint_dict[constraint_type][constraint].append(col_name)
     return constraint_dict
+
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def disable_sqlite_fkeys(op):
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "sqlite":
+        op.execute("PRAGMA foreign_keys=off")
+    yield op
+    if dialect_name == "sqlite":
+        op.execute("PRAGMA foreign_keys=on")

--- a/airflow/migrations/utils.py
+++ b/airflow/migrations/utils.py
@@ -49,6 +49,7 @@ def disable_sqlite_fkeys(op):
     is_sqlite = op.get_bind().dialect.name == 'sqlite'
     if is_sqlite:
         op.execute("PRAGMA foreign_keys=off")
-    yield op
-    if is_sqlite:
+        yield op
         op.execute("PRAGMA foreign_keys=on")
+    else:
+        yield op

--- a/airflow/migrations/utils.py
+++ b/airflow/migrations/utils.py
@@ -46,8 +46,7 @@ def get_mssql_table_constraints(conn, table_name):
 
 @contextmanager
 def disable_sqlite_fkeys(op):
-    is_sqlite = op.get_bind().dialect.name == 'sqlite'
-    if is_sqlite:
+    if op.get_bind().dialect.name == 'sqlite':
         op.execute("PRAGMA foreign_keys=off")
         yield op
         op.execute("PRAGMA foreign_keys=on")

--- a/airflow/migrations/utils.py
+++ b/airflow/migrations/utils.py
@@ -46,9 +46,9 @@ def get_mssql_table_constraints(conn, table_name):
 
 @contextmanager
 def disable_sqlite_fkeys(op):
-    dialect_name = op.get_bind().dialect.name
-    if dialect_name == "sqlite":
+    is_sqlite = op.get_bind().dialect.name == 'sqlite'
+    if is_sqlite:
         op.execute("PRAGMA foreign_keys=off")
     yield op
-    if dialect_name == "sqlite":
+    if is_sqlite:
         op.execute("PRAGMA foreign_keys=on")

--- a/airflow/migrations/versions/0099_f9da662e7089_add_task_log_filename_template_model.py
+++ b/airflow/migrations/versions/0099_f9da662e7089_add_task_log_filename_template_model.py
@@ -26,6 +26,7 @@ Create Date: 2021-12-09 06:11:21.044940
 from alembic import op
 from sqlalchemy import Column, ForeignKey, Integer, Text
 
+from airflow.migrations.utils import disable_sqlite_fkeys
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # Revision identifiers, used by Alembic.
@@ -50,7 +51,8 @@ def upgrade():
         Integer,
         ForeignKey("log_template.id", name="task_instance_log_template_id_fkey", ondelete="NO ACTION"),
     )
-    with op.batch_alter_table("dag_run") as batch_op:
+
+    with disable_sqlite_fkeys(op), op.batch_alter_table("dag_run") as batch_op:
         batch_op.add_column(dag_run_log_filename_id)
 
 


### PR DESCRIPTION
If we do not disable FKs then it has the side effect of deleting all task instances.
