### PR TITLE
Opsgenie: Fix `close_alert` to properly send `kwargs`

### DIFF
--- a/airflow/providers/opsgenie/hooks/opsgenie.py
+++ b/airflow/providers/opsgenie/hooks/opsgenie.py
@@ -103,7 +103,7 @@ class OpsgenieAlertHook(BaseHook):
         identifier: str,
         identifier_type: Optional[str] = 'id',
         payload: Optional[dict] = None,
-        kwargs: Optional[dict] = None,
+        **kwargs: Optional[dict],
     ) -> SuccessResponse:
         """
         Close an alert in Opsgenie

--- a/airflow/providers/opsgenie/hooks/opsgenie.py
+++ b/airflow/providers/opsgenie/hooks/opsgenie.py
@@ -126,7 +126,7 @@ class OpsgenieAlertHook(BaseHook):
                 identifier=identifier,
                 identifier_type=identifier_type,
                 close_alert_payload=close_alert_payload,
-                kwargs=kwargs,
+                **kwargs,
             )
             return api_response
         except OpenApiException as e:

--- a/airflow/providers/opsgenie/operators/opsgenie.py
+++ b/airflow/providers/opsgenie/operators/opsgenie.py
@@ -206,5 +206,5 @@ class OpsgenieCloseAlertOperator(BaseOperator):
             identifier=self.identifier,
             identifier_type=self.identifier_type,
             payload=self._build_opsgenie_close_alert_payload(),
-            **self.close_alert_kwargs,
+            **(self.close_alert_kwargs or {}),
         )

--- a/airflow/providers/opsgenie/operators/opsgenie.py
+++ b/airflow/providers/opsgenie/operators/opsgenie.py
@@ -206,5 +206,5 @@ class OpsgenieCloseAlertOperator(BaseOperator):
             identifier=self.identifier,
             identifier_type=self.identifier_type,
             payload=self._build_opsgenie_close_alert_payload(),
-            kwargs=self.close_alert_kwargs,
+            **self.close_alert_kwargs,
         )

--- a/tests/providers/opsgenie/hooks/test_opsgenie.py
+++ b/tests/providers/opsgenie/hooks/test_opsgenie.py
@@ -130,11 +130,11 @@ class TestOpsgenieAlertHook(unittest.TestCase):
 
         # Then
         hook.close_alert(
-            identifier=identifier, identifier_type=identifier_type, payload=pay_load, kwargs=kwargs
+            identifier=identifier, identifier_type=identifier_type, payload=pay_load, **kwargs
         )
         close_alert_mock.assert_called_once_with(
             identifier=identifier,
             identifier_type=identifier_type,
             close_alert_payload=CloseAlertPayload(**pay_load),
-            kwargs=kwargs,
+            **kwargs,
         )

--- a/tests/providers/opsgenie/hooks/test_opsgenie.py
+++ b/tests/providers/opsgenie/hooks/test_opsgenie.py
@@ -129,9 +129,7 @@ class TestOpsgenieAlertHook(unittest.TestCase):
         kwargs = {'async_req': True}
 
         # Then
-        hook.close_alert(
-            identifier=identifier, identifier_type=identifier_type, payload=pay_load, **kwargs
-        )
+        hook.close_alert(identifier=identifier, identifier_type=identifier_type, payload=pay_load, **kwargs)
         close_alert_mock.assert_called_once_with(
             identifier=identifier,
             identifier_type=identifier_type,

--- a/tests/providers/opsgenie/operators/test_opsgenie.py
+++ b/tests/providers/opsgenie/operators/test_opsgenie.py
@@ -124,7 +124,7 @@ class TestOpsgenieCloseAlertOperator(unittest.TestCase):
     def test_build_opsgenie_payload(self):
         # Given / When
         operator = OpsgenieCloseAlertOperator(
-            task_id='opsgenie_close_alert_job', identifier="id", dag=self.dag, **self._config
+            task_id='opsgenie_close_alert_job', identifier="id", dag=self.dag, close_alert_kwargs=self._config
         )
 
         payload = operator._build_opsgenie_close_alert_payload()
@@ -134,7 +134,7 @@ class TestOpsgenieCloseAlertOperator(unittest.TestCase):
 
     def test_properties(self):
         operator = OpsgenieCloseAlertOperator(
-            task_id='opsgenie_test_properties_job', identifier="id", dag=self.dag, **self._config
+            task_id='opsgenie_test_properties_job', identifier="id", dag=self.dag, close_alert_kwargs=self._config
         )
 
         assert 'opsgenie_default' == operator.opsgenie_conn_id

--- a/tests/providers/opsgenie/operators/test_opsgenie.py
+++ b/tests/providers/opsgenie/operators/test_opsgenie.py
@@ -124,7 +124,7 @@ class TestOpsgenieCloseAlertOperator(unittest.TestCase):
     def test_build_opsgenie_payload(self):
         # Given / When
         operator = OpsgenieCloseAlertOperator(
-            task_id='opsgenie_close_alert_job', identifier="id", dag=self.dag, close_alert_kwargs=self._config
+            task_id='opsgenie_close_alert_job', identifier="id", dag=self.dag, **self._config
         )
 
         payload = operator._build_opsgenie_close_alert_payload()
@@ -134,7 +134,7 @@ class TestOpsgenieCloseAlertOperator(unittest.TestCase):
 
     def test_properties(self):
         operator = OpsgenieCloseAlertOperator(
-            task_id='opsgenie_test_properties_job', identifier="id", dag=self.dag, close_alert_kwargs=self._config
+            task_id='opsgenie_test_properties_job', identifier="id", dag=self.dag, **self._config
         )
 
         assert 'opsgenie_default' == operator.opsgenie_conn_id


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Currently, using the Opsgenie provider `close` feature will fail:
```
Traceback (most recent call last):
  File "/opt/airflow/lib/python3.9/site-packages/airflow/providers/opsgenie/hooks/opsgenie.py", line 125, in close_alert
    api_response = self.alert_api_instance.close_alert(
  File "/opt/airflow/lib/python3.9/site-packages/opsgenie_sdk/api/alert/__init__.py", line 934, in close_alert
    (data) = self.close_alert_with_http_info(identifier, **kwargs)  # noqa: E501
  File "/opt/airflow/lib/python3.9/site-packages/opsgenie_sdk/api/alert/__init__.py", line 965, in close_alert_with_http_info
    raise ApiTypeError(
opsgenie_sdk.exceptions.ApiTypeError: Got an unexpected keyword argument 'kwargs' to method close_alert
```