### PR TITLE
Make copy button blue

### DIFF
--- a/airflow/www/static/js/tree/Clipboard.jsx
+++ b/airflow/www/static/js/tree/Clipboard.jsx
@@ -60,6 +60,6 @@ export const ClipboardButton = forwardRef(
 export const ClipboardText = ({ value }) => (
   <>
     {value}
-    <ClipboardButton value={value} iconOnly variant="ghost" size="xs" fontSize="lg" ml={1} />
+    <ClipboardButton value={value} iconOnly variant="ghost" size="xs" fontSize="xl" ml={1} />
   </>
 );

--- a/airflow/www/static/js/tree/Clipboard.jsx
+++ b/airflow/www/static/js/tree/Clipboard.jsx
@@ -18,6 +18,7 @@ export const ClipboardButton = forwardRef(
       iconOnly = false,
       label = 'copy',
       title = 'Copy',
+      colorScheme = 'blue',
       'aria-label': ariaLabel = 'Copy',
       ...rest
     },
@@ -31,6 +32,7 @@ export const ClipboardButton = forwardRef(
       variant,
       title,
       ref,
+      colorScheme,
       ...rest,
     };
 


### PR DESCRIPTION
Our actions are blue, copy button is an action, ergo it should be blue as well

<img width="386" alt="Screen Shot 2022-04-20 at 9 33 59 AM" src="https://user-images.githubusercontent.com/4600967/164248899-b0199085-5532-4a5d-ba3f-2325b85263d1.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
