### PR TITLE
Add exception to catch single line private keys

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -415,7 +415,7 @@ class SSHHook(BaseHook):
         :return: ``paramiko.PKey`` appropriate for given key
         :raises AirflowException: if key cannot be read
         """
-        if private_key.count("\n") < 2:
+        if len(private_key.split("\n", 2)) < 2:
             raise AirflowException('Key must have BEGIN and END header/footer on separate lines.')
 
         for pkey_class in self._pkey_loaders:

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -415,6 +415,9 @@ class SSHHook(BaseHook):
         :return: ``paramiko.PKey`` appropriate for given key
         :raises AirflowException: if key cannot be read
         """
+        if private_key.count("\n") < 2:
+            raise AirflowException('Key must have BEGIN and END header/footer on separate lines.')
+
         for pkey_class in self._pkey_loaders:
             try:
                 key = pkey_class.from_private_key(StringIO(private_key), password=passphrase)

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -740,6 +740,24 @@ class TestSSHHook(unittest.TestCase):
             session.delete(conn)
             session.commit()
 
+    def test_oneline_key(self):
+        with pytest.raises(Exception) as e_info:
+            TEST_ONELINE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----asdfg-----END OPENSSH PRIVATE KEY-----"
+            session = settings.Session()
+            try:
+                conn = Connection(
+                    conn_id='openssh_pkey',
+                    host='localhost',
+                    conn_type='ssh',
+                    extra={"private_key": TEST_ONELINE_KEY},
+                )
+                session.add(conn)
+                session.flush()
+                hook = SSHHook(ssh_conn_id=conn.conn_id)
+            finally:
+                session.delete(conn)
+                session.commit()
+
     @pytest.mark.flaky(max_runs=5, min_passes=1)
     def test_exec_ssh_client_command(self):
         hook = SSHHook(

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -742,7 +742,7 @@ class TestSSHHook(unittest.TestCase):
 
     def test_oneline_key(self):
         with pytest.raises(Exception):
-            TEST_ONELINE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----asdfg-----END OPENSSH PRIVATE KEY-----"
+            TEST_ONELINE_KEY = "-----BEGIN OPENSSH" + "PRIVATE KEY-----asdfg-----END OPENSSH PRIVATE KEY-----"
             session = settings.Session()
             try:
                 conn = Connection(

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -741,7 +741,7 @@ class TestSSHHook(unittest.TestCase):
             session.commit()
 
     def test_oneline_key(self):
-        with pytest.raises(Exception) as e_info:
+        with pytest.raises(Exception):
             TEST_ONELINE_KEY = "-----BEGIN OPENSSH PRIVATE KEY-----asdfg-----END OPENSSH PRIVATE KEY-----"
             session = settings.Session()
             try:
@@ -753,7 +753,7 @@ class TestSSHHook(unittest.TestCase):
                 )
                 session.add(conn)
                 session.flush()
-                hook = SSHHook(ssh_conn_id=conn.conn_id)
+                SSHHook(ssh_conn_id=conn.conn_id)
             finally:
                 session.delete(conn)
                 session.commit()


### PR DESCRIPTION
This is to address issue #22576 where paramiko expects that any private keys provided have the BEGIN and END header/footer in separate lines. The exception should technically be thrown downstream, but since paramiko doesn't have a clear exception message or specific exception type, we catch it before using the key and present it back to the user.

[Relevant paramiko snippet](https://github.com/paramiko/paramiko/blob/main/paramiko/pkey.py#L325-L338)

closes: #22576