### PR TITLE
Fix regression in ignoring symlinks

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -50,14 +50,8 @@ sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 load_default_connections = True
 
 [logging]
-base_log_folder = {AIRFLOW_HOME}/logs
-logging_level = INFO
-celery_logging_level = WARN
-fab_logging_level = WARN
-log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
-log_processor_filename_template = {{{{ filename }}}}.log
-dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
-worker_log_server_port = 8793
+celery_logging_level = WARNING
+fab_logging_level = WARNING
 
 [cli]
 api_client = airflow.api.client.local_client
@@ -77,8 +71,6 @@ default_hive_mapred_queue = airflow
 base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
-dag_orientation = LR
-dag_default_view = tree
 log_fetch_timeout_sec = 5
 hide_paused_dags_by_default = False
 page_size = 100

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -50,8 +50,14 @@ sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 load_default_connections = True
 
 [logging]
-celery_logging_level = WARNING
-fab_logging_level = WARNING
+base_log_folder = {AIRFLOW_HOME}/logs
+logging_level = INFO
+celery_logging_level = WARN
+fab_logging_level = WARN
+log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
+log_processor_filename_template = {{{{ filename }}}}.log
+dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
+worker_log_server_port = 8793
 
 [cli]
 api_client = airflow.api.client.local_client
@@ -71,6 +77,8 @@ default_hive_mapred_queue = airflow
 base_url = http://localhost:8080
 web_server_host = 0.0.0.0
 web_server_port = 8080
+dag_orientation = LR
+dag_default_view = tree
 log_fetch_timeout_sec = 5
 hide_paused_dags_by_default = False
 page_size = 100

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -238,8 +238,9 @@ def _find_path_from_directory(
         for sd in dirs:
             dirpath = (Path(root) / sd).resolve()
             if dirpath in patterns_by_dir:
-                log.error("Detected recursive loop when walking DAG directory %s: %s has appeared more than once.", base_dir_path, dirpath)
-                raise RuntimeError(f"Detected recursive loop when walking DAG directory {base_dir_path}: {dirpath} has appeared more than once.")
+                raise RuntimeError(
+                    f"Detected recursive loop when walking DAG directory {base_dir_path}: {dirpath} has appeared more than once."
+                )
             patterns_by_dir.update({dirpath: patterns.copy()})
 
         for file in files:

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -57,7 +57,7 @@ class _RegexpIgnoreRule(NamedTuple):
     def compile(pattern: str, base_dir: Path, definition_file: Path) -> Optional[_IgnoreRule]:
         """Build an ignore rule from the supplied regexp pattern and log a useful warning if it is invalid"""
         try:
-            return _RegexpIgnoreRule(re.compile(pattern), base_dir.resolve())
+            return _RegexpIgnoreRule(re.compile(pattern), base_dir.absolute())
         except re.error as e:
             log.warning("Ignoring invalid regex '%s' from %s: %s", pattern, definition_file, e)
             return None
@@ -65,7 +65,7 @@ class _RegexpIgnoreRule(NamedTuple):
     @staticmethod
     def match(path: Path, rules: List[_IgnoreRule]) -> bool:
         """Match a list of ignore rules against the supplied path"""
-        test_path: Path = path.resolve()
+        test_path: Path = path.absolute()
         for rule in rules:
             if not isinstance(rule, _RegexpIgnoreRule):
                 raise ValueError(f"_RegexpIgnoreRule cannot match rules of type: {type(rule)}")
@@ -95,14 +95,14 @@ class _GlobIgnoreRule(NamedTuple):
             # > If there is a separator at the beginning or middle (or both) of the pattern, then the
             # > pattern is relative to the directory level of the particular .gitignore file itself.
             # > Otherwise the pattern may also match at any level below the .gitignore level.
-            relative_to = definition_file.resolve().parent
+            relative_to = definition_file.absolute().parent
         ignore_pattern = GitWildMatchPattern(pattern)
         return _GlobIgnoreRule(ignore_pattern.regex, pattern, ignore_pattern.include, relative_to)
 
     @staticmethod
     def match(path: Path, rules: List[_IgnoreRule]) -> bool:
         """Match a list of ignore rules against the supplied path"""
-        test_path: Path = path.resolve()
+        test_path: Path = path.absolute()
         matched = False
         for r in rules:
             if not isinstance(r, _GlobIgnoreRule):

--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -239,7 +239,8 @@ def _find_path_from_directory(
             dirpath = (Path(root) / sd).resolve()
             if dirpath in patterns_by_dir:
                 raise RuntimeError(
-                    f"Detected recursive loop when walking DAG directory {base_dir_path}: {dirpath} has appeared more than once."
+                    f"Detected recursive loop when walking DAG directory " + \
+                        "{base_dir_path}: {dirpath} has appeared more than once."
                 )
             patterns_by_dir.update({dirpath: patterns.copy()})
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -80,6 +80,7 @@ class TestOpenMaybeZipped(unittest.TestCase):
 class TestListPyFilesPath(unittest.TestCase):
     def setUp(self):
         import tempfile
+
         self.test_dir = tempfile.mkdtemp(prefix="onotole")
         source = os.path.join(self.test_dir, "folder")
         target = os.path.join(self.test_dir, "symlink")
@@ -97,6 +98,7 @@ class TestListPyFilesPath(unittest.TestCase):
     def tearDown(self):
         if self.test_dir:
             import shutil
+
             shutil.rmtree(self.test_dir)
 
     def test_find_path_from_directory_regex_ignore(self):

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -82,14 +82,12 @@ class TestOpenMaybeZipped(unittest.TestCase):
 
 class TestListPyFilesPath():
     @pytest.fixture()
-    def test_dir(self):
-        import tempfile
+    def test_dir(self, tmp_path):
         # create test tree with symlinks
-        tmp_dir = tempfile.mkdtemp(prefix="onotole")
-        source = os.path.join(tmp_dir, "folder")
-        target = os.path.join(tmp_dir, "symlink")
+        source = os.path.join(tmp_path, "folder")
+        target = os.path.join(tmp_path, "symlink")
         py_file = os.path.join(source, "hello_world.py")
-        ignore_file = os.path.join(tmp_dir, ".airflowignore")
+        ignore_file = os.path.join(tmp_path, ".airflowignore")
         os.mkdir(source)
         os.symlink(source, target)
         # write ignore files
@@ -98,11 +96,7 @@ class TestListPyFilesPath():
         # write sample pyfile
         with open(py_file, 'w') as f:
             f.write("print('hello world')")
-
-        yield tmp_dir
-
-        import shutil
-        shutil.rmtree(tmp_dir)
+        return tmp_path
 
     def test_find_path_from_directory_regex_ignore(self):
         should_ignore = [

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -23,7 +23,8 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, mkdirs, open_maybe_zipped
+
+from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, open_maybe_zipped
 from tests.models import TEST_DAGS_FOLDER
 
 
@@ -80,7 +81,7 @@ class TestOpenMaybeZipped(unittest.TestCase):
         assert isinstance(content, str)
 
 
-class TestListPyFilesPath():
+class TestListPyFilesPath:
     @pytest.fixture()
     def test_dir(self, tmp_path):
         # create test tree with symlinks
@@ -158,5 +159,8 @@ class TestListPyFilesPath():
             list(find_path_from_directory(test_dir, ignore_list_file, ignore_file_syntax="glob"))
             assert False, "Walking a self-recursive tree should fail"
         except RuntimeError as err:
-            assert str(err) == f"Detected recursive loop when walking DAG directory {test_dir}: " + \
-                f"{Path(recursing_tgt).resolve()} has appeared more than once."
+            assert (
+                str(err)
+                == f"Detected recursive loop when walking DAG directory {test_dir}: "
+                + f"{Path(recursing_tgt).resolve()} has appeared more than once."
+            )


### PR DESCRIPTION
In 2.3.0 we modified the way files are ignored and introduced a new syntax for ignorefile expressions. Unfortunately this change introduced a regression where ignore rules that refer to symlink paths are not matched. This patch changes the behaviour of the matchers to use unresolved absolute paths in their processing rather than resolved absolute paths, which ensures the symlink names in the path are retained.

closes: #23532
