### PR TITLE
Change trigger dropdown left position

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -436,7 +436,7 @@ label[for="timezone-other"],
 }
 
 .trigger-dropdown-menu {
-  left: -80px;
+  left: -112px;
 }
 
 .dropdown-form-btn {


### PR DESCRIPTION
Move the trigger DAG dropdown further to the left to prevent it from overflowing off the right side of the screen and forcing aa scroll bar to appear.

Before:
<img width="231" alt="Screen Shot 2022-04-14 at 7 52 35 AM" src="https://user-images.githubusercontent.com/4600967/163385862-6753d631-5a26-427f-8b15-ed8ffeffb1a7.png">

After:
<img width="244" alt="Screen Shot 2022-04-14 at 7 52 23 AM" src="https://user-images.githubusercontent.com/4600967/163385880-8247a414-c3e1-47fc-9f01-56e106ebaeb4.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
