### PR TITLE
Catch error in Breeze when docker is not running

### DIFF
--- a/dev/breeze/src/airflow_breeze/shell/enter_shell.py
+++ b/dev/breeze/src/airflow_breeze/shell/enter_shell.py
@@ -33,6 +33,7 @@ from airflow_breeze.utils.docker_command_utils import (
     SOURCE_OF_DEFAULT_VALUES_FOR_VARIABLES,
     VARIABLES_IN_CACHE,
     check_docker_compose_version,
+    check_docker_is_running,
     check_docker_resources,
     check_docker_version,
     construct_env_variables_docker_compose_command,
@@ -190,6 +191,9 @@ def enter_shell(**kwargs):
     """
     verbose = kwargs['verbose']
     dry_run = kwargs['dry_run']
+    if not check_docker_is_running(verbose):
+        console.print(f'[red]Docker is not running. Please make sure Docker is installed ' 'and running.[/]')
+        sys.exit(1)
     check_docker_version(verbose)
     check_docker_compose_version(verbose)
     updated_kwargs = synchronize_cached_params(kwargs)

--- a/dev/breeze/src/airflow_breeze/shell/enter_shell.py
+++ b/dev/breeze/src/airflow_breeze/shell/enter_shell.py
@@ -192,7 +192,10 @@ def enter_shell(**kwargs):
     verbose = kwargs['verbose']
     dry_run = kwargs['dry_run']
     if not check_docker_is_running(verbose):
-        console.print(f'[red]Docker is not running. Please make sure Docker is installed ' 'and running.[/]')
+        console.print(
+            '[red]Docker is not running.[/]\n'
+            '[bright_yellow]Please make sure Docker is installed and running.[/]'
+        )
         sys.exit(1)
     check_docker_version(verbose)
     check_docker_compose_version(verbose)

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -179,11 +179,7 @@ def check_docker_version(verbose: bool):
             text=True,
         )
         if not docker_version_output:
-            console.print(
-                '[red]ERROR[/] Docker version could not be determined. Please make sure Docker is installed '
-                'and running.'
-            )
-            return
+            raise Exception("No running Docker instance found")
         if docker_version_output.returncode == 0:
             docker_version = docker_version_output.stdout.strip()
         if docker_version == '':

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -174,9 +174,9 @@ def check_docker_is_running(verbose: bool) -> bool:
         stdout=subprocess.DEVNULL,
         stderr=subprocess.STDOUT,
     )
-
     if not response:
         return False
+    return True
 
 
 def check_docker_version(verbose: bool):

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -178,6 +178,12 @@ def check_docker_version(verbose: bool):
             capture_output=True,
             text=True,
         )
+        if not docker_version_output:
+            console.print(
+                '[red]ERROR[/] Docker version could not be determined. Please make sure Docker is installed '
+                'and running.'
+            )
+            return
         if docker_version_output.returncode == 0:
             docker_version = docker_version_output.stdout.strip()
         if docker_version == '':

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -159,11 +159,32 @@ def compare_version(current_version: str, min_version: str) -> bool:
     return version.parse(current_version) >= version.parse(min_version)
 
 
+def check_docker_is_running(verbose: bool) -> bool:
+    """
+    Checks if docker is running. Suppressed Dockers stdout and stderr output.
+    :param verbose: print commands when running
+    :return: False if docker is not running.
+    """
+    response = run_command(
+        ["docker", "info"],
+        verbose=verbose,
+        no_output_dump_on_exception=True,
+        text=False,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+
+    if not response:
+        return False
+
+
 def check_docker_version(verbose: bool):
     """
     Checks if the docker compose version is as expected (including some specific modifications done by
     some vendors such as Microsoft (they might have modified version of docker-compose/docker in their
     cloud. In case docker compose version is wrong we continue but print warning for the user.
+
 
     :param verbose: print commands when running
     """
@@ -178,8 +199,6 @@ def check_docker_version(verbose: bool):
             capture_output=True,
             text=True,
         )
-        if not docker_version_output:
-            raise Exception("No running Docker instance found")
         if docker_version_output.returncode == 0:
             docker_version = docker_version_output.stdout.strip()
         if docker_version == '':


### PR DESCRIPTION

Running the new python Breeze environment crashes, if Docker is not running.
This PR will give a descriptive error.

Traceback of the error:
```
  File "/Users/vosjoppe/github/airflow/dev/breeze/src/airflow_breeze/breeze.py", line 707, in shell
    enter_shell(
  File "/Users/vosjoppe/github/airflow/dev/breeze/src/airflow_breeze/shell/enter_shell.py", line 193, in enter_shell
    check_docker_version(verbose)
  File "/Users/vosjoppe/github/airflow/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py", line 181, in check_docker_version
    if docker_version_output.returncode == 0:
AttributeError: 'NoneType' object has no attribute 'returncode'
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**
