### PR TITLE
Fallback Provider's doc URL to "Documentation" meta-data

### DIFF
--- a/docs/apache-airflow-providers/index.rst
+++ b/docs/apache-airflow-providers/index.rst
@@ -280,6 +280,9 @@ You need to do the following to turn an existing Python package into a provider 
   the required provider metadata
 * Create the function that you refer to in the first step as part of your package: this functions returns a
   dictionary that contains all meta-data about your provider package
+* If you want Airflow to link to documentation of your Provider in the providers page, make sure
+  to add "project-url/documentation" `metadata <https://peps.python.org/pep-0621/#example>`_ to your package.
+  This will also add link to your documentation in PyPI.
 * note that the dictionary should be compliant with ``airflow/provider_info.schema.json`` JSON-schema
   specification. The community-managed providers have more fields there that are used to build
   documentation, but the requirement for runtime information only contains several fields which are defined


### PR DESCRIPTION
When Airflow displays provider's Doc URLs it builds the
URL to documentation for community providers but for third party
providers it was wrong.

With this change:
* if provider already has Documentation standard Project-URL
  metadata, Airflow will use it
* if provider is an "apache-airflow" one, it will dynamically
  build the URL from provider info
* if neither of two is available it will direct user to the
  place in documentation where requirements for custom providers
  are explained

Fixes: ##22248

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
