### PR TITLE
Dataproc: Remove default value of `region`

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -34,6 +34,14 @@ Breaking changes
    For more information, see `Deprecation and sunset <https://developers.google.com/google-ads/api/docs/sunset-dates>`_
    and `Upgrading to the newest version <https://developers.google.com/google-ads/api/docs/version-migration>`_
 
+* ``DataprocJobBaseOperator``: order of parameters has changed
+
+* ``region`` parameter has no default value
+  affected functions/classes:
+  ``DataprocHook.cancel_job``
+  ``DataprocCreateClusterOperator``
+  ``DataprocJobBaseOperator``
+
 * ``DatastoreHook``: Remove ``datastore_conn_id``. Please use ``gcp_conn_id``
 
 * ``CloudBuildCreateBuildOperator``: Remove ``body``. Please use ``build``

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -810,13 +810,6 @@ class DataprocHook(GoogleBaseHook):
             ``retry`` is specified, the timeout applies to each individual attempt.
         :param metadata: Additional metadata that is provided to the method.
         """
-        if region is None:
-            warnings.warn(
-                "Default region value `global` will be deprecated. Please, provide region value.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            region = 'global'
         client = self.get_job_client(region=region)
 
         job = client.cancel_job(

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -456,7 +456,7 @@ class DataprocCreateClusterOperator(BaseOperator):
         self,
         *,
         cluster_name: str,
-        region: Optional[str] = None,
+        region: str,
         project_id: Optional[str] = None,
         cluster_config: Optional[Union[Dict, Cluster]] = None,
         virtual_cluster_config: Optional[Dict] = None,
@@ -471,13 +471,6 @@ class DataprocCreateClusterOperator(BaseOperator):
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
-        if region is None:
-            warnings.warn(
-                "Default region value `global` will be deprecated. Please, provide region value.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            region = 'global'
 
         # TODO: remove one day
         if cluster_config is None and virtual_cluster_config is None:
@@ -839,6 +832,7 @@ class DataprocJobBaseOperator(BaseOperator):
     """
     The base class for operators that launch job on DataProc.
 
+    :param region: The specified region where the dataproc cluster is created.
     :param job_name: The job name used in the DataProc cluster. This name by default
         is the task_id appended with the execution data, but can be templated. The
         name will always be appended with a random number to avoid name clashes.
@@ -856,7 +850,6 @@ class DataprocJobBaseOperator(BaseOperator):
     :param labels: The labels to associate with this job. Label keys must contain 1 to 63 characters,
         and must conform to RFC 1035. Label values may be empty, but, if present, must contain 1 to 63
         characters, and must conform to RFC 1035. No more than 32 labels can be associated with a job.
-    :param region: The specified region where the dataproc cluster is created.
     :param job_error_states: Job states that should be considered error states.
         Any states in this set will result in an error being raised and failure of the
         task. Eg, if the ``CANCELLED`` state should also be considered a task failure,
@@ -889,6 +882,7 @@ class DataprocJobBaseOperator(BaseOperator):
     def __init__(
         self,
         *,
+        region: str,
         job_name: str = '{{task.task_id}}_{{ds_nodash}}',
         cluster_name: str = "cluster-1",
         project_id: Optional[str] = None,
@@ -897,7 +891,6 @@ class DataprocJobBaseOperator(BaseOperator):
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         labels: Optional[Dict] = None,
-        region: Optional[str] = None,
         job_error_states: Optional[Set[str]] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         asynchronous: bool = False,
@@ -911,14 +904,6 @@ class DataprocJobBaseOperator(BaseOperator):
         self.cluster_name = cluster_name
         self.dataproc_properties = dataproc_properties
         self.dataproc_jars = dataproc_jars
-
-        if region is None:
-            warnings.warn(
-                "Default region value `global` will be deprecated. Please, provide region value.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            region = 'global'
         self.region = region
 
         self.job_error_states = job_error_states if job_error_states is not None else {'ERROR'}

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -414,16 +414,6 @@ class TestDataprocClusterCreateOperator(DataprocClusterTestBase):
         assert op.cluster_config['worker_config']['num_instances'] == 2
         assert "zones/zone" in op.cluster_config['master_config']["machine_type_uri"]
 
-        with pytest.warns(DeprecationWarning) as warnings:
-            op_default_region = DataprocCreateClusterOperator(
-                task_id=TASK_ID,
-                project_id=GCP_PROJECT,
-                cluster_name="cluster_name",
-                cluster_config=op.cluster_config,
-            )
-        assert_warning("Default region value", warnings)
-        assert op_default_region.region == 'global'
-
     @mock.patch(DATAPROC_PATH.format("Cluster.to_dict"))
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_execute(self, mock_hook, to_dict_mock):


### PR DESCRIPTION
* `region` parameter has no default value.
  affected functions/classes:
  `DataprocHook.cancel_job`
  `DataprocCreateClusterOperator`
  `DataprocJobBaseOperator`

* `DataprocJobBaseOperator`: order of parameters has changed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
