### PR TITLE
Fix renamed .README.md file in clean/check for docker-context-files

### DIFF
--- a/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
+++ b/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
@@ -72,7 +72,7 @@ OPTIONAL_PROD_IMAGE_ARGS = [
 
 def clean_docker_context_files(verbose: bool, dry_run: bool):
     """
-    Cleans up docker context files folder - leaving only README.md there.
+    Cleans up docker context files folder - leaving only .README.md there.
     """
     if verbose or dry_run:
         console.print("[bright_blue]Cleaning docker-context-files[/]")
@@ -81,7 +81,7 @@ def clean_docker_context_files(verbose: bool, dry_run: bool):
     with contextlib.suppress(FileNotFoundError):
         context_files_to_delete = DOCKER_CONTEXT_DIR.glob('**/*')
         for file_to_delete in context_files_to_delete:
-            if file_to_delete.name != 'README.md':
+            if file_to_delete.name != '.README.md':
                 file_to_delete.unlink()
 
 
@@ -96,7 +96,7 @@ def check_docker_context_files(install_from_docker_context_files: bool):
     """
     context_file = DOCKER_CONTEXT_DIR.glob('**/*')
     number_of_context_files = len(
-        [context for context in context_file if context.is_file() and context.name != 'README.md']
+        [context for context in context_file if context.is_file() and context.name != '.README.md']
     )
     if number_of_context_files == 0:
         if install_from_docker_context_files:


### PR DESCRIPTION
The README.md has been renamed to .README.md in docker-context-files
to make it less prone to accidental deletion, but breeze commands
were not updated to account for that change.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
