### PR TITLE
Remove custom signal handling in Triggerer

### DIFF
--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -24,7 +24,7 @@ from daemon.pidfile import TimeoutPIDLockFile
 from airflow import settings
 from airflow.jobs.triggerer_job import TriggererJob
 from airflow.utils import cli as cli_utils
-from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
+from airflow.utils.cli import setup_locations, setup_logging, sigquit_handler
 
 
 @cli_utils.action_cli
@@ -50,7 +50,19 @@ def triggerer(args):
                 job.run()
 
     else:
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
+        # There is a bug in CPython (fixed in March 2022 but not yet released) that
+        # makes async.io handle SIGTERM improperly by using async unsafe
+        # functions and hanging the triggerer receive SIGPIPE while handling
+        # SIGTERN/SIGINT and deadlocking itself. Until the bug is handled
+        # we should rather rely on standard handling of the signals rather than
+        # adding our own signal handlers. Seems that even if our signal handler
+        # just run exit(0) - it caused a race condition that led to the hanging.
+        #
+        # More details:
+        #   * https://bugs.python.org/issue39622
+        #   * https://github.com/python/cpython/issues/83803
+        #
+        # signal.signal(signal.SIGINT, sigint_handler)
+        # signal.signal(signal.SIGTERM, sigint_handler)
         signal.signal(signal.SIGQUIT, sigquit_handler)
         job.run()


### PR DESCRIPTION
There is a bug in CPython (fixed in March 2022 but not yet released) that
makes async.io handle SIGTERM improperly by using async unsafe
functions and hanging the triggerer receive SIGPIPE while handling
SIGTERN/SIGINT and deadlocking itself. Until the bug is handled
we should rather rely on standard handling of the signals rather than
adding our own signal handlers. Seems that even if our signal handler
just run exit(0) - it caused a race condition that led to the hanging.


More details:
    * https://bugs.python.org/issue39622
    * https://github.com/python/cpython/issues/83803

Fixes: #19260

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
