### PR TITLE
Chart/extra manifests

### DIFF
--- a/chart/templates/extra-manifests.yaml
+++ b/chart/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -868,6 +868,54 @@
                 }
             ]
         },
+        "extraManifests": {
+            "description": "Extra Kubernetes manifests to include alongside this chart.",
+            "type": "array",
+            "x-docsSection": "Kubernetes",
+            "default": [],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "apiVersion": {
+                        "description": "Kubernetes API version",
+                        "type": "string"
+                    },
+                    "kind": {
+                        "description": "Kubernetes object type",
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "description": "Data that helps uniquely identify the object",
+                        "type": "object"
+                    },
+                    "spec": {
+                        "description": "Target state for the object",
+                        "type": "object"
+                    }                    
+                },
+                "additionalProperties": false,
+                "required": [
+                    "apiVersion",
+                    "kind",
+                    "metadata",
+                    "spec"
+                ]
+            },
+            "examples": [
+                {
+                    "apiVersion": "cloud.google.com/v1beta1",
+                    "kind": "BackendConfig",
+                    "metadata": {
+                        "name": "{{ .Release.Name }}-test"
+                    },                    
+                    "spec": {
+                        "securityPolicy": {
+                            "name": "gcp-cloud-armor-policy-test"
+                        }
+                    }
+                }
+            ]
+        },
         "data": {
             "description": "Airflow database & redis configuration.",
             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -309,6 +309,20 @@ extraEnvFrom: ~
 #   - configMapRef:
 #       name: '{{ .Release.Name }}-airflow-variables'
 
+# Extra Kubernetes manifests to include alongside this chart
+# This can be used to include ANY Kubernetes YAML resource
+extraManifests: []
+# eg:
+#   extraManifests:
+#    - apiVersion: cloud.google.com/v1beta1
+#      kind: BackendConfig
+#      metadata:
+#        name: "{{ .Release.Name }}-test"
+#      spec:
+#        securityPolicy:
+#          name: "gcp-cloud-armor-policy-test"
+#
+
 # Airflow database & redis config
 data:
   # If secret names are provided, use those secrets


### PR DESCRIPTION
Add the ability to deploy additional kubernetes manifests alongside the chart

closes: #22590 