### PR TITLE
Remove tagging of `constraint-x-y` branch from release process

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -424,7 +424,6 @@ protected_branches:
    git checkout constraints-main
    git checkout -b constraints-${BRANCH_PREFIX}
    git push --set-upstream origin constraints-${BRANCH_PREFIX}
-   git push origin tag constraints-${BRANCH_PREFIX}
    ```
 
 
@@ -1162,6 +1161,7 @@ EOF
 This includes:
 
 - Modify `./scripts/ci/pre_commit/pre_commit_supported_versions.py` and let pre-commit do the job
+- For major/minor release, Update version in `setup.py` and `docs/docker-stack/` to the next likely minor version release.
 - Update the `REVISION_HEADS_MAP` at airflow/utils/db.py to include the revision head of the release even if there are no migrations.
 - Sync `RELEASE_NOTES.rst` (including deleting relevant `newsfragments`) and `README.md` changes
 - Updating issue templates in `.github/ISSUE_TEMPLATE/` with the new version


### PR DESCRIPTION
Also updated the doc to include updating version in main after major/minor release
