### PR TITLE
Fix empty image preparation

### DIFF
--- a/dev/breeze/src/airflow_breeze/build_image/ci/build_ci_image.py
+++ b/dev/breeze/src/airflow_breeze/build_image/ci/build_ci_image.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import multiprocessing as mp
+import os
 import sys
 from typing import List, Tuple
 
@@ -155,6 +156,8 @@ def build_ci_image(
             production_image=False,
         )
         if ci_image_params.empty_image:
+            env = os.environ.copy()
+            env['DOCKER_BUILDKIT'] = "1"
             console.print(f"\n[blue]Building empty CI Image for Python {ci_image_params.python}\n")
             cmd = construct_empty_docker_build_command(image_params=ci_image_params)
             build_result = run_command(
@@ -164,6 +167,7 @@ def build_ci_image(
                 dry_run=dry_run,
                 cwd=AIRFLOW_SOURCES_ROOT,
                 text=True,
+                env=env,
             )
         else:
             console.print(f"\n[blue]Building CI Image for Python {ci_image_params.python}\n")

--- a/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
+++ b/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
@@ -16,6 +16,7 @@
 # under the License.
 """Command to build PROD image."""
 import contextlib
+import os
 import sys
 from typing import Tuple
 
@@ -169,6 +170,8 @@ def build_production_image(
         )
         console.print(f"\n[blue]Building PROD Image for Python {prod_image_params.python}\n")
         if prod_image_params.empty_image:
+            env = os.environ.copy()
+            env['DOCKER_BUILDKIT'] = "1"
             console.print(f"\n[blue]Building empty PROD Image for Python {prod_image_params.python}\n")
             cmd = construct_empty_docker_build_command(image_params=prod_image_params)
             build_command_result = run_command(
@@ -179,6 +182,7 @@ def build_production_image(
                 cwd=AIRFLOW_SOURCES_ROOT,
                 check=False,
                 text=True,
+                env=env,
             )
         else:
             cmd = construct_docker_build_command(


### PR DESCRIPTION
Empty image preparation failed in CI because it was impossible to
build an empty image without buildkit. This change sets DOCKER_BUILDKIT
variable for empty image build which make it always use the buildkit.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
