### PR TITLE
When expanding a task end up skipping it, ensure we don't deadlock the DagRun

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -655,11 +655,15 @@ class DagRun(Base, LoggingMixin):
         if unfinished_tis:
             schedulable_tis = [ut for ut in unfinished_tis if ut.state in SCHEDULEABLE_STATES]
             self.log.debug("number of scheduleable tasks for %s: %s task(s)", self, len(schedulable_tis))
-            schedulable_tis, changed_tis = self._get_ready_tis(schedulable_tis, finished_tis, session)
+            schedulable_tis, changed_tis, expansion_happened = self._get_ready_tis(
+                schedulable_tis,
+                finished_tis,
+                session=session,
+            )
 
-            if changed_tis:
-                # It's possible when we expanded a mapped task that we now skipped some, so what was
-                # previously unfinished might now be finished -- we need to re-compute
+            # During expansion we may change some tis into non-schedulable
+            # states, so we need to re-compute.
+            if expansion_happened:
                 new_unfinished_tis = [t for t in unfinished_tis if t.state in State.unfinished]
                 finished_tis.extend(t for t in unfinished_tis if t.state in State.finished)
                 unfinished_tis = new_unfinished_tis
@@ -677,59 +681,51 @@ class DagRun(Base, LoggingMixin):
         schedulable_tis: List[TI],
         finished_tis: List[TI],
         session: Session,
-    ) -> Tuple[List[TI], bool]:
+    ) -> Tuple[List[TI], bool, bool]:
         old_states = {}
         ready_tis: List[TI] = []
         changed_tis = False
 
         if not schedulable_tis:
-            return ready_tis, changed_tis
+            return ready_tis, changed_tis, False
 
         # If we expand TIs, we need a new list so that we iterate over them too. (We can't alter
         # `schedulable_tis` in place and have the `for` loop pick them up
-        expanded_tis: List[TI] = []
+        additional_tis: List[TI] = []
         dep_context = DepContext(
             flag_upstream_failed=True,
             ignore_unmapped_tasks=True,  # Ignore this Dep, as we will expand it if we can.
             finished_tis=finished_tis,
         )
 
-        # Check dependencies
-        for schedulable in itertools.chain(schedulable_tis, expanded_tis):
-
+        # Check dependencies.
+        expansion_happened = False
+        for schedulable in itertools.chain(schedulable_tis, additional_tis):
             old_state = schedulable.state
-            if schedulable.are_dependencies_met(session=session, dep_context=dep_context):
-                ready_tis.append(schedulable)
-            else:
+            if not schedulable.are_dependencies_met(session=session, dep_context=dep_context):
                 old_states[schedulable.key] = old_state
                 continue
-
-            # This is called in two places: First (and ideally) is in the mini scheduler at the end of
-            # LocalTaskJob, and then as an "expansion of last resort" in the scheduler
-            # to ensure that the mapped task is correctly expanded before we try to execute it.
-            if schedulable.map_index < 0 and schedulable.task.is_mapped:
-                # HACK. This needs a better way, one that copes with multiple upstreams!
-                for ti in finished_tis:
-                    if schedulable.task_id in ti.task.downstream_task_ids:
-
-                        assert isinstance(schedulable.task, MappedOperator)
-                        new_tis, _ = schedulable.task.expand_mapped_task(self.run_id, session=session)
-                        if schedulable.state == TaskInstanceState.SKIPPED:
-                            # Task is now skipped (likely cos upstream returned 0 tasks)
-                            ready_tis.pop()
-                            changed_tis = True
-                            continue
-                        assert new_tis[0] is schedulable
-                        expanded_tis.extend(new_tis[1:])
-                        break
+            # If schedulable is from a mapped task, but not yet expanded, do it
+            # now. This is called in two places: First and ideally in the mini
+            # scheduler at the end of LocalTaskJob, and then as an "expansion of
+            # last resort" in the scheduler to ensure that the mapped task is
+            # correctly expanded before executed.
+            if schedulable.map_index < 0 and isinstance(schedulable.task, MappedOperator):
+                expanded_tis, _ = schedulable.task.expand_mapped_task(self.run_id, session=session)
+                if expanded_tis:
+                    assert expanded_tis[0] is schedulable
+                    additional_tis.extend(expanded_tis[1:])
+                expansion_happened = True
+            if schedulable.state in SCHEDULEABLE_STATES:
+                ready_tis.append(schedulable)
 
         # Check if any ti changed state
-        tis_filter = TI.filter_for_tis(old_states.keys())
-        if not changed_tis or tis_filter is not None:
+        tis_filter = TI.filter_for_tis(old_states)
+        if tis_filter is not None:
             fresh_tis = session.query(TI).filter(tis_filter).all()
             changed_tis = any(ti.state != old_states[ti.key] for ti in fresh_tis)
 
-        return ready_tis, changed_tis
+        return ready_tis, changed_tis, expansion_happened
 
     def _are_premature_tis(
         self,

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -1064,10 +1064,13 @@ def test_ti_scheduling_mapped_zero_length(dag_maker, session):
     session.flush()
 
     decision = dr.task_instance_scheduling_decisions(session=session)
+
+    # ti1 finished execution. ti2 goes directly to finished state because it's
+    # expanded against a zero-length XCom.
     assert decision == TISchedulingDecision(
         tis=[ti1, ti2],
         schedulable_tis=[],
-        changed_tis=True,
+        changed_tis=False,
         unfinished_tis=[],
         finished_tis=[ti1, ti2],
     )

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -30,6 +30,7 @@ from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.decorators import task
 from airflow.models import DAG, DagBag, DagModel, DagRun, TaskInstance as TI, clear_task_instances
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagrun import TISchedulingDecision
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.empty import EmptyOperator
@@ -1055,14 +1056,21 @@ def test_ti_scheduling_mapped_zero_length(dag_maker, session):
         mapped = MockOperator.partial(task_id='task_2').expand(arg2=XComArg(task))
 
     dr: DagRun = dag_maker.create_dagrun()
-    ti1, _ = sorted(dr.task_instances, key=lambda ti: ti.task_id)
+    ti1, ti2 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
     ti1.state = TaskInstanceState.SUCCESS
     session.add(
         TaskMap(dag_id=dr.dag_id, task_id=ti1.task_id, run_id=dr.run_id, map_index=-1, length=0, keys=None)
     )
     session.flush()
 
-    dr.task_instance_scheduling_decisions(session=session)
+    decision = dr.task_instance_scheduling_decisions(session=session)
+    assert decision == TISchedulingDecision(
+        tis=[ti1, ti2],
+        schedulable_tis=[],
+        changed_tis=True,
+        unfinished_tis=[],
+        finished_tis=[ti1, ti2],
+    )
 
     indices = (
         session.query(TI.map_index, TI.state)


### PR DESCRIPTION
I'm not all that sure this is the best fix, but it does fix #23131
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).