### PR TITLE
Add a clipboard button to grid details

### DIFF
--- a/airflow/www/static/js/tree/Clipboard.jsx
+++ b/airflow/www/static/js/tree/Clipboard.jsx
@@ -20,7 +20,7 @@ export const ClipboardButton = forwardRef(
       label = 'copy',
       title = 'Copy',
       'aria-label': ariaLabel = 'Copy',
-      ...otherProps
+      ...rest
     },
     ref,
   ) => {
@@ -32,7 +32,7 @@ export const ClipboardButton = forwardRef(
       variant,
       title,
       ref,
-      ...otherProps,
+      ...rest,
     };
 
     return (

--- a/airflow/www/static/js/tree/Clipboard.jsx
+++ b/airflow/www/static/js/tree/Clipboard.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  Tooltip,
+  useClipboard,
+  forwardRef,
+} from '@chakra-ui/react';
+import { FiCopy } from 'react-icons/fi';
+
+import { useContainerRef } from './context/containerRef';
+
+export const ClipboardButton = forwardRef(
+  (
+    {
+      value,
+      variant = 'outline',
+      iconOnly = false,
+      label = 'copy',
+      title = 'Copy',
+      'aria-label': ariaLabel = 'Copy',
+      ...otherProps
+    },
+    ref,
+  ) => {
+    const { hasCopied, onCopy } = useClipboard(value);
+    const containerRef = useContainerRef();
+
+    const commonProps = {
+      onClick: onCopy,
+      variant,
+      title,
+      ref,
+      ...otherProps,
+    };
+
+    return (
+      <Tooltip
+        label="Copied"
+        isOpen={hasCopied}
+        isDisabled={!hasCopied}
+        closeDelay={500}
+        placement="top"
+        portalProps={{ containerRef }}
+      >
+        {iconOnly ? (
+          <IconButton icon={<FiCopy />} aria-label={ariaLabel} {...commonProps} />
+        ) : (
+          <Button leftIcon={<FiCopy />} {...commonProps}>
+            {label}
+          </Button>
+        )}
+      </Tooltip>
+    );
+  },
+);
+
+export const ClipboardText = ({ value }) => (
+  <Box as="span">
+    {value}
+    <ClipboardButton value={value} iconOnly variant="ghost" size="xs" fontSize="lg" ml={1} />
+  </Box>
+);

--- a/airflow/www/static/js/tree/Clipboard.jsx
+++ b/airflow/www/static/js/tree/Clipboard.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Box,
   Button,
   IconButton,
   Tooltip,
@@ -57,8 +56,8 @@ export const ClipboardButton = forwardRef(
 );
 
 export const ClipboardText = ({ value }) => (
-  <Box as="span">
+  <>
     {value}
     <ClipboardButton value={value} iconOnly variant="ghost" size="xs" fontSize="lg" ml={1} />
-  </Box>
+  </>
 );

--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -28,6 +28,7 @@ import {
 import { MdPlayArrow, MdOutlineAccountTree } from 'react-icons/md';
 
 import { SimpleStatus } from '../../../StatusBox';
+import { ClipboardText } from '../../../Clipboard';
 import { formatDuration } from '../../../../datetime_utils';
 import Time from '../../../Time';
 import MarkFailedRun from './MarkFailedRun';
@@ -91,7 +92,7 @@ const DagRun = ({ runId }) => {
       <Text whiteSpace="nowrap">
         Run Id:
         {' '}
-        {runId}
+        <ClipboardText value={runId} />
       </Text>
       <Text>
         Run Type:

--- a/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
@@ -28,6 +28,7 @@ import { finalStatesMap } from '../../../../utils';
 import { getDuration, formatDuration } from '../../../../datetime_utils';
 import { SimpleStatus } from '../../../StatusBox';
 import Time from '../../../Time';
+import { ClipboardText } from '../../../Clipboard';
 
 const Details = ({ instance, group, operator }) => {
   const isGroup = !!group.children;
@@ -114,12 +115,12 @@ const Details = ({ instance, group, operator }) => {
         <br />
         <Text>
           {taskIdTitle}
-          {taskId}
+          <ClipboardText value={taskId} />
         </Text>
         <Text whiteSpace="nowrap">
           Run Id:
           {' '}
-          {runId}
+          <ClipboardText value={runId} />
         </Text>
         {operator && (
           <Text>


### PR DESCRIPTION
Add a copy button for task id and run id in Grid details.

<img width="466" alt="Screen Shot 2022-04-13 at 11 56 18 AM" src="https://user-images.githubusercontent.com/4600967/163221320-6f33261f-aece-4e03-a089-e5d848581a18.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
