### PR TITLE
Fix screenshot generation for dumb terminal

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
+++ b/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
@@ -43,12 +43,14 @@ def print_help_for_all_commands():
     env['RECORD_BREEZE_WIDTH'] = SCREENSHOT_WIDTH
     env['RECORD_BREEZE_TITLE'] = "Breeze commands"
     env['RECORD_BREEZE_OUTPUT_FILE'] = str(BREEZE_IMAGES_DIR / "output-commands.svg")
+    env['TERM'] = "xterm-256color"
     check_call(["breeze", "--help"], env=env)
     for command in get_command_list():
         env = os.environ.copy()
         env['RECORD_BREEZE_WIDTH'] = SCREENSHOT_WIDTH
         env['RECORD_BREEZE_TITLE'] = f"Command: {command}"
         env['RECORD_BREEZE_OUTPUT_FILE'] = str(BREEZE_IMAGES_DIR / f"output-{command}.svg")
+        env['TERM'] = "xterm-256color"
         check_call(["breeze", command, "--help"], env=env)
 
 


### PR DESCRIPTION
When dumb terminal is set when screenshot image is generated, the terminal width is decreased to 80 and screenshots are changing.

We force 256 color xterm during screenshot generation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
