### PR TITLE
Add git_source to DatabricksSubmitRunOperator

### DIFF
--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -274,6 +274,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
         idempotency_token: Optional[str] = None,
         access_control_list: Optional[List[Dict[str, str]]] = None,
         wait_for_termination: bool = True,
+        git_source: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> None:
         """Creates a new ``DatabricksSubmitRunOperator``."""
@@ -312,6 +313,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
             self.json['idempotency_token'] = idempotency_token
         if access_control_list is not None:
             self.json['access_control_list'] = access_control_list
+        if git_source is not None:
+            self.json['git_source'] = git_source
 
         self.json = _deep_string_coerce(self.json)
         # This variable will be used in case our task gets killed.

--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -242,6 +242,11 @@ class DatabricksSubmitRunOperator(BaseOperator):
     :param databricks_retry_delay: Number of seconds to wait between retries (it
             might be a floating point number).
     :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
+    :param git_source: Optional specification of a remote git repository from which
+        supported task types are retrieved.
+
+        .. seealso::
+            https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit
     """
 
     # Used in airflow.models.BaseOperator

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -193,6 +193,24 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
         )
         assert expected == op.json
 
+    def test_init_with_git_source(self):
+        json = {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': RUN_NAME}
+        git_source = {
+            'git_url': 'https://github.com/apache/airflow',
+            'git_provider': 'github',
+            'git_branch': 'main',
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, git_source=git_source, json=json)
+        expected = databricks_operator._deep_string_coerce(
+            {
+                'new_cluster': NEW_CLUSTER,
+                'notebook_task': NOTEBOOK_TASK,
+                'run_name': RUN_NAME,
+                'git_source': git_source
+            }
+        )
+        assert expected == op.json
+
     def test_init_with_bad_type(self):
         json = {'test': datetime.now()}
         # Looks a bit weird since we have to escape regex reserved symbols.

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -206,7 +206,7 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
                 'new_cluster': NEW_CLUSTER,
                 'notebook_task': NOTEBOOK_TASK,
                 'run_name': RUN_NAME,
-                'git_source': git_source
+                'git_source': git_source,
             }
         )
         assert expected == op.json


### PR DESCRIPTION
The existing `DatabricksSubmitRunOperator` is extended with the support for the `git_source` parameter which allows users to run notebook tasks from files committed to git repositories.

If specified, any notebook task that is part of the payload will clone the repository and check out the commit, tag, or the tip of the specified branch. This is an alternative to dev repos ([docs](https://docs.databricks.com/repos/index.html)) where the checkout/update would have to be triggered manually.

Public documentation for the feature available here: https://docs.databricks.com/dev-tools/api/latest/jobs.html (NB: as noted in the docs, the feature is currently in public preview).