### PR TITLE
add numpy as prerequisites for apache-airflow-providers-oracle

### DIFF
--- a/docs/apache-airflow-providers-oracle/index.rst
+++ b/docs/apache-airflow-providers-oracle/index.rst
@@ -79,6 +79,7 @@ PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.1.0``
 ``cx_Oracle``       ``>=5.1.2``
+``numpy``           ``>=1.20.0``
 ==================  ==================
 
 .. include:: ../../airflow/providers/oracle/CHANGELOG.rst


### PR DESCRIPTION
based on airflow debug log if airflow can't find numpy it will ignore loading oracle provider 
here is the debug log when there is no numpy:
` [2022-04-20 16:54:58,701] {providers_manager.py:150} DEBUG - Exception when importing 'airflow.providers.oracle.hooks.oracle.OracleHook' from 'apache-airflow-providers-oracle' package: No module named 'numpy'
`
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
