### PR TITLE
Add support for timezone as string in cron interval timetable

### DIFF
--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -127,8 +127,11 @@ class CronDataIntervalTimetable(_DataIntervalTimetable):
     Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
     """
 
-    def __init__(self, cron: str, timezone: Timezone) -> None:
+    def __init__(self, cron: str, timezone: Union[str, Timezone]) -> None:
         self._expression = cron_presets.get(cron, cron)
+
+        if isinstance(timezone, str):
+            timezone = Timezone(timezone)
         self._timezone = timezone
 
         descriptor = ExpressionDescriptor(

--- a/tests/timetables/test_interval_timetable.py
+++ b/tests/timetables/test_interval_timetable.py
@@ -153,3 +153,8 @@ def test_validate_failure(timetable: Timetable, error_message: str) -> None:
     with pytest.raises(AirflowTimetableInvalid) as ctx:
         timetable.validate()
     assert str(ctx.value) == error_message
+
+
+def test_cron_interval_timezone_from_string():
+    timetable = CronDataIntervalTimetable("@hourly", "UTC")
+    assert timetable.serialize()['timezone'] == 'UTC'


### PR DESCRIPTION
This allows you to write:
```python
timetable = CronDataIntervalTimetable("@hourly", "UTC")
```