### PR TITLE
fix: DatabricksSubmitRunOperator and DatabricksRunNowOperator cannot define .json as template_ext (#23622)

### DIFF
--- a/airflow/providers/databricks/operators/databricks.py
+++ b/airflow/providers/databricks/operators/databricks.py
@@ -305,7 +305,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
 
     # Used in airflow.models.BaseOperator
     template_fields: Sequence[str] = ('json',)
-    template_ext: Sequence[str] = ('.json',)
+    template_ext: Sequence[str] = ('.json-tpl',)
     # Databricks brand color (blue) under white text
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'
@@ -574,7 +574,7 @@ class DatabricksRunNowOperator(BaseOperator):
 
     # Used in airflow.models.BaseOperator
     template_fields: Sequence[str] = ('json',)
-    template_ext: Sequence[str] = ('.json',)
+    template_ext: Sequence[str] = ('.json-tpl',)
     # Databricks brand color (blue) under white text
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #23622

DatabricksSubmitRunOperator and DatabricksRunNowOperator defines '.json' as template_ext, causing airflow to try opening that file that is meant to be provided as a job parameter to databricks.

This PR removes .json as `template_ext` and defines a more specific instead: '`.json-tpl`'