### PR TITLE
Ensure state is updated on task actions

### DIFF
--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -34,13 +34,12 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const baseDate = getMetaValue('base_date');
 
-const emptyData = {
-  dagRuns: [],
-  groups: {},
-};
-const initialData = formatData(treeData, emptyData);
-
 const useTreeData = () => {
+  const emptyData = {
+    dagRuns: [],
+    groups: {},
+  };
+  const initialData = formatData(treeData, emptyData);
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   const errorToast = useErrorToast();
   return useQuery('treeData', async () => {

--- a/airflow/www/static/js/tree/api/useTreeData.js
+++ b/airflow/www/static/js/tree/api/useTreeData.js
@@ -34,12 +34,13 @@ const numRuns = getMetaValue('num_runs');
 const urlRoot = getMetaValue('root');
 const baseDate = getMetaValue('base_date');
 
+const emptyData = {
+  dagRuns: [],
+  groups: {},
+};
+const initialData = formatData(treeData, emptyData);
+
 const useTreeData = () => {
-  const emptyData = {
-    dagRuns: [],
-    groups: {},
-  };
-  const initialData = formatData(treeData, emptyData);
   const { isRefreshOn, stopRefresh } = useAutoRefresh();
   const errorToast = useErrorToast();
   return useQuery('treeData', async () => {
@@ -59,8 +60,7 @@ const useTreeData = () => {
       throw (error);
     }
   }, {
-    // only enabled and refetch if the refresh switch is on
-    enabled: isRefreshOn,
+    // only refetch if the refresh switch is on
     refetchInterval: isRefreshOn && autoRefreshInterval * 1000,
     initialData,
   });

--- a/airflow/www/static/js/tree/index.jsx
+++ b/airflow/www/static/js/tree/index.jsx
@@ -46,7 +46,14 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
-      retry: 0,
+      retry: 1,
+      retryDelay: 500,
+      staleTime: 60 * 1000, // one minute
+      refetchOnMount: true, // Refetches stale queries, not "always"
+    },
+    mutations: {
+      retry: 1,
+      retryDelay: 500,
     },
   },
 });


### PR DESCRIPTION
When the DAG was paused or autorefresh was off, there was no change when performing a task action. Making it look like it didn't work.

Fix: remove the `enabled` option to make sure that anytime the query is invalidated it does refetch data. But also, to prevent a refetch on load with `staleTime`

Also, updated the retry and refetch options to prevent excessive fetches.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
