### PR TITLE
`S3Hook`: fix `load_bytes` docstring

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -649,7 +649,7 @@ class S3Hook(AwsBaseHook):
         """
         Loads bytes to S3
 
-        This is provided as a convenience to drop a string in S3. It uses the
+        This is provided as a convenience to drop bytes data into S3. It uses the
         boto infrastructure to ship a file to s3.
 
         :param bytes_data: bytes to set as content for the key.


### PR DESCRIPTION
Very small change to correct the docstring for the S3 hook load_bytes method to indicate it is used to upload bytes, not strings.  Previous docstring appeared to be an oversight copy/paste of the load_string method's docstring.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
