### PR TITLE
Improve handling of entry and exit to common Breeze commands

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
+++ b/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance.py
@@ -405,7 +405,7 @@ def free_space(verbose: bool, dry_run: bool, answer: str):
 @option_dry_run
 def resource_check(verbose: bool, dry_run: bool):
     shell_params = ShellParams(verbose=verbose, python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION)
-    check_docker_resources(verbose, shell_params.airflow_image_name, dry_run=dry_run)
+    check_docker_resources(shell_params.airflow_image_name, verbose=verbose, dry_run=dry_run)
 
 
 @main.command(name="fix-ownership", help="Fix ownership of source files to be same as host user.")

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -60,6 +60,7 @@ from airflow_breeze.utils.docker_command_utils import (
     get_extra_docker_flags,
 )
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
+from airflow_breeze.utils.rebuild_image_if_needed import rebuild_ci_image_if_needed
 from airflow_breeze.utils.run_utils import assert_pre_commit_installed, run_command
 
 DEVELOPER_COMMANDS = {
@@ -348,6 +349,7 @@ def build_docs(
 ):
     """Build documentation in the container."""
     params = BuildCiParams(github_repository=github_repository, python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION)
+    rebuild_ci_image_if_needed(build_params=params, dry_run=dry_run, verbose=verbose)
     ci_image_name = params.airflow_image_name
     doc_builder = DocBuildParams(
         package_filter=package_filter,

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -111,7 +111,7 @@ def get_extra_docker_flags(mount_sources: str) -> List[str]:
 
 
 def check_docker_resources(
-    verbose: bool, airflow_image_name: str, dry_run: bool
+    airflow_image_name: str, verbose: bool, dry_run: bool
 ) -> Union[subprocess.CompletedProcess, subprocess.CalledProcessError]:
     """
     Check if we have enough resources to run docker. This is done via running script embedded in our image.

--- a/dev/breeze/src/airflow_breeze/utils/rebuild_image_if_needed.py
+++ b/dev/breeze/src/airflow_breeze/utils/rebuild_image_if_needed.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pathlib import Path
+from typing import Union
+
+from airflow_breeze.build_image.ci.build_ci_image import build_ci_image
+from airflow_breeze.build_image.ci.build_ci_params import BuildCiParams
+from airflow_breeze.shell.shell_params import ShellParams
+from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.docker_command_utils import (
+    check_docker_compose_version,
+    check_docker_resources,
+    check_docker_version,
+)
+from airflow_breeze.utils.path_utils import BUILD_CACHE_DIR
+
+
+def rebuild_ci_image_if_needed(
+    build_params: Union[ShellParams, BuildCiParams], dry_run: bool, verbose: bool
+) -> None:
+    """
+    Rebuilds CI image if needed and user confirms it.
+
+    :param build_params: parameters of the shell
+    :param dry_run: whether it's a dry_run
+    :param verbose: should we print verbose messages
+    """
+    check_docker_version(verbose=verbose)
+    check_docker_compose_version(verbose=verbose)
+    check_docker_resources(build_params.airflow_image_name, verbose=verbose, dry_run=dry_run)
+    build_ci_image_check_cache = Path(
+        BUILD_CACHE_DIR, build_params.airflow_branch, f".built_{build_params.python}"
+    )
+    ci_image_params = BuildCiParams(python=build_params.python, upgrade_to_newer_dependencies=False)
+    if build_ci_image_check_cache.exists():
+        if verbose:
+            get_console().print(f'[info]{build_params.the_image_type} image already built locally.[/]')
+    else:
+        get_console().print(
+            f'[warning]{build_params.the_image_type} image not built locally. Forcing build.[/]'
+        )
+        ci_image_params.force_build = True
+    build_ci_image(verbose, dry_run=dry_run, with_ci_group=False, ci_image_params=ci_image_params)


### PR DESCRIPTION
This PR improves handling of both entry and exit to common
Breeze commands:

* at entry all common commands check if rebuild of image is needed
* when you exit and there is an error from shell commands, rather
  than printing stack trace an error message is printed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
