### PR TITLE
MSSQLToGCSOperator fails: datetime is not JSON Serializable

### DIFF
--- a/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """MsSQL to GCS operator."""
-
+import datetime
 import decimal
 from typing import Dict
 
@@ -84,7 +84,10 @@ class MSSQLToGCSOperator(BaseSQLToGCSOperator):
         """
         Takes a value from MSSQL, and converts it to a value that's safe for
         JSON/Google Cloud Storage/BigQuery.
+        Datetime, Date and Time are converted to ISO formatted strings.
         """
         if isinstance(value, decimal.Decimal):
             return float(value)
+        if isinstance(value, (datetime.date, datetime.time)):
+            return value.isoformat()
         return value

--- a/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
@@ -60,7 +60,7 @@ class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
             (-2, -2),
             (datetime.date(1970, 1, 2), "1970-01-02"),
             (datetime.date(1000, 1, 2), "1000-01-02"),
-            (datetime.datetime(1970, 1, 1, 1, 0, tzinfo=None), "1970-01-01T01:00:00"),
+            (datetime.datetime(1970, 1, 1, 1, 0), "1970-01-01T01:00:00"),
             (datetime.time(hour=0, minute=0, second=0), "00:00:00"),
             (datetime.time(hour=23, minute=59, second=59), "23:59:59"),
         ]

--- a/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
@@ -16,8 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import datetime
 import unittest
 from unittest import mock
+
+from parameterized import parameterized
 
 from airflow import PY38
 
@@ -50,6 +53,28 @@ SCHEMA_JSON = [
 
 @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
 class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("string", "string"),
+            (32.9, 32.9),
+            (-2, -2),
+            (datetime.date(1970, 1, 2), "1970-01-02"),
+            (datetime.date(1000, 1, 2), "1000-01-02"),
+            (datetime.datetime(1970, 1, 1, 1, 0, tzinfo=None), "1970-01-01T01:00:00"),
+            (datetime.time(hour=0, minute=0, second=0), "00:00:00"),
+            (datetime.time(hour=23, minute=59, second=59), "23:59:59"),
+        ]
+    )
+    def test_convert_type(self, value, expected):
+        op = MSSQLToGCSOperator(
+            task_id=TASK_ID,
+            mssql_conn_id=MSSQL_CONN_ID,
+            sql=SQL,
+            bucket=BUCKET,
+            filename=JSON_FILENAME,
+        )
+        assert op.convert_type(value, None) == expected
+
     def test_init(self):
         """Test MySqlToGoogleCloudStorageOperator instance is properly initialized."""
         op = MSSQLToGCSOperator(task_id=TASK_ID, sql=SQL, bucket=BUCKET, filename=JSON_FILENAME)


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/11370

Here is the first draft to add support for `date` `datetime` and `time` to `MSSQLToGCSOperator.convert_type`.
I added some tests to this function.

This way we can export a schema that has date, datetime and time columns.

Date and Time are for now uploaded as STRING field to big query, which is not great. Both of them have `2` returned for type oid, which makes it not trivial to map to the correct big query type.

![schema](https://user-images.githubusercontent.com/14861206/162589255-9cb105be-227d-4fcd-889d-53ab345d6125.png)
![data](https://user-images.githubusercontent.com/14861206/162589258-378a2607-c13a-4ac6-b035-6e3ef4c930b8.png)


