### PR TITLE
Fix dag_id extraction for dag level access checks in web ui

### DIFF
--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -36,7 +36,10 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
 
             appbuilder = current_app.appbuilder
 
-            if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
+            dag_id = (
+                request.args.get("dag_id") or request.form.get("dag_id") or (request.json or {}).get("dag_id")
+            )
+            if appbuilder.sm.check_authorization(permissions, dag_id):
                 return func(*args, **kwargs)
             elif not g.user.is_anonymous and not g.user.perms:
                 return (


### PR DESCRIPTION
Dag level permissions are not checked properly if a post request is sent from within the web ui (i.e. clear a task or dag run). If a user has can_read on any dag any operation that involves a post request is allowed even though the user does not have the can_write permission for this dag as far as the appropriate other permissions like edit_task_instance or edit_dag_run were granted. This is caused by the dag_id being extracted from `request.args` which only exists for get requests (i.e. change the status of a task). Otherwise `None` is used as dag_id in `appbuilder.sm.check_authorization` which essentially leads to ignoring the dag level access permissions.

I added two new tests for this specific issue.
While writing the tests I fixed a small issue in another test (`test_success_fail_for_read_only_task_instance_access`) that resulted in the test succeeding although not for the reason that is under test here.


This PR is a follow up to #21797 as discussed there and addresses the first issue.


At last let me thank you all again for your great work!