### PR TITLE
Move dag_processing.processor_timeouts to counters section from gauges

### DIFF
--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -92,6 +92,7 @@ Name                                        Description
 ``zombies_killed``                          Zombie tasks killed
 ``scheduler_heartbeat``                     Scheduler heartbeats
 ``dag_processing.processes``                Number of currently running DAG parsing processes
+``dag_processing.processor_timeouts``       Number of file processors that have been killed due to taking too long
 ``dag_processing.manager_stalls``           Number of stalled ``DagFileProcessorManager``
 ``dag_file_refresh_error``                  Number of failures loading any DAG files
 ``scheduler.tasks.killed_externally``       Number of tasks killed externally
@@ -129,7 +130,6 @@ Name                                                Description
 ``dag_processing.import_errors``                    Number of errors from trying to parse DAG files
 ``dag_processing.total_parse_time``                 Seconds taken to scan and import all DAG files once
 ``dag_processing.last_run.seconds_ago.<dag_file>``  Seconds since ``<dag_file>`` was last processed
-``dag_processing.processor_timeouts``               Number of file processors that have been killed due to taking too long
 ``scheduler.tasks.running``                         Number of tasks running in executor
 ``scheduler.tasks.starving``                        Number of tasks that cannot be scheduled because of no open slot in pool
 ``scheduler.tasks.executable``                      Number of tasks that are ready for execution (set to queued)


### PR DESCRIPTION
closes: #21897 

The metric `dag_processing.processor_timeouts` is incorrectly listed as a Gauge in the [documentation](https://airflow.apache.org/docs/apache-airflow/2.3.0/logging-monitoring/metrics.html), when in reality it is a counter.
