### PR TITLE
Cleaner default output when breeze starts

### DIFF
--- a/dev/breeze/src/airflow_breeze/build_image/ci/build_ci_params.py
+++ b/dev/breeze/src/airflow_breeze/build_image/ci/build_ci_params.py
@@ -23,7 +23,6 @@ from typing import List, Optional
 
 from airflow_breeze.branch_defaults import AIRFLOW_BRANCH, DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
 from airflow_breeze.global_constants import get_airflow_version
-from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.path_utils import BUILD_CACHE_DIR
 
 
@@ -147,9 +146,6 @@ class BuildCiParams:
     @property
     def md5sum_cache_dir(self) -> Path:
         return Path(BUILD_CACHE_DIR, self.airflow_branch, self.python, "CI")
-
-    def print_info(self):
-        get_console().print(f"CI Image: {self.airflow_version} Python: {self.python}.")
 
 
 REQUIRED_CI_IMAGE_ARGS = [

--- a/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
+++ b/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_image.py
@@ -143,7 +143,7 @@ def build_production_image(
     :param with_ci_group: whether to wrap the build in CI logging group
     :param prod_image_params: PROD image parameters
     """
-    fix_group_permissions()
+    fix_group_permissions(verbose=verbose)
     if verbose or dry_run:
         get_console().print(
             f"\n[info]Building PROD image of airflow from {AIRFLOW_SOURCES_ROOT} "
@@ -154,7 +154,6 @@ def build_production_image(
         f"with tag: {prod_image_params.image_tag}",
         enabled=with_ci_group,
     ):
-        prod_image_params.print_info()
         if prod_image_params.cleanup_context:
             clean_docker_context_files(verbose=verbose, dry_run=dry_run)
         check_docker_context_files(prod_image_params.install_packages_from_context)

--- a/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_params.py
@@ -238,9 +238,6 @@ class BuildProdParams:
     def airflow_image_readme_url(self):
         return "https://raw.githubusercontent.com/apache/airflow/main/docs/docker-stack/README.md"
 
-    def print_info(self):
-        get_console().print(f"CI Image: {self.airflow_version} Python: {self.python}.")
-
     @property
     def airflow_pre_cached_pip_packages(self) -> str:
         airflow_pre_cached_pip = 'true'

--- a/dev/breeze/src/airflow_breeze/shell/enter_shell.py
+++ b/dev/breeze/src/airflow_breeze/shell/enter_shell.py
@@ -122,7 +122,8 @@ def run_shell_with_build_image_checks(
     )
     ci_image_params = BuildCiParams(python=shell_params.python, upgrade_to_newer_dependencies=False)
     if build_ci_image_check_cache.exists():
-        get_console().print(f'[info]{shell_params.the_image_type} image already built locally.[/]')
+        if verbose:
+            get_console().print(f'[info]{shell_params.the_image_type} image already built locally.[/]')
     else:
         get_console().print(
             f'[warning]{shell_params.the_image_type} image not built locally. Forcing build.[/]'

--- a/dev/breeze/src/airflow_breeze/shell/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/shell/shell_params.py
@@ -143,13 +143,14 @@ class ShellParams:
         return sqlite_url
 
     def print_badge_info(self):
-        get_console().print(f'Use {self.the_image_type} image')
-        get_console().print(f'Branch Name: {self.airflow_branch}')
-        get_console().print(f'Docker Image: {self.airflow_image_name_with_tag}')
-        get_console().print(f'Airflow source version:{self.airflow_version}')
-        get_console().print(f'Python Version: {self.python}')
-        get_console().print(f'Backend: {self.backend} {self.backend_version}')
-        get_console().print(f'Airflow used at runtime: {self.use_airflow_version}')
+        if self.verbose:
+            get_console().print(f'[info]Use {self.the_image_type} image[/]')
+            get_console().print(f'[info]Branch Name: {self.airflow_branch}[/]')
+            get_console().print(f'[info]Docker Image: {self.airflow_image_name_with_tag}[/]')
+            get_console().print(f'[info]Airflow source version:{self.airflow_version}[/]')
+            get_console().print(f'[info]Python Version: {self.python}[/]')
+            get_console().print(f'[info]Backend: {self.backend} {self.backend_version}[/]')
+            get_console().print(f'[info]Airflow used at runtime: {self.use_airflow_version}[/]')
 
     @property
     def compose_files(self):

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -440,6 +440,7 @@ def update_expected_environment_variables(env: Dict[str, str]) -> None:
     :param env: environment variables to update with missing values if not set.
     """
     set_value_to_default_if_not_set(env, 'ANSWER', "")
+    set_value_to_default_if_not_set(env, 'AIRFLOW_EXTRAS', "")
     set_value_to_default_if_not_set(env, 'BREEZE', "true")
     set_value_to_default_if_not_set(env, 'CI', "false")
     set_value_to_default_if_not_set(env, 'CI_BUILD_ID', "0")
@@ -475,9 +476,9 @@ def update_expected_environment_variables(env: Dict[str, str]) -> None:
     set_value_to_default_if_not_set(env, 'TEST_TYPE', "")
     set_value_to_default_if_not_set(env, 'UPGRADE_TO_NEWER_DEPENDENCIES', "false")
     set_value_to_default_if_not_set(env, 'USE_PACKAGES_FROM_DIST', "false")
-    set_value_to_default_if_not_set(env, 'USE_PACKAGES_FROM_DIST', "false")
     set_value_to_default_if_not_set(env, 'VERBOSE', "false")
     set_value_to_default_if_not_set(env, 'VERBOSE_COMMANDS', "false")
+    set_value_to_default_if_not_set(env, 'VERSION_SUFFIX_FOR_PYPI', "")
     set_value_to_default_if_not_set(env, 'WHEEL_VERSION', "0.36.2")
 
 

--- a/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
+++ b/dev/breeze/src/airflow_breeze/utils/md5_build_check.py
@@ -86,11 +86,12 @@ def calculate_md5_checksum_for_files(
     return modified_files, not_modified_files
 
 
-def md5sum_check_if_build_is_needed(md5sum_cache_dir: Path) -> bool:
+def md5sum_check_if_build_is_needed(md5sum_cache_dir: Path, verbose: bool) -> bool:
     """
     Checks if build is needed based on whether important files were modified.
 
     :param md5sum_cache_dir: directory where cached md5 sums are stored
+    :param verbose: should we print verbose information
     :return: True if build is needed.
     """
     build_needed = False
@@ -104,9 +105,10 @@ def md5sum_check_if_build_is_needed(md5sum_cache_dir: Path) -> bool:
         get_console().print('\n[warning]Likely CI image needs rebuild[/]\n')
         build_needed = True
     else:
-        get_console().print(
-            'Docker image build is not needed for CI build as no important files are changed!'
-        )
+        if verbose:
+            get_console().print(
+                '[info]Docker image build is not needed for CI build as no important files are changed![/]'
+            )
     return build_needed
 
 

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -211,9 +211,10 @@ def change_directory_permission(directory_to_fix: Path):
 
 
 @working_directory(AIRFLOW_SOURCES_ROOT)
-def fix_group_permissions():
+def fix_group_permissions(verbose: bool):
     """Fixes permissions of all the files and directories that have group-write access."""
-    get_console().print("[info]Fixing group permissions[/]")
+    if verbose:
+        get_console().print("[info]Fixing group permissions[/]")
     files_to_fix_result = run_command(['git', 'ls-files', './'], capture_output=True, text=True)
     if files_to_fix_result.returncode == 0:
         files_to_fix = files_to_fix_result.stdout.strip().split('\n')


### PR DESCRIPTION
There was a bit of noise printed when Breeze started:

* information about branch/python/image/backend used
* information about actions performed (like fixing permissions)
* information that docke image build is not needed
* warnings about missing variables

This PR marks all the messages as "info" and only prints them
when --verbose flag is used and it adds default values for the
variables that generated warnings.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
