### PR TITLE
Fail if task does not push XCom for downstream

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -102,6 +102,13 @@ class UnmappableOperator(AirflowException):
     """Raise when an operator is not implemented to be mappable."""
 
 
+class XComForMappingNotPushed(AirflowException):
+    """Raise when a mapped downstream's dependency fails to push XCom for task mapping."""
+
+    def __str__(self) -> str:
+        return "did not push XCom for task mapping"
+
+
 class UnmappableXComTypePushed(AirflowException):
     """Raise when an unmappable type is pushed as a mapped downstream's dependency."""
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -93,6 +93,7 @@ from airflow.exceptions import (
     TaskDeferred,
     UnmappableXComLengthPushed,
     UnmappableXComTypePushed,
+    XComForMappingNotPushed,
 )
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.models.log import Log
@@ -1627,11 +1628,14 @@ class TaskInstance(Base, LoggingMixin):
         except:  # noqa: E722
             _TASK_EXECUTION_FRAME_LOCAL_STORAGE.frame = currentframe()
             raise
-        # If the task returns a result, push an XCom containing it
-        if task_to_execute.do_xcom_push and result is not None:
-            with create_session() as session:
-                self.xcom_push(key=XCOM_RETURN_KEY, value=result, session=session)
-                self._record_task_map_for_downstreams(task_orig, result, session=session)
+        with create_session() as session:
+            if task_to_execute.do_xcom_push:
+                xcom_value = result
+            else:
+                xcom_value = None
+            if xcom_value is not None:  # If the task returns a result, push an XCom containing it.
+                self.xcom_push(key=XCOM_RETURN_KEY, value=xcom_value, session=session)
+            self._record_task_map_for_downstreams(task_orig, xcom_value, session=session)
         return result
 
     @provide_session
@@ -2310,6 +2314,8 @@ class TaskInstance(Base, LoggingMixin):
         # Phase 2, and we'll need to further analyze the mapped task case.
         if task.is_mapped or not task.has_mapped_dependants():
             return
+        if value is None:
+            raise XComForMappingNotPushed()
         if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
             raise UnmappableXComTypePushed(value)
         task_map = TaskMap.from_task_instance_xcom(self, value)


### PR DESCRIPTION
The task can already fail if an XCom is pushed but unmappable. This extends the check to cover cases where the task returns None, or does not push at all (i.e. `do_xcom_push=False`).