### PR TITLE
Revoke DAG specific permissions once access_control gets empty value

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -503,8 +503,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
                 if (action_name, dag_resource_name) not in perms:
                     self._merge_perm(action_name, dag_resource_name)
 
-            if dag.access_control:
-                self.sync_perm_for_dag(dag_resource_name, dag.access_control)
+            self.sync_perm_for_dag(dag_resource_name, dag.access_control)
 
     def update_admin_permission(self):
         """
@@ -572,8 +571,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         for dag_action_name in self.DAG_ACTIONS:
             self.create_permission(dag_action_name, dag_resource_name)
 
-        if access_control:
-            self._sync_dag_view_permissions(dag_resource_name, access_control)
+        self._sync_dag_view_permissions(dag_resource_name, access_control)
 
     def _sync_dag_view_permissions(self, dag_id, access_control):
         """
@@ -583,6 +581,9 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         :param access_control: a dict where each key is a rolename and
             each value is a set() of action names (e.g. {'can_read'})
         """
+        if access_control is None:
+            access_control = {}
+
         dag_resource_name = permissions.resource_name_for_dag(dag_id)
 
         def _get_or_create_dag_permission(action_name: str) -> Optional[Permission]:


### PR DESCRIPTION
This change is follow-up to this change https://github.com/apache/airflow/pull/15311 and https://github.com/apache/airflow/pull/15464.

Basically this change assures that DAG specific permissions are revoked once access_control field is emptied for DAG.

closes: #17508
related: #8609


