### PR TITLE
Add Python 3.10 trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: System :: Monitoring
     Framework :: Apache Airflow
 project_urls =


### PR DESCRIPTION
Now that 3.10 is officially support it, let's add the trove classifier!