### PR TITLE
Hide Grid view mapped task pagination when data is a single page

### DIFF
--- a/airflow/www/static/js/tree/Table.jsx
+++ b/airflow/www/static/js/tree/Table.jsx
@@ -146,6 +146,7 @@ const Table = ({
           })}
         </Tbody>
       </ChakraTable>
+      {totalEntries > data.length && (
       <Flex alignItems="center" justifyContent="flex-start" my={4}>
         <IconButton
           variant="ghost"
@@ -169,6 +170,7 @@ const Table = ({
           {totalEntries}
         </Text>
       </Flex>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Hide table pagination when all of the data fits onto a single page.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
