### PR TITLE
Replace usage of `DummyOperator` with `EmptyOperator`

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -24,7 +24,7 @@ import pendulum
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 with DAG(
     dag_id='example_bash_operator',
@@ -35,7 +35,7 @@ with DAG(
     tags=['example', 'example2'],
     params={"example_key": "example_value"},
 ) as dag:
-    run_this_last = DummyOperator(
+    run_this_last = EmptyOperator(
         task_id='run_this_last',
     )
 

--- a/airflow/example_dags/example_branch_datetime_operator.py
+++ b/airflow/example_dags/example_branch_datetime_operator.py
@@ -24,7 +24,7 @@ import pendulum
 
 from airflow import DAG
 from airflow.operators.datetime import BranchDateTimeOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 dag = DAG(
     dag_id="example_branch_datetime_operator",
@@ -35,8 +35,8 @@ dag = DAG(
 )
 
 # [START howto_branch_datetime_operator]
-dummy_task_1 = DummyOperator(task_id='date_in_range', dag=dag)
-dummy_task_2 = DummyOperator(task_id='date_outside_range', dag=dag)
+empty_task_1 = EmptyOperator(task_id='date_in_range', dag=dag)
+empty_task_2 = EmptyOperator(task_id='date_outside_range', dag=dag)
 
 cond1 = BranchDateTimeOperator(
     task_id='datetime_branch',
@@ -47,8 +47,8 @@ cond1 = BranchDateTimeOperator(
     dag=dag,
 )
 
-# Run dummy_task_1 if cond1 executes between 2020-10-10 14:00:00 and 2020-10-10 15:00:00
-cond1 >> [dummy_task_1, dummy_task_2]
+# Run empty_task_1 if cond1 executes between 2020-10-10 14:00:00 and 2020-10-10 15:00:00
+cond1 >> [empty_task_1, empty_task_2]
 # [END howto_branch_datetime_operator]
 
 
@@ -60,8 +60,8 @@ dag = DAG(
     schedule_interval="@daily",
 )
 # [START howto_branch_datetime_operator_next_day]
-dummy_task_1 = DummyOperator(task_id='date_in_range', dag=dag)
-dummy_task_2 = DummyOperator(task_id='date_outside_range', dag=dag)
+empty_task_1 = EmptyOperator(task_id='date_in_range', dag=dag)
+empty_task_2 = EmptyOperator(task_id='date_outside_range', dag=dag)
 
 cond2 = BranchDateTimeOperator(
     task_id='datetime_branch',
@@ -73,6 +73,6 @@ cond2 = BranchDateTimeOperator(
 )
 
 # Since target_lower happens after target_upper, target_upper will be moved to the following day
-# Run dummy_task_1 if cond2 executes between 15:00:00, and 00:00:00 of the following day
-cond2 >> [dummy_task_1, dummy_task_2]
+# Run empty_task_1 if cond2 executes between 15:00:00, and 00:00:00 of the following day
+cond2 >> [empty_task_1, empty_task_2]
 # [END howto_branch_datetime_operator_next_day]

--- a/airflow/example_dags/example_branch_day_of_week_operator.py
+++ b/airflow/example_dags/example_branch_day_of_week_operator.py
@@ -22,7 +22,7 @@ Example DAG demonstrating the usage of BranchDayOfWeekOperator.
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
 
 with DAG(
@@ -33,8 +33,8 @@ with DAG(
     schedule_interval="@daily",
 ) as dag:
     # [START howto_operator_day_of_week_branch]
-    dummy_task_1 = DummyOperator(task_id='branch_true', dag=dag)
-    dummy_task_2 = DummyOperator(task_id='branch_false', dag=dag)
+    empty_task_1 = EmptyOperator(task_id='branch_true', dag=dag)
+    empty_task_2 = EmptyOperator(task_id='branch_false', dag=dag)
 
     branch = BranchDayOfWeekOperator(
         task_id="make_choice",
@@ -43,6 +43,6 @@ with DAG(
         week_day="Monday",
     )
 
-    # Run dummy_task_1 if branch executes on Monday
-    branch >> [dummy_task_1, dummy_task_2]
+    # Run empty_task_1 if branch executes on Monday
+    branch >> [empty_task_1, empty_task_2]
     # [END howto_operator_day_of_week_branch]

--- a/airflow/example_dags/example_branch_labels.py
+++ b/airflow/example_dags/example_branch_labels.py
@@ -22,7 +22,7 @@ Example DAG demonstrating the usage of labels with different branches.
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.edgemodifier import Label
 
 with DAG(
@@ -31,13 +31,13 @@ with DAG(
     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
 ) as dag:
-    ingest = DummyOperator(task_id="ingest")
-    analyse = DummyOperator(task_id="analyze")
-    check = DummyOperator(task_id="check_integrity")
-    describe = DummyOperator(task_id="describe_integrity")
-    error = DummyOperator(task_id="email_error")
-    save = DummyOperator(task_id="save")
-    report = DummyOperator(task_id="report")
+    ingest = EmptyOperator(task_id="ingest")
+    analyse = EmptyOperator(task_id="analyze")
+    check = EmptyOperator(task_id="check_integrity")
+    describe = EmptyOperator(task_id="describe_integrity")
+    error = EmptyOperator(task_id="email_error")
+    save = EmptyOperator(task_id="save")
+    report = EmptyOperator(task_id="report")
 
     ingest >> analyse >> check
     check >> Label("No errors") >> save >> report

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -23,7 +23,7 @@ import random
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
@@ -35,7 +35,7 @@ with DAG(
     schedule_interval="@daily",
     tags=['example', 'example2'],
 ) as dag:
-    run_this_first = DummyOperator(
+    run_this_first = EmptyOperator(
         task_id='run_this_first',
     )
 
@@ -47,19 +47,19 @@ with DAG(
     )
     run_this_first >> branching
 
-    join = DummyOperator(
+    join = EmptyOperator(
         task_id='join',
         trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
     )
 
     for option in options:
-        t = DummyOperator(
+        t = EmptyOperator(
             task_id=option,
         )
 
-        dummy_follow = DummyOperator(
+        empty_follow = EmptyOperator(
             task_id='follow_' + option,
         )
 
         # Label is optional here, but it can help identify more complex branches
-        branching >> Label(option) >> t >> dummy_follow >> join
+        branching >> Label(option) >> t >> empty_follow >> join

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -34,7 +34,7 @@ with DAG(
     schedule_interval="@daily",
     tags=['example', 'example2'],
 ) as dag:
-    run_this_first = DummyOperator(
+    run_this_first = EmptyOperator(
         task_id='run_this_first',
     )
 
@@ -48,19 +48,19 @@ with DAG(
 
     run_this_first >> random_choice_instance
 
-    join = DummyOperator(
+    join = EmptyOperator(
         task_id='join',
         trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
     )
 
     for option in options:
-        t = DummyOperator(
+        t = EmptyOperator(
             task_id=option,
         )
 
-        dummy_follow = DummyOperator(
+        empty_follow = EmptyOperator(
             task_id='follow_' + option,
         )
 
         # Label is optional here, but it can help identify more complex branches
-        random_choice_instance >> Label(option) >> t >> dummy_follow >> join
+        random_choice_instance >> Label(option) >> t >> empty_follow >> join

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -23,13 +23,13 @@ or skipped on alternating runs.
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 
 
 def should_run(**kwargs):
     """
-    Determine which dummy_task should be run based on if the execution date minute is even or odd.
+    Determine which empty_task should be run based on if the execution date minute is even or odd.
 
     :param dict kwargs: Context
     :return: Id of the task to run
@@ -41,9 +41,9 @@ def should_run(**kwargs):
         )
     )
     if kwargs['execution_date'].minute % 2 == 0:
-        return "dummy_task_1"
+        return "empty_task_1"
     else:
-        return "dummy_task_2"
+        return "empty_task_2"
 
 
 with DAG(
@@ -59,6 +59,6 @@ with DAG(
         python_callable=should_run,
     )
 
-    dummy_task_1 = DummyOperator(task_id='dummy_task_1')
-    dummy_task_2 = DummyOperator(task_id='dummy_task_2')
-    cond >> [dummy_task_1, dummy_task_2]
+    empty_task_1 = EmptyOperator(task_id='empty_task_1')
+    empty_task_2 = EmptyOperator(task_id='empty_task_2')
+    cond >> [empty_task_1, empty_task_2]

--- a/airflow/example_dags/example_external_task_marker_dag.py
+++ b/airflow/example_dags/example_external_task_marker_dag.py
@@ -40,7 +40,7 @@ interval till one of the following will happen:
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
 
 start_date = pendulum.datetime(2021, 1, 1, tz="UTC")
@@ -78,5 +78,5 @@ with DAG(
         mode="reschedule",
     )
     # [END howto_operator_external_task_sensor]
-    child_task2 = DummyOperator(task_id="child_task2")
+    child_task2 = EmptyOperator(task_id="child_task2")
     child_task1 >> child_task2

--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -21,7 +21,7 @@
 import datetime as dt
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 
 with DAG(
@@ -32,6 +32,6 @@ with DAG(
     tags=['example2', 'example3'],
 ) as dag:
     latest_only = LatestOnlyOperator(task_id='latest_only')
-    task1 = DummyOperator(task_id='task1')
+    task1 = EmptyOperator(task_id='task1')
 
     latest_only >> task1

--- a/airflow/example_dags/example_latest_only_with_trigger.py
+++ b/airflow/example_dags/example_latest_only_with_trigger.py
@@ -25,7 +25,7 @@ import datetime
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -37,10 +37,10 @@ with DAG(
     tags=['example3'],
 ) as dag:
     latest_only = LatestOnlyOperator(task_id='latest_only')
-    task1 = DummyOperator(task_id='task1')
-    task2 = DummyOperator(task_id='task2')
-    task3 = DummyOperator(task_id='task3')
-    task4 = DummyOperator(task_id='task4', trigger_rule=TriggerRule.ALL_DONE)
+    task1 = EmptyOperator(task_id='task1')
+    task2 = EmptyOperator(task_id='task2')
+    task3 = EmptyOperator(task_id='task3')
+    task4 = EmptyOperator(task_id='task4', trigger_rule=TriggerRule.ALL_DONE)
 
     latest_only >> task1 >> [task3, task4]
     task2 >> [task3, task4]

--- a/airflow/example_dags/example_nested_branch_dag.py
+++ b/airflow/example_dags/example_nested_branch_dag.py
@@ -24,7 +24,7 @@ Example DAG demonstrating a workflow with nested branching. The join tasks are c
 import pendulum
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -36,14 +36,14 @@ with DAG(
     tags=["example"],
 ) as dag:
     branch_1 = BranchPythonOperator(task_id="branch_1", python_callable=lambda: "true_1")
-    join_1 = DummyOperator(task_id="join_1", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
-    true_1 = DummyOperator(task_id="true_1")
-    false_1 = DummyOperator(task_id="false_1")
+    join_1 = EmptyOperator(task_id="join_1", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+    true_1 = EmptyOperator(task_id="true_1")
+    false_1 = EmptyOperator(task_id="false_1")
     branch_2 = BranchPythonOperator(task_id="branch_2", python_callable=lambda: "true_2")
-    join_2 = DummyOperator(task_id="join_2", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
-    true_2 = DummyOperator(task_id="true_2")
-    false_2 = DummyOperator(task_id="false_2")
-    false_3 = DummyOperator(task_id="false_3")
+    join_2 = EmptyOperator(task_id="join_2", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+    true_2 = EmptyOperator(task_id="true_2")
+    false_2 = EmptyOperator(task_id="false_2")
+    false_3 = EmptyOperator(task_id="false_3")
 
     branch_1 >> true_1 >> join_1
     branch_1 >> false_1 >> branch_2 >> [true_2, false_2] >> join_2 >> false_3 >> join_1

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -21,7 +21,7 @@ import pendulum
 
 from airflow import DAG
 from airflow.models.baseoperator import chain
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -42,8 +42,8 @@ with DAG(
         python_callable=lambda: False,
     )
 
-    ds_true = [DummyOperator(task_id='true_' + str(i)) for i in [1, 2]]
-    ds_false = [DummyOperator(task_id='false_' + str(i)) for i in [1, 2]]
+    ds_true = [EmptyOperator(task_id='true_' + str(i)) for i in [1, 2]]
+    ds_false = [EmptyOperator(task_id='false_' + str(i)) for i in [1, 2]]
 
     chain(cond_true, *ds_true)
     chain(cond_false, *ds_false)
@@ -51,10 +51,10 @@ with DAG(
 
     # [START howto_operator_short_circuit_trigger_rules]
     [task_1, task_2, task_3, task_4, task_5, task_6] = [
-        DummyOperator(task_id=f"task_{i}") for i in range(1, 7)
+        EmptyOperator(task_id=f"task_{i}") for i in range(1, 7)
     ]
 
-    task_7 = DummyOperator(task_id="task_7", trigger_rule=TriggerRule.ALL_DONE)
+    task_7 = EmptyOperator(task_id="task_7", trigger_rule=TriggerRule.ALL_DONE)
 
     short_circuit = ShortCircuitOperator(
         task_id="short_circuit", ignore_downstream_trigger_rules=False, python_callable=lambda: False

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -16,20 +16,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Example DAG demonstrating the DummyOperator and a custom DummySkipOperator which skips by default."""
+"""Example DAG demonstrating the EmptyOperator and a custom EmptySkipOperator which skips by default."""
 
 import pendulum
 
 from airflow import DAG
 from airflow.exceptions import AirflowSkipException
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.context import Context
 from airflow.utils.trigger_rule import TriggerRule
 
 
 # Create some placeholder operators
-class DummySkipOperator(DummyOperator):
-    """Dummy operator which always skips the task."""
+class EmptySkipOperator(EmptyOperator):
+    """Empty operator which always skips the task."""
 
     ui_color = '#e8b7e4'
 
@@ -45,10 +45,10 @@ def create_test_pipeline(suffix, trigger_rule):
     :param str trigger_rule: TriggerRule for the join task
     :param DAG dag_: The DAG to run the operators on
     """
-    skip_operator = DummySkipOperator(task_id=f'skip_operator_{suffix}')
-    always_true = DummyOperator(task_id=f'always_true_{suffix}')
-    join = DummyOperator(task_id=trigger_rule, trigger_rule=trigger_rule)
-    final = DummyOperator(task_id=f'final_{suffix}')
+    skip_operator = EmptySkipOperator(task_id=f'skip_operator_{suffix}')
+    always_true = EmptyOperator(task_id=f'always_true_{suffix}')
+    join = EmptyOperator(task_id=trigger_rule, trigger_rule=trigger_rule)
+    final = EmptyOperator(task_id=f'final_{suffix}')
 
     skip_operator >> join
     always_true >> join

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -21,7 +21,7 @@
 # [START example_subdag_operator]
 from airflow import DAG
 from airflow.example_dags.subdags.subdag import subdag
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.subdag import SubDagOperator
 from airflow.utils.dates import days_ago
 
@@ -35,7 +35,7 @@ with DAG(
     tags=['example'],
 ) as dag:
 
-    start = DummyOperator(
+    start = EmptyOperator(
         task_id='start',
     )
 
@@ -44,7 +44,7 @@ with DAG(
         subdag=subdag(DAG_NAME, 'section-1', dag.default_args),
     )
 
-    some_other_task = DummyOperator(
+    some_other_task = EmptyOperator(
         task_id='some-other-task',
     )
 
@@ -53,7 +53,7 @@ with DAG(
         subdag=subdag(DAG_NAME, 'section-2', dag.default_args),
     )
 
-    end = DummyOperator(
+    end = EmptyOperator(
         task_id='end',
     )
 

--- a/airflow/example_dags/example_task_group.py
+++ b/airflow/example_dags/example_task_group.py
@@ -21,7 +21,7 @@ import pendulum
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.task_group import TaskGroup
 
 # [START howto_task_group]
@@ -31,33 +31,33 @@ with DAG(
     catchup=False,
     tags=["example"],
 ) as dag:
-    start = DummyOperator(task_id="start")
+    start = EmptyOperator(task_id="start")
 
     # [START howto_task_group_section_1]
     with TaskGroup("section_1", tooltip="Tasks for section_1") as section_1:
-        task_1 = DummyOperator(task_id="task_1")
+        task_1 = EmptyOperator(task_id="task_1")
         task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
-        task_3 = DummyOperator(task_id="task_3")
+        task_3 = EmptyOperator(task_id="task_3")
 
         task_1 >> [task_2, task_3]
     # [END howto_task_group_section_1]
 
     # [START howto_task_group_section_2]
     with TaskGroup("section_2", tooltip="Tasks for section_2") as section_2:
-        task_1 = DummyOperator(task_id="task_1")
+        task_1 = EmptyOperator(task_id="task_1")
 
         # [START howto_task_group_inner_section_2]
         with TaskGroup("inner_section_2", tooltip="Tasks for inner_section2") as inner_section_2:
             task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
-            task_3 = DummyOperator(task_id="task_3")
-            task_4 = DummyOperator(task_id="task_4")
+            task_3 = EmptyOperator(task_id="task_3")
+            task_4 = EmptyOperator(task_id="task_4")
 
             [task_2, task_3] >> task_4
         # [END howto_task_group_inner_section_2]
 
     # [END howto_task_group_section_2]
 
-    end = DummyOperator(task_id='end')
+    end = EmptyOperator(task_id='end')
 
     start >> section_1 >> section_2 >> end
 # [END howto_task_group]

--- a/airflow/example_dags/example_task_group_decorator.py
+++ b/airflow/example_dags/example_task_group_decorator.py
@@ -28,31 +28,31 @@ from airflow.models.dag import DAG
 # Creating Tasks
 @task
 def task_start():
-    """Dummy Task which is First Task of Dag"""
+    """Empty Task which is First Task of Dag"""
     return '[Task_start]'
 
 
 @task
 def task_1(value: int) -> str:
-    """Dummy Task1"""
+    """Empty Task1"""
     return f'[ Task1 {value} ]'
 
 
 @task
 def task_2(value: str) -> str:
-    """Dummy Task2"""
+    """Empty Task2"""
     return f'[ Task2 {value} ]'
 
 
 @task
 def task_3(value: str) -> None:
-    """Dummy Task3"""
+    """Empty Task3"""
     print(f'[ Task3 {value} ]')
 
 
 @task
 def task_end() -> None:
-    """Dummy Task which is Last Task of Dag"""
+    """Empty Task which is Last Task of Dag"""
     print('[ Task_End  ]')
 
 

--- a/airflow/example_dags/example_time_delta_sensor_async.py
+++ b/airflow/example_dags/example_time_delta_sensor_async.py
@@ -26,7 +26,7 @@ import datetime
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.time_delta import TimeDeltaSensorAsync
 
 with DAG(
@@ -37,5 +37,5 @@ with DAG(
     tags=["example"],
 ) as dag:
     wait = TimeDeltaSensorAsync(task_id="wait", delta=datetime.timedelta(seconds=10))
-    finish = DummyOperator(task_id="finish")
+    finish = EmptyOperator(task_id="finish")
     wait >> finish

--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -30,13 +30,13 @@ log = logging.getLogger(__name__)
 
 @task
 def generate_value():
-    """Dummy function"""
+    """Empty function"""
     return "Bring me a shrubbery!"
 
 
 @task
 def print_value(value, ts=None):
-    """Dummy function"""
+    """Empty function"""
     log.info("The knights of Ni say: %s (at %s)", value, ts)
 
 

--- a/airflow/example_dags/subdags/subdag.py
+++ b/airflow/example_dags/subdags/subdag.py
@@ -22,7 +22,7 @@
 import pendulum
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 
 def subdag(parent_dag_name, child_dag_name, args):
@@ -44,7 +44,7 @@ def subdag(parent_dag_name, child_dag_name, args):
     )
 
     for i in range(5):
-        DummyOperator(
+        EmptyOperator(
             task_id=f'{child_dag_name}-task-{i + 1}',
             default_args=args,
             dag=dag_subdag,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1005,13 +1005,13 @@ class DagRun(Base, LoggingMixin):
 
         Each element of ``schedulable_tis`` should have it's ``task`` attribute already set.
 
-        Any DummyOperator without callbacks is instead set straight to the success state.
+        Any EmptyOperator without callbacks is instead set straight to the success state.
 
         All the TIs should belong to this DagRun, but this code is in the hot-path, this is not checked -- it
         is the caller's responsibility to call this function only with TIs from a single dag run.
         """
         # Get list of TI IDs that do not need to executed, these are
-        # tasks using DummyOperator and without on_execute_callback / on_success_callback
+        # tasks using EmptyOperator and without on_execute_callback / on_success_callback
         dummy_ti_ids = []
         schedulable_ti_ids = []
         for ti in schedulable_tis:
@@ -1037,7 +1037,7 @@ class DagRun(Base, LoggingMixin):
                 .update({TI.state: State.SCHEDULED}, synchronize_session=False)
             )
 
-        # Tasks using DummyOperator should not be executed, mark them as success
+        # Tasks using EmptyOperator should not be executed, mark them as success
         if dummy_ti_ids:
             count += (
                 session.query(TI)

--- a/airflow/operators/dummy_operator.py
+++ b/airflow/operators/dummy_operator.py
@@ -15,12 +15,24 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use :mod:`airflow.operators.dummy`."""
+"""This module is deprecated. Please use :mod:`airflow.operators.empty`."""
 
 import warnings
 
-from airflow.operators.dummy import DummyOperator  # noqa
+from airflow.operators.empty import EmptyOperator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.operators.dummy`.", DeprecationWarning, stacklevel=2
+    "This module is deprecated. Please use `airflow.operators.empty`.", DeprecationWarning, stacklevel=2
 )
+
+
+class DummyOperator(EmptyOperator):
+    """This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
+++ b/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
@@ -18,7 +18,11 @@
 from datetime import datetime
 
 from airflow.models import DAG, BaseOperator
-from airflow.operators.dummy import DummyOperator
+
+try:
+    from airflow.operators.empty import EmptyOperator as DummyOperator
+except ModuleNotFoundError:
+    from airflow.operators.dummy import DummyOperator
 from airflow.providers.dbt.cloud.operators.dbt import (
     DbtCloudGetJobRunArtifactOperator,
     DbtCloudRunJobOperator,

--- a/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
+++ b/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
@@ -20,9 +20,9 @@ from datetime import datetime
 from airflow.models import DAG, BaseOperator
 
 try:
-    from airflow.operators.empty import EmptyOperator as DummyOperator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 from airflow.providers.dbt.cloud.operators.dbt import (
     DbtCloudGetJobRunArtifactOperator,
     DbtCloudRunJobOperator,
@@ -37,8 +37,8 @@ with DAG(
     schedule_interval=None,
     catchup=False,
 ) as dag:
-    begin = DummyOperator(task_id="begin")
-    end = DummyOperator(task_id="end")
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
 
     # [START howto_operator_dbt_cloud_run_job]
     trigger_job_run1 = DbtCloudRunJobOperator(

--- a/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
+++ b/airflow/providers/dbt/cloud/example_dags/example_dbt_cloud.py
@@ -22,7 +22,7 @@ from airflow.models import DAG, BaseOperator
 try:
     from airflow.operators.empty import EmptyOperator as DummyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.dummy import DummyOperator  # type: ignore
 from airflow.providers.dbt.cloud.operators.dbt import (
     DbtCloudGetJobRunArtifactOperator,
     DbtCloudRunJobOperator,

--- a/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
+++ b/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
@@ -25,7 +25,7 @@ from airflow import DAG
 try:
     from airflow.operators.empty import EmptyOperator as DummyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.dummy import DummyOperator  # type: ignore
 from airflow.providers.jdbc.operators.jdbc import JdbcOperator
 
 with DAG(

--- a/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
+++ b/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
@@ -21,7 +21,11 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+
+try:
+    from airflow.operators.empty import EmptyOperator as DummyOperator
+except ModuleNotFoundError:
+    from airflow.operators.dummy import DummyOperator
 from airflow.providers.jdbc.operators.jdbc import JdbcOperator
 
 with DAG(

--- a/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
+++ b/airflow/providers/jdbc/example_dags/example_jdbc_queries.py
@@ -23,9 +23,9 @@ from datetime import datetime, timedelta
 from airflow import DAG
 
 try:
-    from airflow.operators.empty import EmptyOperator as DummyOperator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 from airflow.providers.jdbc.operators.jdbc import JdbcOperator
 
 with DAG(
@@ -37,7 +37,7 @@ with DAG(
     catchup=False,
 ) as dag:
 
-    run_this_last = DummyOperator(task_id='run_this_last')
+    run_this_last = EmptyOperator(task_id='run_this_last')
 
     # [START howto_operator_jdbc_template]
     delete_data = JdbcOperator(

--- a/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -20,9 +20,9 @@ from datetime import datetime, timedelta
 from airflow.models import DAG, BaseOperator
 
 try:
-    from airflow.operators.empty import EmptyOperator as DummyOperator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 from airflow.providers.microsoft.azure.operators.data_factory import AzureDataFactoryRunPipelineOperator
 from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor
 from airflow.utils.edgemodifier import Label
@@ -41,8 +41,8 @@ with DAG(
     },
     default_view="graph",
 ) as dag:
-    begin = DummyOperator(task_id="begin")
-    end = DummyOperator(task_id="end")
+    begin = EmptyOperator(task_id="begin")
+    end = EmptyOperator(task_id="end")
 
     # [START howto_operator_adf_run_pipeline]
     run_pipeline1: BaseOperator = AzureDataFactoryRunPipelineOperator(

--- a/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -22,7 +22,7 @@ from airflow.models import DAG, BaseOperator
 try:
     from airflow.operators.empty import EmptyOperator as DummyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.dummy import DummyOperator  # type: ignore
 from airflow.providers.microsoft.azure.operators.data_factory import AzureDataFactoryRunPipelineOperator
 from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor
 from airflow.utils.edgemodifier import Label

--- a/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adf_run_pipeline.py
@@ -18,7 +18,11 @@
 from datetime import datetime, timedelta
 
 from airflow.models import DAG, BaseOperator
-from airflow.operators.dummy import DummyOperator
+
+try:
+    from airflow.operators.empty import EmptyOperator as DummyOperator
+except ModuleNotFoundError:
+    from airflow.operators.dummy import DummyOperator
 from airflow.providers.microsoft.azure.operators.data_factory import AzureDataFactoryRunPipelineOperator
 from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor
 from airflow.utils.edgemodifier import Label

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -29,7 +29,11 @@ This is an example dag for using the WinRMOperator.
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+
+try:
+    from airflow.operators.empty import EmptyOperator as DummyOperator
+except ModuleNotFoundError:
+    from airflow.operators.dummy import DummyOperator
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
 

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -31,9 +31,9 @@ from datetime import datetime, timedelta
 from airflow import DAG
 
 try:
-    from airflow.operators.empty import EmptyOperator as DummyOperator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
 
@@ -46,7 +46,7 @@ with DAG(
     catchup=False,
 ) as dag:
 
-    run_this_last = DummyOperator(task_id='run_this_last')
+    run_this_last = EmptyOperator(task_id='run_this_last')
 
     # [START create_hook]
     winRMHook = WinRMHook(ssh_conn_id='ssh_POC1')

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -33,7 +33,7 @@ from airflow import DAG
 try:
     from airflow.operators.empty import EmptyOperator as DummyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.dummy import DummyOperator  # type: ignore
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
 

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -27,7 +27,7 @@ from airflow.decorators import task
 try:
     from airflow.operators.empty import EmptyOperator as DummyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.dummy import DummyOperator  # type: ignore
 from airflow.operators.python import BranchPythonOperator
 from airflow.providers.qubole.operators.qubole import QuboleOperator
 from airflow.providers.qubole.sensors.qubole import QuboleFileSensor, QubolePartitionSensor

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -25,9 +25,9 @@ from airflow import DAG
 from airflow.decorators import task
 
 try:
-    from airflow.operators.empty import EmptyOperator as DummyOperator
+    from airflow.operators.empty import EmptyOperator
 except ModuleNotFoundError:
-    from airflow.operators.dummy import DummyOperator  # type: ignore
+    from airflow.operators.dummy import DummyOperator as EmptyOperator  # type: ignore
 from airflow.operators.python import BranchPythonOperator
 from airflow.providers.qubole.operators.qubole import QuboleOperator
 from airflow.providers.qubole.sensors.qubole import QuboleFileSensor, QubolePartitionSensor
@@ -104,7 +104,7 @@ with DAG(
 
     [hive_show_table, hive_s3_location] >> compare_result(hive_s3_location, hive_show_table) >> branching
 
-    join = DummyOperator(task_id='join', trigger_rule=TriggerRule.ONE_SUCCESS)
+    join = EmptyOperator(task_id='join', trigger_rule=TriggerRule.ONE_SUCCESS)
 
     # [START howto_operator_qubole_run_hadoop_jar]
     hadoop_jar_cmd = QuboleOperator(

--- a/airflow/providers/qubole/example_dags/example_qubole.py
+++ b/airflow/providers/qubole/example_dags/example_qubole.py
@@ -23,7 +23,11 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.decorators import task
-from airflow.operators.dummy import DummyOperator
+
+try:
+    from airflow.operators.empty import EmptyOperator as DummyOperator
+except ModuleNotFoundError:
+    from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.providers.qubole.operators.qubole import QuboleOperator
 from airflow.providers.qubole.sensors.qubole import QuboleFileSensor, QubolePartitionSensor

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -776,7 +776,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             if not hasattr(op, field):
                 setattr(op, field, None)
 
-        # Used to determine if an Operator is inherited from DummyOperator
+        # Used to determine if an Operator is inherited from EmptyOperator
         setattr(op, "_is_empty", bool(encoded_op.get("_is_empty", False)))
 
     @classmethod

--- a/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.py
+++ b/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.py
@@ -22,7 +22,7 @@ import datetime
 import pendulum
 
 from airflow.models.dag import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 now = pendulum.now(tz="UTC")
 now_to_the_hour = (now - datetime.timedelta(0, 0, 0, 0, 0, 3)).replace(minute=0, second=0, microsecond=0)
@@ -37,9 +37,9 @@ dag = DAG(
     catchup=False,
 )
 
-run_this_1 = DummyOperator(task_id='run_this_1', dag=dag)
-run_this_2 = DummyOperator(task_id='run_this_2', dag=dag)
+run_this_1 = EmptyOperator(task_id='run_this_1', dag=dag)
+run_this_2 = EmptyOperator(task_id='run_this_2', dag=dag)
 run_this_2.set_upstream(run_this_1)
-run_this_3 = DummyOperator(task_id='run_this_3', dag=dag)
+run_this_3 = EmptyOperator(task_id='run_this_3', dag=dag)
 run_this_3.set_upstream(run_this_2)
 # [END dag]

--- a/tests/api/common/test_delete_dag.py
+++ b/tests/api/common/test_delete_dag.py
@@ -22,7 +22,7 @@ import pytest
 from airflow import models
 from airflow.api.common.delete_dag import delete_dag
 from airflow.exceptions import AirflowException, DagNotFound
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -71,7 +71,7 @@ class TestDeleteDAGSuccessfulDelete:
         if for_sub_dag:
             self.key = "test_dag_id.test_subdag"
 
-        task = DummyOperator(
+        task = EmptyOperator(
             task_id='dummy',
             dag=models.DAG(dag_id=self.key, default_args={'start_date': days_ago(2)}),
             owner='airflow',

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -27,7 +27,7 @@ from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.configuration import conf
 from airflow.models import DagBag, DagModel
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from airflow.utils.session import provide_session
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
@@ -75,13 +75,13 @@ def configured_app(minimal_app_for_api):
         params={"foo": 1},
         tags=['example'],
     ) as dag:
-        DummyOperator(task_id=TASK_ID)
+        EmptyOperator(task_id=TASK_ID)
 
     with DAG(DAG2_ID, start_date=datetime(2020, 6, 15)) as dag2:  # no doc_md
-        DummyOperator(task_id=TASK_ID)
+        EmptyOperator(task_id=TASK_ID)
 
     with DAG(DAG3_ID) as dag3:  # DAG start_date set to None
-        DummyOperator(task_id=TASK_ID, start_date=datetime(2019, 6, 12))
+        EmptyOperator(task_id=TASK_ID, start_date=datetime(2019, 6, 12))
 
     dag_bag = DagBag(os.devnull, include_examples=False)
     dag_bag.dags = {dag.dag_id: dag, dag2.dag_id: dag2, dag3.dag_id: dag3}

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -23,7 +23,7 @@ from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import DAG, DagModel, DagRun
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session, provide_session
@@ -1223,7 +1223,7 @@ class TestPatchDagRunState(TestDagRunEndpoint):
         dag_id = "TEST_DAG_ID"
         dag_run_id = 'TEST_DAG_RUN_ID'
         with dag_maker(dag_id) as dag:
-            task = DummyOperator(task_id='task_id', dag=dag)
+            task = EmptyOperator(task_id='task_id', dag=dag)
         self.app.dag_bag.bag_dag(dag, root_dag=dag)
         dr = dag_maker.create_dagrun(run_id=dag_run_id)
         ti = dr.get_task_instance(task_id='task_id')
@@ -1262,7 +1262,7 @@ class TestPatchDagRunState(TestDagRunEndpoint):
         dag_id = "TEST_DAG_ID"
         dag_run_id = 'TEST_DAG_RUN_ID'
         with dag_maker(dag_id):
-            DummyOperator(task_id='task_id')
+            EmptyOperator(task_id='task_id')
         dag_maker.create_dagrun(run_id=dag_run_id)
 
         request_json = {"state": invalid_state}

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -26,7 +26,7 @@ from itsdangerous.url_safe import URLSafeSerializer
 from airflow import DAG
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
@@ -71,7 +71,7 @@ class TestGetLog:
         self.old_modules = dict(sys.modules)
 
         with dag_maker(self.DAG_ID, start_date=timezone.parse(self.default_time), session=session) as dag:
-            DummyOperator(task_id=self.TASK_ID)
+            EmptyOperator(task_id=self.TASK_ID)
         dr = dag_maker.create_dagrun(
             run_id='TEST_DAG_RUN_ID',
             run_type=DagRunType.SCHEDULED,
@@ -85,7 +85,7 @@ class TestGetLog:
         with dag_maker(
             f'{self.DAG_ID}_copy', start_date=timezone.parse(self.default_time), session=session
         ) as dummy_dag:
-            DummyOperator(task_id=self.TASK_ID)
+            EmptyOperator(task_id=self.TASK_ID)
         dag_maker.create_dagrun(
             run_id='TEST_DAG_RUN_ID',
             run_type=DagRunType.SCHEDULED,

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -23,7 +23,7 @@ import pytest
 from airflow import DAG
 from airflow.models import DagBag
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
@@ -60,8 +60,8 @@ class TestTaskEndpoint:
     @pytest.fixture(scope="class")
     def setup_dag(self, configured_app):
         with DAG(self.dag_id, start_date=self.task1_start_date, doc_md="details") as dag:
-            task1 = DummyOperator(task_id=self.task_id, params={'foo': 'bar'})
-            task2 = DummyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
+            task1 = EmptyOperator(task_id=self.task_id, params={'foo': 'bar'})
+            task2 = EmptyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
 
         task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)
@@ -88,7 +88,7 @@ class TestGetTask(TestTaskEndpoint):
     def test_should_respond_200(self):
         expected = {
             "class_ref": {
-                "class_name": "DummyOperator",
+                "class_name": "EmptyOperator",
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
@@ -138,7 +138,7 @@ class TestGetTask(TestTaskEndpoint):
 
         expected = {
             "class_ref": {
-                "class_name": "DummyOperator",
+                "class_name": "EmptyOperator",
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
@@ -203,7 +203,7 @@ class TestGetTasks(TestTaskEndpoint):
             "tasks": [
                 {
                     "class_ref": {
-                        "class_name": "DummyOperator",
+                        "class_name": "EmptyOperator",
                         "module_path": "airflow.operators.dummy",
                     },
                     "depends_on_past": False,
@@ -238,7 +238,7 @@ class TestGetTasks(TestTaskEndpoint):
                 },
                 {
                     "class_ref": {
-                        "class_name": "DummyOperator",
+                        "class_name": "EmptyOperator",
                         "module_path": "airflow.operators.dummy",
                     },
                     "depends_on_past": False,
@@ -300,7 +300,7 @@ class TestGetTasks(TestTaskEndpoint):
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 400
-        assert response.json['detail'] == "'DummyOperator' object has no attribute 'invalid_task_colume_name'"
+        assert response.json['detail'] == "'EmptyOperator' object has no attribute 'invalid_task_colume_name'"
 
     def test_should_respond_404(self):
         dag_id = "xxxx_not_existing"

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -89,7 +89,7 @@ class TestGetTask(TestTaskEndpoint):
         expected = {
             "class_ref": {
                 "class_name": "EmptyOperator",
-                "module_path": "airflow.operators.dummy",
+                "module_path": "airflow.operators.empty",
             },
             "depends_on_past": False,
             "downstream_task_ids": [self.task_id2],
@@ -139,7 +139,7 @@ class TestGetTask(TestTaskEndpoint):
         expected = {
             "class_ref": {
                 "class_name": "EmptyOperator",
-                "module_path": "airflow.operators.dummy",
+                "module_path": "airflow.operators.empty",
             },
             "depends_on_past": False,
             "downstream_task_ids": [self.task_id2],
@@ -204,7 +204,7 @@ class TestGetTasks(TestTaskEndpoint):
                 {
                     "class_ref": {
                         "class_name": "EmptyOperator",
-                        "module_path": "airflow.operators.dummy",
+                        "module_path": "airflow.operators.empty",
                     },
                     "depends_on_past": False,
                     "downstream_task_ids": [self.task_id2],
@@ -239,7 +239,7 @@ class TestGetTasks(TestTaskEndpoint):
                 {
                     "class_ref": {
                         "class_name": "EmptyOperator",
-                        "module_path": "airflow.operators.dummy",
+                        "module_path": "airflow.operators.empty",
                     },
                     "depends_on_past": False,
                     "downstream_task_ids": [],

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -20,7 +20,7 @@ import pytest
 from parameterized import parameterized
 
 from airflow.models import DagModel, DagRun, TaskInstance, XCom
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from airflow.utils.dates import parse_execution_date
 from airflow.utils.session import create_session
@@ -155,7 +155,7 @@ class TestGetXComEntry(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(DummyOperator(task_id=task_id), run_id=run_id)
+            ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
             ti.dag_id = dag_id
             session.add(ti)
         XCom.set(
@@ -329,7 +329,7 @@ class TestGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(DummyOperator(task_id=task_id), run_id=run_id)
+            ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
             ti.dag_id = dag_id
             session.add(ti)
 
@@ -365,7 +365,7 @@ class TestGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun1)
-            ti = TaskInstance(DummyOperator(task_id="invalid_task"), run_id="not_this_run_id")
+            ti = TaskInstance(EmptyOperator(task_id="invalid_task"), run_id="not_this_run_id")
             ti.dag_id = "invalid_dag"
             session.add(ti)
         for i in [1, 2]:
@@ -449,7 +449,7 @@ class TestPaginationGetXComEntries(TestXComEndpoint):
                 run_type=DagRunType.MANUAL,
             )
             session.add(dagrun)
-            ti = TaskInstance(DummyOperator(task_id=self.task_id), run_id=self.run_id)
+            ti = TaskInstance(EmptyOperator(task_id=self.task_id), run_id=self.run_id)
             ti.dag_id = self.dag_id
             session.add(ti)
 

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -28,7 +28,7 @@ from airflow.api_connexion.schemas.task_instance_schema import (
     task_instance_schema,
 )
 from airflow.models import RenderedTaskInstanceFields as RTIF, SlaMiss, TaskInstance as TI
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.platform import getuser
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
@@ -39,7 +39,7 @@ class TestTaskInstanceSchema:
     def set_attrs(self, session, dag_maker):
         self.default_time = datetime(2020, 1, 1)
         with dag_maker(dag_id="TEST_DAG_ID", session=session):
-            self.task = DummyOperator(task_id="TEST_TASK_ID", start_date=self.default_time)
+            self.task = EmptyOperator(task_id="TEST_TASK_ID", start_date=self.default_time)
 
         self.dr = dag_maker.create_dagrun(execution_date=self.default_time)
         session.flush()
@@ -76,7 +76,7 @@ class TestTaskInstanceSchema:
             "hostname": "",
             "map_index": -1,
             "max_tries": 0,
-            "operator": "DummyOperator",
+            "operator": "EmptyOperator",
             "pid": 100,
             "pool": "default_pool",
             "pool_slots": 1,
@@ -118,7 +118,7 @@ class TestTaskInstanceSchema:
             "hostname": "",
             "map_index": -1,
             "max_tries": 0,
-            "operator": "DummyOperator",
+            "operator": "EmptyOperator",
             "pid": 100,
             "pool": "default_pool",
             "pool_slots": 1,

--- a/tests/api_connexion/schemas/test_task_schema.py
+++ b/tests/api_connexion/schemas/test_task_schema.py
@@ -18,12 +18,12 @@
 from datetime import datetime
 
 from airflow.api_connexion.schemas.task_schema import TaskCollection, task_collection_schema, task_schema
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 
 class TestTaskSchema:
     def test_serialize(self):
-        op = DummyOperator(
+        op = EmptyOperator(
             task_id="task_id",
             start_date=datetime(2020, 6, 16),
             end_date=datetime(2020, 6, 26),
@@ -32,7 +32,7 @@ class TestTaskSchema:
         expected = {
             "class_ref": {
                 "module_path": "airflow.operators.dummy",
-                "class_name": "DummyOperator",
+                "class_name": "EmptyOperator",
             },
             "depends_on_past": False,
             "downstream_task_ids": [],
@@ -62,14 +62,14 @@ class TestTaskSchema:
 
 class TestTaskCollectionSchema:
     def test_serialize(self):
-        tasks = [DummyOperator(task_id="task_id1", params={'foo': 'bar'})]
+        tasks = [EmptyOperator(task_id="task_id1", params={'foo': 'bar'})]
         collection = TaskCollection(tasks, 1)
         result = task_collection_schema.dump(collection)
         expected = {
             "tasks": [
                 {
                     "class_ref": {
-                        "class_name": "DummyOperator",
+                        "class_name": "EmptyOperator",
                         "module_path": "airflow.operators.dummy",
                     },
                     "depends_on_past": False,

--- a/tests/api_connexion/schemas/test_task_schema.py
+++ b/tests/api_connexion/schemas/test_task_schema.py
@@ -31,7 +31,7 @@ class TestTaskSchema:
         result = task_schema.dump(op)
         expected = {
             "class_ref": {
-                "module_path": "airflow.operators.dummy",
+                "module_path": "airflow.operators.empty",
                 "class_name": "EmptyOperator",
             },
             "depends_on_past": False,
@@ -70,7 +70,7 @@ class TestTaskCollectionSchema:
                 {
                     "class_ref": {
                         "class_name": "EmptyOperator",
-                        "module_path": "airflow.operators.dummy",
+                        "module_path": "airflow.operators.empty",
                     },
                     "depends_on_past": False,
                     "downstream_task_ids": [],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -406,8 +406,8 @@ def dag_maker(request):
     the same argument as DAG::
 
         with dag_maker(dag_id="mydag") as dag:
-            task1 = DummyOperator(task_id='mytask')
-            task2 = DummyOperator(task_id='mytask2')
+            task1 = EmptyOperator(task_id='mytask')
+            task2 = EmptyOperator(task_id='mytask2')
 
     If the DagModel you want to use needs different parameters than the one
     automatically created by the dag_maker, you have to update the DagModel as below::
@@ -621,13 +621,13 @@ def dag_maker(request):
 @pytest.fixture
 def create_dummy_dag(dag_maker):
     """
-    This fixture creates a `DAG` with a single `DummyOperator` task.
+    This fixture creates a `DAG` with a single `EmptyOperator` task.
     DagRun and DagModel is also created.
 
     Apart from the already existing arguments, any other argument in kwargs
-    is passed to the DAG and not to the DummyOperator task.
+    is passed to the DAG and not to the EmptyOperator task.
 
-    If you have an argument that you want to pass to the DummyOperator that
+    If you have an argument that you want to pass to the EmptyOperator that
     is not here, please use `default_args` so that the DAG will pass it to the
     Task::
 
@@ -635,7 +635,7 @@ def create_dummy_dag(dag_maker):
 
     You cannot be able to alter the created DagRun or DagModel, use `dag_maker` fixture instead.
     """
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.empty import EmptyOperator
     from airflow.utils.types import DagRunType
 
     def create_dag(
@@ -654,7 +654,7 @@ def create_dummy_dag(dag_maker):
         **kwargs,
     ):
         with dag_maker(dag_id, **kwargs) as dag:
-            op = DummyOperator(
+            op = EmptyOperator(
                 task_id=task_id,
                 max_active_tis_per_dag=max_active_tis_per_dag,
                 executor_config=executor_config,

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -26,7 +26,7 @@ from airflow.exceptions import AirflowTaskTimeout
 from airflow.models import DagRun, TaskFail, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
@@ -124,7 +124,7 @@ class TestCore:
         execution_ds_nodash = execution_ds.replace('-', '')
 
         with dag_maker(schedule_interval=timedelta(weeks=1)):
-            task = DummyOperator(task_id='test_externally_triggered_dag_context')
+            task = EmptyOperator(task_id='test_externally_triggered_dag_context')
         dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=execution_date,
@@ -153,11 +153,11 @@ class TestCore:
             schedule_interval=timedelta(weeks=1),
             params={'key_1': 'value_1', 'key_2': 'value_2_old'},
         ):
-            task1 = DummyOperator(
+            task1 = EmptyOperator(
                 task_id='task1',
                 params={'key_2': 'value_2_new', 'key_3': 'value_3'},
             )
-            task2 = DummyOperator(task_id='task2')
+            task2 = EmptyOperator(task_id='task2')
         dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             external_trigger=True,

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -80,11 +80,11 @@ class TestStats(unittest.TestCase):
         self.statsd_client.timing.assert_called_once_with('dummy_timer', 123)
 
     def test_gauge(self):
-        self.stats.gauge("dummy", 123)
+        self.stats.gauge("empty", 123)
         self.statsd_client.gauge.assert_called_once_with('dummy', 123, 1, False)
 
     def test_decr(self):
-        self.stats.decr("dummy")
+        self.stats.decr("empty")
         self.statsd_client.decr.assert_called_once_with('dummy', 1, 1)
 
     def test_enabled_by_config(self):
@@ -190,11 +190,11 @@ class TestDogStats(unittest.TestCase):
         self.dogstatsd_client.timing.assert_called_with(metric='dummy_timer', value=123.0, tags=[])
 
     def test_gauge(self):
-        self.dogstatsd.gauge("dummy", 123)
+        self.dogstatsd.gauge("empty", 123)
         self.dogstatsd_client.gauge.assert_called_once_with(metric='dummy', sample_rate=1, value=123, tags=[])
 
     def test_decr(self):
-        self.dogstatsd.decr("dummy")
+        self.dogstatsd.decr("empty")
         self.dogstatsd_client.decrement.assert_called_once_with(
             metric='dummy', sample_rate=1, value=1, tags=[]
         )

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -66,9 +66,9 @@ class TestStats(unittest.TestCase):
         self.statsd_client.assert_not_called()
 
     def test_timer(self):
-        with self.stats.timer("dummy_timer"):
+        with self.stats.timer("empty_timer"):
             pass
-        self.statsd_client.timer.assert_called_once_with('dummy_timer')
+        self.statsd_client.timer.assert_called_once_with('empty_timer')
 
     def test_empty_timer(self):
         with self.stats.timer():
@@ -76,16 +76,16 @@ class TestStats(unittest.TestCase):
         self.statsd_client.timer.assert_not_called()
 
     def test_timing(self):
-        self.stats.timing("dummy_timer", 123)
-        self.statsd_client.timing.assert_called_once_with('dummy_timer', 123)
+        self.stats.timing("empty_timer", 123)
+        self.statsd_client.timing.assert_called_once_with('empty_timer', 123)
 
     def test_gauge(self):
         self.stats.gauge("empty", 123)
-        self.statsd_client.gauge.assert_called_once_with('dummy', 123, 1, False)
+        self.statsd_client.gauge.assert_called_once_with('empty', 123, 1, False)
 
     def test_decr(self):
         self.stats.decr("empty")
-        self.statsd_client.decr.assert_called_once_with('dummy', 1, 1)
+        self.statsd_client.decr.assert_called_once_with('empty', 1, 1)
 
     def test_enabled_by_config(self):
         """Test that enabling this sets the right instance properties"""
@@ -122,7 +122,7 @@ class TestStats(unittest.TestCase):
             ),
         ):
             importlib.reload(airflow.stats)
-            airflow.stats.Stats.incr("dummy_key")
+            airflow.stats.Stats.incr("empty_key")
         importlib.reload(airflow.stats)
 
 
@@ -153,27 +153,27 @@ class TestDogStats(unittest.TestCase):
         self.dogstatsd_client.assert_not_called()
 
     def test_does_send_stats_using_dogstatsd_when_dogstatsd_on(self):
-        self.dogstatsd.incr("dummy_key")
+        self.dogstatsd.incr("empty_key")
         self.dogstatsd_client.increment.assert_called_once_with(
-            metric='dummy_key', sample_rate=1, tags=[], value=1
+            metric='empty_key', sample_rate=1, tags=[], value=1
         )
 
     def test_does_send_stats_using_dogstatsd_with_tags(self):
-        self.dogstatsd.incr("dummy_key", 1, 1, ['key1:value1', 'key2:value2'])
+        self.dogstatsd.incr("empty_key", 1, 1, ['key1:value1', 'key2:value2'])
         self.dogstatsd_client.increment.assert_called_once_with(
-            metric='dummy_key', sample_rate=1, tags=['key1:value1', 'key2:value2'], value=1
+            metric='empty_key', sample_rate=1, tags=['key1:value1', 'key2:value2'], value=1
         )
 
     def test_does_send_stats_using_dogstatsd_when_statsd_and_dogstatsd_both_on(self):
-        self.dogstatsd.incr("dummy_key")
+        self.dogstatsd.incr("empty_key")
         self.dogstatsd_client.increment.assert_called_once_with(
-            metric='dummy_key', sample_rate=1, tags=[], value=1
+            metric='empty_key', sample_rate=1, tags=[], value=1
         )
 
     def test_timer(self):
-        with self.dogstatsd.timer("dummy_timer"):
+        with self.dogstatsd.timer("empty_timer"):
             pass
-        self.dogstatsd_client.timed.assert_called_once_with('dummy_timer', tags=[])
+        self.dogstatsd_client.timed.assert_called_once_with('empty_timer', tags=[])
 
     def test_empty_timer(self):
         with self.dogstatsd.timer():
@@ -183,20 +183,20 @@ class TestDogStats(unittest.TestCase):
     def test_timing(self):
         import datetime
 
-        self.dogstatsd.timing("dummy_timer", 123)
-        self.dogstatsd_client.timing.assert_called_once_with(metric='dummy_timer', value=123, tags=[])
+        self.dogstatsd.timing("empty_timer", 123)
+        self.dogstatsd_client.timing.assert_called_once_with(metric='empty_timer', value=123, tags=[])
 
-        self.dogstatsd.timing("dummy_timer", datetime.timedelta(seconds=123))
-        self.dogstatsd_client.timing.assert_called_with(metric='dummy_timer', value=123.0, tags=[])
+        self.dogstatsd.timing("empty_timer", datetime.timedelta(seconds=123))
+        self.dogstatsd_client.timing.assert_called_with(metric='empty_timer', value=123.0, tags=[])
 
     def test_gauge(self):
         self.dogstatsd.gauge("empty", 123)
-        self.dogstatsd_client.gauge.assert_called_once_with(metric='dummy', sample_rate=1, value=123, tags=[])
+        self.dogstatsd_client.gauge.assert_called_once_with(metric='empty', sample_rate=1, value=123, tags=[])
 
     def test_decr(self):
         self.dogstatsd.decr("empty")
         self.dogstatsd_client.decrement.assert_called_once_with(
-            metric='dummy', sample_rate=1, value=1, tags=[]
+            metric='empty', sample_rate=1, value=1, tags=[]
         )
 
     def test_enabled_by_config(self):
@@ -281,7 +281,7 @@ class TestCustomStatsName(unittest.TestCase):
     @mock.patch("statsd.StatsClient")
     def test_does_not_send_stats_using_statsd_when_the_name_is_not_valid(self, mock_statsd):
         importlib.reload(airflow.stats)
-        airflow.stats.Stats.incr("dummy_key")
+        airflow.stats.Stats.incr("empty_key")
         mock_statsd.return_value.assert_not_called()
 
     @conf_vars(
@@ -293,7 +293,7 @@ class TestCustomStatsName(unittest.TestCase):
     @mock.patch("datadog.DogStatsd")
     def test_does_not_send_stats_using_dogstatsd_when_the_name_is_not_valid(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
-        airflow.stats.Stats.incr("dummy_key")
+        airflow.stats.Stats.incr("empty_key")
         mock_dogstatsd.return_value.assert_not_called()
 
     @conf_vars(
@@ -305,8 +305,8 @@ class TestCustomStatsName(unittest.TestCase):
     @mock.patch("statsd.StatsClient")
     def test_does_send_stats_using_statsd_when_the_name_is_valid(self, mock_statsd):
         importlib.reload(airflow.stats)
-        airflow.stats.Stats.incr("dummy_key")
-        mock_statsd.return_value.incr.assert_called_once_with('dummy_key', 1, 1)
+        airflow.stats.Stats.incr("empty_key")
+        mock_statsd.return_value.incr.assert_called_once_with('empty_key', 1, 1)
 
     @conf_vars(
         {
@@ -317,9 +317,9 @@ class TestCustomStatsName(unittest.TestCase):
     @mock.patch("datadog.DogStatsd")
     def test_does_send_stats_using_dogstatsd_when_the_name_is_valid(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
-        airflow.stats.Stats.incr("dummy_key")
+        airflow.stats.Stats.incr("empty_key")
         mock_dogstatsd.return_value.increment.assert_called_once_with(
-            metric='dummy_key', sample_rate=1, tags=[], value=1
+            metric='empty_key', sample_rate=1, tags=[], value=1
         )
 
     def tearDown(self) -> None:

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -32,7 +32,7 @@ from airflow.dag_processing.manager import DagFileProcessorAgent
 from airflow.dag_processing.processor import DagFileProcessor
 from airflow.models import DagBag, DagModel, SlaMiss, TaskInstance, errors
 from airflow.models.taskinstance import SimpleTaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.dates import days_ago
 from airflow.utils.session import create_session
@@ -211,7 +211,7 @@ class TestDagFileProcessor:
             dag_id='test_sla_miss',
             default_args={'start_date': test_start_date, 'sla': datetime.timedelta(days=1)},
         ) as dag:
-            task = DummyOperator(task_id='dummy')
+            task = EmptyOperator(task_id='dummy')
 
         dag_maker.create_dagrun(execution_date=test_start_date, state=State.SUCCESS)
 
@@ -289,7 +289,7 @@ class TestDagFileProcessor:
         session.merge(TaskInstance(task=task, execution_date=test_start_date, state='Success'))
 
         email2 = 'test2@test.com'
-        DummyOperator(task_id='sla_not_missed', dag=dag, owner='airflow', email=email2)
+        EmptyOperator(task_id='sla_not_missed', dag=dag, owner='airflow', email=email2)
 
         session.merge(SlaMiss(task_id='sla_missed', dag_id='test_sla_miss', execution_date=test_start_date))
 

--- a/tests/dags/test_dag_with_no_tags.py
+++ b/tests/dags/test_dag_with_no_tags.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -28,4 +28,4 @@ default_args = {
 }
 
 with DAG(dag_id="test_dag_with_no_tags", default_args=default_args, schedule_interval='@once') as dag:
-    task_a = DummyOperator(task_id="test_task_a")
+    task_a = EmptyOperator(task_id="test_task_a")

--- a/tests/dags/test_double_trigger.py
+++ b/tests/dags/test_double_trigger.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -28,4 +28,4 @@ args = {
 }
 
 dag = DAG(dag_id='test_localtaskjob_double_trigger', default_args=args)
-task = DummyOperator(task_id='test_localtaskjob_double_trigger_task', dag=dag)
+task = EmptyOperator(task_id='test_localtaskjob_double_trigger_task', dag=dag)

--- a/tests/dags/test_example_bash_operator.py
+++ b/tests/dags/test_example_bash_operator.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 
 from airflow.models import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 
 args = {'owner': 'airflow', 'retries': 3, 'start_date': days_ago(2)}
@@ -32,7 +32,7 @@ dag = DAG(
 )
 
 cmd = 'ls -l'
-run_this_last = DummyOperator(task_id='run_this_last', dag=dag)
+run_this_last = EmptyOperator(task_id='run_this_last', dag=dag)
 
 run_this = BashOperator(task_id='run_after_loop', bash_command='echo 1', dag=dag)
 run_this.set_downstream(run_this_last)

--- a/tests/dags/test_invalid_cron.py
+++ b/tests/dags/test_invalid_cron.py
@@ -17,7 +17,7 @@
 # under the License.
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.timezone import datetime
 
 # The schedule_interval specified here is an INVALID
@@ -25,4 +25,4 @@ from airflow.utils.timezone import datetime
 # test whether dagbag.process_file() can identify
 # invalid Cron expression.
 dag1 = DAG(dag_id='test_invalid_cron', start_date=datetime(2015, 1, 1), schedule_interval="0 100 * * *")
-dag1_task1 = DummyOperator(task_id='task1', dag=dag1, owner='airflow')
+dag1_task1 = EmptyOperator(task_id='task1', dag=dag1, owner='airflow')

--- a/tests/dags/test_issue_1225.py
+++ b/tests/dags/test_issue_1225.py
@@ -25,7 +25,7 @@ Addresses issue #1225.
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -40,7 +40,7 @@ def fail():
 # DAG tests backfill with pooled tasks
 # Previously backfill would queue the task but never run it
 dag1 = DAG(dag_id='test_backfill_pooled_task_dag', default_args=default_args)
-dag1_task1 = DummyOperator(
+dag1_task1 = EmptyOperator(
     task_id='test_backfill_pooled_task',
     dag=dag1,
     pool='test_backfill_pooled_task_pool',
@@ -51,7 +51,7 @@ dag1_task1 = DummyOperator(
 # DAG tests that a Dag run that doesn't complete is marked failed
 dag3 = DAG(dag_id='test_dagrun_states_fail', default_args=default_args)
 dag3_task1 = PythonOperator(task_id='test_dagrun_fail', dag=dag3, python_callable=fail)
-dag3_task2 = DummyOperator(
+dag3_task2 = EmptyOperator(
     task_id='test_dagrun_succeed',
     dag=dag3,
 )
@@ -64,12 +64,12 @@ dag4_task1 = PythonOperator(
     dag=dag4,
     python_callable=fail,
 )
-dag4_task2 = DummyOperator(task_id='test_dagrun_succeed', dag=dag4, trigger_rule=TriggerRule.ALL_FAILED)
+dag4_task2 = EmptyOperator(task_id='test_dagrun_succeed', dag=dag4, trigger_rule=TriggerRule.ALL_FAILED)
 dag4_task2.set_upstream(dag4_task1)
 
 # DAG tests that a Dag run that completes but has a root failure is marked fail
 dag5 = DAG(dag_id='test_dagrun_states_root_fail', default_args=default_args)
-dag5_task1 = DummyOperator(
+dag5_task1 = EmptyOperator(
     task_id='test_dagrun_succeed',
     dag=dag5,
 )
@@ -81,12 +81,12 @@ dag5_task2 = PythonOperator(
 
 # DAG tests that a Dag run that is deadlocked with no states is failed
 dag6 = DAG(dag_id='test_dagrun_states_deadlock', default_args=default_args)
-dag6_task1 = DummyOperator(
+dag6_task1 = EmptyOperator(
     task_id='test_depends_on_past',
     depends_on_past=True,
     dag=dag6,
 )
-dag6_task2 = DummyOperator(
+dag6_task2 = EmptyOperator(
     task_id='test_depends_on_past_2',
     depends_on_past=True,
     dag=dag6,
@@ -96,7 +96,7 @@ dag6_task2.set_upstream(dag6_task1)
 
 # DAG tests that a Dag run that doesn't complete but has a root failure is marked running
 dag8 = DAG(dag_id='test_dagrun_states_root_fail_unfinished', default_args=default_args)
-dag8_task1 = DummyOperator(
+dag8_task1 = EmptyOperator(
     task_id='test_dagrun_unfinished',  # The test will unset the task instance state after
     # running this test
     dag=dag8,
@@ -109,11 +109,11 @@ dag8_task2 = PythonOperator(
 
 # DAG tests that a Dag run that completes but has a root in the future is marked as success
 dag9 = DAG(dag_id='test_dagrun_states_root_future', default_args=default_args)
-dag9_task1 = DummyOperator(
+dag9_task1 = EmptyOperator(
     task_id='current',
     dag=dag9,
 )
-dag9_task2 = DummyOperator(
+dag9_task2 = EmptyOperator(
     task_id='future',
     dag=dag9,
     start_date=DEFAULT_DATE + timedelta(days=1),

--- a/tests/dags/test_latest_runs.py
+++ b/tests/dags/test_latest_runs.py
@@ -20,8 +20,8 @@
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 for i in range(1, 2):
     dag = DAG(dag_id=f'test_latest_runs_{i}')
-    task = DummyOperator(task_id='dummy_task', dag=dag, owner='airflow', start_date=datetime(2016, 2, 1))
+    task = EmptyOperator(task_id='dummy_task', dag=dag, owner='airflow', start_date=datetime(2016, 2, 1))

--- a/tests/dags/test_miscellaneous.py
+++ b/tests/dags/test_miscellaneous.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 
 args = {
@@ -39,7 +39,7 @@ dag = DAG(
     params={"example_key": "example_value"},
 )
 
-run_this_last = DummyOperator(
+run_this_last = EmptyOperator(
     task_id='run_this_last',
     dag=dag,
 )

--- a/tests/dags/test_missing_owner.py
+++ b/tests/dags/test_missing_owner.py
@@ -19,7 +19,7 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 
 with DAG(
@@ -29,6 +29,6 @@ with DAG(
     dagrun_timeout=timedelta(minutes=60),
     tags=["example"],
 ) as dag:
-    run_this_last = DummyOperator(
+    run_this_last = EmptyOperator(
         task_id="test_task",
     )

--- a/tests/dags/test_on_failure_callback.py
+++ b/tests/dags/test_on_failure_callback.py
@@ -19,7 +19,7 @@ import os
 from datetime import datetime
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -36,6 +36,6 @@ def write_data_to_callback(*arg, **kwargs):
         f.write("Callback fired")
 
 
-task = DummyOperator(
+task = EmptyOperator(
     task_id='test_om_failure_callback_task', dag=dag, on_failure_callback=write_data_to_callback
 )

--- a/tests/dags/test_on_kill.py
+++ b/tests/dags/test_on_kill.py
@@ -18,12 +18,12 @@
 import time
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.context import Context
 from airflow.utils.timezone import datetime
 
 
-class DummyWithOnKill(DummyOperator):
+class DummyWithOnKill(EmptyOperator):
     def execute(self, context: Context):
         import os
 

--- a/tests/dags/test_only_empty_tasks.py
+++ b/tests/dags/test_only_empty_tasks.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from typing import Sequence
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
@@ -28,10 +28,10 @@ default_args = {
     "start_date": DEFAULT_DATE,
 }
 
-dag = DAG(dag_id="test_only_dummy_tasks", default_args=default_args, schedule_interval='@once')
+dag = DAG(dag_id="test_only_empty_tasks", default_args=default_args, schedule_interval='@once')
 
 
-class MyDummyOperator(DummyOperator):
+class MyEmptyOperator(EmptyOperator):
     template_fields_renderers = {"body": "json"}
     template_fields: Sequence[str] = ("body",)
 
@@ -41,14 +41,14 @@ class MyDummyOperator(DummyOperator):
 
 
 with dag:
-    task_a = DummyOperator(task_id="test_task_a")
+    task_a = EmptyOperator(task_id="test_task_a")
 
-    task_b = DummyOperator(task_id="test_task_b")
+    task_b = EmptyOperator(task_id="test_task_b")
 
     task_a >> task_b
 
-    task_c = MyDummyOperator(task_id="test_task_c", body={"hello": "world"})
+    task_c = MyEmptyOperator(task_id="test_task_c", body={"hello": "world"})
 
-    task_d = DummyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: 1)
+    task_d = EmptyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: 1)
 
-    task_e = DummyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: 1)
+    task_e = EmptyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: 1)

--- a/tests/dags/test_only_empty_tasks.py
+++ b/tests/dags/test_only_empty_tasks.py
@@ -49,6 +49,6 @@ with dag:
 
     task_c = MyEmptyOperator(task_id="test_task_c", body={"hello": "world"})
 
-    task_d = EmptyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: 1)
+    task_d = EmptyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: None)
 
-    task_e = EmptyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: 1)
+    task_e = EmptyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: None)

--- a/tests/dags/test_prev_dagrun_dep.py
+++ b/tests/dags/test_prev_dagrun_dep.py
@@ -19,7 +19,7 @@
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 default_args = dict(start_date=DEFAULT_DATE, owner="airflow")
@@ -27,7 +27,7 @@ default_args = dict(start_date=DEFAULT_DATE, owner="airflow")
 # DAG tests depends_on_past dependencies
 dag_dop = DAG(dag_id="test_depends_on_past", default_args=default_args)
 with dag_dop:
-    dag_dop_task = DummyOperator(
+    dag_dop_task = EmptyOperator(
         task_id="test_dop_task",
         depends_on_past=True,
     )
@@ -35,11 +35,11 @@ with dag_dop:
 # DAG tests wait_for_downstream dependencies
 dag_wfd = DAG(dag_id="test_wait_for_downstream", default_args=default_args)
 with dag_wfd:
-    dag_wfd_upstream = DummyOperator(
+    dag_wfd_upstream = EmptyOperator(
         task_id="upstream_task",
         wait_for_downstream=True,
     )
-    dag_wfd_downstream = DummyOperator(
+    dag_wfd_downstream = EmptyOperator(
         task_id="downstream_task",
     )
     dag_wfd_upstream >> dag_wfd_downstream

--- a/tests/dags/test_scheduler_dags.py
+++ b/tests/dags/test_scheduler_dags.py
@@ -19,17 +19,17 @@
 from datetime import datetime, timedelta
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
 
 # DAG tests backfill with pooled tasks
 # Previously backfill would queue the task but never run it
 dag1 = DAG(dag_id='test_start_date_scheduling', start_date=datetime.utcnow() + timedelta(days=1))
-dag1_task1 = DummyOperator(task_id='dummy', dag=dag1, owner='airflow')
+dag1_task1 = EmptyOperator(task_id='dummy', dag=dag1, owner='airflow')
 
 dag2 = DAG(dag_id='test_task_start_date_scheduling', start_date=DEFAULT_DATE)
-dag2_task1 = DummyOperator(
+dag2_task1 = EmptyOperator(
     task_id='dummy1', dag=dag2, owner='airflow', start_date=DEFAULT_DATE + timedelta(days=3)
 )
-dag2_task2 = DummyOperator(task_id='dummy2', dag=dag2, owner='airflow')
+dag2_task2 = EmptyOperator(task_id='dummy2', dag=dag2, owner='airflow')

--- a/tests/dags/test_subdag.py
+++ b/tests/dags/test_subdag.py
@@ -25,7 +25,7 @@ import warnings
 from datetime import datetime, timedelta
 
 from airflow.models.dag import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.subdag import SubDagOperator
 
 DAG_NAME = 'test_subdag_operator'
@@ -48,7 +48,7 @@ def subdag(parent_dag_name, child_dag_name, args):
     )
 
     for i in range(2):
-        DummyOperator(
+        EmptyOperator(
             task_id=f'{child_dag_name}-task-{i + 1}',
             default_args=args,
             dag=dag_subdag,
@@ -65,7 +65,7 @@ with DAG(
     schedule_interval=timedelta(minutes=1),
 ) as dag:
 
-    start = DummyOperator(
+    start = EmptyOperator(
         task_id='start',
     )
 
@@ -76,7 +76,7 @@ with DAG(
             default_args=DEFAULT_TASK_ARGS,
         )
 
-    some_other_task = DummyOperator(
+    some_other_task = EmptyOperator(
         task_id='some-other-task',
     )
 

--- a/tests/dags/test_with_non_default_owner.py
+++ b/tests/dags/test_with_non_default_owner.py
@@ -19,7 +19,7 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dates import days_ago
 
 with DAG(
@@ -29,7 +29,7 @@ with DAG(
     dagrun_timeout=timedelta(minutes=60),
     tags=["example"],
 ) as dag:
-    run_this_last = DummyOperator(
+    run_this_last = EmptyOperator(
         task_id="test_task",
         owner="John",
     )

--- a/tests/dags_with_system_exit/b_test_scheduler_dags.py
+++ b/tests/dags_with_system_exit/b_test_scheduler_dags.py
@@ -19,10 +19,10 @@
 from datetime import datetime
 
 from airflow.models import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2000, 1, 1)
 
 dag1 = DAG(dag_id='exit_test_dag', start_date=DEFAULT_DATE)
 
-dag1_task1 = DummyOperator(task_id='dummy', dag=dag1, owner='airflow')
+dag1_task1 = EmptyOperator(task_id='dummy', dag=dag1, owner='airflow')

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1440,6 +1440,10 @@ OPERATORS = [
         "airflow.operators.dummy_operator.DummyOperator",
     ),
     (
+        "airflow.operators.empty.EmptyOperator",
+        "airflow.operators.dummy.DummyOperator",
+    ),
+    (
         "airflow.providers.amazon.aws.operators.ec2.EC2StartInstanceOperator",
         "airflow.providers.amazon.aws.operators.ec2_start_instance.EC2StartInstanceOperator",
     ),

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1436,7 +1436,7 @@ OPERATORS = [
         "airflow.operators.subdag_operator.SubDagOperator",
     ),
     (
-        "airflow.operators.dummy.DummyOperator",
+        "airflow.operators.empty.emptyOperator",
         "airflow.operators.dummy_operator.DummyOperator",
     ),
     (

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1436,7 +1436,7 @@ OPERATORS = [
         "airflow.operators.subdag_operator.SubDagOperator",
     ),
     (
-        "airflow.operators.empty.emptyOperator",
+        "airflow.operators.empty.EmptyOperator",
         "airflow.operators.dummy_operator.DummyOperator",
     ),
     (

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -41,7 +41,7 @@ from airflow.models import DagBag, Pool, TaskInstance as TI
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstanceKey
 from airflow.models.taskmap import TaskMap
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
@@ -92,7 +92,7 @@ class TestBackfillJob:
         **kwargs,
     ):
         with dag_maker_fixture(dag_id=dag_id, schedule_interval='@daily', **kwargs) as dag:
-            DummyOperator(task_id=task_id, pool=pool, max_active_tis_per_dag=max_active_tis_per_dag)
+            EmptyOperator(task_id=task_id, pool=pool, max_active_tis_per_dag=max_active_tis_per_dag)
 
         return dag
 
@@ -675,8 +675,8 @@ class TestBackfillJob:
     def test_backfill_rerun_upstream_failed_tasks(self, dag_maker):
 
         with dag_maker(dag_id='test_backfill_rerun_upstream_failed', schedule_interval='@daily') as dag:
-            op1 = DummyOperator(task_id='test_backfill_rerun_upstream_failed_task-1')
-            op2 = DummyOperator(task_id='test_backfill_rerun_upstream_failed_task-2')
+            op1 = EmptyOperator(task_id='test_backfill_rerun_upstream_failed_task-1')
+            op2 = EmptyOperator(task_id='test_backfill_rerun_upstream_failed_task-2')
             op1.set_upstream(op2)
         dag_maker.create_dagrun(state=None)
 
@@ -746,7 +746,7 @@ class TestBackfillJob:
                 'retry_delay': datetime.timedelta(seconds=0),
             },
         ) as dag:
-            task1 = DummyOperator(task_id="task1")
+            task1 = EmptyOperator(task_id="task1")
         dag_maker.create_dagrun(state=None)
 
         executor = MockExecutor(parallelism=16)
@@ -773,7 +773,7 @@ class TestBackfillJob:
                 'retry_delay': datetime.timedelta(seconds=0),
             },
         ) as dag:
-            task1 = DummyOperator(task_id="task1")
+            task1 = EmptyOperator(task_id="task1")
         dr = dag_maker.create_dagrun(state=None)
 
         executor = MockExecutor(parallelism=16)
@@ -796,11 +796,11 @@ class TestBackfillJob:
             dag_id='test_backfill_ordered_concurrent_execute',
             schedule_interval="@daily",
         ) as dag:
-            op1 = DummyOperator(task_id='leave1')
-            op2 = DummyOperator(task_id='leave2')
-            op3 = DummyOperator(task_id='upstream_level_1')
-            op4 = DummyOperator(task_id='upstream_level_2')
-            op5 = DummyOperator(task_id='upstream_level_3')
+            op1 = EmptyOperator(task_id='leave1')
+            op2 = EmptyOperator(task_id='leave2')
+            op3 = EmptyOperator(task_id='upstream_level_1')
+            op4 = EmptyOperator(task_id='upstream_level_2')
+            op5 = EmptyOperator(task_id='upstream_level_3')
             # order randomly
             op2.set_downstream(op3)
             op1.set_downstream(op3)
@@ -943,10 +943,10 @@ class TestBackfillJob:
             max_active_runs=max_active_runs,
             **kwargs,
         ) as dag:
-            op1 = DummyOperator(task_id='leave1')
-            op2 = DummyOperator(task_id='leave2')
-            op3 = DummyOperator(task_id='upstream_level_1')
-            op4 = DummyOperator(task_id='upstream_level_2')
+            op1 = EmptyOperator(task_id='leave1')
+            op2 = EmptyOperator(task_id='leave2')
+            op3 = EmptyOperator(task_id='upstream_level_1')
+            op4 = EmptyOperator(task_id='upstream_level_2')
 
             op1 >> op2 >> op3
             op4 >> op3
@@ -1086,11 +1086,11 @@ class TestBackfillJob:
         with dag_maker(
             'test_sub_set_subdag',
         ) as dag:
-            op1 = DummyOperator(task_id='leave1')
-            op2 = DummyOperator(task_id='leave2')
-            op3 = DummyOperator(task_id='upstream_level_1')
-            op4 = DummyOperator(task_id='upstream_level_2')
-            op5 = DummyOperator(task_id='upstream_level_3')
+            op1 = EmptyOperator(task_id='leave1')
+            op2 = EmptyOperator(task_id='leave2')
+            op3 = EmptyOperator(task_id='upstream_level_1')
+            op4 = EmptyOperator(task_id='upstream_level_2')
+            op5 = EmptyOperator(task_id='upstream_level_3')
             # order randomly
             op2.set_downstream(op3)
             op1.set_downstream(op3)
@@ -1116,12 +1116,12 @@ class TestBackfillJob:
         with dag_maker(
             'test_backfill_fill_blanks',
         ) as dag:
-            op1 = DummyOperator(task_id='op1')
-            op2 = DummyOperator(task_id='op2')
-            op3 = DummyOperator(task_id='op3')
-            op4 = DummyOperator(task_id='op4')
-            op5 = DummyOperator(task_id='op5')
-            op6 = DummyOperator(task_id='op6')
+            op1 = EmptyOperator(task_id='op1')
+            op2 = EmptyOperator(task_id='op2')
+            op3 = EmptyOperator(task_id='op3')
+            op4 = EmptyOperator(task_id='op4')
+            op5 = EmptyOperator(task_id='op5')
+            op6 = EmptyOperator(task_id='op6')
 
         dr = dag_maker.create_dagrun(state=None)
 
@@ -1271,7 +1271,7 @@ class TestBackfillJob:
         session.add(dr)
 
         removed_task_ti = TI(
-            task=DummyOperator(task_id='removed_task'), run_id=dr.run_id, state=State.REMOVED
+            task=EmptyOperator(task_id='removed_task'), run_id=dr.run_id, state=State.REMOVED
         )
         removed_task_ti.dag_id = subdag.dag_id
         dr.task_instances.append(removed_task_ti)
@@ -1301,7 +1301,7 @@ class TestBackfillJob:
 
     def test_update_counters(self, dag_maker, session):
         with dag_maker(dag_id='test_manage_executor_state', start_date=DEFAULT_DATE, session=session) as dag:
-            task1 = DummyOperator(task_id='dummy', owner='airflow')
+            task1 = EmptyOperator(task_id='dummy', owner='airflow')
         dr = dag_maker.create_dagrun(state=None)
         job = BackfillJob(dag=dag)
 
@@ -1398,7 +1398,7 @@ class TestBackfillJob:
         with dag_maker(
             dag_id='dagrun_infos_between', start_date=DEFAULT_DATE, schedule_interval="@hourly"
         ) as test_dag:
-            DummyOperator(
+            EmptyOperator(
                 task_id='dummy',
                 owner='airflow',
             )
@@ -1464,7 +1464,7 @@ class TestBackfillJob:
         with dag_maker(dag_id=prefix) as dag:
             for i in range(len(states)):
                 task_id = f"{prefix}_task_{i}"
-                task = DummyOperator(task_id=task_id)
+                task = EmptyOperator(task_id=task_id)
                 tasks.append(task)
 
         session = settings.Session()
@@ -1526,7 +1526,7 @@ class TestBackfillJob:
             schedule_interval='@daily',
             session=session,
         ) as dag:
-            DummyOperator(task_id=task_id, dag=dag)
+            EmptyOperator(task_id=task_id, dag=dag)
 
         job = BackfillJob(dag=dag)
         # make two dagruns, only reset for one
@@ -1553,7 +1553,7 @@ class TestBackfillJob:
     def test_job_id_is_assigned_to_dag_run(self, dag_maker):
         dag_id = 'test_job_id_is_assigned_to_dag_run'
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily') as dag:
-            DummyOperator(task_id="dummy_task", dag=dag)
+            EmptyOperator(task_id="dummy_task", dag=dag)
 
         job = BackfillJob(
             dag=dag, executor=MockExecutor(), start_date=timezone.utcnow() - datetime.timedelta(days=1)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -36,7 +36,7 @@ from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.task.task_runner.standard_task_runner import StandardTaskRunner
 from airflow.utils import timezone
@@ -101,7 +101,7 @@ class TestLocalTaskJob:
         proper values without intervention
         """
         with dag_maker('test_localtaskjob_essential_attr'):
-            op1 = DummyOperator(task_id='op1')
+            op1 = EmptyOperator(task_id='op1')
 
         dr = dag_maker.create_dagrun()
 
@@ -120,7 +120,7 @@ class TestLocalTaskJob:
     def test_localtaskjob_heartbeat(self, dag_maker):
         session = settings.Session()
         with dag_maker('test_localtaskjob_heartbeat'):
-            op1 = DummyOperator(task_id='op1')
+            op1 = EmptyOperator(task_id='op1')
 
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
@@ -156,7 +156,7 @@ class TestLocalTaskJob:
     def test_localtaskjob_heartbeat_with_run_as_user(self, psutil_mock, _, dag_maker):
         session = settings.Session()
         with dag_maker('test_localtaskjob_heartbeat'):
-            op1 = DummyOperator(task_id='op1', run_as_user='myuser')
+            op1 = EmptyOperator(task_id='op1', run_as_user='myuser')
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti.state = State.RUNNING
@@ -199,7 +199,7 @@ class TestLocalTaskJob:
     def test_localtaskjob_heartbeat_with_default_impersonation(self, psutil_mock, _, dag_maker):
         session = settings.Session()
         with dag_maker('test_localtaskjob_heartbeat'):
-            op1 = DummyOperator(task_id='op1')
+            op1 = EmptyOperator(task_id='op1')
         dr = dag_maker.create_dagrun()
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti.state = State.RUNNING
@@ -917,7 +917,7 @@ def test_number_of_queries_single_loop(mock_get_task_runner, dag_maker):
 
     unique_prefix = str(uuid.uuid4())
     with dag_maker(dag_id=f'{unique_prefix}_test_number_of_queries'):
-        task = DummyOperator(task_id='test_state_succeeded1')
+        task = EmptyOperator(task_id='test_state_succeeded1')
 
     dr = dag_maker.create_dagrun(run_id=unique_prefix, state=State.NONE)
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3940,9 +3940,9 @@ class TestSchedulerJob:
         dr.refresh_from_db(session)
         assert dr.state == DagRunState.SUCCESS
 
-    def test_should_mark_dummy_task_as_success(self):
+    def test_should_mark_empty_task_as_success(self):
         dag_file = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), '../dags/test_only_dummy_tasks.py'
+            os.path.dirname(os.path.realpath(__file__)), '../dags/test_only_empty_tasks.py'
         )
 
         # Write DAGs to dag and serialized_dag table
@@ -3951,7 +3951,7 @@ class TestSchedulerJob:
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.processor_agent = mock.MagicMock()
-        dag = self.scheduler_job.dagbag.get_dag("test_only_dummy_tasks")
+        dag = self.scheduler_job.dagbag.get_dag("test_only_empty_tasks")
 
         # Create DagRun
         session = settings.Session()
@@ -3968,7 +3968,7 @@ class TestSchedulerJob:
             tis = session.query(TaskInstance).all()
 
         dags = self.scheduler_job.dagbag.dags.values()
-        assert ['test_only_dummy_tasks'] == [dag.dag_id for dag in dags]
+        assert ['test_only_empty_tasks'] == [dag.dag_id for dag in dags]
         assert 5 == len(tis)
         assert {
             ('test_task_a', 'success'),

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -51,7 +51,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKey
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths
@@ -211,7 +211,7 @@ class TestSchedulerJob:
 
         session = settings.Session()
         with dag_maker(dag_id=dag_id, fileloc='/test_path1/'):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
         ti1 = dag_maker.create_dagrun().get_task_instance(task1.task_id)
 
         mock_stats_incr.reset_mock()
@@ -246,7 +246,7 @@ class TestSchedulerJob:
         mock_stats_incr.assert_has_calls(
             [
                 mock.call('scheduler.tasks.killed_externally'),
-                mock.call('operator_failures_DummyOperator', 1, 1),
+                mock.call('operator_failures_EmptyOperator', 1, 1),
                 mock.call('ti_failures'),
             ],
             any_order=True,
@@ -267,7 +267,7 @@ class TestSchedulerJob:
 
         session = settings.Session()
         with dag_maker(dag_id=dag_id, fileloc='/test_path1/'):
-            task1 = DummyOperator(task_id=task_id_1, retries=1)
+            task1 = EmptyOperator(task_id=task_id_1, retries=1)
         ti1 = dag_maker.create_dagrun(
             run_id='dr2', execution_date=DEFAULT_DATE + timedelta(hours=1)
         ).get_task_instance(task1.task_id)
@@ -303,7 +303,7 @@ class TestSchedulerJob:
         mock_stats_incr.assert_has_calls(
             [
                 mock.call('scheduler.tasks.killed_externally'),
-                mock.call('operator_failures_DummyOperator', 1, 1),
+                mock.call('operator_failures_EmptyOperator', 1, 1),
                 mock.call('ti_failures'),
             ],
             any_order=True,
@@ -316,7 +316,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy_task'
 
         with dag_maker(dag_id=dag_id, fileloc='/test_path1/') as dag:
-            task1 = DummyOperator(task_id=task_id_1, on_failure_callback=lambda x: print("hi"))
+            task1 = EmptyOperator(task_id=task_id_1, on_failure_callback=lambda x: print("hi"))
         ti1 = dag_maker.create_dagrun().get_task_instance(task1.task_id)
 
         mock_stats_incr.reset_mock()
@@ -358,7 +358,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy_task'
 
         with dag_maker(dag_id=dag_id, fileloc='/test_path1/'):
-            task1 = DummyOperator(task_id=task_id_1, on_failure_callback=lambda x: print("hi"))
+            task1 = EmptyOperator(task_id=task_id_1, on_failure_callback=lambda x: print("hi"))
         ti1 = dag_maker.create_dagrun().get_task_instance(task1.task_id)
 
         mock_stats_incr.reset_mock()
@@ -386,7 +386,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy_task'
 
         with dag_maker(dag_id=dag_id, session=session) as dag:
-            DummyOperator(task_id=task_id_1)
+            EmptyOperator(task_id=task_id_1)
         assert isinstance(dag, SerializedDAG)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -408,7 +408,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy_task'
 
         with dag_maker(dag_id=dag_id):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -449,7 +449,7 @@ class TestSchedulerJob:
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_backfill'
         task_id_1 = 'dummy'
         with dag_maker(dag_id=dag_id, max_active_tasks=16):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -480,8 +480,8 @@ class TestSchedulerJob:
         task_id_2 = 'dummydummy'
         session = settings.Session()
         with dag_maker(dag_id=dag_id, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id_1, pool='a', priority_weight=2)
-            DummyOperator(task_id=task_id_2, pool='b', priority_weight=1)
+            EmptyOperator(task_id=task_id_1, pool='a', priority_weight=2)
+            EmptyOperator(task_id=task_id_2, pool='b', priority_weight=1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -533,8 +533,8 @@ class TestSchedulerJob:
         task_id_2 = 'dummydummy'
 
         with dag_maker(dag_id=dag_id, session=session):
-            DummyOperator(task_id=task_id_1)
-            DummyOperator(task_id=task_id_2)
+            EmptyOperator(task_id=task_id_1)
+            EmptyOperator(task_id=task_id_2)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -560,11 +560,11 @@ class TestSchedulerJob:
         task_id = 'task-a'
         session = settings.Session()
         with dag_maker(dag_id=dag_id_1, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
         dr1 = dag_maker.create_dagrun(execution_date=DEFAULT_DATE + timedelta(hours=1))
 
         with dag_maker(dag_id=dag_id_2, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
         dr2 = dag_maker.create_dagrun()
 
         dr1 = session.merge(dr1, load=False)
@@ -588,11 +588,11 @@ class TestSchedulerJob:
         task_id = 'task-a'
         session = settings.Session()
         with dag_maker(dag_id=dag_id_1, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id, priority_weight=1)
+            EmptyOperator(task_id=task_id, priority_weight=1)
         dr1 = dag_maker.create_dagrun()
 
         with dag_maker(dag_id=dag_id_2, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id, priority_weight=4)
+            EmptyOperator(task_id=task_id, priority_weight=4)
         dr2 = dag_maker.create_dagrun()
 
         dr1 = session.merge(dr1, load=False)
@@ -625,9 +625,9 @@ class TestSchedulerJob:
         session.add(Pool(pool='pool2', slots=32))
 
         with dag_maker(dag_id=dag_id, max_active_tasks=2):
-            op1 = DummyOperator(task_id='dummy1', priority_weight=1, pool='pool1')
-            op2 = DummyOperator(task_id='dummy2', priority_weight=2, pool='pool2')
-            op3 = DummyOperator(task_id='dummy3', priority_weight=3, pool='pool1')
+            op1 = EmptyOperator(task_id='dummy1', priority_weight=1, pool='pool1')
+            op2 = EmptyOperator(task_id='dummy2', priority_weight=2, pool='pool2')
+            op3 = EmptyOperator(task_id='dummy3', priority_weight=3, pool='pool1')
 
         dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
@@ -655,11 +655,11 @@ class TestSchedulerJob:
         task_id = 'task-a'
         session = settings.Session()
         with dag_maker(dag_id=dag_id_1, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id, priority_weight=1)
+            EmptyOperator(task_id=task_id, priority_weight=1)
         dr1 = dag_maker.create_dagrun()
 
         with dag_maker(dag_id=dag_id_2, max_active_tasks=16, session=session):
-            DummyOperator(task_id=task_id, priority_weight=4)
+            EmptyOperator(task_id=task_id, priority_weight=4)
         dr2 = dag_maker.create_dagrun(execution_date=DEFAULT_DATE + timedelta(hours=1))
 
         dr1 = session.merge(dr1, load=False)
@@ -681,8 +681,8 @@ class TestSchedulerJob:
 
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_in_default_pool'
         with dag_maker(dag_id=dag_id):
-            op1 = DummyOperator(task_id='dummy1')
-            op2 = DummyOperator(task_id='dummy2')
+            op1 = EmptyOperator(task_id='dummy1')
+            op2 = EmptyOperator(task_id='dummy2')
 
         executor = MockExecutor(do_update=True)
         self.scheduler_job = SchedulerJob(executor=executor)
@@ -719,8 +719,8 @@ class TestSchedulerJob:
         task_id_2 = 'dummydummy'
 
         with dag_maker(dag_id=dag_id, session=session, default_args={"max_active_tis_per_dag": 1}):
-            DummyOperator(task_id=task_id_1)
-            DummyOperator(task_id=task_id_2)
+            EmptyOperator(task_id=task_id_1)
+            EmptyOperator(task_id=task_id_2)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag = mock.MagicMock()
@@ -743,7 +743,7 @@ class TestSchedulerJob:
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'
         with dag_maker(dag_id=dag_id, max_active_tasks=16):
-            DummyOperator(task_id="dummy_wrong_pool", pool="this_pool_doesnt_exist")
+            EmptyOperator(task_id="dummy_wrong_pool", pool="this_pool_doesnt_exist")
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -763,7 +763,7 @@ class TestSchedulerJob:
     def test_infinite_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_infinite_pool'
         with dag_maker(dag_id=dag_id, concurrency=16):
-            DummyOperator(task_id="dummy", pool="infinite_pool")
+            EmptyOperator(task_id="dummy", pool="infinite_pool")
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -784,8 +784,8 @@ class TestSchedulerJob:
     def test_not_enough_pool_slots(self, caplog, dag_maker):
         dag_id = 'SchedulerJobTest.test_test_not_enough_pool_slots'
         with dag_maker(dag_id=dag_id, concurrency=16):
-            DummyOperator(task_id="cannot_run", pool="some_pool", pool_slots=4)
-            DummyOperator(task_id="can_run", pool="some_pool", pool_slots=1)
+            EmptyOperator(task_id="cannot_run", pool="some_pool", pool_slots=4)
+            EmptyOperator(task_id="can_run", pool="some_pool", pool_slots=1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -828,7 +828,7 @@ class TestSchedulerJob:
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_none'
         task_id_1 = 'dummy'
         with dag_maker(dag_id=dag_id, max_active_tasks=16):
-            DummyOperator(task_id=task_id_1)
+            EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -844,7 +844,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy'
 
         with dag_maker(dag_id):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.QUEUED)
         dr2 = dag_maker.create_dagrun_after(dr1, run_type=DagRunType.SCHEDULED)
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -869,7 +869,7 @@ class TestSchedulerJob:
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_concurrency'
         session = settings.Session()
         with dag_maker(dag_id=dag_id, max_active_tasks=2, session=session):
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -907,9 +907,9 @@ class TestSchedulerJob:
     def test_find_executable_task_instances_concurrency_queued(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_concurrency_queued'
         with dag_maker(dag_id=dag_id, max_active_tasks=3):
-            task1 = DummyOperator(task_id='dummy1')
-            task2 = DummyOperator(task_id='dummy2')
-            task3 = DummyOperator(task_id='dummy3')
+            task1 = EmptyOperator(task_id='dummy1')
+            task2 = EmptyOperator(task_id='dummy2')
+            task3 = EmptyOperator(task_id='dummy3')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -941,8 +941,8 @@ class TestSchedulerJob:
         task_id_1 = 'dummy'
         task_id_2 = 'dummy2'
         with dag_maker(dag_id=dag_id, max_active_tasks=16):
-            task1 = DummyOperator(task_id=task_id_1, max_active_tis_per_dag=2)
-            task2 = DummyOperator(task_id=task_id_2)
+            task1 = EmptyOperator(task_id=task_id_1, max_active_tis_per_dag=2)
+            task2 = EmptyOperator(task_id=task_id_2)
 
         executor = MockExecutor(do_update=True)
         self.scheduler_job = SchedulerJob(executor=executor)
@@ -1018,7 +1018,7 @@ class TestSchedulerJob:
         dag_id = 'SchedulerJobTest.test_change_state_for__no_tis_with_state'
         task_id_1 = 'dummy'
         with dag_maker(dag_id=dag_id, max_active_tasks=2):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -1052,8 +1052,8 @@ class TestSchedulerJob:
 
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_enough_pool_slots_for_first'
         with dag_maker(dag_id=dag_id):
-            op1 = DummyOperator(task_id='dummy1', priority_weight=2, pool_slots=2)
-            op2 = DummyOperator(task_id='dummy2', priority_weight=1, pool_slots=1)
+            op1 = EmptyOperator(task_id='dummy1', priority_weight=2, pool_slots=2)
+            op2 = EmptyOperator(task_id='dummy2', priority_weight=1, pool_slots=1)
 
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
@@ -1083,12 +1083,12 @@ class TestSchedulerJob:
         )
 
         with dag_maker(dag_id=dag_id_1, max_active_tasks=1):
-            op1a = DummyOperator(task_id='dummy1-a', priority_weight=2)
-            op1b = DummyOperator(task_id='dummy1-b', priority_weight=2)
+            op1a = EmptyOperator(task_id='dummy1-a', priority_weight=2)
+            op1b = EmptyOperator(task_id='dummy1-b', priority_weight=2)
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
         with dag_maker(dag_id=dag_id_2):
-            op2 = DummyOperator(task_id='dummy2', priority_weight=1)
+            op2 = EmptyOperator(task_id='dummy2', priority_weight=1)
         dr2 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
         ti1a = dr1.get_task_instance(op1a.task_id, session)
@@ -1114,8 +1114,8 @@ class TestSchedulerJob:
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_enough_task_concurrency_for_first'
 
         with dag_maker(dag_id=dag_id):
-            op1a = DummyOperator(task_id='dummy1-a', priority_weight=2, max_active_tis_per_dag=1)
-            op1b = DummyOperator(task_id='dummy1-b', priority_weight=1)
+            op1a = EmptyOperator(task_id='dummy1-a', priority_weight=2, max_active_tis_per_dag=1)
+            op1b = EmptyOperator(task_id='dummy1-b', priority_weight=1)
         dr1 = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
         dr2 = dag_maker.create_dagrun_after(dr1, run_type=DagRunType.SCHEDULED)
 
@@ -1142,7 +1142,7 @@ class TestSchedulerJob:
 
         dag_id = 'SchedulerJobTest.test_emit_pool_starving_tasks_metrics'
         with dag_maker(dag_id=dag_id):
-            op = DummyOperator(task_id='op', pool_slots=2)
+            op = EmptyOperator(task_id='op', pool_slots=2)
 
         dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
@@ -1186,7 +1186,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy'
         session = settings.Session()
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, session=session):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -1206,7 +1206,7 @@ class TestSchedulerJob:
         task_id_1 = 'dummy'
         session = settings.Session()
         with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE, session=session):
-            task1 = DummyOperator(task_id=task_id_1)
+            task1 = EmptyOperator(task_id=task_id_1)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -1232,8 +1232,8 @@ class TestSchedulerJob:
         # check the num tasks once so if max_active_tasks was 3,
         # we could execute arbitrarily many tasks in the second run
         with dag_maker(dag_id=dag_id, max_active_tasks=3, session=session) as dag:
-            task1 = DummyOperator(task_id=task_id_1)
-            task2 = DummyOperator(task_id=task_id_2)
+            task1 = EmptyOperator(task_id=task_id_1)
+            task2 = EmptyOperator(task_id=task_id_2)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -1286,8 +1286,8 @@ class TestSchedulerJob:
         # check the num tasks once so if max_active_tasks was 3,
         # we could execute arbitrarily many tasks in the second run
         with dag_maker(dag_id=dag_id, max_active_tasks=16, session=session):
-            task1 = DummyOperator(task_id=task_id_1)
-            task2 = DummyOperator(task_id=task_id_2)
+            task1 = EmptyOperator(task_id=task_id_1)
+            task2 = EmptyOperator(task_id=task_id_2)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -1337,8 +1337,8 @@ class TestSchedulerJob:
         session = settings.Session()
 
         with dag_maker(dag_id=dag_id, max_active_tasks=1024, session=session):
-            task1 = DummyOperator(task_id=task_id_1)
-            task2 = DummyOperator(task_id=task_id_2)
+            task1 = EmptyOperator(task_id=task_id_1)
+            task2 = EmptyOperator(task_id=task_id_2)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
 
@@ -1370,7 +1370,7 @@ class TestSchedulerJob:
     def test_adopt_or_reset_orphaned_tasks(self, dag_maker):
         session = settings.Session()
         with dag_maker('test_execute_helper_reset_orphaned_tasks') as dag:
-            op1 = DummyOperator(task_id='op1')
+            op1 = EmptyOperator(task_id='op1')
 
         dr = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
@@ -1433,7 +1433,7 @@ class TestSchedulerJob:
     def test_queued_dagruns_stops_creating_when_max_active_is_reached(self, dag_maker):
         """This tests that queued dagruns stops creating once max_active_runs is reached"""
         with dag_maker(max_active_runs=10) as dag:
-            DummyOperator(task_id='mytask')
+            EmptyOperator(task_id='mytask')
 
         session = settings.Session()
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -1511,7 +1511,7 @@ class TestSchedulerJob:
             max_active_runs=1,
             dagrun_timeout=datetime.timedelta(seconds=60),
         ) as dag:
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag = dag_maker.dagbag
@@ -1576,7 +1576,7 @@ class TestSchedulerJob:
             dagrun_timeout=datetime.timedelta(seconds=60),
             session=session,
         ):
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
 
@@ -1617,7 +1617,7 @@ class TestSchedulerJob:
             dag_id='test_scheduler_fail_dagrun_timeout',
             dagrun_timeout=datetime.timedelta(seconds=60),
         ):
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         dr = dag_maker.create_dagrun(start_date=timezone.utcnow() - datetime.timedelta(days=1))
         # check that next_dagrun is dr.execution_date
@@ -1653,7 +1653,7 @@ class TestSchedulerJob:
             on_success_callback=lambda x: print("success"),
             on_failure_callback=lambda x: print("failed"),
         ) as dag:
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.executor = MockExecutor()
@@ -1688,7 +1688,7 @@ class TestSchedulerJob:
         that the dagrun details are up to date when the callbacks are run.
         """
         with dag_maker(dag_id='test_dagrun_callbacks_commited_before_sent'):
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.processor_agent = mock.Mock()
@@ -1797,7 +1797,7 @@ class TestSchedulerJob:
             dag_id='test_scheduler_do_not_schedule_removed_task',
             schedule_interval=schedule_interval,
         ):
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         session = settings.Session()
 
@@ -2592,10 +2592,10 @@ class TestSchedulerJob:
             dag_name1, schedule_interval='* * * * *', max_active_runs=1, default_args=default_args
         ) as dag1:
 
-            run_this_1 = DummyOperator(task_id='run_this_1')
-            run_this_2 = DummyOperator(task_id='run_this_2')
+            run_this_1 = EmptyOperator(task_id='run_this_1')
+            run_this_2 = EmptyOperator(task_id='run_this_2')
             run_this_2.set_upstream(run_this_1)
-            run_this_3 = DummyOperator(task_id='run_this_3')
+            run_this_3 = EmptyOperator(task_id='run_this_3')
             run_this_3.set_upstream(run_this_2)
 
         dr = dag_maker.create_dagrun()
@@ -2677,7 +2677,7 @@ class TestSchedulerJob:
         dag_id = 'test_reset_orphaned_tasks_external_triggered_dag'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
             task_id = dag_id + '_task'
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2696,7 +2696,7 @@ class TestSchedulerJob:
         dag_id = 'test_adopt_or_reset_orphaned_tasks_backfill_dag'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
             task_id = dag_id + '_task'
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2719,7 +2719,7 @@ class TestSchedulerJob:
         dag_id = 'test_reset_orphaned_tasks_no_orphans'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
             task_id = dag_id + '_task'
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2743,7 +2743,7 @@ class TestSchedulerJob:
         dag_id = 'test_reset_orphaned_tasks_non_running_dagruns'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
             task_id = dag_id + '_task'
-            DummyOperator(task_id=task_id)
+            EmptyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2765,8 +2765,8 @@ class TestSchedulerJob:
     def test_adopt_or_reset_orphaned_tasks_stale_scheduler_jobs(self, dag_maker):
         dag_id = 'test_adopt_or_reset_orphaned_tasks_stale_scheduler_jobs'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
-            DummyOperator(task_id='task1')
-            DummyOperator(task_id='task2')
+            EmptyOperator(task_id='task1')
+            EmptyOperator(task_id='task2')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2844,7 +2844,7 @@ class TestSchedulerJob:
         """Test SLA Callbacks are not sent when check_slas is False"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_disabled'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
-            DummyOperator(task_id='task1')
+            EmptyOperator(task_id='task1')
 
         with patch.object(settings, "CHECK_SLAS", False):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -2857,7 +2857,7 @@ class TestSchedulerJob:
         """Test SLA Callbacks are not sent when no task SLAs are defined"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_no_task_slas'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
-            DummyOperator(task_id='task1')
+            EmptyOperator(task_id='task1')
 
         with patch.object(settings, "CHECK_SLAS", True):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -2870,7 +2870,7 @@ class TestSchedulerJob:
         """Test SLA Callbacks are sent to the DAG Processor when SLAs are defined on tasks"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_with_task_slas'
         with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
-            DummyOperator(task_id='task1', sla=timedelta(seconds=60))
+            EmptyOperator(task_id='task1', sla=timedelta(seconds=60))
 
         with patch.object(settings, "CHECK_SLAS", True):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -2890,7 +2890,7 @@ class TestSchedulerJob:
         - That dag_model has next_dagrun
         """
         with dag_maker(dag_id='test_create_dag_runs') as dag:
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         dag_model = dag_maker.dag_model
 
@@ -2917,7 +2917,7 @@ class TestSchedulerJob:
         - emit the right DagRun metrics
         """
         with dag_maker(dag_id='test_start_dag_runs') as dag:
-            DummyOperator(
+            EmptyOperator(
                 task_id='dummy',
             )
 
@@ -2973,7 +2973,7 @@ class TestSchedulerJob:
         in serialized_dag table
         """
         with dag_maker(dag_id='test_scheduler_create_dag_runs_does_not_raise_error', serialized=False):
-            DummyOperator(
+            EmptyOperator(
                 task_id='dummy',
             )
 
@@ -3002,7 +3002,7 @@ class TestSchedulerJob:
             max_active_runs=5,
             catchup=True,
         ) as dag:
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         session = settings.Session()
 
@@ -3061,7 +3061,7 @@ class TestSchedulerJob:
             dag_id='test_scheduler_create_dag_runs_check_existing_run',
             schedule_interval=timedelta(days=1),
         ) as dag:
-            DummyOperator(
+            EmptyOperator(
                 task_id='dummy',
             )
 
@@ -3166,7 +3166,7 @@ class TestSchedulerJob:
             max_active_runs=1,
             session=session,
         ):
-            # Can't use DummyOperator as that goes straight to success
+            # Can't use EmptyOperator as that goes straight to success
             BashOperator(task_id='dummy1', bash_command='true')
 
         run1 = dag_maker.create_dagrun(
@@ -3193,7 +3193,7 @@ class TestSchedulerJob:
         more dagruns
         """
         with dag_maker(max_active_runs=1):
-            DummyOperator(task_id='task')
+            EmptyOperator(task_id='task')
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.executor = MockExecutor(do_update=False)
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
@@ -3298,7 +3298,7 @@ class TestSchedulerJob:
             schedule_interval='@once',
             max_active_runs=1,
         ) as dag:
-            # Can't use DummyOperator as that goes straight to success
+            # Can't use EmptyOperator as that goes straight to success
             task1 = BashOperator(task_id='dummy1', bash_command='true')
             task2 = BashOperator(task_id='dummy2', bash_command='true')
 
@@ -3352,7 +3352,7 @@ class TestSchedulerJob:
             schedule_interval=timedelta(hours=1),
             max_active_runs=1,
         ):
-            DummyOperator(task_id='mytask')
+            EmptyOperator(task_id='mytask')
 
         dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.QUEUED)
         for _ in range(29):
@@ -3363,7 +3363,7 @@ class TestSchedulerJob:
             start_date=timezone.datetime(2020, 1, 1),
             schedule_interval=timedelta(hours=1),
         ):
-            DummyOperator(task_id='mytask')
+            EmptyOperator(task_id='mytask')
 
         dr = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, state=State.QUEUED)
         for _ in range(9):
@@ -3390,7 +3390,7 @@ class TestSchedulerJob:
     def test_start_queued_dagruns_do_follow_execution_date_order(self, dag_maker):
         session = settings.Session()
         with dag_maker('test_dag1', max_active_runs=1) as dag:
-            DummyOperator(task_id='mytask')
+            EmptyOperator(task_id='mytask')
         date = dag.following_schedule(DEFAULT_DATE)
         for i in range(30):
             dr = dag_maker.create_dagrun(
@@ -3432,7 +3432,7 @@ class TestSchedulerJob:
         # first dag and dagruns
         date = timezone.datetime(2016, 1, 1)
         with dag_maker('test_dagrun_states_are_correct_1', max_active_runs=1, start_date=date) as dag:
-            task1 = DummyOperator(task_id='dummy_task')
+            task1 = EmptyOperator(task_id='dummy_task')
 
         dr1_running = dag_maker.create_dagrun(run_id='dr1_run_1', execution_date=date)
         dag_maker.create_dagrun(
@@ -3443,7 +3443,7 @@ class TestSchedulerJob:
         # second dag and dagruns
         date = timezone.datetime(2020, 1, 1)
         with dag_maker('test_dagrun_states_are_correct_2', start_date=date) as dag:
-            DummyOperator(task_id='dummy_task')
+            EmptyOperator(task_id='dummy_task')
         for i in range(16):
             dr = dag_maker.create_dagrun(run_id=f'dr2_run_{i+1}', state=State.RUNNING, execution_date=date)
             date = dr.execution_date + timedelta(hours=1)
@@ -3456,7 +3456,7 @@ class TestSchedulerJob:
         # third dag and dagruns
         date = timezone.datetime(2021, 1, 1)
         with dag_maker('test_dagrun_states_are_correct_3', start_date=date) as dag:
-            DummyOperator(task_id='dummy_task')
+            EmptyOperator(task_id='dummy_task')
         for i in range(16):
             dr = dag_maker.create_dagrun(run_id=f'dr3_run_{i+1}', state=State.RUNNING, execution_date=date)
             date = dr.execution_date + timedelta(hours=1)
@@ -3713,7 +3713,7 @@ class TestSchedulerJob:
             max_active_runs=1,
             session=session,
         ):
-            DummyOperator(task_id='dummy1')
+            EmptyOperator(task_id='dummy1')
 
         # Create a Task Instance for the task that is allegedly deferred
         # but past its timeout, and one that is still good.
@@ -4025,7 +4025,7 @@ class TestSchedulerJob:
             max_active_runs=1,
             session=session,
         ) as dag:
-            DummyOperator(task_id='dummy')
+            EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.executor = MockExecutor()
@@ -4073,9 +4073,9 @@ def test_task_with_upstream_skip_process_task_instances():
     with DAG(
         dag_id='test_task_with_upstream_skip_dag', start_date=DEFAULT_DATE, schedule_interval=None
     ) as dag:
-        dummy1 = DummyOperator(task_id='dummy1')
-        dummy2 = DummyOperator(task_id="dummy2")
-        dummy3 = DummyOperator(task_id="dummy3")
+        dummy1 = EmptyOperator(task_id='dummy1')
+        dummy2 = EmptyOperator(task_id="dummy2")
+        dummy3 = EmptyOperator(task_id="dummy3")
         [dummy1, dummy2] >> dummy3
 
     # dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -25,7 +25,7 @@ import pytest
 
 from airflow.jobs.triggerer_job import TriggererJob, TriggerRunner
 from airflow.models import DagModel, DagRun, TaskInstance, Trigger
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.triggers.base import TriggerEvent
 from airflow.triggers.temporal import TimeDeltaTrigger
@@ -426,7 +426,7 @@ def test_invalid_trigger(session, dag_maker):
 
     # Create the test DAG and task
     with dag_maker(dag_id='test_invalid_trigger', session=session):
-        DummyOperator(task_id='dummy1')
+        EmptyOperator(task_id='dummy1')
 
     dr = dag_maker.create_dagrun()
     task_instance = dr.task_instances[0]

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -21,7 +21,7 @@ from airflow.lineage import AUTO, apply_lineage, get_backend, prepare_lineage
 from airflow.lineage.backend import LineageBackend
 from airflow.lineage.entities import File
 from airflow.models import TaskInstance as TI
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
@@ -44,17 +44,17 @@ class TestLineage:
         file3 = File(f3s)
 
         with dag_maker(dag_id='test_prepare_lineage', start_date=DEFAULT_DATE) as dag:
-            op1 = DummyOperator(
+            op1 = EmptyOperator(
                 task_id='leave1',
                 inlets=file1,
                 outlets=[
                     file2,
                 ],
             )
-            op2 = DummyOperator(task_id='leave2')
-            op3 = DummyOperator(task_id='upstream_level_1', inlets=AUTO, outlets=file3)
-            op4 = DummyOperator(task_id='upstream_level_2')
-            op5 = DummyOperator(task_id='upstream_level_3', inlets=["leave1", "upstream_level_1"])
+            op2 = EmptyOperator(task_id='leave2')
+            op3 = EmptyOperator(task_id='upstream_level_1', inlets=AUTO, outlets=file3)
+            op4 = EmptyOperator(task_id='upstream_level_2')
+            op5 = EmptyOperator(task_id='upstream_level_3', inlets=["leave1", "upstream_level_1"])
 
             op1.set_downstream(op3)
             op2.set_downstream(op3)
@@ -102,7 +102,7 @@ class TestLineage:
         # tests inlets / outlets are rendered if they are added
         # after initialization
         with dag_maker(dag_id='test_lineage_render', start_date=DEFAULT_DATE):
-            op1 = DummyOperator(task_id='task1')
+            op1 = EmptyOperator(task_id='task1')
         dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
         f1s = "/tmp/does_not_exist_1-{}"
@@ -131,7 +131,7 @@ class TestLineage:
         mock_get_backend.return_value = TestBackend()
 
         with dag_maker(dag_id='test_lineage_is_sent_to_backend', start_date=DEFAULT_DATE):
-            op1 = DummyOperator(task_id='task1')
+            op1 = EmptyOperator(task_id='task1')
         dag_run = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED)
 
         file1 = File("/tmp/some_file")

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -660,7 +660,7 @@ class TestBaseOperator:
         ):
             BaseOperator(task_id="op1", trigger_rule="some_rule")
 
-    @pytest.mark.parametrize(("rule"), [("dummy"), (TriggerRule.DUMMY)])
+    @pytest.mark.parametrize(("rule"), [("empty"), (TriggerRule.DUMMY)])
     def test_replace_dummy_trigger_rule(self, rule):
         with pytest.warns(
             DeprecationWarning, match="dummy Trigger Rule is deprecated. Please use `TriggerRule.ALWAYS`."

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -660,7 +660,7 @@ class TestBaseOperator:
         ):
             BaseOperator(task_id="op1", trigger_rule="some_rule")
 
-    @pytest.mark.parametrize(("rule"), [("empty"), (TriggerRule.DUMMY)])
+    @pytest.mark.parametrize(("rule"), [("dummy"), (TriggerRule.DUMMY)])
     def test_replace_dummy_trigger_rule(self, rule):
         with pytest.warns(
             DeprecationWarning, match="dummy Trigger Rule is deprecated. Please use `TriggerRule.ALWAYS`."

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -22,7 +22,7 @@ import pytest
 
 from airflow import settings
 from airflow.models import DAG, TaskInstance as TI, TaskReschedule, clear_task_instances
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.python import PythonSensor
 from airflow.utils.session import create_session
 from airflow.utils.state import State, TaskInstanceState
@@ -46,8 +46,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            task0 = DummyOperator(task_id='0')
-            task1 = DummyOperator(task_id='1', retries=2)
+            task0 = EmptyOperator(task_id='0')
+            task1 = EmptyOperator(task_id='1', retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -84,7 +84,7 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            DummyOperator(task_id='task0')
+            EmptyOperator(task_id='task0')
 
         ti0 = dag_maker.create_dagrun().task_instances[0]
         ti0.state = State.SUCCESS
@@ -119,8 +119,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            DummyOperator(task_id='0')
-            DummyOperator(task_id='1', retries=2)
+            EmptyOperator(task_id='0')
+            EmptyOperator(task_id='1', retries=2)
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
             run_type=DagRunType.SCHEDULED,
@@ -152,8 +152,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            task0 = DummyOperator(task_id='task0')
-            task1 = DummyOperator(task_id='task1', retries=2)
+            task0 = EmptyOperator(task_id='task0')
+            task1 = EmptyOperator(task_id='task1', retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -195,8 +195,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ) as dag:
-            task0 = DummyOperator(task_id='task0')
-            task1 = DummyOperator(task_id='task1', retries=2)
+            task0 = EmptyOperator(task_id='task0')
+            task1 = EmptyOperator(task_id='task1', retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -283,8 +283,8 @@ class TestClearTasks:
         with dag_maker(
             'test_dag_clear', start_date=DEFAULT_DATE, end_date=DEFAULT_DATE + datetime.timedelta(days=10)
         ) as dag:
-            task0 = DummyOperator(task_id='test_dag_clear_task_0')
-            task1 = DummyOperator(task_id='test_dag_clear_task_1', retries=2)
+            task0 = EmptyOperator(task_id='test_dag_clear_task_0')
+            task1 = EmptyOperator(task_id='test_dag_clear_task_1', retries=2)
 
         dr = dag_maker.create_dagrun(
             state=State.RUNNING,
@@ -339,7 +339,7 @@ class TestClearTasks:
                 start_date=DEFAULT_DATE,
                 end_date=DEFAULT_DATE + datetime.timedelta(days=10),
             )
-            task = DummyOperator(task_id='test_task_clear_' + str(i), owner='test', dag=dag)
+            task = EmptyOperator(task_id='test_task_clear_' + str(i), owner='test', dag=dag)
 
             dr = dag.create_dagrun(
                 execution_date=DEFAULT_DATE,
@@ -409,8 +409,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ):
-            op1 = DummyOperator(task_id='test1')
-            op2 = DummyOperator(task_id='test2', retries=1)
+            op1 = EmptyOperator(task_id='test1')
+            op2 = EmptyOperator(task_id='test2', retries=1)
             op1 >> op2
 
         dr = dag_maker.create_dagrun(

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -393,14 +393,14 @@ class TestDagBag:
         Test that if a DAG does not exist in serialized_dag table (as the DAG file was removed),
         remove dags from the DagBag
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
 
         with dag_maker(
             dag_id="test_dag_removed_if_serialized_dag_is_removed",
             schedule_interval=None,
             start_date=tz.datetime(2021, 10, 12),
         ) as dag:
-            DummyOperator(task_id="task_1")
+            EmptyOperator(task_id="task_1")
         dag_maker.create_dagrun()
         dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False, read_dags_from_db=True)
         dagbag.dags = {dag.dag_id: SerializedDAG.from_dict(SerializedDAG.to_dict(dag))}
@@ -457,7 +457,7 @@ class TestDagBag:
             import datetime
 
             from airflow.models import DAG
-            from airflow.operators.dummy import DummyOperator
+            from airflow.operators.empty import EmptyOperator
             from airflow.operators.subdag import SubDagOperator
 
             dag_name = 'parent'
@@ -476,18 +476,18 @@ class TestDagBag:
 
                 def subdag_0():
                     subdag_0 = DAG('parent.op_subdag_0', default_args=default_args)
-                    DummyOperator(task_id='subdag_0.task', dag=subdag_0)
+                    EmptyOperator(task_id='subdag_0.task', dag=subdag_0)
                     return subdag_0
 
                 def subdag_1():
                     subdag_1 = DAG('parent.op_subdag_1', default_args=default_args)
-                    DummyOperator(task_id='subdag_1.task', dag=subdag_1)
+                    EmptyOperator(task_id='subdag_1.task', dag=subdag_1)
                     return subdag_1
 
                 op_subdag_0 = SubDagOperator(task_id='op_subdag_0', dag=dag, subdag=subdag_0())
                 op_subdag_1 = SubDagOperator(task_id='op_subdag_1', dag=dag, subdag=subdag_1())
 
-                op_a = DummyOperator(task_id='A')
+                op_a = EmptyOperator(task_id='A')
                 op_a.set_downstream(op_subdag_0)
                 op_a.set_downstream(op_subdag_1)
             return dag
@@ -508,7 +508,7 @@ class TestDagBag:
             import datetime
 
             from airflow.models import DAG
-            from airflow.operators.dummy import DummyOperator
+            from airflow.operators.empty import EmptyOperator
             from airflow.operators.subdag import SubDagOperator
 
             dag_name = 'parent'
@@ -537,22 +537,22 @@ class TestDagBag:
 
                 def subdag_a():
                     subdag_a = DAG('parent.op_subdag_0.opSubdag_A', default_args=default_args)
-                    DummyOperator(task_id='subdag_a.task', dag=subdag_a)
+                    EmptyOperator(task_id='subdag_a.task', dag=subdag_a)
                     return subdag_a
 
                 def subdag_b():
                     subdag_b = DAG('parent.op_subdag_0.opSubdag_B', default_args=default_args)
-                    DummyOperator(task_id='subdag_b.task', dag=subdag_b)
+                    EmptyOperator(task_id='subdag_b.task', dag=subdag_b)
                     return subdag_b
 
                 def subdag_c():
                     subdag_c = DAG('parent.op_subdag_1.opSubdag_C', default_args=default_args)
-                    DummyOperator(task_id='subdag_c.task', dag=subdag_c)
+                    EmptyOperator(task_id='subdag_c.task', dag=subdag_c)
                     return subdag_c
 
                 def subdag_d():
                     subdag_d = DAG('parent.op_subdag_1.opSubdag_D', default_args=default_args)
-                    DummyOperator(task_id='subdag_d.task', dag=subdag_d)
+                    EmptyOperator(task_id='subdag_d.task', dag=subdag_d)
                     return subdag_d
 
                 def subdag_0():
@@ -570,7 +570,7 @@ class TestDagBag:
                 op_subdag_0 = SubDagOperator(task_id='op_subdag_0', dag=dag, subdag=subdag_0())
                 op_subdag_1 = SubDagOperator(task_id='op_subdag_1', dag=dag, subdag=subdag_1())
 
-                op_a = DummyOperator(task_id='A')
+                op_a = EmptyOperator(task_id='A')
                 op_a.set_downstream(op_subdag_0)
                 op_a.set_downstream(op_subdag_1)
 
@@ -601,7 +601,7 @@ class TestDagBag:
             import datetime
 
             from airflow.models import DAG
-            from airflow.operators.dummy import DummyOperator
+            from airflow.operators.empty import EmptyOperator
 
             dag_name = 'cycle_dag'
             default_args = {'owner': 'owner1', 'start_date': datetime.datetime(2016, 1, 1)}
@@ -609,7 +609,7 @@ class TestDagBag:
 
             # A -> A
             with dag:
-                op_a = DummyOperator(task_id='A')
+                op_a = EmptyOperator(task_id='A')
                 op_a.set_downstream(op_a)
 
             return dag
@@ -631,7 +631,7 @@ class TestDagBag:
             import datetime
 
             from airflow.models import DAG
-            from airflow.operators.dummy import DummyOperator
+            from airflow.operators.empty import EmptyOperator
             from airflow.operators.subdag import SubDagOperator
 
             dag_name = 'nested_cycle'
@@ -660,24 +660,24 @@ class TestDagBag:
 
                 def subdag_a():
                     subdag_a = DAG('nested_cycle.op_subdag_0.opSubdag_A', default_args=default_args)
-                    DummyOperator(task_id='subdag_a.task', dag=subdag_a)
+                    EmptyOperator(task_id='subdag_a.task', dag=subdag_a)
                     return subdag_a
 
                 def subdag_b():
                     subdag_b = DAG('nested_cycle.op_subdag_0.opSubdag_B', default_args=default_args)
-                    DummyOperator(task_id='subdag_b.task', dag=subdag_b)
+                    EmptyOperator(task_id='subdag_b.task', dag=subdag_b)
                     return subdag_b
 
                 def subdag_c():
                     subdag_c = DAG('nested_cycle.op_subdag_1.opSubdag_C', default_args=default_args)
-                    op_subdag_c_task = DummyOperator(task_id='subdag_c.task', dag=subdag_c)
+                    op_subdag_c_task = EmptyOperator(task_id='subdag_c.task', dag=subdag_c)
                     # introduce a loop in opSubdag_C
                     op_subdag_c_task.set_downstream(op_subdag_c_task)
                     return subdag_c
 
                 def subdag_d():
                     subdag_d = DAG('nested_cycle.op_subdag_1.opSubdag_D', default_args=default_args)
-                    DummyOperator(task_id='subdag_d.task', dag=subdag_d)
+                    EmptyOperator(task_id='subdag_d.task', dag=subdag_d)
                     return subdag_d
 
                 def subdag_0():
@@ -695,7 +695,7 @@ class TestDagBag:
                 op_subdag_0 = SubDagOperator(task_id='op_subdag_0', dag=dag, subdag=subdag_0())
                 op_subdag_1 = SubDagOperator(task_id='op_subdag_1', dag=dag, subdag=subdag_1())
 
-                op_a = DummyOperator(task_id='A')
+                op_a = EmptyOperator(task_id='A')
                 op_a.set_downstream(op_subdag_0)
                 op_a.set_downstream(op_subdag_1)
 

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -22,7 +22,7 @@ from airflow import settings
 from airflow.exceptions import AirflowException, PoolNotFound
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import TaskInstance as TI
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -68,8 +68,8 @@ class TestPool:
             dag_id='test_open_slots',
             start_date=DEFAULT_DATE,
         ):
-            op1 = DummyOperator(task_id='dummy1', pool='test_pool')
-            op2 = DummyOperator(task_id='dummy2', pool='test_pool')
+            op1 = EmptyOperator(task_id='dummy1', pool='test_pool')
+            op2 = EmptyOperator(task_id='dummy2', pool='test_pool')
         dag_maker.create_dagrun()
         ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
         ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
@@ -107,8 +107,8 @@ class TestPool:
         with dag_maker(
             dag_id='test_infinite_slots',
         ):
-            op1 = DummyOperator(task_id='dummy1', pool='test_pool')
-            op2 = DummyOperator(task_id='dummy2', pool='test_pool')
+            op1 = EmptyOperator(task_id='dummy1', pool='test_pool')
+            op2 = EmptyOperator(task_id='dummy2', pool='test_pool')
         dag_maker.create_dagrun()
         ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
         ti2 = TI(task=op2, execution_date=DEFAULT_DATE)
@@ -148,8 +148,8 @@ class TestPool:
         with dag_maker(
             dag_id='test_default_pool_open_slots',
         ):
-            op1 = DummyOperator(task_id='dummy1')
-            op2 = DummyOperator(task_id='dummy2', pool_slots=2)
+            op1 = EmptyOperator(task_id='dummy1')
+            op2 = EmptyOperator(task_id='dummy2', pool_slots=2)
         dag_maker.create_dagrun()
         ti1 = TI(task=op1, execution_date=DEFAULT_DATE)
         ti2 = TI(task=op2, execution_date=DEFAULT_DATE)

--- a/tests/models/test_skipmixin.py
+++ b/tests/models/test_skipmixin.py
@@ -25,7 +25,7 @@ import pytest
 from airflow import settings
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.taskinstance import TaskInstance as TI
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -52,7 +52,7 @@ class TestSkipMixin:
         now = datetime.datetime.utcnow().replace(tzinfo=pendulum.timezone('UTC'))
         mock_now.return_value = now
         with dag_maker('dag'):
-            tasks = [DummyOperator(task_id='task')]
+            tasks = [EmptyOperator(task_id='task')]
         dag_run = dag_maker.create_dagrun(
             run_type=DagRunType.MANUAL,
             execution_date=now,
@@ -77,7 +77,7 @@ class TestSkipMixin:
             'dag',
             session=session,
         ):
-            tasks = [DummyOperator(task_id='task')]
+            tasks = [EmptyOperator(task_id='task')]
         dag_maker.create_dagrun(execution_date=now)
         SkipMixin().skip(dag_run=None, execution_date=now, tasks=tasks, session=session)
 
@@ -108,9 +108,9 @@ class TestSkipMixin:
         with dag_maker(
             'dag_test_skip_all_except',
         ):
-            task1 = DummyOperator(task_id='task1')
-            task2 = DummyOperator(task_id='task2')
-            task3 = DummyOperator(task_id='task3')
+            task1 = EmptyOperator(task_id='task1')
+            task2 = EmptyOperator(task_id='task2')
+            task3 = EmptyOperator(task_id='task3')
 
             task1 >> [task2, task3]
         dag_maker.create_dagrun()

--- a/tests/models/test_timestamp.py
+++ b/tests/models/test_timestamp.py
@@ -20,7 +20,7 @@ import pytest
 from freezegun import freeze_time
 
 from airflow.models import Log, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
@@ -37,7 +37,7 @@ def clear_db():
 
 def add_log(execdate, session, dag_maker, timezone_override=None):
     with dag_maker(dag_id='logging', default_args={'start_date': execdate}):
-        task = DummyOperator(task_id='dummy')
+        task = EmptyOperator(task_id='dummy')
     dag_maker.create_dagrun()
     task_instance = TaskInstance(task=task, execution_date=execdate, state='success')
     session.merge(task_instance)

--- a/tests/models/test_trigger.py
+++ b/tests/models/test_trigger.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.jobs.triggerer_job import TriggererJob
 from airflow.models import TaskInstance, Trigger
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.triggers.base import TriggerEvent
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -70,7 +70,7 @@ def test_clean_unused(session, create_task_instance):
     )
     task_instance.trigger_id = trigger1.id
     session.add(task_instance)
-    fake_task = DummyOperator(task_id="fake2", dag=task_instance.task.dag)
+    fake_task = EmptyOperator(task_id="fake2", dag=task_instance.task.dag)
     task_instance = TaskInstance(task=fake_task, run_id=task_instance.run_id)
     task_instance.state = State.SUCCESS
     task_instance.trigger_id = trigger2.id

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -27,7 +27,7 @@ from airflow.configuration import conf
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.models.xcom import XCOM_RETURN_KEY, BaseXCom, XCom, resolve_xcom_backend
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.settings import json
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -57,7 +57,7 @@ def task_instance_factory(request, session: Session):
             execution_date=execution_date,
         )
         session.add(run)
-        ti = TaskInstance(DummyOperator(task_id=task_id), run_id=run_id)
+        ti = TaskInstance(EmptyOperator(task_id=task_id), run_id=run_id)
         ti.dag_id = dag_id
         session.add(ti)
         session.commit()
@@ -84,7 +84,7 @@ def task_instance(task_instance_factory):
 
 @pytest.fixture()
 def task_instances(session, task_instance):
-    ti2 = TaskInstance(DummyOperator(task_id="task_2"), run_id=task_instance.run_id)
+    ti2 = TaskInstance(EmptyOperator(task_id="task_2"), run_id=task_instance.run_id)
     ti2.dag_id = task_instance.dag_id
     session.add(ti2)
     session.commit()

--- a/tests/operators/test_branch_operator.py
+++ b/tests/operators/test_branch_operator.py
@@ -21,7 +21,7 @@ import unittest
 
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.operators.branch import BaseBranchOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -57,8 +57,8 @@ class TestBranchOperator(unittest.TestCase):
             schedule_interval=INTERVAL,
         )
 
-        self.branch_1 = DummyOperator(task_id='branch_1', dag=self.dag)
-        self.branch_2 = DummyOperator(task_id='branch_2', dag=self.dag)
+        self.branch_1 = EmptyOperator(task_id='branch_1', dag=self.dag)
+        self.branch_2 = EmptyOperator(task_id='branch_2', dag=self.dag)
         self.branch_3 = None
         self.branch_op = None
 
@@ -97,7 +97,7 @@ class TestBranchOperator(unittest.TestCase):
         self.branch_op = ChooseBranchOneTwo(task_id='make_choice', dag=self.dag)
         self.branch_1.set_upstream(self.branch_op)
         self.branch_2.set_upstream(self.branch_op)
-        self.branch_3 = DummyOperator(task_id='branch_3', dag=self.dag)
+        self.branch_3 = EmptyOperator(task_id='branch_3', dag=self.dag)
         self.branch_3.set_upstream(self.branch_op)
         self.dag.clear()
 

--- a/tests/operators/test_datetime.py
+++ b/tests/operators/test_datetime.py
@@ -24,7 +24,7 @@ import freezegun
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.operators.datetime import BranchDateTimeOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -57,8 +57,8 @@ class TestBranchDateTimeOperator(unittest.TestCase):
             schedule_interval=INTERVAL,
         )
 
-        self.branch_1 = DummyOperator(task_id='branch_1', dag=self.dag)
-        self.branch_2 = DummyOperator(task_id='branch_2', dag=self.dag)
+        self.branch_1 = EmptyOperator(task_id='branch_1', dag=self.dag)
+        self.branch_2 = EmptyOperator(task_id='branch_2', dag=self.dag)
 
         self.branch_op = BranchDateTimeOperator(
             task_id='datetime_branch',

--- a/tests/operators/test_latest_only_operator.py
+++ b/tests/operators/test_latest_only_operator.py
@@ -23,7 +23,7 @@ from freezegun import freeze_time
 from airflow import settings
 from airflow.models import DagRun, TaskInstance
 from airflow.models.dag import DAG
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -76,9 +76,9 @@ class TestLatestOnlyOperator:
 
     def test_skipping_non_latest(self):
         latest_task = LatestOnlyOperator(task_id='latest', dag=self.dag)
-        downstream_task = DummyOperator(task_id='downstream', dag=self.dag)
-        downstream_task2 = DummyOperator(task_id='downstream_2', dag=self.dag)
-        downstream_task3 = DummyOperator(
+        downstream_task = EmptyOperator(task_id='downstream', dag=self.dag)
+        downstream_task2 = EmptyOperator(task_id='downstream_2', dag=self.dag)
+        downstream_task3 = EmptyOperator(
             task_id='downstream_3', trigger_rule=TriggerRule.NONE_FAILED, dag=self.dag
         )
 
@@ -146,8 +146,8 @@ class TestLatestOnlyOperator:
 
     def test_not_skipping_external(self):
         latest_task = LatestOnlyOperator(task_id='latest', dag=self.dag)
-        downstream_task = DummyOperator(task_id='downstream', dag=self.dag)
-        downstream_task2 = DummyOperator(task_id='downstream_2', dag=self.dag)
+        downstream_task = EmptyOperator(task_id='downstream', dag=self.dag)
+        downstream_task2 = EmptyOperator(task_id='downstream_2', dag=self.dag)
 
         downstream_task.set_upstream(latest_task)
         downstream_task2.set_upstream(downstream_task)

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -32,7 +32,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import clear_task_instances, set_current_context
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import (
     BranchPythonOperator,
     PythonOperator,
@@ -392,8 +392,8 @@ class TestBranchOperator(unittest.TestCase):
             schedule_interval=INTERVAL,
         )
 
-        self.branch_1 = DummyOperator(task_id='branch_1', dag=self.dag)
-        self.branch_2 = DummyOperator(task_id='branch_2', dag=self.dag)
+        self.branch_1 = EmptyOperator(task_id='branch_1', dag=self.dag)
+        self.branch_2 = EmptyOperator(task_id='branch_2', dag=self.dag)
         self.branch_3 = None
 
     def tearDown(self):
@@ -601,8 +601,8 @@ class TestShortCircuitOperator:
         )
 
         with self.dag:
-            self.op1 = DummyOperator(task_id="op1")
-            self.op2 = DummyOperator(task_id="op2")
+            self.op1 = EmptyOperator(task_id="op1")
+            self.op2 = EmptyOperator(task_id="op2")
             self.op1.set_downstream(self.op2)
 
     def teardown(self):
@@ -1258,8 +1258,8 @@ def test_empty_branch(dag_maker, choice, expected_states):
         start_date=DEFAULT_DATE,
     ) as dag:
         branch = BranchPythonOperator(task_id='branch', python_callable=lambda: choice)
-        task1 = DummyOperator(task_id='task1')
-        join = DummyOperator(task_id='join', trigger_rule="none_failed_min_one_success")
+        task1 = EmptyOperator(task_id='task1')
+        join = EmptyOperator(task_id='join', trigger_rule="none_failed_min_one_success")
 
         branch >> [task1, join]
         task1 >> join

--- a/tests/operators/test_sql.py
+++ b/tests/operators/test_sql.py
@@ -24,7 +24,7 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, Connection, DagRun, TaskInstance as TI, XCom
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.sql import (
     BranchSQLOperator,
     SQLCheckOperator,
@@ -406,8 +406,8 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
             default_args={"owner": "airflow", "start_date": DEFAULT_DATE},
             schedule_interval=INTERVAL,
         )
-        self.branch_1 = DummyOperator(task_id="branch_1", dag=self.dag)
-        self.branch_2 = DummyOperator(task_id="branch_2", dag=self.dag)
+        self.branch_1 = EmptyOperator(task_id="branch_1", dag=self.dag)
+        self.branch_2 = EmptyOperator(task_id="branch_2", dag=self.dag)
         self.branch_3 = None
 
     def tearDown(self):
@@ -635,7 +635,7 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
 
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
-        self.branch_3 = DummyOperator(task_id="branch_3", dag=self.dag)
+        self.branch_3 = EmptyOperator(task_id="branch_3", dag=self.dag)
         self.branch_3.set_upstream(branch_op)
         self.dag.clear()
 

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -24,7 +24,7 @@ import pytest
 import airflow
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.subdag import SkippedStatePropagationOptions, SubDagOperator
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -93,7 +93,7 @@ class TestSubDagOperator:
         session.add(pool_10)
         session.commit()
 
-        DummyOperator(task_id='dummy', dag=subdag, pool='test_pool_1')
+        EmptyOperator(task_id='dummy', dag=subdag, pool='test_pool_1')
 
         with pytest.raises(AirflowException):
             SubDagOperator(task_id='child', dag=dag, subdag=subdag, pool='test_pool_1')
@@ -121,7 +121,7 @@ class TestSubDagOperator:
         session.add(pool_10)
         session.commit()
 
-        DummyOperator(task_id='dummy', dag=subdag, pool='test_pool_10')
+        EmptyOperator(task_id='dummy', dag=subdag, pool='test_pool_10')
 
         mock_session = Mock()
         SubDagOperator(task_id='child', dag=dag, subdag=subdag, pool='test_pool_1', session=mock_session)
@@ -261,7 +261,7 @@ class TestSubDagOperator:
         """
         with create_session() as session:
             with dag_maker('parent.test', default_args=default_args, session=session) as subdag:
-                dummy_task = DummyOperator(task_id='dummy')
+                dummy_task = EmptyOperator(task_id='dummy')
             sub_dagrun = dag_maker.create_dagrun(
                 run_type=DagRunType.SCHEDULED,
                 execution_date=DEFAULT_DATE,
@@ -311,7 +311,7 @@ class TestSubDagOperator:
         Note that the skipped state propagation only takes affect when the dagrun's state is SUCCESS.
         """
         with dag_maker('parent.test', default_args=default_args) as subdag:
-            dummy_subdag_tasks = [DummyOperator(task_id=f'dummy_subdag_{i}') for i in range(len(states))]
+            dummy_subdag_tasks = [EmptyOperator(task_id=f'dummy_subdag_{i}') for i in range(len(states))]
         dag_maker.create_dagrun(execution_date=DEFAULT_DATE)
 
         with dag_maker('parent', default_args=default_args):
@@ -321,7 +321,7 @@ class TestSubDagOperator:
                 poke_interval=1,
                 propagate_skipped_state=propagate_option,
             )
-            dummy_dag_task = DummyOperator(task_id='dummy_dag')
+            dummy_dag_task = EmptyOperator(task_id='dummy_dag')
             subdag_task >> dummy_dag_task
         dag_run = dag_maker.create_dagrun(execution_date=DEFAULT_DATE)
 

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -38,13 +38,13 @@ TRIGGERED_DAG_ID = "triggerdag"
 DAG_SCRIPT = (
     "from datetime import datetime\n\n"
     "from airflow.models import DAG\n"
-    "from airflow.operators.dummy import DummyOperator\n\n"
+    "from airflow.operators.empty import EmptyOperator\n\n"
     "dag = DAG(\n"
     'dag_id="{dag_id}", \n'
     'default_args={{"start_date": datetime(2019, 1, 1)}}, \n'
     "schedule_interval=None,\n"
     ")\n"
-    'task = DummyOperator(task_id="test", dag=dag)'
+    'task = EmptyOperator(task_id="test", dag=dag)'
 ).format(dag_id=TRIGGERED_DAG_ID)
 
 

--- a/tests/operators/test_weekday.py
+++ b/tests/operators/test_weekday.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance as TI, XCom
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -53,8 +53,8 @@ class TestBranchDayOfWeekOperator(unittest.TestCase):
             start_date=DEFAULT_DATE,
             schedule_interval=INTERVAL,
         )
-        self.branch_1 = DummyOperator(task_id="branch_1", dag=self.dag)
-        self.branch_2 = DummyOperator(task_id="branch_2", dag=self.dag)
+        self.branch_1 = EmptyOperator(task_id="branch_1", dag=self.dag)
+        self.branch_2 = EmptyOperator(task_id="branch_2", dag=self.dag)
         self.branch_3 = None
 
     def tearDown(self):
@@ -109,7 +109,7 @@ class TestBranchDayOfWeekOperator(unittest.TestCase):
 
         self.branch_1.set_upstream(branch_op)
         self.branch_2.set_upstream(branch_op)
-        self.branch_3 = DummyOperator(task_id="branch_3", dag=self.dag)
+        self.branch_3 = EmptyOperator(task_id="branch_3", dag=self.dag)
         self.branch_3.set_upstream(branch_op)
         self.dag.clear()
 

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -661,7 +661,7 @@ class TestSageMakerHook(unittest.TestCase):
     def test_find_processing_job_by_name_job_not_exists_should_return_false(self, mock_conn):
         error_resp = {"Error": {"Code": "ValidationException"}}
         mock_conn().describe_processing_job.side_effect = ClientError(
-            error_response=error_resp, operation_name="dummy"
+            error_response=error_resp, operation_name="empty"
         )
         hook = SageMakerHook(aws_conn_id='sagemaker_test_conn_id')
 

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -24,7 +24,7 @@ from unittest.mock import ANY, call
 from watchtower import CloudWatchLogHandler
 
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.providers.amazon.aws.log.cloudwatch_task_handler import CloudwatchTaskHandler
 from airflow.utils.state import State
@@ -64,7 +64,7 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
         dag_id = 'dag_for_testing_cloudwatch_task_handler'
         task_id = 'task_for_testing_cloudwatch_log_handler'
         self.dag = DAG(dag_id=dag_id, start_date=date)
-        task = DummyOperator(task_id=task_id, dag=self.dag)
+        task = EmptyOperator(task_id=task_id, dag=self.dag)
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test")
         self.ti = TaskInstance(task=task)
         self.ti.dag_run = dag_run

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -25,7 +25,7 @@ import pytest
 from botocore.exceptions import ClientError
 
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler
 from airflow.utils.state import State
@@ -59,7 +59,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
         date = datetime(2016, 1, 1)
         self.dag = DAG('dag_for_testing_s3_task_handler', start_date=date)
-        task = DummyOperator(task_id='task_for_testing_s3_log_handler', dag=self.dag)
+        task = EmptyOperator(task_id='task_for_testing_s3_log_handler', dag=self.dag)
         dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test")
         self.ti = TaskInstance(task=task)
         self.ti.dag_run = dag_run

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -24,7 +24,7 @@ from freezegun import freeze_time
 from airflow.exceptions import AirflowException, AirflowRescheduleException, AirflowSensorTimeout
 from airflow.models import TaskReschedule
 from airflow.models.xcom import XCom
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.base import BaseSensorOperator, PokeReturnValue, poke_mode_only
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.utils import timezone
@@ -94,7 +94,7 @@ class TestBaseSensor:
                 else:
                     sensor = DummySensor(task_id=task_id, return_value=return_value, **kwargs)
 
-                dummy_op = DummyOperator(task_id=DUMMY_OP)
+                dummy_op = EmptyOperator(task_id=DUMMY_OP)
                 sensor >> dummy_op
             return sensor, dag_maker.create_dagrun()
 

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -26,7 +26,7 @@ from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
 from airflow.sensors.time_sensor import TimeSensor
 from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -229,7 +229,7 @@ exit 0
         task_external_with_failure = BashOperator(
             task_id="task_external_with_failure", bash_command=bash_command_code, retries=0, dag=dag_external
         )
-        task_external_without_failure = DummyOperator(
+        task_external_without_failure = EmptyOperator(
             task_id="task_external_without_failure", retries=0, dag=dag_external
         )
 
@@ -515,7 +515,7 @@ def dag_bag_ext():
     dag_bag = DagBag(dag_folder=DEV_NULL, include_examples=False)
 
     dag_0 = DAG("dag_0", start_date=DEFAULT_DATE, schedule_interval=None)
-    task_a_0 = DummyOperator(task_id="task_a_0", dag=dag_0)
+    task_a_0 = EmptyOperator(task_id="task_a_0", dag=dag_0)
     task_b_0 = ExternalTaskMarker(
         task_id="task_b_0", external_dag_id="dag_1", external_task_id="task_a_1", recursion_depth=3, dag=dag_0
     )
@@ -543,7 +543,7 @@ def dag_bag_ext():
     task_a_3 = ExternalTaskSensor(
         task_id="task_a_3", external_dag_id=dag_2.dag_id, external_task_id=task_b_2.task_id, dag=dag_3
     )
-    task_b_3 = DummyOperator(task_id="task_b_3", dag=dag_3)
+    task_b_3 = EmptyOperator(task_id="task_b_3", dag=dag_3)
     task_a_3 >> task_b_3
 
     for dag in [dag_0, dag_1, dag_2, dag_3]:
@@ -778,7 +778,7 @@ def dag_bag_cyclic():
 
         with DAG("dag_0", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
             dags.append(dag)
-            task_a_0 = DummyOperator(task_id="task_a_0")
+            task_a_0 = EmptyOperator(task_id="task_a_0")
             task_b_0 = ExternalTaskMarker(
                 task_id="task_b_0", external_dag_id="dag_1", external_task_id="task_a_1", recursion_depth=3
             )
@@ -870,9 +870,9 @@ def dag_bag_multiple():
     dag_bag.bag_dag(dag=daily_dag, root_dag=daily_dag)
     dag_bag.bag_dag(dag=agg_dag, root_dag=agg_dag)
 
-    daily_task = DummyOperator(task_id="daily_tas", dag=daily_dag)
+    daily_task = EmptyOperator(task_id="daily_tas", dag=daily_dag)
 
-    begin = DummyOperator(task_id="begin", dag=agg_dag)
+    begin = EmptyOperator(task_id="begin", dag=agg_dag)
     for i in range(8):
         task = ExternalTaskMarker(
             task_id=f"{daily_task.task_id}_{i}",
@@ -929,7 +929,7 @@ def dag_bag_head_tail():
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )
-        body = DummyOperator(task_id="body")
+        body = EmptyOperator(task_id="body")
         tail = ExternalTaskMarker(
             task_id="tail",
             external_dag_id=dag.dag_id,

--- a/tests/sensors/test_smart_sensor_operator.py
+++ b/tests/sensors/test_smart_sensor_operator.py
@@ -27,7 +27,7 @@ from freezegun import freeze_time
 from airflow import DAG, settings
 from airflow.configuration import conf
 from airflow.models import DagRun, SensorInstance, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.sensors.base import BaseSensorOperator
 from airflow.sensors.smart_sensor import SmartSensorOperator
 from airflow.utils import timezone
@@ -147,7 +147,7 @@ class SmartSensorTest(unittest.TestCase):
 
         smart_task = DummySmartSensor(task_id=SMART_OP + "_" + str(index), dag=self.dag, **kwargs)
 
-        dummy_op = DummyOperator(task_id=DUMMY_OP, dag=self.dag)
+        dummy_op = EmptyOperator(task_id=DUMMY_OP, dag=self.dag)
         dummy_op.set_upstream(smart_task)
         return smart_task
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -921,7 +921,7 @@ class TestStringifiedDAGs:
                 return 'https://www.google.com'
 
         class MyOperator(BaseOperator):
-            """Just a DummyOperator using above defined Extra Operator Link"""
+            """Just a EmptyOperator using above defined Extra Operator Link"""
 
             operator_extra_links = [TaskStateLink()]
 
@@ -1148,12 +1148,12 @@ class TestStringifiedDAGs:
         """
         Test task resources serialization/deserialization.
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
 
         execution_date = datetime(2020, 1, 1)
         task_id = 'task1'
         with DAG("test_task_resources", start_date=execution_date) as dag:
-            task = DummyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
+            task = EmptyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
 
         SerializedDAG.validate_schema(SerializedDAG.to_dict(dag))
 
@@ -1166,19 +1166,19 @@ class TestStringifiedDAGs:
         """
         Test TaskGroup serialization/deserialization.
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
 
         execution_date = datetime(2020, 1, 1)
         with DAG("test_task_group_serialization", start_date=execution_date) as dag:
-            task1 = DummyOperator(task_id="task1")
+            task1 = EmptyOperator(task_id="task1")
             with TaskGroup("group234") as group234:
-                _ = DummyOperator(task_id="task2")
+                _ = EmptyOperator(task_id="task2")
 
                 with TaskGroup("group34") as group34:
-                    _ = DummyOperator(task_id="task3")
-                    _ = DummyOperator(task_id="task4")
+                    _ = EmptyOperator(task_id="task3")
+                    _ = EmptyOperator(task_id="task4")
 
-            task5 = DummyOperator(task_id="task5")
+            task5 = EmptyOperator(task_id="task5")
             task1 >> group234
             group34 >> task5
 
@@ -1214,7 +1214,7 @@ class TestStringifiedDAGs:
         """
         Tests serialize_operator, make sure the deps is in order
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
         from airflow.sensors.external_task import ExternalTaskSensor
 
         execution_date = datetime(2020, 1, 1)
@@ -1224,7 +1224,7 @@ class TestStringifiedDAGs:
                 external_dag_id="external_dag_id",
                 mode="reschedule",
             )
-            task2 = DummyOperator(task_id="task2")
+            task2 = EmptyOperator(task_id="task2")
             task1 >> task2
 
         serialize_op = SerializedBaseOperator.serialize_operator(dag.task_dict["task1"])
@@ -1253,10 +1253,10 @@ class TestStringifiedDAGs:
             SerializedBaseOperator.serialize_operator(dag.task_dict["task1"])
 
     def test_error_on_unregistered_ti_dep_deserialization(self):
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
 
         with DAG("test_error_on_unregistered_ti_dep_deserialization", start_date=datetime(2019, 8, 1)) as dag:
-            DummyOperator(task_id="task1")
+            EmptyOperator(task_id="task1")
         serialize_op = SerializedBaseOperator.serialize_operator(dag.task_dict["task1"])
         serialize_op['deps'] = [
             'airflow.ti_deps.deps.not_in_retry_period_dep.NotInRetryPeriodDep',
@@ -1299,7 +1299,7 @@ class TestStringifiedDAGs:
         """
         Tests serialize_task_group, make sure the list is in order
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
         from airflow.serialization.serialized_objects import SerializedTaskGroup
 
         """
@@ -1320,24 +1320,24 @@ class TestStringifiedDAGs:
         """
         execution_date = datetime(2020, 1, 1)
         with DAG(dag_id="test_task_group_sorted", start_date=execution_date) as dag:
-            start = DummyOperator(task_id="start")
+            start = EmptyOperator(task_id="start")
 
             with TaskGroup("task_group_up1") as task_group_up1:
-                _ = DummyOperator(task_id="task_up1")
+                _ = EmptyOperator(task_id="task_up1")
 
             with TaskGroup("task_group_up2") as task_group_up2:
-                _ = DummyOperator(task_id="task_up2")
+                _ = EmptyOperator(task_id="task_up2")
 
             with TaskGroup("task_group_middle") as task_group_middle:
-                _ = DummyOperator(task_id="task_middle")
+                _ = EmptyOperator(task_id="task_middle")
 
             with TaskGroup("task_group_down1") as task_group_down1:
-                _ = DummyOperator(task_id="task_down1")
+                _ = EmptyOperator(task_id="task_down1")
 
             with TaskGroup("task_group_down2") as task_group_down2:
-                _ = DummyOperator(task_id="task_down2")
+                _ = EmptyOperator(task_id="task_down2")
 
-            end = DummyOperator(task_id='end')
+            end = EmptyOperator(task_id='end')
 
             start >> task_group_up1
             start >> task_group_up2
@@ -1370,12 +1370,12 @@ class TestStringifiedDAGs:
         """
         Tests edge_info serialization/deserialization.
         """
-        from airflow.operators.dummy import DummyOperator
+        from airflow.operators.empty import EmptyOperator
         from airflow.utils.edgemodifier import Label
 
         with DAG("test_edge_info_serialization", start_date=datetime(2020, 1, 1)) as dag:
-            task1 = DummyOperator(task_id="task1")
-            task2 = DummyOperator(task_id="task2")
+            task1 = EmptyOperator(task_id="task1")
+            task2 = EmptyOperator(task_id="task2")
             task1 >> Label("test label") >> task2
 
         dag_dict = SerializedDAG.to_dict(dag)
@@ -1722,12 +1722,12 @@ def test_task_resources_serde():
     """
     Test task resources serialization/deserialization.
     """
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.empty import EmptyOperator
 
     execution_date = datetime(2020, 1, 1)
     task_id = 'task1'
     with DAG("test_task_resources", start_date=execution_date) as _:
-        task = DummyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
+        task = EmptyOperator(task_id=task_id, resources={"cpus": 0.1, "ram": 2048})
 
     serialized = SerializedBaseOperator._serialize(task)
     assert serialized['resources'] == {
@@ -1813,7 +1813,7 @@ def test_dummy_operator_serde(is_inherit):
     """
 
     # In this test we should NOT switch the DummyOperator to EmptyOperator.
-    # This test can be removed in Airflow 3.0 as DummyOperator will be removed then.
+    # This test can be removed in Airflow 3.0 as EmptyOperator will be removed then.
     from airflow.operators.dummy import DummyOperator
 
     class MyDummyOperator(DummyOperator):
@@ -1826,7 +1826,7 @@ def test_dummy_operator_serde(is_inherit):
     assert serialized == {
         '_is_empty': is_inherit,
         '_task_module': 'tests.serialization.test_dag_serialization',
-        '_task_type': 'MyDummyOperator',
+        '_task_type': 'MyEmptyOperator',
         '_outlets': [],
         '_inlets': [],
         'downstream_task_ids': [],

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1826,7 +1826,7 @@ def test_dummy_operator_serde(is_inherit):
     assert serialized == {
         '_is_empty': is_inherit,
         '_task_module': 'tests.serialization.test_dag_serialization',
-        '_task_type': 'MyEmptyOperator',
+        '_task_type': 'MyDummyOperator',
         '_outlets': [],
         '_inlets': [],
         'downstream_task_ids': [],

--- a/tests/ti_deps/deps/test_not_previously_skipped_dep.py
+++ b/tests/ti_deps/deps/test_not_previously_skipped_dep.py
@@ -20,7 +20,7 @@ import pendulum
 import pytest
 
 from airflow.models import DagRun, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
@@ -46,7 +46,7 @@ def test_no_parent(session, dag_maker):
         start_date=start_date,
         session=session,
     ):
-        op1 = DummyOperator(task_id="op1")
+        op1 = EmptyOperator(task_id="op1")
 
     (ti1,) = dag_maker.create_dagrun(execution_date=start_date).task_instances
     ti1.refresh_from_task(op1)
@@ -59,7 +59,7 @@ def test_no_parent(session, dag_maker):
 
 def test_no_skipmixin_parent(session, dag_maker):
     """
-    A simple DAG with no branching. Both op1 and op2 are DummyOperator. NotPreviouslySkippedDep is met.
+    A simple DAG with no branching. Both op1 and op2 are EmptyOperator. NotPreviouslySkippedDep is met.
     """
     start_date = pendulum.datetime(2020, 1, 1)
     with dag_maker(
@@ -68,8 +68,8 @@ def test_no_skipmixin_parent(session, dag_maker):
         start_date=start_date,
         session=session,
     ):
-        op1 = DummyOperator(task_id="op1")
-        op2 = DummyOperator(task_id="op2")
+        op1 = EmptyOperator(task_id="op1")
+        op2 = EmptyOperator(task_id="op2")
         op1 >> op2
 
     _, ti2 = dag_maker.create_dagrun().task_instances
@@ -93,7 +93,7 @@ def test_parent_follow_branch(session, dag_maker):
         session=session,
     ):
         op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op2")
-        op2 = DummyOperator(task_id="op2")
+        op2 = EmptyOperator(task_id="op2")
         op1 >> op2
 
     dagrun = dag_maker.create_dagrun(run_type=DagRunType.MANUAL, state=State.RUNNING)
@@ -118,8 +118,8 @@ def test_parent_skip_branch(session, dag_maker):
         session=session,
     ):
         op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3")
-        op2 = DummyOperator(task_id="op2")
-        op3 = DummyOperator(task_id="op3")
+        op2 = EmptyOperator(task_id="op2")
+        op3 = EmptyOperator(task_id="op3")
         op1 >> [op2, op3]
 
     tis = {
@@ -147,8 +147,8 @@ def test_parent_not_executed(session, dag_maker):
         session=session,
     ):
         op1 = BranchPythonOperator(task_id="op1", python_callable=lambda: "op3")
-        op2 = DummyOperator(task_id="op2")
-        op3 = DummyOperator(task_id="op3")
+        op2 = EmptyOperator(task_id="op2")
+        op3 = EmptyOperator(task_id="op3")
         op1 >> [op2, op3]
 
     _, ti2, _ = dag_maker.create_dagrun().task_instances

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -23,7 +23,7 @@ import pytest
 from airflow import settings
 from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -41,7 +41,7 @@ def get_task_instance(session, dag_maker):
                 task_id='test_task', trigger_rule=trigger_rule, start_date=datetime(2015, 1, 1)
             )
             if upstream_task_ids:
-                [DummyOperator(task_id=task_id) for task_id in upstream_task_ids] >> task
+                [EmptyOperator(task_id=task_id) for task_id in upstream_task_ids] >> task
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
@@ -625,11 +625,11 @@ class TestTriggerRuleDep:
         dag = DAG('test_dagrun_with_pre_tis', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='D')
-            op5 = DummyOperator(task_id='E', trigger_rule=TriggerRule.ONE_FAILED)
+            op1 = EmptyOperator(task_id='A')
+            op2 = EmptyOperator(task_id='B')
+            op3 = EmptyOperator(task_id='C')
+            op4 = EmptyOperator(task_id='D')
+            op5 = EmptyOperator(task_id='E', trigger_rule=TriggerRule.ONE_FAILED)
 
             op1.set_downstream([op2, op3])  # op1 >> op2, op3
             op4.set_upstream([op3, op2])  # op3, op2 >> op4

--- a/tests/utils/test_dag_cycle.py
+++ b/tests/utils/test_dag_cycle.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow import DAG
 from airflow.exceptions import AirflowDagCycleException
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.dag_cycle_tester import check_cycle
 from tests.models import DEFAULT_DATE
 
@@ -38,7 +38,7 @@ class TestCycleTester(unittest.TestCase):
         dag = DAG('dag', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
 
         with dag:
-            DummyOperator(task_id='A')
+            EmptyOperator(task_id='A')
 
         assert not check_cycle(dag)
 
@@ -49,11 +49,11 @@ class TestCycleTester(unittest.TestCase):
         #      B -> D
         # E -> F
         with dag:
-            create_cluster = DummyOperator(task_id="c")
-            pod_task = DummyOperator(task_id="p")
-            pod_task_xcom = DummyOperator(task_id="x")
-            delete_cluster = DummyOperator(task_id="d")
-            pod_task_xcom_result = DummyOperator(task_id="r")
+            create_cluster = EmptyOperator(task_id="c")
+            pod_task = EmptyOperator(task_id="p")
+            pod_task_xcom = EmptyOperator(task_id="x")
+            delete_cluster = EmptyOperator(task_id="d")
+            pod_task_xcom_result = EmptyOperator(task_id="r")
             create_cluster >> pod_task >> delete_cluster
             create_cluster >> pod_task_xcom >> delete_cluster
             pod_task_xcom >> pod_task_xcom_result
@@ -66,12 +66,12 @@ class TestCycleTester(unittest.TestCase):
         #      B -> D
         # E -> F
         with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='D')
-            op5 = DummyOperator(task_id='E')
-            op6 = DummyOperator(task_id='F')
+            op1 = EmptyOperator(task_id='A')
+            op2 = EmptyOperator(task_id='B')
+            op3 = EmptyOperator(task_id='C')
+            op4 = EmptyOperator(task_id='D')
+            op5 = EmptyOperator(task_id='E')
+            op6 = EmptyOperator(task_id='F')
             op1.set_downstream(op2)
             op2.set_downstream(op3)
             op2.set_downstream(op4)
@@ -85,7 +85,7 @@ class TestCycleTester(unittest.TestCase):
 
         # A -> A
         with dag:
-            op1 = DummyOperator(task_id='A')
+            op1 = EmptyOperator(task_id='A')
             op1.set_downstream(op1)
 
         with pytest.raises(AirflowDagCycleException):
@@ -97,11 +97,11 @@ class TestCycleTester(unittest.TestCase):
 
         # A -> B -> C -> D -> E -> E
         with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='D')
-            op5 = DummyOperator(task_id='E')
+            op1 = EmptyOperator(task_id='A')
+            op2 = EmptyOperator(task_id='B')
+            op3 = EmptyOperator(task_id='C')
+            op4 = EmptyOperator(task_id='D')
+            op5 = EmptyOperator(task_id='E')
             op1.set_downstream(op2)
             op2.set_downstream(op3)
             op3.set_downstream(op4)
@@ -117,11 +117,11 @@ class TestCycleTester(unittest.TestCase):
 
         # A -> B -> C -> D -> E -> A
         with dag:
-            start = DummyOperator(task_id='start')
+            start = EmptyOperator(task_id='start')
             current = start
 
             for i in range(10000):
-                next_task = DummyOperator(task_id=f'task_{i}')
+                next_task = EmptyOperator(task_id=f'task_{i}')
                 current.set_downstream(next_task)
                 current = next_task
 
@@ -136,11 +136,11 @@ class TestCycleTester(unittest.TestCase):
         # E-> A -> B -> F -> A
         #       -> C -> F
         with dag:
-            op1 = DummyOperator(task_id='A')
-            op2 = DummyOperator(task_id='B')
-            op3 = DummyOperator(task_id='C')
-            op4 = DummyOperator(task_id='E')
-            op5 = DummyOperator(task_id='F')
+            op1 = EmptyOperator(task_id='A')
+            op2 = EmptyOperator(task_id='B')
+            op3 = EmptyOperator(task_id='C')
+            op4 = EmptyOperator(task_id='E')
+            op5 = EmptyOperator(task_id='F')
             op1.set_downstream(op2)
             op1.set_downstream(op3)
             op4.set_downstream(op1)

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.serialization.serialized_objects import DagDependency
 from airflow.utils import dot_renderer, timezone
@@ -138,26 +138,26 @@ class TestDotRenderer:
 
     def test_render_task_group(self):
         with DAG(dag_id="example_task_group", start_date=START_DATE) as dag:
-            start = DummyOperator(task_id="start")
+            start = EmptyOperator(task_id="start")
 
             with TaskGroup("section_1", tooltip="Tasks for section_1") as section_1:
-                task_1 = DummyOperator(task_id="task_1")
+                task_1 = EmptyOperator(task_id="task_1")
                 task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
-                task_3 = DummyOperator(task_id="task_3")
+                task_3 = EmptyOperator(task_id="task_3")
 
                 task_1 >> [task_2, task_3]
 
             with TaskGroup("section_2", tooltip="Tasks for section_2") as section_2:
-                task_1 = DummyOperator(task_id="task_1")
+                task_1 = EmptyOperator(task_id="task_1")
 
                 with TaskGroup("inner_section_2", tooltip="Tasks for inner_section2"):
                     task_2 = BashOperator(task_id="task_2", bash_command='echo 1')
-                    task_3 = DummyOperator(task_id="task_3")
-                    task_4 = DummyOperator(task_id="task_4")
+                    task_3 = EmptyOperator(task_id="task_3")
+                    task_4 = EmptyOperator(task_id="task_4")
 
                     [task_2, task_3] >> task_4
 
-            end = DummyOperator(task_id='end')
+            end = EmptyOperator(task_id='end')
 
             start >> section_1 >> section_2 >> end
 

--- a/tests/utils/test_edgemodifier.py
+++ b/tests/utils/test_edgemodifier.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow import DAG
 from airflow.models.xcom_arg import XComArg
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.edgemodifier import Label
 from airflow.utils.task_group import TaskGroup
@@ -73,17 +73,17 @@ def test_complex_taskgroup_dag():
 
     with DAG(dag_id="test_complex_dag", default_args=DEFAULT_ARGS) as dag:
         with TaskGroup("group_1") as group:
-            group_dm1 = DummyOperator(task_id="group_dummy1")
-            group_dm2 = DummyOperator(task_id="group_dummy2")
-            group_dm3 = DummyOperator(task_id="group_dummy3")
-        dm_in1 = DummyOperator(task_id="dummy_in1")
-        dm_in2 = DummyOperator(task_id="dummy_in2")
-        dm_in3 = DummyOperator(task_id="dummy_in3")
-        dm_in4 = DummyOperator(task_id="dummy_in4")
-        dm_out1 = DummyOperator(task_id="dummy_out1")
-        dm_out2 = DummyOperator(task_id="dummy_out2")
-        dm_out3 = DummyOperator(task_id="dummy_out3")
-        dm_out4 = DummyOperator(task_id="dummy_out4")
+            group_dm1 = EmptyOperator(task_id="group_dummy1")
+            group_dm2 = EmptyOperator(task_id="group_dummy2")
+            group_dm3 = EmptyOperator(task_id="group_dummy3")
+        dm_in1 = EmptyOperator(task_id="dummy_in1")
+        dm_in2 = EmptyOperator(task_id="dummy_in2")
+        dm_in3 = EmptyOperator(task_id="dummy_in3")
+        dm_in4 = EmptyOperator(task_id="dummy_in4")
+        dm_out1 = EmptyOperator(task_id="dummy_out1")
+        dm_out2 = EmptyOperator(task_id="dummy_out2")
+        dm_out3 = EmptyOperator(task_id="dummy_out3")
+        dm_out4 = EmptyOperator(task_id="dummy_out4")
         op_in1 = PythonOperator(python_callable=f, task_id="op_in1")
         op_out1 = PythonOperator(python_callable=f, task_id="op_out1")
 

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -23,7 +23,7 @@ from airflow.decorators import dag, task_group as task_group_decorator
 from airflow.models import DAG
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.task_group import TaskGroup
@@ -145,15 +145,15 @@ EXPECTED_JSON = {
 def test_build_task_group_context_manager():
     execution_date = pendulum.parse("20200101")
     with DAG("test_build_task_group_context_manager", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
+        task1 = EmptyOperator(task_id="task1")
         with TaskGroup("group234") as group234:
-            _ = DummyOperator(task_id="task2")
+            _ = EmptyOperator(task_id="task2")
 
             with TaskGroup("group34") as group34:
-                _ = DummyOperator(task_id="task3")
-                _ = DummyOperator(task_id="task4")
+                _ = EmptyOperator(task_id="task3")
+                _ = EmptyOperator(task_id="task4")
 
-        task5 = DummyOperator(task_id="task5")
+        task5 = EmptyOperator(task_id="task5")
         task1 >> group234
         group34 >> task5
 
@@ -182,13 +182,13 @@ def test_build_task_group():
     """
     execution_date = pendulum.parse("20200101")
     dag = DAG("test_build_task_group", start_date=execution_date)
-    task1 = DummyOperator(task_id="task1", dag=dag)
+    task1 = EmptyOperator(task_id="task1", dag=dag)
     group234 = TaskGroup("group234", dag=dag)
-    _ = DummyOperator(task_id="task2", dag=dag, task_group=group234)
+    _ = EmptyOperator(task_id="task2", dag=dag, task_group=group234)
     group34 = TaskGroup("group34", dag=dag, parent_group=group234)
-    _ = DummyOperator(task_id="task3", dag=dag, task_group=group34)
-    _ = DummyOperator(task_id="task4", dag=dag, task_group=group34)
-    task5 = DummyOperator(task_id="task5", dag=dag)
+    _ = EmptyOperator(task_id="task3", dag=dag, task_group=group34)
+    _ = EmptyOperator(task_id="task4", dag=dag, task_group=group34)
+    task5 = EmptyOperator(task_id="task5", dag=dag)
 
     task1 >> group234
     group34 >> task5
@@ -216,17 +216,17 @@ def test_build_task_group_with_prefix():
     """
     execution_date = pendulum.parse("20200101")
     with DAG("test_build_task_group_with_prefix", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
+        task1 = EmptyOperator(task_id="task1")
         with TaskGroup("group234", prefix_group_id=False) as group234:
-            task2 = DummyOperator(task_id="task2")
+            task2 = EmptyOperator(task_id="task2")
 
             with TaskGroup("group34") as group34:
-                task3 = DummyOperator(task_id="task3")
+                task3 = EmptyOperator(task_id="task3")
 
                 with TaskGroup("group4", prefix_group_id=False) as group4:
-                    task4 = DummyOperator(task_id="task4")
+                    task4 = EmptyOperator(task_id="task4")
 
-        task5 = DummyOperator(task_id="task5")
+        task5 = EmptyOperator(task_id="task5")
         task1 >> group234
         group34 >> task5
 
@@ -350,19 +350,19 @@ def test_sub_dag_task_group():
     """
     execution_date = pendulum.parse("20200101")
     with DAG("test_test_task_group_sub_dag", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
+        task1 = EmptyOperator(task_id="task1")
         with TaskGroup("group234") as group234:
-            _ = DummyOperator(task_id="task2")
+            _ = EmptyOperator(task_id="task2")
 
             with TaskGroup("group34") as group34:
-                _ = DummyOperator(task_id="task3")
-                _ = DummyOperator(task_id="task4")
+                _ = EmptyOperator(task_id="task3")
+                _ = EmptyOperator(task_id="task4")
 
         with TaskGroup("group6") as group6:
-            _ = DummyOperator(task_id="task6")
+            _ = EmptyOperator(task_id="task6")
 
-        task7 = DummyOperator(task_id="task7")
-        task5 = DummyOperator(task_id="task5")
+        task7 = EmptyOperator(task_id="task7")
+        task5 = EmptyOperator(task_id="task5")
 
         task1 >> group234
         group34 >> task5
@@ -423,37 +423,37 @@ def test_sub_dag_task_group():
 def test_dag_edges():
     execution_date = pendulum.parse("20200101")
     with DAG("test_dag_edges", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
+        task1 = EmptyOperator(task_id="task1")
         with TaskGroup("group_a") as group_a:
             with TaskGroup("group_b") as group_b:
-                task2 = DummyOperator(task_id="task2")
-                task3 = DummyOperator(task_id="task3")
-                task4 = DummyOperator(task_id="task4")
+                task2 = EmptyOperator(task_id="task2")
+                task3 = EmptyOperator(task_id="task3")
+                task4 = EmptyOperator(task_id="task4")
                 task2 >> [task3, task4]
 
-            task5 = DummyOperator(task_id="task5")
+            task5 = EmptyOperator(task_id="task5")
 
             task5 << group_b
 
         task1 >> group_a
 
         with TaskGroup("group_c") as group_c:
-            task6 = DummyOperator(task_id="task6")
-            task7 = DummyOperator(task_id="task7")
-            task8 = DummyOperator(task_id="task8")
+            task6 = EmptyOperator(task_id="task6")
+            task7 = EmptyOperator(task_id="task7")
+            task8 = EmptyOperator(task_id="task8")
             [task6, task7] >> task8
             group_a >> group_c
 
         task5 >> task8
 
-        task9 = DummyOperator(task_id="task9")
-        task10 = DummyOperator(task_id="task10")
+        task9 = EmptyOperator(task_id="task9")
+        task10 = EmptyOperator(task_id="task10")
 
         group_c >> [task9, task10]
 
         with TaskGroup("group_d") as group_d:
-            task11 = DummyOperator(task_id="task11")
-            task12 = DummyOperator(task_id="task12")
+            task11 = EmptyOperator(task_id="task11")
+            task12 = EmptyOperator(task_id="task12")
             task11 >> task12
 
         group_d << group_c
@@ -536,13 +536,13 @@ def test_duplicate_group_id():
 
     with pytest.raises(DuplicateTaskIdFound, match=r".* 'task1' .*"):
         with DAG("test_duplicate_group_id", start_date=execution_date):
-            _ = DummyOperator(task_id="task1")
+            _ = EmptyOperator(task_id="task1")
             with TaskGroup("task1"):
                 pass
 
     with pytest.raises(DuplicateTaskIdFound, match=r".* 'group1' .*"):
         with DAG("test_duplicate_group_id", start_date=execution_date):
-            _ = DummyOperator(task_id="task1")
+            _ = EmptyOperator(task_id="task1")
             with TaskGroup("group1", prefix_group_id=False):
                 with TaskGroup("group1"):
                     pass
@@ -550,19 +550,19 @@ def test_duplicate_group_id():
     with pytest.raises(DuplicateTaskIdFound, match=r".* 'group1' .*"):
         with DAG("test_duplicate_group_id", start_date=execution_date):
             with TaskGroup("group1", prefix_group_id=False):
-                _ = DummyOperator(task_id="group1")
+                _ = EmptyOperator(task_id="group1")
 
     with pytest.raises(DuplicateTaskIdFound, match=r".* 'group1.downstream_join_id' .*"):
         with DAG("test_duplicate_group_id", start_date=execution_date):
-            _ = DummyOperator(task_id="task1")
+            _ = EmptyOperator(task_id="task1")
             with TaskGroup("group1"):
-                _ = DummyOperator(task_id="downstream_join_id")
+                _ = EmptyOperator(task_id="downstream_join_id")
 
     with pytest.raises(DuplicateTaskIdFound, match=r".* 'group1.upstream_join_id' .*"):
         with DAG("test_duplicate_group_id", start_date=execution_date):
-            _ = DummyOperator(task_id="task1")
+            _ = EmptyOperator(task_id="task1")
             with TaskGroup("group1"):
-                _ = DummyOperator(task_id="upstream_join_id")
+                _ = EmptyOperator(task_id="upstream_join_id")
 
 
 def test_task_without_dag():
@@ -571,9 +571,9 @@ def test_task_without_dag():
     has a DAG, the task should be added to the root TaskGroup of the other task's DAG.
     """
     dag = DAG(dag_id='test_task_without_dag', start_date=pendulum.parse("20200101"))
-    op1 = DummyOperator(task_id='op1', dag=dag)
-    op2 = DummyOperator(task_id='op2')
-    op3 = DummyOperator(task_id="op3")
+    op1 = EmptyOperator(task_id='op1', dag=dag)
+    op2 = EmptyOperator(task_id='op2')
+    op3 = EmptyOperator(task_id="op3")
     op1 >> op2
     op3 >> op2
 
@@ -819,9 +819,9 @@ def test_task_group_context_mix():
 
         with TaskGroup("section_1", tooltip="section_1") as section_1:
             sec_2 = section_2(t_start.output)
-            task_s1 = DummyOperator(task_id="task_1")
+            task_s1 = EmptyOperator(task_id="task_1")
             task_s2 = BashOperator(task_id="task_2", bash_command='echo 1')
-            task_s3 = DummyOperator(task_id="task_3")
+            task_s3 = EmptyOperator(task_id="task_3")
 
             sec_2.set_downstream(task_s1)
             task_s1 >> [task_s2, task_s3]
@@ -870,9 +870,9 @@ def test_default_args():
         },
     ):
         with TaskGroup("group1", default_args={"owner": "group"}):
-            task_1 = DummyOperator(task_id='task_1')
-            task_2 = DummyOperator(task_id='task_2', owner='task')
-            task_3 = DummyOperator(task_id='task_3', default_args={"owner": "task"})
+            task_1 = EmptyOperator(task_id='task_1')
+            task_2 = EmptyOperator(task_id='task_2', owner='task')
+            task_3 = EmptyOperator(task_id='task_3', default_args={"owner": "task"})
 
             assert task_1.owner == 'group'
             assert task_2.owner == 'task'
@@ -1079,10 +1079,10 @@ def test_topological_sort1():
     # A -> C -> D
     # ordered: B, D, C, A or D, B, C, A or D, C, B, A
     with dag:
-        op1 = DummyOperator(task_id='A')
-        op2 = DummyOperator(task_id='B')
-        op3 = DummyOperator(task_id='C')
-        op4 = DummyOperator(task_id='D')
+        op1 = EmptyOperator(task_id='A')
+        op2 = EmptyOperator(task_id='B')
+        op3 = EmptyOperator(task_id='C')
+        op4 = EmptyOperator(task_id='D')
         [op2, op3] >> op1
         op3 >> op4
 
@@ -1105,11 +1105,11 @@ def test_topological_sort2():
     # C -> E
     # ordered: E | D, A | B, C
     with dag:
-        op1 = DummyOperator(task_id='A')
-        op2 = DummyOperator(task_id='B')
-        op3 = DummyOperator(task_id='C')
-        op4 = DummyOperator(task_id='D')
-        op5 = DummyOperator(task_id='E')
+        op1 = EmptyOperator(task_id='A')
+        op2 = EmptyOperator(task_id='B')
+        op3 = EmptyOperator(task_id='C')
+        op4 = EmptyOperator(task_id='D')
+        op5 = EmptyOperator(task_id='E')
         op3 << [op1, op2]
         op4 >> [op1, op2]
         op5 >> op3
@@ -1136,13 +1136,13 @@ def test_topological_sort2():
 def test_topological_nested_groups():
     execution_date = pendulum.parse("20200101")
     with DAG("test_dag_edges", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
-        task5 = DummyOperator(task_id="task5")
+        task1 = EmptyOperator(task_id="task1")
+        task5 = EmptyOperator(task_id="task5")
         with TaskGroup("group_a") as group_a:
             with TaskGroup("group_b"):
-                task2 = DummyOperator(task_id="task2")
-                task3 = DummyOperator(task_id="task3")
-                task4 = DummyOperator(task_id="task4")
+                task2 = EmptyOperator(task_id="task2")
+                task3 = EmptyOperator(task_id="task3")
+                task4 = EmptyOperator(task_id="task4")
                 task2 >> [task3, task4]
 
         task1 >> group_a
@@ -1171,14 +1171,14 @@ def test_topological_nested_groups():
 def test_topological_group_dep():
     execution_date = pendulum.parse("20200101")
     with DAG("test_dag_edges", start_date=execution_date) as dag:
-        task1 = DummyOperator(task_id="task1")
-        task6 = DummyOperator(task_id="task6")
+        task1 = EmptyOperator(task_id="task1")
+        task6 = EmptyOperator(task_id="task6")
         with TaskGroup("group_a") as group_a:
-            task2 = DummyOperator(task_id="task2")
-            task3 = DummyOperator(task_id="task3")
+            task2 = EmptyOperator(task_id="task2")
+            task3 = EmptyOperator(task_id="task3")
         with TaskGroup("group_b") as group_b:
-            task4 = DummyOperator(task_id="task4")
-            task5 = DummyOperator(task_id="task5")
+            task4 = EmptyOperator(task_id="task4")
+            task5 = EmptyOperator(task_id="task5")
 
         task1 >> group_a >> group_b >> task6
 

--- a/tests/utils/test_task_handler_with_custom_formatter.py
+++ b/tests/utils/test_task_handler_with_custom_formatter.py
@@ -21,7 +21,7 @@ import pytest
 
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DAG, TaskInstance
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.utils.log.logging_mixin import set_context
 from airflow.utils.state import DagRunState
 from airflow.utils.timezone import datetime
@@ -55,7 +55,7 @@ def custom_task_log_handler_config():
 @pytest.fixture()
 def task_instance():
     dag = DAG(DAG_ID, start_date=DEFAULT_DATE)
-    task = DummyOperator(task_id=TASK_ID, dag=dag)
+    task = EmptyOperator(task_id=TASK_ID, dag=dag)
     dagrun = dag.create_dagrun(DagRunState.RUNNING, execution_date=DEFAULT_DATE, run_type=DagRunType.MANUAL)
     ti = TaskInstance(task=task, run_id=dagrun.run_id)
     ti.log.disabled = False

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -216,7 +216,7 @@ def test_mark_task_instance_state(test_app):
     - Set DagRun to QUEUED.
     """
     from airflow.models import DAG, DagBag, TaskInstance
-    from airflow.operators.dummy import DummyOperator
+    from airflow.operators.empty import EmptyOperator
     from airflow.utils.session import create_session
     from airflow.utils.state import State
     from airflow.utils.timezone import datetime
@@ -227,11 +227,11 @@ def test_mark_task_instance_state(test_app):
     clear_db_runs()
     start_date = datetime(2020, 1, 1)
     with DAG("test_mark_task_instance_state", start_date=start_date) as dag:
-        task_1 = DummyOperator(task_id="task_1")
-        task_2 = DummyOperator(task_id="task_2")
-        task_3 = DummyOperator(task_id="task_3")
-        task_4 = DummyOperator(task_id="task_4")
-        task_5 = DummyOperator(task_id="task_5")
+        task_1 = EmptyOperator(task_id="task_1")
+        task_2 = EmptyOperator(task_id="task_2")
+        task_3 = EmptyOperator(task_id="task_3")
+        task_4 = EmptyOperator(task_id="task_4")
+        task_5 = EmptyOperator(task_id="task_5")
 
         task_1 >> [task_2, task_3, task_4, task_5]
 

--- a/tests/www/views/test_views_blocked.py
+++ b/tests/www/views/test_views_blocked.py
@@ -20,7 +20,7 @@ import pytest
 from airflow.models import DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.serialized_dag import SerializedDagModel
-from airflow.operators.dummy import DummyOperator
+from airflow.operators.empty import EmptyOperator
 from airflow.operators.subdag import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -31,7 +31,7 @@ from tests.test_utils.db import clear_db_runs
 @pytest.fixture()
 def running_subdag(admin_client, dag_maker):
     with dag_maker(dag_id="running_dag.subdag") as subdag:
-        DummyOperator(task_id="dummy")
+        EmptyOperator(task_id="empty")
 
     with pytest.deprecated_call(), dag_maker(dag_id="running_dag") as dag:
         SubDagOperator(task_id="subdag", subdag=subdag)


### PR DESCRIPTION

This is a followup PR to https://github.com/apache/airflow/pull/22832

1. Example dags in Providers are handled differently because Providers should be compatible with Airflow 2.1
2. In core / tests all changed to `EmptyOperator`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
