### PR TITLE
Make sure all mapped node labels are updated.

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -102,7 +102,12 @@ const updateNodeLabels = (node, instances) => {
     haveLabelsChanged = true;
   }
 
-  if (node.children) return node.children.some((n) => updateNodeLabels(n, instances));
+  if (node.children) {
+    // Iterate through children and return true if at least one has been changed
+    const updatedNodes = node.children.map((n) => updateNodeLabels(n, instances));
+    return updatedNodes.some((changed) => changed);
+  }
+
   return haveLabelsChanged;
 };
 


### PR DESCRIPTION
In Graph view, there was an issue that only the first mapped task was having `[ ]` being appended to its label. That is because `Array.some()` stops running the first time it is `true`. Therefore, we should map through all children nodes first to apply labels and then check if any have been changed.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
