### PR TITLE
Fix deriving of PyPI branch from airflow version

### DIFF
--- a/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/build_image/prod/build_prod_params.py
@@ -144,12 +144,14 @@ class BuildProdParams:
             self.airflow_branch_for_pypi_preloading = "v2-1-test"
         elif self.airflow_version == 'v2-2-test':
             self.airflow_branch_for_pypi_preloading = "v2-2-test"
-        elif re.match(r'v?2\.0*', self.airflow_version):
+        elif re.match(r'^2\.0.*$', self.airflow_version):
             self.airflow_branch_for_pypi_preloading = "v2-0-stable"
-        elif re.match(r'v?2\.1*', self.airflow_version):
+        elif re.match(r'^2\.1.*$', self.airflow_version):
             self.airflow_branch_for_pypi_preloading = "v2-1-stable"
-        elif re.match(r'v?2\.2*', self.airflow_version):
+        elif re.match(r'^2\.2.*$', self.airflow_version):
             self.airflow_branch_for_pypi_preloading = "v2-2-stable"
+        elif re.match(r'^2\.3.*$', self.airflow_version):
+            self.airflow_branch_for_pypi_preloading = "v2-3-stable"
         else:
             self.airflow_branch_for_pypi_preloading = AIRFLOW_BRANCH
         return build_args


### PR DESCRIPTION
The regexp expression for deriving right branch from version was
missing . for version numbers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
