### PR TITLE
Use appropriate TaskInstance object related to TaskFail to get execution_date

### DIFF
--- a/airflow/models/taskfail.py
+++ b/airflow/models/taskfail.py
@@ -18,6 +18,8 @@
 """Taskfail tracks the failed run durations of each task instance"""
 
 from sqlalchemy import Column, ForeignKeyConstraint, Integer
+from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm import relationship
 
 from airflow.models.base import Base, StringID
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -36,6 +38,9 @@ class TaskFail(Base):
     start_date = Column(UtcDateTime)
     end_date = Column(UtcDateTime)
     duration = Column(Integer)
+
+    task_instance = relationship("TaskInstance", lazy='joined', innerjoin=True)
+    execution_date = association_proxy("task_instance", "execution_date")
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/airflow/models/taskfail.py
+++ b/airflow/models/taskfail.py
@@ -39,7 +39,7 @@ class TaskFail(Base):
     end_date = Column(UtcDateTime)
     duration = Column(Integer)
 
-    task_instance = relationship("TaskInstance", lazy='select', innerjoin=True)
+    task_instance = relationship("TaskInstance", innerjoin=True)
     execution_date = association_proxy("task_instance", "execution_date")
 
     __table_args__ = (

--- a/airflow/models/taskfail.py
+++ b/airflow/models/taskfail.py
@@ -39,7 +39,7 @@ class TaskFail(Base):
     end_date = Column(UtcDateTime)
     duration = Column(Integer)
 
-    task_instance = relationship("TaskInstance", lazy='joined', innerjoin=True)
+    task_instance = relationship("TaskInstance", lazy='select', innerjoin=True)
     execution_date = association_proxy("task_instance", "execution_date")
 
     __table_args__ = (

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2901,26 +2901,23 @@ class Airflow(AirflowBaseView):
             min_date = task_instances[0].execution_date
         else:
             min_date = timezone.utc_epoch()
-
         ti_fails = (
-            session.query(TaskFail, TaskInstance)
+            session.query(TaskFail)
             .filter(
                 TaskFail.dag_id == dag.dag_id,
                 DagRun.execution_date >= min_date,
                 DagRun.execution_date <= base_date,
                 TaskFail.task_id.in_([t.task_id for t in dag.tasks]),
-                TaskFail.run_id == TaskInstance.run_id,
-                TaskFail.task_id == TaskInstance.task_id,
             )
             .all()
         )
-        fails_totals = defaultdict(int)
 
-        for failed_task_instance, task_instance in ti_fails:
+        fails_totals = defaultdict(int)
+        for failed_task_instance in ti_fails:
             dict_key = (
                 failed_task_instance.dag_id,
                 failed_task_instance.task_id,
-                task_instance.execution_date,
+                failed_task_instance.execution_date,
             )
             if failed_task_instance.duration:
                 fails_totals[dict_key] += failed_task_instance.duration

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3244,7 +3244,11 @@ class Airflow(AirflowBaseView):
             .order_by(TaskInstance.start_date)
         )
 
-        ti_fails = session.query(TaskFail).filter(DagRun.execution_date == dttm, TaskFail.dag_id == dag_id)
+        ti_fails = (
+            session.query(TaskFail)
+            .options(joinedload(TaskFail.task_instance))
+            .filter(DagRun.execution_date == dttm, TaskFail.dag_id == dag_id)
+        )
 
         tasks = []
         for ti in tis:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2903,6 +2903,7 @@ class Airflow(AirflowBaseView):
             min_date = timezone.utc_epoch()
         ti_fails = (
             session.query(TaskFail)
+            .options(joinedload(TaskFail.task_instance))
             .filter(
                 TaskFail.dag_id == dag.dag_id,
                 DagRun.execution_date >= min_date,


### PR DESCRIPTION
`TaskFail` instance has no execution_date attribute. Fetch execution_date from the relevant `TaskInstance` object to form the dictionary key tuple.

closes: #22933
related: #22933