### PR TITLE
Add IPV6 form of the address in cassandra status check

### DIFF
--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -18,8 +18,7 @@
 version: "3.7"
 services:
   cassandra:
-    # TODO: fix cassandra to 3.0.25 as latest 3.0 (3.0.26) does not start cleanly
-    image: cassandra:3.0.25
+    image: cassandra:3.0
     environment:
       HEAP_NEWSIZE: 128M
       MAX_HEAP_SIZE: 256M
@@ -27,7 +26,9 @@ services:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - cassandra-db-volume:/var/lib/cassandra
     healthcheck:
-      test: "[ $$(nodetool statusgossip) = running ]"
+      # We use IPv6 variant of the check to workaround the problem with 3.0.26 version
+      # of Cassandra https://issues.apache.org/jira/browse/CASSANDRA-17581
+      test: "[ $$(nodetool --host '::FFFF:127.0.0.1' statusgossip) = running ]"
       interval: 5s
       timeout: 30s
       retries: 50


### PR DESCRIPTION
This PR fixes problem introduced in 3.0.26 of cassandra image which
adds square brackets around IP address regardless of its type.

The problem was workarounded by pinning cassandra to 3.0.25 in
the ##23522 as a quick fix, but this one introducec permanent,
future-proof solution.

Based on discussion in https://issues.apache.org/jira/browse/CASSANDRA-17612

Fixes: #23523

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
