### PR TITLE
Add logging in to Github Registry for breeze pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   # All other permissions are set to none
   contents: read
+  packages: read
 env:
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   ANSWER: "yes"

--- a/dev/breeze/src/airflow_breeze/commands/ci_image_tools.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_tools.py
@@ -135,6 +135,7 @@ CI_IMAGE_TOOLS_PARAMETERS = {
             "options": [
                 "--image-tag",
                 "--python",
+                "--github-token",
                 "--verify-image",
                 "--wait-for-image",
                 "--tag-as-latest",
@@ -233,6 +234,7 @@ def build_image(
 @option_run_in_parallel
 @option_parallelism
 @option_python_versions
+@option_github_token
 @option_verify_image
 @option_wait_for_image
 @option_tag_as_latest
@@ -245,6 +247,7 @@ def pull_image(
     github_repository: str,
     run_in_parallel: bool,
     python_versions: str,
+    github_token: str,
     parallelism: int,
     image_tag: Optional[str],
     wait_for_image: bool,
@@ -256,7 +259,12 @@ def pull_image(
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)
         ci_image_params_list = [
-            BuildCiParams(image_tag=image_tag, python=python, github_repository=github_repository)
+            BuildCiParams(
+                image_tag=image_tag,
+                python=python,
+                github_repository=github_repository,
+                github_token=github_token,
+            )
             for python in python_version_list
         ]
         run_pull_in_parallel(
@@ -271,7 +279,9 @@ def pull_image(
             extra_pytest_args=extra_pytest_args if extra_pytest_args is not None else (),
         )
     else:
-        image_params = BuildCiParams(image_tag=image_tag, python=python, github_repository=github_repository)
+        image_params = BuildCiParams(
+            image_tag=image_tag, python=python, github_repository=github_repository, github_token=github_token
+        )
         return_code, info = run_pull_image(
             image_params=image_params,
             dry_run=dry_run,

--- a/dev/breeze/src/airflow_breeze/commands/production_image_tools.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_tools.py
@@ -150,6 +150,7 @@ PRODUCTION_IMAGE_TOOLS_PARAMETERS = {
             "options": [
                 "--image-tag",
                 "--python",
+                "--github-token",
                 "--verify-image",
                 "--wait-for-image",
                 "--tag-as-latest",
@@ -287,6 +288,7 @@ def build_prod_image(
 @option_run_in_parallel
 @option_parallelism
 @option_python_versions
+@option_github_token
 @option_image_tag
 @option_wait_for_image
 @option_tag_as_latest
@@ -300,6 +302,7 @@ def pull_prod_image(
     run_in_parallel: bool,
     parallelism: int,
     python_versions: str,
+    github_token: str,
     image_tag: Optional[str],
     wait_for_image: bool,
     tag_as_latest: bool,
@@ -310,7 +313,12 @@ def pull_prod_image(
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)
         prod_image_params_list = [
-            BuildProdParams(image_tag=image_tag, python=python, github_repository=github_repository)
+            BuildProdParams(
+                image_tag=image_tag,
+                python=python,
+                github_repository=github_repository,
+                github_token=github_token,
+            )
             for python in python_version_list
         ]
         run_pull_in_parallel(
@@ -326,7 +334,7 @@ def pull_prod_image(
         )
     else:
         image_params = BuildProdParams(
-            image_tag=image_tag, python=python, github_repository=github_repository
+            image_tag=image_tag, python=python, github_repository=github_repository, github_token=github_token
         )
         return_code, info = run_pull_image(
             image_params=image_params,

--- a/dev/breeze/src/airflow_breeze/utils/pulll_image.py
+++ b/dev/breeze/src/airflow_breeze/utils/pulll_image.py
@@ -24,6 +24,7 @@ from airflow_breeze.build_image.ci.build_ci_params import BuildCiParams
 from airflow_breeze.build_image.prod.build_prod_params import BuildProdParams
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.parallel import check_async_run_results
+from airflow_breeze.utils.registry import login_to_docker_registry
 from airflow_breeze.utils.run_tests import verify_an_image
 from airflow_breeze.utils.run_utils import run_command
 
@@ -96,6 +97,7 @@ def run_pull_image(
         f"with wait for image: {wait_for_image}[/]\n"
     )
     while True:
+        login_to_docker_registry(image_params, dry_run=dry_run)
         command_to_run = ["docker", "pull", image_params.airflow_image_name_with_tag]
         command_result = run_command(
             command_to_run,

--- a/images/breeze/output-pull-image.svg
+++ b/images/breeze/output-pull-image.svg
@@ -1,4 +1,4 @@
-<svg width="1720.0" height="956" viewBox="0 0 1720.0 956"
+<svg width="1720.0" height="978" viewBox="0 0 1720.0 978"
      xmlns="http://www.w3.org/2000/svg">
     <style>
         @font-face {
@@ -17,30 +17,30 @@
             font-style: bold;
             font-weight: 700;
         }
-        .rich-svg-921580930-terminal-wrapper span {
+        .rich-svg-2481567883-terminal-wrapper span {
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: 18px;
             font-family:'Rich Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }
-        .rich-svg-921580930-terminal-wrapper a {
+        .rich-svg-2481567883-terminal-wrapper a {
             text-decoration: none;
             color: inherit;
         }
-        .rich-svg-921580930-terminal-body .blink {
-           animation: rich-svg-921580930-blinker 1s infinite;
+        .rich-svg-2481567883-terminal-body .blink {
+           animation: rich-svg-2481567883-blinker 1s infinite;
         }
-        @keyframes rich-svg-921580930-blinker {
+        @keyframes rich-svg-2481567883-blinker {
             from { opacity: 1.0; }
             50% { opacity: 0.3; }
             to { opacity: 1.0; }
         }
-        .rich-svg-921580930-terminal-wrapper {
+        .rich-svg-2481567883-terminal-wrapper {
             padding: 140px;
             padding-top: 100px;
         }
-        .rich-svg-921580930-terminal {
+        .rich-svg-2481567883-terminal {
             position: relative;
             display: flex;
             flex-direction: column;
@@ -49,7 +49,7 @@
             border-radius: 14px;
             box-shadow: 0 0 0 1px #484848;
         }
-        .rich-svg-921580930-terminal:after {
+        .rich-svg-2481567883-terminal:after {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -60,7 +60,7 @@
             transform: rotate(-4.5deg);
             z-index: -1;
         }
-        .rich-svg-921580930-terminal-header {
+        .rich-svg-2481567883-terminal-header {
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -72,7 +72,7 @@
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }
-        .rich-svg-921580930-terminal-title-tab {
+        .rich-svg-2481567883-terminal-title-tab {
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -85,36 +85,36 @@
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }
-        .rich-svg-921580930-terminal-traffic-lights {
+        .rich-svg-2481567883-terminal-traffic-lights {
             position: absolute;
             top: 24px;
             left: 20px;
         }
-        .rich-svg-921580930-terminal-body {
+        .rich-svg-2481567883-terminal-body {
             line-height: 22px;
             padding: 14px;
         }
-        .rich-svg-921580930-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r2 {font-weight: bold;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r3 {color: #e5e510; text-decoration-color: #e5e510; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r4 {color: #7f7f7f; text-decoration-color: #7f7f7f;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r5 {color: #11a8cd; text-decoration-color: #11a8cd; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r6 {color: #0dbc79; text-decoration-color: #0dbc79; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-921580930-terminal-body .r7 {color: #78780e; text-decoration-color: #78780e;background-color: #0c0c0c;}
+        .rich-svg-2481567883-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r2 {font-weight: bold;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r3 {color: #e5e510; text-decoration-color: #e5e510; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r4 {color: #7f7f7f; text-decoration-color: #7f7f7f;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r5 {color: #11a8cd; text-decoration-color: #11a8cd; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r6 {color: #0dbc79; text-decoration-color: #0dbc79; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-2481567883-terminal-body .r7 {color: #78780e; text-decoration-color: #78780e;background-color: #0c0c0c;}
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div class="rich-svg-921580930-terminal-wrapper">
-                <div class="rich-svg-921580930-terminal">
-                    <div class="rich-svg-921580930-terminal-header">
-                        <svg class="rich-svg-921580930-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+            <div class="rich-svg-2481567883-terminal-wrapper">
+                <div class="rich-svg-2481567883-terminal">
+                    <div class="rich-svg-2481567883-terminal-header">
+                        <svg class="rich-svg-2481567883-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="14" cy="8" r="8" fill="#ff6159"/>
                             <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
                             <circle cx="62" cy="8" r="8" fill="#28c941"/>
                         </svg>
-                        <div class="rich-svg-921580930-terminal-title-tab">Command: pull-image</div>
+                        <div class="rich-svg-2481567883-terminal-title-tab">Command: pull-image</div>
                     </div>
-                    <div class="rich-svg-921580930-terminal-body">
+                    <div class="rich-svg-2481567883-terminal-body">
                         <div><span class="r2">                                                                                                                        </span></div>
 <div><span class="r2"> </span><span class="r3">Usage: </span><span class="r2">breeze pull-image [OPTIONS] [EXTRA_PYTEST_ARGS]...                                                              </span></div>
 <div><span class="r2">                                                                                                                        </span></div>
@@ -124,6 +124,7 @@
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--image-tag</span><span class="r1">       </span><span class="r6">-t</span><span class="r1">  </span><span class="r1">Tag added to the default naming conventions of Airflow CI/PROD images.</span><span class="r1"> </span><span class="r7">(TEXT)</span><span class="r1">               </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--python</span><span class="r1">          </span><span class="r6">-p</span><span class="r1">  </span><span class="r1">Python major/minor version used in Airflow image for images.</span><span class="r1"> </span><span class="r7">(&gt;3.7&lt; | 3.8 | 3.9 | 3.10)</span><span class="r1">     </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">                        </span><span class="r4">[default: 3.7]                                              </span><span class="r1"> </span><span class="r1">                               </span><span class="r1">  </span><span class="r4">│</span></div>
+<div><span class="r4">│</span><span class="r1">  </span><span class="r5">--github-token</span><span class="r1">    </span><span class="r1">  </span><span class="r1">  </span><span class="r1">The token used to authenticate to GitHub.</span><span class="r1"> </span><span class="r7">(TEXT)</span><span class="r1">                                            </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--verify-image</span><span class="r1">    </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Verify image.                                                                               </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--wait-for-image</span><span class="r1">  </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Wait until image is available.                                                              </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--tag-as-latest</span><span class="r1">   </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Tags the image as latest and update checksum of all files after pulling. Used in CI to pull </span><span class="r1">  </span><span class="r4">│</span></div>

--- a/images/breeze/output-pull-prod-image.svg
+++ b/images/breeze/output-pull-prod-image.svg
@@ -1,4 +1,4 @@
-<svg width="1720.0" height="956" viewBox="0 0 1720.0 956"
+<svg width="1720.0" height="978" viewBox="0 0 1720.0 978"
      xmlns="http://www.w3.org/2000/svg">
     <style>
         @font-face {
@@ -17,30 +17,30 @@
             font-style: bold;
             font-weight: 700;
         }
-        .rich-svg-1620392287-terminal-wrapper span {
+        .rich-svg-604093544-terminal-wrapper span {
             display: inline-block;
             white-space: pre;
             vertical-align: top;
             font-size: 18px;
             font-family:'Rich Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
         }
-        .rich-svg-1620392287-terminal-wrapper a {
+        .rich-svg-604093544-terminal-wrapper a {
             text-decoration: none;
             color: inherit;
         }
-        .rich-svg-1620392287-terminal-body .blink {
-           animation: rich-svg-1620392287-blinker 1s infinite;
+        .rich-svg-604093544-terminal-body .blink {
+           animation: rich-svg-604093544-blinker 1s infinite;
         }
-        @keyframes rich-svg-1620392287-blinker {
+        @keyframes rich-svg-604093544-blinker {
             from { opacity: 1.0; }
             50% { opacity: 0.3; }
             to { opacity: 1.0; }
         }
-        .rich-svg-1620392287-terminal-wrapper {
+        .rich-svg-604093544-terminal-wrapper {
             padding: 140px;
             padding-top: 100px;
         }
-        .rich-svg-1620392287-terminal {
+        .rich-svg-604093544-terminal {
             position: relative;
             display: flex;
             flex-direction: column;
@@ -49,7 +49,7 @@
             border-radius: 14px;
             box-shadow: 0 0 0 1px #484848;
         }
-        .rich-svg-1620392287-terminal:after {
+        .rich-svg-604093544-terminal:after {
             position: absolute;
             width: 100%;
             height: 100%;
@@ -60,7 +60,7 @@
             transform: rotate(-4.5deg);
             z-index: -1;
         }
-        .rich-svg-1620392287-terminal-header {
+        .rich-svg-604093544-terminal-header {
             position: relative;
             width: 100%;
             background-color: #2e2e2e;
@@ -72,7 +72,7 @@
             box-shadow: inset 0px -1px 0px 0px #4e4e4e,
                         inset 0px -4px 8px 0px #1a1a1a;
         }
-        .rich-svg-1620392287-terminal-title-tab {
+        .rich-svg-604093544-terminal-title-tab {
             display: inline-block;
             margin-top: 14px;
             margin-left: 124px;
@@ -85,36 +85,36 @@
                         inset 1px 0px 0px 0px #4e4e4e,
                         inset -1px 0px 0px 0px #4e4e4e;
         }
-        .rich-svg-1620392287-terminal-traffic-lights {
+        .rich-svg-604093544-terminal-traffic-lights {
             position: absolute;
             top: 24px;
             left: 20px;
         }
-        .rich-svg-1620392287-terminal-body {
+        .rich-svg-604093544-terminal-body {
             line-height: 22px;
             padding: 14px;
         }
-        .rich-svg-1620392287-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r2 {font-weight: bold;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r3 {color: #e5e510; text-decoration-color: #e5e510; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r4 {color: #7f7f7f; text-decoration-color: #7f7f7f;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r5 {color: #11a8cd; text-decoration-color: #11a8cd; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r6 {color: #0dbc79; text-decoration-color: #0dbc79; font-weight: bold;background-color: #0c0c0c;}
-.rich-svg-1620392287-terminal-body .r7 {color: #78780e; text-decoration-color: #78780e;background-color: #0c0c0c;}
+        .rich-svg-604093544-terminal-body .r1 {color: #f2f2f2; text-decoration-color: #f2f2f2;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r2 {font-weight: bold;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r3 {color: #e5e510; text-decoration-color: #e5e510; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r4 {color: #7f7f7f; text-decoration-color: #7f7f7f;color: #f2f2f2; text-decoration-color: #f2f2f2;;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r5 {color: #11a8cd; text-decoration-color: #11a8cd; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r6 {color: #0dbc79; text-decoration-color: #0dbc79; font-weight: bold;background-color: #0c0c0c;}
+.rich-svg-604093544-terminal-body .r7 {color: #78780e; text-decoration-color: #78780e;background-color: #0c0c0c;}
     </style>
     <foreignObject x="0" y="0" width="100%" height="100%">
         <body xmlns="http://www.w3.org/1999/xhtml">
-            <div class="rich-svg-1620392287-terminal-wrapper">
-                <div class="rich-svg-1620392287-terminal">
-                    <div class="rich-svg-1620392287-terminal-header">
-                        <svg class="rich-svg-1620392287-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
+            <div class="rich-svg-604093544-terminal-wrapper">
+                <div class="rich-svg-604093544-terminal">
+                    <div class="rich-svg-604093544-terminal-header">
+                        <svg class="rich-svg-604093544-terminal-traffic-lights" width="90" height="21" viewBox="0 0 90 21" xmlns="http://www.w3.org/2000/svg">
                             <circle cx="14" cy="8" r="8" fill="#ff6159"/>
                             <circle cx="38" cy="8" r="8" fill="#ffbd2e"/>
                             <circle cx="62" cy="8" r="8" fill="#28c941"/>
                         </svg>
-                        <div class="rich-svg-1620392287-terminal-title-tab">Command: pull-prod-image</div>
+                        <div class="rich-svg-604093544-terminal-title-tab">Command: pull-prod-image</div>
                     </div>
-                    <div class="rich-svg-1620392287-terminal-body">
+                    <div class="rich-svg-604093544-terminal-body">
                         <div><span class="r2">                                                                                                                        </span></div>
 <div><span class="r2"> </span><span class="r3">Usage: </span><span class="r2">breeze pull-prod-image [OPTIONS] [EXTRA_PYTEST_ARGS]...                                                         </span></div>
 <div><span class="r2">                                                                                                                        </span></div>
@@ -124,6 +124,7 @@
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--image-tag</span><span class="r1">       </span><span class="r6">-t</span><span class="r1">  </span><span class="r1">Tag added to the default naming conventions of Airflow CI/PROD images.</span><span class="r1"> </span><span class="r7">(TEXT)</span><span class="r1">               </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--python</span><span class="r1">          </span><span class="r6">-p</span><span class="r1">  </span><span class="r1">Python major/minor version used in Airflow image for images.</span><span class="r1"> </span><span class="r7">(&gt;3.7&lt; | 3.8 | 3.9 | 3.10)</span><span class="r1">     </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">                        </span><span class="r4">[default: 3.7]                                              </span><span class="r1"> </span><span class="r1">                               </span><span class="r1">  </span><span class="r4">│</span></div>
+<div><span class="r4">│</span><span class="r1">  </span><span class="r5">--github-token</span><span class="r1">    </span><span class="r1">  </span><span class="r1">  </span><span class="r1">The token used to authenticate to GitHub.</span><span class="r1"> </span><span class="r7">(TEXT)</span><span class="r1">                                            </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--verify-image</span><span class="r1">    </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Verify image.                                                                               </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--wait-for-image</span><span class="r1">  </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Wait until image is available.                                                              </span><span class="r1">  </span><span class="r4">│</span></div>
 <div><span class="r4">│</span><span class="r1">  </span><span class="r5">--tag-as-latest</span><span class="r1">   </span><span class="r1">  </span><span class="r1">  </span><span class="r1">Tags the image as latest and update checksum of all files after pulling. Used in CI to pull </span><span class="r1">  </span><span class="r4">│</span></div>


### PR DESCRIPTION
All of the Airlfow Images are Public in ghcr.io but default setting
for iamges is "private" and when users want to build CI workflows
in their forks, had to manually change their images to Public, so
that ci.yml workflow can pull the images prepared in the build-images
workflow.

This PR adds logging in for `breeze pull` command when GITHUB_TOKEN
is available, also the workflow gets packages: read permissions.

This way ci should works in forks of users without any action from
user except first-time workflow enabling.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
