### PR TITLE
Add special exception for "host field is not hashable"

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -19,10 +19,11 @@
 import logging
 import sys
 from collections import defaultdict
+from collections.abc import Hashable
 from datetime import datetime
 from operator import attrgetter
 from time import time
-from typing import Hashable, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 from urllib.parse import quote
 
 # Using `from elasticsearch import *` would break elasticsearch mocking used in unit test.


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #15613
related: #15613

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
I am adding a special exception to the es_task_handler for cases in which the "hosts" field in an elastic record is not hashable. (i.e. a dict) It seems to be a common problem, but its not really a problem with airflow itself, rather "incomaptible defaults" of airflow and filebeat. See my comment here: https://github.com/apache/airflow/issues/15613#issuecomment-1104487752

I considered making `_group_logs_by_host` "smart" and let it handle "common" `host` objects. (Like the ones add_host_metadata or filebeat itself are producing) 
But it struck me as risky in case someone does something else with the `host` field. Making an assumption like taking the `host.hostname` if it is available might have unintended side-effects if a worker node changes hostname / ip / Mac. Turning the entire `host` into a string might also cause issues if the `host` object happens to contain volatile values like "uptime" or "load". 

closes: #15613
