### PR TITLE
Remove Grid labels and differentiate runs from tasks more

### DIFF
--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -88,7 +88,7 @@ const DagRunBar = ({
           <Flex
             width="10px"
             height={`${(run.duration / max) * BAR_HEIGHT}px`}
-            minHeight="12px"
+            minHeight="14px"
             backgroundColor={stateColors[run.state]}
             borderRadius={2}
             cursor="pointer"

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -56,7 +56,7 @@ const DagRuns = ({ tableWidth }) => {
 
   return (
     <Tr
-      borderBottomWidth={2}
+      borderBottomWidth={3}
       borderBottomColor="gray.200"
       position="relative"
     >
@@ -89,8 +89,6 @@ const DagRuns = ({ tableWidth }) => {
         <Box position="absolute" bottom="100px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
         <Box position="absolute" bottom="50px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
         <Box position="absolute" bottom="4px" borderBottomWidth={1} zIndex={0} opacity={0.7} width={tickWidth} />
-        <Text transform="rotate(-90deg)" position="absolute" left="-23px" top="120px" zIndex={2}>Runs</Text>
-        <Text transform="rotate(-90deg)" position="absolute" left="-23px" top="175px" zIndex={2}>Tasks</Text>
       </Td>
       <Td p={0} align="right" verticalAlign="bottom" borderBottom={0} width={`${runs.length * 16}px`}>
         <Flex justifyContent="flex-end">


### PR DESCRIPTION
At some point the "Runs" and "Tasks" labels on grid view were pushed off-screen because they were placed with magical absolutely positioning. But it took a while for anyone to notice and when demoing to various people, noone felt the need for them. Only sometimes did they appear for a pixel or two on the far side.

Instead, let's rip them out and improve the visual difference between runs and tasks by expanding the border between them and increasing the minimum height of a run.

Before:
<img width="1118" alt="Screen Shot 2022-04-12 at 10 42 09 AM" src="https://user-images.githubusercontent.com/4600967/162989679-27b5f285-b360-4c34-afba-5b065cb861fa.png">


After:
<img width="1101" alt="Screen Shot 2022-04-12 at 10 40 53 AM" src="https://user-images.githubusercontent.com/4600967/162989702-56796e87-4fce-4d01-b754-7d1a30d8dab0.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
