### PR TITLE
Don't add planned tasks for legacy DAG runs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2652,7 +2652,7 @@ class Airflow(AirflowBaseView):
             for dr in dag_states
         ]
 
-        if dag_states:
+        if dag_states and dag_states[-1].data_interval_start and dag_states[-1].data_interval_end:
             last_automated_data_interval = DataInterval(
                 dag_states[-1].data_interval_start, dag_states[-1].data_interval_end
             )


### PR DESCRIPTION
A bug was introduced in #22941 that when a DAG is last run before upgrading to Airflow 2.2, the calendar view would fail with an error because that last run does not contain data interval information.

This fixes the issue by simply not showing planned runs if the last run was made with data interval information. Technically we could still infer planned runs in this situation, but since it only affects the DAG temporarily and will "fix" itself after that DAG is run one time against 2.2 anyway, that's probably not worth it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
