### PR TITLE
Add max width to task group tooltips

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -457,6 +457,7 @@ label[for="timezone-other"],
 
 .tooltip {
   z-index: 0;
+  max-width: 300px;
 }
 
 .tooltip.in,

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -495,7 +495,7 @@ function groupTooltip(node, tis) {
   });
 
   const groupDuration = convertSecsToHumanReadable(moment(maxEnd).diff(minStart, 'second'));
-  const tooltipText = node.tooltip ? `<p>${node.tooltip}</p>` : '';
+  const tooltipText = node.tooltip ? `<p style="max-width: 300px;">${node.tooltip}</p>` : '';
 
   let tt = `
     ${tooltipText}

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -495,7 +495,7 @@ function groupTooltip(node, tis) {
   });
 
   const groupDuration = convertSecsToHumanReadable(moment(maxEnd).diff(minStart, 'second'));
-  const tooltipText = node.tooltip ? `<p style="max-width: 300px;">${node.tooltip}</p>` : '';
+  const tooltipText = node.tooltip ? `<p>${node.tooltip}</p>` : '';
 
   let tt = `
     ${tooltipText}


### PR DESCRIPTION
Add a max width to the tooltip css class to make long task group descriptions wrap.

Fixes: https://github.com/apache/airflow/issues/22912

Before:
<img width="1680" alt="Screen Shot 2022-04-13 at 9 12 54 AM" src="https://user-images.githubusercontent.com/4600967/163188297-e7369d02-bb87-42de-8827-4de0884a9e62.png">


After:
<img width="612" alt="Screen Shot 2022-04-13 at 9 11 52 AM" src="https://user-images.githubusercontent.com/4600967/163188319-7ede8211-25e4-4f9d-8edf-a0ed1a7c47b6.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
