### PR TITLE
Improve logging of optional provider features messages

### DIFF
--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -182,7 +182,7 @@ class TestProviderManager(unittest.TestCase):
 
     @patch("airflow.providers_manager.import_string")
     def test_optional_feature_debug(self, mock_importlib_import_string):
-        with self._caplog.at_level(logging.DEBUG):
+        with self._caplog.at_level(logging.INFO):
             mock_importlib_import_string.side_effect = AirflowOptionalProviderFeatureException()
             providers_manager = ProvidersManager()
             providers_manager._hook_provider_dict["test_connection"] = HookClassProvider(
@@ -192,6 +192,5 @@ class TestProviderManager(unittest.TestCase):
                 hook_class_name=None, provider_info=None, package_name=None, connection_type="test_connection"
             )
             assert [
-                "Optional feature disabled on exception when importing 'HookClass' from "
-                "'test_package' package"
+                "Optional provider feature disabled when importing 'HookClass' from " "'test_package' package"
             ] == self._caplog.messages


### PR DESCRIPTION
The optional provider features are now better detected and we
are just logging an info message in case some missing imports
are detected during provider importing hooks.

Fixes: #23033

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
