### PR TITLE
Fix duplicated Kubernetes DeprecationWarnings

### DIFF
--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -17,17 +17,18 @@
 # under the License.
 """
 This module is deprecated.
-Please use :mod:`kubernetes.client.models for V1ResourceRequirements and Port.
+Please use :mod:`kubernetes.client.models` for `V1ResourceRequirements` and `Port`.
 """
 # flake8: noqa
 
 import warnings
 
 with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
     from airflow.providers.cncf.kubernetes.backcompat.pod import Port, Resources  # noqa: autoflake
 
 warnings.warn(
-    "This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port.",
+    "This module is deprecated. Please use `kubernetes.client.models` for `V1ResourceRequirements` and `Port`.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/kubernetes/pod_runtime_info_env.py
+++ b/airflow/kubernetes/pod_runtime_info_env.py
@@ -19,6 +19,7 @@
 import warnings
 
 with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
     from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv  # noqa
 
 warnings.warn(

--- a/airflow/kubernetes/volume.py
+++ b/airflow/kubernetes/volume.py
@@ -19,6 +19,7 @@
 import warnings
 
 with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
     from airflow.providers.cncf.kubernetes.backcompat.volume import Volume  # noqa: autoflake
 
 warnings.warn(

--- a/airflow/kubernetes/volume_mount.py
+++ b/airflow/kubernetes/volume_mount.py
@@ -19,6 +19,7 @@
 import warnings
 
 with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
     from airflow.providers.cncf.kubernetes.backcompat.volume_mount import VolumeMount  # noqa: autoflake
 
 warnings.warn(


### PR DESCRIPTION
I noticed we weren't actually ignoring the nested DeprecationWarnings. This fixes it so we only get 1, at the right stacklevel as well.