### PR TITLE
Update gcs_to_local.rst

### DIFF
--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
@@ -35,7 +35,7 @@ GCSToLocalFilesystemOperator
 data from GCS to local filesystem.
 
 
-Below is an example of using this operator to upload a file to GCS.
+Below is an example of using this operator to download a file from GCS.
 
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_gcs_to_local.py
     :language: python


### PR DESCRIPTION
Change:
`to upload a file to GCS.` -> `to download a file from GCS.`
Reason:
`GCSToLocalFilesystemOperator` downloads a file from GCS to your local file system. 

There is a different operator, `LocalFilesystemToGCSOperator`, which can upload files from your local filesystem to GCS.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
