### PR TITLE
Fix the error caused by passing unused context in JiraSensor.poke

### DIFF
--- a/airflow/providers/jira/sensors/jira.py
+++ b/airflow/providers/jira/sensors/jira.py
@@ -60,7 +60,7 @@ class JiraSensor(BaseSensorOperator):
         jira_result = getattr(resource, self.method_name)(**self.method_params)
         if self.result_processor is None:
             return jira_result
-        return self.result_processor(context, jira_result)
+        return self.result_processor(jira_result)
 
 
 class JiraTicketSensor(JiraSensor):

--- a/tests/providers/jira/sensors/test_jira.py
+++ b/tests/providers/jira/sensors/test_jira.py
@@ -74,5 +74,5 @@ class TestJiraSensor(unittest.TestCase):
         assert jira_mock.return_value.issue.called
 
     @staticmethod
-    def field_checker_func(context, issue):
+    def field_checker_func(issue):
         return "test-label-1" in issue['fields']['labels']

--- a/tests/providers/jira/sensors/test_jira.py
+++ b/tests/providers/jira/sensors/test_jira.py
@@ -28,15 +28,22 @@ from airflow.utils import db, timezone
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 jira_client_mock = Mock(name="jira_client_for_test")
 
-minimal_test_ticket = {
-    "id": "911539",
-    "self": "https://sandbox.localhost/jira/rest/api/2/issue/911539",
-    "key": "TEST-1226",
-    "fields": {
-        "labels": ["test-label-1", "test-label-2"],
-        "description": "this is a test description",
-    },
-}
+
+class _MockJiraTicket(dict):
+    class _TicketFields:
+        labels = ["test-label-1", "test-label-2"]
+        description = "this is a test description"
+
+    fields = _TicketFields
+
+
+minimal_test_ticket = _MockJiraTicket(
+    {
+        "id": "911539",
+        "self": "https://sandbox.localhost/jira/rest/api/2/issue/911539",
+        "key": "TEST-1226",
+    }
+)
 
 
 class TestJiraSensor(unittest.TestCase):
@@ -62,7 +69,8 @@ class TestJiraSensor(unittest.TestCase):
             method_name='issue',
             task_id='search-ticket-test',
             ticket_id='TEST-1226',
-            field_checker_func=TestJiraSensor.field_checker_func,
+            field='labels',
+            expected_value='test-label-1',
             timeout=518400,
             poke_interval=10,
             dag=self.dag,
@@ -72,7 +80,3 @@ class TestJiraSensor(unittest.TestCase):
 
         assert jira_mock.called
         assert jira_mock.return_value.issue.called
-
-    @staticmethod
-    def field_checker_func(issue):
-        return "test-label-1" in issue['fields']['labels']


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
#### This tiny PR attempts to fix the error caused by https://github.com/apache/airflow/pull/23046
(original issue: #22810 )