### PR TITLE
Fix X-Frame enabled behaviour

### DIFF
--- a/airflow/www/extensions/init_security.py
+++ b/airflow/www/extensions/init_security.py
@@ -31,12 +31,11 @@ def init_xframe_protection(app):
     See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
     """
     x_frame_enabled = conf.getboolean('webserver', 'X_FRAME_ENABLED', fallback=True)
-    if not x_frame_enabled:
+    if x_frame_enabled:
         return
 
     def apply_caching(response):
-        if not x_frame_enabled:
-            response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Frame-Options"] = "DENY"
         return response
 
     app.after_request(apply_caching)

--- a/newsfragments/23222.significant.rst
+++ b/newsfragments/23222.significant.rst
@@ -1,0 +1,13 @@
+The webserver.X_FRAME_ENABLED configuration works according to description now.
+
+In Airflow 2.0.0 - 2.2.4 the webserver.X_FRAME_ENABLED parameter worked the opposite of its description,
+setting the value to "true" caused "X-Frame-Options" header to "DENY" (not allowing Airflow to be used
+in an IFrame). When you set it to "false", the header was not added, so Airflow could be embedded in an
+IFrame. By default Airflow could not be embedded in an IFrame.
+
+In Airflow 2.2.5 there was a bug introduced that made it impossible to disable Airflow to
+work in IFrame. No matter what the configuration was set, it was possible to embed Airflow in an IFrame.
+
+Airflow 2.3.0 restores the original meaning to the parameter. If you set it to "true" (default) Airflow
+can be embedded in an IFrame (no header is added), but when you set it to "false" the header is added
+and Airflow cannot be embedded in an IFrame.


### PR DESCRIPTION
The #19491 incorrectly changed condition on assigning the
X-Frame-Options header DENY. It actually was not possible to set
the DENY header.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
