### PR TITLE
Fix false warnings re non-JSON extra params

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -297,9 +297,9 @@ class Connection(Base, LoggingMixin):
     def set_extra(self, value: str):
         """Encrypt extra-data and save in object attribute to object."""
         if value:
+            self._validate_extra(value, self.conn_id)
             fernet = get_fernet()
             self._extra = fernet.encrypt(bytes(value, 'utf-8')).decode()
-            self._validate_extra(self._extra, self.conn_id)
             self.is_extra_encrypted = fernet.is_encrypted
         else:
             self._extra = value


### PR DESCRIPTION
We were validating JSON-serializability on the fernet-encoded value, which of course won't be JSON-serializable!
