### PR TITLE
Add XComArg to lazy-imported list of Airflow module

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -37,7 +37,7 @@ from airflow import version
 
 __version__ = version.version
 
-__all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39', 'PY310']
+__all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39', 'PY310', 'XComArg']
 
 # Make `airflow` an namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
@@ -54,18 +54,30 @@ PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
 PY310 = sys.version_info >= (3, 10)
 
+# Things to lazy import in form 'name': 'path.to.module'
+__lazy_imports = {
+    'DAG': 'airflow.models.dag',
+    'XComArg': 'airflow.models.xcom_arg',
+    'AirflowException': 'airflow.exceptions',
+}
+
 
 def __getattr__(name):
     # PEP-562: Lazy loaded attributes on python modules
-    if name == "DAG":
-        from airflow.models.dag import DAG
+    path = __lazy_imports.get(name)
+    if path:
+        import operator
 
-        return DAG
-    if name == "AirflowException":
-        from airflow.exceptions import AirflowException
+        # Strip of the "airflow." prefix because of how `__import__` works (it always returns the top level
+        # module)
+        without_prefix = path.split('.', 1)[-1]
 
-        return AirflowException
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+        getter = operator.attrgetter(f'{without_prefix}.{name}')
+        val = getter(__import__(path))
+        # Store for next time
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 if not settings.LAZY_LOAD_PLUGINS:
@@ -89,6 +101,7 @@ STATICA_HACK = True
 globals()['kcah_acitats'[::-1].upper()] = False
 if STATICA_HACK:  # pragma: no cover
     from airflow.models.dag import DAG
+    from airflow.models.xcom_arg import XComArg
     from airflow.exceptions import AirflowException
 
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -70,7 +70,7 @@ def __getattr__(name):
 
     import operator
 
-    # Strip of the "airflow." prefix because of how `__import__` works (it always returns the top level
+    # Strip off the "airflow." prefix because of how `__import__` works (it always returns the top level
     # module)
     without_prefix = path.split('.', 1)[-1]
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -65,19 +65,20 @@ __lazy_imports = {
 def __getattr__(name):
     # PEP-562: Lazy loaded attributes on python modules
     path = __lazy_imports.get(name)
-    if path:
-        import operator
+    if not path:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-        # Strip of the "airflow." prefix because of how `__import__` works (it always returns the top level
-        # module)
-        without_prefix = path.split('.', 1)[-1]
+    import operator
 
-        getter = operator.attrgetter(f'{without_prefix}.{name}')
-        val = getter(__import__(path))
-        # Store for next time
-        globals()[name] = val
-        return val
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    # Strip of the "airflow." prefix because of how `__import__` works (it always returns the top level
+    # module)
+    without_prefix = path.split('.', 1)[-1]
+
+    getter = operator.attrgetter(f'{without_prefix}.{name}')
+    val = getter(__import__(path))
+    # Store for next time
+    globals()[name] = val
+    return val
 
 
 if not settings.LAZY_LOAD_PLUGINS:


### PR DESCRIPTION
In writing the docs for Dynamic Task Mapping (AIP-42) I noticed that
there are some cases where users need to use XComArg directly, and it
didn't feel right to make the import things from `airflow.models`.

And I've now refactored the lazy import to be "data-driven" as three
blocks of almost identical code was my limit.

Example dag from the docs (future PR) that inspired this change:

```python
    from datetime import datetime

    from airflow import DAG
    from airflow.decorators import task
    from airflow.models.xcom_arg import XComArg  # <--- this I wasn't happy about
    from airflow.providers.amazon.aws.hooks.s3 import S3Hook
    from airflow.providers.amazon.aws.operators.s3 import S3ListOperator


    with DAG(dag_id="mapped_s3", start_date=datetime(2020,4,7)) as dag:
        files = S3ListOperator(
            task_id="get_input",
            bucket="example-bucket",
            prefix='incoming/provider_a/{{ data_interval_start.strftime("%Y-%m-%d") }}',
        )

        @task
        def count_lines(aws_conn_id, bucket, file):
            hook = S3Hook(aws_conn_id=aws_conn_id)

            return len(hook.read_key(file, bucket).splitlines())

        @task
        def total(lines):
            return sum(lines) 

        counts = count_lines.partial(aws_conn_id="aws_default", bucket=files.bucket).expand(file=XComArg(files))
        total(lines=counts)
```