### PR TITLE
Fix tests using has_calls to use assert_has_calls.

### DIFF
--- a/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
@@ -109,10 +109,20 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
         )
-        mock_get_conn.return_value.get_instance.has_calls(
+        mock_get_conn.return_value.get_instance.assert_has_calls(
             [
-                mock.call(name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA),
-                mock.call(name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA),
+                mock.call(
+                    request=dict(name=TEST_NAME_DEFAULT_PROJECT_ID),
+                    retry=TEST_RETRY,
+                    timeout=TEST_TIMEOUT,
+                    metadata=TEST_METADATA,
+                ),
+                mock.call(
+                    request=dict(name=TEST_NAME_DEFAULT_PROJECT_ID),
+                    retry=TEST_RETRY,
+                    timeout=TEST_TIMEOUT,
+                    metadata=TEST_METADATA,
+                ),
             ]
         )
         mock_get_conn.return_value.create_instance.assert_called_once_with(
@@ -263,16 +273,20 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
         )
-        mock_get_conn.return_value.get_instance.has_calls(
+        mock_get_conn.return_value.get_instance.assert_has_calls(
             [
                 mock.call(
-                    name="projects/test-project-id/locations/test-location/instances/test-instance-id",
+                    request=dict(
+                        name="projects/test-project-id/locations/test-location/instances/test-instance-id"
+                    ),
                     retry=TEST_RETRY,
                     timeout=TEST_TIMEOUT,
                     metadata=TEST_METADATA,
                 ),
                 mock.call(
-                    name="projects/test-project-id/locations/test-location/instances/test-instance-id",
+                    request=dict(
+                        name="projects/test-project-id/locations/test-location/instances/test-instance-id"
+                    ),
                     retry=TEST_RETRY,
                     timeout=TEST_TIMEOUT,
                     metadata=TEST_METADATA,
@@ -500,10 +514,20 @@ class TestCloudMemorystoreMemcachedWithDefaultProjectIdHook(TestCase):
             timeout=TEST_TIMEOUT,
             metadata=TEST_METADATA,
         )
-        mock_get_conn.return_value.get_instance.has_calls(
+        mock_get_conn.return_value.get_instance.assert_has_calls(
             [
-                mock.call(name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA),
-                mock.call(name=TEST_NAME, retry=TEST_RETRY, timeout=TEST_TIMEOUT, metadata=TEST_METADATA),
+                mock.call(
+                    name=TEST_NAME_DEFAULT_PROJECT_ID,
+                    retry=TEST_RETRY,
+                    timeout=TEST_TIMEOUT,
+                    metadata=TEST_METADATA,
+                ),
+                mock.call(
+                    name=TEST_NAME_DEFAULT_PROJECT_ID,
+                    retry=TEST_RETRY,
+                    timeout=TEST_TIMEOUT,
+                    metadata=TEST_METADATA,
+                ),
             ]
         )
         mock_get_conn.return_value.create_instance.assert_called_once_with(

--- a/tests/providers/google/cloud/hooks/test_looker.py
+++ b/tests/providers/google/cloud/hooks/test_looker.py
@@ -62,7 +62,7 @@ class TestLookerHook(unittest.TestCase):
             mock.call(materialization_id=JOB_ID),
             mock.call(materialization_id=JOB_ID),
         ]
-        mock_pdt_build_status.has_calls(calls)
+        mock_pdt_build_status.assert_has_calls(calls)
 
     @mock.patch(HOOK_PATH.format("get_looker_sdk"))
     def test_check_pdt_build(self, mock_sdk):

--- a/tests/providers/google/cloud/transfers/test_calendar_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_calendar_to_gcs.py
@@ -85,6 +85,7 @@ class TestGoogleCalendarToGCSOperator:
         context = {}
         data = [EVENT]
         mock_upload_data.side_effect = PATH
+        mock_calendar_hook.return_value.get_events.return_value = data
 
         op = GoogleCalendarToGCSOperator(
             api_version=API_VERSION,
@@ -104,26 +105,23 @@ class TestGoogleCalendarToGCSOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
-        call = mock.call(
+        mock_calendar_hook.return_value.get_events.assert_called_once_with(
             calendar_id=CALENDAR_ID,
-            iCalUID=None,
-            maxAttendees=None,
-            maxResults=None,
-            orderBy=None,
-            pageToken=None,
-            privateExtendedProperty=None,
+            i_cal_uid=None,
+            max_attendees=None,
+            max_results=None,
+            order_by=None,
+            private_extended_property=None,
             q=None,
-            sharedExtendedProperty=None,
-            showDeleted=False,
-            showHiddenInvitations=False,
-            singleEvents=False,
-            syncToken=None,
-            timeMax=None,
-            timeMin=None,
-            timeZone=None,
-            updatedMin=None,
+            shared_extended_property=None,
+            show_deleted=None,
+            show_hidden_invitation=None,
+            single_events=None,
+            sync_token=None,
+            time_max=None,
+            time_min=None,
+            time_zone=None,
+            updated_min=None,
         )
-        mock_calendar_hook.return_value.get_values.has_calls(call)
 
-        call = mock.call(data)
-        mock_upload_data.has_calls(call)
+        mock_upload_data.assert_called_once_with(data)


### PR DESCRIPTION
Changes made

tests/providers/google/cloud/transfers/test_calendar_to_gcs.py

* Use snake case instead of camel case and mock correct method `get_events` method instead of `get_values`.

tests/providers/google/cloud/hooks/test_cloud_memorystore.py

* Use request instead of name argument as per other tests.
* Use TEST_NAME_DEFAULT_PROJECT_ID when project_id is not passed explicitly and default project_id is set,

closes: #20453
related: #20453
