### PR TITLE
Correct default conn ID in WASB connection doc

### DIFF
--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
@@ -48,7 +48,7 @@ configure multiple connections.
 Default Connection IDs
 ----------------------
 
-All hooks and operators related to Microsoft Azure Blob Storage use ``azure_container_volume_default`` by default.
+All hooks and operators related to Microsoft Azure Blob Storage use ``wasb_default`` by default.
 
 Configuring the Connection
 --------------------------


### PR DESCRIPTION
The current connection doc references `azure_container_volume_default` as the default connection ID for all things Azure Blob Storage which is incorrect.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
