### PR TITLE
Fix cassandra to 3.0.25

### DIFF
--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -18,7 +18,8 @@
 version: "3.7"
 services:
   cassandra:
-    image: cassandra:3.0
+    # TODO: fix cassandra to 3.0.25 as latest 3.0 (3.0.26) does not start cleanly
+    image: cassandra:3.0.25
     environment:
       HEAP_NEWSIZE: 128M
       MAX_HEAP_SIZE: 256M


### PR DESCRIPTION
fix cassandra to 3.0.25 as latest 3.0 (3.0.26) does not start cleanly

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
