### PR TITLE
Add support for webserver.hostAliases to Helm Chart

### DIFF
--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -110,6 +110,10 @@ spec:
 {{ toYaml $tolerations | indent 8 }}
       topologySpreadConstraints:
 {{ toYaml $topologySpreadConstraints | indent 8 }}
+{{- if .Values.webserver.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.webserver.hostAliases | indent 8 }}
+{{- end }}
       restartPolicy: Always
       securityContext: {{ $securityContext | nindent 8 }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2908,6 +2908,28 @@
                         "$ref": "#/definitions/io.k8s.api.core.v1.TopologySpreadConstraint"
                     }
                 },
+                "hostAliases": {
+                    "description": "Specify HostAliases for webserver.",
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.HostAlias"
+                    },
+                    "type": "array",
+                    "default": [],
+                    "examples": [
+                        {
+                            "ip": "127.0.0.2",
+                            "hostnames": [
+                                "test.hostname.one"
+                            ]
+                        },
+                        {
+                            "ip": "127.0.0.3",
+                            "hostnames": [
+                                "test.hostname.two"
+                            ]
+                        }
+                    ]
+                },
                 "podAnnotations": {
                     "description": "Annotations to add to the webserver pods.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -940,6 +940,16 @@ webserver:
   #      weight: 100
   tolerations: []
   topologySpreadConstraints: []
+  # hostAliases to use in webserver pod.
+  # See:
+  # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  hostAliases: []
+  # - ip: "127.0.0.2"
+  #   hostnames:
+  #   - "test.hostname.one"
+  # - ip: "127.0.0.3"
+  #   hostnames:
+  #   - "test.hostname.two"
 
   podAnnotations: {}
 

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -184,6 +184,19 @@ class WebserverDeploymentTest(unittest.TestCase):
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.template.spec.initContainers[-1]", docs[0])
 
+    def test_webserver_host_aliases(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}],
+                },
+            },
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+
+        assert "127.0.0.2" == jmespath.search("spec.template.spec.hostAliases[0].ip", docs[0])
+        assert "test.hostname" == jmespath.search("spec.template.spec.hostAliases[0].hostnames[0]", docs[0])
+
     def test_should_create_valid_affinity_tolerations_and_node_selector(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
This change adds support for [`webserver.hostAliases`](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) property to Airflow's Helm Chart.

Development was adapted from #14681, which added same property for worker pods.