### PR TITLE
Switch bitnami images in tests to "standard" ones

### DIFF
--- a/tests/providers/docker/decorators/test_docker.py
+++ b/tests/providers/docker/decorators/test_docker.py
@@ -24,7 +24,7 @@ DEFAULT_DATE = timezone.datetime(2021, 9, 1)
 
 class TestDockerDecorator:
     def test_basic_docker_operator(self, dag_maker):
-        @task.docker(image="quay.io/bitnami/python:3.9")
+        @task.docker(image="python:3.9-slim")
         def f():
             import random
 
@@ -39,7 +39,7 @@ class TestDockerDecorator:
         assert len(ti.xcom_pull()) == 100
 
     def test_basic_docker_operator_with_param(self, dag_maker):
-        @task.docker(image="quay.io/bitnami/python:3.9")
+        @task.docker(image="python:3.9-slim")
         def f(num_results):
             import random
 
@@ -57,7 +57,7 @@ class TestDockerDecorator:
 
     def test_basic_docker_operator_multiple_output(self, dag_maker):
         @task.docker(
-            image="quay.io/bitnami/python:3.9",
+            image="python:3.9-slim",
             multiple_outputs=True,
         )
         def return_dict(number: int):
@@ -76,7 +76,7 @@ class TestDockerDecorator:
         assert ti.xcom_pull() == {"number": test_number + 1, "43": 43}
 
     def test_no_return(self, dag_maker):
-        @task.docker(image="quay.io/bitnami/python:3.9")
+        @task.docker(image="python:3.9-slim")
         def f():
             pass
 
@@ -92,7 +92,7 @@ class TestDockerDecorator:
         """Test calling decorated function 21 times in a DAG"""
 
         @task.docker(
-            image="quay.io/bitnami/python:3.9",
+            image="python:3.9-slim",
             network_mode="bridge",
             api_version="auto",
         )


### PR DESCRIPTION
We aren't using anything special in those images, and all of bitnami's images on quay.io seem to have disappeared.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).