### PR TITLE
Fix assuming "Feature" answer on CI when generating docs

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -37,6 +37,7 @@ from enum import Enum
 from functools import lru_cache
 from os.path import dirname, relpath
 from pathlib import Path
+from random import choice
 from shutil import copyfile
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, Union
 
@@ -1138,12 +1139,23 @@ class TypeOfChange(Enum):
     SKIP = "s"
 
 
-def get_type_of_changes() -> TypeOfChange:
+def get_type_of_changes(answer: Optional[str]) -> TypeOfChange:
     """
     Ask user to specify type of changes (case-insensitive).
     :return: Type of change.
     """
     given_answer = ""
+    if answer and answer.lower() in ["yes", "y"]:
+        # Simulate all possible non-terminal answers
+        return choice(
+            [
+                TypeOfChange.DOCUMENTATION,
+                TypeOfChange.BUGFIX,
+                TypeOfChange.FEATURE,
+                TypeOfChange.BREAKING_CHANGE,
+                TypeOfChange.SKIP,
+            ]
+        )
     while given_answer not in [*[t.value for t in TypeOfChange], "q"]:
         console.print(
             "[yellow]Type of change (d)ocumentation, (b)ugfix, (f)eature, (x)breaking "
@@ -1223,7 +1235,7 @@ def update_release_notes(
             console.print()
             return False
         else:
-            type_of_change = get_type_of_changes()
+            type_of_change = get_type_of_changes(answer=answer)
             if type_of_change == TypeOfChange.DOCUMENTATION:
                 if isinstance(latest_change, Change):
                     mark_latest_changes_as_documentation_only(provider_package_id, latest_change)


### PR DESCRIPTION
We have now different answers posisble when generating docs, and
for testing we assume we answered randomly during the generation
of documentation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
