### PR TITLE
Add longer timeout for execution for flaky lambda invoke test

### DIFF
--- a/tests/providers/amazon/aws/operators/test_lambda.py
+++ b/tests/providers/amazon/aws/operators/test_lambda.py
@@ -21,6 +21,7 @@ import json
 import unittest
 import zipfile
 
+import pytest
 from moto import mock_iam, mock_lambda, mock_sts
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
@@ -96,6 +97,7 @@ class TestAwsLambdaInvokeFunctionOperator(unittest.TestCase):
         )
         return resp
 
+    @pytest.mark.execution_timeout(120)
     def test_invoke_lambda(self):
         self.create_lambda_function('test')
         test_event_input = {"TestInput": "Testdata"}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
