### PR TITLE
Fix main failure after moto upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -629,7 +629,7 @@ devel_only = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto[glue]>=3.1.0',
+    'moto[glue]>=3.1.6',
     'parameterized',
     'paramiko',
     'pipdeptree',

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -75,7 +75,7 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
             ':', '_'
         )
 
-        moto.core.moto_api_backend.reset()
+        moto.moto_api._internal.models.moto_api_backend.reset()
         self.conn = boto3.client('logs', region_name=self.region_name)
 
     def tearDown(self):

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -70,7 +70,7 @@ class TestS3TaskHandler(unittest.TestCase):
         self.conn = boto3.client('s3')
         # We need to create the bucket since this is all in Moto's 'virtual'
         # AWS account
-        moto.core.moto_api_backend.reset()
+        moto.moto_api._internal.models.moto_api_backend.reset()
         self.conn.create_bucket(Bucket="bucket")
 
     def tearDown(self):


### PR DESCRIPTION
The moto library 3.1.6 extracted MotoAPI to dedicated module
(How about SemVer?).

https://github.com/spulec/moto/pull/5055

This broke our S3/CloudWatch tests.

This PR bumps minimum version of Moto to 3.1.6 and switches to
the new module when importing the API.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
