### PR TITLE
Allow DagParam to hold falsy values

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -985,7 +985,7 @@ class DAG(LoggingMixin):
     def pickle_id(self, value: int) -> None:
         self._pickle_id = value
 
-    def param(self, name: str, default=None) -> DagParam:
+    def param(self, name: str, default: Any = NOTSET) -> DagParam:
         """
         Return a DagParam object for current dag.
 


### PR DESCRIPTION
Fix #22843.

This uses the NOTSET sentinel instead of None as the "default" sentinel, so it's now possible to supply None to a DagParam. The value presence check is also tightened up, so all falsy values can be stored.

Also fixed some deprecation warnings, added type annotations, converted tests to pytest, and removed some weird expressions along the way.