### PR TITLE
Fix Graph overflow, position and padding

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -125,6 +125,25 @@ g.node text {
   border-radius: 4px;
   background-color: #f0f0f0;
   cursor: move;
+  overflow: hidden;
+  height: 100%;
+  width: 100%;
+}
+
+#graph-svg {
+  overflow: visible;
+}
+
+.refresh-actions {
+  justify-content: flex-end;
+  min-width: 225px;
+  display: inline-flex;
+  align-items: center;
+  right: 20px;
+  margin-top: 10px;
+  margin-bottom: 15px;
+  position: absolute;
+  background-color: #f0f0f0ee; /* the last two chars apply an opacity to the background color */
 }
 
 .legend-item.dag {

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -246,7 +246,7 @@ function setUpZoomSupport() {
   const graphWidth = g.graph().width;
   const graphHeight = g.graph().height;
   // Get SVG dimensions
-  const padding = 20;
+  const padding = 80;
   const svgBb = svg.node().getBoundingClientRect();
   const width = svgBb.width - padding * 2;
   const height = svgBb.height - padding; // we are not centering the dag vertically


### PR DESCRIPTION
Fixes: #23042

The padding in the graph view is applied to the node and not the edge. Therefore an edge that goes above the highest node, can be cut off. Also, the autorefresh buttons creates a hidden cutoff where `overflow: hidden` style is being applied.

This fix increases the padding, makes the refresh actions absolutely positioned to prevent it from cutting off the screen, moves around which elements allow overflow or not, and then apply a transparent background to the refresh actions to make  any overlap less jarring.

![graph overflow demo](https://user-images.githubusercontent.com/4600967/163586211-977db726-5bed-4ad6-9fa4-cd364b1c0b59.gif)

This moves a lot right now, so I want to make sure it works for all DAGs so we will merge this _after_ 2.3.0.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
