### PR TITLE
`GoogleDriveToGCSOperator`: Remove `destination_bucket`, `destination_object`

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -34,6 +34,8 @@ Breaking changes
    For more information, see `Deprecation and sunset <https://developers.google.com/google-ads/api/docs/sunset-dates>`_
    and `Upgrading to the newest version <https://developers.google.com/google-ads/api/docs/version-migration>`_
 
+* ``GoogleDriveToGCSOperator``: Remove ``destination_bucket`` and ``destination_object``. Please use ``bucket_name`` and ``object_name``.
+
 6.8.0
 .....
 

--- a/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import warnings
 from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
@@ -38,8 +37,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
         file should be written to
     :param object_name: The Google Cloud Storage object name for the object created by the operator.
         For example: ``path/to/my/file/file.txt``.
-    :param destination_bucket: Same as bucket_name, but for backward compatibly
-    :param destination_object: Same as object_name, but for backward compatibly
     :param folder_id: The folder id of the folder in which the Google Drive file resides
     :param file_name: The name of the file residing in Google Drive
     :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
@@ -69,10 +66,8 @@ class GoogleDriveToGCSOperator(BaseOperator):
     def __init__(
         self,
         *,
-        bucket_name: Optional[str] = None,
+        bucket_name: str,
         object_name: Optional[str] = None,
-        destination_bucket: Optional[str] = None,  # deprecated
-        destination_object: Optional[str] = None,  # deprecated
         file_name: str,
         folder_id: str,
         drive_id: Optional[str] = None,
@@ -82,23 +77,8 @@ class GoogleDriveToGCSOperator(BaseOperator):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if destination_bucket:
-            warnings.warn(
-                "`destination_bucket` is deprecated please use `bucket_name`",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        actual_bucket = destination_bucket or bucket_name
-        if actual_bucket is None:
-            raise RuntimeError("One of the destination_bucket or bucket_name must be set")
-        self.bucket_name: str = actual_bucket
-        self.object_name = destination_object or object_name
-        if destination_object:
-            warnings.warn(
-                "`destination_object` is deprecated please use `object_name`",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+        self.bucket_name = bucket_name
+        self.object_name = object_name
         self.folder_id = folder_id
         self.drive_id = drive_id
         self.file_name = file_name

--- a/tests/providers/google/cloud/transfers/test_gdrive_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gdrive_to_gcs.py
@@ -39,8 +39,8 @@ class TestGoogleDriveToGCSOperator:
             folder_id=FOLDER_ID,
             file_name=FILE_NAME,
             drive_id=DRIVE_ID,
-            destination_bucket=BUCKET,
-            destination_object=OBJECT,
+            bucket_name=BUCKET,
+            object_name=OBJECT,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )


### PR DESCRIPTION
The next Google provider release is major (breaking changes) so I want to take the opportunity to clean up some deprecations

Related: https://github.com/apache/airflow/pull/23050
