### PR TITLE
Revert disabling run task button

### DIFF
--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Run.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Run.jsx
@@ -22,21 +22,15 @@ import {
   Button,
   Flex,
   ButtonGroup,
-  Tooltip,
 } from '@chakra-ui/react';
 
 import { useRunTask } from '../../../../api';
-import { getMetaValue } from '../../../../../utils';
-import { useContainerRef } from '../../../../context/containerRef';
-
-const canRun = getMetaValue('k8s_or_k8scelery_executor') === 'True';
 
 const Run = ({
   dagId,
   runId,
   taskId,
 }) => {
-  const containerRef = useContainerRef();
   const [ignoreAllDeps, setIgnoreAllDeps] = useState(false);
   const onToggleAllDeps = () => setIgnoreAllDeps(!ignoreAllDeps);
 
@@ -58,7 +52,7 @@ const Run = ({
 
   return (
     <Flex justifyContent="space-between" width="100%">
-      <ButtonGroup isAttached variant="outline" isDisabled={!canRun}>
+      <ButtonGroup isAttached variant="outline">
         <Button
           bg={ignoreAllDeps && 'gray.100'}
           onClick={onToggleAllDeps}
@@ -81,16 +75,9 @@ const Run = ({
           Ignore Task Deps
         </Button>
       </ButtonGroup>
-      <Tooltip
-        label="Only works with the Celery, CeleryKubernetes or Kubernetes executors"
-        shouldWrapChildren // Will show the tooltip even if the button is disabled
-        disabled={canRun}
-        portalProps={{ containerRef }}
-      >
-        <Button colorScheme="blue" onClick={onClick} isLoading={isLoading} disabled={!canRun}>
-          Run
-        </Button>
-      </Tooltip>
+      <Button colorScheme="blue" onClick={onClick} isLoading={isLoading}>
+        Run
+      </Button>
     </Flex>
   );
 };

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -284,9 +284,6 @@
             <input type="hidden" name="map_index">
             <input type="hidden" name="origin" value="{{ request.base_url }}">
             <div class="row">
-              <span class="col-xs-12 col-sm-9 text-danger" style="font-size: 12px">
-                {{ "Only works with the Celery, CeleryKubernetes or Kubernetes executors" if not k8s_or_k8scelery_executor else "" }}
-            </span>
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">
                 <label
                   class="btn btn-default"
@@ -305,7 +302,7 @@
                 </label>
               </span>
               <span class="col-xs-12 col-sm-3 task-instance-modal-column">
-                <button type="submit" id="btn_run" class="btn btn-primary btn-block" title="Runs a single task instance" {{ " disabled" if not k8s_or_k8scelery_executor else "" }}>
+                <button type="submit" id="btn_run" class="btn btn-primary btn-block" title="Runs a single task instance">
                   Run
                 </button>
               </span>


### PR DESCRIPTION
I messed up and forgot that the variable `k8s_or_k8scelery_executor` that we used to disable/enable the Run task button does not actually check for CeleryExecutor. This PR reverts that change and goes back to relying on the webserver to return an error instead of preemptively disabling the button.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
