### PR TITLE
Add doc notes for keyword-only args for `expand()` and `partial()`

### DIFF
--- a/docs/apache-airflow/concepts/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/concepts/dynamic-task-mapping.rst
@@ -62,6 +62,8 @@ The grid view also provides visibility into your mapped tasks in the details pan
 
 .. image:: /img/mapping-simple-grid.png
 
+.. note:: Only keyword arguments are allowed to be passed to ``expand()``.
+
 .. note:: Values passed from the mapped task is a lazy proxy
 
     In the above example, ``values`` received by ``sum_it`` is an aggregation of all values returned by each mapped instance of ``add_one``. However, since it is impossible to know how many instances of ``add_one`` we will have in advance, ``values`` is not a normal list, but a "lazy sequence" that retrieves each individual value only when asked. Therefore, if you run ``print(values)`` directly, you would get something like this::
@@ -174,6 +176,8 @@ It is possible to use ``partial`` and ``expand`` with classic style operators as
     BashOperator.partial(task_id="bash", do_xcom_push=False).expand(
         bash_command=["echo 1", "echo 2"]
     )
+
+.. note:: Only keyword arguments are allowed to be passed to ``partial()``.
 
 Mapping over result of classic operators
 ----------------------------------------


### PR DESCRIPTION
While going through some exercises for Dynamic Task Mapping, I found myself passing positional arguments to `expand()` and getting met with valid `TypeError` exceptions for expecting only 1 positional argument when creating mapped tasks. Passing keyword-only arguments to `expand()` can be inferred from all of the great examples in the doc, but I thought it might be best to be explicit.  I also added a similar, explicit note for `partial()` as well.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
