### PR TITLE
Don't show grid actions if server would reject with permission denied

### DIFF
--- a/airflow/www/static/js/tree/Table.jsx
+++ b/airflow/www/static/js/tree/Table.jsx
@@ -72,6 +72,24 @@ const Table = ({
   const lowerCount = (offset || 0) + 1;
   const upperCount = lowerCount + data.length - 1;
 
+  // Don't show row selection if selectRows doesn't exist
+  const selectProps = selectRows
+    ? [useRowSelect,
+      (hooks) => {
+        hooks.visibleColumns.push((cols) => [
+          {
+            id: 'selection',
+            Cell: ({ row }) => (
+              <div>
+                <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
+              </div>
+            ),
+          },
+          ...cols,
+        ]);
+      }]
+    : [];
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -98,20 +116,7 @@ const Table = ({
     },
     useSortBy,
     usePagination,
-    useRowSelect,
-    (hooks) => {
-      hooks.visibleColumns.push((cols) => [
-        {
-          id: 'selection',
-          Cell: ({ row }) => (
-            <div>
-              <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} />
-            </div>
-          ),
-        },
-        ...cols,
-      ]);
-    },
+    ...selectProps,
   );
 
   const handleNext = () => {

--- a/airflow/www/static/js/tree/details/content/ConfirmDialog.jsx
+++ b/airflow/www/static/js/tree/details/content/ConfirmDialog.jsx
@@ -55,7 +55,7 @@ const ConfirmDialog = ({
 
           <AlertDialogBody>
             <Text mb={2}>{description}</Text>
-            {body.map((ti) => (<Code key={ti} fontSize="lg">{ti}</Code>))}
+            {Array.isArray(body) && body.map((ti) => (<Code key={ti} fontSize="lg">{ti}</Code>))}
           </AlertDialogBody>
 
           <AlertDialogFooter>

--- a/airflow/www/static/js/tree/details/content/dagRun/ClearRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/ClearRun.jsx
@@ -22,6 +22,9 @@ import { Button, useDisclosure } from '@chakra-ui/react';
 
 import { useClearRun } from '../../../api';
 import ConfirmDialog from '../ConfirmDialog';
+import { getMetaValue } from '../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const ClearRun = ({ dagId, runId }) => {
   const [affectedTasks, setAffectedTasks] = useState([]);
@@ -42,7 +45,13 @@ const ClearRun = ({ dagId, runId }) => {
 
   return (
     <>
-      <Button onClick={onClick} isLoading={isLoading}>Clear existing tasks</Button>
+      <Button
+        onClick={onClick}
+        isLoading={isLoading}
+        isDisabled={!canEdit}
+      >
+        Clear existing tasks
+      </Button>
       <ConfirmDialog
         isOpen={isOpen}
         onClose={onClose}

--- a/airflow/www/static/js/tree/details/content/dagRun/MarkFailedRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/MarkFailedRun.jsx
@@ -22,6 +22,9 @@ import { Button, useDisclosure } from '@chakra-ui/react';
 
 import { useMarkFailedRun } from '../../../api';
 import ConfirmDialog from '../ConfirmDialog';
+import { getMetaValue } from '../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const MarkFailedRun = ({ dagId, runId }) => {
   const [affectedTasks, setAffectedTasks] = useState([]);
@@ -42,7 +45,7 @@ const MarkFailedRun = ({ dagId, runId }) => {
 
   return (
     <>
-      <Button onClick={onClick} colorScheme="red" isLoading={isLoading}>Mark Failed</Button>
+      <Button onClick={onClick} colorScheme="red" isLoading={isLoading} isDisabled={!canEdit}>Mark Failed</Button>
       <ConfirmDialog
         isOpen={isOpen}
         onClose={onClose}

--- a/airflow/www/static/js/tree/details/content/dagRun/MarkSuccessRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/MarkSuccessRun.jsx
@@ -22,6 +22,9 @@ import { Button, useDisclosure } from '@chakra-ui/react';
 
 import { useMarkSuccessRun } from '../../../api';
 import ConfirmDialog from '../ConfirmDialog';
+import { getMetaValue } from '../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const MarkSuccessRun = ({ dagId, runId }) => {
   const [affectedTasks, setAffectedTasks] = useState([]);
@@ -42,7 +45,7 @@ const MarkSuccessRun = ({ dagId, runId }) => {
 
   return (
     <>
-      <Button onClick={onClick} colorScheme="green" isLoading={isLoading}>Mark Success</Button>
+      <Button onClick={onClick} colorScheme="green" isLoading={isLoading} isDisabled={!canEdit}>Mark Success</Button>
       <ConfirmDialog
         isOpen={isOpen}
         onClose={onClose}

--- a/airflow/www/static/js/tree/details/content/dagRun/QueueRun.jsx
+++ b/airflow/www/static/js/tree/details/content/dagRun/QueueRun.jsx
@@ -22,6 +22,9 @@ import { Button, useDisclosure } from '@chakra-ui/react';
 
 import { useQueueRun } from '../../../api';
 import ConfirmDialog from '../ConfirmDialog';
+import { getMetaValue } from '../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const QueueRun = ({ dagId, runId }) => {
   const [affectedTasks, setAffectedTasks] = useState([]);
@@ -49,6 +52,7 @@ const QueueRun = ({ dagId, runId }) => {
         isLoading={isLoading}
         ml="5px"
         title="Queue up new tasks to make the DAG run up-to-date with any DAG file changes."
+        isDisabled={!canEdit}
       >
         Queue up new tasks
       </Button>

--- a/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/MappedInstances.jsx
@@ -36,6 +36,7 @@ import { useMappedInstances } from '../../../api';
 import { SimpleStatus } from '../../../StatusBox';
 import Table from '../../../Table';
 
+const canEdit = getMetaValue('can_edit') === 'True';
 const renderedTemplatesUrl = getMetaValue('rendered_templates_url');
 const logUrl = getMetaValue('log_url');
 const taskUrl = getMetaValue('task_url');
@@ -147,7 +148,7 @@ const MappedInstances = ({
         pageSize={limit}
         setSortBy={setSortBy}
         isLoading={isLoading}
-        selectRows={selectRows}
+        selectRows={canEdit && selectRows}
       />
     </Box>
   );

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Clear.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Clear.jsx
@@ -28,6 +28,9 @@ import {
 import ActionButton from './ActionButton';
 import ConfirmDialog from '../../ConfirmDialog';
 import { useClearTask } from '../../../../api';
+import { getMetaValue } from '../../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const Run = ({
   dagId,
@@ -96,7 +99,7 @@ const Run = ({
 
   return (
     <Flex justifyContent="space-between" width="100%">
-      <ButtonGroup isAttached variant="outline">
+      <ButtonGroup isAttached variant="outline" isDisabled={!canEdit}>
         <ActionButton bg={past && 'gray.100'} onClick={onTogglePast} name="Past" />
         <ActionButton bg={future && 'gray.100'} onClick={onToggleFuture} name="Future" />
         <ActionButton bg={upstream && 'gray.100'} onClick={onToggleUpstream} name="Upstream" />
@@ -108,6 +111,7 @@ const Run = ({
         colorScheme="blue"
         onClick={onClick}
         isLoading={isLoading}
+        isDisabled={!canEdit}
         title="Clearing deletes the previous state of the task instance, allowing it to get re-triggered by the scheduler or a backfill command"
       >
         Clear

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkFailed.jsx
@@ -28,6 +28,9 @@ import {
 import ActionButton from './ActionButton';
 import { useConfirmMarkTask, useMarkFailedTask } from '../../../../api';
 import ConfirmDialog from '../../ConfirmDialog';
+import { getMetaValue } from '../../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const MarkFailed = ({
   dagId,
@@ -90,13 +93,13 @@ const MarkFailed = ({
 
   return (
     <Flex justifyContent="space-between" width="100%">
-      <ButtonGroup isAttached variant="outline">
+      <ButtonGroup isAttached variant="outline" isDisabled={!canEdit}>
         <ActionButton bg={past && 'gray.100'} onClick={onTogglePast} name="Past" />
         <ActionButton bg={future && 'gray.100'} onClick={onToggleFuture} name="Future" />
         <ActionButton bg={upstream && 'gray.100'} onClick={onToggleUpstream} name="Upstream" />
         <ActionButton bg={downstream && 'gray.100'} onClick={onToggleDownstream} name="Downstream" />
       </ButtonGroup>
-      <Button colorScheme="red" onClick={onClick} isLoading={isLoading}>
+      <Button colorScheme="red" onClick={onClick} isLoading={isLoading} isDisabled={!canEdit}>
         Mark Failed
       </Button>
       <ConfirmDialog

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkSuccess.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/MarkSuccess.jsx
@@ -28,6 +28,9 @@ import {
 import ConfirmDialog from '../../ConfirmDialog';
 import ActionButton from './ActionButton';
 import { useMarkSuccessTask, useConfirmMarkTask } from '../../../../api';
+import { getMetaValue } from '../../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const MarkSuccess = ({
   dagId, runId, taskId, mapIndexes,
@@ -85,13 +88,13 @@ const MarkSuccess = ({
 
   return (
     <Flex justifyContent="space-between" width="100%">
-      <ButtonGroup isAttached variant="outline">
+      <ButtonGroup isAttached variant="outline" isDisabled={!canEdit}>
         <ActionButton bg={past && 'gray.100'} onClick={onTogglePast} name="Past" />
         <ActionButton bg={future && 'gray.100'} onClick={onToggleFuture} name="Future" />
         <ActionButton bg={upstream && 'gray.100'} onClick={onToggleUpstream} name="Upstream" />
         <ActionButton bg={downstream && 'gray.100'} onClick={onToggleDownstream} name="Downstream" />
       </ButtonGroup>
-      <Button colorScheme="green" onClick={onClick} isLoading={isLoading}>
+      <Button colorScheme="green" onClick={onClick} isLoading={isLoading} isDisabled={!canEdit}>
         Mark Success
       </Button>
       <ConfirmDialog

--- a/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Run.jsx
+++ b/airflow/www/static/js/tree/details/content/taskInstance/taskActions/Run.jsx
@@ -25,6 +25,9 @@ import {
 } from '@chakra-ui/react';
 
 import { useRunTask } from '../../../../api';
+import { getMetaValue } from '../../../../../utils';
+
+const canEdit = getMetaValue('can_edit') === 'True';
 
 const Run = ({
   dagId,
@@ -54,7 +57,7 @@ const Run = ({
 
   return (
     <Flex justifyContent="space-between" width="100%">
-      <ButtonGroup isAttached variant="outline">
+      <ButtonGroup isAttached variant="outline" isDisabled={!canEdit}>
         <Button
           bg={ignoreAllDeps && 'gray.100'}
           onClick={onToggleAllDeps}
@@ -77,7 +80,7 @@ const Run = ({
           Ignore Task Deps
         </Button>
       </ButtonGroup>
-      <Button colorScheme="blue" onClick={onClick} isLoading={isLoading}>
+      <Button colorScheme="blue" onClick={onClick} isLoading={isLoading} isDisabled={!canEdit}>
         Run
       </Button>
     </Flex>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -82,6 +82,9 @@
   {% endif %}
   {% if external_log_name is defined %}
   <meta name="external_log_name" content="{{ external_log_name }}">
+  {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
+  <meta name="can_edit" content="{{ appbuilder.sm.can_edit_dag(dag.dag_id) }}">
+  {% endif %}
 {% endif %}
 {% endblock %}
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -83,7 +83,7 @@
   {% if external_log_name is defined %}
   <meta name="external_log_name" content="{{ external_log_name }}">
   {% endif %}
-  <meta name="can_edit" content="{{ appbuilder.sm.can_edit_dag(dag.dag_id) }}">
+  <meta name="can_edit" content="{{ dag.can_edit }}">
 {% endblock %}
 
 {% block content %}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -82,10 +82,8 @@
   {% endif %}
   {% if external_log_name is defined %}
   <meta name="external_log_name" content="{{ external_log_name }}">
-  {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
-  <meta name="can_edit" content="{{ appbuilder.sm.can_edit_dag(dag.dag_id) }}">
   {% endif %}
-{% endif %}
+  <meta name="can_edit" content="{{ appbuilder.sm.can_edit_dag(dag.dag_id) }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
The Grid view wasn't checking DAG edit permissions. Also, the permission error body response is HTML, not json.

- Check if `body` in `ConfirmDialog` is an array to prevent the grid view from crashing
- Add `canEdit` check to disabled all grid view action buttons, and don't show mapped instance selection at all

Before:
![2022-04-28 20 16 50](https://user-images.githubusercontent.com/4600967/165788729-e4a37fdd-f76f-4acc-b13d-c2ae694c0cea.gif)

After:
<img width="996" alt="Screen Shot 2022-04-28 at 11 19 20 AM" src="https://user-images.githubusercontent.com/4600967/165787286-b25c1c2a-35d8-4c80-950d-789d8d966910.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
