### PR TITLE
Change ComputeSSH to throw provider import error instead paramiko

### DIFF
--- a/airflow/providers/google/cloud/hooks/compute_ssh.py
+++ b/airflow/providers/google/cloud/hooks/compute_ssh.py
@@ -20,8 +20,6 @@ import time
 from io import StringIO
 from typing import Any, Dict, Optional
 
-import paramiko
-
 if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
@@ -33,6 +31,11 @@ from airflow import AirflowException
 from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook
 from airflow.providers.google.cloud.hooks.os_login import OSLoginHook
 from airflow.providers.ssh.hooks.ssh import SSHHook
+
+# Paramiko should be imported after airflow.providers.ssh. Then the import will fail with
+# cannot import "airflow.providers.ssh" and will be correctly discovered as optional feature
+# TODO:(potiuk) We should add test harness detecting such cases shortly
+import paramiko  # isort:skip
 
 
 class _GCloudAuthorizedSSHClient(paramiko.SSHClient):


### PR DESCRIPTION
The paramiko import should be done after ssh provider to properly
detect it as an optional Google Provider feature.

Part of: #23033

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
