### PR TITLE
Add no_status to state priority list

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -75,24 +75,26 @@ def get_instance_with_map(task_instance, session):
     return get_mapped_summary(task_instance, mapped_instances)
 
 
-def get_mapped_summary(parent_instance, task_instances):
-    priority = [
-        TaskInstanceState.FAILED,
-        TaskInstanceState.UPSTREAM_FAILED,
-        TaskInstanceState.UP_FOR_RETRY,
-        TaskInstanceState.UP_FOR_RESCHEDULE,
-        TaskInstanceState.QUEUED,
-        TaskInstanceState.SCHEDULED,
-        TaskInstanceState.DEFERRED,
-        TaskInstanceState.SENSING,
-        TaskInstanceState.RUNNING,
-        TaskInstanceState.SHUTDOWN,
-        TaskInstanceState.RESTARTING,
-        TaskInstanceState.REMOVED,
-        TaskInstanceState.SUCCESS,
-        TaskInstanceState.SKIPPED,
-    ]
+priority = [
+    TaskInstanceState.FAILED,
+    TaskInstanceState.UPSTREAM_FAILED,
+    TaskInstanceState.UP_FOR_RETRY,
+    TaskInstanceState.UP_FOR_RESCHEDULE,
+    TaskInstanceState.QUEUED,
+    TaskInstanceState.SCHEDULED,
+    TaskInstanceState.DEFERRED,
+    TaskInstanceState.SENSING,
+    TaskInstanceState.RUNNING,
+    TaskInstanceState.SHUTDOWN,
+    TaskInstanceState.RESTARTING,
+    TaskInstanceState.REMOVED,
+    None,
+    TaskInstanceState.SUCCESS,
+    TaskInstanceState.SKIPPED,
+]
 
+
+def get_mapped_summary(parent_instance, task_instances):
     mapped_states = [ti.state for ti in task_instances]
 
     group_state = None

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -255,23 +255,6 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
     ]
 
     def get_summary(dag_run, children):
-        priority = [
-            TaskInstanceState.FAILED,
-            TaskInstanceState.UPSTREAM_FAILED,
-            TaskInstanceState.UP_FOR_RETRY,
-            TaskInstanceState.UP_FOR_RESCHEDULE,
-            TaskInstanceState.QUEUED,
-            TaskInstanceState.SCHEDULED,
-            TaskInstanceState.DEFERRED,
-            TaskInstanceState.SENSING,
-            TaskInstanceState.RUNNING,
-            TaskInstanceState.SHUTDOWN,
-            TaskInstanceState.RESTARTING,
-            TaskInstanceState.REMOVED,
-            TaskInstanceState.SUCCESS,
-            TaskInstanceState.SKIPPED,
-        ]
-
         child_instances = [child['instances'] for child in children if 'instances' in child]
         child_instances = [item for sublist in child_instances for item in sublist]
 
@@ -284,7 +267,7 @@ def task_group_to_tree(task_item_or_group, dag, dag_runs, tis, session):
         children_states = [item['state'] for item in child_instances if item['run_id'] == dag_run.run_id]
 
         group_state = None
-        for state in priority:
+        for state in wwwutils.priority:
             if state in children_states:
                 group_state = state
                 break


### PR DESCRIPTION
Add `none` to the priority list for task group and mapped task summaries. This is the same order we use in `graph.js`.
Also, getting rid of duplicate code.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
