### PR TITLE
Add isLoading to ConfirmDialog

### DIFF
--- a/airflow/www/static/js/tree/api/useConfirmMarkTask.js
+++ b/airflow/www/static/js/tree/api/useConfirmMarkTask.js
@@ -20,12 +20,14 @@
 import axios from 'axios';
 import { useMutation } from 'react-query';
 import { getMetaValue } from '../../utils';
+import useErrorToast from '../useErrorToast';
 
 const confirmUrl = getMetaValue('confirm_url');
 
 export default function useConfirmMarkTask({
   dagId, runId, taskId, state,
 }) {
+  const errorToast = useErrorToast();
   return useMutation(
     ['confirmStateChange', dagId, runId, taskId, state],
     ({
@@ -47,6 +49,9 @@ export default function useConfirmMarkTask({
       });
 
       return axios.get(confirmUrl, { params });
+    },
+    {
+      onError: (error) => errorToast({ error }),
     },
   );
 }

--- a/airflow/www/static/js/tree/details/content/ConfirmDialog.jsx
+++ b/airflow/www/static/js/tree/details/content/ConfirmDialog.jsx
@@ -33,7 +33,7 @@ import {
 import { useContainerRef } from '../../context/containerRef';
 
 const ConfirmDialog = ({
-  isOpen, onClose, title = 'Wait a minute', description, body = [], onConfirm,
+  isOpen, onClose, title = 'Wait a minute', description, body = [], onConfirm, isLoading = false,
 }) => {
   const initialFocusRef = useRef();
   const containerRef = useContainerRef();
@@ -62,7 +62,7 @@ const ConfirmDialog = ({
             <Button onClick={onClose}>
               Cancel
             </Button>
-            <Button colorScheme="blue" onClick={onConfirm} ml={3} ref={initialFocusRef}>
+            <Button colorScheme="blue" onClick={onConfirm} ml={3} ref={initialFocusRef} isLoading={isLoading}>
               Confirm
             </Button>
           </AlertDialogFooter>

--- a/airflow/www/static/js/tree/details/content/dagRun/ClearRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/ClearRun.jsx
@@ -47,6 +47,7 @@ const ClearRun = ({ dagId, runId }) => {
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to clear:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/dagRun/MarkFailedRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/MarkFailedRun.jsx
@@ -47,6 +47,7 @@ const MarkFailedRun = ({ dagId, runId }) => {
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to mark as failed or skipped:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/dagRun/MarkSuccessRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/MarkSuccessRun.jsx
@@ -47,6 +47,7 @@ const MarkSuccessRun = ({ dagId, runId }) => {
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to mark as success:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/dagRun/QueueRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/QueueRun.jsx
@@ -56,6 +56,7 @@ const QueueRun = ({ dagId, runId }) => {
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to queue:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Clear.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Clear.jsx
@@ -116,6 +116,7 @@ const Run = ({
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to clear:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
@@ -86,6 +86,8 @@ const MarkFailed = ({
     onClose();
   };
 
+  const isLoading = isMarkLoading || isConfirmLoading;
+
   return (
     <Flex justifyContent="space-between" width="100%">
       <ButtonGroup isAttached variant="outline">
@@ -94,13 +96,14 @@ const MarkFailed = ({
         <ActionButton bg={upstream && 'gray.100'} onClick={onToggleUpstream} name="Upstream" />
         <ActionButton bg={downstream && 'gray.100'} onClick={onToggleDownstream} name="Downstream" />
       </ButtonGroup>
-      <Button colorScheme="red" onClick={onClick} isLoading={isMarkLoading || isConfirmLoading}>
+      <Button colorScheme="red" onClick={onClick} isLoading={isLoading}>
         Mark Failed
       </Button>
       <ConfirmDialog
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to mark as failed:"
         body={affectedTasks}
       />

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkSuccess.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkSuccess.jsx
@@ -81,6 +81,8 @@ const MarkSuccess = ({
     onClose();
   };
 
+  const isLoading = isMarkLoading || isConfirmLoading;
+
   return (
     <Flex justifyContent="space-between" width="100%">
       <ButtonGroup isAttached variant="outline">
@@ -89,13 +91,14 @@ const MarkSuccess = ({
         <ActionButton bg={upstream && 'gray.100'} onClick={onToggleUpstream} name="Upstream" />
         <ActionButton bg={downstream && 'gray.100'} onClick={onToggleDownstream} name="Downstream" />
       </ButtonGroup>
-      <Button colorScheme="green" onClick={onClick} isLoading={isMarkLoading || isConfirmLoading}>
+      <Button colorScheme="green" onClick={onClick} isLoading={isLoading}>
         Mark Success
       </Button>
       <ConfirmDialog
         isOpen={isOpen}
         onClose={onClose}
         onConfirm={onConfirm}
+        isLoading={isLoading}
         description="Task instances you are about to mark as success:"
         body={affectedTasks}
       />


### PR DESCRIPTION
Prevent double clicking on "Confirm" button and clearing a task twice by adding a `isLoading` prop to the button.

Also, add an error toast to `useConfirmMarkTask` to make sure the error is bubbled up to the user appropriately.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
