### PR TITLE
Fix connection test button

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3847,8 +3847,8 @@ class ConnectionFormWidget(FormWidget):
     def testable_connection_types(self):
         return [
             connection_type
-            for connection_type, provider_info in ProvidersManager().hooks.items()
-            if provider_info.connection_testable
+            for connection_type, hook_info in ProvidersManager().hooks.items()
+            if hook_info and hook_info.connection_testable
         ]
 
 


### PR DESCRIPTION
The connection test button was always disabled if any of your hooks had
import errors, for example because of a missing module. This handles
that scenario.