### PR TITLE
Fix KPO to have hyphen instead of period

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -433,7 +433,7 @@ class KubernetesPodOperator(BaseOperator):
             raise AirflowException("`name` is required unless `pod_template_file` or `full_pod_spec` is set")
 
         validate_key(name, max_length=220)
-        return re.sub(r'[^a-z0-9.-]+', '-', name.lower())
+        return re.sub(r'[^a-z0-9-]+', '-', name.lower())
 
     def patch_already_checked(self, pod: k8s.V1Pod):
         """Add an "already checked" annotation to ensure we don't reattach on retries"""


### PR DESCRIPTION
I don't know how it got missed after all the changes done, but the main logic still wasn't applied to have no period afterall.

In other words, the main single character change wasn't done to achieve the purpose. See changes included.
https://github.com/apache/airflow/pull/19036