### PR TITLE
`GCSFileTransformOperator`: New templated fields `source_object`, `destination_object`

### DIFF
--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -538,8 +538,10 @@ class GCSFileTransformOperator(BaseOperator):
 
     :param source_bucket: The bucket to locate the source_object. (templated)
     :param source_object: The key to be retrieved from GCS. (templated)
-    :param destination_bucket: The bucket to upload the key after transformation. (templated)
-    :param destination_object: The key to be written in GCS. (templated)
+    :param destination_bucket: The bucket to upload the key after transformation.
+        If not provided, source_bucket will be used. (templated)
+    :param destination_object: The key to be written in GCS.
+        If not provided, source_object will be used. (templated)
     :param transform_script: location of the executable transformation script or list of arguments
         passed to subprocess ex. `['python', 'script.py', 10]`. (templated)
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -536,8 +536,10 @@ class GCSFileTransformOperator(BaseOperator):
     data from source, transform it and write the output to the local
     destination file.
 
-    :param source_bucket: The key to be retrieved from GCS. (templated)
-    :param destination_bucket: The key to be written from GCS. (templated)
+    :param source_bucket: The bucket to locate the source_object. (templated)
+    :param source_object: The key to be retrieved from GCS. (templated)
+    :param destination_bucket: The bucket to upload the key after transformation. (templated)
+    :param destination_object: The key to be written in GCS. (templated)
     :param transform_script: location of the executable transformation script or list of arguments
         passed to subprocess ex. `['python', 'script.py', 10]`. (templated)
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
@@ -553,7 +555,9 @@ class GCSFileTransformOperator(BaseOperator):
 
     template_fields: Sequence[str] = (
         'source_bucket',
+        'source_object',
         'destination_bucket',
+        'destination_object',
         'transform_script',
         'impersonation_chain',
     )


### PR DESCRIPTION


* Add `source_object`, `destination_object` as templated fields
* fix docstring

closes: #23327

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
