### PR TITLE
Fix "Reason: Expired: too old resource version: 379140622 (380367990)"

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -133,7 +133,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             for key, value in kube_config.kube_client_request_args.items():
                 kwargs[key] = value
 
-        last_resource_version: Optional[str] = None
+        last_resource_version: str = "0"
         if self.multi_namespace_mode:
             list_worker_pods = functools.partial(
                 watcher.stream, kube_client.list_pod_for_all_namespaces, **kwargs
@@ -167,7 +167,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 resource_version=task.metadata.resource_version,
                 event=event,
             )
-            last_resource_version = task.metadata.resource_version
+            task_resource_version = task.metadata.resource_version
+            if task_resource_version:
+                last_resource_version = str(max(int(last_resource_version), int(task_resource_version)))
 
         return last_resource_version
 


### PR DESCRIPTION
The previous implementation relied on watch returning the events
sorted by resource_version which is not guaranteed at least in EKS. 

So previously you could end up with KubernetesJobWatcher retrying watch from a resource_version that is not valid (too old already) 

```
2022-05-05 08:41:40,522] {kubernetes_executor.py:126} INFO - Event: and now my watch begins starting at resource_version: 379140622
[2022-05-05 08:41:40,545] {kubernetes_executor.py:111} ERROR - Unknown error in KubernetesJobWatcher. Failing
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 379140622 (380367990)
```