### PR TITLE
recipes documentation: update airflow version

### DIFF
--- a/docs/docker-stack/recipes.rst
+++ b/docs/docker-stack/recipes.rst
@@ -88,5 +88,5 @@ Then build a new image.
 
   docker build . \
     --pull \
-    --build-arg BASE_AIRFLOW_IMAGE="apache/airflow:2.0.2" \
+    --build-arg BASE_AIRFLOW_IMAGE="apache/airflow:2.2.5" \
     --tag my-airflow-image:0.0.1


### PR DESCRIPTION
Not sure if there's a way to generate the version automatically, seems like there's something like that [here](https://github.com/apache/airflow/blob/main/docs/docker-stack/docker-examples/extending/add-providers/Dockerfile#L18) that finally generates the latest version [here](https://airflow.apache.org/docs/docker-stack/build.html#example-of-upgrading-airflow-provider-packages).
