### PR TITLE
Fix artifact for MyPy checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -744,11 +744,17 @@ repos:
         ## ADD MOST PRE-COMMITS ABOVE THAT LINE
         # The below pre-commits are those requiring CI image to be built
       - id: mypy
-        name: Run mypy
+        name: Run mypy for core
         language: system
         entry: ./scripts/ci/pre_commit/pre_commit_mypy.sh --namespace-packages
         files: \.py$
-        exclude: ^provider_packages|^docs|^airflow/_vendor/
+        exclude: ^provider_packages|^docs|^airflow/_vendor/|^airflow/providers|^airflow/migrations
+        require_serial: true
+      - id: mypy
+        name: Run mypy for providers
+        language: system
+        entry: ./scripts/ci/pre_commit/pre_commit_mypy.sh --namespace-packages
+        files: ^airflow/providers/.*\.py$
         require_serial: true
       - id: mypy
         name: Run mypy for /docs/ folder

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -32,7 +32,8 @@ from airflow.exceptions import (
     AirflowSensorTimeout,
     AirflowSkipException,
 )
-from airflow.models import BaseOperator, SensorInstance
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.sensorinstance import SensorInstance
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep


### PR DESCRIPTION
Occasionally MyPy detects errors which have not been detected
before. This is likely caused by having too many files passed
to MyPY. If the number of files to pass to MyPy is too big,
pre-commit will automatically split the list of files into
several "mypy" commands. If we are unlucky the list of files
will cause MyPy to detect slightly different errors.

We split the mypy checks to be run separately for airflow core
and airflow providers to limit the list of files to be shorter.

We are also preparing for splitting off providers so this is
good idea in general.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
