### PR TITLE
fix cli airflow show dags for mapped operator

### DIFF
--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -23,6 +23,7 @@ import graphviz
 
 from airflow import AirflowException
 from airflow.models import TaskInstance
+from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.taskmixin import DependencyMixin
@@ -114,7 +115,7 @@ def _draw_nodes(
     node: DependencyMixin, parent_graph: graphviz.Digraph, states_by_task_id: Optional[Dict[str, str]]
 ) -> None:
     """Draw the node and its children on the given parent_graph recursively."""
-    if isinstance(node, BaseOperator):
+    if isinstance(node, BaseOperator) or isinstance(node, AbstractOperator):
         _draw_task(node, parent_graph, states_by_task_id)
     else:
         if not isinstance(node, TaskGroup):

--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -17,15 +17,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Renderer DAG (tasks and dependencies) to the graphviz object."""
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import graphviz
 
 from airflow import AirflowException
 from airflow.models import TaskInstance
-from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
+from airflow.models.mappedoperator import MappedOperator
 from airflow.models.taskmixin import DependencyMixin
 from airflow.serialization.serialized_objects import DagDependency
 from airflow.utils.state import State
@@ -50,7 +50,9 @@ def _refine_color(color: str):
 
 
 def _draw_task(
-    task: BaseOperator, parent_graph: graphviz.Digraph, states_by_task_id: Optional[Dict[Any, Any]]
+    task: Union[MappedOperator, BaseOperator],
+    parent_graph: graphviz.Digraph,
+    states_by_task_id: Optional[Dict[Any, Any]],
 ) -> None:
     """Draw a single task on the given parent_graph"""
     if states_by_task_id:
@@ -115,7 +117,7 @@ def _draw_nodes(
     node: DependencyMixin, parent_graph: graphviz.Digraph, states_by_task_id: Optional[Dict[str, str]]
 ) -> None:
     """Draw the node and its children on the given parent_graph recursively."""
-    if isinstance(node, BaseOperator) or isinstance(node, AbstractOperator):
+    if isinstance(node, BaseOperator) or isinstance(node, MappedOperator):
         _draw_task(node, parent_graph, states_by_task_id)
     else:
         if not isinstance(node, TaskGroup):

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -107,6 +107,20 @@ class TestDotRenderer:
             'third [color=black fillcolor=lime label=third shape=rectangle style="filled,rounded"]' in source
         )
 
+    def test_should_render_dag_with_abstract_mapped_operator(self, session, dag_maker):
+        with dag_maker(dag_id="DAG_ID", session=session) as dag:
+            task_1 = BashOperator.partial(task_id="first").expand(
+                bash_command=["echo hello", "echo world"]
+            )
+
+        dot = dot_renderer.render_dag(dag)
+        source = dot.source
+        # Should render DAG title
+        assert "label=DAG_ID" in source
+        assert (
+            'first [color="#000000" fillcolor="#f0ede4" label=first shape=rectangle style="filled,rounded"]' in source
+        )
+
     def test_should_render_dag_orientation(self, session, dag_maker):
         orientation = "TB"
         with dag_maker(dag_id="DAG_ID", orientation=orientation, session=session) as dag:

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -109,16 +109,15 @@ class TestDotRenderer:
 
     def test_should_render_dag_with_abstract_mapped_operator(self, session, dag_maker):
         with dag_maker(dag_id="DAG_ID", session=session) as dag:
-            task_1 = BashOperator.partial(task_id="first").expand(
-                bash_command=["echo hello", "echo world"]
-            )
+            BashOperator.partial(task_id="first").expand(bash_command=["echo hello", "echo world"])
 
         dot = dot_renderer.render_dag(dag)
         source = dot.source
         # Should render DAG title
         assert "label=DAG_ID" in source
         assert (
-            'first [color="#000000" fillcolor="#f0ede4" label=first shape=rectangle style="filled,rounded"]' in source
+            'first [color="#000000" fillcolor="#f0ede4" label=first shape=rectangle style="filled,rounded"]'
+            in source
         )
 
     def test_should_render_dag_orientation(self, session, dag_maker):

--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -107,7 +107,7 @@ class TestDotRenderer:
             'third [color=black fillcolor=lime label=third shape=rectangle style="filled,rounded"]' in source
         )
 
-    def test_should_render_dag_with_abstract_mapped_operator(self, session, dag_maker):
+    def test_should_render_dag_with_mapped_operator(self, session, dag_maker):
         with dag_maker(dag_id="DAG_ID", session=session) as dag:
             BashOperator.partial(task_id="first").expand(bash_command=["echo hello", "echo world"])
 


### PR DESCRIPTION
For mapped operators, `airflow show dags <dag_id>` is broken (see #23315 )

Task expansion creates a MappedOperator, which ultimately inherits from AbstractOperator and not BaseOperator.

`airflow dags show` ultimately calls [dot_renderer.py](https://github.com/apache/airflow/blob/main/airflow/utils/dot_renderer.py#L117-L118) to draw the DAG, and it checks that each node is either a `TaskGroup` or a `BaseOperator`, thus the error. Adding a check to see if the node is an `AbstractOperator` fixes this.

closes: #23315 
