### PR TITLE
Do not validate Params with no default value during DAG parsing

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -404,7 +404,7 @@ class DagBag(LoggingMixin):
             try:
                 dag.timetable.validate()
                 # validate dag params
-                dag.params.validate()
+                dag.params.validate(is_dag_parsing=True)
                 self.bag_dag(dag=dag, root_dag=dag)
                 found_dags.append(dag)
                 found_dags += dag.subdags

--- a/tests/dags/test_invalid_param_int.py
+++ b/tests/dags/test_invalid_param_int.py
@@ -22,12 +22,12 @@ from airflow.models.param import Param
 from airflow.operators.python import PythonOperator
 
 with DAG(
-    "test_invalid_param",
+    "test_invalid_param_int",
     start_date=datetime(2021, 1, 1),
     schedule_interval="@once",
     params={
-        # string param with above limit default value
-        "str_param": Param('longerthan4', type="string", minLength=2, maxLength=4),
+        # integer param with above limit default value
+        "int_param": Param(10, type="integer", minimum=2, maximum=4),
     },
 ) as the_dag:
 
@@ -39,6 +39,6 @@ with DAG(
         task_id="ref_params",
         python_callable=print_these,
         op_args=[
-            "{{ params.str_param }}",
+            "{{ params.int_param }}",
         ],
     )

--- a/tests/dags/test_mandatory_param_pass.py
+++ b/tests/dags/test_mandatory_param_pass.py
@@ -22,12 +22,12 @@ from airflow.models.param import Param
 from airflow.operators.python import PythonOperator
 
 with DAG(
-    "test_invalid_param",
+    "test_mandatory_params_pass",
     start_date=datetime(2021, 1, 1),
     schedule_interval="@once",
     params={
-        # string param with above limit default value
-        "str_param": Param('longerthan4', type="string", minLength=2, maxLength=4),
+        # a mandatory int param no error if no value is provided
+        "int_param": Param(type="integer", minimum=2, maximum=4),
     },
 ) as the_dag:
 
@@ -39,6 +39,6 @@ with DAG(
         task_id="ref_params",
         python_callable=print_these,
         op_args=[
-            "{{ params.str_param }}",
+            "{{ params.int_param }}",
         ],
     )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2629,6 +2629,7 @@ class TestSchedulerJob:
             'test_ignore_this.py',
             'test_invalid_param.py',
             'test_nested_dag.py',
+            'test_invalid_param_int.py',
         }
         for root, _, files in os.walk(TEST_DAG_FOLDER):
             for file_name in files:

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -283,6 +283,32 @@ class TestDagBag:
         assert len(dagbag.import_errors) == len(invalid_dag_files)
         assert len(dagbag.dags) == 0
 
+    def test_process_file_invalid_param_check_int(self):
+        """
+        test if an invalid param in the dag param can be identified
+        """
+        invalid_dag_files = ["test_invalid_param_int.py"]
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+
+        assert len(dagbag.import_errors) == 0
+        for file in invalid_dag_files:
+            dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, file))
+        assert len(dagbag.import_errors) == len(invalid_dag_files)
+        assert len(dagbag.dags) == 0
+
+    def test_process_file_mandatory_param_no_default_value_pass(self):
+        """
+        test if a mandatory param is passed, no error on dag parsing if no default
+        """
+        invalid_dag_files = ["test_mandatory_param_pass.py"]
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
+
+        assert len(dagbag.import_errors) == 0
+        for file in invalid_dag_files:
+            dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, file))
+        assert len(dagbag.import_errors) == 0
+        assert len(dagbag.dags) == 1
+
     @patch.object(DagModel, 'get_current')
     def test_get_dag_without_refresh(self, mock_dagmodel):
         """


### PR DESCRIPTION
We shouldn't validate params with no default value during dag parsing. It should be done
when dag is triggered. Currently, it causes import error if default value is not provided
in a dag.

Another alternative is to update the doc and make it compulsory to have a default value in params