### PR TITLE
Fix BigQueryGetDataOperator Response Serialisation

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -467,6 +467,14 @@ class BigQueryGetDataOperator(BaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
 
+        if not self.selected_fields:
+            schema: Dict[str, list] = hook.get_schema(
+                dataset_id=self.dataset_id,
+                table_id=self.table_id,
+            )
+            if "fields" in schema:
+                self.selected_fields = ','.join([field["name"] for field in schema["fields"]])
+
         rows = hook.list_rows(
             dataset_id=self.dataset_id,
             table_id=self.table_id,


### PR DESCRIPTION
Currently, if I do not pass the `selected_fields` parameter in  BigQueryGetDataOperator which is equivalent to `select * from table` and bigquery table has a column having type Date, Time, Datetime or Decimal then the Python JSON module fails to serialise the response of this operator and the task fails.

This happens because when we do not pass the column name in the google client request then it returns a column value in form of an object Python JSON fails to serialise it but if I'm passing the column name then it is returned as a string 

There is existing work around it by setting `enable_xcom_pickling`  to true in default_airflow.cfg but this is insecure

Changes:
- Send all columns as selected_fields in case the selected_fields param is None

After this change below task will succeed and store the response in xcom for any bigquery column type without  setting up enable_xcom_pickling to true
```
get_data = BigQueryGetDataOperator(
        task_id='get_data_from_bq',
        dataset_id=DATASET_NAME,
        table_id='dummy_table',
        max_results=100,
    )
```

@kaxil @phanikumv 