### PR TITLE
Breeze fixups

### DIFF
--- a/breeze
+++ b/breeze
@@ -64,7 +64,7 @@ function check_breeze_installed() {
             if "${MY_DIR}/scripts/tools/confirm" "Installing breeze?"; then
                 pipx ensurepath --force
                 pipx install -e "${MY_DIR}/dev/breeze/" --force
-                ${BREEZE_BINARY} setup-autocomplete --force --answer yes
+                ${BREEZE_BINARY} setup-autocomplete
                 echo
                 echo "${COLOR_YELLOW}Please close and re-open the shell and retry. Then rerun your last command!${COLOR_RESET}"
                 echo

--- a/breeze
+++ b/breeze
@@ -78,4 +78,4 @@ function check_breeze_installed() {
 
 check_breeze_installed
 
-${BREEZE_BINARY} "${@}"
+${BREEZE_BINARY} "$@"

--- a/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
+++ b/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
@@ -248,7 +248,7 @@ def setup_autocomplete(verbose: bool, dry_run: bool, force: bool, answer: Option
     )
     console.print(f"[bright_blue]Activation command script is available here: {autocomplete_path}[/]\n")
     console.print(f"[bright_yellow]We need to add above script to your {detected_shell} profile.[/]\n")
-    given_answer = user_confirm("Would you like me to do that automatically?", default_answer=Answer.NO, timeout=3)
+    given_answer = user_confirm("Would you like me to do that automatically?", default_answer=Answer.NO, timeout=30)
     if given_answer == Answer.YES:
         if detected_shell == 'bash':
             script_path = str(Path('~').expanduser() / '.bash_completion')

--- a/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
+++ b/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
@@ -234,7 +234,8 @@ def setup_autocomplete(verbose: bool, dry_run: bool, force: bool, answer: Option
     """
     Enables autocompletion of breeze commands.
     """
-    set_forced_answer(answer)
+    if force:
+        set_forced_answer(answer)
     # Determine if the shell is bash/zsh/powershell. It helps to build the autocomplete path
     detected_shell = os.environ.get('SHELL')
     detected_shell = None if detected_shell is None else detected_shell.split(os.sep)[-1]
@@ -247,7 +248,7 @@ def setup_autocomplete(verbose: bool, dry_run: bool, force: bool, answer: Option
     )
     console.print(f"[bright_blue]Activation command script is available here: {autocomplete_path}[/]\n")
     console.print(f"[bright_yellow]We need to add above script to your {detected_shell} profile.[/]\n")
-    given_answer = user_confirm("Should we proceed ?", default_answer=Answer.NO, timeout=3)
+    given_answer = user_confirm("Would you like me to do that automatically?", default_answer=Answer.NO, timeout=3)
     if given_answer == Answer.YES:
         if detected_shell == 'bash':
             script_path = str(Path('~').expanduser() / '.bash_completion')

--- a/dev/breeze/src/airflow_breeze/utils/confirm.py
+++ b/dev/breeze/src/airflow_breeze/utils/confirm.py
@@ -45,9 +45,9 @@ def user_confirm(
 
     :rtype: object
     :param message: message to display to the user (should end with the question mark)
-    :param timeout: time given user to answer
-    :param default_answer: default value returned on timeout. If no default - the question is
-        repeated until user answers.
+    :param timeout: time (in seconds) given user to answer
+    :param default_answer: default value returned on timeout. If no default answer is
+        given the timeout is disabled.
     :param quit_allowed: whether quit answer is allowed
     :return:
     """
@@ -64,7 +64,7 @@ def user_confirm(
                 user_status = inputimeout(
                     prompt=f'\n{message} \nPress {allowed_answers}'
                     + (f" in {timeout} seconds: " if timeout is not None else ": "),
-                    timeout=timeout,
+                    timeout=timeout and default_answer is not None,
                 )
             if user_status.upper() in ['Y', 'YES']:
                 return Answer.YES
@@ -75,9 +75,8 @@ def user_confirm(
             else:
                 print(f"Wrong answer given {user_status}. Should be one of {allowed_answers}. Try again.")
         except TimeoutOccurred:
-            if default_answer is not None:
-                return default_answer
-            print(f"Timeout after {timeout} seconds. Try again.")
+            print(f"Timeout after {timeout} seconds. Quitting.")
+            sys.exit(0)
         except KeyboardInterrupt:
             if quit_allowed:
                 return Answer.QUIT

--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -48,7 +48,7 @@ def ask_to_reinstall_breeze(breeze_sources: Path):
     """
     answer = user_confirm(
         f"Do you want to reinstall Breeze from {breeze_sources.parent.parent}?",
-        timeout=3,
+        timeout=None,
         default_answer=Answer.NO,
     )
     if answer == Answer.YES:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR improves Breeze timeout behavior and tries to ensure that Breeze asks for permission before modifying user config files, which are global to the user.

* The timeout period while waiting for user input to modify their user config file has been increased, giving slow readers more time to read and think through the implications of their choices.
* The timeout for reinstalling breeze has been disabled. Since we can't know if the user _needs_ to do so or not, we should refuse the temptation to guess either way.
* Timeouts _without_ default answer values are now ignored, instead of constantly and endlessly re-prompting the user.
* Breeze should now explicitly ask for permission before overwriting user config files.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
