### PR TITLE
`CloudBuildCreateBuildOperator`: Remove deprecated `body` parameter

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -34,6 +34,8 @@ Breaking changes
    For more information, see `Deprecation and sunset <https://developers.google.com/google-ads/api/docs/sunset-dates>`_
    and `Upgrading to the newest version <https://developers.google.com/google-ads/api/docs/version-migration>`_
 
+* ``CloudBuildCreateBuildOperator``: Remove ``body``. Please use ``build``
+
 * ``BigtableCreateInstanceOperator`` Remove ``replica_cluster_id``, ``replica_cluster_zone``. Please use ``replica_clusters``.
 
 * ``BigtableHook.create_instance``: Remove ``replica_cluster_id``, ``replica_cluster_zone``. Please use ``replica_clusters``.

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -20,7 +20,6 @@
 
 import json
 import re
-import warnings
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 from urllib.parse import unquote, urlparse
@@ -113,10 +112,9 @@ class CloudBuildCreateBuildOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:CloudBuildCreateBuildOperator`
 
-    :param build: Optional, the build resource to create. If a dict is provided, it must be of
+    :param build: The build resource to create. If a dict is provided, it must be of
         the same form as the protobuf message `google.cloud.devtools.cloudbuild_v1.types.Build`.
         Only either build or body should be passed.
-    :param body: (Deprecated) The build resource to create.
         This parameter has been deprecated. You should pass the build parameter instead.
     :param project_id: Optional, Google Cloud Project project_id where the function belongs.
         If set to None or missing, the default project_id from the GCP connection is used.
@@ -144,8 +142,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     def __init__(
         self,
         *,
-        build: Optional[Union[Dict, Build]] = None,
-        body: Optional[Dict] = None,
+        build: Union[Dict, Build],
         project_id: Optional[str] = None,
         wait: bool = True,
         retry: Union[Retry, _MethodDefault] = DEFAULT,
@@ -163,25 +160,9 @@ class CloudBuildCreateBuildOperator(BaseOperator):
         self.metadata = metadata
         self.gcp_conn_id = gcp_conn_id
         self.impersonation_chain = impersonation_chain
-        self.body = body
-
-        if body and build:
-            raise AirflowException("You should not pass both build or body parameters. Both are set.")
-        if body is not None:
-            warnings.warn(
-                "The body parameter has been deprecated. You should pass body using the build parameter.",
-                DeprecationWarning,
-                stacklevel=4,
-            )
-            actual_build = body
-        else:
-            if build is None:
-                raise AirflowException("You should pass one of the build or body parameters. Both are None")
-            actual_build = build
-
-        self.build = actual_build
+        self.build = build
         # Not template fields to keep original value
-        self.build_raw = actual_build
+        self.build_raw = build
 
     def prepare_template(self) -> None:
         # if no file is specified, skip

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -114,8 +114,6 @@ class CloudBuildCreateBuildOperator(BaseOperator):
 
     :param build: The build resource to create. If a dict is provided, it must be of
         the same form as the protobuf message `google.cloud.devtools.cloudbuild_v1.types.Build`.
-        Only either build or body should be passed.
-        This parameter has been deprecated. You should pass the build parameter instead.
     :param project_id: Optional, Google Cloud Project project_id where the function belongs.
         If set to None or missing, the default project_id from the GCP connection is used.
     :param wait: Optional, wait for operation to finish.
@@ -137,7 +135,7 @@ class CloudBuildCreateBuildOperator(BaseOperator):
     :rtype: dict
     """
 
-    template_fields: Sequence[str] = ("project_id", "build", "body", "gcp_conn_id", "impersonation_chain")
+    template_fields: Sequence[str] = ("project_id", "build", "gcp_conn_id", "impersonation_chain")
 
     def __init__(
         self,

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -88,23 +88,10 @@ class TestCloudBuildOperator(TestCase):
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.cloud_build.CloudBuildHook")
-    def test_create_build_with_body(self, mock_hook):
+    def test_create_build_with_missing_build(self, mock_hook):
         mock_hook.return_value.create_build.return_value = Build()
-        operator = CloudBuildCreateBuildOperator(body=BUILD, task_id="id")
-        operator.execute(context=None)
-        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=None)
-        build = Build(BUILD)
-        mock_hook.return_value.create_build.assert_called_once_with(
-            build=build, project_id=None, wait=True, retry=DEFAULT, timeout=None, metadata=()
-        )
-
-    @mock.patch("airflow.providers.google.cloud.operators.cloud_build.CloudBuildHook")
-    def test_create_build_with_body_and_build(self, mock_hook):
-        mock_hook.return_value.create_build.return_value = Build()
-        with pytest.raises(
-            AirflowException, match="You should not pass both build or body parameters. Both are set."
-        ):
-            CloudBuildCreateBuildOperator(build=BUILD, body=BUILD, task_id="id")
+        with pytest.raises(AirflowException, match="missing keyword argument 'build'"):
+            CloudBuildCreateBuildOperator(task_id="id")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
* `CloudBuildCreateBuildOperator`: Remove `body`. Please use `build`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
