### PR TITLE
Changed word 'the' instead of 'his'

### DIFF
--- a/dev/breeze/doc/adr/0012-asking-user-for-confirmation.md
+++ b/dev/breeze/doc/adr/0012-asking-user-for-confirmation.md
@@ -53,7 +53,7 @@ In case 1) - we should present the user with information on what is going to cha
 not be surprised with the effect of it.
 
 In case 2) - we should not break the workflow of the user, unless this is really necessary or the user
-chooses to break his workflow. This is important in situation when the user needs to perform an action
+chooses to break the workflow. This is important in situation when the user needs to perform an action
 quickly and disrupting the workflow would be annoying and undesired. In this case the confirmation of
 the "long" action should not be "necessary" - when user does not expect the action to wait for confirmation.
 


### PR DESCRIPTION
According to this issue: https://github.com/apache/airflow/pull/23090
the word "his" won't be allowed.

We were having this issue here:

`No relative imports......................................................................Passed
Check for language that we do not accept as community....................................Failed
- hook id: check-for-inclusive-language
- exit code: 1

dev/breeze/doc/adr/0012-asking-user-for-confirmation.md:56:chooses to break his workflow. This is important in situation when the user needs to perform an action

Check BaseOperator[Link] core imports....................................................Passed`

I just change the word "his" for 'the'