### PR TITLE
Support importing connections from files with ".yml" extension

### DIFF
--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -109,7 +109,6 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         return {}, [FileSyntaxError(line_no=1, message="The file is empty.")]
     try:
         secrets = yaml.safe_load(content)
-
     except yaml.MarkedYAMLError as e:
         err_line_no = e.problem_mark.line if e.problem_mark else -1
         return {}, [FileSyntaxError(line_no=err_line_no, message=str(e))]
@@ -167,7 +166,7 @@ def _parse_secret_file(file_path: str) -> Dict[str, Any]:
 
     if ext not in FILE_PARSERS:
         raise AirflowException(
-            "Unsupported file format. The file must have the extension .env or .json or .yaml"
+            "Unsupported file format. The file must have one of the following extensions: .env .json .yaml .yml"
         )
 
     secrets, parse_errors = FILE_PARSERS[ext](file_path)

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -145,6 +145,7 @@ FILE_PARSERS = {
     "env": _parse_env_file,
     "json": _parse_json_file,
     "yaml": _parse_yaml_file,
+    "yml": _parse_yaml_file,
 }
 
 

--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -166,7 +166,8 @@ def _parse_secret_file(file_path: str) -> Dict[str, Any]:
 
     if ext not in FILE_PARSERS:
         raise AirflowException(
-            "Unsupported file format. The file must have one of the following extensions: .env .json .yaml .yml"
+            "Unsupported file format. The file must have one of the following extensions: "
+            ".env .json .yaml .yml"
         )
 
     secrets, parse_errors = FILE_PARSERS[ext](file_path)

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -630,7 +630,7 @@ class TestCliImportConnections:
         with pytest.raises(SystemExit, match=r"Missing connections file."):
             connection_command.connections_import(self.parser.parse_args(["connections", "import", filepath]))
 
-    @pytest.mark.parametrize('filepath', ["sample.jso", "sample.yml", "sample.environ"])
+    @pytest.mark.parametrize('filepath', ["sample.jso", "sample.environ"])
     @mock.patch('os.path.exists')
     def test_cli_connections_import_should_return_error_if_file_format_is_invalid(
         self, mock_exists, filepath
@@ -638,7 +638,7 @@ class TestCliImportConnections:
         mock_exists.return_value = True
         with pytest.raises(
             AirflowException,
-            match=r"Unsupported file format. The file must have the extension .env or .json or .yaml",
+            match=r"Unsupported file format. The file must have one of the following extensions: .env .json .yaml .yml",
         ):
             connection_command.connections_import(self.parser.parse_args(["connections", "import", filepath]))
 

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -638,7 +638,10 @@ class TestCliImportConnections:
         mock_exists.return_value = True
         with pytest.raises(
             AirflowException,
-            match=r"Unsupported file format. The file must have one of the following extensions: .env .json .yaml .yml",
+            match=(
+                "Unsupported file format. The file must have one of the following extensions: "
+                ".env .json .yaml .yml"
+            ),
         ):
             connection_command.connections_import(self.parser.parse_args(["connections", "import", filepath]))
 

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -403,7 +403,7 @@ class TestLoadConnection(unittest.TestCase):
                 conn_id: conn.get_uri() for conn_id, conn in yml_conn.items()
             }
 
-            self.assertDictEqual(yaml_conn_uri_by_conn_id, yml_conn_uri_by_conn_id)
+            assert yaml_conn_uri_by_conn_id == yml_conn_uri_by_conn_id
 
 
 class TestLocalFileBackend(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -122,8 +122,9 @@ class TestLoadVariables(unittest.TestCase):
     )
     def test_yaml_file_should_load_variables(self, file_content, expected_variables):
         with mock_local_file(file_content):
-            variables = local_filesystem.load_variables('a.yaml')
-            assert expected_variables == variables
+            vars_yaml = local_filesystem.load_variables('a.yaml')
+            vars_yml = local_filesystem.load_variables('a.yml')
+            assert expected_variables == vars_yaml == vars_yml
 
 
 class TestLoadConnection(unittest.TestCase):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -390,6 +390,21 @@ class TestLoadConnection(unittest.TestCase):
             with pytest.raises(ConnectionNotUnique):
                 local_filesystem.load_connections_dict("a.yaml")
 
+    @parameterized.expand((("conn_a: mysql://hosta"),),)
+    def test_yaml_extension_parsers_return_same_result(self, file_content):
+        with mock_local_file(file_content):
+            yaml_conn = local_filesystem.load_connections_dict("a.yaml")
+            yaml_conn_uri_by_conn_id = {
+                conn_id: conn.get_uri() for conn_id, conn in yaml_conn.items()
+            }
+
+            yml_conn = local_filesystem.load_connections_dict("a.yml")
+            yml_conn_uri_by_conn_id = {
+                conn_id: conn.get_uri() for conn_id, conn in yml_conn.items()
+            }
+
+            self.assertDictEqual(yaml_conn_uri_by_conn_id, yml_conn_uri_by_conn_id)
+
 
 class TestLocalFileBackend(unittest.TestCase):
     def test_should_read_variable(self):

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -391,20 +391,20 @@ class TestLoadConnection(unittest.TestCase):
             with pytest.raises(ConnectionNotUnique):
                 local_filesystem.load_connections_dict("a.yaml")
 
-    @parameterized.expand((("conn_a: mysql://hosta"),),)
+    @parameterized.expand(
+        (("conn_a: mysql://hosta"),),
+    )
     def test_yaml_extension_parsers_return_same_result(self, file_content):
         with mock_local_file(file_content):
-            yaml_conn = local_filesystem.load_connections_dict("a.yaml")
-            yaml_conn_uri_by_conn_id = {
-                conn_id: conn.get_uri() for conn_id, conn in yaml_conn.items()
+            conn_uri_by_conn_id_yaml = {
+                conn_id: conn.get_uri()
+                for conn_id, conn in local_filesystem.load_connections_dict("a.yaml").items()
             }
-
-            yml_conn = local_filesystem.load_connections_dict("a.yml")
-            yml_conn_uri_by_conn_id = {
-                conn_id: conn.get_uri() for conn_id, conn in yml_conn.items()
+            conn_uri_by_conn_id_yml = {
+                conn_id: conn.get_uri()
+                for conn_id, conn in local_filesystem.load_connections_dict("a.yml").items()
             }
-
-            assert yaml_conn_uri_by_conn_id == yml_conn_uri_by_conn_id
+            assert conn_uri_by_conn_id_yaml == conn_uri_by_conn_id_yml
 
 
 class TestLocalFileBackend(unittest.TestCase):


### PR DESCRIPTION
Closes #22473

This PR adds support for importing connections from files with the `.yml` extension. #22473 also describes adding the option to _export_ connections to `.yml` files. I decided to skip this out of consideration for the robustness principle (be conservative about output, be liberal about input).
