### PR TITLE
Speed up `has_access` decorator by ~200ms

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -1,2 +1,3 @@
             f"DELETE {source_table} FROM { ', '.join(_from_name(tbl) for tbl in stmt.froms) }"
         for frm in source_query.selectable.froms:
+    roles = relationship("Role", secondary=assoc_user_role, backref="user", lazy="selectin")

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -35,7 +35,10 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
             __tracebackhide__ = True  # Hide from pytest traceback.
 
             appbuilder = current_app.appbuilder
-            if not g.user.is_anonymous and not g.user.perms:
+
+            if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
+                return func(*args, **kwargs)
+            elif not g.user.is_anonymous and not g.user.perms:
                 return (
                     render_template(
                         'airflow/no_roles_permissions.html',
@@ -46,9 +49,6 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
                     ),
                     403,
                 )
-
-            if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
-                return func(*args, **kwargs)
             else:
                 access_denied = "Access is Denied"
                 flash(access_denied, "danger")

--- a/airflow/www/fab_security/sqla/models.py
+++ b/airflow/www/fab_security/sqla/models.py
@@ -239,7 +239,7 @@ class User(Model):
                     .join(sm.permission_model.action)
                     .join(sm.permission_model.resource)
                     .join(sm.permission_model.role)
-                    .filter(sm.role_model.user.contains(g.user))
+                    .filter(sm.role_model.user.contains(self))
                     .all()
                 )
             else:

--- a/airflow/www/fab_security/sqla/models.py
+++ b/airflow/www/fab_security/sqla/models.py
@@ -229,12 +229,12 @@ class User(Model):
 
     @property
     def perms(self):
-        if not self._perms_cache:
+        if not self._perms:
             # Using the ORM here is _slow_ (Creating lots of objects to then throw them away) since this is in
             # the path for every request. Avoid it if we can!
             if current_app:
                 sm = current_app.appbuilder.sm
-                self._perms_cache: Set[Tuple[str, str]] = set(
+                self._perms: Set[Tuple[str, str]] = set(
                     sm.get_session.query(sm.action_model.name, sm.resource_model.name)
                     .join(sm.permission_model.action)
                     .join(sm.permission_model.resource)
@@ -243,10 +243,10 @@ class User(Model):
                     .all()
                 )
             else:
-                self._perms_cache = {
+                self._perms = {
                     (perm.action.name, perm.resource.name) for role in self.roles for perm in role.permissions
                 }
-        return self._perms_cache
+        return self._perms
 
     def get_id(self):
         return self.id
@@ -257,7 +257,7 @@ class User(Model):
     def __repr__(self):
         return self.get_full_name()
 
-    _perms_cache = None
+    _perms = None
 
 
 class RegisterUser(Model):

--- a/airflow/www/fab_security/sqla/models.py
+++ b/airflow/www/fab_security/sqla/models.py
@@ -20,9 +20,9 @@ import datetime
 # This product contains a modified portion of 'Flask App Builder' developed by Daniel Vaz Gaspar.
 # (https://github.com/dpgaspar/Flask-AppBuilder).
 # Copyright 2013, Daniel Vaz Gaspar
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Set, Tuple, Union
 
-from flask import g
+from flask import current_app, g
 from flask_appbuilder.models.sqla import Model
 from sqlalchemy import (
     Boolean,
@@ -181,7 +181,7 @@ class User(Model):
     last_login = Column(DateTime)
     login_count = Column(Integer)
     fail_login_count = Column(Integer)
-    roles = relationship("Role", secondary=assoc_user_role, backref="user", lazy="joined")
+    roles = relationship("Role", secondary=assoc_user_role, backref="user", lazy="selectin")
     created_on = Column(DateTime, default=datetime.datetime.now, nullable=True)
     changed_on = Column(DateTime, default=datetime.datetime.now, nullable=True)
 
@@ -229,10 +229,24 @@ class User(Model):
 
     @property
     def perms(self):
-        perms = set()
-        for role in self.roles:
-            perms.update((perm.action.name, perm.resource.name) for perm in role.permissions)
-        return perms
+        if not self._perms_cache:
+            # Using the ORM here is _slow_ (Creating lots of objects to then throw them away) since this is in
+            # the path for every request. Avoid it if we can!
+            if current_app:
+                sm = current_app.appbuilder.sm
+                self._perms_cache: Set[Tuple[str, str]] = set(
+                    sm.get_session.query(sm.action_model.name, sm.resource_model.name)
+                    .join(sm.permission_model.action)
+                    .join(sm.permission_model.resource)
+                    .join(sm.permission_model.role)
+                    .filter(sm.role_model.user.contains(g.user))
+                    .all()
+                )
+            else:
+                self._perms_cache = {
+                    (perm.action.name, perm.resource.name) for role in self.roles for perm in role.permissions
+                }
+        return self._perms_cache
 
     def get_id(self):
         return self.id
@@ -242,6 +256,8 @@ class User(Model):
 
     def __repr__(self):
         return self.get_full_name()
+
+    _perms_cache = None
 
 
 class RegisterUser(Model):

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -56,6 +56,8 @@ def create_user(app, username, role_name=None, email=None, permissions=None):
     if role_name:
         delete_role(app, role_name)
         role = create_role(app, role_name, permissions)
+    else:
+        role = []
 
     return appbuilder.sm.add_user(
         username=username,
@@ -80,12 +82,12 @@ def create_role(app, name, permissions=None):
     return role
 
 
-def set_user_single_role(app, username, role_name):
+def set_user_single_role(app, user, role_name):
     role = create_role(app, role_name)
-    user = app.appbuilder.sm.find_user(username)
     if role not in user.roles:
         user.roles = [role]
         app.appbuilder.sm.update_user(user)
+        user._perms = None
 
 
 def delete_role(app, name):

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -30,7 +30,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 
 
 def test_index(admin_client):
-    with assert_queries_count(12):
+    with assert_queries_count(14):
         resp = admin_client.get('/', follow_redirects=True)
     check_content_in_response('DAGs', resp)
 


### PR DESCRIPTION
Using the ORM to create all the Role, Permission, Action and Resource objects, only to throw them all away _on every request_ is slow. And since we are now using the API more and more in the UI it's starting to get noticeable

This changes the `user.perm` property to issue a custom query that returns the tuple of action_name, permission_name we want, bypassing the ORM object inflation entirely, and since `user.roles` isn't needed in most requests we no longer eagerly load that.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).