### PR TITLE
Fix `version_added` for `[sensors] default_timeout`

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2430,7 +2430,7 @@
     - name: default_timeout
       description: |
         Sensor default timeout, 7 days by default (7 * 24 * 60 * 60).
-      version_added: 2.2.1
+      version_added: 2.3.0
       type: float
       example: ~
       default: "604800"


### PR DESCRIPTION
This was actually released in `2.3.0`, not `.2.2.1`.