### PR TITLE
Adds resultBackendSecretName warning in Helm production docs

### DIFF
--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -49,12 +49,11 @@ configure the secret name:
 
   data:
     metadataSecretName: mydatabase
-    resultBackendSecretName: mydatabase
 
 .. _production-guide:pgbouncer:
 
 .. warning::
-  `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` or `postgres://` and wont work with `db+postgresql://`. To solve this, it might be necessary to create multiple secrets.
+  If you use `CeleryExecutor`, keep in mind that `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` and wont work with `db+postgresql://`. You'll need to create separate secrets with the correct schema.
 
 PgBouncer
 ---------

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -49,8 +49,12 @@ configure the secret name:
 
   data:
     metadataSecretName: mydatabase
+    resultBackendSecretName: mydatabase
 
 .. _production-guide:pgbouncer:
+
+.. warning::
+  `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` or `postgres://` and wont work with `db+postgresql://`. To solve this, it might be necessary to create multiple secrets.
 
 PgBouncer
 ---------

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -53,7 +53,7 @@ configure the secret name:
 .. _production-guide:pgbouncer:
 
 .. warning::
-  If you use `CeleryExecutor`, keep in mind that `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` and wont work with `db+postgresql://`. You'll need to create separate secrets with the correct schema.
+  If you use `CeleryExecutor`, keep in mind that `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` and wont work with `db+postgresql://`. You'll need to create separate secrets with the correct scheme.
 
 PgBouncer
 ---------

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -53,7 +53,7 @@ configure the secret name:
 .. _production-guide:pgbouncer:
 
 .. warning::
-  If you use `CeleryExecutor`, keep in mind that `resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` and wont work with `db+postgresql://`. You'll need to create separate secrets with the correct scheme.
+  If you use ``CeleryExecutor``, keep in mind that ``resultBackendSecretName`` expects a url that starts with ``db+postgresql://``, while ``metadataSecretName`` expects ``postgresql://`` and won't work with ``db+postgresql://``. You'll need to create separate secrets with the correct scheme.
 
 PgBouncer
 ---------


### PR DESCRIPTION
Adds resultBackendSecretName warning in Helm production docs.

`resultBackendSecretName` expects a url that starts with `db+postgresql://`, while `metadataSecretName` expects `postgresql://` or `postgres://` and wont work with `db+postgresql://`. To solve this, it might be necessary to create multiple secrets.

closes: #23306