### PR TITLE
Don't try to truncate tracebacks in Tasks outside of "user" code

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -23,18 +23,17 @@ import math
 import os
 import pickle
 import signal
-import threading
 import warnings
 from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import partial
-from inspect import currentframe
 from tempfile import NamedTemporaryFile
 from types import TracebackType
 from typing import (
     IO,
     TYPE_CHECKING,
     Any,
+    Callable,
     ContextManager,
     Dict,
     Generator,
@@ -136,8 +135,6 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG, DagModel
     from airflow.models.dagrun import DagRun
     from airflow.models.operator import Operator
-
-_TASK_EXECUTION_FRAME_LOCAL_STORAGE = threading.local()
 
 
 @contextlib.contextmanager
@@ -1625,31 +1622,27 @@ class TaskInstance(Base, LoggingMixin):
             execute_callable = task_to_execute.execute
         # If a timeout is specified for the task, make it fail
         # if it goes beyond
-        try:
-            if task_to_execute.execution_timeout:
-                # If we are coming in with a next_method (i.e. from a deferral),
-                # calculate the timeout from our start_date.
-                if self.next_method:
-                    timeout_seconds = (
-                        task_to_execute.execution_timeout - (timezone.utcnow() - self.start_date)
-                    ).total_seconds()
-                else:
-                    timeout_seconds = task_to_execute.execution_timeout.total_seconds()
-                try:
-                    # It's possible we're already timed out, so fast-fail if true
-                    if timeout_seconds <= 0:
-                        raise AirflowTaskTimeout()
-                    # Run task in timeout wrapper
-                    with timeout(timeout_seconds):
-                        result = execute_callable(context=context)
-                except AirflowTaskTimeout:
-                    task_to_execute.on_kill()
-                    raise
+        if task_to_execute.execution_timeout:
+            # If we are coming in with a next_method (i.e. from a deferral),
+            # calculate the timeout from our start_date.
+            if self.next_method:
+                timeout_seconds = (
+                    task_to_execute.execution_timeout - (timezone.utcnow() - self.start_date)
+                ).total_seconds()
             else:
-                result = execute_callable(context=context)
-        except:  # noqa: E722
-            _TASK_EXECUTION_FRAME_LOCAL_STORAGE.frame = currentframe()
-            raise
+                timeout_seconds = task_to_execute.execution_timeout.total_seconds()
+            try:
+                # It's possible we're already timed out, so fast-fail if true
+                if timeout_seconds <= 0:
+                    raise AirflowTaskTimeout()
+                # Run task in timeout wrapper
+                with timeout(timeout_seconds):
+                    result = execute_callable(context=context)
+            except AirflowTaskTimeout:
+                task_to_execute.on_kill()
+                raise
+        else:
+            result = execute_callable(context=context)
         with create_session() as session:
             if task_to_execute.do_xcom_push:
                 xcom_value = result
@@ -1845,33 +1838,21 @@ class TaskInstance(Base, LoggingMixin):
         session.commit()
         self.log.info('Rescheduling task, marking task as UP_FOR_RESCHEDULE')
 
-    def get_truncated_error_traceback(self, error: BaseException) -> Optional[TracebackType]:
+    @staticmethod
+    def get_truncated_error_traceback(error: BaseException, truncate_to: Callable) -> Optional[TracebackType]:
         """
-        Returns truncated error traceback.
-
-        This method returns traceback of the error truncated to the
-        frame saved by earlier try/except along the way. If the frame
-        is found, the traceback will be truncated to below the frame.
+        Truncates the traceback of an exception to the first frame called from within a given function
 
         :param error: exception to get traceback from
-        :return: traceback to print
+        :param truncate_to: Function to truncate TB to. Must have a ``__code__`` attribute
+
+        :meta private:
         """
         tb = error.__traceback__
-        try:
-            execution_frame = _TASK_EXECUTION_FRAME_LOCAL_STORAGE.frame
-        except AttributeError:
-            self.log.warning(
-                "We expected to get frame set in local storage but it was not."
-                " Please report this as an issue with full logs"
-                " at https://github.com/apache/airflow/issues/new",
-                exc_info=True,
-            )
-            return tb
-        _TASK_EXECUTION_FRAME_LOCAL_STORAGE.frame = None
+        code = truncate_to.__func__.__code__  # type: ignore[attr-defined]
         while tb is not None:
-            if tb.tb_frame is execution_frame:
-                tb = tb.tb_next
-                break
+            if tb.tb_frame.f_code is code:
+                return tb.tb_next
             tb = tb.tb_next
         return tb or error.__traceback__
 
@@ -1890,7 +1871,7 @@ class TaskInstance(Base, LoggingMixin):
 
         if error:
             if isinstance(error, BaseException):
-                tb = self.get_truncated_error_traceback(error)
+                tb = self.get_truncated_error_traceback(error, truncate_to=self._execute_task)
                 self.log.error("Task failed with exception", exc_info=(type(error), error, tb))
             else:
                 self.log.error("%s", error)


### PR DESCRIPTION
There are a few ways we can get an exception before ever making it to user code, and if that happens _also_ warning about "this shouldn't happen" is obfuscating the original error.

Before:

```
[2022-04-20, 14:48:44 BST]  1103834 QueuedLocalWorker-3 {{airflow.models.taskinstance.TaskInstance taskinstance.py:1865}} WARNING - We expected to get frame set in local storage but it was not. Please report this as an issue with full logs at https://github.com/apache/airflow/issues/new
Traceback (most recent call last):
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 1442, in _run_raw_task
    self._execute_task_with_callbacks(context, test_mode)
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 1546, in _execute_task_with_callbacks
    task_orig = self.render_templates(context=context)
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 2210, in render_templates
    rendered_task = self.task.render_template_fields(context)
  File "/home/ash/code/airflow/airflow/airflow/models/mappedoperator.py", line 724, in render_template_fields
    unmapped_task = self.unmap(unmap_kwargs=kwargs)
  File "/home/ash/code/airflow/airflow/airflow/models/mappedoperator.py", line 510, in unmap
    op = self.operator_class(**unmap_kwargs, _airflow_from_mapped=True)
  File "/home/ash/code/airflow/airflow/airflow/models/baseoperator.py", line 390, in apply_defaults
    result = func(self, **kwargs, default_args=default_args)
  File "/home/ash/code/airflow/airflow/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 259, in __init__
    self.name = self._set_name(name)
  File "/home/ash/code/airflow/airflow/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 442, in _set_name
    raise AirflowException("`name` is required unless `pod_template_file` or `full_pod_spec` is set")
airflow.exceptions.AirflowException: `name` is required unless `pod_template_file` or `full_pod_spec` is set

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 1863, in get_truncated_error_traceback
    execution_frame = _TASK_EXECUTION_FRAME_LOCAL_STORAGE.frame
AttributeError: '_thread._local' object has no attribute 'frame'
[2022-04-20, 14:48:44 BST]  1103834 QueuedLocalWorker-3 {{airflow.models.taskinstance.TaskInstance taskinstance.py:1896}} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 1442, in _run_raw_task
    self._execute_task_with_callbacks(context, test_mode)
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 1546, in _execute_task_with_callbacks
    task_orig = self.render_templates(context=context)
  File "/home/ash/code/airflow/airflow/airflow/models/taskinstance.py", line 2210, in render_templates
    rendered_task = self.task.render_template_fields(context)
  File "/home/ash/code/airflow/airflow/airflow/models/mappedoperator.py", line 724, in render_template_fields
    unmapped_task = self.unmap(unmap_kwargs=kwargs)
  File "/home/ash/code/airflow/airflow/airflow/models/mappedoperator.py", line 510, in unmap
    op = self.operator_class(**unmap_kwargs, _airflow_from_mapped=True)
  File "/home/ash/code/airflow/airflow/airflow/models/baseoperator.py", line 390, in apply_defaults
    result = func(self, **kwargs, default_args=default_args)
  File "/home/ash/code/airflow/airflow/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 259, in __init__
    self.name = self._set_name(name)
  File "/home/ash/code/airflow/airflow/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 442, in _set_name
    raise AirflowException("`name` is required unless `pod_template_file` or `full_pod_spec` is set")
airflow.exceptions.AirflowException: `name` is required unless `pod_template_file` or `full_pod_spec` is set
```

After we only see the error once, which is much better


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).