### PR TITLE
Fix GCSToGCSOperator ignores replace parameter when there is no wildcard

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -284,8 +284,7 @@ class GCSToGCSOperator(BaseOperator):
                 delimiter=delimiter,
             )
             existing_objects = [
-                dest_object.replace(self.destination_object, prefix, 1)
-                for dest_object in destination_objects
+                dest_object.replace(self.destination_object, prefix, 1) for dest_object in destination_objects
             ]
 
         objects = set(objects) - set(existing_objects)

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -272,7 +272,8 @@ class GCSToGCSOperator(BaseOperator):
         # list all files in the Destination GCS bucket
         # and only keep those files which are present in
         # Source GCS bucket and not in Destination GCS bucket
-        delimiter = kwargs.get('delimiter') or self.delimiter
+        delimiter = kwargs.get('delimiter')
+        objects = kwargs.get('objects')
         if self.destination_object is None:
             existing_objects = hook.list(self.destination_bucket, prefix=prefix, delimiter=delimiter)
         else:
@@ -292,7 +293,6 @@ class GCSToGCSOperator(BaseOperator):
             self.log.info('%s files are going to be synced: %s.', len(objects), objects)
         else:
             self.log.info('There are no new files to sync. Have a nice day!')
-        
         return objects
 
     def _copy_source_without_wildcard(self, hook, prefix):
@@ -339,7 +339,7 @@ class GCSToGCSOperator(BaseOperator):
 
         if not self.replace:
             # If we are not replacing, ignore files already existing in source buckets
-            objects = self._ignore_existing_files(hook, prefix)
+            objects = self._ignore_existing_files(hook, prefix, objects=objects, delimiter=self.delimiter)
 
         # If objects is empty and we have prefix, let's check if prefix is a blob
         # and copy directly
@@ -378,7 +378,7 @@ class GCSToGCSOperator(BaseOperator):
             # If we are not replacing, list all files in the Destination GCS bucket
             # and only keep those files which are present in
             # Source GCS bucket and not in Destination GCS bucket
-            objects = self._ignore_existing_files(hook, prefix_, delimiter=delimiter)
+            objects = self._ignore_existing_files(hook, prefix_, delimiter=delimiter, objects=objects)
 
         for source_object in objects:
             if self.destination_object is None:

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -105,6 +105,23 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
         mock_hook.return_value.list.assert_has_calls(mock_calls)
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook')
+    def test_execute_no_wildcard_with_replace_flag_false(self, mock_hook):
+        operator = GCSToGCSOperator(
+            task_id=TASK_ID,
+            source_bucket=TEST_BUCKET,
+            source_object=SOURCE_OBJECT_NO_WILDCARD,
+            destination_bucket=DESTINATION_BUCKET,
+            replace=False,
+        )
+
+        operator.execute(None)
+        mock_calls = [
+            mock.call(TEST_BUCKET, prefix="test_object.txt", delimiter=None),
+            mock.call(DESTINATION_BUCKET, prefix="test_object.txt", delimiter=None),
+        ]
+        mock_hook.return_value.list.assert_has_calls(mock_calls)
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_gcs.GCSHook')
     def test_execute_prefix_and_suffix(self, mock_hook):
         operator = GCSToGCSOperator(
             task_id=TASK_ID,


### PR DESCRIPTION
closes: [23162](https://github.com/apache/airflow/issues/23162)

This PR fixes the issue whereby files are replaced even when replace=False parameter is available in GCSToGCSOperator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
