### PR TITLE
Fix dag run date in details header

### DIFF
--- a/airflow/www/static/js/tree/details/Header.jsx
+++ b/airflow/www/static/js/tree/details/Header.jsx
@@ -50,7 +50,7 @@ const Header = () => {
   let runLabel;
   if (dagRun) {
     if (runId.includes('manual__') || runId.includes('scheduled__') || runId.includes('backfill__')) {
-      runLabel = (<Time dateTime={dagRun.dataIntervalEnd} />);
+      runLabel = (<Time dateTime={dagRun.dataIntervalStart || dagRun.executionDate} />);
     } else {
       runLabel = runId;
     }


### PR DESCRIPTION
We were using `dataIntervalEnd` even though the rest of the app uses `dataIntervalStart`.
Also, adding in `executionDate` as a backup incase the data interval is undefined on an old dag run.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
