### PR TITLE
Support annotations on volumeClaimTemplates

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -97,6 +97,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: redis-db
+        {{- if .Values.redis.persistence.annotations }}
+        annotations:
+          {{- toYaml .Values.redis.persistence.annotations | nindent 10 }}
+        {{- end }}
       spec:
       {{- if .Values.redis.persistence.storageClassName }}
         storageClassName: {{ .Values.redis.persistence.storageClassName }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -261,6 +261,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: logs
+        {{- if .Values.workers.persistence.annotations }}
+        annotations:
+          {{- toYaml .Values.workers.persistence.annotations | nindent 10 }}
+        {{- end }}
       spec:
       {{- if .Values.workers.persistence.storageClassName }}
         storageClassName: {{ .Values.workers.persistence.storageClassName }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -317,6 +317,10 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: logs
+        {{- if .Values.workers.persistence.annotations }}
+        annotations:
+          {{- toYaml .Values.workers.persistence.annotations | nindent 10 }}
+        {{- end }}
       spec:
       {{- if .Values.workers.persistence.storageClassName }}
         storageClassName: {{ .Values.workers.persistence.storageClassName }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1256,6 +1256,14 @@
                             "description": "Execute init container to chown log directory. This is currently only needed in kind, due to usage of local-path provisioner.",
                             "type": "boolean",
                             "default": false
+                        },
+                        "annotations": {
+                            "description": "Annotations to add to worker volumes.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 },
@@ -3689,6 +3697,14 @@
                                 "null"
                             ],
                             "default": null
+                        },
+                        "annotations": {
+                            "description": "Annotations to add to redis volumes.",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -476,6 +476,8 @@ workers:
     # This is currently only needed in kind, due to usage
     # of local-path provisioner.
     fixPermissions: false
+    # Annotations to add to worker volumes
+    annotations: {}
 
   kerberosSidecar:
     # Enable kerberos sidecar
@@ -1305,6 +1307,8 @@ redis:
     size: 1Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
+    # Annotations to add to redis volumes
+    annotations: {}
 
   resources: {}
   #  limits:

--- a/tests/charts/test_redis.py
+++ b/tests/charts/test_redis.py
@@ -320,3 +320,10 @@ class RedisTest(unittest.TestCase):
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations["helm.sh/hook-weight"] == "0"
+
+    def test_persistence_volume_annotations(self):
+        docs = render_chart(
+            values={"redis": {"persistence": {"annotations": {"foo": "bar"}}}},
+            show_only=["templates/redis/redis-statefulset.yaml"],
+        )
+        assert {"foo": "bar"} == jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0])

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -530,3 +530,10 @@ class SchedulerTest(unittest.TestCase):
                 "memory": "2Gi",
             },
         } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
+
+    def test_persistence_volume_annotations(self):
+        docs = render_chart(
+            values={"executor": "LocalExecutor", "workers": {"persistence": {"annotations": {"foo": "bar"}}}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        assert {"foo": "bar"} == jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0])

--- a/tests/charts/test_worker.py
+++ b/tests/charts/test_worker.py
@@ -529,3 +529,10 @@ class WorkerTest(unittest.TestCase):
                 "memory": "2Gi",
             },
         } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
+
+    def test_persistence_volume_annotations(self):
+        docs = render_chart(
+            values={"workers": {"persistence": {"annotations": {"foo": "bar"}}}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert {"foo": "bar"} == jmespath.search("spec.volumeClaimTemplates[0].metadata.annotations", docs[0])


### PR DESCRIPTION
This allows for annotations to be added to volumeClaimTemplates, so any volume created by our StatefulSets get them.