### PR TITLE
Rework contract of try_adopt_task_instances method

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,7 +17,7 @@
 """Base executor - this is the base class for all the implemented executors."""
 import sys
 from collections import OrderedDict
-from typing import Any, Counter, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Counter, Dict, List, Optional, Set, Tuple, Union, Sequence
 
 from airflow.callbacks.base_callback_sink import BaseCallbackSink
 from airflow.callbacks.callback_requests import CallbackRequest
@@ -298,7 +298,7 @@ class BaseExecutor(LoggingMixin):
         """This method is called when the daemon receives a SIGTERM"""
         raise NotImplementedError()
 
-    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+    def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """
         Try to adopt running task instances that have been abandoned by a SchedulerJob dying.
 
@@ -306,7 +306,7 @@ class BaseExecutor(LoggingMixin):
         re-scheduling)
 
         :return: any TaskInstances that were unable to be adopted
-        :rtype: list[airflow.models.TaskInstance]
+        :rtype: Sequence[airflow.models.TaskInstance]
         """
         # By default, assume Executors cannot adopt tasks, so just say we failed to adopt anything.
         # Subclasses can do better!

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,7 +17,7 @@
 """Base executor - this is the base class for all the implemented executors."""
 import sys
 from collections import OrderedDict
-from typing import Any, Counter, Dict, List, Optional, Set, Tuple, Union, Sequence
+from typing import Any, Counter, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 from airflow.callbacks.base_callback_sink import BaseCallbackSink
 from airflow.callbacks.callback_requests import CallbackRequest

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -32,7 +32,7 @@ import traceback
 from collections import OrderedDict
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import cpu_count
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set, Tuple, Union, Sequence
 
 from celery import Celery, Task, states as celery_states
 from celery.backends.base import BaseKeyValueStoreBackend
@@ -443,7 +443,7 @@ class CeleryExecutor(BaseExecutor):
     def terminate(self):
         pass
 
-    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+    def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         # See which of the TIs are still alive (or have finished even!)
         #
         # Since Celery doesn't store "SENT" state for queued commands (if we create an AsyncResult with a made

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -32,7 +32,7 @@ import traceback
 from collections import OrderedDict
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import cpu_count
-from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set, Tuple, Union, Sequence
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple, Union
 
 from celery import Celery, Task, states as celery_states
 from celery.backends.base import BaseKeyValueStoreBackend

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, Sequence
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType
@@ -153,7 +153,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
 
         return {**cleared_events_from_celery, **cleared_events_from_kubernetes}
 
-    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+    def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """
         Try to adopt running task instances that have been abandoned by a SchedulerJob dying.
 
@@ -161,7 +161,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
         re-scheduling)
 
         :return: any TaskInstances that were unable to be adopted
-        :rtype: list[airflow.models.TaskInstance]
+        :rtype: Sequence[airflow.models.TaskInstance]
         """
         celery_tis = []
         kubernetes_tis = []

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Optional, Set, Union, Sequence
+from typing import Dict, List, Optional, Sequence, Set, Union
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -28,7 +28,7 @@ import multiprocessing
 import time
 from datetime import timedelta
 from queue import Empty, Queue
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Sequence
 
 from kubernetes import client, watch
 from kubernetes.client import Configuration, models as k8s
@@ -684,7 +684,7 @@ class KubernetesExecutor(BaseExecutor):
                 self.log.debug('Could not find key: %s', str(key))
         self.event_buffer[key] = state, None
 
-    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+    def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         tis_to_flush = [ti for ti in tis if not ti.queued_by_job_id]
         scheduler_job_ids = {ti.queued_by_job_id for ti in tis}
         pod_ids = {ti.key: ti for ti in tis if ti.queued_by_job_id}

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -28,7 +28,7 @@ import multiprocessing
 import time
 from datetime import timedelta
 from queue import Empty, Queue
-from typing import Any, Dict, List, Optional, Tuple, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from kubernetes import client, watch
 from kubernetes.client import Configuration, models as k8s

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union, Sequence
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType
@@ -152,7 +152,7 @@ class LocalKubernetesExecutor(LoggingMixin):
 
         return {**cleared_events_from_local, **cleared_events_from_kubernetes}
 
-    def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
+    def try_adopt_task_instances(self, tis: Sequence[TaskInstance]) -> Sequence[TaskInstance]:
         """
         Try to adopt running task instances that have been abandoned by a SchedulerJob dying.
 

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -162,17 +162,12 @@ class LocalKubernetesExecutor(LoggingMixin):
         :return: any TaskInstances that were unable to be adopted
         :rtype: list[airflow.models.TaskInstance]
         """
-        local_tis = []
-        kubernetes_tis = []
-        abandoned_tis = []
-        for ti in tis:
-            if ti.queue == self.KUBERNETES_QUEUE:
-                kubernetes_tis.append(ti)
-            else:
-                local_tis.append(ti)
-        abandoned_tis.extend(self.local_executor.try_adopt_task_instances(local_tis))
-        abandoned_tis.extend(self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis))
-        return abandoned_tis
+        local_tis = [ti for ti in tis if ti.queue != self.KUBERNETES_QUEUE]
+        kubernetes_tis = [ti for ti in tis if ti.queue == self.KUBERNETES_QUEUE]
+        return [
+            *self.local_executor.try_adopt_task_instances(local_tis),
+            *self.kubernetes_executor.try_adopt_task_instances(kubernetes_tis),
+        ]
 
     def end(self) -> None:
         """End local and kubernetes executor"""

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, List, Optional, Set, Union, Sequence
+from typing import Dict, List, Optional, Sequence, Set, Union
 
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType


### PR DESCRIPTION
Use sequence in contract instead of lists.

related: #20982 
@uranusjr is this what you wanted?

---

Use sequence in contract as the implementation does not depend on the ordering of the elements. 
