### PR TITLE
Add Variable "description" fields available in the API

### DIFF
--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -40,13 +40,13 @@ def delete_variable(*, variable_key: str) -> Response:
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_VARIABLE)])
-def get_variable(*, variable_key: str) -> Response:
+@provide_session
+def get_variable(*, variable_key: str, session: Session = NEW_SESSION) -> Response:
     """Get a variables by key"""
-    try:
-        var = Variable.get(variable_key)
-    except KeyError:
+    variable = session.query(Variable).filter(Variable.key == variable_key).one_or_none()
+    if variable is None:
         raise NotFound("Variable not found")
-    return variable_schema.dump({"key": variable_key, "val": var})
+    return variable_schema.dump(variable)
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_VARIABLE)])

--- a/airflow/api_connexion/schemas/variable_schema.py
+++ b/airflow/api_connexion/schemas/variable_schema.py
@@ -23,6 +23,7 @@ class VariableSchema(Schema):
 
     key = fields.String(required=True)
     value = fields.String(attribute="val", required=True)
+    description = fields.String()
 
 
 class VariableCollectionSchema(Schema):

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -109,7 +109,7 @@ class TestGetVariable(TestVariableEndpoint):
             "/api/v1/variables/TEST_VARIABLE_KEY", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
-        assert response.json == {"key": "TEST_VARIABLE_KEY", "value": expected_value}
+        assert response.json == {"key": "TEST_VARIABLE_KEY", "value": expected_value, "description": None}
 
     def test_should_respond_404_if_not_found(self):
         response = self.client.get(
@@ -132,8 +132,8 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=2&offset=0",
                 {
                     "variables": [
-                        {"key": "var1", "value": "1"},
-                        {"key": "var2", "value": "foo"},
+                        {"key": "var1", "value": "1", "description": None},
+                        {"key": "var2", "value": "foo", "description": None},
                     ],
                     "total_entries": 3,
                 },
@@ -142,8 +142,8 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=2&offset=1",
                 {
                     "variables": [
-                        {"key": "var2", "value": "foo"},
-                        {"key": "var3", "value": "[100, 101]"},
+                        {"key": "var2", "value": "foo", "description": None},
+                        {"key": "var3", "value": "[100, 101]", "description": None},
                     ],
                     "total_entries": 3,
                 },
@@ -152,7 +152,7 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=1&offset=2",
                 {
                     "variables": [
-                        {"key": "var3", "value": "[100, 101]"},
+                        {"key": "var3", "value": "[100, 101]", "description": None},
                     ],
                     "total_entries": 3,
                 },
@@ -279,6 +279,7 @@ class TestPostVariables(TestVariableEndpoint):
         assert response.json == {
             "key": "var_create",
             "value": "{}",
+            "description": None,
         }
 
     def test_should_reject_invalid_request(self):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #22007
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #22007

This PR adds description field to the returned json in variable API.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
