### PR TITLE
Remove installation instructions from Breeze's cheatsheet

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/visuals.py
+++ b/dev/breeze/src/airflow_breeze/utils/visuals.py
@@ -76,19 +76,6 @@ CHEATSHEET = f"""
 
                        [bold][bright_blue]Airflow Breeze Cheatsheet[/][/]
 
-    [bright_blue]* Installation[/]
-
-        When you have multiple copies of Airflow, it's better if you use `./breeze` from those
-        repository as it will have the latest version of breeze and it's dependencies.
-
-        However if you only have one Airflow repository and you have `pipx` installed, you can use
-        `pipx` to install `breeze` command in your path (`breeze` command is run from this repository then)
-
-            pipx install -e ./dev/breeze --force
-
-        In case you use `pipx`, you might need to occasionally reinstall `breeze` with the `--force` flag
-        when dependencies change for it. You do not have to do it when you use it via `./breeze`
-
     [bright_blue]* Port forwarding:[/]
 
         Ports are forwarded to the running docker containers for webserver and database


### PR DESCRIPTION
The cheatsheet is displayed only after Breeze is installed so it
makes no sense to display installation instructions in the
cheathsheet.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
