### PR TITLE
Expand/collapse all groups

### DIFF
--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -41,6 +41,7 @@ import DagRuns from './dagRuns';
 import Details from './details';
 import useSelection from './utils/useSelection';
 import { useAutoRefresh } from './context/autorefresh';
+import ToggleGroups from './ToggleGroups';
 
 const sidePanelKey = 'hideSidePanel';
 
@@ -86,22 +87,25 @@ const Grid = () => {
 
   return (
     <Box>
-      <Flex flexGrow={1} justifyContent="flex-end" alignItems="center">
-        <ResetRoot />
-        <FormControl display="flex" width="auto" mr={2}>
-          {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
-          <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
-            Auto-refresh
-          </FormLabel>
-          <Switch
-            id="auto-refresh"
-            onChange={() => toggleRefresh(true)}
-            isDisabled={isPaused}
-            isChecked={isRefreshOn}
-            size="lg"
-            title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
-          />
-        </FormControl>
+      <Flex flexGrow={1} justifyContent="space-between" alignItems="center">
+        <Flex alignItems="center">
+          <FormControl display="flex" width="auto" mr={2}>
+            {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
+            <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
+              Auto-refresh
+            </FormLabel>
+            <Switch
+              id="auto-refresh"
+              onChange={() => toggleRefresh(true)}
+              isDisabled={isPaused}
+              isChecked={isRefreshOn}
+              size="lg"
+              title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
+            />
+          </FormControl>
+          <ToggleGroups groups={groups} />
+          <ResetRoot />
+        </Flex>
         <Button
           onClick={toggleSidePanel}
           aria-label={isOpen ? 'Show Details' : 'Hide Details'}

--- a/airflow/www/static/js/grid/TaskName.jsx
+++ b/airflow/www/static/js/grid/TaskName.jsx
@@ -25,13 +25,13 @@ import {
 import { FiChevronUp, FiChevronDown } from 'react-icons/fi';
 
 const TaskName = ({
-  isGroup = false, isMapped = false, onToggle, isOpen, level, taskName,
+  isGroup = false, isMapped = false, onToggle, isOpen, level, label,
 }) => (
   <Flex
     as={isGroup ? 'button' : 'div'}
     onClick={onToggle}
-    aria-label={taskName}
-    title={taskName}
+    aria-label={label}
+    title={label}
     mr={4}
     width="100%"
     alignItems="center"
@@ -42,7 +42,7 @@ const TaskName = ({
       ml={level * 4 + 4}
       isTruncated
     >
-      {taskName}
+      {label}
       {isMapped && (
         ' [ ]'
       )}

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -1,0 +1,78 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global localStorage, CustomEvent, document */
+
+import React, { useState } from 'react';
+import { Button } from '@chakra-ui/react';
+
+import { getMetaValue } from '../utils';
+
+const dagId = getMetaValue('dag_id');
+
+const getGroupIds = (groups) => {
+  const groupIds = [];
+  const checkTasks = (tasks) => tasks.forEach((task) => {
+    if (task.children) {
+      groupIds.push(task.label);
+      checkTasks(task.children);
+    }
+  });
+  checkTasks(groups);
+  return groupIds;
+};
+
+const ToggleGroups = ({ groups }) => {
+  const storageKey = `${dagId}-open-groups`;
+  const allGroupIds = getGroupIds(groups.children);
+  const openGroupIds = JSON.parse(localStorage.getItem(storageKey)) || [];
+  const [shouldExpand, setShouldExpand] = useState(allGroupIds.length > openGroupIds.length);
+  // Don't show button if the DAG has no task groups
+  const hasGroups = groups.children.find((c) => !!c.children);
+  if (!hasGroups) return null;
+
+  const onToggle = () => {
+    if (shouldExpand) {
+      const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: true } });
+      document.dispatchEvent(closeEvent);
+      localStorage.setItem(storageKey, JSON.stringify(allGroupIds));
+    } else {
+      const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, closeGroups: true } });
+      document.dispatchEvent(closeEvent);
+      localStorage.removeItem(storageKey);
+    }
+    setShouldExpand(!shouldExpand);
+  };
+
+  const action = shouldExpand ? 'Expand' : 'Collapse';
+
+  return (
+    <Button
+      onClick={onToggle}
+      mr={2}
+      title={`${action} all task groups`}
+      aria-label={`${action} all task groups`}
+    >
+      {action}
+      {' all'}
+    </Button>
+  );
+};
+
+export default ToggleGroups;

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -42,12 +42,16 @@ const ToggleGroups = ({ groups }) => {
   const storageKey = `${dagId}-open-groups`;
   const allGroupIds = getGroupIds(groups.children);
   const openGroupIds = JSON.parse(localStorage.getItem(storageKey)) || [];
+
+  // Default to expand all if at least one group is closed
   const [shouldExpand, setShouldExpand] = useState(allGroupIds.length > openGroupIds.length);
+
   // Don't show button if the DAG has no task groups
   const hasGroups = groups.children.find((c) => !!c.children);
   if (!hasGroups) return null;
 
   const onToggle = () => {
+    // Dispatch an event to expand/collapse so the respective task component can update
     if (shouldExpand) {
       const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: true } });
       document.dispatchEvent(closeEvent);

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -20,7 +20,8 @@
 /* global localStorage, CustomEvent, document */
 
 import React, { useState } from 'react';
-import { Button } from '@chakra-ui/react';
+import { Flex, IconButton } from '@chakra-ui/react';
+import { MdExpand, MdCompress } from 'react-icons/md';
 
 import { getMetaValue } from '../utils';
 
@@ -39,43 +40,52 @@ const getGroupIds = (groups) => {
 };
 
 const ToggleGroups = ({ groups }) => {
-  const storageKey = `${dagId}-open-groups`;
+  const openGroupsKey = `${dagId}-open-groups`;
   const allGroupIds = getGroupIds(groups.children);
-  const openGroupIds = JSON.parse(localStorage.getItem(storageKey)) || [];
+  const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
+  const [openGroupIds, setOpenGroupIds] = useState(storedGroups);
 
-  // Default to expand all if at least one group is closed
-  const [shouldExpand, setShouldExpand] = useState(allGroupIds.length > openGroupIds.length);
+  const isExpandDisabled = allGroupIds.length === openGroupIds.length;
+  const isCollapseDisabled = !openGroupIds.length;
 
   // Don't show button if the DAG has no task groups
   const hasGroups = groups.children.find((c) => !!c.children);
   if (!hasGroups) return null;
 
-  const onToggle = () => {
-    // Dispatch an event to expand/collapse so the respective task component can update
-    if (shouldExpand) {
-      const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: true } });
-      document.dispatchEvent(closeEvent);
-      localStorage.setItem(storageKey, JSON.stringify(allGroupIds));
-    } else {
-      const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, closeGroups: true } });
-      document.dispatchEvent(closeEvent);
-      localStorage.removeItem(storageKey);
-    }
-    setShouldExpand(!shouldExpand);
+  const onExpand = () => {
+    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: true } });
+    document.dispatchEvent(closeEvent);
+    localStorage.setItem(openGroupsKey, JSON.stringify(allGroupIds));
+    setOpenGroupIds(allGroupIds);
   };
 
-  const action = shouldExpand ? 'Expand' : 'Collapse';
+  const onCollapse = () => {
+    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, closeGroups: true } });
+    document.dispatchEvent(closeEvent);
+    localStorage.removeItem(openGroupsKey);
+    setOpenGroupIds([]);
+  };
 
   return (
-    <Button
-      onClick={onToggle}
-      mr={2}
-      title={`${action} all task groups`}
-      aria-label={`${action} all task groups`}
-    >
-      {action}
-      {' all'}
-    </Button>
+    <Flex>
+      <IconButton
+        fontSize="2xl"
+        onClick={onExpand}
+        title="Expand all task groups"
+        aria-label="Expand all task groups"
+        icon={<MdExpand />}
+        isDisabled={isExpandDisabled}
+        mr={2}
+      />
+      <IconButton
+        fontSize="2xl"
+        onClick={onCollapse}
+        title="Collapse all task groups"
+        aria-label="Collapse all task groups"
+        isDisabled={isCollapseDisabled}
+        icon={<MdCompress />}
+      />
+    </Flex>
   );
 };
 

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -40,7 +40,7 @@ const getGroupIds = (groups) => {
 };
 
 const ToggleGroups = ({ groups }) => {
-  const openGroupsKey = `${dagId}-open-groups`;
+  const openGroupsKey = `${dagId}/open-groups`;
   const allGroupIds = getGroupIds(groups.children);
   const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
   const [openGroupIds, setOpenGroupIds] = useState(storedGroups);

--- a/airflow/www/static/js/grid/ToggleGroups.test.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.test.jsx
@@ -111,28 +111,34 @@ const mockGridData = {
   ],
 };
 
+const EXPAND = 'Expand all task groups';
+const COLLAPSE = 'Collapse all task groups';
+
 describe('Test ToggleGroups', () => {
-  test('Button text changes on click', () => {
-    const { getByText } = render(
+  test('Buttons are disabled if all groups are expanded or collapsed', () => {
+    const { getByTitle } = render(
       <ToggleGroups groups={mockGridData.groups} />,
       { wrapper: Wrapper },
     );
 
-    const toggleButton = getByText('Expand all');
+    const expandButton = getByTitle(EXPAND);
+    const collapseButton = getByTitle(COLLAPSE);
 
-    expect(toggleButton).toBeInTheDocument();
+    expect(expandButton).toBeEnabled();
+    expect(collapseButton).toBeDisabled();
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(expandButton);
 
-    expect(getByText('Collapse all')).toBeInTheDocument();
+    expect(collapseButton).toBeEnabled();
+    expect(expandButton).toBeDisabled();
   });
 
-  test('Toggle button opens and closes nested groups', async () => {
+  test('Expand/collapse buttons toggle nested groups', async () => {
     global.gridData = mockGridData;
     const dagRunIds = mockGridData.dagRuns.map((dr) => dr.runId);
     const task = mockGridData.groups;
 
-    const { getByText, queryAllByTestId } = render(
+    const { getByText, queryAllByTestId, getByTitle } = render(
       <Flex>
         <ToggleGroups groups={task} />
         <Table>
@@ -144,7 +150,8 @@ describe('Test ToggleGroups', () => {
       { wrapper: Wrapper },
     );
 
-    const toggleButton = getByText('Collapse all');
+    const expandButton = getByTitle(EXPAND);
+    const collapseButton = getByTitle(COLLAPSE);
 
     const groupName = getByText('group_1');
 
@@ -154,14 +161,14 @@ describe('Test ToggleGroups', () => {
     expect(queryAllByTestId('open-group')).toHaveLength(2);
     expect(queryAllByTestId('closed-group')).toHaveLength(0);
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(collapseButton);
 
     await waitFor(() => expect(queryAllByTestId('task-instance')).toHaveLength(1));
     expect(queryAllByTestId('open-group')).toHaveLength(0);
     // Since the groups are nested, only the parent row is rendered
     expect(queryAllByTestId('closed-group')).toHaveLength(1);
 
-    fireEvent.click(toggleButton);
+    fireEvent.click(expandButton);
 
     await waitFor(() => expect(queryAllByTestId('task-instance')).toHaveLength(3));
     expect(queryAllByTestId('open-group')).toHaveLength(2);

--- a/airflow/www/static/js/grid/ToggleGroups.test.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.test.jsx
@@ -1,0 +1,170 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect */
+
+import React from 'react';
+import { Flex, Table, Tbody } from '@chakra-ui/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+
+import renderTaskRows from './renderTaskRows';
+import ToggleGroups from './ToggleGroups';
+import { Wrapper } from './utils/testUtils';
+
+const mockGridData = {
+  groups: {
+    id: null,
+    label: null,
+    children: [
+      {
+        extraLinks: [],
+        id: 'group_1',
+        label: 'group_1',
+        instances: [
+          {
+            dagId: 'dagId',
+            duration: 0,
+            endDate: '2021-10-26T15:42:03.391939+00:00',
+            executionDate: '2021-10-25T15:41:09.726436+00:00',
+            operator: 'DummyOperator',
+            runId: 'run1',
+            startDate: '2021-10-26T15:42:03.391917+00:00',
+            state: 'success',
+            taskId: 'group_1',
+            tryNumber: 1,
+          },
+        ],
+        children: [
+          {
+            id: 'group_1.task_1',
+            label: 'task_1',
+            extraLinks: [],
+            instances: [
+              {
+                dagId: 'dagId',
+                duration: 0,
+                endDate: '2021-10-26T15:42:03.391939+00:00',
+                executionDate: '2021-10-25T15:41:09.726436+00:00',
+                operator: 'DummyOperator',
+                runId: 'run1',
+                startDate: '2021-10-26T15:42:03.391917+00:00',
+                state: 'success',
+                taskId: 'group_1.task_1',
+                tryNumber: 1,
+              },
+            ],
+            children: [
+              {
+                id: 'group_1.task_1.sub_task_1',
+                label: 'sub_task_1',
+                extraLinks: [],
+                instances: [
+                  {
+                    dagId: 'dagId',
+                    duration: 0,
+                    endDate: '2021-10-26T15:42:03.391939+00:00',
+                    executionDate: '2021-10-25T15:41:09.726436+00:00',
+                    operator: 'DummyOperator',
+                    runId: 'run1',
+                    startDate: '2021-10-26T15:42:03.391917+00:00',
+                    state: 'success',
+                    taskId: 'group_1.task_1.sub_task_1',
+                    tryNumber: 1,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    instances: [],
+  },
+  dagRuns: [
+    {
+      dagId: 'dagId',
+      runId: 'run1',
+      dataIntervalStart: new Date(),
+      dataIntervalEnd: new Date(),
+      startDate: '2021-11-08T21:14:19.704433+00:00',
+      endDate: '2021-11-08T21:17:13.206426+00:00',
+      state: 'failed',
+      runType: 'scheduled',
+      executionDate: '2021-11-08T21:14:19.704433+00:00',
+    },
+  ],
+};
+
+describe('Test ToggleGroups', () => {
+  test('Button text changes on click', () => {
+    const { getByText } = render(
+      <ToggleGroups groups={mockGridData.groups} />,
+      { wrapper: Wrapper },
+    );
+
+    const toggleButton = getByText('Expand all');
+
+    expect(toggleButton).toBeInTheDocument();
+
+    fireEvent.click(toggleButton);
+
+    expect(getByText('Collapse all')).toBeInTheDocument();
+  });
+
+  test('Toggle button opens and closes nested groups', async () => {
+    global.gridData = mockGridData;
+    const dagRunIds = mockGridData.dagRuns.map((dr) => dr.runId);
+    const task = mockGridData.groups;
+
+    const { getByText, queryAllByTestId } = render(
+      <Flex>
+        <ToggleGroups groups={task} />
+        <Table>
+          <Tbody>
+            {renderTaskRows({ task, dagRunIds })}
+          </Tbody>
+        </Table>
+      </Flex>,
+      { wrapper: Wrapper },
+    );
+
+    const toggleButton = getByText('Collapse all');
+
+    const groupName = getByText('group_1');
+
+    expect(queryAllByTestId('task-instance')).toHaveLength(3);
+    expect(groupName).toBeInTheDocument();
+
+    expect(queryAllByTestId('open-group')).toHaveLength(2);
+    expect(queryAllByTestId('closed-group')).toHaveLength(0);
+
+    fireEvent.click(toggleButton);
+
+    await waitFor(() => expect(queryAllByTestId('task-instance')).toHaveLength(1));
+    expect(queryAllByTestId('open-group')).toHaveLength(0);
+    // Since the groups are nested, only the parent row is rendered
+    expect(queryAllByTestId('closed-group')).toHaveLength(1);
+
+    fireEvent.click(toggleButton);
+
+    await waitFor(() => expect(queryAllByTestId('task-instance')).toHaveLength(3));
+    expect(queryAllByTestId('open-group')).toHaveLength(2);
+    expect(queryAllByTestId('closed-group')).toHaveLength(0);
+  });
+});

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -87,7 +87,7 @@ const TaskInstances = ({
   </Flex>
 );
 
-const storageKey = `${dagId}-open-groups`;
+const openGroupsKey = `${dagId}/open-groups`;
 
 const Row = (props) => {
   const {
@@ -103,7 +103,7 @@ const Row = (props) => {
   const isGroup = !!task.children;
   const isSelected = selected.taskId === task.id;
 
-  const openGroups = JSON.parse(localStorage.getItem(storageKey)) || [];
+  const openGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
   const defaultIsOpen = openGroups.some((g) => g === task.label);
 
   const {
@@ -129,10 +129,10 @@ const Row = (props) => {
     () => {
       if (isGroup) {
         if (!isOpen) {
-          localStorage.setItem(storageKey, JSON.stringify([...openGroups, task.label]));
+          localStorage.setItem(openGroupsKey, JSON.stringify([...openGroups, task.label]));
         } else {
           localStorage.setItem(
-            storageKey,
+            openGroupsKey,
             JSON.stringify(openGroups.filter((g) => g !== task.label)),
           );
         }

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-/* global localStorage */
+/* global localStorage, document */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   Tr,
   Td,
@@ -51,7 +51,6 @@ const renderTaskRows = ({
     key={t.id}
     task={t}
     level={level}
-    prevTaskId={task.id}
   />
 ));
 
@@ -88,11 +87,12 @@ const TaskInstances = ({
   </Flex>
 );
 
+const storageKey = `${dagId}-open-groups`;
+
 const Row = (props) => {
   const {
     task,
     level,
-    prevTaskId,
     isParentOpen = true,
     dagRunIds,
   } = props;
@@ -103,23 +103,43 @@ const Row = (props) => {
   const isGroup = !!task.children;
   const isSelected = selected.taskId === task.id;
 
-  const taskName = prevTaskId ? task.id.replace(`${prevTaskId}.`, '') : task.id;
-
-  const storageKey = `${dagId}-open-groups`;
   const openGroups = JSON.parse(localStorage.getItem(storageKey)) || [];
-  const isGroupId = openGroups.some((g) => g === taskName);
-  const onOpen = () => {
-    localStorage.setItem(storageKey, JSON.stringify([...openGroups, taskName]));
-  };
-  const onClose = () => {
-    localStorage.setItem(storageKey, JSON.stringify(openGroups.filter((g) => g !== taskName)));
-  };
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isGroupId, onClose, onOpen });
+  const defaultIsOpen = openGroups.some((g) => g === task.label);
+
+  const {
+    isOpen, onToggle, onOpen, onClose,
+  } = useDisclosure({ defaultIsOpen });
+
+  // Listen to changes from ToggleGroups
+  useEffect(() => {
+    const handleChange = ({ detail }) => {
+      if (detail.dagId === dagId) {
+        if (detail.closeGroups) onClose();
+        else if (detail.openGroups) onOpen();
+      }
+    };
+    if (isGroup) document.addEventListener('toggleGroups', handleChange);
+    return () => {
+      if (isGroup) document.removeEventListener('toggleGroups', handleChange);
+    };
+  });
 
   // assure the function is the same across renders
   const memoizedToggle = useCallback(
-    () => isGroup && onToggle(),
-    [onToggle, isGroup],
+    () => {
+      if (isGroup) {
+        if (!isOpen) {
+          localStorage.setItem(storageKey, JSON.stringify([...openGroups, task.label]));
+        } else {
+          localStorage.setItem(
+            storageKey,
+            JSON.stringify(openGroups.filter((g) => g !== task.label)),
+          );
+        }
+        onToggle();
+      }
+    },
+    [onToggle, isGroup, isOpen, openGroups, task.label],
   );
 
   const parentTasks = task.id.split('.');
@@ -154,7 +174,7 @@ const Row = (props) => {
               onToggle={memoizedToggle}
               isGroup={isGroup}
               isMapped={task.isMapped}
-              taskName={taskName}
+              label={task.label}
               isOpen={isOpen}
               level={level}
             />


### PR DESCRIPTION
Add an expand/collapse all task groups button to grid view.
Place this and the autorefresh button above the grid part, and keep the "Show/hide details panel" button fixed to the right side of the screen.

![May-05-2022 09-57-46](https://user-images.githubusercontent.com/4600967/166939354-8ebce8eb-d5d1-4bce-9197-7abbf40e2530.gif)

<img width="840" alt="Screen Shot 2022-05-05 at 9 58 21 AM" src="https://user-images.githubusercontent.com/4600967/166939417-22ea2b56-9e35-4eb9-939d-0e5f6d4d206a.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
