### PR TITLE
Improve verbose output of Breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -24,7 +24,7 @@ import sys
 from distutils.version import StrictVersion
 from functools import lru_cache
 from pathlib import Path
-from typing import List, Mapping, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
@@ -66,10 +66,7 @@ def run_command(
     workdir: str = str(cwd) if cwd else os.getcwd()
     if verbose or dry_run:
         command_to_print = ' '.join(shlex.quote(c) for c in cmd)
-        # if we pass environment variables to execute, then
-        env_to_print = ' '.join(f'{key}="{val}"' for (key, val) in env.items()) if env else ''
-        if env_to_print:
-            env_to_print += ' '
+        env_to_print = get_environments_to_print(env)
         get_console().print(f"\n[info]Working directory {workdir} [/]\n")
         # Soft wrap allows to copy&paste and run resulting output as it has no hard EOL
         get_console().print(f"\n[info]{env_to_print}{command_to_print}[/]\n", soft_wrap=True)
@@ -101,6 +98,23 @@ def run_command(
         if check:
             raise
         return ex
+
+
+def get_environments_to_print(env: Optional[Mapping[str, str]]):
+    if not env:
+        return "# No environment variables \\\n"
+    system_env: Dict[str, str] = {}
+    my_env: Dict[str, str] = {}
+    for key, val in env.items():
+        if os.environ.get(key) == val:
+            system_env[key] = val
+        else:
+            my_env[key] = val
+    env_to_print = ''.join(f'{key}="{val}" \\\n' for (key, val) in sorted(system_env.items()))
+    env_to_print += r"""\
+"""
+    env_to_print += ''.join(f'{key}="{val}" \\\n' for (key, val) in sorted(my_env.items()))
+    return env_to_print
 
 
 def assert_pre_commit_installed(verbose: bool):


### PR DESCRIPTION
When you add --verbose or --dry-run options to breeze it will
print the commands it is executing (or is supposed to in dry-run
mode). The output contains environment variables as they
often contain crucial information to execute the command (for
example in docker-compose run commands it contains COMPOSE_FILE
variable which is the list of compose files that are used). This
is done in a fashion that you can copy the whole command and
execute it, but it very unfriendly for visual inspection as
all the variables were printed in one line and in semi-random
order and also the variables contained often all system variables
set by the shell before.

This change keeps the proerty of "we can copy&paste the command
and run it" but it improves the visual aspect of it:

1) each env variable is kept in one line
2) first all system variables are printed and then variables that
   were specifically added for this command
3) variables in each group are sorted alphabetically which helps
   in finding the variable you are looking for when you visually
   inspect the output.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
