### PR TITLE
Clarify breeze install message re pipx vs `./breeze`

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/visuals.py
+++ b/dev/breeze/src/airflow_breeze/utils/visuals.py
@@ -78,16 +78,19 @@ CHEATSHEET = f"""
 
     [bright_blue]* Installation[/]
 
-        When you have multiple copies of Airflow, it's better if you use `./breeze` from those
-        repository as it will have the latest version of breeze and it's dependencies.
+        You can invoke the breeze command with `./breeze`.  Optionally you may install with `pipx` and then
+        you can invoke with `breeze`.
 
-        However if you only have one Airflow repository and you have `pipx` installed, you can use
+        If you use multiple copies of the Airflow repo, it's better if you use `./breeze` from within each
+        repository as it will have the right version of breeze and it's dependencies.
+
+        However if you only use one Airflow repository and you have `pipx` installed, you can use
         `pipx` to install `breeze` command in your path (`breeze` command is run from this repository then)
 
             pipx install -e ./dev/breeze --force
 
-        In case you use `pipx`, you might need to occasionally reinstall `breeze` with the `--force` flag
-        when dependencies change for it. You do not have to do it when you use it via `./breeze`
+        If using `pipx`, you might need to occasionally reinstall `breeze` with the `--force` flag
+        when dependencies change for it. You do not have to do this when invoking with `./breeze`
 
     [bright_blue]* Port forwarding:[/]
 


### PR DESCRIPTION
The first sentence, "When you have multiple copies of Airflow" was momentarily confusing.  It wasn't obvious that the context was "to use pipx or ./breeze".  I try to make that a little clearer here.
