### PR TITLE
Fix broken dagrun links when many runs start at the same time

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -201,9 +201,19 @@ def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
     default_dag_run = conf.getint('webserver', 'default_dag_run_display_number')
     num_runs = www_request.args.get('num_runs', default=default_dag_run, type=int)
 
+    # When base_date has been rounded up because of the DateTimeField widget, we want
+    # to use the execution_date as the starting point for our query just to ensure a
+    # link targetting a specific dag run actually loads that dag run.  If there are
+    # more than num_runs dag runs in the "rounded period" then those dagruns would get
+    # loaded and the actual requested run would be excluded by the limit().  Once
+    # the user has changed base date to be anything else we want to use that instead.
+    query_date = base_date
+    if date_time < base_date and date_time + timedelta(seconds=1) >= base_date:
+        query_date = date_time
+
     drs = (
         session.query(DagRun)
-        .filter(DagRun.dag_id == dag.dag_id, DagRun.execution_date <= base_date)
+        .filter(DagRun.dag_id == dag.dag_id, DagRun.execution_date <= query_date)
         .order_by(desc(DagRun.execution_date))
         .limit(num_runs)
         .all()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -203,7 +203,7 @@ def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
 
     # When base_date has been rounded up because of the DateTimeField widget, we want
     # to use the execution_date as the starting point for our query just to ensure a
-    # link targetting a specific dag run actually loads that dag run.  If there are
+    # link targeting a specific dag run actually loads that dag run.  If there are
     # more than num_runs dag runs in the "rounded period" then those dagruns would get
     # loaded and the actual requested run would be excluded by the limit().  Once
     # the user has changed base date to be anything else we want to use that instead.

--- a/tests/www/views/test_views_graph_gantt.py
+++ b/tests/www/views/test_views_graph_gantt.py
@@ -16,14 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import timedelta
-import pytest
 from urllib.parse import quote
+
+import pytest
 
 from airflow.configuration import conf
 from airflow.models import DAG
 from airflow.utils import timezone
-from airflow.utils.state import State
 from airflow.utils.session import provide_session
+from airflow.utils.state import State
 
 DAG_ID = "dag_for_testing_dt_nr_dr_form"
 DEFAULT_DATE = timezone.datetime(2017, 9, 1)
@@ -225,13 +226,15 @@ def very_close_dagruns(dag, session):
     dag_runs = []
     for idx, (run_id, _) in enumerate(RUNS_DATA):
         execution_date = VERY_CLOSE_RUNS_DATE.replace(microsecond=idx)
-        dag_runs.append(dag.create_dagrun(
-            run_id=run_id+'_close',
-            execution_date=execution_date,
-            data_interval=(execution_date, execution_date),
-            state=State.SUCCESS,
-            external_trigger=True,
-        ))
+        dag_runs.append(
+            dag.create_dagrun(
+                run_id=run_id + '_close',
+                execution_date=execution_date,
+                data_interval=(execution_date, execution_date),
+                state=State.SUCCESS,
+                external_trigger=True,
+            )
+        )
     yield dag_runs
     for dag_run in dag_runs:
         session.delete(dag_run)
@@ -257,7 +260,9 @@ def test_rounds_base_date_but_queries_with_execution_date(admin_client, very_clo
 
 
 @pytest.mark.parametrize("endpoint", ENDPOINTS)
-def test_uses_execution_date_on_filter_application_if_base_date_hasnt_changed(admin_client, very_close_dagruns, endpoint):
+def test_uses_execution_date_on_filter_application_if_base_date_hasnt_changed(
+    admin_client, very_close_dagruns, endpoint
+):
     base_date = quote((VERY_CLOSE_RUNS_DATE + timedelta(seconds=1)).isoformat())
     exec_date = quote(very_close_dagruns[1].execution_date.isoformat())
     response = admin_client.get(

--- a/tests/www/views/test_views_graph_gantt.py
+++ b/tests/www/views/test_views_graph_gantt.py
@@ -15,12 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import timedelta
 import pytest
+from urllib.parse import quote
 
 from airflow.configuration import conf
 from airflow.models import DAG
 from airflow.utils import timezone
 from airflow.utils.state import State
+from airflow.utils.session import provide_session
 
 DAG_ID = "dag_for_testing_dt_nr_dr_form"
 DEFAULT_DATE = timezone.datetime(2017, 9, 1)
@@ -30,6 +33,7 @@ RUNS_DATA = [
     ("dag_run_for_testing_dt_nr_dr_form_2", timezone.datetime(2018, 2, 2)),
     ("dag_run_for_testing_dt_nr_dr_form_1", timezone.datetime(2018, 1, 1)),
 ]
+VERY_CLOSE_RUNS_DATE = timezone.datetime(2020, 1, 1, 0, 0, 0)
 
 ENDPOINTS = [
     "/graph?dag_id=dag_for_testing_dt_nr_dr_form",
@@ -44,9 +48,10 @@ def dag(app):
     return dag
 
 
+@provide_session
 @pytest.fixture(scope="module")
-def runs(dag):
-    return [
+def runs(dag, session):
+    dag_runs = [
         dag.create_dagrun(
             run_id=run_id,
             execution_date=execution_date,
@@ -56,6 +61,9 @@ def runs(dag):
         )
         for run_id, execution_date, in RUNS_DATA
     ]
+    yield dag_runs
+    for dag_run in dag_runs:
+        session.delete(dag_run)
 
 
 def _assert_run_is_in_dropdown_not_selected(run, data):
@@ -66,6 +74,10 @@ def _assert_run_is_in_dropdown_not_selected(run, data):
 def _assert_run_is_selected(run, data):
     exec_date = run.execution_date.isoformat()
     assert f'<option selected value="{exec_date}">{run.run_id}</option>' in data
+
+
+def _assert_base_date(base_date, data):
+    assert f'name="base_date" required type="text" value="{base_date.isoformat()}"' in data
 
 
 def _assert_base_date_and_num_runs(base_date, num, data):
@@ -205,3 +217,78 @@ def test_with_base_date_and_num_runs_and_execution_date_within(admin_client, run
     _assert_run_is_not_in_dropdown(runs[1], data)
     _assert_run_is_in_dropdown_not_selected(runs[2], data)
     _assert_run_is_selected(runs[3], data)
+
+
+@provide_session
+@pytest.fixture
+def very_close_dagruns(dag, session):
+    dag_runs = []
+    for idx, (run_id, _) in enumerate(RUNS_DATA):
+        execution_date = VERY_CLOSE_RUNS_DATE.replace(microsecond=idx)
+        dag_runs.append(dag.create_dagrun(
+            run_id=run_id+'_close',
+            execution_date=execution_date,
+            data_interval=(execution_date, execution_date),
+            state=State.SUCCESS,
+            external_trigger=True,
+        ))
+    yield dag_runs
+    for dag_run in dag_runs:
+        session.delete(dag_run)
+    session.commit()
+
+
+@pytest.mark.parametrize("endpoint", ENDPOINTS)
+def test_rounds_base_date_but_queries_with_execution_date(admin_client, very_close_dagruns, endpoint):
+    exec_date = quote(very_close_dagruns[1].execution_date.isoformat())
+    response = admin_client.get(
+        f'{endpoint}&num_runs=2&execution_date={exec_date}',
+        data={"username": "test", "password": "test"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    data = response.data.decode()
+    _assert_base_date(VERY_CLOSE_RUNS_DATE + timedelta(seconds=1), data)
+    _assert_run_is_in_dropdown_not_selected(very_close_dagruns[0], data)
+    _assert_run_is_selected(very_close_dagruns[1], data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[2], data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[3], data)
+
+
+@pytest.mark.parametrize("endpoint", ENDPOINTS)
+def test_uses_execution_date_on_filter_application_if_base_date_hasnt_changed(admin_client, very_close_dagruns, endpoint):
+    base_date = quote((VERY_CLOSE_RUNS_DATE + timedelta(seconds=1)).isoformat())
+    exec_date = quote(very_close_dagruns[1].execution_date.isoformat())
+    response = admin_client.get(
+        f'{endpoint}&base_date={base_date}&num_runs=2&execution_date={exec_date}',
+        data={"username": "test", "password": "test"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    data = response.data.decode()
+    _assert_base_date(VERY_CLOSE_RUNS_DATE + timedelta(seconds=1), data)
+    _assert_run_is_in_dropdown_not_selected(very_close_dagruns[0], data)
+    _assert_run_is_selected(very_close_dagruns[1], data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[2], data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[3], data)
+
+
+@pytest.mark.parametrize("endpoint", ENDPOINTS)
+def test_uses_base_date_if_changed_away_from_execution_date(admin_client, very_close_dagruns, endpoint):
+    base_date = quote((VERY_CLOSE_RUNS_DATE + timedelta(seconds=2)).isoformat())
+    exec_date = quote(very_close_dagruns[1].execution_date.isoformat())
+    response = admin_client.get(
+        f'{endpoint}&base_date={base_date}&num_runs=2&execution_date={exec_date}',
+        data={"username": "test", "password": "test"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    data = response.data.decode()
+    _assert_base_date(VERY_CLOSE_RUNS_DATE + timedelta(seconds=2), data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[0], data)
+    _assert_run_is_not_in_dropdown(very_close_dagruns[1], data)
+    _assert_run_is_in_dropdown_not_selected(very_close_dagruns[2], data)
+    _assert_run_is_selected(very_close_dagruns[3], data)


### PR DESCRIPTION
DagRun links in the UI to `/graph` can currently be broken if you have several runs starting at (basically) the same time. The UI control that airflow uses for base_date only has per-second resolution (it loses everything sub-second), so to account for that the current implementation defaults base_date to exec_date rounded up to the nearest second. The problem occurs when several other dagruns were triggered in that rounded second - those other dagruns are loaded first (up to `num_runs`) so it's possible the requested dagrun does not even get loaded.  I know it sounds like an uncommon scenario but it actually happens to us a lot, as we have several processes that kick off many dagruns at the same time.  

This PR maintains the existing rounding behavior for the base_date UI control, but uses the requested exec_date for the database query when the base_date has been rounded. This way the requested dagrun will always be the first record returned, even when base_date has been rounded up.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
