### PR TITLE
Simplify flash message for _airflow_moved tables

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -82,13 +82,11 @@
   {% endfor %}
   {% if migration_moved_data_alerts %}
     {% call show_message(category='warning', dismissible=false) %}
-      During upgrade, Airflow had to move some bad data in order to apply new constraints in the metadatabase.
+      While upgrading the metadatabase, Airflow had to move some bad data in order to apply new constraints.
       The moved data can be found in the following tables:<br>
-      <code>
         {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
-        {{ original_table_name }} -> {{ moved_table_name }}<br>
+        <code>{{ original_table_name }} -> {{ moved_table_name }}</code><br>
         {% endfor %}
-      </code>
       Please inspect the moved data to decide whether you need to keep them, and manually drop
       the <code>moved</code> tables to dismiss this warning. Read more about it
       in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -84,9 +84,18 @@
     {% call show_message(category='warning', dismissible=false) %}
       While upgrading the metadatabase, Airflow had to move some bad data in order to apply new constraints.
       The moved data can be found in the following tables:<br>
-        {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
-        <code>{{ original_table_name }} -> {{ moved_table_name }}</code><br>
-        {% endfor %}
+        <table>
+          <tr>
+            <th style="padding-right:10px">Source table</th>
+            <th>Moved data</th>
+          </tr>
+          {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
+            <tr>
+              <td style="padding-right:10px"><code>{{ original_table_name }}</code></td>
+              <td><code>{{ moved_table_name }}</code></td>
+            </tr>
+          {% endfor %}
+        </table>
       Please inspect the moved data to decide whether you need to keep them, and manually drop
       the <code>moved</code> tables to dismiss this warning. Read more about it
       in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -97,7 +97,7 @@
           {% endfor %}
         </table>
       Please inspect the moved data to decide whether you need to keep them, and manually drop
-      the <code>moved</code> tables to dismiss this warning. Read more about it
+      the moved tables to dismiss this warning. Read more about it
       in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
     {% endcall %}
   {% endif %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -80,15 +80,18 @@
   {% for m in dashboard_alerts %}
     {{ show_message(m.message, m.category) }}
   {% endfor %}
-  {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
-    {% call show_message(category='error', dismissible=false) %}
-      Airflow found incompatible data in the <code>{{ original_table_name }}</code> table in the
-      metadatabase, and has moved them to <code>{{ moved_table_name }}</code> during the database migration
-      to upgrade. Please inspect the moved data to decide whether you need to keep them, and manually drop
-      the <code>{{ moved_table_name }}</code> table to dismiss this warning. Read more about it
-      in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
-    {% endcall %}
-  {% endfor %}
+  {% call show_message(category='warning', dismissible=false) %}
+    During upgrade, Airflow had to move some bad data in order to apply new constraints in the metadatabase.
+    The moved data can be found in the following tables:<br>
+    <code>
+      {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
+      {{ original_table_name }} -> {{ moved_table_name }}<br>
+      {% endfor %}
+    </code>
+    Please inspect the moved data to decide whether you need to keep them, and manually drop
+    the <code>moved</code> tables to dismiss this warning. Read more about it
+    in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
+  {% endcall %}
   {{ super() }}
   {% if sqlite_warning | default(true) %}
     {% call show_message(category='warning', dismissible=false) %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -80,18 +80,20 @@
   {% for m in dashboard_alerts %}
     {{ show_message(m.message, m.category) }}
   {% endfor %}
-  {% call show_message(category='warning', dismissible=false) %}
-    During upgrade, Airflow had to move some bad data in order to apply new constraints in the metadatabase.
-    The moved data can be found in the following tables:<br>
-    <code>
-      {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
-      {{ original_table_name }} -> {{ moved_table_name }}<br>
-      {% endfor %}
-    </code>
-    Please inspect the moved data to decide whether you need to keep them, and manually drop
-    the <code>moved</code> tables to dismiss this warning. Read more about it
-    in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
-  {% endcall %}
+  {% if migration_moved_data_alerts %}
+    {% call show_message(category='warning', dismissible=false) %}
+      During upgrade, Airflow had to move some bad data in order to apply new constraints in the metadatabase.
+      The moved data can be found in the following tables:<br>
+      <code>
+        {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
+        {{ original_table_name }} -> {{ moved_table_name }}<br>
+        {% endfor %}
+      </code>
+      Please inspect the moved data to decide whether you need to keep them, and manually drop
+      the <code>moved</code> tables to dismiss this warning. Read more about it
+      in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
+    {% endcall %}
+  {% endif %}
   {{ super() }}
   {% if sqlite_warning | default(true) %}
     {% call show_message(category='warning', dismissible=false) %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -87,7 +87,7 @@
         <table>
           <tr>
             <th style="padding-right:10px">Source table</th>
-            <th>Moved data</th>
+            <th>Table with moved rows</th>
           </tr>
           {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
             <tr>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -831,13 +831,13 @@ class Airflow(AirflowBaseView):
 
         def _iter_parsed_moved_data_table_names():
             for table_name in inspect(session.get_bind()).get_table_names():
-                segments = table_name.split("__", 2)
+                segments = table_name.split("__", 3)
                 if len(segments) < 3:
                     continue
                 if segments[0] != settings.AIRFLOW_MOVED_TABLE_PREFIX:
                     continue
                 # Second segment is a version marker that we don't need to show.
-                yield segments[2], table_name
+                yield segments[3], table_name
 
         if (
             permissions.ACTION_CAN_ACCESS_MENU,


### PR DESCRIPTION
Previously we created one message for each table. Now that there are more such tables, it gets to be a bit much.  Here I consolidate all the warnings in one single flash message, and we make it a little less scary by using a "warning" color (yellow?) instead of an "error" color (red).

Before change:

<img width="1379" alt="image" src="https://user-images.githubusercontent.com/15932138/167773479-435858f3-1cc2-490f-9b06-e78853adaf1b.png">

After change:

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/15932138/167776138-e3ce90a7-d310-42e7-9d51-713911d33c61.png">

I also fix the logic where we infer the "original" table (currently it's not correct, e.g. "dangling__xcom" instead of "xcom"
