### PR TITLE
Fix constraint generation on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1499,9 +1499,12 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
       - name: "Generate constraints"
         run: |
-          breeze generate-constraints --generate-constraints-mode source-providers --answer yes
-          breeze generate-constraints --generate-constraints-mode pypi-providers --answer yes
-          breeze generate-constraints --generate-constraints-mode no-providers --answer yes
+          breeze generate-constraints --run-in-parallel --generate-constraints-mode source-providers
+          breeze generate-constraints --run-in-parallel --generate-constraints-mode pypi-providers
+          breeze generate-constraints --run-in-parallel --generate-constraints-mode no-providers
+        env:
+          PYTHON_VERSIONS: ${{ needs.build-info.outputs.pythonVersionsListAsString }}
+          ANSWER: "yes"
       - name: "Set constraints branch name"
         id: constraints-branch
         run: ./scripts/ci/constraints/ci_branch_constraints.sh


### PR DESCRIPTION
This is another small aftermath after the #23104 - this could not
be tested during PRs because generate-constraints only run in
main in apache/airflow repo and a problem crept in that I have
forgotten to add --run-in-parallel for those breeze commands,
which resulted in missing the python version to generate
constraints for.

This change adds --run-in-parallell and list of python versions
to work on so that generate constraints might start work again.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
