### PR TITLE
Fix `PythonVirtualenvOperator` templated_fields

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -327,12 +327,7 @@ class PythonVirtualenvOperator(PythonOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     """
 
-    template_fields: Sequence[str] = tuple(
-        {
-            'requirements',
-        }
-        | set(PythonOperator.template_fields)
-    )
+    template_fields: Sequence[str] = tuple({'requirements'} | set(PythonOperator.template_fields))
 
     template_ext: Sequence[str] = ('.txt',)
     BASE_SERIALIZABLE_CONTEXT_KEYS = {

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -327,7 +327,13 @@ class PythonVirtualenvOperator(PythonOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     """
 
-    template_fields: Sequence[str] = ('requirements',)
+    template_fields: Sequence[str] = tuple(
+        {
+            'requirements',
+        }
+        | set(PythonOperator.template_fields)
+    )
+
     template_ext: Sequence[str] = ('.txt',)
     BASE_SERIALIZABLE_CONTEXT_KEYS = {
         'ds',

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -868,6 +868,9 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         return task
 
+    def test_template_fields(self):
+        assert set(PythonOperator.template_fields).issubset(PythonVirtualenvOperator.template_fields)
+
     def test_add_dill(self):
         def f():
             """Ensure dill is correctly installed."""


### PR DESCRIPTION
The `PythonVirtualenvOperator` templated_fields override `PythonOperator` templated_fields which caused functionality not to work as expected.
fixes: https://github.com/apache/airflow/issues/23557

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
