### PR TITLE
KubernetesHook should try incluster first when not otherwise configured

### DIFF
--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -114,8 +114,8 @@ class TestKubernetesHook:
         in_cluster_fails,
     ):
         """
-        Verifies whether in_cluster is called depending on combination of hook param and connection extra.
-        Hook param should beat extra.
+        Verifies the behavior of the ``_get_default_client`` function.  It should try the "in cluster"
+        loader first but if that fails, try to use the default kubeconfig file.
         """
         if in_cluster_fails:
             mock_incluster.side_effect = ConfigException('any')

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -100,9 +100,6 @@ class TestKubernetesHook:
             mock_loader.assert_not_called()
         else:
             mock_get_default_client.assert_called()
-            # mock_in_cluster_loader.assert_not_called()
-            # mock_merger.assert_called_once_with(KUBE_CONFIG_PATH)
-            # mock_loader.assert_called_once()
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize('in_cluster_fails', [True, False])

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -25,6 +25,7 @@ from unittest.mock import patch
 
 import kubernetes
 import pytest
+from kubernetes.config import ConfigException
 
 from airflow import AirflowException
 from airflow.models import Connection
@@ -75,8 +76,10 @@ class TestKubernetesHook:
     @patch("kubernetes.config.kube_config.KubeConfigLoader")
     @patch("kubernetes.config.kube_config.KubeConfigMerger")
     @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
+    @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
     def test_in_cluster_connection(
         self,
+        mock_get_default_client,
         mock_in_cluster_loader,
         mock_merger,
         mock_loader,
@@ -89,15 +92,46 @@ class TestKubernetesHook:
         Hook param should beat extra.
         """
         kubernetes_hook = KubernetesHook(conn_id=conn_id, in_cluster=in_cluster_param)
+        mock_get_default_client.return_value = kubernetes.client.api_client.ApiClient()
         api_conn = kubernetes_hook.get_conn()
         if in_cluster_called:
             mock_in_cluster_loader.assert_called_once()
             mock_merger.assert_not_called()
             mock_loader.assert_not_called()
         else:
-            mock_in_cluster_loader.assert_not_called()
+            mock_get_default_client.assert_called()
+            # mock_in_cluster_loader.assert_not_called()
+            # mock_merger.assert_called_once_with(KUBE_CONFIG_PATH)
+            # mock_loader.assert_called_once()
+        assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
+
+    @pytest.mark.parametrize('in_cluster_fails', [True, False])
+    @patch("kubernetes.config.kube_config.KubeConfigLoader")
+    @patch("kubernetes.config.kube_config.KubeConfigMerger")
+    @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
+    def test_get_default_client(
+        self,
+        mock_incluster,
+        mock_merger,
+        mock_loader,
+        in_cluster_fails,
+    ):
+        """
+        Verifies whether in_cluster is called depending on combination of hook param and connection extra.
+        Hook param should beat extra.
+        """
+        if in_cluster_fails:
+            mock_incluster.side_effect = ConfigException('any')
+        kubernetes_hook = KubernetesHook()
+        api_conn = kubernetes_hook._get_default_client()
+        if in_cluster_fails:
+            mock_incluster.assert_called_once()
             mock_merger.assert_called_once_with(KUBE_CONFIG_PATH)
             mock_loader.assert_called_once()
+        else:
+            mock_incluster.assert_called_once()
+            mock_merger.assert_not_called()
+            mock_loader.assert_not_called()
         assert isinstance(api_conn, kubernetes.client.api_client.ApiClient)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
**note** this is part of the path to getting k8s hook into KPO, but i've separated it out for easier review.

Currently when K8s hook receives no configuration (e.g. incluster vs config file content vs config file path) the default client generation process will try to load the kube config in the default location.  This is inconsistent with airflow core's behavior in kubernetes executor and kubernetes pod operator (in_cluster=True is the default with those).

To make k8s hook's behavior consistent, we can first try incluster, then if that fails, try default kubeconfig.  This should be safe to do.  The kubernetes client will check for 2 environment variables that an in-cluster environment should have and if it doesn't find them, it will raise ConfigException (see here: https://github.com/kubernetes-client/python/blob/1271465acdb80bf174c50564a384fd6898635ea6/kubernetes/base/config/incluster_config.py#L60-L62).  If ConfigException is raised, K8s hook will fall back to looking for the default config.
