### PR TITLE
implements #22859 - Add .sql as templatable extension

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2070,7 +2070,10 @@ class BigQueryInsertJobOperator(BaseOperator):
         "job_id",
         "impersonation_chain",
     )
-    template_ext: Sequence[str] = (".json",)
+    template_ext: Sequence[str] = (
+        ".json",
+        ".sql",
+    )
     template_fields_renderers = {"configuration": "json", "configuration.query.query": "sql"}
     ui_color = BigQueryUIColors.QUERY.value
 


### PR DESCRIPTION
This enables developers to template `.sql` files in Jinja when using `BigQueryInsertJobOperator`. This means that the parameter `configuration.query.query` can now refer to a proper `.sql` template file while keeping the rest of `configuration` in the top-level code of the operator.