### PR TITLE
Add server default for map_index in Log table

### DIFF
--- a/airflow/migrations/versions/0107_75d5ed6c2b43_add_map_index_to_log.py
+++ b/airflow/migrations/versions/0107_75d5ed6c2b43_add_map_index_to_log.py
@@ -23,7 +23,7 @@ Revises: 909884dea523
 Create Date: 2022-03-15 16:35:54.816863
 """
 from alembic import op
-from sqlalchemy import Column, Integer, text
+from sqlalchemy import Column, Integer
 
 # Revision identifiers, used by Alembic.
 revision = "75d5ed6c2b43"
@@ -35,7 +35,7 @@ airflow_version = '2.3.0'
 
 def upgrade():
     """Add map_index to Log."""
-    op.add_column("log", Column("map_index", Integer, server_default=text('NULL')))
+    op.add_column("log", Column("map_index", Integer))
 
 
 def downgrade():

--- a/airflow/migrations/versions/0107_75d5ed6c2b43_add_map_index_to_log.py
+++ b/airflow/migrations/versions/0107_75d5ed6c2b43_add_map_index_to_log.py
@@ -23,7 +23,7 @@ Revises: 909884dea523
 Create Date: 2022-03-15 16:35:54.816863
 """
 from alembic import op
-from sqlalchemy import Column, Integer
+from sqlalchemy import Column, Integer, text
 
 # Revision identifiers, used by Alembic.
 revision = "75d5ed6c2b43"
@@ -35,7 +35,7 @@ airflow_version = '2.3.0'
 
 def upgrade():
     """Add map_index to Log."""
-    op.add_column("log", Column("map_index", Integer))
+    op.add_column("log", Column("map_index", Integer, server_default=text('NULL')))
 
 
 def downgrade():

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sqlalchemy import Column, Index, Integer, String, Text
+from sqlalchemy import Column, Index, Integer, String, Text, text
 
 from airflow.models.base import Base, StringID
 from airflow.utils import timezone
@@ -32,7 +32,7 @@ class Log(Base):
     dttm = Column(UtcDateTime)
     dag_id = Column(StringID())
     task_id = Column(StringID())
-    map_index = Column(Integer)
+    map_index = Column(Integer, server_default=text('NULL'))
     event = Column(String(30))
     execution_date = Column(UtcDateTime)
     owner = Column(String(500))


### PR DESCRIPTION
When logging CLI actions we insert a record into the Log table.  But for 2.3 we add column map_index to Log, and if the Log model expects map_index to be there the insert will fail and a warning will be emitted.

We can avoid the error and warning by adding a server_default of NULL on map_index in Log. I choose NULL instead of -1 because generally speaking map_index doesn't make sense for Log tables.
