### PR TITLE
Fix Grid view font sizing

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -295,7 +295,7 @@ th {
   box-sizing: border-box;
 }
 html {
-  font-size: 10px;
+  font-size: 12px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 body {

--- a/airflow/www/static/js/tree/InstanceTooltip.jsx
+++ b/airflow/www/static/js/tree/InstanceTooltip.jsx
@@ -78,7 +78,7 @@ const InstanceTooltip = ({
   }
 
   return (
-    <Box fontSize="12px" py="2px">
+    <Box py="2px">
       {group.tooltip && (
         <Text>{group.tooltip}</Text>
       )}

--- a/airflow/www/static/js/tree/StatusBox.jsx
+++ b/airflow/www/static/js/tree/StatusBox.jsx
@@ -73,7 +73,6 @@ const StatusBox = ({
   return (
     <Tooltip
       label={<InstanceTooltip instance={instance} group={group} />}
-      fontSize="md"
       portalProps={{ containerRef }}
       hasArrow
       placement="top"

--- a/airflow/www/static/js/tree/TaskName.jsx
+++ b/airflow/www/static/js/tree/TaskName.jsx
@@ -39,7 +39,6 @@ const TaskName = ({
   >
     <Text
       display="inline"
-      fontSize="12px"
       ml={level * 4 + 4}
       isTruncated
     >

--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -83,7 +83,7 @@ const Tree = () => {
         <ResetRoot />
         <FormControl display="flex" width="auto" mr={2}>
           {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
-          <FormLabel htmlFor="auto-refresh" mb={0} fontSize="12px" fontWeight="normal">
+          <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
             Auto-refresh
           </FormLabel>
           <Switch

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -106,7 +106,7 @@ const DagRunBar = ({
       </Flex>
       {index < totalRuns - 3 && index % 10 === 0 && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
-        <Text fontSize="10px" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
+        <Text fontSize="sm" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
           <Time dateTime={run.executionDate} format="MMM DD, HH:mm" />
         </Text>
         <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />

--- a/airflow/www/static/js/tree/dagRuns/Tooltip.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Tooltip.jsx
@@ -28,7 +28,7 @@ const DagRunTooltip = ({
     state, duration, dataIntervalEnd,
   },
 }) => (
-  <Box fontSize="12px" py="2px">
+  <Box py="2px">
     <Text>
       Status:
       {' '}

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -32,7 +32,7 @@ import { getDuration, formatDuration } from '../../datetime_utils';
 import { useSelection } from '../context/selection';
 
 const DurationTick = ({ children, ...rest }) => (
-  <Text fontSize={10} color="gray.400" right={1} position="absolute" whiteSpace="nowrap" {...rest}>
+  <Text fontSize="sm" color="gray.400" right={1} position="absolute" whiteSpace="nowrap" {...rest}>
     {children}
   </Text>
 );

--- a/airflow/www/static/js/tree/details/Header.jsx
+++ b/airflow/www/static/js/tree/details/Header.jsx
@@ -24,6 +24,7 @@ import {
   BreadcrumbLink,
   Box,
   Heading,
+  Text,
 } from '@chakra-ui/react';
 import { MdPlayArrow } from 'react-icons/md';
 
@@ -72,22 +73,22 @@ const Header = () => {
   const isTaskDetails = runId && taskId;
 
   return (
-    <Breadcrumb color="gray.300" mt={4}>
+    <Breadcrumb mt={4} separator={<Text color="gray.300">/</Text>}>
       <BreadcrumbItem isCurrentPage={isDagDetails}>
-        <BreadcrumbLink onClick={clearSelection} color="black" _hover={isDagDetails ? { cursor: 'default' } : undefined}>
+        <BreadcrumbLink onClick={clearSelection} _hover={isDagDetails ? { cursor: 'default' } : undefined}>
           <LabelValue label="DAG" value={dagId} />
         </BreadcrumbLink>
       </BreadcrumbItem>
       {runId && (
         <BreadcrumbItem isCurrentPage={isRunDetails}>
-          <BreadcrumbLink onClick={() => onSelect({ runId })} color="black" _hover={isRunDetails ? { cursor: 'default' } : undefined}>
+          <BreadcrumbLink onClick={() => onSelect({ runId })} _hover={isRunDetails ? { cursor: 'default' } : undefined}>
             <LabelValue label="Run" value={runLabel} />
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}
       {taskId && (
         <BreadcrumbItem isCurrentPage>
-          <BreadcrumbLink color="black" _hover={isTaskDetails ? { cursor: 'default' } : undefined}>
+          <BreadcrumbLink _hover={isTaskDetails ? { cursor: 'default' } : undefined}>
             <LabelValue label="Task" value={`${taskName}${isMapped ? ' []' : ''}`} />
           </BreadcrumbLink>
         </BreadcrumbItem>

--- a/airflow/www/static/js/tree/details/content/Dag.jsx
+++ b/airflow/www/static/js/tree/details/content/Dag.jsx
@@ -96,7 +96,7 @@ const Dag = () => {
       </Button>
       {durations.length > 0 && (
         <>
-          <Heading size="md" mt={4} mb={2}>DAG Runs Summary</Heading>
+          <Heading size="sm" mt={4} mb={2}>DAG Runs Summary</Heading>
           <Table variant="striped">
             <Tbody>
               <Tr>
@@ -140,7 +140,7 @@ const Dag = () => {
           </Table>
         </>
       )}
-      <Heading size="md" mt={4} mb={2}>DAG Summary</Heading>
+      <Heading size="sm" mt={4} mb={2}>DAG Summary</Heading>
       <Table variant="striped">
         <Tbody>
           {description && (

--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -66,7 +66,7 @@ const DagRun = ({ runId }) => {
   const detailsLink = appendSearchParams(dagRunDetailsUrl, detailsParams);
 
   return (
-    <Box fontSize="12px" py="4px">
+    <Box py="4px">
       <Flex justifyContent="space-between" alignItems="center">
         <Button as={Link} variant="ghost" colorScheme="blue" href={detailsLink}>DAG Run Details</Button>
         <Button as={Link} variant="ghost" colorScheme="blue" href={graphLink} leftIcon={<MdOutlineAccountTree />}>

--- a/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/index.jsx
@@ -69,7 +69,7 @@ const TaskInstance = ({ taskId, runId }) => {
   const instance = group.instances.find((ti) => ti.runId === runId);
 
   return (
-    <Box fontSize="12px" py="4px">
+    <Box py="4px">
       {!isGroup && (
         <TaskNav
           taskId={taskId}

--- a/airflow/www/static/js/tree/index.jsx
+++ b/airflow/www/static/js/tree/index.jsx
@@ -21,7 +21,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme } from '@chakra-ui/react';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -51,11 +51,21 @@ const queryClient = new QueryClient({
   },
 });
 
+const theme = extendTheme({
+  components: {
+    Tooltip: {
+      baseStyle: {
+        fontSize: 'md',
+      },
+    },
+  },
+});
+
 function App() {
   return (
     <React.StrictMode>
       <CacheProvider value={myCache}>
-        <ChakraProvider>
+        <ChakraProvider theme={theme}>
           <ContainerRefProvider>
             <QueryClientProvider client={queryClient}>
               <TimezoneProvider>


### PR DESCRIPTION
Too many font sizes in Grid view were being set to `10px` from how we define `html { }`. Across the rest of the UI, this is overwritten by the style in `body { }`, but not in the shadow root we had to create for the react sections. After resetting a default size, this enabled us to clean up a lot of manual styling. 

Also included: Cleaned up the Details header panel to remove the need of `color="black"` which was inconsistent with the rest of our colors.

Before:
<img width="1193" alt="Screen Shot 2022-04-08 at 2 35 56 PM" src="https://user-images.githubusercontent.com/4600967/162501919-61149ae7-bf19-4b52-b37a-22dd0c07a550.png">

After:
<img width="1177" alt="Screen Shot 2022-04-08 at 2 35 24 PM" src="https://user-images.githubusercontent.com/4600967/162501974-7552940f-4876-4d95-8686-4972f62c2fec.png">

Before:
<img width="1195" alt="Screen Shot 2022-04-08 at 2 36 10 PM" src="https://user-images.githubusercontent.com/4600967/162502018-5c419f89-852d-47af-9e23-00199895e7cf.png">

After:
<img width="1181" alt="Screen Shot 2022-04-08 at 2 35 00 PM" src="https://user-images.githubusercontent.com/4600967/162502032-d7cd5a37-b414-4bff-9c9c-1cc6102a6de4.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
