### PR TITLE
Update ecs_task_id on reattaching

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -413,6 +413,7 @@ class ECSOperator(BaseOperator):
         )
         if previous_task_arn in running_tasks:
             self.arn = previous_task_arn
+            self.ecs_task_id = self.arn.split("/")[-1]
             self.log.info("Reattaching previously launched task: %s", self.arn)
         else:
             self.log.info("No active previously launched task found to reattach")

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -207,6 +207,7 @@ class TestECSOperator(unittest.TestCase):
         wait_mock.assert_called_once_with()
         check_mock.assert_called_once_with()
         assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+        assert self.ecs.ecs_task_id == 'd8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
 
     def test_execute_with_failures(self):
         client_mock = self.aws_hook_mock.return_value.get_conn.return_value
@@ -478,6 +479,7 @@ class TestECSOperator(unittest.TestCase):
         check_mock.assert_called_once_with()
         xcom_del_mock.assert_called_once()
         assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+        assert self.ecs.ecs_task_id == 'd8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
 
     @parameterized.expand(
         [
@@ -526,6 +528,7 @@ class TestECSOperator(unittest.TestCase):
         check_mock.assert_called_once_with()
         xcom_del_mock.assert_called_once()
         assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+        assert self.ecs.ecs_task_id == 'd8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
 
     def test_execute_xcom_with_log(self):
         self.ecs.do_xcom_push = True


### PR DESCRIPTION
Resolve an issue that can occur when reattaching to ECS tasks.

closes: #22878

The code for fetching AWS logs, looks for the ecs_task_id field. When executing the task for the first time, this is updated after fetching the ARN for the first time. However, when the task is reattached to an existing ECS task, the current code will update the ARN, but will not update the ecs_task_id. The code change will ensure that the ecs_task_id is updated when the ARN is updated at the time of reattaching.