### PR TITLE
Default Grid details panel to open vs closed

### DIFF
--- a/airflow/www/static/js/tree/Tree.jsx
+++ b/airflow/www/static/js/tree/Tree.jsx
@@ -42,7 +42,7 @@ import Details from './details';
 import { useSelection } from './context/selection';
 import { useAutoRefresh } from './context/autorefresh';
 
-const sidePanelKey = 'showSidePanel';
+const sidePanelKey = 'hideSidePanel';
 
 const Tree = () => {
   const scrollRef = useRef();
@@ -50,16 +50,16 @@ const Tree = () => {
   const [tableWidth, setTableWidth] = useState('100%');
   const { data: { groups = {}, dagRuns = [] } } = useTreeData();
   const { isRefreshOn, toggleRefresh, isPaused } = useAutoRefresh();
-  const isPanelOpen = JSON.parse(localStorage.getItem(sidePanelKey));
+  const isPanelOpen = localStorage.getItem(sidePanelKey) !== 'true';
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isPanelOpen });
 
   const { clearSelection } = useSelection();
   const toggleSidePanel = () => {
     if (!isOpen) {
-      localStorage.setItem(sidePanelKey, true);
+      localStorage.setItem(sidePanelKey, false);
     } else {
       clearSelection();
-      localStorage.setItem(sidePanelKey, false);
+      localStorage.setItem(sidePanelKey, true);
     }
     onToggle();
   };


### PR DESCRIPTION
We were defaulting the Grid view side panel to be closed. This can cause confusion for users because they don't see the Run and Task actions or other metadata. And may never think to click the open details button.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
