### PR TITLE
Use run_id for ti.mark_success_url

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -803,13 +803,12 @@ class TaskInstance(Base, LoggingMixin):
     @property
     def mark_success_url(self):
         """URL to mark TI success"""
-        iso = quote(self.execution_date.isoformat())
         base_url = conf.get('webserver', 'BASE_URL')
         return base_url + (
             "/confirm"
             f"?task_id={self.task_id}"
             f"&dag_id={self.dag_id}"
-            f"&execution_date={iso}"
+            f"&dag_run_id={quote(self.run_id)}"
             "&upstream=false"
             "&downstream=false"
             "&state=success"

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1312,7 +1312,8 @@ class TestTaskInstance:
         )
         assert query['dag_id'][0] == 'dag'
         assert query['task_id'][0] == 'op'
-        assert pendulum.parse(query['execution_date'][0]) == now
+        assert query['dag_run_id'][0] == 'test'
+        assert ti.execution_date == now
 
     def test_overwrite_params_with_dag_run_conf(self, create_task_instance):
         ti = create_task_instance()


### PR DESCRIPTION
`/confirm` doesn't accept execution_date anymore

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
