### PR TITLE
Change chart annotation generator to use RELEASE_NOTES

### DIFF
--- a/dev/chart/build_changelog_annotations.py
+++ b/dev/chart/build_changelog_annotations.py
@@ -85,8 +85,9 @@ def print_entry(section: str, description: str, pr_number: Optional[int]):
 
 
 in_first_release = False
+past_significant_changes = False
 section = ""
-with open("chart/CHANGELOG.txt") as f:
+with open("chart/RELEASE_NOTES.rst") as f:
     for line in f:
         line = line.strip()
         if not line:
@@ -97,8 +98,17 @@ with open("chart/CHANGELOG.txt") as f:
                 break
             in_first_release = True
             continue
-        if line.startswith('"""') or line.startswith('----'):
+        if line.startswith('"""') or line.startswith('----') or line.startswith('^^^^'):
             continue
+
+        # Make sure we get past "significant features" before we actually start keeping track
+        if not past_significant_changes:
+            if line == "New Features":
+                section = line
+                past_significant_changes = True
+                continue
+            continue
+
         if not line.startswith('- '):
             section = line
             continue

--- a/dev/chart/build_changelog_annotations.py
+++ b/dev/chart/build_changelog_annotations.py
@@ -106,7 +106,6 @@ with open("chart/RELEASE_NOTES.rst") as f:
             if line == "New Features":
                 section = line
                 past_significant_changes = True
-                continue
             continue
 
         if not line.startswith('- '):


### PR DESCRIPTION
The script that builds the changelog for ArtifactHub needs to be updated to use the new RELEASE_NOTES.