### PR TITLE
Handle undefined data interval in grid runs

### DIFF
--- a/airflow/www/static/js/tree/dagRuns/Tooltip.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Tooltip.jsx
@@ -25,7 +25,7 @@ import Time from '../Time';
 
 const DagRunTooltip = ({
   dagRun: {
-    state, duration, dataIntervalEnd,
+    state, duration, dataIntervalStart, executionDate,
   },
 }) => (
   <Box py="2px">
@@ -37,7 +37,7 @@ const DagRunTooltip = ({
     <Text whiteSpace="nowrap">
       Run:
       {' '}
-      <Time dateTime={dataIntervalEnd} />
+      <Time dateTime={dataIntervalStart || executionDate} />
     </Text>
     <Text>
       Duration:

--- a/airflow/www/static/js/tree/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/index.jsx
@@ -127,19 +127,22 @@ const DagRun = ({ runId }) => {
         <Time dateTime={endDate} />
       </Text>
       )}
-      <br />
-      <Text as="strong">Data Interval:</Text>
-      <Text>
-        Start:
-        {' '}
-        <Time dateTime={dataIntervalStart} />
-      </Text>
-      <Text>
-        End:
-        {' '}
-        <Time dateTime={dataIntervalEnd} />
-      </Text>
-
+      {dataIntervalStart && dataIntervalEnd && (
+        <>
+          <br />
+          <Text as="strong">Data Interval:</Text>
+          <Text>
+            Start:
+            {' '}
+            <Time dateTime={dataIntervalStart} />
+          </Text>
+          <Text>
+            End:
+            {' '}
+            <Time dateTime={dataIntervalEnd} />
+          </Text>
+        </>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
Continuation of #22999

Use `dataIntervalStart` and a backup of `executionDate` for dag run tooltips.
Hide data interval text if it is not defined.

Before: (Tooltip and details header are different)
<img width="544" alt="Screen Shot 2022-04-26 at 12 16 54 PM" src="https://user-images.githubusercontent.com/4600967/165346028-eb3b8716-56ef-4546-9eeb-4145ea90d0d4.png">

After: (they are the same)
<img width="551" alt="Screen Shot 2022-04-26 at 12 16 38 PM" src="https://user-images.githubusercontent.com/4600967/165346132-f4c4ca28-52ac-49b3-80e2-8c41a7f5ae55.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
