### PR TITLE
Change `[api] auth_backends` to be comma separated

### DIFF
--- a/airflow/api/__init__.py
+++ b/airflow/api/__init__.py
@@ -34,9 +34,9 @@ def load_auth():
         pass
 
     backends = []
-    for backend in auth_backends.split():
+    for backend in auth_backends.split(","):
         try:
-            auth = import_module(backend)
+            auth = import_module(backend.strip())
             log.info("Loaded API auth backend: %s", backend)
             backends.append(auth)
         except ImportError as err:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -826,8 +826,8 @@
       default: "False"
     - name: auth_backends
       description: |
-        How to authenticate users of the API. See
-        https://airflow.apache.org/docs/apache-airflow/stable/security.html for possible values.
+        Comma separated list of auth backends to authenticate users of the API. See
+        https://airflow.apache.org/docs/apache-airflow/stable/security/api.html for possible values.
         ("airflow.api.auth.backend.default" allows all requests for historic reasons)
       version_added: ~
       type: string

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -446,8 +446,8 @@ fail_fast = False
 #   `RELEASE_NOTES.rst <https://github.com/apache/airflow/blob/main/RELEASE_NOTES.rst>`_
 enable_experimental_api = False
 
-# How to authenticate users of the API. See
-# https://airflow.apache.org/docs/apache-airflow/stable/security.html for possible values.
+# Comma separated list of auth backends to authenticate users of the API. See
+# https://airflow.apache.org/docs/apache-airflow/stable/security/api.html for possible values.
 # ("airflow.api.auth.backend.default" allows all requests for historic reasons)
 auth_backends = airflow.api.auth.backend.session
 

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -325,7 +325,7 @@ class AirflowConfigParser(ConfigParser):
             # handled by deprecated_values
             pass
         elif old_value.find('airflow.api.auth.backend.session') == -1:
-            new_value = old_value + "\nairflow.api.auth.backend.session"
+            new_value = old_value + ",airflow.api.auth.backend.session"
             self._update_env_var(section="api", name="auth_backends", new_value=new_value)
             warnings.warn(
                 'The auth_backends setting in [api] has had airflow.api.auth.backend.session added '

--- a/airflow/www/extensions/init_security.py
+++ b/airflow/www/extensions/init_security.py
@@ -51,7 +51,7 @@ def init_api_experimental_auth(app):
         pass
 
     app.api_auth = []
-    for backend in auth_backends.split():
+    for backend in auth_backends.split(','):
         try:
             auth = import_module(backend.strip())
             auth.init_app(app)

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -34,10 +34,10 @@ check the user session:
     In Airflow <1.10.11, the default setting was to allow all API requests without authentication, but this
     posed security risks for if the Webserver is publicly accessible.
 
-.. versionchanged:: 2.3
+.. versionchanged:: 2.3.0
 
-    In Airflow <2.3 this setting was ``auth_backend`` and allowed only one
-    value. In 2.3 it was changed to support multiple backends that are tried
+    In Airflow <2.3.0 this setting was ``auth_backend`` and allowed only one
+    value. In 2.3.0 it was changed to support multiple backends that are tried
     in turn.
 
 If you want to check which authentication backends are currently set, you can use ``airflow config get-value api auth_backends``

--- a/tests/api_connexion/test_auth.py
+++ b/tests/api_connexion/test_auth.py
@@ -177,7 +177,7 @@ class TestSessionWithBasicAuthFallback(BaseTestAuth):
                     (
                         "api",
                         "auth_backends",
-                    ): "airflow.api.auth.backend.session\nairflow.api.auth.backend.basic_auth"
+                    ): "airflow.api.auth.backend.session,airflow.api.auth.backend.basic_auth"
                 }
             ):
                 init_api_experimental_auth(minimal_app_for_api)

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -613,7 +613,7 @@ AIRFLOW_HOME = /root/airflow
             test_conf.validate()
             assert (
                 test_conf.get('api', 'auth_backends')
-                == 'airflow.api.auth.backend.basic_auth\nairflow.api.auth.backend.session'
+                == 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
I could infer that this config accepted more than 1 value, but it wasn't obvious how it was split. This makes it match our other multi-value config options, plus adds it to the docs.

This also fixes the docs link referenced in config.