### PR TITLE
Add optional Prometheus Service Monitor

### DIFF
--- a/chart/templates/statsd/prometheus-service-monitor.yaml
+++ b/chart/templates/statsd/prometheus-service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.statsd.enabled .Values.statsd.enableServiceMonitor }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .Release.Name }}-servicemonitor
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      tier: airflow
+      component: statsd
+      release: "{{ .Release.Name }}"
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: statsd-scrape
+{{- end }}

--- a/chart/templates/statsd/prometheus-service-monitor.yaml
+++ b/chart/templates/statsd/prometheus-service-monitor.yaml
@@ -1,3 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+########################################
+## Airflow Prometheus ServiceMonitor
+########################################
 {{- if and .Values.statsd.enabled .Values.statsd.enableServiceMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3180,6 +3180,11 @@
                     "type": "boolean",
                     "default": true
                 },
+                "enableServiceMonitor": {
+                    "description": "Enable PrometheusOperator ServiceMonitor",
+                    "type": "boolean",
+                    "default": false
+                },
                 "extraNetworkPolicies": {
                     "description": "Additional NetworkPolicies as needed.",
                     "type": "array",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1123,6 +1123,7 @@ flower:
 # StatsD settings
 statsd:
   enabled: true
+  enableServiceMonitor: false
 
   # Create ServiceAccount
   serviceAccount:


### PR DESCRIPTION


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Add a ServiceMonitor object for use with the [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator). 
---

We've been using this with great effect internally and thought it would be useful for others as well. I've set it up to be entirely optional, as it does require the Prometheus Operator to already be installed and configured in the kube cluster.
