### PR TITLE
Make Breeze help generation indepdent from having breeze installed

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
+++ b/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.py
@@ -25,7 +25,8 @@ from rich.console import Console
 
 AIRFLOW_SOURCES_DIR = Path(__file__).parents[3].absolute()
 BREEZE_IMAGES_DIR = AIRFLOW_SOURCES_DIR / "images" / "breeze"
-BREEZE_SOURCES_DIR = AIRFLOW_SOURCES_DIR / "dev" / "breeze" / "src"
+BREEZE_INSTALL_DIR = AIRFLOW_SOURCES_DIR / "dev" / "breeze"
+BREEZE_SOURCES_DIR = BREEZE_INSTALL_DIR / "src"
 
 SCREENSHOT_WIDTH = "120"
 
@@ -66,11 +67,7 @@ def print_help_for_all_commands():
     if old_hash == new_hash:
         console.print(f"[bright_blue]Skip generation of SVG images as command hash is unchanged {old_hash}")
         return
-    if run(["breeze", "--help"], check=False).returncode != 0:
-        console.print("[red]ERROR! You need to install breeze with pipx to run this pre-commit[/]")
-        console.print("\n[bright_blue]Run this command:[/]\n")
-        console.print("        pip install -e ./dev/breeze --force\n")
-        sys.exit(1)
+    run([sys.executable, "-m", "pip", "install", "--upgrade", "-e", BREEZE_INSTALL_DIR])
     env = os.environ.copy()
     env['AIRFLOW_SOURCES_ROOT'] = str(AIRFLOW_SOURCES_DIR)
     env['RECORD_BREEZE_WIDTH'] = SCREENSHOT_WIDTH


### PR DESCRIPTION
Generation of Breeze help requires breeze to be installed. However
if you have locally installed breeze with different dependencies
and did not run self-upgrade, the results of generation of the
images might be different (for example when different rich
version is used). This change works in the way that:
* you do not have to have breeze installed at all to make it work
* it always upgrades to latest breeze when it is not installed
* but this only happens when you actually modified some breeze code

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
