### PR TITLE
Apply specific ID collation to root_dag_id too

### DIFF
--- a/airflow/migrations/versions/0045_b3b105409875_add_root_dag_id_to_dag.py
+++ b/airflow/migrations/versions/0045_b3b105409875_add_root_dag_id_to_dag.py
@@ -27,6 +27,8 @@ Create Date: 2019-09-28 23:20:01.744775
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.db_types import StringID
+
 # revision identifiers, used by Alembic.
 revision = 'b3b105409875'
 down_revision = 'd38e04c12aa2'
@@ -37,7 +39,7 @@ airflow_version = '1.10.7'
 
 def upgrade():
     """Apply Add ``root_dag_id`` to ``DAG``"""
-    op.add_column('dag', sa.Column('root_dag_id', sa.String(length=250), nullable=True))
+    op.add_column('dag', sa.Column('root_dag_id', StringID(), nullable=True))
     op.create_index('idx_root_dag_id', 'dag', ['root_dag_id'], unique=False)
 
 


### PR DESCRIPTION
#### Motivation
In certain databases there is a need to set the collation for ID fields like `dag_id` or `task_id` to something different than the database default. This is because in MySQL with utf8mb4 the index size becomes too big for the MySQL limits. In past pull requests this was handled [#7570](https://github.com/apache/airflow/pull/7570), [#17729](https://github.com/apache/airflow/pull/17729), but the `root_dag_id` field on the dag model was missed. Since this field is used to join with the `dag_id` in various other models ([and self-referentially](https://github.com/apache/airflow/blob/451c7cbc42a83a180c4362693508ed33dd1d1dab/airflow/models/dag.py#L2766)), it also needs to have the same collation as other ID fields.

This can be seen by running `airflow db reset` before and after applying this change while also specifying `sql_engine_collation_for_ids` in the configuration.

Without this change affected database setups could see issues like the following:
```py
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (1267, "Illegal mix of collations (utf8_unicode_ci,IMPLICIT) and (utf8_general_ci,IMPLICIT) for operation '='")
```

Which could also be resolved manually by running something similar to the generated SQL. For example, in MySQL 5.7:
```sql
ALTER TABLE dag MODIFY root_dag_id VARCHAR(250) COLLATE utf8mb3_general_ci DEFAULT NULL;
```

Other related pull requests: [#19408](https://github.com/apache/airflow/pull/19408)

#### Backwards Compatibility

Since the downgrade is just to drop the column, there shouldn't be any problems.

#### Tests?
Since there weren't many tests covering these cases when the changes were made in the previously referenced pull requests, it didn't seem needed in this specific case. Let me know if that's not the case though we can talk about what those might look like.