### PR TITLE
image building documentation: adding new provider example

### DIFF
--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -292,7 +292,7 @@ Example of adding Airflow Provider package and ``apt`` package
 The following example adds ``apache-spark`` airflow-providers which requires both ``java`` and
 python package from PyPI.
 
-.. exampleinclude:: docker-examples/extending/add-provider-extend/Dockerfile
+.. exampleinclude:: docker-examples/extending/add-providers/Dockerfile
     :language: Dockerfile
     :start-after: [START Dockerfile]
     :end-before: [END Dockerfile]

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -275,7 +275,7 @@ Examples of image extending
 ---------------------------
 
 Example of customizing Airflow Provider packages
-..............................................
+................................................
 
 The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of core
 Airflow and sometimes you might want to upgrade specific providers only to fix some problems or
@@ -286,10 +286,11 @@ use features available in that provider version. Here is an example of how you c
     :start-after: [START Dockerfile]
     :end-before: [END Dockerfile]
 
-Example of adding Airflow Provider packages
-...................................................
+Example of adding Airflow Provider package and ``apt`` package
+..............................................................
 
-The following example adds ``apache-spark`` airflow-providers which requires both ``java``.
+The following example adds ``apache-spark`` airflow-providers which requires both ``java`` and
+python package from PyPI.
 
 .. exampleinclude:: docker-examples/extending/add-provider-extend/Dockerfile
     :language: Dockerfile

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -274,18 +274,27 @@ You should be aware, about a few things:
 Examples of image extending
 ---------------------------
 
-Example of upgrading Airflow Provider packages
+Example of customizing Airflow Provider packages
 ..............................................
 
 The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of core
 Airflow and sometimes you might want to upgrade specific providers only to fix some problems or
 use features available in that provider version. Here is an example of how you can do it
 
-.. exampleinclude:: docker-examples/extending/add-providers/Dockerfile
+.. exampleinclude:: docker-examples/extending/custom-providers/Dockerfile
     :language: Dockerfile
     :start-after: [START Dockerfile]
     :end-before: [END Dockerfile]
 
+Example of adding Airflow Provider packages
+...................................................
+
+The following example adds ``apache-spark`` airflow-providers which requires both ``java``.
+
+.. exampleinclude:: docker-examples/extending/add-provider-extend/Dockerfile
+    :language: Dockerfile
+    :start-after: [START Dockerfile]
+    :end-before: [END Dockerfile]
 
 Example of adding ``apt`` package
 .................................

--- a/docs/docker-stack/docker-examples/extending/custom-providers/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/custom-providers/Dockerfile
@@ -16,14 +16,5 @@
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
 FROM apache/airflow:2.3.0.dev0
-USER root
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-         openjdk-11-jre-headless \
-  && apt-get autoremove -yqq --purge \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-USER airflow
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-RUN pip install --no-cache-dir apache-airflow-providers-apache-spark==2.1.3
+RUN pip install --no-cache-dir apache-airflow-providers-docker==2.5.1
 # [END Dockerfile]


### PR DESCRIPTION
* Current "upgrading provider" example is misleading. 
`apache-airflow-providers-docker==2.1.0` is actually a downgrade now days in `apache/airflow:2.2.5` (which shipped with `apache-airflow-providers-docker==2.5.2` ) - so it's more downgrade than upgrade. 
That's why I renamed it to "custom" provider version (as it hard to maintain the version in the example) and I picked a version "in the middle" - 2.5.1
* Following the [last comment](https://stackoverflow.com/a/71142395/1011253) in StackOverflow answer I'm adding a common example of Spark usage which combine both python provider package and `apt` package (+ setting mandatory environment variable `JAVA_HOME`).