### PR TITLE
Include message in Graph view errors

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -445,8 +445,9 @@ function handleRefresh() {
         setTimeout(() => { $('#loading-dots').hide(); }, 500);
         $('#error').hide();
       },
-    ).fail((_, textStatus, err) => {
-      $('#error_msg').text(`${textStatus}: ${err}`);
+    ).fail((response, textStatus, err) => {
+      const description = (response.responseJSON && response.responseJSON.error) || 'Something went wrong.';
+      $('#error_msg').text(`${textStatus}: ${err} ${description}`);
       $('#error').show();
       setTimeout(() => { $('#loading-dots').hide(); }, 500);
       $('#chart_section').hide(1000);

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3376,7 +3376,9 @@ class Airflow(AirflowBaseView):
         if dttm:
             dttm = timezone.parse(dttm)
         else:
-            return "Error: Invalid execution_date"
+            response = jsonify({'error': f"Invalid execution_date {dttm}"})
+            response.status_code = 400
+            return response
 
         with create_session() as session:
             task_instances = {


### PR DESCRIPTION
One issue in https://github.com/apache/airflow/issues/23017 was that when an error occurred, the message wasn't being displayed.

This PR parses an error message and displays it or shows a backup "Something went wrong."

<img width="846" alt="Screen Shot 2022-04-14 at 11 23 40 AM" src="https://user-images.githubusercontent.com/4600967/163432770-45bf0546-92c7-46c6-85d7-1553a580bfc4.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
