### PR TITLE
Update multiplatform doc image tagging to use regctl

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -28,6 +28,7 @@
   - [[\Optional\] Prepare new release branches and cache](#%5Coptional%5C-prepare-new-release-branches-and-cache)
   - [Prepare PyPI convenience "snapshot" packages](#prepare-pypi-convenience-snapshot-packages)
   - [Prepare production Docker Image](#prepare-production-docker-image)
+  - [Prerequisites](#prerequisites)
   - [Setting environment with emulation](#setting-environment-with-emulation)
   - [Setting up cache refreshing with hardware ARM/AMD support](#setting-up-cache-refreshing-with-hardware-armamd-support)
   - [Prepare issue for testing status of rc](#prepare-issue-for-testing-status-of-rc)
@@ -489,6 +490,12 @@ Production Docker images should be manually prepared and pushed by the release m
 who has access to Airflow's DockerHub. Note that we started releasing a multi-platform build, so you need
 to have an environment prepared to build multi-platform images. You can achieve it with either emulation
 (very slow) or if you have two types of hardware (AMD64 and ARM64) you can configure Hardware builders.
+
+## Prerequisites
+
+You need to have buildx plugin installed to run the build. Also you need to have regctl
+installed from https://github.com/regclient/regclient in order to tag the multi-platform images in
+DockerHub. The script to build images will refuse to work if you do not have those two installed.
 
 ## Setting environment with emulation
 

--- a/dev/retag_docker_images.py
+++ b/dev/retag_docker_images.py
@@ -61,9 +61,7 @@ def pull_push_all_images(
                 prefix=target_prefix, branch=target_branch, repo=target_repo, python=python
             )
             print(f"Copying image: {source_image} -> {target_image}")
-            subprocess.run(["docker", "pull", source_image], check=True)
-            subprocess.run(["docker", "tag", source_image, target_image], check=True)
-            subprocess.run(["docker", "push", target_image], check=True)
+            subprocess.run(["regctl", "image", "copy", source_image, target_image], check=True)
 
 
 @click.group(invoke_without_command=True)


### PR DESCRIPTION
You cannot use 'docker tag' to move multiplatform image, instead
we should use regctl.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
