### PR TITLE
Added a task try table for better log file retrieval.

### DIFF
--- a/airflow/migrations/versions/9999_000000000000_add_task_try_table.py
+++ b/airflow/migrations/versions/9999_000000000000_add_task_try_table.py
@@ -1,0 +1,53 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add ``task_try`` table
+
+Revision ID: 1b38cef5b76e
+Revises: 52d714495f0
+Create Date: 2015-10-27 08:31:48.475140
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from airflow.migrations.db_types import StringID
+
+# revision identifiers, used by Alembic.
+revision = '0000000000000'
+down_revision = '0000000000000'
+branch_labels = None
+depends_on = None
+airflow_version = '9.9.9'
+
+
+def upgrade():
+    op.create_table(
+        'task_try',
+        sa.Column('dag_id', StringID(), nullable=False),
+        sa.Column('run_id', StringID(), nullable=False),
+        sa.Column('task_id', StringID(), nullable=False),
+        sa.Column('try_number', sa.Integer(), nullable=False),
+        sa.Column('hostname', sa.String(length=1000), nullable=True),
+        sa.PrimaryKeyConstraint('dag_id', 'task_id', 'run_id', 'try_number'),
+    )
+
+
+def downgrade():
+    op.drop_table('task_try')

--- a/airflow/migrations/versions/9999_000000000000_add_task_try_table.py
+++ b/airflow/migrations/versions/9999_000000000000_add_task_try_table.py
@@ -20,7 +20,7 @@
 
 Revision ID: 1b38cef5b76e
 Revises: 52d714495f0
-Create Date: 2015-10-27 08:31:48.475140
+Create Date: 2022-XX-XX XX:XX:XX.XXXXXX
 
 """
 
@@ -34,7 +34,7 @@ revision = '0000000000000'
 down_revision = '0000000000000'
 branch_labels = None
 depends_on = None
-airflow_version = '9.9.9'
+airflow_version = '2.4.0'
 
 
 def upgrade():
@@ -43,9 +43,10 @@ def upgrade():
         sa.Column('dag_id', StringID(), nullable=False),
         sa.Column('run_id', StringID(), nullable=False),
         sa.Column('task_id', StringID(), nullable=False),
+        sa.Column('map_index', sa.Integer(), nullable=False),
         sa.Column('try_number', sa.Integer(), nullable=False),
         sa.Column('hostname', sa.String(length=1000), nullable=True),
-        sa.PrimaryKeyConstraint('dag_id', 'task_id', 'run_id', 'try_number'),
+        sa.PrimaryKeyConstraint('dag_id', 'task_id', 'run_id', 'map_index', 'try_number'),
     )
 
 

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -39,6 +39,7 @@ from airflow.models.slamiss import SlaMiss
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskinstance import TaskInstance, clear_task_instances
 from airflow.models.taskreschedule import TaskReschedule
+from airflow.models.tasktry import TaskTry
 from airflow.models.trigger import Trigger
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
@@ -70,6 +71,7 @@ __all__ = [
     "TaskFail",
     "TaskInstance",
     "TaskReschedule",
+    "TaskTry",
     "Trigger",
     "Variable",
     "XCom",

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1351,7 +1351,7 @@ class TaskInstance(Base, LoggingMixin):
         self.log.info(hr_line_break)
         self._try_number += 1
 
-        session.add(TaskTry(self.dag_id, self.task_id, self.run_id, self._try_number, self.hostname))
+        session.add(TaskTry(self.dag_id, self.task_id, self.run_id, self.map_index, self._try_number, self.hostname))
 
         if not test_mode:
             session.add(Log(State.RUNNING, self))

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1350,6 +1350,8 @@ class TaskInstance(Base, LoggingMixin):
         self.log.info(hr_line_break)
         self._try_number += 1
 
+        session.add(TaskTry(self.dag_id, self.task_id, self.run_id, self._try_number, self.hostname))
+
         if not test_mode:
             session.add(Log(State.RUNNING, self))
         self.state = State.RUNNING

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -101,6 +101,7 @@ from airflow.models.param import ParamsDict
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskmap import TaskMap
 from airflow.models.taskreschedule import TaskReschedule
+from airflow.models.tasktry import TaskTry
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
 from airflow.plugins_manager import integrate_macros_plugins
 from airflow.sentry import Sentry

--- a/airflow/models/tasktry.py
+++ b/airflow/models/tasktry.py
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Table to store information about mapped task instances (AIP-42)."""
+
+import collections.abc
+import enum
+from typing import TYPE_CHECKING, Any, Collection, List, Optional
+
+from sqlalchemy import Column, ForeignKeyConstraint, Integer, String
+
+from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
+from airflow.utils.sqlalchemy import ExtendedJSON
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
+
+
+class TaskMapVariant(enum.Enum):
+    """Task map variant.
+    Possible values are **dict** (for a key-value mapping) and **list** (for an
+    ordered value sequence).
+    """
+
+    DICT = "dict"
+    LIST = "list"
+
+
+class TaskTry(Base):
+    """Model to track individual TaskInstance tries.
+    This is currently only used for storing appropriate hostnames.
+    """
+
+    __tablename__ = "task_try"
+
+    # Link to upstream TaskInstance creating this dynamic mapping information.
+    dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    run_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    try_number = Column(Integer, primary_key=True)
+
+    hostname = Column(String(1000), nullable=False)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [dag_id, task_id, run_id],
+            [
+                "task_instance.dag_id",
+                "task_instance.task_id",
+                "task_instance.run_id",
+            ],
+            name="task_try_task_instance_fkey",
+            ondelete="CASCADE",
+        ),
+    )
+
+    def __init__(
+        self,
+        dag_id: str,
+        task_id: str,
+        run_id: str,
+        try_number: int,
+        hostname: str,
+    ) -> None:
+        self.dag_id = dag_id
+        self.task_id = task_id
+        self.run_id = run_id
+        self.try_number = try_number
+        self.hostname = hostname

--- a/airflow/models/tasktry.py
+++ b/airflow/models/tasktry.py
@@ -16,19 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Table to store information about mapped task instances (AIP-42)."""
-
-import collections.abc
-import enum
-from typing import TYPE_CHECKING, Any, Collection, List, Optional
+"""Table to store information about individual task tries."""
 
 from sqlalchemy import Column, ForeignKeyConstraint, Integer, String
 
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
-from airflow.utils.sqlalchemy import ExtendedJSON
-
-if TYPE_CHECKING:
-    from airflow.models.taskinstance import TaskInstance
 
 
 class TaskTry(Base):
@@ -42,17 +34,19 @@ class TaskTry(Base):
     dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
     task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
     run_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    map_index = Column(Integer, primary_key=True)
     try_number = Column(Integer, primary_key=True)
 
     hostname = Column(String(1000), nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(
-            [dag_id, task_id, run_id],
+            [dag_id, task_id, run_id, map_index],
             [
                 "task_instance.dag_id",
                 "task_instance.task_id",
                 "task_instance.run_id",
+                "task_instance.map_index",
             ],
             name="task_try_task_instance_fkey",
             ondelete="CASCADE",

--- a/airflow/models/tasktry.py
+++ b/airflow/models/tasktry.py
@@ -69,16 +69,3 @@ class TaskTry(Base):
         ),
     )
 
-    def __init__(
-        self,
-        dag_id: str,
-        task_id: str,
-        run_id: str,
-        try_number: int,
-        hostname: str,
-    ) -> None:
-        self.dag_id = dag_id
-        self.task_id = task_id
-        self.run_id = run_id
-        self.try_number = try_number
-        self.hostname = hostname

--- a/airflow/models/tasktry.py
+++ b/airflow/models/tasktry.py
@@ -31,16 +31,6 @@ if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
 
 
-class TaskMapVariant(enum.Enum):
-    """Task map variant.
-    Possible values are **dict** (for a key-value mapping) and **list** (for an
-    ordered value sequence).
-    """
-
-    DICT = "dict"
-    LIST = "list"
-
-
 class TaskTry(Base):
     """Model to track individual TaskInstance tries.
     This is currently only used for storing appropriate hostnames.

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -146,6 +146,7 @@ class FileTaskHandler(logging.Handler):
                 TaskTry.dag_id == ti.dag_id,
                 TaskTry.run_id == ti.run_id,
                 TaskTry.task_id == ti.task_id,
+                TaskTry.map_index == ti.map_index,
                 TaskTry.try_number == try_number
         ).first()
 


### PR DESCRIPTION
This PR aims to fix a long-standing logging bug present in Airflow. In particular, any clusters of more than one worker do not handle their logs appropriately - always fetching files from the host used in the last run.

This change adds a lookup table for per-try information for TaskInstances. That allows storing a separate hostname for each try of a task. 

Questions to consider before merging - comments would be appreciated:
 - [ ] What kinds of tests should be added?
 - [ ] What is the appropriate way to add a database migration to the codebase?

This is a redesign of a previous PR #23135.

closes: #16472
