### PR TITLE
Add k8s container's error message in airflow exception

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -43,7 +43,12 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume_mount,
 )
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar  # type: ignore[attr-defined]
-from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLaunchFailedException, PodManager, PodPhase
+from airflow.providers.cncf.kubernetes.utils.pod_manager import (
+    PodLaunchFailedException,
+    PodManager,
+    PodPhase,
+    get_container_termination_message
+)
 from airflow.settings import pod_mutation_hook
 from airflow.utils import yaml
 from airflow.utils.helpers import prune_dict, validate_key
@@ -409,7 +414,11 @@ class KubernetesPodOperator(BaseOperator):
                     self.patch_already_checked(pod)
             with _suppress(Exception):
                 self.process_pod_deletion(pod)
-            raise AirflowException(f'Pod {pod and pod.metadata.name} returned a failure: {remote_pod}')
+            error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)
+            error_message = "\n" + error_message if error_message else ""
+            raise AirflowException(
+                f'Pod {pod and pod.metadata.name} returned a failure:{error_message}\n{remote_pod}'
+            )
         else:
             with _suppress(Exception):
                 self.process_pod_deletion(pod)

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -47,7 +47,7 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchFailedException,
     PodManager,
     PodPhase,
-    get_container_termination_message
+    get_container_termination_message,
 )
 from airflow.settings import pod_mutation_hook
 from airflow.utils import yaml

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -82,6 +82,15 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
     return container_status.state.running is not None
 
 
+def get_container_termination_message(pod: V1Pod, container_name: str):
+    try:
+        container_statuses = pod.status.container_statuses
+        container_status = next(iter([x for x in container_statuses if x.name == container_name]), None)
+        return container_status.state.terminated.message
+    except AttributeError:
+        return None
+
+
 @dataclass
 class PodLoggingStatus:
     """Used for returning the status of the pod and last log time when exiting from `fetch_container_logs`"""

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -86,7 +86,7 @@ def get_container_termination_message(pod: V1Pod, container_name: str):
     try:
         container_statuses = pod.status.container_statuses
         container_status = next(iter([x for x in container_statuses if x.name == container_name]), None)
-        return container_status.state.terminated.message
+        return container_status.state.terminated.message if container_status else None
     except AttributeError:
         return None
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -550,7 +550,7 @@ class TestKubernetesPodOperator:
         remote_pod_mock.status.phase = 'Failed'
         self.await_pod_mock.return_value = remote_pod_mock
 
-        with pytest.raises(AirflowException, match=f"Pod {name_base}.[a-z0-9]+ returned a failure: .*"):
+        with pytest.raises(AirflowException, match=f"Pod {name_base}.[a-z0-9]+ returned a failure:.*"):
             context = create_context(k)
             k.execute(context=context)
 


### PR DESCRIPTION
closes: #22693
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
If container task writes error message in /dev/termination-log, it will show up in Pod's status message. Include this message in the Exception so that it appears at the top.

---

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
