### PR TITLE
Fix TaskInstance actions with upstream/downstream

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -144,12 +144,12 @@ def set_state(
 
     # now look for the task instances that are affected
 
-    qry_dag = _get_all_dag_task_query(dag, session, state, task_id_map_index_list, dag_run_ids)
+    qry_dag = get_all_dag_task_query(dag, session, state, task_id_map_index_list, dag_run_ids)
 
     if commit:
         tis_altered = qry_dag.with_for_update().all()
         if sub_dag_run_ids:
-            qry_sub_dag = _all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
+            qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.with_for_update().all()
         for task_instance in tis_altered:
             task_instance.set_state(state, session=session)
@@ -157,12 +157,12 @@ def set_state(
     else:
         tis_altered = qry_dag.all()
         if sub_dag_run_ids:
-            qry_sub_dag = _all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
+            qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.all()
     return tis_altered
 
 
-def _all_subdag_tasks_query(
+def all_subdag_tasks_query(
     sub_dag_run_ids: List[str],
     session: SASession,
     state: TaskInstanceState,
@@ -177,7 +177,7 @@ def _all_subdag_tasks_query(
     return qry_sub_dag
 
 
-def _get_all_dag_task_query(
+def get_all_dag_task_query(
     dag: DAG,
     session: SASession,
     state: TaskInstanceState,

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Collection, Iterable, Iterator, List, NamedTuple, Optional, Tuple, Union
 
 from sqlalchemy import or_
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import lazyload
 from sqlalchemy.orm.session import Session as SASession
 
 from airflow.models.dag import DAG
@@ -32,7 +32,6 @@ from airflow.operators.subdag import SubDagOperator
 from airflow.utils import timezone
 from airflow.utils.helpers import exactly_one
 from airflow.utils.session import NEW_SESSION, provide_session
-from airflow.utils.sqlalchemy import tuple_in_condition
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
@@ -79,7 +78,7 @@ def _create_dagruns(
 @provide_session
 def set_state(
     *,
-    tasks: Union[Collection[Operator], Collection[Tuple[Operator, int]]],
+    tasks: Collection[Union[Operator, Tuple[Operator, int]]],
     run_id: Optional[str] = None,
     execution_date: Optional[datetime] = None,
     upstream: bool = False,
@@ -98,9 +97,9 @@ def set_state(
     on the schedule (but it will as for subdag dag runs if needed).
 
     :param tasks: the iterable of tasks or (task, map_index) tuples from which to work.
-        task.task.dag needs to be set
+        ``task.dag`` needs to be set
     :param run_id: the run_id of the dagrun to start looking from
-    :param execution_date: the execution date from which to start looking(deprecated)
+    :param execution_date: the execution date from which to start looking (deprecated)
     :param upstream: Mark all parents (upstream tasks)
     :param downstream: Mark all siblings (downstream tasks) of task_id, including SubDags
     :param future: Mark all future tasks on the interval of the dag up until
@@ -134,13 +133,7 @@ def set_state(
 
     dag_run_ids = get_run_ids(dag, run_id, future, past)
     task_id_map_index_list = list(find_task_relatives(tasks, downstream, upstream))
-    task_ids = [task_id for task_id, _ in task_id_map_index_list]
-    # check if task_id_map_index_list contains map_index of None
-    # if it contains None, there was no map_index supplied for the task
-    for _, index in task_id_map_index_list:
-        if index is None:
-            task_id_map_index_list = [task_id for task_id, _ in task_id_map_index_list]
-            break
+    task_ids = [task_id if isinstance(task_id, str) else task_id[0] for task_id in task_id_map_index_list]
 
     confirmed_infos = list(_iter_existing_dag_run_infos(dag, dag_run_ids))
     confirmed_dates = [info.logical_date for info in confirmed_infos]
@@ -151,24 +144,25 @@ def set_state(
 
     # now look for the task instances that are affected
 
-    qry_dag = get_all_dag_task_query(dag, session, state, task_id_map_index_list, confirmed_dates)
+    qry_dag = _get_all_dag_task_query(dag, session, state, task_id_map_index_list, dag_run_ids)
 
     if commit:
         tis_altered = qry_dag.with_for_update().all()
         if sub_dag_run_ids:
-            qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
+            qry_sub_dag = _all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.with_for_update().all()
         for task_instance in tis_altered:
-            task_instance.set_state(state)
+            task_instance.set_state(state, session=session)
+        session.flush()
     else:
         tis_altered = qry_dag.all()
         if sub_dag_run_ids:
-            qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
+            qry_sub_dag = _all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.all()
     return tis_altered
 
 
-def all_subdag_tasks_query(
+def _all_subdag_tasks_query(
     sub_dag_run_ids: List[str],
     session: SASession,
     state: TaskInstanceState,
@@ -183,30 +177,22 @@ def all_subdag_tasks_query(
     return qry_sub_dag
 
 
-def get_all_dag_task_query(
+def _get_all_dag_task_query(
     dag: DAG,
     session: SASession,
     state: TaskInstanceState,
-    task_ids: Union[List[str], List[Tuple[str, int]]],
-    confirmed_dates: Iterable[datetime],
+    task_ids: List[Union[str, Tuple[str, int]]],
+    run_ids: Iterable[str],
 ):
     """Get all tasks of the main dag that will be affected by a state change"""
-    is_string_list = isinstance(task_ids[0], str)
-    qry_dag = (
-        session.query(TaskInstance)
-        .join(TaskInstance.dag_run)
-        .filter(
-            TaskInstance.dag_id == dag.dag_id,
-            DagRun.execution_date.in_(confirmed_dates),
-        )
+    qry_dag = session.query(TaskInstance).filter(
+        TaskInstance.dag_id == dag.dag_id,
+        TaskInstance.run_id.in_(run_ids),
+        TaskInstance.filter_for_task_id_map_index_lists(task_ids),
     )
 
-    if is_string_list:
-        qry_dag = qry_dag.filter(TaskInstance.task_id.in_(task_ids))
-    else:
-        qry_dag = qry_dag.filter(tuple_in_condition((TaskInstance.task_id, TaskInstance.map_index), task_ids))
     qry_dag = qry_dag.filter(or_(TaskInstance.state.is_(None), TaskInstance.state != state)).options(
-        contains_eager(TaskInstance.dag_run)
+        lazyload(TaskInstance.dag_run)
     )
     return qry_dag
 
@@ -287,15 +273,16 @@ def find_task_relatives(tasks, downstream, upstream):
     for item in tasks:
         if isinstance(item, tuple):
             task, map_index = item
+            yield task.task_id, map_index
         else:
-            task, map_index = item, None
-        yield task.task_id, map_index
+            task = item
+            yield task.task_id
         if downstream:
             for relative in task.get_flat_relatives(upstream=False):
-                yield relative.task_id, map_index
+                yield relative.task_id
         if upstream:
             for relative in task.get_flat_relatives(upstream=True):
-                yield relative.task_id, map_index
+                yield relative.task_id
 
 
 @provide_session

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -188,7 +188,7 @@ def get_all_dag_task_query(
     qry_dag = session.query(TaskInstance).filter(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id.in_(run_ids),
-        TaskInstance.filter_for_task_id_map_index_lists(task_ids),
+        TaskInstance.ti_selector_condition(task_ids),
     )
 
     qry_dag = qry_dag.filter(or_(TaskInstance.state.is_(None), TaskInstance.state != state)).options(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1447,11 +1447,8 @@ class DAG(LoggingMixin):
             tis = tis.filter(TaskInstance.run_id == run_id)
         if start_date:
             tis = tis.filter(DagRun.execution_date >= start_date)
-
-        if task_ids is None:
-            pass  # Disable filter if not set.
-        else:
-            tis = tis.filter(TaskInstance.filter_for_task_id_map_index_lists(task_ids))
+        if task_ids is not None:
+            tis = tis.filter(TaskInstance.ti_selector_condition(task_ids))
 
         # This allows allow_trigger_in_future config to take affect, rather than mandating exec_date <= UTC
         if end_date or not self.allow_future_exec_dates:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2546,6 +2546,7 @@ class TaskInstance(Base, LoggingMixin):
         """
         # Compute a filter for TI.task_id and TI.map_index based on input values
         # For each item, it will either be a task_id, or (task_id, map_index)
+        assert len(vals)
         task_id_only = list(filter(lambda v: isinstance(v, str), vals))
         with_map_index = list(filter(lambda v: not isinstance(v, str), vals))
         filters = []

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2041,18 +2041,24 @@ class Airflow(AirflowBaseView):
         recursive = request.form.get('recursive') == "true"
         only_failed = request.form.get('only_failed') == "true"
 
+        task_ids: List[Union[str, Tuple[str, int]]]
+        if map_indexes is None:
+            task_ids = [task_id]
+        else:
+            task_ids = [(task_id, map_index) for map_index in map_indexes]
+
         dag = dag.partial_subset(
-            task_ids_or_regex=fr"^{task_id}$",
+            task_ids_or_regex=[task_id],
             include_downstream=downstream,
             include_upstream=upstream,
         )
+
+        if len(dag.task_dict) > 1:
+            # If we had upstream/downstream etc then also include those!
+            task_ids.extend(tid for tid in dag.task_dict if tid != task_id)
+
         end_date = execution_date if not future else None
         start_date = execution_date if not past else None
-
-        if map_indexes is None:
-            task_ids: Union[List[str], List[Tuple[str, int]]] = [task_id]
-        else:
-            task_ids = [(task_id, map_index) for map_index in map_indexes]
 
         return self._clear_dag_tis(
             dag,

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -143,7 +143,12 @@ class TestMarkTasks:
         TI = models.TaskInstance
         DR = models.DagRun
 
-        tis = session.query(TI).filter(TI.dag_id == dag.dag_id, DR.execution_date.in_(execution_dates)).all()
+        tis = (
+            session.query(TI)
+            .join(TI.dag_run)
+            .filter(TI.dag_id == dag.dag_id, DR.execution_date.in_(execution_dates))
+            .all()
+        )
         assert len(tis) > 0
 
         unexpected_tis = []

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -159,9 +159,9 @@ class TestMarkTasks:
                     if (ti.task_id, ti.map_index) in map_task_pairs:
                         assert ti.state == state
                 else:
-                    assert ti.state == state
+                    assert ti.state == state, ti
                 if ti.state in State.finished:
-                    assert ti.end_date is not None
+                    assert ti.end_date is not None, ti
             else:
                 for old_ti in old_tis:
                     if (
@@ -413,6 +413,7 @@ class TestMarkTasks:
     @pytest.mark.backend("sqlite", "postgres")
     def test_mark_tasks_subdag(self):
         # set one task to success towards end of scheduled dag runs
+        snapshot = TestMarkTasks.snapshot_state(self.dag2, self.execution_dates)
         task = self.dag2.get_task("section-1")
         relatives = task.get_flat_relatives(upstream=False)
         task_ids = [t.task_id for t in relatives]
@@ -431,10 +432,7 @@ class TestMarkTasks:
         )
         assert len(altered) == 14
 
-        # cannot use snapshot here as that will require drilling down the
-        # sub dag tree essentially recreating the same code as in the
-        # tested logic.
-        self.verify_state(self.dag2, task_ids, [self.execution_dates[0]], State.SUCCESS, [])
+        self.verify_state(self.dag2, task_ids, [self.execution_dates[0]], State.SUCCESS, snapshot)
 
     def test_mark_mapped_task_instance_state(self, session):
         # set mapped task instance to success

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -43,6 +43,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.config import conf_vars
+from tests.test_utils.mapping import expand_mapped_task
 from tests.test_utils.mock_operators import DeprecatedOperator, MockOperator
 
 
@@ -903,12 +904,7 @@ def test_expand_mapped_task_instance_skipped_on_zero(dag_maker, session):
 
     dr = dag_maker.create_dagrun()
 
-    session.add(
-        TaskMap(dag_id=dr.dag_id, task_id=task1.task_id, run_id=dr.run_id, map_index=-1, length=0, keys=None)
-    )
-    session.flush()
-
-    mapped.expand_mapped_task(dr.run_id, session=session)
+    expand_mapped_task(mapped, dr.run_id, task1.task_id, length=0, session=session)
 
     indices = (
         session.query(TaskInstance.map_index, TaskInstance.state)

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -65,6 +65,7 @@ from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.db import clear_db_dags, clear_db_runs
+from tests.test_utils.mapping import expand_mapped_task
 from tests.test_utils.timetables import cron_timetable, delta_timetable
 
 TEST_DATE = datetime_tz(2015, 1, 2, 0, 0)
@@ -1423,11 +1424,18 @@ class TestDag(unittest.TestCase):
         self._clean_up(dag_id)
         task_id = 't1'
 
+        dag = DAG(dag_id, start_date=DEFAULT_DATE, max_active_runs=1)
+
+        @dag.task
+        def make_arg_lists():
+            return [[1], [2], [{'a': 'b'}]]
+
         def consumer(value):
             print(value)
 
-        dag = DAG(dag_id, start_date=DEFAULT_DATE, max_active_runs=1)
-        PythonOperator.partial(task_id=task_id, dag=dag, python_callable=consumer).expand(op_args=[1, 2, 4])
+        mapped = PythonOperator.partial(task_id=task_id, dag=dag, python_callable=consumer).expand(
+            op_args=make_arg_lists()
+        )
 
         session = settings.Session()
         dagrun_1 = dag.create_dagrun(
@@ -1435,28 +1443,20 @@ class TestDag(unittest.TestCase):
             state=State.FAILED,
             start_date=DEFAULT_DATE,
             execution_date=DEFAULT_DATE,
+            session=session,
         )
-        session.merge(dagrun_1)
-        ti = (
-            session.query(TI)
-            .filter(TI.map_index == 0, TI.task_id == task_id, TI.dag_id == dag.dag_id)
-            .first()
-        )
-        ti2 = (
-            session.query(TI)
-            .filter(TI.map_index == 1, TI.task_id == task_id, TI.dag_id == dag.dag_id)
-            .first()
-        )
+        expand_mapped_task(mapped, dagrun_1.run_id, "make_arg_lists", length=2, session=session)
+
+        upstream_ti = dagrun_1.get_task_instance("make_arg_lists", session=session)
+        ti = dagrun_1.get_task_instance(task_id, map_index=0, session=session)
+        ti2 = dagrun_1.get_task_instance(task_id, map_index=1, session=session)
+        upstream_ti.state = State.SUCCESS
         ti.state = State.SUCCESS
         ti2.state = State.SUCCESS
-        ti.execution_date = DEFAULT_DATE
-        ti2.execution_date = DEFAULT_DATE
-        session.merge(ti)
-        session.merge(ti2)
         session.flush()
 
         dag.clear(
-            task_ids=[(task_id, 0)],
+            task_ids=[(task_id, 0), ("make_arg_lists")],
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=1),
             dag_run_state=dag_run_state,
@@ -1464,16 +1464,10 @@ class TestDag(unittest.TestCase):
             include_parentdag=False,
             session=session,
         )
-        ti = (
-            session.query(TI)
-            .filter(TI.map_index == ti.map_index, TI.task_id == ti.task_id, TI.dag_id == ti.dag_id)
-            .first()
-        )
-        ti2 = (
-            session.query(TI)
-            .filter(TI.map_index == ti2.map_index, TI.task_id == ti2.task_id, TI.dag_id == ti2.dag_id)
-            .first()
-        )
+        session.refresh(upstream_ti)
+        session.refresh(ti)
+        session.refresh(ti2)
+        assert upstream_ti.state is None  # cleared
         assert ti.state is None  # cleared
         assert ti2.state == State.SUCCESS  # not cleared
         dagruns = (

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -30,7 +30,6 @@ from airflow.callbacks.callback_requests import DagCallbackRequest
 from airflow.decorators import task
 from airflow.models import DAG, DagBag, DagModel, DagRun, TaskInstance as TI, clear_task_instances
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.dagrun import TISchedulingDecision
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.empty import EmptyOperator
@@ -1067,13 +1066,7 @@ def test_ti_scheduling_mapped_zero_length(dag_maker, session):
 
     # ti1 finished execution. ti2 goes directly to finished state because it's
     # expanded against a zero-length XCom.
-    assert decision == TISchedulingDecision(
-        tis=[ti1, ti2],
-        schedulable_tis=[],
-        changed_tis=False,
-        unfinished_tis=[],
-        finished_tis=[ti1, ti2],
-    )
+    assert decision.finished_tis == [ti1, ti2]
 
     indices = (
         session.query(TI.map_index, TI.state)

--- a/tests/test_utils/mapping.py
+++ b/tests/test_utils/mapping.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import TYPE_CHECKING
+
+from airflow.models.taskmap import TaskMap
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from airflow.models.mappedoperator import MappedOperator
+
+
+def expand_mapped_task(
+    mapped: "MappedOperator", run_id: str, upstream_task_id: str, length: int, session: "Session"
+):
+    session.add(
+        TaskMap(
+            dag_id=mapped.dag_id,
+            task_id=upstream_task_id,
+            run_id=run_id,
+            map_index=-1,
+            length=length,
+            keys=None,
+        )
+    )
+    session.flush()
+
+    mapped.expand_mapped_task(run_id, session=session)


### PR DESCRIPTION
When we added clearing individual mapped tasks, we unfortunately broke
the up/down stream feature

This was because when passing task_id/task_id+map_index down that
limited it to _just_ that task_id.

So we need to change it to also support the up/downstream we need to add
those tasks to the list we pass on, meaning that we have to support
task_id and (task_id,map_index) tuples in the same `task_id` list.

This almost certainly needs tests adding!
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).