### PR TITLE
Prevent KubernetesJobWatcher getting stuck on resource too old

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -109,6 +109,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 time.sleep(1)
             except Exception:
                 self.log.exception('Unknown error in KubernetesJobWatcher. Failing')
+                self.resource_version = "0"
                 ResourceVersion().resource_version = "0"
                 raise
             else:
@@ -289,6 +290,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
             self.log.error(
                 'Error while health checking kube watcher process. Process died for unknown reasons'
             )
+            ResourceVersion().resource_version = "0"
             self.kube_watcher = self._make_kube_watcher()
 
     def run_next(self, next_job: KubernetesJobType) -> None:

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -109,6 +109,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
                 time.sleep(1)
             except Exception:
                 self.log.exception('Unknown error in KubernetesJobWatcher. Failing')
+                ResourceVersion().resource_version = "0"
                 raise
             else:
                 self.log.warning(

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -39,6 +39,7 @@ try:
         AirflowKubernetesScheduler,
         KubernetesExecutor,
         KubernetesJobWatcher,
+        ResourceVersion,
         create_pod_id,
         get_base_pod_from_template,
     )
@@ -957,3 +958,36 @@ class TestKubernetesJobWatcher(unittest.TestCase):
             f"Kubernetes failure for {raw_object['reason']} "
             f"with code {raw_object['code']} and message: {raw_object['message']}"
         )
+
+    def test_recover_from_resource_too_old(self):
+        # too old resource
+        mock_underscore_run = mock.MagicMock()
+
+        def effect():
+            yield '500'
+            while True:
+                yield Exception('sentinel')
+
+        mock_underscore_run.side_effect = effect()
+
+        self.watcher._run = mock_underscore_run
+
+        with mock.patch('airflow.executors.kubernetes_executor.get_kube_client'):
+            try:
+                # self.watcher._run() is mocked and return "500" as last resource_version
+                self.watcher.run()
+            except Exception as e:
+                assert e.args == ('sentinel',)
+
+            # both  resource_version should be 0 after _run raises and exception
+            assert self.watcher.resource_version == '0'
+            assert ResourceVersion().resource_version == '0'
+
+            # check that in the next run, _run is invoked with resource_version = 0
+            mock_underscore_run.reset_mock()
+            try:
+                self.watcher.run()
+            except Exception as e:
+                assert e.args == ('sentinel',)
+
+            mock_underscore_run.assert_called_once_with(mock.ANY, '0', mock.ANY, mock.ANY)


### PR DESCRIPTION
Currently in airflow 2.3.0 the scheduler will get into an infinite loop if the k8s API ever response with a 410 (too old resource version / resource version too old). 

This currently happen in airflow deployments in separate EKS 1.21 clusters, where every hour or so the scheduler will be stuck printing the error below in a tight loop, and will require manual restart.

Below is a log except from a scheduler in such state (tight loop of `too old resource version` error). As you can see the `now my watch begins starting at resource_version: 380528372` repeats itself at 9:58:19,950, then one second later at 09:58:21,012, the again half second later  at 09:58:21,541.  Always asking k8s to start a watch from the same exact resourceVersion that will always return `too old resource version` 

```
[2022-05-07 09:58:19,941] {kubernetes_executor.py:288} ERROR - Error while health checking kube watcher process. Process died for unknown reasons
[2022-05-07 09:58:19,950] {kubernetes_executor.py:126} INFO - Event: and now my watch begins starting at resource_version: 380528372
[2022-05-07 09:58:19,965] {kubernetes_executor.py:111} ERROR - Unknown error in KubernetesJobWatcher. Failing
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
Process KubernetesJobWatcher-164543:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
[2022-05-07 09:58:21,002] {kubernetes_executor.py:288} ERROR - Error while health checking kube watcher process. Process died for unknown reasons
[2022-05-07 09:58:21,012] {kubernetes_executor.py:126} INFO - Event: and now my watch begins starting at resource_version: 380528372
[2022-05-07 09:58:21,025] {kubernetes_executor.py:111} ERROR - Unknown error in KubernetesJobWatcher. Failing
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
Process KubernetesJobWatcher-164544:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
[2022-05-07 09:58:21,531] {kubernetes_executor.py:288} ERROR - Error while health checking kube watcher process. Process died for unknown reasons
[2022-05-07 09:58:21,541] {kubernetes_executor.py:126} INFO - Event: and now my watch begins starting at resource_version: 380528372
[2022-05-07 09:58:21,556] {kubernetes_executor.py:111} ERROR - Unknown error in KubernetesJobWatcher. Failing
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
Process KubernetesJobWatcher-164545:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 102, in run
    self.resource_version = self._run(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/executors/kubernetes_executor.py", line 145, in _run
    for event in list_worker_pods():
  File "/home/airflow/.local/lib/python3.8/site-packages/kubernetes/watch/watch.py", line 182, in stream
    raise client.rest.ApiException(
kubernetes.client.exceptions.ApiException: (410)
Reason: Expired: too old resource version: 380528372 (382477719)
```


The situation is as follows 
* KubernetesJobWatcher will start a get/list/watch cycle starting at resource_version=0 using the [kubernetes-client/python library kubernetes.watch.stream() ](https://github.com/kubernetes-client/python)
* The client will eventually get disconnected
* KubernetesJobWatcher will try to start a new get/list/watch cycle starting at what KubernetesJobWatcher thinks it's the latest resource version 380528372.
  * KubernetesJobWatcher tries hard to keep track of the last resource_version seen but there are inherent limitations on the k8s api (like the initial get/list does not guarantee ordering)
  * even if it did a perfect job tracking resource version the watch from a specific resource version is not guaranteed to work as stated in [Kubernetes documentation > efficient detection of changes](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
> A given Kubernetes server will only preserve a historical record of changes for a limited time. Clusters using etcd 3 preserve changes in the last 5 minutes by default. When the requested watch operations fail because the historical version of that resource is not available, clients must handle the case by recognizing the status code 410 Gone, clearing their local cache, **performing a new get or list operation, and starting the watch from the resourceVersion that was returned.** [ecerulm: using the resourceVersion that was returned in the get/list operation, not the one that KubernetesJobWatcher saved]
* This new attempt to watch from resourceVersion 380528372 will fail with a 410 resource too old (in my scenario this happens with high probability after the scheduler has been up for 1 hour) . Again this is expected non-exceptional case, there is no guarantee that you can restart the watch for resource version 380528372. 
* When the watch operation fails immediately with `kubernetes.client.exceptions.ApiException: (410) 
 Reason: Expired: too old resource version: 380528372 (382477719)` KubernetesJobWatcher  will die 
* Then a new KubernetesJobWatcher will start that tries again to start the watch from exactly the same resource version 380528372 and that will again fail for the same reason  
* From this point on the scheduler will be stuck with no progress, will continue in a tight infinite loop of starting KubernetesJobWatcher, letting it do a watch that will always fails, noticing that KubernetesJobWatcher died again, starting it again, etc 


This PR solves the situation (already tested for 10 hours in one of my airflow deployments in EKS) by always starting a fresh watch (resourceVersion=0) after KubernetesJobWatcher dies.  


closes: #21087
related: #15500
related: #17629
related: #22407
related: #12644

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
