### PR TITLE
Allow re-use of decorated tasks

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -385,6 +385,11 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
 
         return attr.evolve(self, kwargs={**self.kwargs, "op_kwargs": op_kwargs})
 
+    def override(self, **kwargs) -> "_TaskDecorator[Function, OperatorSubclass]":
+        kw = copy.copy(self.kwargs)
+        kw.update(kwargs)
+        return attr.evolve(self, kwargs=kw)
+
 
 def _merge_kwargs(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail_reason: str) -> Dict[str, Any]:
     duplicated_keys = set(kwargs1).intersection(kwargs2)

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import collections.abc
 import functools
 import inspect
 import re

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import collections.abc
 import functools
 import inspect
 import re
@@ -386,9 +387,7 @@ class _TaskDecorator(Generic[Function, OperatorSubclass]):
         return attr.evolve(self, kwargs={**self.kwargs, "op_kwargs": op_kwargs})
 
     def override(self, **kwargs) -> "_TaskDecorator[Function, OperatorSubclass]":
-        kw = copy.copy(self.kwargs)
-        kw.update(kwargs)
-        return attr.evolve(self, kwargs=kw)
+        return attr.evolve(self, kwargs={**self.kwargs, **kwargs})
 
 
 def _merge_kwargs(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail_reason: str) -> Dict[str, Any]:

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -160,6 +160,65 @@ the dependencies as shown below.
     :start-after: [START main_flow]
     :end-before: [END main_flow]
 
+
+Re-using a decorated task
+-------------------------
+
+Decorated tasks are flexible. You can re-use a decorated task in multiple DAGs, overriding the operator
+parameters such as the ``task_id``, ``queue``, ``pool``, etc, as well as the task's arguments.
+
+Below is an example of how you can re-use a decorated task in multiple DAGs:
+
+.. code-block:: python
+    from airflow.decorators import task, dag
+    from datetime import datetime
+
+
+    @task
+    def add_task(x, y):
+        print(f"Task args: x={x}, y={y}")
+        return x + y
+
+
+    @dag(start_date=datetime(2022, 1, 1))
+    def mydag():
+        start = add_task.override(task_id="start")(1, 2)
+        for i in range(3):
+            start >> add_task.override(task_id=f"add_start_{i}")(start, i)
+
+
+    @dag(start_date=datetime(2022, 1, 1))
+    def mydag2():
+        start = add_task(1, 2)
+        for i in range(3):
+            start >> add_task.override(task_id=f"new_add_task_{i}")(start, i)
+
+
+    first_dag = mydag()
+    second_dag = mydag2()
+
+You can also import the above ``add_task`` and use it in another DAG file.
+Suppose the code above lives in a file called ``common.py``. You can do this:
+
+.. code-block:: python
+
+    from common import add_task
+    from airflow.decorators import dag
+    from datetime import datetime
+
+
+    @dag(start_date=datetime(2022, 1, 1))
+    def use_add_task():
+        start = add_task.override(priority_weight=3)(1, 2)
+        for i in range(3):
+            start >> add_task.override(task_id=f"new_add_task_{i}", pool="default_pool")(
+                start, i
+            )
+
+
+    created_dag = use_add_task()
+
+
 Using the TaskFlow API with Docker or Virtual Environments
 ----------------------------------------------------------
 

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -170,6 +170,7 @@ parameters such as the ``task_id``, ``queue``, ``pool``, etc.
 Below is an example of how you can reuse a decorated task in multiple DAGs:
 
 .. code-block:: python
+
     from airflow.decorators import task, dag
     from datetime import datetime
 

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -161,13 +161,13 @@ the dependencies as shown below.
     :end-before: [END main_flow]
 
 
-Re-using a decorated task
+Reusing a decorated task
 -------------------------
 
-Decorated tasks are flexible. You can re-use a decorated task in multiple DAGs, overriding the operator
-parameters such as the ``task_id``, ``queue``, ``pool``, etc, as well as the task's arguments.
+Decorated tasks are flexible. You can reuse a decorated task in multiple DAGs, overriding the operator
+parameters such as the ``task_id``, ``queue``, ``pool``, etc., as well as the task's arguments.
 
-Below is an example of how you can re-use a decorated task in multiple DAGs:
+Below is an example of how you can reuse a decorated task in multiple DAGs:
 
 .. code-block:: python
     from airflow.decorators import task, dag
@@ -198,7 +198,7 @@ Below is an example of how you can re-use a decorated task in multiple DAGs:
     second_dag = mydag2()
 
 You can also import the above ``add_task`` and use it in another DAG file.
-Suppose the code above lives in a file called ``common.py``. You can do this:
+Suppose the ``add_task`` code lives in a file called ``common.py``. You can do this:
 
 .. code-block:: python
 

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -164,8 +164,8 @@ the dependencies as shown below.
 Reusing a decorated task
 -------------------------
 
-Decorated tasks are flexible. You can reuse a decorated task in multiple DAGs, overriding the operator
-parameters such as the ``task_id``, ``queue``, ``pool``, etc., as well as the task's arguments.
+Decorated tasks are flexible. You can reuse a decorated task in multiple DAGs, overriding the task
+parameters such as the ``task_id``, ``queue``, ``pool``, etc.
 
 Below is an example of how you can reuse a decorated task in multiple DAGs:
 
@@ -211,9 +211,7 @@ Suppose the ``add_task`` code lives in a file called ``common.py``. You can do t
     def use_add_task():
         start = add_task.override(priority_weight=3)(1, 2)
         for i in range(3):
-            start >> add_task.override(task_id=f"new_add_task_{i}", pool="default_pool")(
-                start, i
-            )
+            start >> add_task.override(task_id=f"new_add_task_{i}", retries=4)(start, i)
 
 
     created_dag = use_add_task()

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -519,8 +519,9 @@ class TestAirflowTaskDecorator:
         with self.dag:
             for i in range(3):
                 hello.override(task_id=f'my_task_id_{i * 2}')()
+            hello()  # This task would have hello_task as the task_id
 
-        assert self.dag.task_ids == ['my_task_id_0', 'my_task_id_2', 'my_task_id_4']
+        assert self.dag.task_ids == ['my_task_id_0', 'my_task_id_2', 'my_task_id_4', 'hello_task']
 
     def test_user_provided_pool_and_priority_weight_works(self):
         """Tests that when looping that user provided pool, priority_weight etc is used"""

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -506,6 +506,42 @@ class TestAirflowTaskDecorator:
 
         assert ret.operator.doc_md.strip(), "Adds 2 to number."
 
+    def test_user_provided_task_id_in_a_loop_is_used(self):
+        """Tests that when looping that user provided task_id is used"""
+
+        @task_decorator(task_id='hello_task')
+        def hello():
+            """
+            Print Hello world
+            """
+            print("Hello world")
+
+        with self.dag:
+            for i in range(3):
+                hello.override(task_id=f'my_task_id_{i * 2}')()
+
+        assert self.dag.task_ids == ['my_task_id_0', 'my_task_id_2', 'my_task_id_4']
+
+    def test_user_provided_pool_and_priority_weight_works(self):
+        """Tests that when looping that user provided pool, priority_weight etc is used"""
+
+        @task_decorator(task_id='hello_task')
+        def hello():
+            """
+            Print Hello world
+            """
+            print("Hello world")
+
+        with self.dag:
+            for i in range(3):
+                hello.override(pool='my_pool', priority_weight=i)()
+
+        weights = []
+        for task in self.dag.tasks:
+            assert task.pool == 'my_pool'
+            weights.append(task.priority_weight)
+        assert weights == [0, 1, 2]
+
 
 def test_mapped_decorator_shadow_context() -> None:
     @task_decorator


### PR DESCRIPTION
This opens up the possibility of using one decorated task
in different dag files.
Take for example the below task:
- common.py

```python
@task(task_id='hello')
def hello():
    print('Hello')
```
defined in a file and called in different dag files using different task ids:
- dag_file1.py:

```python
from common import hello

@dag
def mydag():
    for i in range(3):
        hello.override(task_id=f'myhellotask_{i}')()
```

- dag_file2.py:

```python
from common import hello

@dag():
def mydag2():
    for i in range(3):
        hello.override(task_id=f'welcome_message_{i}', pool='mypool')()
```

They would all run with different task ids
