### PR TITLE
Remove color change for highly nested groups

### DIFF
--- a/airflow/www/static/js/grid/TaskName.jsx
+++ b/airflow/www/static/js/grid/TaskName.jsx
@@ -30,7 +30,6 @@ const TaskName = ({
   <Flex
     as={isGroup ? 'button' : 'div'}
     onClick={onToggle}
-    color={level > 4 && 'white'}
     aria-label={taskName}
     title={taskName}
     mr={4}


### PR DESCRIPTION
In the first version of the Grid view, we used a gray background color for tasks inside of a task group. We removed that but forgot one spot where the text color had changed when the background color got too dark.

Fixes: https://github.com/apache/airflow/issues/23476

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
