### PR TITLE
Fix pushing image cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1664,7 +1664,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
           UPGRADE_TO_NEWER_DEPENDENCIES: "false"
           DOCKER_CACHE: ${{ needs.build-info.outputs.cacheDirective }}
-          IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           PLATFORM: "linux/amd64,linux/arm64"
           PREPARE_BUILDX_CACHE: "true"
           VERSION_SUFFIX_FOR_PYPI: dev0
@@ -1687,7 +1686,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: breeze prepare-airflow-package --package-format wheel
       - name: "Move dist packages to docker-context files"
         run: mv -v ./dist/*.whl ./docker-context-files
-      - name: Build & Push PROD image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
+      - name: Build & Push PROD image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:latest
         run: >
           breeze build-prod-image
           --push-image
@@ -1698,7 +1697,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
           UPGRADE_TO_NEWER_DEPENDENCIES: "false"
           DOCKER_CACHE: ${{ needs.build-info.outputs.cacheDirective }}
-          IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           PLATFORM: "linux/amd64,linux/arm64"
           PREPARE_BUILDX_CACHE: "true"
           VERSION_SUFFIX_FOR_PYPI: "dev0"


### PR DESCRIPTION
After converting to `breeze` commands, pushing cache started to fail
as the image tag was used (but for cache we always build and push
using 'latest' images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
