### PR TITLE
Add cleanup of docker-context-files

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -344,6 +344,6 @@ jobs:
           IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
       - name: Push empty PROD image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         if: failure() || cancelled()
-        run: breeze build-prod-image --push-image --empty-image
+        run: breeze build-prod-image --cleanup-docker-context-files --push-image --empty-image
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}

--- a/dev/REFRESHING_CI_CACHE.md
+++ b/dev/REFRESHING_CI_CACHE.md
@@ -142,6 +142,6 @@ export CI="true"
 breeze build-image --python-version 3.7 \
     --prepare-buildx-cache --platform linux/amd64,linux/arm64 --verbose
 
-breeze build-prod-image --python-version 3.7 \
+breeze build-prod-image --python-version 3.7 --cleanup-docker-context-files \
     --prepare-buildx-cache --platform linux/amd64,linux/arm64 --verbose
 ```

--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -25,5 +25,5 @@ export CI="true"
 breeze build-image --build-multiple-images \
      --prepare-buildx-cache --platform linux/amd64,linux/arm64 --verbose
 
-breeze build-prod-image --build-multiple-images \
+breeze build-prod-image --build-multiple-images --cleanup-docker-context-files \
      --prepare-buildx-cache --platform linux/amd64,linux/arm64 --verbose


### PR DESCRIPTION
Seems that some files can be left in the repositories of ours. This
prevents empty prod images to build propoerly.

This change adds --cleanup-docker-context files empty
build-prod-image on CI

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
