### PR TITLE
Visually distinguish task group summaries

### DIFF
--- a/airflow/www/static/js/grid/TaskName.jsx
+++ b/airflow/www/static/js/grid/TaskName.jsx
@@ -35,6 +35,7 @@ const TaskName = ({
     mr={4}
     width="100%"
     alignItems="center"
+    fontWeight={isGroup || isMapped ? 'bold' : 'normal'}
   >
     <Text
       display="inline"

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -132,7 +132,7 @@ const Row = (props) => {
       <Tr
         bg={isSelected && 'blue.100'}
         borderBottomWidth={isFullyOpen ? 1 : 0}
-        borderBottomColor="gray.200"
+        borderBottomColor={isGroup && isOpen ? 'gray.400' : 'gray.200'}
         role="group"
         _hover={!isSelected && { bg: hoverBlue }}
         transition="background-color 0.2s"


### PR DESCRIPTION
Emphasize Task Group summaries with bold names and, when open, a darker bottom border.

Emphasize mapped task summaries with bold text too

<img width="507" alt="Screen Shot 2022-05-04 at 10 39 44 AM" src="https://user-images.githubusercontent.com/4600967/166749922-8da0f2db-dd3d-405f-8aec-c5eecc8aaa60.png">

![May-04-2022 10-41-30](https://user-images.githubusercontent.com/4600967/166749926-ae2035ba-bcea-415f-ae4d-e900e4e5cb51.gif)

<img width="321" alt="Screen Shot 2022-05-04 at 10 45 01 AM" src="https://user-images.githubusercontent.com/4600967/166766320-db152fdb-9b03-47a0-9410-c7c2cca6ce59.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
