### PR TITLE
Restore Breeze while preparing the images

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -232,10 +232,22 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
     git tag -s ${VERSION} -m "Apache Airflow ${VERSION}"
     ```
 
-- Clean the checkout: the sdist step below will
+- Clean the checkout repo
 
     ```shell script
     git clean -fxd
+    ```
+
+- Restore breeze installation (The breeze's `.egginfo` is cleared by git-clean)
+
+    ```shell script
+    pipx install -e ./dev/breeze --force
+    ```
+
+- Make sure you have the latest CI image
+
+    ```shell script
+    breeze pull-image --python 3.7
     ```
 
 - Tarball the repo


### PR DESCRIPTION
When you prepare the release images you clean git repo
and it removes Breeze's .egg-info files. Also when you create
a new branch you might simply not have the breeze image
available which will not allow you to build airflow packages.

This adds two steps to release process:

* reinstalling Breeze
* pulling the Breeze CI image

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
