### PR TITLE
When exec fails in breeze we do not print stack-trace

### DIFF
--- a/dev/breeze/src/airflow_breeze/shell/enter_shell.py
+++ b/dev/breeze/src/airflow_breeze/shell/enter_shell.py
@@ -151,18 +151,14 @@ def find_airflow_container(verbose, dry_run) -> Optional[str]:
     env_variables = construct_env_variables_docker_compose_command(exec_shell_params)
     cmd = ['docker-compose', 'ps', '--all', '--filter', 'status=running', 'airflow']
     docker_compose_ps_command = run_command(
-        cmd,
-        verbose=verbose,
-        dry_run=dry_run,
-        text=True,
-        capture_output=True,
-        env=env_variables,
-        # print output if run in verbose mode to better diagnose problems.
-        no_output_dump_on_exception=not verbose,
+        cmd, verbose=verbose, dry_run=dry_run, text=True, capture_output=True, env=env_variables, check=False
     )
     if dry_run:
         return "CONTAINER_ID"
     if docker_compose_ps_command.returncode != 0:
+        if verbose:
+            get_console().print(docker_compose_ps_command.stdout)
+            get_console().print(docker_compose_ps_command.stderr)
         stop_exec_on_error(docker_compose_ps_command.returncode)
         return None
 


### PR DESCRIPTION
When you run exec and breeze is not running, there was a stack
trace printed rather than straightforward error message.

This fixes it - stacktrace is only printed now when verbose is
used. If not just error message is printed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
