### PR TITLE
Validate conn_type and values for extra_field_name_mapping

### DIFF
--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -109,6 +109,7 @@ def test_process_form_extras_both(mock_pm_hooks, mock_import_str, field_name):
         "conn_id": "extras_test",
         "extra": '{"param1": "param1_val"}',
         "extra__test__custom_field": "custom_field_val",
+        "extra__other_conn_type__custom_field": "another_field_val",
     }
 
     cmv = ConnectionModelView()
@@ -164,17 +165,18 @@ def test_process_form_extras_custom_only(mock_pm_hooks, mock_import_str, field_n
     mock_form.data = {
         "conn_type": "test3",
         "conn_id": "extras_test3",
-        "extra__test3__custom_field": "custom_field_val3",
+        "extra__test3__custom_field": False,
+        "extra__other_conn_type__custom_field": "another_field_val",
     }
 
     cmv = ConnectionModelView()
-    cmv.extra_fields = ["extra__test3__custom_field"]  # Custom field
+    cmv.extra_fields = ["extra__test3__custom_field", "extra__test3__custom_bool_field"]  # Custom fields
 
     # this is set by `lazy_add_provider_discovered_options_to_connection_form`
     cmv.extra_field_name_mapping['extra__test3__custom_field'] = field_name
     cmv.process_form(form=mock_form, is_created=True)
 
-    assert json.loads(mock_form.extra.data) == {field_name: "custom_field_val3"}
+    assert json.loads(mock_form.extra.data) == {field_name: False}
 
 
 @pytest.mark.parametrize('field_name', ['extra__test4__custom_field', 'custom_field'])


### PR DESCRIPTION
Related: #22607

There are a few connections which have default values for particular extra fields namely Google (`extra__google_cloud_platform__num_retries`: 5), Kubernetes (`extra__kubernetes__in_cluster`: False), and Snowflake (`extra__snowflake__insecure_mode`: False). Since all extra fields are available in the form data, a check is needed to only add extra fields that are germane to the connection type of the submission.  Otherwise, the extras with default values could be added to a connection's URI and `extra_dejson` incorrectly.

For example, before this change, assuming a user submits a connection like so:
<img width="799" alt="image" src="https://user-images.githubusercontent.com/48934154/165216271-933e0293-1d7a-4086-b448-d416c5fcbcf8.png">

The connection data stores extra information for `extra__google_cloud_platform__num_retries`:
<img width="1408" alt="image" src="https://user-images.githubusercontent.com/48934154/165216385-c98140ce-047a-4605-9c51-5f009e4497d6.png">

With this change, the connection data does not contain extras which are not of the same connection type as the form submission:
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/48934154/165216516-1ad564f2-3cce-4b50-be68-2e7238e6d2c7.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
