### PR TITLE
Fix expand/collapse all buttons

### DIFF
--- a/airflow/www/static/js/grid/AutoRefresh.jsx
+++ b/airflow/www/static/js/grid/AutoRefresh.jsx
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import {
+  Switch,
+  FormControl,
+  FormLabel,
+  Spinner,
+} from '@chakra-ui/react';
+
+import { useAutoRefresh } from './context/autorefresh';
+
+const AutoRefresh = () => {
+  const { isRefreshOn, toggleRefresh, isPaused } = useAutoRefresh();
+
+  return (
+    <FormControl display="flex" width="auto" mr={2}>
+      <Spinner color="blue.500" speed="1s" mr="4px" visibility={isRefreshOn ? 'visible' : 'hidden'} />
+      <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
+        Auto-refresh
+      </FormLabel>
+      <Switch
+        id="auto-refresh"
+        onChange={() => toggleRefresh(true)}
+        isDisabled={isPaused}
+        isChecked={isRefreshOn}
+        size="lg"
+        title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
+      />
+    </FormControl>
+  );
+};
+
+export default AutoRefresh;

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -24,10 +24,6 @@ import {
   Table,
   Tbody,
   Box,
-  Switch,
-  FormControl,
-  FormLabel,
-  Spinner,
   Thead,
   Flex,
 } from '@chakra-ui/react';
@@ -36,21 +32,17 @@ import { useGridData } from './api';
 import renderTaskRows from './renderTaskRows';
 import ResetRoot from './ResetRoot';
 import DagRuns from './dagRuns';
-import { useAutoRefresh } from './context/autorefresh';
 import ToggleGroups from './ToggleGroups';
-import FilterBar from './FilterBar';
-import LegendRow from './LegendRow';
+import { getMetaValue } from '../utils';
+import AutoRefresh from './AutoRefresh';
 
 const dagId = getMetaValue('dag_id');
 
-const Grid = ({ isPanelOpen }) => {
+const Grid = ({ isPanelOpen = false }) => {
   const scrollRef = useRef();
   const tableRef = useRef();
 
   const { data: { groups, dagRuns } } = useGridData();
-  const dagRunIds = dagRuns.map((dr) => dr.runId);
-
-  const { isRefreshOn, toggleRefresh, isPaused } = useAutoRefresh();
 
   const openGroupsKey = `${dagId}/open-groups`;
   const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
@@ -93,20 +85,7 @@ const Grid = ({ isPanelOpen }) => {
       minWidth={isPanelOpen && '300px'}
     >
       <Flex alignItems="center">
-        <FormControl display="flex" width="auto" mr={2}>
-          {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
-          <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
-            Auto-refresh
-          </FormLabel>
-          <Switch
-            id="auto-refresh"
-            onChange={() => toggleRefresh(true)}
-            isDisabled={isPaused}
-            isChecked={isRefreshOn}
-            size="lg"
-            title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
-          />
-        </FormControl>
+        <AutoRefresh />
         <ToggleGroups
           groups={groups}
           openGroupIds={openGroupIds}
@@ -119,7 +98,14 @@ const Grid = ({ isPanelOpen }) => {
           <DagRuns />
         </Thead>
         {/* TODO: remove hardcoded values. 665px is roughly the total heade+footer height */}
-        <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
+        <Tbody
+          display="block"
+          width="100%"
+          maxHeight="calc(100vh - 665px)"
+          minHeight="500px"
+          ref={tableRef}
+          pr="10px"
+        >
           {renderTaskRows({
             task: groups, dagRunIds, openGroupIds, onToggleGroups,
           })}

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -43,11 +43,11 @@ const Grid = ({ isPanelOpen = false }) => {
   const tableRef = useRef();
 
   const { data: { groups, dagRuns } } = useGridData();
+  const dagRunIds = dagRuns.map((dr) => dr.runId);
 
   const openGroupsKey = `${dagId}/open-groups`;
   const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
   const [openGroupIds, setOpenGroupIds] = useState(storedGroups);
-
 
   const onToggleGroups = (groupIds) => {
     localStorage.setItem(openGroupsKey, JSON.stringify(groupIds));

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -19,7 +19,7 @@
 
 /* global localStorage, ResizeObserver */
 
-import React, { useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   Table,
   Tbody,
@@ -30,25 +30,20 @@ import {
   Spinner,
   Thead,
   Flex,
-  useDisclosure,
-  Button,
-  Divider,
 } from '@chakra-ui/react';
 
 import { useGridData } from './api';
 import renderTaskRows from './renderTaskRows';
 import ResetRoot from './ResetRoot';
 import DagRuns from './dagRuns';
-import Details from './details';
-import useSelection from './utils/useSelection';
 import { useAutoRefresh } from './context/autorefresh';
 import ToggleGroups from './ToggleGroups';
 import FilterBar from './FilterBar';
 import LegendRow from './LegendRow';
 
-const sidePanelKey = 'hideSidePanel';
+const dagId = getMetaValue('dag_id');
 
-const Grid = () => {
+const Grid = ({ isPanelOpen }) => {
   const scrollRef = useRef();
   const tableRef = useRef();
 
@@ -56,18 +51,15 @@ const Grid = () => {
   const dagRunIds = dagRuns.map((dr) => dr.runId);
 
   const { isRefreshOn, toggleRefresh, isPaused } = useAutoRefresh();
-  const isPanelOpen = localStorage.getItem(sidePanelKey) !== 'true';
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isPanelOpen });
 
-  const { clearSelection } = useSelection();
-  const toggleSidePanel = () => {
-    if (!isOpen) {
-      localStorage.setItem(sidePanelKey, false);
-    } else {
-      clearSelection();
-      localStorage.setItem(sidePanelKey, true);
-    }
-    onToggle();
+  const openGroupsKey = `${dagId}/open-groups`;
+  const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
+  const [openGroupIds, setOpenGroupIds] = useState(storedGroups);
+
+
+  const onToggleGroups = (groupIds) => {
+    localStorage.setItem(openGroupsKey, JSON.stringify(groupIds));
+    setOpenGroupIds(groupIds);
   };
 
   const scrollOnResize = new ResizeObserver(() => {
@@ -91,64 +83,48 @@ const Grid = () => {
   }, [tableRef, scrollOnResize]);
 
   return (
-    <Box mt={3}>
-      <FilterBar />
-      <LegendRow />
-      <Divider mb={5} borderBottomWidth={2} />
-      <Flex flexGrow={1} justifyContent="space-between" alignItems="center">
-        <Flex alignItems="center">
-          <FormControl display="flex" width="auto" mr={2}>
-            {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
-            <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
-              Auto-refresh
-            </FormLabel>
-            <Switch
-              id="auto-refresh"
-              onChange={() => toggleRefresh(true)}
-              isDisabled={isPaused}
-              isChecked={isRefreshOn}
-              size="lg"
-              title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
-            />
-          </FormControl>
-          <ToggleGroups groups={groups} />
-          <ResetRoot />
-        </Flex>
-        <Button
-          onClick={toggleSidePanel}
-          aria-label={isOpen ? 'Show Details' : 'Hide Details'}
-          variant={isOpen ? 'solid' : 'outline'}
-        >
-          {isOpen ? 'Hide ' : 'Show '}
-          Details Panel
-        </Button>
+    <Box
+      position="relative"
+      mt={2}
+      m="12px"
+      overflow="auto"
+      ref={scrollRef}
+      flexGrow={1}
+      minWidth={isPanelOpen && '300px'}
+    >
+      <Flex alignItems="center">
+        <FormControl display="flex" width="auto" mr={2}>
+          {isRefreshOn && <Spinner color="blue.500" speed="1s" mr="4px" />}
+          <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
+            Auto-refresh
+          </FormLabel>
+          <Switch
+            id="auto-refresh"
+            onChange={() => toggleRefresh(true)}
+            isDisabled={isPaused}
+            isChecked={isRefreshOn}
+            size="lg"
+            title={isPaused ? 'Autorefresh is disabled while the DAG is paused' : ''}
+          />
+        </FormControl>
+        <ToggleGroups
+          groups={groups}
+          openGroupIds={openGroupIds}
+          onToggleGroups={onToggleGroups}
+        />
+        <ResetRoot />
       </Flex>
-      <Flex flexDirection="row" justifyContent="space-between">
-        <Box
-          position="relative"
-          mt={2}
-          m="12px"
-          overflow="auto"
-          ref={scrollRef}
-          flexGrow={1}
-          minWidth={isOpen && '300px'}
-        >
-          <Table>
-            <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">
-              <DagRuns />
-            </Thead>
-            {/* TODO: remove hardcoded values. 665px is roughly the total header+footer height */}
-            <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
-              {renderTaskRows({
-                task: groups, dagRunIds,
-              })}
-            </Tbody>
-          </Table>
-        </Box>
-        {isOpen && (
-          <Details />
-        )}
-      </Flex>
+      <Table>
+        <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">
+          <DagRuns />
+        </Thead>
+        {/* TODO: remove hardcoded values. 665px is roughly the total heade+footer height */}
+        <Tbody display="block" width="100%" maxHeight="calc(100vh - 665px)" minHeight="500px" ref={tableRef} pr="10px">
+          {renderTaskRows({
+            task: groups, dagRunIds, openGroupIds, onToggleGroups,
+          })}
+        </Tbody>
+      </Table>
     </Box>
   );
 };

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -77,14 +77,14 @@ const Grid = ({ isPanelOpen = false }) => {
   return (
     <Box
       position="relative"
-      mt={2}
-      m="12px"
+      m={3}
+      mt={0}
       overflow="auto"
       ref={scrollRef}
       flexGrow={1}
       minWidth={isPanelOpen && '300px'}
     >
-      <Flex alignItems="center">
+      <Flex alignItems="center" position="sticky" top={0} left={0}>
         <AutoRefresh />
         <ToggleGroups
           groups={groups}

--- a/airflow/www/static/js/grid/Main.jsx
+++ b/airflow/www/static/js/grid/Main.jsx
@@ -25,6 +25,7 @@ import {
   Flex,
   useDisclosure,
   Button,
+  Divider,
 } from '@chakra-ui/react';
 
 import Details from './details';

--- a/airflow/www/static/js/grid/Main.jsx
+++ b/airflow/www/static/js/grid/Main.jsx
@@ -1,0 +1,79 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global localStorage */
+
+import React from 'react';
+import {
+  Box,
+  Flex,
+  useDisclosure,
+  Button,
+} from '@chakra-ui/react';
+
+import Details from './details';
+import useSelection from './utils/useSelection';
+import Grid from './Grid';
+import FilterBar from './FilterBar';
+import LegendRow from './LegendRow';
+
+const detailsPanelKey = 'hideDetailsPanel';
+
+const Main = () => {
+  const isPanelOpen = localStorage.getItem(detailsPanelKey) !== 'true';
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isPanelOpen });
+  const { clearSelection } = useSelection();
+
+  const toggleDetailsPanel = () => {
+    if (!isOpen) {
+      localStorage.setItem(detailsPanelKey, false);
+    } else {
+      clearSelection();
+      localStorage.setItem(detailsPanelKey, true);
+    }
+    onToggle();
+  };
+
+  return (
+    <Box>
+      <FilterBar />
+      <LegendRow />
+      <Divider mb={5} borderBottomWidth={2} />
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Grid isPanelOpen={isOpen} />
+        <Box borderLeftWidth={isOpen ? 1 : 0} position="relative">
+          <Button
+            position="absolute"
+            top={0}
+            right={0}
+            onClick={toggleDetailsPanel}
+            aria-label={isOpen ? 'Show Details' : 'Hide Details'}
+            variant={isOpen ? 'solid' : 'outline'}
+          >
+            {isOpen ? 'Hide ' : 'Show '}
+            Details Panel
+          </Button>
+          {isOpen && (<Details />)}
+        </Box>
+      </Flex>
+    </Box>
+  );
+};
+
+export default Main;

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -17,15 +17,9 @@
  * under the License.
  */
 
-/* global localStorage, CustomEvent, document */
-
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Flex, IconButton } from '@chakra-ui/react';
 import { MdExpand, MdCompress } from 'react-icons/md';
-
-import { getMetaValue } from '../utils';
-
-const dagId = getMetaValue('dag_id');
 
 const getGroupIds = (groups) => {
   const groupIds = [];
@@ -39,44 +33,22 @@ const getGroupIds = (groups) => {
   return groupIds;
 };
 
-const ToggleGroups = ({ groups }) => {
-  const openGroupsKey = `${dagId}/open-groups`;
+const ToggleGroups = ({ groups, openGroupIds, onToggleGroups }) => {
   const allGroupIds = getGroupIds(groups.children);
-  const storedGroups = JSON.parse(localStorage.getItem(openGroupsKey)) || [];
-  const [openGroupIds, setOpenGroupIds] = useState(storedGroups);
 
   const isExpandDisabled = allGroupIds.length === openGroupIds.length;
   const isCollapseDisabled = !openGroupIds.length;
-
-  // Listen to changes from ToggleGroups
-  useEffect(() => {
-    const handleChange = ({ detail }) => {
-      if (detail.dagId === dagId) {
-        setOpenGroupIds(detail.openGroups);
-      }
-    };
-    document.addEventListener('toggleGroup', handleChange);
-    return () => {
-      document.removeEventListener('toggleGroup', handleChange);
-    };
-  });
 
   // Don't show button if the DAG has no task groups
   const hasGroups = groups.children.find((c) => !!c.children);
   if (!hasGroups) return null;
 
   const onExpand = () => {
-    const openEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: allGroupIds } });
-    document.dispatchEvent(openEvent);
-    localStorage.setItem(openGroupsKey, JSON.stringify(allGroupIds));
-    setOpenGroupIds(allGroupIds);
+    onToggleGroups(allGroupIds);
   };
 
   const onCollapse = () => {
-    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: [] } });
-    document.dispatchEvent(closeEvent);
-    localStorage.removeItem(openGroupsKey);
-    setOpenGroupIds([]);
+    onToggleGroups([]);
   };
 
   return (

--- a/airflow/www/static/js/grid/ToggleGroups.jsx
+++ b/airflow/www/static/js/grid/ToggleGroups.jsx
@@ -19,7 +19,7 @@
 
 /* global localStorage, CustomEvent, document */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Flex, IconButton } from '@chakra-ui/react';
 import { MdExpand, MdCompress } from 'react-icons/md';
 
@@ -48,19 +48,32 @@ const ToggleGroups = ({ groups }) => {
   const isExpandDisabled = allGroupIds.length === openGroupIds.length;
   const isCollapseDisabled = !openGroupIds.length;
 
+  // Listen to changes from ToggleGroups
+  useEffect(() => {
+    const handleChange = ({ detail }) => {
+      if (detail.dagId === dagId) {
+        setOpenGroupIds(detail.openGroups);
+      }
+    };
+    document.addEventListener('toggleGroup', handleChange);
+    return () => {
+      document.removeEventListener('toggleGroup', handleChange);
+    };
+  });
+
   // Don't show button if the DAG has no task groups
   const hasGroups = groups.children.find((c) => !!c.children);
   if (!hasGroups) return null;
 
   const onExpand = () => {
-    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: true } });
-    document.dispatchEvent(closeEvent);
+    const openEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: allGroupIds } });
+    document.dispatchEvent(openEvent);
     localStorage.setItem(openGroupsKey, JSON.stringify(allGroupIds));
     setOpenGroupIds(allGroupIds);
   };
 
   const onCollapse = () => {
-    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, closeGroups: true } });
+    const closeEvent = new CustomEvent('toggleGroups', { detail: { dagId, openGroups: [] } });
     document.dispatchEvent(closeEvent);
     localStorage.removeItem(openGroupsKey);
     setOpenGroupIds([]);

--- a/airflow/www/static/js/grid/api/useGridData.test.jsx
+++ b/airflow/www/static/js/grid/api/useGridData.test.jsx
@@ -40,7 +40,7 @@ const pendingGridData = {
   ],
 };
 
-describe('Test useTreeData hook', () => {
+describe('Test useGridData hook', () => {
   beforeAll(() => {
     global.autoRefreshInterval = 5;
   });

--- a/airflow/www/static/js/grid/details/index.jsx
+++ b/airflow/www/static/js/grid/details/index.jsx
@@ -33,7 +33,7 @@ import useSelection from '../utils/useSelection';
 const Details = () => {
   const { selected } = useSelection();
   return (
-    <Flex borderLeftWidth="1px" flexDirection="column" pl={3} mr={3} flexGrow={1} maxWidth="750px">
+    <Flex flexDirection="column" pl={3} mr={3} flexGrow={1} maxWidth="750px">
       <Header />
       <Divider my={2} />
       <Box minWidth="750px">

--- a/airflow/www/static/js/grid/index.jsx
+++ b/airflow/www/static/js/grid/index.jsx
@@ -27,7 +27,7 @@ import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import Grid from './Grid';
+import Main from './Main';
 import { ContainerRefProvider } from './context/containerRef';
 import { TimezoneProvider } from './context/timezone';
 import { AutoRefreshProvider } from './context/autorefresh';
@@ -77,7 +77,7 @@ function App() {
               <TimezoneProvider>
                 <AutoRefreshProvider>
                   <BrowserRouter>
-                    <Grid />
+                    <Main />
                   </BrowserRouter>
                 </AutoRefreshProvider>
               </TimezoneProvider>

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -84,8 +84,8 @@ const Row = (props) => {
   const {
     task,
     level,
-    isParentOpen = true,
     dagRunIds,
+    openParentCount = 0,
     openGroupIds = [],
     onToggleGroups = () => {},
   } = props;
@@ -97,11 +97,6 @@ const Row = (props) => {
   const isSelected = selected.taskId === task.id;
 
   const isOpen = openGroupIds.some((g) => g === task.label);
-
-  const parentTasks = task.id.split('.');
-  parentTasks.splice(-1);
-
-  const isFullyOpen = isParentOpen && parentTasks.every((p) => openGroupIds.some((g) => g === p));
 
   // assure the function is the same across renders
   const memoizedToggle = useCallback(
@@ -118,6 +113,8 @@ const Row = (props) => {
     },
     [isGroup, isOpen, task.label, openGroupIds, onToggleGroups],
   );
+
+  const isFullyOpen = level === openParentCount;
 
   return (
     <>
@@ -171,7 +168,7 @@ const Row = (props) => {
       </Tr>
       {isGroup && (
         renderTaskRows({
-          ...props, level: level + 1, isParentOpen: isOpen,
+          ...props, level: level + 1, openParentCount: openParentCount + (isOpen ? 1 : 0),
         })
       )}
     </>

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -86,7 +86,7 @@ const Row = (props) => {
     level,
     isParentOpen = true,
     dagRunIds,
-    openGroupIds,
+    openGroupIds = [],
     onToggleGroups,
   } = props;
   const { colors } = useTheme();

--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -87,7 +87,7 @@ const Row = (props) => {
     isParentOpen = true,
     dagRunIds,
     openGroupIds = [],
-    onToggleGroups,
+    onToggleGroups = () => {},
   } = props;
   const { colors } = useTheme();
   const { selected, onSelect } = useSelection();

--- a/airflow/www/static/js/grid/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.test.jsx
@@ -20,98 +20,60 @@
 /* global describe, test, expect */
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import renderTaskRows from './renderTaskRows';
 import { TableWrapper } from './utils/testUtils';
 
-const mockGridData = {
-  groups: {
-    id: null,
-    label: null,
-    children: [
-      {
-        extraLinks: [],
-        id: 'group_1',
-        label: 'group_1',
-        instances: [
-          {
-            dagId: 'dagId',
-            duration: 0,
-            endDate: '2021-10-26T15:42:03.391939+00:00',
-            executionDate: '2021-10-25T15:41:09.726436+00:00',
-            operator: 'DummyOperator',
-            runId: 'run1',
-            startDate: '2021-10-26T15:42:03.391917+00:00',
-            state: 'success',
-            taskId: 'group_1',
-            tryNumber: 1,
-          },
-        ],
-        children: [
-          {
-            id: 'group_1.task_1',
-            label: 'group_1.task_1',
-            extraLinks: [],
-            instances: [
-              {
-                dagId: 'dagId',
-                duration: 0,
-                endDate: '2021-10-26T15:42:03.391939+00:00',
-                executionDate: '2021-10-25T15:41:09.726436+00:00',
-                operator: 'DummyOperator',
-                runId: 'run1',
-                startDate: '2021-10-26T15:42:03.391917+00:00',
-                state: 'success',
-                taskId: 'group_1.task_1',
-                tryNumber: 1,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    instances: [],
-  },
-  dagRuns: [
+const mockGroup = {
+  id: null,
+  label: null,
+  children: [
     {
-      dagId: 'dagId',
-      runId: 'run1',
-      dataIntervalStart: new Date(),
-      dataIntervalEnd: new Date(),
-      startDate: '2021-11-08T21:14:19.704433+00:00',
-      endDate: '2021-11-08T21:17:13.206426+00:00',
-      state: 'failed',
-      runType: 'scheduled',
-      executionDate: '2021-11-08T21:14:19.704433+00:00',
+      extraLinks: [],
+      id: 'group_1',
+      label: 'group_1',
+      instances: [
+        {
+          dagId: 'dagId',
+          duration: 0,
+          endDate: '2021-10-26T15:42:03.391939+00:00',
+          executionDate: '2021-10-25T15:41:09.726436+00:00',
+          operator: 'DummyOperator',
+          runId: 'run1',
+          startDate: '2021-10-26T15:42:03.391917+00:00',
+          state: 'success',
+          taskId: 'group_1',
+          tryNumber: 1,
+        },
+      ],
+      children: [
+        {
+          id: 'group_1.task_1',
+          label: 'group_1.task_1',
+          extraLinks: [],
+          instances: [
+            {
+              dagId: 'dagId',
+              duration: 0,
+              endDate: '2021-10-26T15:42:03.391939+00:00',
+              executionDate: '2021-10-25T15:41:09.726436+00:00',
+              operator: 'DummyOperator',
+              runId: 'run1',
+              startDate: '2021-10-26T15:42:03.391917+00:00',
+              state: 'success',
+              taskId: 'group_1.task_1',
+              tryNumber: 1,
+            },
+          ],
+        },
+      ],
     },
   ],
+  instances: [],
 };
 
 describe('Test renderTaskRows', () => {
-  test('Group defaults to closed but clicking on the name will open a group', () => {
-    global.gridData = mockGridData;
-    const dagRunIds = mockGridData.dagRuns.map((dr) => dr.runId);
-    const task = mockGridData.groups;
-
-    const { getByTestId, getByText, getAllByTestId } = render(
-      <>{renderTaskRows({ task, dagRunIds })}</>,
-      { wrapper: TableWrapper },
-    );
-
-    const groupName = getByText('group_1');
-
-    expect(getAllByTestId('task-instance')).toHaveLength(1);
-    expect(groupName).toBeInTheDocument();
-    expect(getByTestId('closed-group')).toBeInTheDocument();
-
-    fireEvent.click(groupName);
-
-    expect(getByTestId('open-group')).toBeInTheDocument();
-    // task instances are only rendered when their group is expanded
-    expect(getAllByTestId('task-instance')).toHaveLength(2);
-  });
-
   test('Still renders names if there are no instances', () => {
     global.gridData = {
       groups: {
@@ -137,7 +99,7 @@ describe('Test renderTaskRows', () => {
       },
       dagRuns: [],
     };
-    const task = mockGridData.groups;
+    const task = mockGroup;
 
     const { queryByTestId, getByText } = render(
       <>{renderTaskRows({ task, dagRunIds: [] })}</>,


### PR DESCRIPTION
There were a few issues in https://github.com/apache/airflow/pull/23487 and how we dealt with open/closing groups.

The open/closed group logic was being handled in two separate places and could have different sources of truth. This logic was moved to a parent component and using a more conventional `useState` as opposed to dispatching a custom event.

Included a bit of code reorganization to set `<Main />` as the main wrapper for the grid and details panel. `<Grid />` then only refers to the actual grid place and its associated controls (expand/collapse groups, and auto-refresh). AutoRefresh also gets its own component.

Also, while refactoring, I removed is depending on `task.id.split('.')` to determine if all parent tasks were also open as task_id can include periods. Now it just matches the open parent count to the level count.

Fixes: https://github.com/apache/airflow/issues/23580

<img width="1152" alt="Screen Shot 2022-05-09 at 10 55 23 AM" src="https://user-images.githubusercontent.com/4600967/167437479-f2a83825-9033-4aee-b1df-9e33e8ece402.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
