### PR TITLE
Call mapped_dependants only on the original task

### DIFF
--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from logging import Logger
 
     from airflow.models.dag import DAG
+    from airflow.models.mappedoperator import MappedOperator
     from airflow.utils.edgemodifier import EdgeModifier
     from airflow.utils.task_group import TaskGroup
 
@@ -290,7 +291,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
         """This is used by SerializedTaskGroup to serialize a task group's content."""
         raise NotImplementedError()
 
-    def mapped_dependants(self) -> Iterator["DAGNode"]:
+    def mapped_dependants(self) -> Iterator["MappedOperator"]:
         """Return any mapped nodes that are direct dependencies of the current task
 
         For now, this walks the entire DAG to find mapped nodes that has this

--- a/tests/dags/test_mapped_classic.py
+++ b/tests/dags/test_mapped_classic.py
@@ -32,3 +32,6 @@ def consumer(value):
 
 with DAG(dag_id='test_mapped_classic', start_date=days_ago(2)) as dag:
     PythonOperator.partial(task_id='consumer', python_callable=consumer).expand(op_args=make_arg_lists())
+    PythonOperator.partial(task_id='consumer_literal', python_callable=consumer).expand(
+        op_args=[[1], [2], [3]],
+    )

--- a/tests/dags/test_mapped_taskflow.py
+++ b/tests/dags/test_mapped_taskflow.py
@@ -29,3 +29,4 @@ with DAG(dag_id='test_mapped_taskflow', start_date=days_ago(2)) as dag:
         print(repr(value))
 
     consumer.expand(value=make_list())
+    consumer.expand(value=[1, 2, 3])


### PR DESCRIPTION
We've made change on this in the scheduler, but need to match it in the BackfillJob.

Should be the last piece to fix #22626.