### PR TITLE
Resolve XComArgs before trying to unmap MappedOperators

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -465,7 +465,7 @@ class DecoratedMappedOperator(MappedOperator):
         seen_oids: Optional[Set] = None,
     ) -> Any:
         if hasattr(self, '_combined_op_kwargs') and value is self._combined_op_kwargs:
-            # Avoid rendering values that came oout of resolved XComArgs
+            # Avoid rendering values that came out of resolved XComArgs
             return {
                 k: v
                 if k in self._already_resolved_op_kwargs

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import collections.abc
 import functools
 import inspect
 import re
@@ -39,7 +38,6 @@ from typing import (
 
 import attr
 import typing_extensions
-from sqlalchemy.orm import Session
 
 from airflow.compat.functools import cache, cached_property
 from airflow.exceptions import AirflowException
@@ -68,6 +66,9 @@ from airflow.utils.task_group import TaskGroup, TaskGroupContext
 from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
+    import jinja2  # Slow import.
+    from sqlalchemy.orm import Session
+
     from airflow.models.mappedoperator import Mappable
 
 
@@ -430,6 +431,7 @@ class DecoratedMappedOperator(MappedOperator):
             self.mapped_op_kwargs,
             fail_reason="mapping already partial",
         )
+        self._combined_op_kwargs = op_kwargs
         return {
             "dag": self.dag,
             "task_group": self.task_group,
@@ -441,13 +443,38 @@ class DecoratedMappedOperator(MappedOperator):
             **self.mapped_kwargs,
         }
 
-    def _expand_mapped_field(self, key: str, content: Any, context: Context, *, session: Session) -> Any:
-        if key != "op_kwargs" or not isinstance(content, collections.abc.Mapping):
-            return content
-        # The magic super() doesn't work here, so we use the explicit form.
-        # Not using super(..., self) to work around pyupgrade bug.
-        sup: Any = super(DecoratedMappedOperator, DecoratedMappedOperator)
-        return {k: sup._expand_mapped_field(self, k, v, context, session=session) for k, v in content.items()}
+    def _resolve_expansion_kwargs(
+        self, kwargs: Dict[str, Any], template_fields: Set[str], context: Context, session: "Session"
+    ) -> None:
+        expansion_kwargs = self._get_expansion_kwargs()
+
+        self._already_resolved_op_kwargs = set()
+        for k, v in expansion_kwargs.items():
+            if isinstance(v, XComArg):
+                self._already_resolved_op_kwargs.add(k)
+                v = v.resolve(context, session=session)
+            v = self._expand_mapped_field(k, v, context, session=session)
+            kwargs['op_kwargs'][k] = v
+            template_fields.discard(k)
+
+    def render_template(
+        self,
+        value: Any,
+        context: Context,
+        jinja_env: Optional["jinja2.Environment"] = None,
+        seen_oids: Optional[Set] = None,
+    ) -> Any:
+        if hasattr(self, '_combined_op_kwargs') and value is self._combined_op_kwargs:
+            # Avoid rendering values that came oout of resolved XComArgs
+            return {
+                k: v
+                if k in self._already_resolved_op_kwargs
+                else super(DecoratedMappedOperator, DecoratedMappedOperator).render_template(
+                    self, v, context, jinja_env=jinja_env, seen_oids=seen_oids
+                )
+                for k, v in value.items()
+            }
+        return super().render_template(value, context, jinja_env=jinja_env, seen_oids=seen_oids)
 
 
 class Task(Generic[Function]):

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -104,11 +104,6 @@ class LocalTaskJob(BaseJob):
         try:
             self.task_runner.start()
 
-            # Unmap the task _after_ it has forked/execed. (This is a bit of a kludge, but if we unmap before
-            # fork, then the "run_raw_task" command will see the mapping index and an Non-mapped task and
-            # fail)
-            self.task_instance.task = self.task_instance.task.unmap()
-
             heartbeat_time_limit = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
 
             # task callback invocation happens either here or in

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -491,7 +491,7 @@ class MappedOperator(AbstractOperator):
         Get the "normal" Operator after applying the current mapping.
 
         If ``operator_class`` is not a class (i.e. this DAG has been deserialized) then this will return a
-        SeriSerializedBaseOperator that aims to "look like" the real operator.
+        SerializedBaseOperator that aims to "look like" the real operator.
 
         :param unmap_kwargs: Override the args to pass to the Operator constructor. Only used when
             ``operator_class`` is still an actual class.

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -490,7 +490,7 @@ class MappedOperator(AbstractOperator):
         """
         Get the "normal" Operator after applying the current mapping.
 
-        If ``operator_class`` is not a class (i.e. this DAG has been deserialized) then this will erturn a
+        If ``operator_class`` is not a class (i.e. this DAG has been deserialized) then this will return a
         SeriSerializedBaseOperator that aims to "look like" the real operator.
 
         :param unmap_kwargs: Override the args to pass to the Operator constructor. Only used when

--- a/docs/apache-airflow/concepts/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/concepts/dynamic-task-mapping.rst
@@ -224,6 +224,42 @@ Currently it is only possible to map against a dict, a list, or one of those typ
 
 If an upstream task returns an unmappable type, the mapped task will fail at run-time with an ``UnmappableXComTypePushed`` exception. For instance, you can't have the upstream task return a plain string – it must be a list or a dict.
 
+How to templated fields and mapped arguments interact?
+======================================================
+
+All arguments to an operator can be mapped, even those that do not accept templated parameters.
+
+If a field is marked as being templated and is mapped, it **will not be templated**.
+
+For example, this will print ``{{ ds }}`` and not a date stamp:
+
+.. code-block:: python
+
+    @task
+    def make_list():
+        return ["{{ ds }}"]
+
+
+    @task
+    def printer(val):
+        print(val)
+
+
+    printer.expand(val=make_list())
+
+If you want to interpolate values either call ``task.render_template`` yourself, or use interpolation:
+
+.. code-block:: python
+
+    @task
+    def make_list(ds):
+        return [ds]
+
+
+    @task
+    def make_list(**context):
+        return [context["task"].render_template("{{ ds }}", context)]
+
 Placing limits on mapped tasks
 ==============================
 

--- a/docs/apache-airflow/concepts/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/concepts/dynamic-task-mapping.rst
@@ -224,7 +224,7 @@ Currently it is only possible to map against a dict, a list, or one of those typ
 
 If an upstream task returns an unmappable type, the mapped task will fail at run-time with an ``UnmappableXComTypePushed`` exception. For instance, you can't have the upstream task return a plain string – it must be a list or a dict.
 
-How to templated fields and mapped arguments interact?
+How do templated fields and mapped arguments interact?
 ======================================================
 
 All arguments to an operator can be mapped, even those that do not accept templated parameters.

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -27,6 +27,10 @@ from airflow.decorators import task as task_decorator
 from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskmap import TaskMap
+from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.models.xcom_arg import XComArg
 from airflow.utils import timezone
 from airflow.utils.state import State
@@ -641,3 +645,39 @@ def test_mapped_decorator_converts_partial_kwargs():
     mapped_task1 = dag.get_task("task1")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)  # Operator default.
     mapped_task1.unmap().retry_delay == timedelta(seconds=300)  # Operator default.
+
+
+def test_mapped_render_template_fields(dag_maker, session):
+    @task_decorator
+    def fn(arg1, arg2):
+        ...
+
+    with dag_maker(session=session):
+        task1 = BaseOperator(task_id="op1")
+        xcom_arg = XComArg(task1)
+        mapped = fn.partial(arg2='{{ ti.task_id }}').expand(arg1=xcom_arg)
+
+    dr = dag_maker.create_dagrun()
+    ti: TaskInstance = dr.get_task_instance(task1.task_id, session=session)
+
+    ti.xcom_push(key=XCOM_RETURN_KEY, value=['{{ ds }}'], session=session)
+
+    session.add(
+        TaskMap(
+            dag_id=dr.dag_id,
+            task_id=task1.task_id,
+            run_id=dr.run_id,
+            map_index=-1,
+            length=1,
+            keys=None,
+        )
+    )
+    session.flush()
+
+    mapped_ti: TaskInstance = dr.get_task_instance(mapped.operator.task_id, session=session)
+    mapped_ti.map_index = 0
+    op = mapped.operator.render_template_fields(context=mapped_ti.get_template_context(session=session))
+    assert op
+
+    assert op.op_kwargs['arg1'] == "{{ ds }}"
+    assert op.op_kwargs['arg2'] == "fn"

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -33,6 +33,7 @@ from airflow.models.baseoperator import BaseOperator, BaseOperatorMeta, chain, c
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
+from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.models.xcom_arg import XComArg
 from airflow.utils.context import Context
 from airflow.utils.edgemodifier import Label
@@ -944,3 +945,45 @@ def test_mapped_task_applies_default_args_taskflow(dag_maker):
 
     assert dag.get_task("simple").execution_timeout == timedelta(minutes=30)
     assert dag.get_task("mapped").execution_timeout == timedelta(minutes=30)
+
+
+def test_mapped_render_template_fields_validating_operator(dag_maker, session):
+    class MyOperator(MockOperator):
+        def __init__(self, value, arg1, **kwargs):
+            assert isinstance(value, str), "value should have been resolved before unmapping"
+            assert isinstance(arg1, str), "value should have been resolved before unmapping"
+            super().__init__(arg1=arg1, **kwargs)
+            self.value = value
+
+    with dag_maker(session=session):
+        task1 = BaseOperator(task_id="op1")
+        xcom_arg = XComArg(task1)
+        mapped = MyOperator.partial(task_id='a', arg2='{{ ti.task_id }}').expand(
+            value=xcom_arg, arg1=xcom_arg
+        )
+
+    dr = dag_maker.create_dagrun()
+    ti: TaskInstance = dr.get_task_instance(task1.task_id, session=session)
+
+    ti.xcom_push(key=XCOM_RETURN_KEY, value=['{{ ds }}'], session=session)
+
+    session.add(
+        TaskMap(
+            dag_id=dr.dag_id,
+            task_id=task1.task_id,
+            run_id=dr.run_id,
+            map_index=-1,
+            length=1,
+            keys=None,
+        )
+    )
+    session.flush()
+
+    mapped_ti: TaskInstance = dr.get_task_instance(mapped.task_id, session=session)
+    mapped_ti.map_index = 0
+    op = mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
+    assert isinstance(op, MyOperator)
+
+    assert op.value == "{{ ds }}", "Should not be templated!"
+    assert op.arg1 == "{{ ds }}"
+    assert op.arg2 == "a"


### PR DESCRIPTION
Many operators do some type validation inside `__init__`
(DateTimeSensor for instance -- which requires a str or a datetime)
which then fail when mapped as they get an XComArg instead.

To fix this we have had to change the order we unmap and resolve
templates:

- first we get the unmapping kwargs, we resolve expansion/mapping args
  in that
- Then we create the operator (this should fix the constructor getting
  XComArg problem)
- Then we render templates, but only for values that _weren't_ expanded
  already
