### PR TITLE
Clarify 2.3.0 kubernetes min version is about library not cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ Airflow is not a streaming solution, but it is often used to process real-time d
 
 Apache Airflow is tested with:
 
-|                     | Main version (dev)      | Stable version (2.3.0)   |
-|---------------------|-------------------------|--------------------------|
-| Python              | 3.7, 3.8, 3.9, 3.10     | 3.6, 3.7, 3.8, 3.9       |
-| Platform            | AMD64/ARM64(\*)         | AMD64                    |
-| Kubernetes          | 1.20, 1.21, 1.22, 1.23  | 1.18, 1.19, 1.20         |
-| PostgreSQL          | 10, 11, 12, 13          | 9.6, 10, 11, 12, 13      |
-| MySQL               | 5.7, 8                  | 5.7, 8                   |
-| SQLite              | 3.15.0+                 | 3.15.0+                  |
-| MSSQL               | 2017(\*), 2019 (\*)     |                          |
+|                     | Main version (dev)      | Stable version (2.3.0)  |
+|---------------------|-------------------------|-------------------------|
+| Python              | 3.7, 3.8, 3.9, 3.10     | 3.6, 3.7, 3.8, 3.9      |
+| Platform            | AMD64/ARM64(\*)         | AMD64                   |
+| Kubernetes          | 1.20, 1.21, 1.22, 1.23  | 1.20, 1.21, 1.22, 1.23  |
+| PostgreSQL          | 10, 11, 12, 13          | 9.6, 10, 11, 12, 13     |
+| MySQL               | 5.7, 8                  | 5.7, 8                  |
+| SQLite              | 3.15.0+                 | 3.15.0+                 |
+| MSSQL               | 2017(\*), 2019 (\*)     |                         |
 
 \* Experimental
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -41,8 +41,13 @@ Previously, a task’s log is dynamically rendered from the ``[core] log_filenam
 
 A new ``log_template`` table is introduced to solve this problem. This table is synchronized with the aforementioned config values every time Airflow starts, and a new field ``log_template_id`` is added to every DAG run to point to the format used by tasks (``NULL`` indicates the first ever entry for compatibility).
 
-Minimum kubernetes version bumped from ``3.0.0`` to ``21.7.0`` (#20759)
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Minimum kubernetes library version bumped from ``3.0.0`` to ``21.7.0`` (#20759)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. note::
+
+   This is only about changing the ``kubernetes`` library, not the Kubernetes cluster. Airflow support for
+   Kubernetes version is described in `Installation prerequisites <https://airflow.apache.org/docs/apache-airflow/stable/installation/prerequisites.html>`_.
 
 No change in behavior is expected.  This was necessary in order to take advantage of a `bugfix <https://github.com/kubernetes-client/python-base/commit/70b78cd8488068c014b6d762a0c8d358273865b4>`_ concerning refreshing of Kubernetes API tokens with EKS, which enabled the removal of some `workaround code <https://github.com/apache/airflow/pull/20759>`_.
 


### PR DESCRIPTION
It was not clear from the release notes that the minimum version
of the kubernetes was about the library rather than cluster version.

Also README was not updated with min versions of Kubernetes cluster
for 2.3.0 version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
