### PR TITLE
Temporarily pin xmltodict to 0.12.0 to fix main failure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,9 @@ amazon = [
     pandas_requirement,
     'mypy-boto3-rds>=1.21.0',
     'mypy-boto3-redshift-data>=1.21.0',
+    # XML to dict 0.13.0 breaks some EMR tests
+    # It should be removed once we solve https://github.com/apache/airflow/issues/23576
+    'xmltodict<0.13.0',
 ]
 apache_beam = [
     'apache-beam>=2.33.0',


### PR DESCRIPTION
The xmltodict 0,13.0 breaks some tests and likely 0.13.0 is buggy
as the error is ValueError: Malformatted input.

We pin it to 0.12.0 to fix the main failing.

Related: #23576

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
