### PR TITLE
Further improvement of Databricks Jobs operators (mostly docs)

### DIFF
--- a/docs/apache-airflow-providers-databricks/operators/run_now.rst
+++ b/docs/apache-airflow-providers-databricks/operators/run_now.rst
@@ -33,35 +33,15 @@ to call the ``api/2.1/jobs/run-now`` endpoint and pass it directly to our ``Data
 Another way to accomplish the same thing is to use the named parameters of the ``DatabricksRunNowOperator`` directly.
 Note that there is exactly one named parameter for each top level parameter in the ``jobs/run-now`` endpoint.
 
-.. list-table::
-   :widths: 15 25
-   :header-rows: 1
+The only required parameters are either:
 
-   * - Parameter
-     - Input
-   * - job_id: str
-     - ID of the existing Databricks jobs (required if ``job_name`` isn't provided).
-   * - job_name: str
-     - Name of the existing Databricks job (required if ``job_id`` isn't provided). It will throw exception if job isn't found, of if there are multiple jobs with the same name.
-   * - jar_params: list[str]
-     - A list of parameters for jobs with JAR tasks, e.g. ``"jar_params": ["john doe", "35"]``. The parameters will be passed to JAR file as command line parameters. If specified upon run-now, it would overwrite the parameters specified in job setting. The json representation of this field (i.e. ``{"jar_params":["john doe","35"]}``) cannot exceed 10,000 bytes. This field will be templated.
-   * - notebook_params: dict[str,str]
-     - A dict from keys to values for jobs with notebook task, e.g.``"notebook_params": {"name": "john doe", "age":  "35"}```. The map is passed to the notebook and will be accessible through the ``dbutils.widgets.get function``. See `Widgets <https://docs.databricks.com/notebooks/widgets.html>`_ for more information. If not specified upon run-now, the triggered run will use the job’s base parameters. ``notebook_params`` cannot be specified in conjunction with ``jar_params``. The json representation of this field (i.e. ``{"notebook_params":{"name":"john doe","age":"35"}}``) cannot exceed 10,000 bytes. This field will be templated.
-   * - python_params: list[str]
-     - A list of parameters for jobs with python tasks, e.g. ``"python_params": ["john doe", "35"]``. The parameters will be passed to python file as command line parameters. If specified upon run-now, it would overwrite the parameters specified in job setting. The json representation of this field (i.e. ``{"python_params":["john doe","35"]}``) cannot exceed 10,000 bytes. This field will be templated.
-   * - spark_submit_params: list[str]
-     - A list of parameters for jobs with spark submit task,  e.g. ``"spark_submit_params": ["--class", "org.apache.spark.examples.SparkPi"]``. The parameters will be passed to spark-submit script as command line parameters. If specified upon run-now, it would overwrite the parameters specified in job setting. The json representation of this field cannot exceed 10,000 bytes. This field will be templated.
-   * - timeout_seconds: int
-     - The timeout for this run. By default a value of 0 is used  which means to have no timeout. This field will be templated.
-   * - databricks_conn_id: string
-     - the name of the Airflow connection to use
-   * - polling_period_seconds: integer
-     - controls the rate which we poll for the result of this run
-   * - databricks_retry_limit: integer
-     - amount of times retry if the Databricks backend is unreachable
-   * - databricks_retry_delay: decimal
-     - number of seconds to wait between retries
-   * - databricks_retry_args: dict
-     - An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
-   * - do_xcom_push: boolean
-     - whether we should push run_id and run_page_url to xcom
+* ``job_id`` - to specify ID of the existing Databricks job
+* ``job_name`` - Name of the existing Databricks job. It will throw exception if job isn't found, of if there are multiple jobs with the same name.
+
+All other parameters are optional and described in documentation for ``DatabricksRunNowOperator``.  For example, you can pass additional parameters to a job using one of the following parameters, depending on the type of tasks in the job:
+
+* ``notebook_params``
+* ``python_params``
+* ``python_named_parameters``
+* ``jar_params``
+* ``spark_submit_params``

--- a/docs/apache-airflow-providers-databricks/operators/submit_run.rst
+++ b/docs/apache-airflow-providers-databricks/operators/submit_run.rst
@@ -31,49 +31,27 @@ Using the Operator
 ------------------
 
 There are two ways to instantiate this operator. In the first way, you can take the JSON payload that you typically use
-to call the ``api/2.1/jobs/runs/submit`` endpoint and pass it directly to our ``DatabricksSubmitRunOperator`` through the ``json`` parameter.
+to call the ``api/2.1/jobs/runs/submit`` endpoint and pass it directly to our ``DatabricksSubmitRunOperator`` through the
+``json`` parameter.  With this approach you get full control over the underlying payload to Jobs REST API, including
+execution of Databricks jobs with multiple tasks, but it's harder to detect errors because of the lack of the type checking.
 
 Another way to accomplish the same thing is to use the named parameters of the ``DatabricksSubmitRunOperator`` directly. Note that there is exactly
-one named parameter for each top level parameter in the ``runs/submit`` endpoint.
+one named parameter for each top level parameter in the ``runs/submit`` endpoint.  When using named parameters you must to specify following:
 
-.. list-table::
-   :widths: 25 25
-   :header-rows: 1
+* Task specification - it should be one of:
 
-   * - Parameter
-     - Input
-   * - spark_jar_task: dict
-     - main class and parameters for the JAR task
-   * - notebook_task: dict
-     - notebook path and parameters for the task
-   * - spark_python_task: dict
-     - python file path and parameters to run the python file with
-   * - spark_submit_task: dict
-     - parameters needed to run a spark-submit command
-   * - pipeline_task: dict
-     - parameters needed to run a Delta Live Tables pipeline
-   * - new_cluster: dict
-     - specs for a new cluster on which this task will be run
-   * - existing_cluster_id: string
-     - ID for existing cluster on which to run this task
-   * - libraries: list of dict
-     - libraries which this run will use
-   * - run_name: string
-     - run name used for this task
-   * - timeout_seconds: integer
-     - The timeout for this run
-   * - databricks_conn_id: string
-     - the name of the Airflow connection to use
-   * - polling_period_seconds: integer
-     - controls the rate which we poll for the result of this run
-   * - databricks_retry_limit: integer
-     - amount of times retry if the Databricks backend is unreachable
-   * - databricks_retry_delay: decimal
-     - number of seconds to wait between retries
-   * - databricks_retry_args: dict
-     - An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
-   * - do_xcom_push: boolean
-     - whether we should push run_id and run_page_url to xcom
+  * ``spark_jar_task`` - main class and parameters for the JAR task
+  * ``notebook_task`` - notebook path and parameters for the task
+  * ``spark_python_task`` - python file path and parameters to run the python file with
+  * ``spark_submit_task`` - parameters needed to run a ``spark-submit`` command
+  * ``pipeline_task`` - parameters needed to run a Delta Live Tables pipeline
+
+* Cluster specification - it should be one of:
+  * ``new_cluster`` - specs for a new cluster on which this task will be run
+  * ``existing_cluster_id`` - ID for existing cluster on which to run this task
+
+All other parameters are optional, and described in the documentation of the ``DatabricksSubmitRunOperator`` class.
+
 
 Examples
 --------


### PR DESCRIPTION
This PR includes following changes:

* Document missed parameters for `DatabricksSubmitRunOperator` and `DatabricksRunNowOperator`
* Add support for new parameters in `DatabricksRunNowOperator`: `python_named_parameters` and `idempotency_token`
* Rework documentation for both operators based on the feedback from another PR
