### PR TITLE
Fix permission issue for dag that has dot in name

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -640,10 +640,10 @@ class DagBag(LoggingMixin):
         from airflow.security.permissions import DAG_ACTIONS, resource_name_for_dag
         from airflow.www.fab_security.sqla.models import Action, Permission, Resource
 
-        root_dag_id = dag.parent_dag.dag_id if dag.parent_dag else None
+        root_dag_id = dag.parent_dag.dag_id if dag.parent_dag else dag.dag_id
 
         def needs_perms(dag_id: str) -> bool:
-            dag_resource_name = resource_name_for_dag(dag_id, root_dag_id)
+            dag_resource_name = resource_name_for_dag(dag_id)
             for permission_name in DAG_ACTIONS:
                 if not (
                     session.query(Permission)
@@ -656,9 +656,9 @@ class DagBag(LoggingMixin):
                     return True
             return False
 
-        if dag.access_control or needs_perms(dag.dag_id):
-            self.log.debug("Syncing DAG permissions: %s to the DB", dag.dag_id)
+        if dag.access_control or needs_perms(root_dag_id):
+            self.log.debug("Syncing DAG permissions: %s to the DB", root_dag_id)
             from airflow.www.security import ApplessAirflowSecurityManager
 
             security_manager = ApplessAirflowSecurityManager(session=session)
-            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, root_dag_id)
+            security_manager.sync_perm_for_dag(root_dag_id, dag.access_control)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -641,7 +641,7 @@ class DagBag(LoggingMixin):
         from airflow.www.fab_security.sqla.models import Action, Permission, Resource
 
         def needs_perms(dag_id: str) -> bool:
-            dag_resource_name = resource_name_for_dag(dag_id)
+            dag_resource_name = resource_name_for_dag(dag_id, dag.is_subdag)
             for permission_name in DAG_ACTIONS:
                 if not (
                     session.query(Permission)
@@ -659,4 +659,4 @@ class DagBag(LoggingMixin):
             from airflow.www.security import ApplessAirflowSecurityManager
 
             security_manager = ApplessAirflowSecurityManager(session=session)
-            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control)
+            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, dag.is_subdag)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -641,7 +641,7 @@ class DagBag(LoggingMixin):
         from airflow.www.fab_security.sqla.models import Action, Permission, Resource
 
         def needs_perms(dag_id: str) -> bool:
-            dag_resource_name = resource_name_for_dag(dag_id, dag.is_subdag)
+            dag_resource_name = resource_name_for_dag(dag_id, dag.parent_dag)
             for permission_name in DAG_ACTIONS:
                 if not (
                     session.query(Permission)
@@ -659,4 +659,4 @@ class DagBag(LoggingMixin):
             from airflow.www.security import ApplessAirflowSecurityManager
 
             security_manager = ApplessAirflowSecurityManager(session=session)
-            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, dag.is_subdag)
+            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, dag.parent_dag)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -640,8 +640,10 @@ class DagBag(LoggingMixin):
         from airflow.security.permissions import DAG_ACTIONS, resource_name_for_dag
         from airflow.www.fab_security.sqla.models import Action, Permission, Resource
 
+        root_dag_id = dag.parent_dag.dag_id if dag.parent_dag else None
+
         def needs_perms(dag_id: str) -> bool:
-            dag_resource_name = resource_name_for_dag(dag_id, dag.parent_dag)
+            dag_resource_name = resource_name_for_dag(dag_id, root_dag_id)
             for permission_name in DAG_ACTIONS:
                 if not (
                     session.query(Permission)
@@ -659,4 +661,4 @@ class DagBag(LoggingMixin):
             from airflow.www.security import ApplessAirflowSecurityManager
 
             security_manager = ApplessAirflowSecurityManager(session=session)
-            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, dag.parent_dag)
+            security_manager.sync_perm_for_dag(dag.dag_id, dag.access_control, root_dag_id)

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -69,7 +69,6 @@ DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT, ACTION_CAN_DELETE}
 
 def resource_name_for_dag(dag_id, is_subdag=False):
     """Returns the resource name for a DAG id."""
-    print('DAG_ID: %s', dag_id, is_subdag)
     if dag_id == RESOURCE_DAG:
         return dag_id
 

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -16,6 +16,7 @@
 # under the License.
 
 # Resource Constants
+
 RESOURCE_ACTION = "Permissions"
 RESOURCE_ADMIN_MENU = "Admin"
 RESOURCE_AIRFLOW = "Airflow"
@@ -66,14 +67,17 @@ DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT, ACTION_CAN_DELETE}
 
 
-def resource_name_for_dag(dag_id):
+def resource_name_for_dag(dag_id, is_subdag=False):
     """Returns the resource name for a DAG id."""
+    print('DAG_ID: %s', dag_id, is_subdag)
     if dag_id == RESOURCE_DAG:
         return dag_id
 
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    # To account for SubDags
-    root_dag_id = dag_id.split(".")[0]
-    return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
+    if is_subdag:
+        # To account for SubDags
+        root_dag_id = dag_id.split(".")[0]
+        return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
+    return f"{RESOURCE_DAG_PREFIX}{dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -66,7 +66,7 @@ DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT, ACTION_CAN_DELETE}
 
 
-def resource_name_for_dag(dag_id, is_subdag=False):
+def resource_name_for_dag(dag_id, parent_dag=None):
     """Returns the resource name for a DAG id."""
     if dag_id == RESOURCE_DAG:
         return dag_id
@@ -74,8 +74,7 @@ def resource_name_for_dag(dag_id, is_subdag=False):
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    if is_subdag:
+    if parent_dag:
         # To account for SubDags
-        root_dag_id = dag_id.split(".", 1)[0]
-        return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
+        return f"{RESOURCE_DAG_PREFIX}{parent_dag.dag_id}"
     return f"{RESOURCE_DAG_PREFIX}{dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -16,7 +16,6 @@
 # under the License.
 
 # Resource Constants
-
 RESOURCE_ACTION = "Permissions"
 RESOURCE_ADMIN_MENU = "Admin"
 RESOURCE_AIRFLOW = "Airflow"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -66,15 +66,15 @@ DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT, ACTION_CAN_DELETE}
 
 
-def resource_name_for_dag(dag_id, root_dag_id=None):
-    """Returns the resource name for a DAG id."""
-    if dag_id == RESOURCE_DAG:
-        return dag_id
+def resource_name_for_dag(root_dag_id: str) -> str:
+    """Returns the resource name for a DAG id.
 
-    if dag_id.startswith(RESOURCE_DAG_PREFIX):
-        return dag_id
-
-    if root_dag_id:
-        # To account for SubDags
-        return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
-    return f"{RESOURCE_DAG_PREFIX}{dag_id}"
+    Note that since a sub-DAG should follow the permission of its
+    parent DAG, you should pass ``DagModel.root_dag_id`` to this function,
+    for a subdag. A normal dag should pass the DagModel.dag_id
+    """
+    if root_dag_id == RESOURCE_DAG:
+        return root_dag_id
+    if root_dag_id.startswith(RESOURCE_DAG_PREFIX):
+        return root_dag_id
+    return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -76,6 +76,6 @@ def resource_name_for_dag(dag_id, is_subdag=False):
 
     if is_subdag:
         # To account for SubDags
-        root_dag_id = dag_id.split(".")[0]
+        root_dag_id = dag_id.split(".", 1)[0]
         return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
     return f"{RESOURCE_DAG_PREFIX}{dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -74,7 +74,7 @@ def resource_name_for_dag(dag_id, is_subdag=False):
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    if is_subdag:
+    if '.' in dag_id and is_subdag:
         # To account for SubDags
         root_dag_id = dag_id.split(".")[0]
         return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -66,7 +66,7 @@ DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT, ACTION_CAN_DELETE}
 
 
-def resource_name_for_dag(dag_id, parent_dag=None):
+def resource_name_for_dag(dag_id, root_dag_id=None):
     """Returns the resource name for a DAG id."""
     if dag_id == RESOURCE_DAG:
         return dag_id
@@ -74,7 +74,7 @@ def resource_name_for_dag(dag_id, parent_dag=None):
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    if parent_dag:
+    if root_dag_id:
         # To account for SubDags
-        return f"{RESOURCE_DAG_PREFIX}{parent_dag.dag_id}"
+        return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"
     return f"{RESOURCE_DAG_PREFIX}{dag_id}"

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -71,7 +71,7 @@ def resource_name_for_dag(root_dag_id: str) -> str:
 
     Note that since a sub-DAG should follow the permission of its
     parent DAG, you should pass ``DagModel.root_dag_id`` to this function,
-    for a subdag. A normal dag should pass the DagModel.dag_id
+    for a subdag. A normal dag should pass the ``DagModel.dag_id``.
     """
     if root_dag_id == RESOURCE_DAG:
         return root_dag_id

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -74,7 +74,7 @@ def resource_name_for_dag(dag_id, is_subdag=False):
     if dag_id.startswith(RESOURCE_DAG_PREFIX):
         return dag_id
 
-    if '.' in dag_id and is_subdag:
+    if is_subdag:
         # To account for SubDags
         root_dag_id = dag_id.split(".")[0]
         return f"{RESOURCE_DAG_PREFIX}{root_dag_id}"

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -202,11 +202,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def _is_subdag(self, dag_id):
         if '.' in dag_id:
-            dm = (
-                self.get_session.query(DagModel.dag_id, DagModel.is_subdag)
-                .filter(DagModel.dag_id == dag_id)
-                .first()
-            )
+            dm = self.get_session.query(DagModel.is_subdag).filter(DagModel.dag_id == dag_id).first()
             return dm.is_subdag if dm else False
         return False
 

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -202,8 +202,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def _is_subdag(self, dag_id):
         if '.' in dag_id:
-            dm = self.get_session.query(DagModel.is_subdag).filter(DagModel.dag_id == dag_id).first()
-            return dm.is_subdag if dm else False
+            return self.get_session.query(DagModel.is_subdag).filter(DagModel.dag_id == dag_id).scalar()
         return False
 
     def init_role(self, role_name, perms):

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -201,12 +201,14 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         self.perms = None
 
     def _is_subdag(self, dag_id):
-        dm = (
-            self.get_session.query(DagModel.dag_id, DagModel.is_subdag)
-            .filter(DagModel.dag_id == dag_id)
-            .first()
-        )
-        return dm.is_subdag if dm else False
+        if '.' in dag_id:
+            dm = (
+                self.get_session.query(DagModel.dag_id, DagModel.is_subdag)
+                .filter(DagModel.dag_id == dag_id)
+                .first()
+            )
+            return dm.is_subdag if dm else False
+        return False
 
     def init_role(self, role_name, perms):
         """

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -882,7 +882,7 @@ class TestDagBag:
 
             # perms dont exist
             _sync_perms()
-            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None, dag.parent_dag)
+            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None)
 
             # perms now exist
             _sync_perms()
@@ -892,7 +892,7 @@ class TestDagBag:
             dag.access_control = {"Public": {"can_read"}}
             _sync_perms()
             mock_sync_perm_for_dag.assert_called_once_with(
-                "test_example_bash_operator", {"Public": {"can_read"}}, dag.parent_dag
+                "test_example_bash_operator", {"Public": {"can_read"}}
             )
 
     @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -882,7 +882,7 @@ class TestDagBag:
 
             # perms dont exist
             _sync_perms()
-            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None)
+            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None, dag.is_subdag)
 
             # perms now exist
             _sync_perms()
@@ -892,7 +892,7 @@ class TestDagBag:
             dag.access_control = {"Public": {"can_read"}}
             _sync_perms()
             mock_sync_perm_for_dag.assert_called_once_with(
-                "test_example_bash_operator", {"Public": {"can_read"}}
+                "test_example_bash_operator", {"Public": {"can_read"}}, dag.is_subdag
             )
 
     @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -882,7 +882,7 @@ class TestDagBag:
 
             # perms dont exist
             _sync_perms()
-            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None, dag.is_subdag)
+            mock_sync_perm_for_dag.assert_called_once_with("test_example_bash_operator", None, dag.parent_dag)
 
             # perms now exist
             _sync_perms()
@@ -892,7 +892,7 @@ class TestDagBag:
             dag.access_control = {"Public": {"can_read"}}
             _sync_perms()
             mock_sync_perm_for_dag.assert_called_once_with(
-                "test_example_bash_operator", {"Public": {"can_read"}}, dag.is_subdag
+                "test_example_bash_operator", {"Public": {"can_read"}}, dag.parent_dag
             )
 
     @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -192,10 +192,7 @@ def sample_dags(security_manager):
 @pytest.fixture(scope="module")
 def has_dag_perm(security_manager, session):
     def _has_dag_perm(perm, dag_id, user):
-        is_subdag = False
-        dm = session.query(DagModel).filter(DagModel.dag_id == dag_id).first()
-        if dm:
-            is_subdag = dm.is_subdag
+        is_subdag = security_manager._is_subdag(dag_id)
         return security_manager.has_access(perm, permissions.resource_name_for_dag(dag_id, is_subdag), user)
 
     return _has_dag_perm

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -554,7 +554,6 @@ def test_access_control_with_non_existent_role(security_manager):
             access_control={
                 'this-role-does-not-exist': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]
             },
-            is_subdag=False,
         )
     assert "role does not exist" in str(ctx.value)
 
@@ -593,7 +592,7 @@ def test_access_control_with_invalid_permission(app, security_manager):
         for action in invalid_actions:
             with pytest.raises(AirflowException) as ctx:
                 security_manager.sync_perm_for_dag(
-                    'access_control_test', access_control={rolename: {action}}, is_subdag=False
+                    'access_control_test', access_control={rolename: {action}},
                 )
             assert "invalid permissions" in str(ctx.value)
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -592,7 +592,8 @@ def test_access_control_with_invalid_permission(app, security_manager):
         for action in invalid_actions:
             with pytest.raises(AirflowException) as ctx:
                 security_manager.sync_perm_for_dag(
-                    'access_control_test', access_control={rolename: {action}},
+                    'access_control_test',
+                    access_control={rolename: {action}},
                 )
             assert "invalid permissions" in str(ctx.value)
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -734,7 +734,7 @@ def test_create_dag_specific_permissions(session, security_manager, monkeypatch,
 
     del dagbag_mock.dags["has_access_control"]
     with assert_queries_count(2):  # two query to get all perms; dagbag is mocked
-        # The extra query happens at permissions.resource_name_for_dag()
+        # The extra query happens at permission check
         security_manager.create_dag_specific_permissions()
 
 


### PR DESCRIPTION
How we determine if a DAG is a subdag in `airflow.security.permissions.resource_name_for_dag` is not right.
If a `dag_id` contains a dot, the permission is not recorded correctly.

The current solution makes a query every time we check for permission for dags that has a dot in the name. Not that I like it but I think it's better than other options I considered such as changing how we name dags for subdag. That's not
good in UX. Another option I considered was making a query when parsing, that's not good and it's avoided
by passing `root_dag` to `resource_name_for_dag`

This PR is an attempt to fix this

Closes: https://github.com/apache/airflow/issues/23473