### PR TITLE
Show a consistent duration format

### DIFF
--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global moment, $, document */
+/* global moment, $, document, convertSecsToHumanReadable */
 export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
 export const defaultTZFormat = 'z (Z)';
@@ -106,10 +106,8 @@ export const getDuration = (startDate, endDate) => (
 );
 
 export const formatDuration = (dur) => {
-  const duration = moment.duration(dur);
-  const days = duration.days();
-  // .as('milliseconds') is necessary for .format() to work correctly
-  return `${days > 0 ? `${days}d` : ''}${moment.utc(duration.as('milliseconds')).format('HH:mm:ss')}`;
+  const duration = moment.duration(dur).as('seconds');
+  return convertSecsToHumanReadable(duration);
 };
 
 export const approxTimeFromNow = (dur) => {

--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -17,13 +17,46 @@
  * under the License.
  */
 
-/* global moment, $, document, convertSecsToHumanReadable */
+/* global moment, $, document */
 export const defaultFormat = 'YYYY-MM-DD, HH:mm:ss';
 export const defaultFormatWithTZ = 'YYYY-MM-DD, HH:mm:ss z';
 export const defaultTZFormat = 'z (Z)';
 export const dateTimeAttrFormat = 'YYYY-MM-DDThh:mm:ssTZD';
 
 export const TimezoneEvent = 'timezone';
+
+export function convertSecsToHumanReadable(seconds) {
+  const oriSeconds = seconds;
+  const floatingPart = oriSeconds - Math.floor(oriSeconds);
+
+  seconds = Math.floor(seconds);
+
+  const secondsPerHour = 60 * 60;
+  const secondsPerMinute = 60;
+
+  const hours = Math.floor(seconds / secondsPerHour);
+  seconds -= hours * secondsPerHour;
+
+  const minutes = Math.floor(seconds / secondsPerMinute);
+  seconds -= minutes * secondsPerMinute;
+
+  let readableFormat = '';
+  if (hours > 0) {
+    readableFormat += `${hours}Hours `;
+  }
+  if (minutes > 0) {
+    readableFormat += `${minutes}Min `;
+  }
+  if (seconds + floatingPart > 0) {
+    if (Math.floor(oriSeconds) === oriSeconds) {
+      readableFormat += `${seconds}Sec`;
+    } else {
+      seconds += floatingPart;
+      readableFormat += `${seconds.toFixed(3)}Sec`;
+    }
+  }
+  return readableFormat;
+}
 
 export function formatTimezone(what) {
   if (what instanceof moment) {

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -21,13 +21,14 @@
 
 /*
   global d3, document, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $,
-  autoRefreshInterval, moment, convertSecsToHumanReadable
+  autoRefreshInterval, moment,
 */
 
 import { getMetaValue, finalStatesMap } from './utils';
 import { escapeHtml } from './main';
 import tiTooltip, { taskNoInstanceTooltip } from './task_instances';
 import { callModal } from './dag';
+import { convertSecsToHumanReadable } from './datetime_utils';
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -61,46 +61,13 @@ function changeDisplayedTimezone(tz) {
 
 const el = document.createElement('span');
 
+// eslint-disable-next-line import/prefer-default-export
 export function escapeHtml(text) {
   el.textContent = text;
   return el.innerHTML;
 }
 
 window.escapeHtml = escapeHtml;
-
-export function convertSecsToHumanReadable(seconds) {
-  const oriSeconds = seconds;
-  const floatingPart = oriSeconds - Math.floor(oriSeconds);
-
-  seconds = Math.floor(seconds);
-
-  const secondsPerHour = 60 * 60;
-  const secondsPerMinute = 60;
-
-  const hours = Math.floor(seconds / secondsPerHour);
-  seconds -= hours * secondsPerHour;
-
-  const minutes = Math.floor(seconds / secondsPerMinute);
-  seconds -= minutes * secondsPerMinute;
-
-  let readableFormat = '';
-  if (hours > 0) {
-    readableFormat += `${hours}Hours `;
-  }
-  if (minutes > 0) {
-    readableFormat += `${minutes}Min `;
-  }
-  if (seconds + floatingPart > 0) {
-    if (Math.floor(oriSeconds) === oriSeconds) {
-      readableFormat += `${seconds}Sec`;
-    } else {
-      seconds += floatingPart;
-      readableFormat += `${seconds.toFixed(3)}Sec`;
-    }
-  }
-  return readableFormat;
-}
-window.convertSecsToHumanReadable = convertSecsToHumanReadable;
 
 function postAsForm(url, parameters) {
   const form = $('<form></form>');

--- a/airflow/www/static/js/task_instances.js
+++ b/airflow/www/static/js/task_instances.js
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-/* global window, moment, convertSecsToHumanReadable */
+/* global window, moment */
 
 // We don't re-import moment again, otherwise webpack will include it twice in the bundle!
 import { escapeHtml } from './main';
-import { defaultFormat, formatDateTime } from './datetime_utils';
+import { defaultFormat, formatDateTime, convertSecsToHumanReadable } from './datetime_utils';
 import { dagTZ } from './dag';
 import { finalStatesMap } from './utils';
 

--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -80,7 +80,7 @@ const DagRuns = ({ tableWidth }) => {
             {formatDuration(max / 2)}
           </DurationTick>
           <DurationTick bottom={0}>
-            00:00:00
+            0Sec
           </DurationTick>
         </>
         )}

--- a/airflow/www/static/js/tree/dagRuns/index.test.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.test.jsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global describe, test, expect */
+/* global describe, test, expect, beforeAll */
 
 import React from 'react';
 import { render } from '@testing-library/react';
@@ -30,8 +30,7 @@ import { ContainerRefProvider } from '../context/containerRef';
 import { SelectionProvider } from '../context/selection';
 import { TimezoneProvider } from '../context/timezone';
 import { AutoRefreshProvider } from '../context/autorefresh';
-
-global.moment = moment;
+import { convertSecsToHumanReadable } from '../../datetime_utils';
 
 const Wrapper = ({ children }) => {
   const queryClient = new QueryClient();
@@ -58,30 +57,35 @@ const Wrapper = ({ children }) => {
   );
 };
 
+const dagRuns = [
+  {
+    dagId: 'dagId',
+    runId: 'run1',
+    dataIntervalStart: new Date(),
+    dataIntervalEnd: new Date(),
+    startDate: '2021-11-08T21:14:19.704433+00:00',
+    endDate: '2021-11-08T21:17:13.206426+00:00',
+    state: 'failed',
+    runType: 'scheduled',
+    executionDate: '2021-11-08T21:14:19.704433+00:00',
+  },
+  {
+    dagId: 'dagId',
+    runId: 'run2',
+    dataIntervalStart: new Date(),
+    dataIntervalEnd: new Date(),
+    state: 'success',
+    runType: 'manual',
+    startDate: '2021-11-09T00:19:43.023200+00:00',
+    endDate: '2021-11-09T00:22:18.607167+00:00',
+  },
+];
+
 describe('Test DagRuns', () => {
-  const dagRuns = [
-    {
-      dagId: 'dagId',
-      runId: 'run1',
-      dataIntervalStart: new Date(),
-      dataIntervalEnd: new Date(),
-      startDate: '2021-11-08T21:14:19.704433+00:00',
-      endDate: '2021-11-08T21:17:13.206426+00:00',
-      state: 'failed',
-      runType: 'scheduled',
-      executionDate: '2021-11-08T21:14:19.704433+00:00',
-    },
-    {
-      dagId: 'dagId',
-      runId: 'run2',
-      dataIntervalStart: new Date(),
-      dataIntervalEnd: new Date(),
-      state: 'success',
-      runType: 'manual',
-      startDate: '2021-11-09T00:19:43.023200+00:00',
-      endDate: '2021-11-09T00:22:18.607167+00:00',
-    },
-  ];
+  beforeAll(() => {
+    global.moment = moment;
+    global.convertSecsToHumanReadable = convertSecsToHumanReadable;
+  });
 
   test('Durations and manual run arrow render correctly, but without any date ticks', () => {
     global.treeData = JSON.stringify({
@@ -94,8 +98,8 @@ describe('Test DagRuns', () => {
     expect(queryAllByTestId('run')).toHaveLength(2);
     expect(queryAllByTestId('manual-run')).toHaveLength(1);
 
-    expect(getByText('00:02:53')).toBeInTheDocument();
-    expect(getByText('00:01:26')).toBeInTheDocument();
+    expect(getByText('2Min 53.502Sec')).toBeInTheDocument();
+    expect(getByText('1Min 26.751Sec')).toBeInTheDocument();
     expect(queryByText(moment.utc(dagRuns[0].executionDate).format('MMM DD, HH:mm'))).toBeNull();
   });
 


### PR DESCRIPTION
We were writing durations in Grid view like `00:00:15` while the rest of the app would be like `15Sec`. This PR switches that to use the same format.

I'm also open to updating the `convertSecsToHumanReadable()` function. I'm not sure if we need millisecond precision.

Before:
<img width="1184" alt="Screen Shot 2022-04-13 at 2 25 07 PM" src="https://user-images.githubusercontent.com/4600967/163248890-102224f7-fb77-4937-9fbf-8b058f61b1a5.png">


After:
<img width="1197" alt="Screen Shot 2022-04-13 at 2 22 27 PM" src="https://user-images.githubusercontent.com/4600967/163248905-6dfd8213-fdd4-4af4-bc1a-1955bae723cb.png">


Very long DAG run duration:
<img width="411" alt="Screen Shot 2022-04-13 at 2 47 06 PM" src="https://user-images.githubusercontent.com/4600967/163249332-f432d988-f5bc-4099-9b91-8d4b2aaa94d0.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
