### PR TITLE
Make sure jobs triggered by airflow web are not identified as orphaned.

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -700,7 +700,7 @@ class KubernetesExecutor(BaseExecutor):
         self.event_buffer[key] = state, None
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
-        scheduler_job_ids = {ti.queued_by_job_id for ti in tis}
+        scheduler_job_ids = {ti.queued_by_job_id for ti in tis if ti.queued_by_job_id}
 
         # Tasks triggered through API will have no ti.queued_by_job_id
         # and their pod will have label 'airflow-worker=manual'
@@ -716,7 +716,7 @@ class KubernetesExecutor(BaseExecutor):
             for pod in pod_list.items:
                 self.adopt_launched_task(kube_client, pod, pod_ids)
         self._adopt_completed_pods(kube_client)
-        return pod_ids.values()
+        return [pod for pod in pod_ids.values()]
 
     def adopt_launched_task(
         self, kube_client: client.CoreV1Api, pod: k8s.V1Pod, pod_ids: Dict[TaskInstanceKey, k8s.V1Pod]

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -700,9 +700,14 @@ class KubernetesExecutor(BaseExecutor):
         self.event_buffer[key] = state, None
 
     def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
-        tis_to_flush = [ti for ti in tis if not ti.queued_by_job_id]
         scheduler_job_ids = {ti.queued_by_job_id for ti in tis}
-        pod_ids = {ti.key: ti for ti in tis if ti.queued_by_job_id}
+
+        # Tasks triggered through API will have no ti.queued_by_job_id
+        # and their pod will have label 'airflow-worker=manual'
+        if any(ti for ti in tis if not ti.queued_by_job_id):
+            scheduler_job_ids.add('manual')
+
+        pod_ids = {ti.key: ti for ti in tis}
         kube_client: client.CoreV1Api = self.kube_client
         for scheduler_job_id in scheduler_job_ids:
             scheduler_job_id = pod_generator.make_safe_label_value(str(scheduler_job_id))
@@ -711,8 +716,7 @@ class KubernetesExecutor(BaseExecutor):
             for pod in pod_list.items:
                 self.adopt_launched_task(kube_client, pod, pod_ids)
         self._adopt_completed_pods(kube_client)
-        tis_to_flush.extend(pod_ids.values())
-        return tis_to_flush
+        return pod_ids.values()
 
     def adopt_launched_task(
         self, kube_client: client.CoreV1Api, pod: k8s.V1Pod, pod_ids: Dict[TaskInstanceKey, k8s.V1Pod]

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -547,7 +547,9 @@ class TestKubernetesExecutor:
 
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesExecutor.adopt_launched_task')
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesExecutor._adopt_completed_pods')
-    def test_try_adopt_task_instances_manual_runs(self, mock_adopt_completed_pods, mock_adopt_launched_task):
+    def test_try_adopt_task_instance_triggered_by_run_action(
+        self, mock_adopt_completed_pods, mock_adopt_launched_task
+    ):
         executor = self.kubernetes_executor
         executor.scheduler_job_id = "10"
         ti_key = annotations_to_key(
@@ -559,7 +561,7 @@ class TestKubernetesExecutor:
             }
         )
         mock_ti = mock.MagicMock(
-            external_executor_id="1", key=ti_key, run_type=DagRunType.MANUAL, queued_by_job_id=None
+            external_executor_id="1", key=ti_key, run_type=DagRunType.SCHEDULED, queued_by_job_id=None
         )
         pod = k8s.V1Pod(metadata=k8s.V1ObjectMeta(name="foo"))
         mock_kube_client = mock.MagicMock()


### PR DESCRIPTION
closes: #20982 

---
Updated the kubernetes_executor code to take into account manually launched tasks (through the web-ui).
This way they are not reset as orphaned tasks. 