### PR TITLE
Update codeowners for Google provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,9 @@
 /airflow/secrets  @dstandish @kaxil @potiuk @ashb
 
 # Providers
-/airflow/providers/google/ @turbaszek
+/airflow/providers/google/ @turbaszek @bhirsz
+/docs/apache-airflow-providers-google/ @bhirsz
+/tests/system/providers/google/ @bhirsz
 /airflow/providers/snowflake/ @turbaszek @potiuk @mik-laj
 /airflow/providers/cncf/kubernetes @jedcunningham
 /docs/apache-airflow-providers-cncf-kubernetes @jedcunningham

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -23,6 +23,7 @@ labelPRBasedOnFilePath:
     - airflow/providers/google/**/*
     - docs/apache-airflow-providers-google/**/*
     - tests/providers/google/**/*
+    - tests/system/providers/google/**/*
 
   provider:AWS:
     - airflow/providers/amazon/aws/**/*


### PR DESCRIPTION
@potiuk 

(PR to test if it's possible to update codeowner with someone who don't have write access)

It appears that there are errors when trying to update codeowners with user who don't have write access:
![image](https://user-images.githubusercontent.com/8532066/162714732-d8398ccb-3f00-4861-b7f9-ccb50a08e565.png)
