### PR TITLE
`TriggerDagRunOperator`: Fix `DeprecationWarning` on `v2.2-stable`

### DIFF
--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -20,6 +20,8 @@ import json
 from datetime import datetime
 from typing import List, Optional, Union
 
+import pendulum
+
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.utils import timezone
@@ -88,6 +90,9 @@ def _trigger_dag(
             conf=run_conf,
             external_trigger=True,
             dag_hash=dag_bag.dags_hash.get(dag_id),
+            data_interval=_dag.timetable.infer_manual_data_interval(
+                run_after=pendulum.instance(execution_date)
+            ),
         )
         dag_runs.append(dag_run)
 


### PR DESCRIPTION
Co-authored-by: mingshi <mingshi.wang@coinbase.com>

closes: #23124
related: #20781 

Based on the discussion we had on  #23124 , the purpose of this PR is to cherry-pick [`82e466d`](https://github.com/apache/airflow/commit/82e466d8f9b196e1efba44cc15214b9d0bd3b2d1) in order to disable the `DeprecationWarning` on `v2.2-stable`