### PR TITLE
Use inherited 'trigger_tasks' method

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -218,7 +218,8 @@ class BaseExecutor(LoggingMixin):
             else:
                 task_tuples.append((key, command, queue, ti.executor_config))
 
-        self._process_tasks(task_tuples)
+        if task_tuples:
+            self._process_tasks(task_tuples)
 
     def _process_tasks(self, task_tuples: List[TaskTuple]) -> None:
         for key, command, queue, executor_config in task_tuples:

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -49,6 +49,9 @@ QueuedTaskInstanceType = Tuple[CommandType, int, Optional[str], TaskInstance]
 # Tuple of: state, info
 EventBufferValueType = Tuple[Optional[str], Any]
 
+# Task tuple to send to be executed
+TaskTuple = Tuple[TaskInstanceKey, CommandType, Optional[str], Optional[Any]]
+
 
 class BaseExecutor(LoggingMixin):
     """
@@ -186,6 +189,7 @@ class BaseExecutor(LoggingMixin):
         :param open_slots: Number of open slots
         """
         sorted_queue = self.order_queued_tasks_by_priority()
+        task_tuples = []
 
         for _ in range(min((open_slots, len(self.queued_tasks)))):
             key, (command, _, queue, ti) = sorted_queue.pop(0)
@@ -212,9 +216,15 @@ class BaseExecutor(LoggingMixin):
                 del self.attempts[key]
                 del self.queued_tasks[key]
             else:
-                del self.queued_tasks[key]
-                self.running.add(key)
-                self.execute_async(key=key, command=command, queue=queue, executor_config=ti.executor_config)
+                task_tuples.append((key, command, queue, ti.executor_config))
+
+        self._process_tasks(task_tuples)
+
+    def _process_tasks(self, task_tuples: List[TaskTuple]) -> None:
+        for key, command, queue, executor_config in task_tuples:
+            del self.queued_tasks[key]
+            self.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
+            self.running.add(key)
 
     def change_state(self, key: TaskInstanceKey, state: str, info=None) -> None:
         """

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -225,19 +225,19 @@ class TestCeleryExecutor:
 
             # Test that when heartbeat is called again, task is published again to Celery Queue
             executor.heartbeat()
-            assert dict(executor.task_publish_retries) == {key: 2}
+            assert dict(executor.task_publish_retries) == {key: 1}
             assert 1 == len(executor.queued_tasks), "Task should remain in queue"
             assert executor.event_buffer == {}
             assert f"[Try 1 of 3] Task Timeout Error for Task: ({key})." in caplog.text
 
             executor.heartbeat()
-            assert dict(executor.task_publish_retries) == {key: 3}
+            assert dict(executor.task_publish_retries) == {key: 2}
             assert 1 == len(executor.queued_tasks), "Task should remain in queue"
             assert executor.event_buffer == {}
             assert f"[Try 2 of 3] Task Timeout Error for Task: ({key})." in caplog.text
 
             executor.heartbeat()
-            assert dict(executor.task_publish_retries) == {key: 4}
+            assert dict(executor.task_publish_retries) == {key: 3}
             assert 1 == len(executor.queued_tasks), "Task should remain in queue"
             assert executor.event_buffer == {}
             assert f"[Try 3 of 3] Task Timeout Error for Task: ({key})." in caplog.text

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -755,7 +755,7 @@ class TestLocalTaskJob:
                 scheduler_job.processor_agent.end()
 
     @conf_vars({('scheduler', 'schedule_after_task_execution'): 'True'})
-    def test_mini_scheduler_works_with_wait_for_upstream(self, caplog, dag_maker):
+    def test_mini_scheduler_works_with_wait_for_downstream(self, caplog, dag_maker):
         session = settings.Session()
         with dag_maker(default_args={'wait_for_downstream': True}, catchup=False) as dag:
             task_a = PythonOperator(task_id='A', python_callable=lambda: True)
@@ -786,13 +786,17 @@ class TestLocalTaskJob:
 
         job1 = LocalTaskJob(task_instance=ti2_a, ignore_ti_state=True, executor=SequentialExecutor())
         job1.task_runner = StandardTaskRunner(job1)
+        t = time.time()
         job1.run()
+        d = time.time() - t
 
         ti2_a.refresh_from_db(session)
         ti2_b.refresh_from_db(session)
         assert ti2_a.state == State.SUCCESS
         assert ti2_b.state == State.NONE
-        assert "0 downstream tasks scheduled from follow-on schedule" in caplog.text
+        assert (
+            "0 downstream tasks scheduled from follow-on schedule" in caplog.text
+        ), f"Failed after {d.total_seconds()}: {caplog.text}"
 
         failed_deps = list(ti2_b.get_failed_dep_statuses(session=session))
         assert len(failed_deps) == 1


### PR DESCRIPTION
This is a follow-up to #21316 which did not take into account that `CeleryExecutor` overrides `trigger_tasks` and thus would ignore if a task was already running.