### PR TITLE
Protect against using try_number from context in provider

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_check_2_1_compatibility.py
+++ b/scripts/ci/pre_commit/pre_commit_check_2_1_compatibility.py
@@ -35,6 +35,7 @@ errors: List[str] = []
 
 GET_ATTR_MATCHER = re.compile(r".*getattr\((ti|TI), ['\"]run_id['\"]\).*")
 TI_RUN_ID_MATCHER = re.compile(r".*(ti|TI)\.run_id.*")
+TRY_NUM_MATCHER = re.compile(r".*context.*\[[\"']try_number[\"']].*")
 
 
 def _check_file(_file: Path):
@@ -78,6 +79,15 @@ def _check_file(_file: Path):
                 f"(Airflow 2.3+ only):[/]\n\n"
                 f"{lines[index]}\n\n"
                 f"[yellow]You should not use map_index field in providers "
+                f"as it is not available in Airflow 2.2[/]"
+            )
+
+        if TRY_NUM_MATCHER.match(line):
+            errors.append(
+                f"[red]In {_file}:{index} there is a forbidden construct "
+                f"(Airflow 2.3+ only):[/]\n\n"
+                f"{lines[index]}\n\n"
+                f"[yellow]You should not expect try_number field for context in providers "
                 f"as it is not available in Airflow 2.2[/]"
             )
 


### PR DESCRIPTION
This is a (temporary and not perfect - until we figure out a better way)
protection against using constructs and interfaces which are not
present in Airflow 2.1 in providers.

Follow-up after #23059

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
