### PR TITLE
Add support for multiple codespace configuration

### DIFF
--- a/.devcontainer/mysql/devcontainer.json
+++ b/.devcontainer/mysql/devcontainer.json
@@ -1,9 +1,10 @@
 {
-    "name": "Apache Airflow - sqlite",
+    "name": "Apache Airflow - mysql",
     "dockerComposeFile": [
         "../scripts/ci/docker-compose/devcontainer.yml",
         "../scripts/ci/docker-compose/local.yml",
-        "../scripts/ci/docker-compose/backend-sqlite.yml",
+        "../scripts/ci/docker-compose/backend-mysql.yml",
+        "../scripts/ci/docker-compose/devcontainer-mysql.yml"
     ],
     "extensions": [
         "ms-python.python",

--- a/.devcontainer/postgres/devcontainer.json
+++ b/.devcontainer/postgres/devcontainer.json
@@ -1,9 +1,10 @@
 {
-    "name": "Apache Airflow - sqlite",
+    "name": "Apache Airflow - postgres",
     "dockerComposeFile": [
         "../scripts/ci/docker-compose/devcontainer.yml",
         "../scripts/ci/docker-compose/local.yml",
-        "../scripts/ci/docker-compose/backend-sqlite.yml",
+        "../scripts/ci/docker-compose/backend-postgres.yml",
+        "../scripts/ci/docker-compose/devcontainer-postgres.yml"
     ],
     "extensions": [
         "ms-python.python",


### PR DESCRIPTION
Today GitHub released support for multiple codespace
configurations. This PR adds mysql and sqlite
configurations on top of the existing postgres
one.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
