### PR TITLE
Fix Grid view run/task alignment

### DIFF
--- a/airflow/www/static/js/tree/dagRuns/index.jsx
+++ b/airflow/www/static/js/tree/dagRuns/index.jsx
@@ -37,7 +37,7 @@ const DurationTick = ({ children, ...rest }) => (
   </Text>
 );
 
-const DagRuns = ({ tableWidth }) => {
+const DagRuns = () => {
   const { data: { dagRuns = [] } } = useTreeData();
   const { selected, onSelect } = useSelection();
   const durations = [];
@@ -68,7 +68,7 @@ const DagRuns = ({ tableWidth }) => {
         backgroundColor="white"
         zIndex={2}
         borderBottom={0}
-        width={`${tableWidth - (runs.length * 16)}px`}
+        width="100%"
       >
         {!!runs.length && (
         <>

--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -95,7 +95,6 @@ const Row = (props) => {
     prevTaskId,
     isParentOpen = true,
     dagRunIds,
-    tableWidth,
   } = props;
   const { colors } = useTheme();
   const { selected, onSelect } = useSelection();
@@ -147,7 +146,7 @@ const Row = (props) => {
           position="sticky"
           left={0}
           borderBottom={0}
-          width={`${tableWidth - (dagRunIds.length * columnWidth)}px`}
+          width="100%"
           zIndex={1}
         >
           <Collapse in={isFullyOpen} unmountOnExit>


### PR DESCRIPTION
In the Grid view, sometimes the dag runs were becoming unaligned with the task instances. This is because of how we calculated the width of the label column to make auto-scrolling to the end of the div work.

This PR fixes this by changing how we determine when to scroll by using a `ResizeObserver` and removes the need for any tracking of `tableWidth` via state.

Before:
![before](https://user-images.githubusercontent.com/4600967/163460098-5642935d-8113-4c1b-8454-e97eecf6b216.gif)


After:
![after](https://user-images.githubusercontent.com/4600967/163460111-5ee52d73-fd80-4159-9195-1005f6f3d759.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
