### PR TITLE
Add backward compatibility for core__sql_alchemy_conn__cmd

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -140,6 +140,8 @@ class AirflowConfigParser(ConfigParser):
         ('atlas', 'password'),
         ('smtp', 'smtp_password'),
         ('webserver', 'secret_key'),
+        # The following options are deprecated
+        ('core', 'sql_alchemy_conn')
     }
 
     # A mapping of (new section, new option) -> (old section, old option, since_version).

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -141,7 +141,7 @@ class AirflowConfigParser(ConfigParser):
         ('smtp', 'smtp_password'),
         ('webserver', 'secret_key'),
         # The following options are deprecated
-        ('core', 'sql_alchemy_conn')
+        ('core', 'sql_alchemy_conn'),
     }
 
     # A mapping of (new section, new option) -> (old section, old option, since_version).


### PR DESCRIPTION
This adds backwards compatibility to use the __cmd option on core__sql_alchemy_conn which was lost in the 2.3.0 update.

closes: [#23408]
related: [#23408]