### PR TITLE
Ensure TaskMap only checks "relevant" dependencies

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -266,7 +266,7 @@ class BackfillJob(BaseJob):
             if ti.state not in self.STATES_COUNT_AS_RUNNING:
                 # Don't use ti.task; if this task is mapped, that attribute
                 # would hold the unmapped task. We need to original task here.
-                for node in self.dag.get_task(ti.task_id, include_subdags=True).mapped_dependants():
+                for node in self.dag.get_task(ti.task_id, include_subdags=True).iter_mapped_dependants():
                     new_tis, num_mapped_tis = node.expand_mapped_task(ti.run_id, session=session)
                     yield node, ti.run_id, new_tis, num_mapped_tis
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -30,6 +30,7 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    Iterator,
     List,
     Optional,
     Sequence,
@@ -76,6 +77,7 @@ if TYPE_CHECKING:
 
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.models.dag import DAG
+    from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
@@ -774,6 +776,13 @@ class MappedOperator(AbstractOperator):
             if i == found_index:
                 return k, v
         raise IndexError(f"index {map_index} is over mapped length")
+
+    def iter_mapped_dependencies(self) -> Iterator["Operator"]:
+        """Upstream dependencies that provide XComs used by this task for task mapping."""
+        from airflow.models.xcom_arg import XComArg
+
+        for ref in XComArg.iter_xcom_args(self._get_expansion_kwargs()):
+            yield ref.operator
 
     @cached_property
     def parse_time_mapped_ti_count(self) -> Optional[int]:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2333,7 +2333,7 @@ class TaskInstance(Base, LoggingMixin):
         # currently possible for a downstream to depend on one individual mapped
         # task instance, only a task as a whole. This will change in AIP-42
         # Phase 2, and we'll need to further analyze the mapped task case.
-        if task.is_mapped or not task.has_mapped_dependants():
+        if task.is_mapped or next(task.iter_mapped_dependants(), None) is None:
             return
         if value is None:
             raise XComForMappingNotPushed()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2382,8 +2382,8 @@ class TestTaskInstanceRecordTaskMapXComPush:
             session.query(TaskMap).delete()
 
     @pytest.mark.parametrize("xcom_value", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
-    def test_not_recorded_for_unused(self, dag_maker, xcom_value):
-        """A value not used for task-mapping should not be recorded."""
+    def test_not_recorded_if_leaf(self, dag_maker, xcom_value):
+        """Return value should not be recorded if there are no downstreams."""
         with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
 
             @dag.task()
@@ -2396,6 +2396,53 @@ class TestTaskInstanceRecordTaskMapXComPush:
         ti.run()
 
         assert dag_maker.session.query(TaskMap).count() == 0
+
+    @pytest.mark.parametrize("xcom_value", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
+    def test_not_recorded_if_not_used(self, dag_maker, xcom_value):
+        """Return value should not be recorded if no downstreams are mapped."""
+        with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
+
+            @dag.task()
+            def push_something():
+                return xcom_value
+
+            @dag.task()
+            def completely_different():
+                pass
+
+            push_something() >> completely_different()
+
+        ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
+        ti.run()
+
+        assert dag_maker.session.query(TaskMap).count() == 0
+
+    @pytest.mark.parametrize("xcom_value", [[1, 2, 3], {"a": 1, "b": 2}, "abc"])
+    def test_not_recorded_if_irrelevant(self, dag_maker, xcom_value):
+        """Return value should only be recorded if a mapped downstream uses the it."""
+        with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
+
+            @dag.task()
+            def push_1():
+                return xcom_value
+
+            @dag.task()
+            def push_2():
+                return [-1, -2]
+
+            @dag.task()
+            def show(arg1, arg2):
+                print(arg1, arg2)
+
+            show.partial(arg1=push_1()).expand(arg2=push_2())
+
+        tis = {ti.task_id: ti for ti in dag_maker.create_dagrun().task_instances}
+
+        tis["push_1"].run()
+        assert dag_maker.session.query(TaskMap).count() == 0
+
+        tis["push_2"].run()
+        assert dag_maker.session.query(TaskMap).count() == 1
 
     @pytest.mark.parametrize(
         "return_value, exception_type, error_message",


### PR DESCRIPTION
When looking for "mapped dependants" of a task, we only want a task if it not only is a direct downstream of the task, but also it actually "uses" the task's pushed XCom for task mapping. So we need to peek into the mapped downstream task's expansion kwargs, and only count it as a mapped dependant if the upstream is referenced there.

Fix #23018.