### PR TITLE
Replace `pytest.mark.xfail` in Postgres tests

### DIFF
--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -315,7 +315,6 @@ class TestPostgresHook(unittest.TestCase):
         for row in rows:
             self.cur.execute.assert_any_call(sql, row)
 
-    @pytest.mark.xfail
     @pytest.mark.backend("postgres")
     def test_insert_rows_replace_missing_target_field_arg(self):
         table = "table"
@@ -330,9 +329,11 @@ class TestPostgresHook(unittest.TestCase):
             ),
         ]
         fields = ("id", "value")
-        self.db_hook.insert_rows(table, rows, replace=True, replace_index=fields[0])
+        with pytest.raises(ValueError) as ctx:
+            self.db_hook.insert_rows(table, rows, replace=True, replace_index=fields[0])
 
-    @pytest.mark.xfail
+        assert str(ctx.value) == "PostgreSQL ON CONFLICT upsert syntax requires column names"
+
     @pytest.mark.backend("postgres")
     def test_insert_rows_replace_missing_replace_index_arg(self):
         table = "table"
@@ -347,7 +348,10 @@ class TestPostgresHook(unittest.TestCase):
             ),
         ]
         fields = ("id", "value")
-        self.db_hook.insert_rows(table, rows, fields, replace=True)
+        with pytest.raises(ValueError) as ctx:
+            self.db_hook.insert_rows(table, rows, fields, replace=True)
+
+        assert str(ctx.value) == "PostgreSQL ON CONFLICT upsert syntax requires an unique index"
 
     @pytest.mark.backend("postgres")
     def test_rowcount(self):


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/23539

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
