### PR TITLE
Only count bad refs when `moved` table exists

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1070,7 +1070,7 @@ def _move_dangling_data_to_new_table(
     first_moved_row = session.execute(moved_rows_exist_query).all()
     if not first_moved_row:
         log.debug("no rows moved; dropping %s", target_table_name)
-        target_table.drop(bind=settings.engine, checkfirst=True)
+        target_table.drop(bind=session.get_bind(), checkfirst=True)
     else:
         log.debug("rows moved; purging from %s", source_table.name)
         delete = source_table.delete().where(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1065,7 +1065,7 @@ def _move_dangling_data_to_new_table(
     moved_rows_exist_query = select([1]).select_from(target_table).limit(1)
     first_moved_row = session.execute(moved_rows_exist_query).all()
     if not first_moved_row:
-        # bad rows were found; drop moved rows table.
+        # no bad rows were found; drop moved rows table.
         session.execute(f"DROP TABLE {target_table.name}")
     else:
         # purge the bad rows

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1067,7 +1067,7 @@ def _move_dangling_data_to_new_table(
     first_moved_row = session.execute(moved_rows_exist_query).all()
     if not first_moved_row:
         # no bad rows were found; drop moved rows table.
-        target_table.drop(bind=session.execute)
+        target_table.drop(bind=settings.engine)
     else:
         # purge the bad rows
         delete = source_table.delete().where(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1062,12 +1062,14 @@ def _move_dangling_data_to_new_table(
         source_table_name=source_table.name,
         session=session,
     )
-    session.commit()  # required at least for MS Sql Server; otherwise, when no data, drop fails;
+    session.commit()
 
     target_table = source_table.to_metadata(source_table.metadata, name=target_table_name)
     log.debug("checking whether rows were moved for table %s", target_table_name)
     moved_rows_exist_query = select([1]).select_from(target_table).limit(1)
     first_moved_row = session.execute(moved_rows_exist_query).all()
+    session.commit()
+
     if not first_moved_row:
         log.debug("no rows moved; dropping %s", target_table_name)
         target_table.drop(bind=session.get_bind(), checkfirst=True)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1083,7 +1083,6 @@ def _move_dangling_data_to_new_table(
             )
         log.debug(delete.compile())
         session.execute(delete)
-        
     session.commit()
 
     log.debug("exiting move function")

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1067,7 +1067,7 @@ def _move_dangling_data_to_new_table(
     first_moved_row = session.execute(moved_rows_exist_query).all()
     if not first_moved_row:
         # no bad rows were found; drop moved rows table.
-        target_table.drop(bind=settings.engine)
+        target_table.drop(bind=settings.engine, checkfirst=True)
     else:
         # purge the bad rows
         delete = source_table.delete().where(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1083,6 +1083,8 @@ def _move_dangling_data_to_new_table(
             )
         log.debug(delete.compile())
         session.execute(delete)
+        
+    session.commit()
 
     log.debug("exiting move function")
 


### PR DESCRIPTION
This keeps the logic to fail without upgrading when (A) there are bad rows and (B) the "moved" table already exists.  But we optimize so that we don't count the bad rows unless the "moved" table is there.  Previously we counted _always_, but the first time a user attempts upgrade, the tables won't be there so there's no point in counting.

Instead what we do is skip right to the CTAS, creating the `_airflow_moved` tables.  If there aren't any rows in the "moved" table, then we delete the table immediately.

Also included here is a delete optimization, where we join to the moved table instead of running the not exists query again.

Tested on all 4 dialects with small sample data to ensure that behavior is correct.