### PR TITLE
Fix HiveToMySqlOperator's wrong docstring

### DIFF
--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -43,8 +43,8 @@ class HiveToMySqlOperator(BaseOperator):
     :param mysql_table: target MySQL table, use dot notation to target a
         specific database. (templated)
     :param mysql_conn_id: source mysql connection
-    :param metastore_conn_id: Reference to the
-        :ref:`metastore thrift service connection id <howto/connection:hive_metastore>`.
+    :param hiveserver2_conn_id: Reference to the
+        :ref:`Hive Server2 thrift service connection id <howto/connection:hiveserver2>`.
     :param mysql_preoperator: sql statement to run against mysql prior to
         import, typically use to truncate of delete in place
         of the data coming in, allowing the task to be idempotent (running


### PR DESCRIPTION
https://airflow.apache.org/docs/apache-airflow-providers-apache-hive/2.3.2/_api/airflow/providers/apache/hive/transfers/hive_to_mysql/index.html#airflow.providers.apache.hive.transfers.hive_to_mysql.HiveToMySqlOperator

Its docstring says as follows, but it actually has
the hiveserver2_conn_id parameter instead.

```
:param metastore_conn_id: Reference to the
    :ref:`metastore thrift service connection id <howto/connection:hive_metastore>`.
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
