### PR TITLE
Fix Task Duration Calculation & Display

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -500,7 +500,7 @@ function groupTooltip(node, tis) {
     }
   });
 
-  const groupDuration = convertSecsToHumanReadable(moment(maxEnd).diff(minStart, 'second'));
+  const groupDuration = convertSecsToHumanReadable(moment(maxEnd).diff(minStart, 'second', true));
   const tooltipText = node.tooltip ? `<p>${node.tooltip}</p>` : '';
 
   let tt = `

--- a/airflow/www/static/js/task_instances.js
+++ b/airflow/www/static/js/task_instances.js
@@ -102,11 +102,11 @@ export default function tiTooltip(ti, { includeTryNumber = false } = {}) {
   // Calculate duration on the fly if task instance is still running
   if (ti.state === 'running') {
     const startDate = ti.start_date instanceof moment ? ti.start_date : moment(ti.start_date);
-    ti.duration = moment().diff(startDate, 'second');
+    ti.duration = moment().diff(startDate, 'second', true);
   } else if (!ti.duration && ti.end_date) {
     const startDate = ti.start_date instanceof moment ? ti.start_date : moment(ti.start_date);
     const endDate = ti.end_date instanceof moment ? ti.end_date : moment(ti.end_date);
-    ti.duration = moment(endDate).diff(startDate, 'second');
+    ti.duration = moment(endDate).diff(startDate, 'second', true);
   }
 
   tt += `Duration: ${escapeHtml(convertSecsToHumanReadable(ti.duration))}<br>`;

--- a/newsfragments/23173.bugfix.rst
+++ b/newsfragments/23173.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where task run duration would not be displayed properly when duration is less than 1 second


### PR DESCRIPTION
closes: #23169
Prevent moment from truncating the result of diff to zero decimal places

As moment.diff has the default behavior of truncating the decimal places of diff results (i.e. rounding down to the nearest integer), when the duration of a task run is less than a full second moment rounds the duration down to 0. This behavior results in the task duration rendering as empty/null rather than as the correct task run duration.

Moment's diff function accepts a third, optional boolean argument that dictates its result truncation behavior. By default this value is false which leads to the unwanted behavior described above. Setting this argument to true when calling diff will allow the result to exist as a decimal, fixing the situation where task run duration is rounded down to 0 seconds.