### PR TITLE
Calculate duration in UI

### DIFF
--- a/airflow/www/static/js/tree/InstanceTooltip.jsx
+++ b/airflow/www/static/js/tree/InstanceTooltip.jsx
@@ -27,7 +27,7 @@ import Time from './Time';
 const InstanceTooltip = ({
   group,
   instance: {
-    startDate, endDate, duration, state, runId, mappedStates,
+    startDate, endDate, state, runId, mappedStates,
   },
 }) => {
   const isGroup = !!group.children;
@@ -91,7 +91,7 @@ const InstanceTooltip = ({
       <Text>
         Duration:
         {' '}
-        {formatDuration(duration || getDuration(startDate, endDate))}
+        {formatDuration(getDuration(startDate, endDate))}
       </Text>
     </Box>
   );

--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -29,7 +29,7 @@ import { MdPlayArrow, MdOutlineAccountTree } from 'react-icons/md';
 
 import { SimpleStatus } from '../../../StatusBox';
 import { ClipboardText } from '../../../Clipboard';
-import { formatDuration } from '../../../../datetime_utils';
+import { formatDuration, getDuration } from '../../../../datetime_utils';
 import Time from '../../../Time';
 import MarkFailedRun from './MarkFailedRun';
 import MarkSuccessRun from './MarkSuccessRun';
@@ -50,7 +50,6 @@ const DagRun = ({ runId }) => {
     executionDate,
     state,
     runType,
-    duration,
     lastSchedulingDecision,
     dataIntervalStart,
     dataIntervalEnd,
@@ -103,7 +102,7 @@ const DagRun = ({ runId }) => {
       <Text>
         Duration:
         {' '}
-        {formatDuration(duration)}
+        {formatDuration(getDuration(startDate, endDate))}
       </Text>
       {lastSchedulingDecision && (
       <Text>

--- a/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/Details.jsx
@@ -37,7 +37,6 @@ const Details = ({ instance, group, operator }) => {
   const {
     taskId,
     runId,
-    duration,
     startDate,
     endDate,
     state,
@@ -134,7 +133,7 @@ const Details = ({ instance, group, operator }) => {
           {isOverall}
           Duration:
           {' '}
-          {formatDuration(duration || getDuration(startDate, endDate))}
+          {formatDuration(getDuration(startDate, endDate))}
         </Text>
         {startDate && (
         <Text>

--- a/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
@@ -31,7 +31,7 @@ import {
 } from 'react-icons/md';
 
 import { getMetaValue } from '../../../../utils';
-import { formatDateTime, formatDuration } from '../../../../datetime_utils';
+import { formatDateTime, formatDuration, getDuration } from '../../../../datetime_utils';
 import { useMappedInstances } from '../../../api';
 import { SimpleStatus } from '../../../StatusBox';
 import Table from '../../../Table';
@@ -83,7 +83,7 @@ const MappedInstances = ({
             {mi.state || 'no status'}
           </Flex>
         ),
-        duration: mi.duration && formatDuration(mi.duration),
+        duration: mi.duration && formatDuration(getDuration(mi.startDate, mi.endDate)),
         startDate: mi.startDate && formatDateTime(mi.startDate),
         endDate: mi.endDate && formatDateTime(mi.endDate),
         links: (

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -146,7 +146,6 @@ def encode_ti(
         'run_id': task_instance.run_id,
         'map_index': task_instance.map_index,
         'state': task_instance.state,
-        'duration': task_instance.duration,
         'start_date': datetime_to_string(task_instance.start_date),
         'end_date': datetime_to_string(task_instance.end_date),
         'try_number': try_count,


### PR DESCRIPTION
We had two sources of truth on duration, this led to duration being 0 sometimes because one was seconds and another was milliseconds. I figured it was better to just have the UI manage it and (marginally) simplify the json object for grid data.

Fixes: https://github.com/apache/airflow/issues/23068

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
