### PR TITLE
Add advanced secrets backend configurations

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -782,6 +782,17 @@
       type: string
       example: ~
       default: ""
+    - name: backends_config
+      description: |
+        Advanced secrets backend configuration, allow to user configure more than one secret backend,
+        order of secrets backend and turn off built-in backends.
+        Expected JSON list of objects. See
+        https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html#advanced-configuration
+        for more details.
+      version_added: 2.4.0
+      example: ~
+      type: string
+      default: ""
 - name: cli
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -422,6 +422,13 @@ backend =
 # ``{{"connections_prefix": "/airflow/connections", "profile_name": "default"}}``
 backend_kwargs =
 
+# Advanced secrets backend configuration, allow to user configure more than one secret backend,
+# order of secrets backend and turn off built-in backends.
+# Expected JSON list of objects. See
+# https://airflow.apache.org/docs/apache-airflow/stable/security/secrets/secrets-backend/index.html#advanced-configuration
+# for more details.
+backends_config =
+
 [cli]
 # In what way should the cli access the API. The LocalClient will use the
 # database directly, while the json_client will use the api running on the

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1544,7 +1544,7 @@ def initialize_secrets_backends() -> Sequence[BaseSecretsBackend]:
     * import secrets backend classes
     * instantiate them and return them in a list
     """
-    list_backends = []
+    backend_list = []
 
     secrets_backend_config = conf.getjson(section='secrets', key='backends_config', fallback=None)
     if secrets_backend_config:
@@ -1558,24 +1558,24 @@ def initialize_secrets_backends() -> Sequence[BaseSecretsBackend]:
 
         for config in secrets_backend_config:
             try:
-                list_backends.append(SecretsBackendConfig(**config).initialize())
+                backend_list.append(SecretsBackendConfig(**config).initialize())
             except Exception as e:
                 raise AirflowConfigException(
                     f"Cannot read config: {config!r} from [secrets] 'backends_config'.\n{e}"
                 ) from e
 
     else:
-        list_backends.extend(
+        backend_list.extend(
             SecretsBackendConfig(**config).initialize() for config in DEFAULT_SECRETS_SEARCH_PATH
         )
         custom_secrets_backend_config = SecretsBackendConfig.from_config()
         if not custom_secrets_backend_config:
             # Returns default secrets backend list for further checks in `ensure_secrets_loaded()`.
-            return DefaultSecretsBackend(list_backends)
+            return DefaultSecretsBackend(backend_list)
 
-        list_backends.insert(0, custom_secrets_backend_config.initialize())
+        backend_list.insert(0, custom_secrets_backend_config.initialize())
 
-    return list_backends
+    return backend_list
 
 
 @functools.lru_cache(maxsize=None)

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -41,7 +41,7 @@ from urllib.parse import urlparse
 from typing_extensions import overload
 
 from airflow.exceptions import AirflowConfigException
-from airflow.secrets.base_secrets import BaseSecretsBackend
+from airflow.secrets import BaseSecretsBackend
 from airflow.utils import yaml
 from airflow.utils.module_loading import import_string
 from airflow.utils.weight_rule import WeightRule

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1504,21 +1504,6 @@ class DefaultSecretsBackend(UserList):
     """List Container which use for store default secrets backends."""
 
 
-class UniqueSecretsBackendsConfigs(UserList):
-    """List Container which use for store unique secrets backends configs."""
-
-    def append(self, item) -> None:
-        """Append item to a list if it not exists yet"""
-        if item in self.data:
-            return
-        self.data.append(item)
-
-    def extend(self, other) -> None:
-        """Extends item if it not exists yet"""
-        for item in other:
-            self.append(item)
-
-
 @dataclass(frozen=True)
 class SecretsBackendConfig:
     """Secrets Backend Config dataclass helper."""
@@ -1554,6 +1539,22 @@ class SecretsBackendConfig:
     def initialize(self) -> BaseSecretsBackend:
         """Initialize Secrets Backend."""
         return import_string(self.backend)(**self.backend_kwargs)
+
+
+class UniqueSecretsBackendsConfigs(UserList):
+    """List Container which use for store unique secrets backends configs."""
+
+    def append(self, config) -> None:
+        """Append item to a list if it not exists yet"""
+        if config in self.data:
+            log.warning("%r already exists.", config)
+            return
+        self.data.append(config)
+
+    def extend(self, configs) -> None:
+        """Extends item if it not exists yet"""
+        for config in configs:
+            self.append(config)
 
 
 def ensure_secrets_loaded() -> Sequence[BaseSecretsBackend]:

--- a/airflow/secrets/__init__.py
+++ b/airflow/secrets/__init__.py
@@ -22,11 +22,6 @@ Secrets framework provides means of getting connection objects from various sour
     * Metastore database
     * AWS SSM Parameter store
 """
-__all__ = ['BaseSecretsBackend', 'DEFAULT_SECRETS_SEARCH_PATH']
+__all__ = ['BaseSecretsBackend']
 
 from airflow.secrets.base_secrets import BaseSecretsBackend
-
-DEFAULT_SECRETS_SEARCH_PATH = [
-    "airflow.secrets.environment_variables.EnvironmentVariablesBackend",
-    "airflow.secrets.metastore.MetastoreBackend",
-]

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1184,7 +1184,7 @@ sql_alchemy_conn=sqlite://test
 
     @pytest.mark.parametrize("display_source", [True, False])
     @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET": "secret_path'"}, clear=True)
-    @mock.patch("airflow.secrets.base_secrets.BaseSecretsBackend.get_config")
+    @mock.patch("airflow.secrets.BaseSecretsBackend.get_config")
     def test_conf_as_dict_when_deprecated_value_in_secrets(self, mock_get_config, display_source: bool):
         mock_get_config.return_value = "postgresql://"
         with use_config(config="empty.cfg"):
@@ -1208,7 +1208,7 @@ sql_alchemy_conn=sqlite://test
 
     @pytest.mark.parametrize("display_source", [True, False])
     @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET": "secret_path'"}, clear=True)
-    @mock.patch("airflow.secrets.base_secrets.BaseSecretsBackend.get_config")
+    @mock.patch("airflow.secrets.BaseSecretsBackend.get_config")
     def test_conf_as_dict_when_deprecated_value_in_secrets_disabled_env(
         self, mock_get_config, display_source: bool
     ):
@@ -1234,7 +1234,7 @@ sql_alchemy_conn=sqlite://test
                 assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'
 
     @pytest.mark.parametrize("display_source", [True, False])
-    @mock.patch("airflow.secrets.base_secrets.BaseSecretsBackend.get_config")
+    @mock.patch("airflow.secrets.BaseSecretsBackend.get_config")
     @mock.patch.dict('os.environ', {}, clear=True)
     def test_conf_as_dict_when_deprecated_value_in_secrets_disabled_config(
         self, mock_get_config, display_source: bool

--- a/tests/secrets/test_secrets.py
+++ b/tests/secrets/test_secrets.py
@@ -265,9 +265,11 @@ class TestSecretsBackendsConfig(unittest.TestCase):
         ]
 
         with conf_vars({("secrets", "backends_config"): json.dumps(secrets_backend_config)}):
-            backends = ensure_secrets_loaded()
-            backend_classes = [backend.__class__.__name__ for backend in backends]
+            with self.assertLogs(level='WARNING') as capture_logs:
+                backends = ensure_secrets_loaded()
+                assert len(capture_logs.records) == 4
 
+            backend_classes = [backend.__class__.__name__ for backend in backends]
             assert backend_classes == [
                 "EnvironmentVariablesBackend",
                 "MetastoreBackend",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
At that moment Airflow have only predefined order for secrets backend
1. Alternative secrets backend (if defined)
2. Environment Variables Secrets backend
3. Metastore Backend

~This PR add ability to change priority for Alternative secrets backend in relative of Environment Variables and Metastore~
~So it make possible for check variables/connections in Environment Variables / Metastore before Alternative secrets backend~


This PR add advanced configurations for Secrets Backends which allow

* Configure more than one alternative secrets backend.
* Change search ordering of secrets backends.
* Turn off built-in backends (environment variables or the metastore database).

By providing in `[secrets] backends_config` JSON configuration 

```json
[
  {
    "backend":"airflow.secrets.environment_variables.EnvironmentVariablesBackend"
  },
  {
    "backend":"airflow.secrets.local_filesystem.LocalFilesystemBackend",
    "backend_kwargs":{
      "variables_file_path":"/local_backend/variables.yaml",
      "connections_file_path":"/local_backend/connections.yaml",
      "profile_name":"default"
    }
  },
  {
    "backend":"airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
    "backend_kwargs":{
      "connections_prefix":"/airflow/connections",
      "variables_prefix": "/airflow/variables",
      "profile_name":"default"
    }
  },
  {
    "backend":"airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend",
    "backend_kwargs":{
      "connections_prefix":"/another/connections",
      "variables_prefix": "/another/variables",
      "profile_name":"awesome",
      "region_name": "ap-southeast-1"
    }
  },
  {
    "backend":"airflow.secrets.metastore.MetastoreBackend"
  }
]
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
