### PR TITLE
Fix standalone command hanging on kill

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -279,6 +279,7 @@ class SubCommand(threading.Thread):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=self.env,
+            preexec_fn=os.setsid,
         )
         for line in self.process.stdout:
             self.parent.output_queue.append((self.name, line))


### PR DESCRIPTION
It appears signals were not being forwarded properly.  After appropriating the preexec_fn from SubprocessHook, the issue is resolved.

I'm not sure why this code is necessary.  I was able to find some context around the original addition of this logic to bash operator:
The initial commit: https://github.com/apache/airflow/commit/ca961042c146d49504e00e4abefc7779f0747782
The jira issue: https://issues.apache.org/jira/browse/AIRFLOW-1745
a referenced stackoverflow post: https://stackoverflow.com/questions/22077881/yes-reporting-error-with-subprocess-communicate

