### PR TITLE
Fix timezone display for logs on UI

### DIFF
--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -78,7 +78,7 @@ export function updateAllDateTimes() {
     const dt = moment($el.attr('datetime'));
     // eslint-disable-next-line no-underscore-dangle
     if (dt._isValid) {
-      $el.text(dt.format(defaultFormat));
+      $el.text(dt.format($el.data('with-tz') ? defaultFormatWithTZ : defaultFormat));
     }
     if ($el.attr('title') !== undefined) {
       // If displayed date is not UTC, have the UTC date in a title attribute

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global document, window, $, moment, Airflow */
+/* global document, window, $ */
 import { escapeHtml } from './main';
 import { getMetaValue } from './utils';
 import { formatDateTime } from './datetime_utils';
@@ -118,10 +118,9 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 
         // The message may contain HTML, so either have to escape it or write it as text.
         const escapedMessage = escapeHtml(item[1]);
-        const tzOffset = moment().tz(Airflow.serverTimezone).format('Z');
         const linkifiedMessage = escapedMessage
           .replace(urlRegex, (url) => `<a href="${url}" target="_blank">${url}</a>`)
-          .replaceAll(dateRegex, (date) => `<time datetime="${date}${tzOffset}">${formatDateTime(`${date}${tzOffset}`)}</time>`);
+          .replaceAll(dateRegex, (date) => `<time datetime="${date}+00:00" data-with-tz="true">${formatDateTime(`${date}+00:00`)}</time>`);
         logBlock.innerHTML += `${linkifiedMessage}\n`;
       });
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have fixed the bug with logs display in UI. The problem is that our time conversion doesn't work correctly. I will try to describe it below. On server side we create a logs in UTC time. After that on UI JavaScript takes this logs and for each timestamps changes UTC flag to flag which is indicated like serverTimezone. But without time conversion, for example for PDT timezone: 2022-04-13 12:15:00,117+00:00 time in log file, on UI will be changed to 2022-04-13 12:15:00,117−07:00 time. Then another JS code using a correct convert function converts this timestamp to a time with a serverTimezone and in result we will see 2022-04-13, 12:15:00 PDT. How you see now we have UTC time with PDT label and each next conversion will create an incorrect time view.

Co-authored-by: Wojciech Januszek [januszek@google.com](mailto:januszek@google.com)
Co-authored-by: Lukasz Wyszomirski [wyszomirski@google.com](mailto:wyszomirski@google.com)
Co-authored-by: Maksim Yermakou [maksimy@google.com](mailto:maksimy@google.com)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
