### PR TITLE
Make provider doc preparation a bit more fun :)

### DIFF
--- a/scripts/in_container/run_prepare_provider_documentation.sh
+++ b/scripts/in_container/run_prepare_provider_documentation.sh
@@ -45,22 +45,18 @@ function run_prepare_documentation() {
             skipped_documentation+=("${provider_package}")
             continue
             echo "${COLOR_YELLOW}Skipping provider package '${provider_package}'${COLOR_RESET}"
-        fi
-        if [[ ${res} == "65" ]]; then
+        elif [[ ${res} == "65" ]]; then
             echo "${COLOR_RED}Exiting as the user chose to quit!${COLOR_RESET}"
             exit 1
-        fi
-        if [[ ${res} == "128" ]]; then
+        elif [[ ${res} == "128" ]]; then
             echo "${COLOR_RED}Exiting as there wes a serious error during processing '${provider_package}'${COLOR_RESET}"
             error_documentation+=("${provider_package}")
             exit 1
-        fi
-        if [[ ${res} == "66" ]]; then
+        elif [[ ${res} == "66" ]]; then
             echo "${COLOR_YELLOW}Provider package '${provider_package}' marked as documentation-only!${COLOR_RESET}"
             doc_only_documentation+=("${provider_package}")
             continue
-        fi
-        if [[ ${res} != "0" ]]; then
+        elif [[ ${res} != "0" ]]; then
             echo "${COLOR_RED}Error when generating provider package '${provider_package}'${COLOR_RESET}"
             error_documentation+=("${provider_package}")
             continue
@@ -75,8 +71,7 @@ function run_prepare_documentation() {
             skipped_documentation+=("${provider_package}")
             continue
             echo "${COLOR_YELLOW}Skipping provider package '${provider_package}'${COLOR_RESET}"
-        fi
-        if [[ ${res} == "65" ]]; then
+        elif [[ ${res} == "65" ]]; then
             echo "${COLOR_RED}Exiting as the user chose to quit!${COLOR_RESET}"
             exit 1
         fi


### PR DESCRIPTION
Previously you had to manually add versions when changelog was
modified. But why not to get a bit more fun and get the versions
bumped automatically based on your assesment when reviewing the
provideers rather than after looking at the generated changelog.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
