### PR TITLE
`PubSubPullSensor`: Remove `project` and `return_immediately`

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -39,7 +39,8 @@ Breaking changes
 * ``GCSObjectsWtihPrefixExistenceSensor`` removed. Please use ``GCSObjectsWithPrefixExistenceSensor``.
 
 * ``PubSubPullSensor``: Remove ``project``. Please use ``project_id``
-  ``PubSubPullSensor``: Remove ``return_immediately``
+
+* ``PubSubPullSensor``: Remove ``return_immediately``
 
 6.8.0
 .....

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -38,6 +38,9 @@ Breaking changes
 
 * ``GCSObjectsWtihPrefixExistenceSensor`` removed. Please use ``GCSObjectsWithPrefixExistenceSensor``.
 
+* ``PubSubPullSensor``: Remove ``project``. Please use ``project_id``
+  ``PubSubPullSensor``: Remove ``return_immediately``
+
 6.8.0
 .....
 


### PR DESCRIPTION
The next Google provider release is major (breaking changes) so I want to take the opportunity to clean up some deprecations

Related: https://github.com/apache/airflow/pull/23050
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
