### PR TITLE
Rename cluster_policy to task_policy

### DIFF
--- a/docs/apache-airflow/concepts/cluster-policies.rst
+++ b/docs/apache-airflow/concepts/cluster-policies.rst
@@ -57,17 +57,12 @@ This policy checks if each DAG has at least one tag defined:
 Task policies
 -------------
 
-Here's an example of enforcing a maximum timeout policy on every task::
+Here's an example of enforcing a maximum timeout policy on every task:
 
-    class TimedOperator(BaseOperator, ABC):
-        timeout: timedelta
-
-
-    def task_policy(task: TimedOperator):
-        if task.task_type == 'HivePartitionSensor':
-            task.queue = "sensor_queue"
-        if task.timeout > timedelta(hours=48):
-            task.timeout = timedelta(hours=48)
+.. literalinclude:: /../../tests/cluster_policies/__init__.py
+        :language: python
+        :start-after: [START example_task_cluster_policy]
+        :end-before: [END example_task_cluster_policy]
 
 You could also implement to protect against common errors, rather than as technical security controls. For example, don't run tasks without airflow owners:
 

--- a/docs/apache-airflow/concepts/cluster-policies.rst
+++ b/docs/apache-airflow/concepts/cluster-policies.rst
@@ -57,12 +57,17 @@ This policy checks if each DAG has at least one tag defined:
 Task policies
 -------------
 
-Here's an example of enforcing a maximum timeout policy on every task:
+Here's an example of enforcing a maximum timeout policy on every task::
 
-.. literalinclude:: /../../tests/cluster_policies/__init__.py
-        :language: python
-        :start-after: [START example_task_cluster_policy]
-        :end-before: [END example_task_cluster_policy]
+    class TimedOperator(BaseOperator, ABC):
+        timeout: timedelta
+
+
+    def task_policy(task: TimedOperator):
+        if task.task_type == 'HivePartitionSensor':
+            task.queue = "sensor_queue"
+        if task.timeout > timedelta(hours=48):
+            task.timeout = timedelta(hours=48)
 
 You could also implement to protect against common errors, rather than as technical security controls. For example, don't run tasks without airflow owners:
 

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from abc import ABC
+from datetime import timedelta
 from typing import Callable, List
 
 from airflow.configuration import conf
@@ -60,7 +62,7 @@ def _check_task_rules(current_task: BaseOperator):
         )
 
 
-def task_policy(task: BaseOperator):
+def example_task_policy(task: BaseOperator):
     """Ensure Tasks have non-default owners."""
     _check_task_rules(task)
 
@@ -77,6 +79,22 @@ def dag_policy(dag: DAG):
 
 
 # [END example_dag_cluster_policy]
+
+
+# [START example_task_cluster_policy]
+class TimedOperator(BaseOperator, ABC):
+    timeout: timedelta
+
+
+def task_policy(task: TimedOperator):
+    if task.task_type == 'HivePartitionSensor':
+        task.queue = "sensor_queue"
+    if task.timeout > timedelta(hours=48):
+        task.timeout = timedelta(hours=48)
+
+
+# [END example_task_cluster_policy]
+
 
 # [START example_task_mutation_hook]
 def task_instance_mutation_hook(task_instance: TaskInstance):

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -15,8 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from abc import ABC
-from datetime import timedelta
 from typing import Callable, List
 
 from airflow.configuration import conf
@@ -62,7 +60,7 @@ def _check_task_rules(current_task: BaseOperator):
         )
 
 
-def cluster_policy(task: BaseOperator):
+def task_policy(task: BaseOperator):
     """Ensure Tasks have non-default owners."""
     _check_task_rules(task)
 
@@ -79,22 +77,6 @@ def dag_policy(dag: DAG):
 
 
 # [END example_dag_cluster_policy]
-
-
-class TimedOperator(BaseOperator, ABC):
-    timeout: timedelta
-
-
-# [START example_task_cluster_policy]
-def task_policy(task: TimedOperator):
-    if task.task_type == 'HivePartitionSensor':
-        task.queue = "sensor_queue"
-    if task.timeout > timedelta(hours=48):
-        task.timeout = timedelta(hours=48)
-
-
-# [END example_task_cluster_policy]
-
 
 # [START example_task_mutation_hook]
 def task_instance_mutation_hook(task_instance: TaskInstance):

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -955,7 +955,7 @@ class TestDagBag:
             assert serialized_dag.dag_id == dag.dag_id
             assert set(serialized_dag.task_dict) == set(dag.task_dict)
 
-    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.example_task_policy)
     def test_task_cluster_policy_violation(self):
         """
         test that file processing results in import error when task does not
@@ -974,7 +974,7 @@ class TestDagBag:
         }
         assert expected_import_errors == dagbag.import_errors
 
-    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.example_task_policy)
     def test_task_cluster_policy_nonstring_owner(self):
         """
         test that file processing results in import error when task does not
@@ -994,7 +994,7 @@ class TestDagBag:
         }
         assert expected_import_errors == dagbag.import_errors
 
-    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.example_task_policy)
     def test_task_cluster_policy_obeyed(self):
         """
         test that dag successfully imported without import errors when tasks

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -955,7 +955,7 @@ class TestDagBag:
             assert serialized_dag.dag_id == dag.dag_id
             assert set(serialized_dag.task_dict) == set(dag.task_dict)
 
-    @patch("airflow.settings.task_policy", cluster_policies.cluster_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
     def test_task_cluster_policy_violation(self):
         """
         test that file processing results in import error when task does not
@@ -974,7 +974,7 @@ class TestDagBag:
         }
         assert expected_import_errors == dagbag.import_errors
 
-    @patch("airflow.settings.task_policy", cluster_policies.cluster_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
     def test_task_cluster_policy_nonstring_owner(self):
         """
         test that file processing results in import error when task does not
@@ -994,7 +994,7 @@ class TestDagBag:
         }
         assert expected_import_errors == dagbag.import_errors
 
-    @patch("airflow.settings.task_policy", cluster_policies.cluster_policy)
+    @patch("airflow.settings.task_policy", cluster_policies.task_policy)
     def test_task_cluster_policy_obeyed(self):
         """
         test that dag successfully imported without import errors when tasks


### PR DESCRIPTION
From [documentation](https://airflow.apache.org/docs/apache-airflow/stable/concepts/overview.html), there are only three policies (`dag_policy`, `task_policy`, `task_instance_mutation_hook`)

But example code uses `cluster_policy`, so I rename `cluster_policy` to `task_policy`.

And to pass flake8, move python code to docs.

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/8676247/166617744-2c27f4b6-31c6-4f6c-b1d9-8824b7bacdbc.png">

Left part is generated docs, and right part is stable docs.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
