### PR TITLE
Remove deprecated parameters from BigQueryHook

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -73,6 +73,10 @@ Breaking changes
 
 * ``CloudDatastoreExportEntitiesOperator`` : Remove ``xcom_push``. Please use ``BaseOperator.do_xcom_push``
 
+* ``BigQueryHook.create_empty_table`` Remove ``num_retries``. Please use ``retry``.
+
+* ``BigQueryHook.run_grant_dataset_view_access`` Remove ``source_project``. Please use ``project_id``.
+
 6.8.0
 .....
 

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -318,7 +318,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         materialized_view: Optional[Dict] = None,
         encryption_configuration: Optional[Dict] = None,
         retry: Optional[Retry] = DEFAULT_RETRY,
-        num_retries: Optional[int] = None,
         location: Optional[str] = None,
         exists_ok: bool = True,
     ) -> Table:
@@ -374,8 +373,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :param exists_ok: If ``True``, ignore "already exists" errors when creating the table.
         :return: Created table
         """
-        if num_retries:
-            warnings.warn("Parameter `num_retries` is deprecated", DeprecationWarning)
 
         _table_resource: Dict[str, Any] = {}
 
@@ -1069,7 +1066,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         source_dataset: str,
         view_dataset: str,
         view_table: str,
-        source_project: Optional[str] = None,
         view_project: Optional[str] = None,
         project_id: Optional[str] = None,
     ) -> Dict[str, Any]:
@@ -1087,12 +1083,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             self.project_id will be used.
         :return: the datasets resource of the source dataset.
         """
-        if source_project:
-            project_id = source_project
-            warnings.warn(
-                "Parameter ``source_project`` is deprecated. Use ``project_id``.",
-                DeprecationWarning,
-            )
         view_project = view_project or project_id
         view_access = AccessEntry(
             role=None,


### PR DESCRIPTION
* `BigQueryHook.create_empty_table` Remove `num_retries`. Please use `retry`.

* `BigQueryHook.run_grant_dataset_view_access` Remove `source_project`. Please use `project_id`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
