### PR TITLE
Databricks SQL operators are now Python 3.10 compatible

### DIFF
--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -37,9 +37,6 @@ versions:
 additional-dependencies:
   - apache-airflow>=2.1.0
 
-excluded-python-versions:
-  - "3.10"
-
 integrations:
   - integration-name: Databricks
     external-doc-url: https://databricks.com/

--- a/docs/apache-airflow-providers-databricks/index.rst
+++ b/docs/apache-airflow-providers-databricks/index.rst
@@ -80,7 +80,7 @@ PIP requirements
 PIP package                   Version required
 ============================  ===================
 ``apache-airflow``            ``>=2.1.0``
-``databricks-sql-connector``  ``>=1.0.0, <2.0.0``
+``databricks-sql-connector``  ``>=1.0.2, <2.0.0``
 ``requests``                  ``>=2.26.0, <3``
 ============================  ===================
 

--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ dask = [
 ]
 databricks = [
     'requests>=2.26.0, <3',
-    'databricks-sql-connector>=1.0.0, <2.0.0',
+    'databricks-sql-connector>=1.0.2, <2.0.0',
 ]
 datadog = [
     'datadog>=0.14.0',

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -24,7 +24,7 @@ from unittest import mock
 import pytest
 from databricks.sql.types import Row
 
-from airflow import PY310, AirflowException
+from airflow import AirflowException
 from airflow.providers.databricks.operators.databricks_sql import (
     DatabricksCopyIntoOperator,
     DatabricksSqlOperator,
@@ -83,12 +83,6 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         db_mock.run.assert_called_once_with(sql, parameters=None)
 
 
-@pytest.mark.skipif(
-    PY310,
-    reason="Databricks SQL tests not run on Python 3.10 because there is direct Iterable import from"
-    " collections in the databricks SQL library, where it should be imported from collections.abc."
-    " This could be removed when https://github.com/apache/airflow/issues/22220 is solved",
-)
 class TestDatabricksSqlCopyIntoOperator(unittest.TestCase):
     def test_copy_with_files(self):
         op = DatabricksCopyIntoOperator(


### PR DESCRIPTION
New version of `databricks-sql-connector` fixes incompatibility with Python 3.10, so rolling back #22221, and bumping dependency.

 closes #22220
