### PR TITLE
Remove deprecated `params` from google operators

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -34,6 +34,10 @@ Breaking changes
    For more information, see `Deprecation and sunset <https://developers.google.com/google-ads/api/docs/sunset-dates>`_
    and `Upgrading to the newest version <https://developers.google.com/google-ads/api/docs/version-migration>`_
 
+* ``GoogleDisplayVideo360CreateReportOperator``: remove ``params``. Please use ``parameters``
+
+* ``FacebookAdsReportToGcsOperator``: remove ``params``. Please use ``parameters``
+
 * ``GoogleDriveToGCSOperator``: Remove ``destination_bucket`` and ``destination_object``. Please use ``bucket_name`` and ``object_name``.
 
 * ``GCSObjectsWtihPrefixExistenceSensor`` removed. Please use ``GCSObjectsWithPrefixExistenceSensor``.

--- a/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
@@ -18,7 +18,6 @@
 """This module contains Facebook Ad Reporting to GCS operators."""
 import csv
 import tempfile
-import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 

--- a/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
@@ -66,9 +66,6 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         it will use the Facebook business SDK default version.
     :param fields: List of fields that is obtained from Facebook. Found in AdsInsights.Field class.
         https://developers.facebook.com/docs/marketing-api/insights/parameters/v6.0
-    :param params: Parameters that determine the query for Facebook. This keyword is deprecated,
-        please use `parameters` keyword to pass the parameters.
-        https://developers.facebook.com/docs/marketing-api/insights/parameters/v6.0
     :param parameters: Parameters that determine the query for Facebook
         https://developers.facebook.com/docs/marketing-api/insights/parameters/v6.0
     :param gzip: Option to compress local file or file data for upload
@@ -100,7 +97,6 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         bucket_name: str,
         object_name: str,
         fields: List[str],
-        params: Optional[Dict[str, Any]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         gzip: bool = False,
         upload_as_account: bool = False,
@@ -121,17 +117,6 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         self.gzip = gzip
         self.upload_as_account = upload_as_account
         self.impersonation_chain = impersonation_chain
-
-        if params is None and parameters is None:
-            raise AirflowException("Argument ['parameters'] is required")
-        if params and parameters is None:
-            # TODO: Remove in provider version 6.0
-            warnings.warn(
-                "Please use 'parameters' instead of 'params'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.parameters = params
 
     def execute(self, context: 'Context'):
         service = FacebookAdsReportingHook(

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -21,7 +21,6 @@ import json
 import shutil
 import tempfile
 import urllib.request
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from urllib.parse import urlparse
 
@@ -322,9 +321,6 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
         `https://developers.google.com/bid-manager/v1/queries/runquery`
 
     :param report_id: Report ID to run.
-    :param params: Parameters for running a report as described here:
-        https://developers.google.com/bid-manager/v1/queries/runquery. Please note that this
-        keyword is deprecated, please use `parameters` keyword to pass the parameters.
     :param parameters: Parameters for running a report as described here:
         https://developers.google.com/bid-manager/v1/queries/runquery
     :param api_version: The version of the api that will be requested for example 'v3'.
@@ -352,7 +348,6 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
         self,
         *,
         report_id: str,
-        params: Optional[Dict[str, Any]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         api_version: str = "v1",
         gcp_conn_id: str = "google_cloud_default",
@@ -368,17 +363,6 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
         self.parameters = parameters
         self.impersonation_chain = impersonation_chain
 
-        if params is None and parameters is None:
-            raise AirflowException("Argument ['parameters'] is required")
-        if params and parameters is None:
-            # TODO: Remove in provider version 6.0
-            warnings.warn(
-                "Please use 'parameters' instead of 'params'",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.parameters = params
-
     def execute(self, context: 'Context') -> None:
         hook = GoogleDisplayVideo360Hook(
             gcp_conn_id=self.gcp_conn_id,
@@ -387,7 +371,7 @@ class GoogleDisplayVideo360RunReportOperator(BaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
         self.log.info(
-            "Running report %s with the following params:\n %s",
+            "Running report %s with the following parameters:\n %s",
             self.report_id,
             self.parameters,
         )


### PR DESCRIPTION
The next Google provider release is major (breaking changes) so I want to take the opportunity to clean up some deprecations

Related: https://github.com/apache/airflow/pull/18143 for `GoogleDisplayVideo360CreateReportOperator` and `FacebookAdsReportToGcsOperator`

Related: https://github.com/apache/airflow/pull/23050


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
