### PR TITLE
Ensure that BackfillJob re-runs existing mapped task instances

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -706,7 +706,7 @@ class DagRun(Base, LoggingMixin):
                     if schedulable.task_id in ti.task.downstream_task_ids:
 
                         assert isinstance(schedulable.task, MappedOperator)
-                        new_tis = schedulable.task.expand_mapped_task(self.run_id, session=session)
+                        new_tis, _ = schedulable.task.expand_mapped_task(self.run_id, session=session)
                         if schedulable.state == TaskInstanceState.SKIPPED:
                             # Task is now skipped (likely cos upstream returned 0 tasks
                             continue

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -579,10 +579,11 @@ class MappedOperator(AbstractOperator):
 
         return map_lengths
 
-    def expand_mapped_task(self, run_id: str, *, session: Session) -> Sequence["TaskInstance"]:
+    def expand_mapped_task(self, run_id: str, *, session: Session) -> Tuple[Sequence["TaskInstance"], int]:
         """Create the mapped task instances for mapped task.
 
-        :return: The mapped task instances, in ascending order by map index.
+        :return: The newly created mapped TaskInstances (if any) in ascending order by map index, and the
+            maximum map_index.
         """
         from airflow.models.taskinstance import TaskInstance
         from airflow.settings import task_instance_mutation_hook
@@ -619,7 +620,7 @@ class MappedOperator(AbstractOperator):
                 )
                 unmapped_ti.state = TaskInstanceState.SKIPPED
                 session.flush()
-                return ret
+                return ret, 0
             # Otherwise convert this into the first mapped index, and create
             # TaskInstance for other indexes.
             unmapped_ti.map_index = 0
@@ -661,7 +662,7 @@ class MappedOperator(AbstractOperator):
 
         session.flush()
 
-        return ret
+        return ret, total_length
 
     def prepare_for_execution(self) -> "MappedOperator":
         # Since a mapped operator cannot be used for execution, and an unmapped

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2537,8 +2537,8 @@ class TestMappedTaskInstanceReceiveValue:
         emit_ti.run()
 
         show_task = dag.get_task("show")
-        mapped_tis = show_task.expand_mapped_task(dag_run.run_id, session=session)
-        assert len(mapped_tis) == len(upstream_return)
+        mapped_tis, num = show_task.expand_mapped_task(dag_run.run_id, session=session)
+        assert num == len(mapped_tis) == len(upstream_return)
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):
             ti.refresh_from_task(show_task)
@@ -2571,8 +2571,8 @@ class TestMappedTaskInstanceReceiveValue:
             ti.run()
 
         show_task = dag.get_task("show")
-        mapped_tis = show_task.expand_mapped_task(dag_run.run_id, session=session)
-        assert len(mapped_tis) == 6
+        mapped_tis, num = show_task.expand_mapped_task(dag_run.run_id, session=session)
+        assert len(mapped_tis) == 6 == num
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):
             ti.refresh_from_task(show_task)
@@ -2609,8 +2609,8 @@ class TestMappedTaskInstanceReceiveValue:
         ti.run()
 
         show_task = dag.get_task("show")
-        mapped_tis = show_task.expand_mapped_task(dag_run.run_id, session=session)
-        assert len(mapped_tis) == 4
+        mapped_tis, num = show_task.expand_mapped_task(dag_run.run_id, session=session)
+        assert num == len(mapped_tis) == 4
 
         for ti in sorted(mapped_tis, key=operator.attrgetter("map_index")):
             ti.refresh_from_task(show_task)
@@ -2646,7 +2646,8 @@ class TestMappedTaskInstanceReceiveValue:
             ti.run()
 
         bash_task = dag.get_task("dynamic.bash")
-        mapped_bash_tis = bash_task.expand_mapped_task(dag_run.run_id, session=session)
+        mapped_bash_tis, num = bash_task.expand_mapped_task(dag_run.run_id, session=session)
+        assert num == 2 * 2
         for ti in sorted(mapped_bash_tis, key=operator.attrgetter("map_index")):
             ti.refresh_from_task(bash_task)
             ti.run()
@@ -2706,7 +2707,7 @@ def test_ti_mapped_depends_on_mapped_xcom_arg(dag_maker, session):
         ti.run()
 
     task_345 = dag.get_task("add_one__1")
-    for ti in task_345.expand_mapped_task(dagrun.run_id, session=session):
+    for ti in task_345.expand_mapped_task(dagrun.run_id, session=session)[0]:
         ti.refresh_from_task(task_345)
         ti.run()
 


### PR DESCRIPTION
`expand_mapped_task` only returns _new_ TaskInstances, so if a backfill
job was run for a dag that already existed the mapped task would never
be executed.

The test for this is a bit more direct/tied to the implementation than I'm happy with, but this does test the problem and make the test quick to run.