### PR TITLE
When marking future tasks, ensure we don't touch other mapped TIs

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1653,7 +1653,6 @@ class DAG(LoggingMixin):
         task.dag = self
 
         tasks_to_set_state: List[Union[Operator, Tuple[Operator, int]]]
-        task_ids_to_exclude_from_clear = {task_id}
         if map_indexes is None:
             tasks_to_set_state = [task]
         else:
@@ -1703,7 +1702,7 @@ class DAG(LoggingMixin):
             only_failed=True,
             session=session,
             # Exclude the task itself from being cleared
-            exclude_task_ids=task_ids_to_exclude_from_clear,
+            exclude_task_ids={task_id},
         )
 
         return altered

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1649,25 +1649,15 @@ class DAG(LoggingMixin):
         if not exactly_one(execution_date, run_id):
             raise ValueError("Exactly one of execution_date or run_id must be provided")
 
-        if execution_date is None:
-            dag_run = (
-                session.query(DagRun).filter(DagRun.run_id == run_id, DagRun.dag_id == self.dag_id).one()
-            )  # Raises an error if not found
-            resolve_execution_date = dag_run.execution_date
-        else:
-            resolve_execution_date = execution_date
-
         task = self.get_task(task_id)
         task.dag = self
 
         tasks_to_set_state: List[Union[Operator, Tuple[Operator, int]]]
-        task_ids_to_exclude_from_clear: Set[Union[str, Tuple[str, int]]]
+        task_ids_to_exclude_from_clear = {task_id}
         if map_indexes is None:
             tasks_to_set_state = [task]
-            task_ids_to_exclude_from_clear = {task_id}
         else:
             tasks_to_set_state = [(task, map_index) for map_index in map_indexes]
-            task_ids_to_exclude_from_clear = {(task_id, map_index) for map_index in map_indexes}
 
         altered = set_state(
             tasks=tasks_to_set_state,
@@ -1693,6 +1683,14 @@ class DAG(LoggingMixin):
             include_downstream=True,
             include_upstream=False,
         )
+
+        if execution_date is None:
+            dag_run = (
+                session.query(DagRun).filter(DagRun.run_id == run_id, DagRun.dag_id == self.dag_id).one()
+            )  # Raises an error if not found
+            resolve_execution_date = dag_run.execution_date
+        else:
+            resolve_execution_date = execution_date
 
         end_date = resolve_execution_date if not future else None
         start_date = resolve_execution_date if not past else None

--- a/tests/test_utils/mapping.py
+++ b/tests/test_utils/mapping.py
@@ -41,3 +41,4 @@ def expand_mapped_task(
     session.flush()
 
     mapped.expand_mapped_task(run_id, session=session)
+    mapped.run_time_mapped_ti_count.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
We had a logic bug where if you selected "Map Index 1" to mark as
success, the other mapped TIs of that run would get cleared too.

This was because the `partial_dag.clear` was picking up the other
instances of the task.

Fixes #23171


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).