### PR TITLE
Fix typo in dbt Cloud provider description

### DIFF
--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -19,7 +19,7 @@
 package-name: apache-airflow-providers-dbt-cloud
 name: dbt Cloud
 description: |
-    `dbt Cloud <https://www.getdbt.com/product/what-is-dbt/>`__).
+    `dbt Cloud <https://www.getdbt.com/product/what-is-dbt/>`__
 
 versions:
   - 1.0.2


### PR DESCRIPTION
In the Providers view in the Airflow UI, the description for the dbt Cloud provider has some errant, trailing characters. Fixing this typo.

**Before**
<img width="508" alt="image" src="https://user-images.githubusercontent.com/48934154/164787628-602cbfc4-b3db-4a69-baa7-6ffc1753e6d1.png">


**After**
<img width="546" alt="image" src="https://user-images.githubusercontent.com/48934154/164787563-7418f1ad-4ef1-4f59-99f0-e1358a1b913d.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
