### PR TITLE
Added uninstall apache-airflow-breeze with pipx

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1435,3 +1435,13 @@ Breeze uses built-in capability of ``rich`` to record and print the command help
 It's enabled by setting ``RECORD_BREEZE_OUTPUT_FILE`` to a file name where it will be recorded.
 By default it records the screenshots with default characters width and with "Breeze screenshot" title,
 but you can override it with ``RECORD_BREEZE_WIDTH`` and ``RECORD_BREEZE_TITLE`` variables respectively.
+
+Uninstalling Breeze
+===================
+Breeze was installed with ``pix``, with ``pipx list``, you can list the installed packages.
+Once you have the name of the package you can proceed to uninstall it.
+.. code-block:: bash
+    pipx list
+This will also remove breeze from the folder: ${HOME}.local/bin/
+.. code-block:: bash
+    pipx uninstall apache-airflow-breeze

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1440,8 +1440,13 @@ Uninstalling Breeze
 ===================
 Breeze was installed with ``pix``, with ``pipx list``, you can list the installed packages.
 Once you have the name of the package you can proceed to uninstall it.
+
 .. code-block:: bash
+
     pipx list
+
 This will also remove breeze from the folder: ${HOME}.local/bin/
+
 .. code-block:: bash
+
     pipx uninstall apache-airflow-breeze

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1438,14 +1438,14 @@ but you can override it with ``RECORD_BREEZE_WIDTH`` and ``RECORD_BREEZE_TITLE``
 
 Uninstalling Breeze
 ===================
-Breeze was installed with ``pix``, with ``pipx list``, you can list the installed packages.
-Once you have the name of the package you can proceed to uninstall it.
+Breeze was installed with ``pipx``, with ``pipx list``, you can list the installed packages.
+Once you have the name of ``breeze`` package you can proceed to uninstall it.
 
 .. code-block:: bash
 
     pipx list
 
-This will also remove breeze from the folder: ${HOME}.local/bin/
+This will also remove breeze from the folder: ``${HOME}.local/bin/``
 
 .. code-block:: bash
 


### PR DESCRIPTION

closes #23005 
In case the user doesn't want to use breeze, the documentation to uninstall breeze with `pipx` is in BREEZE.rst




<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
