### PR TITLE
ExternalTaskSensor respects soft_fail if the external task enters a failed_state

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -24,8 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Collection, FrozenSet, Iterable
 import attr
 from sqlalchemy import func
 
-from airflow.exceptions import AirflowException
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.baseoperator import BaseOperatorLink
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -25,6 +25,7 @@ import attr
 from sqlalchemy import func
 
 from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowSkipException
 from airflow.models.baseoperator import BaseOperatorLink
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
@@ -56,6 +57,24 @@ class ExternalTaskSensor(BaseSensorOperator):
     """
     Waits for a different DAG or a task in a different DAG to complete for a
     specific logical date.
+
+    By default the ExternalTaskSensor will wait for the external task to
+    succeed, at which point it will also succeed. However, by default it will
+    *not* fail if the external task fails, but will continue to check the status
+    until the sensor times out (thus giving you time to retry the external task
+    without also having to clear the sensor).
+
+    It is possible to alter the default behavior by setting states which
+    cause the sensor to fail, e.g. by setting ``allowed_states=[State.FAILED]``
+    and ``failed_states=[State.SUCCESS]`` you will flip the behaviour to get a
+    sensor which goes green when the external task *fails* and immediately goes
+    red if the external task *succeeds*!
+
+    Note that ``soft_fail`` is respected when examining the failed_states. Thus
+    if the external task enters a failed state and ``soft_fail == True`` the
+    sensor will _skip_ rather than fail. As a result, setting ``soft_fail=True``
+    and ``failed_states=[State.SKIPPED]`` will result in the sensor skipping if
+    the external task skips.
 
     :param external_dag_id: The dag_id that contains the task you want to
         wait for
@@ -184,11 +203,20 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         if count_failed == len(dttm_filter):
             if self.external_task_ids:
+                if self.soft_fail:
+                    raise AirflowSkipException(
+                        f'Some of the external tasks {self.external_task_ids} '
+                        f'in DAG {self.external_dag_id} failed. Skipping due to soft_fail.'
+                    )
                 raise AirflowException(
                     f'Some of the external tasks {self.external_task_ids} '
                     f'in DAG {self.external_dag_id} failed.'
                 )
             else:
+                if self.soft_fail:
+                    raise AirflowSkipException(
+                        f'The external DAG {self.external_dag_id} failed. ' 'Skipping due to soft_fail'
+                    )
                 raise AirflowException(f'The external DAG {self.external_dag_id} failed.')
 
         return count_allowed == len(dttm_filter)

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -215,7 +215,7 @@ class ExternalTaskSensor(BaseSensorOperator):
             else:
                 if self.soft_fail:
                     raise AirflowSkipException(
-                        f'The external DAG {self.external_dag_id} failed. ' 'Skipping due to soft_fail'
+                        f'The external DAG {self.external_dag_id} failed. Skipping due to soft_fail.'
                     )
                 raise AirflowException(f'The external DAG {self.external_dag_id} failed.')
 

--- a/newsfragments/23647.bugfix.rst
+++ b/newsfragments/23647.bugfix.rst
@@ -1,0 +1,1 @@
+``ExternalTaskSensor`` now supports the ``soft_fail`` flag to skip if external task or dag enters a failed state

--- a/newsfragments/23647.bugfix.rst
+++ b/newsfragments/23647.bugfix.rst
@@ -1,1 +1,1 @@
-``ExternalTaskSensor`` now supports the ``soft_fail`` flag to skip if external task or dag enters a failed state
+``ExternalTaskSensor`` now supports the ``soft_fail`` flag to skip if external task or DAG enters a failed state.

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -134,6 +134,28 @@ class TestExternalTaskSensor(unittest.TestCase):
                 "unit_test_dag failed."
             )
 
+    def test_external_task_sensor_soft_fail_failed_states_as_skipped(self, session=None):
+        self.test_time_sensor()
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id=TEST_DAG_ID,
+            external_task_id=TEST_TASK_ID,
+            allowed_states=[State.FAILED],
+            failed_states=[State.SUCCESS],
+            soft_fail=True,
+            dag=self.dag,
+        )
+
+        # when
+        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        # then
+        session = settings.Session()
+        TI = TaskInstance
+        task_instances: list[TI] = session.query(TI).filter(TI.task_id == op.task_id).all()
+        assert len(task_instances) == 1, "Unexpected number of task instances"
+        assert task_instances[0].state == State.SKIPPED, "Unexpected external task state"
+
     def test_external_task_sensor_external_task_id_param(self):
         """Test external_task_ids is set properly when external_task_id is passed as a template"""
         self.test_time_sensor()
@@ -141,10 +163,7 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_task_sensor_check',
             external_dag_id='{{ params.dag_id }}',
             external_task_id='{{ params.task_id }}',
-            params={
-                'dag_id': TEST_DAG_ID,
-                'task_id': TEST_TASK_ID,
-            },
+            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID,},
             dag=self.dag,
         )
 
@@ -162,10 +181,7 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_task_sensor_check',
             external_dag_id='{{ params.dag_id }}',
             external_task_ids=['{{ params.task_id }}'],
-            params={
-                'dag_id': TEST_DAG_ID,
-                'task_id': TEST_TASK_ID,
-            },
+            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID,},
             dag=self.dag,
         )
 
@@ -213,6 +229,31 @@ class TestExternalTaskSensor(unittest.TestCase):
             dag=self.dag,
         )
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_external_dag_sensor_soft_fail_as_skipped(self):
+        other_dag = DAG('other_dag', default_args=self.args, end_date=DEFAULT_DATE, schedule_interval='@once')
+        other_dag.create_dagrun(
+            run_id='test', start_date=DEFAULT_DATE, execution_date=DEFAULT_DATE, state=State.SUCCESS
+        )
+        op = ExternalTaskSensor(
+            task_id='test_external_dag_sensor_check',
+            external_dag_id='other_dag',
+            external_task_id=None,
+            allowed_states=["failed"],
+            failed_states=["success"],
+            soft_fail=True,
+            dag=self.dag,
+        )
+
+        # when
+        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+        # then
+        session = settings.Session()
+        TI = TaskInstance
+        task_instances: list[TI] = session.query(TI).filter(TI.task_id == op.task_id).all()
+        assert len(task_instances) == 1, "Unexpected number of task instances"
+        assert task_instances[0].state == State.SKIPPED, "Unexpected external task state"
 
     def test_external_task_sensor_fn_multiple_execution_dates(self):
         bash_command_code = """
@@ -452,9 +493,7 @@ exit 0
 def test_external_task_sensor_templated(dag_maker, app):
     with dag_maker():
         ExternalTaskSensor(
-            task_id='templated_task',
-            external_dag_id='dag_{{ ds }}',
-            external_task_id='task_{{ ds }}',
+            task_id='templated_task', external_dag_id='dag_{{ ds }}', external_task_id='task_{{ ds }}',
         )
 
     dagrun = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, execution_date=DEFAULT_DATE)
@@ -645,24 +684,14 @@ def assert_ti_state_equal(task_instance, state):
 
 @provide_session
 def clear_tasks(
-    dag_bag,
-    dag,
-    task,
-    session,
-    start_date=DEFAULT_DATE,
-    end_date=DEFAULT_DATE,
-    dry_run=False,
+    dag_bag, dag, task, session, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, dry_run=False,
 ):
     """
     Clear the task and its downstream tasks recursively for the dag in the given dagbag.
     """
     partial: DAG = dag.partial_subset(task_ids_or_regex=[task.task_id], include_downstream=True)
     return partial.clear(
-        start_date=start_date,
-        end_date=end_date,
-        dag_bag=dag_bag,
-        dry_run=dry_run,
-        session=session,
+        start_date=start_date, end_date=end_date, dag_bag=dag_bag, dry_run=dry_run, session=session,
     )
 
 
@@ -788,9 +817,7 @@ def dag_bag_cyclic():
             with DAG(f"dag_{n}", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
                 dags.append(dag)
                 task_a = ExternalTaskSensor(
-                    task_id=f"task_a_{n}",
-                    external_dag_id=f"dag_{n-1}",
-                    external_task_id=f"task_b_{n-1}",
+                    task_id=f"task_a_{n}", external_dag_id=f"dag_{n-1}", external_task_id=f"task_b_{n-1}",
                 )
                 task_b = ExternalTaskMarker(
                     task_id=f"task_b_{n}",
@@ -970,10 +997,7 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
     assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
     assert (
         dag.clear(
-            start_date=DEFAULT_DATE,
-            end_date=execution_date,
-            dag_bag=dag_bag_head_tail,
-            session=session,
+            start_date=DEFAULT_DATE, end_date=execution_date, dag_bag=dag_bag_head_tail, session=session,
         )
         == 30
     )

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -163,7 +163,7 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_task_sensor_check',
             external_dag_id='{{ params.dag_id }}',
             external_task_id='{{ params.task_id }}',
-            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID,},
+            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID},
             dag=self.dag,
         )
 
@@ -181,7 +181,7 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_task_sensor_check',
             external_dag_id='{{ params.dag_id }}',
             external_task_ids=['{{ params.task_id }}'],
-            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID,},
+            params={'dag_id': TEST_DAG_ID, 'task_id': TEST_TASK_ID},
             dag=self.dag,
         )
 
@@ -239,8 +239,8 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_dag_sensor_check',
             external_dag_id='other_dag',
             external_task_id=None,
-            allowed_states=["failed"],
-            failed_states=["success"],
+            allowed_states=[State.Failed],
+            failed_states=[State.Success],
             soft_fail=True,
             dag=self.dag,
         )

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -239,8 +239,8 @@ class TestExternalTaskSensor(unittest.TestCase):
             task_id='test_external_dag_sensor_check',
             external_dag_id='other_dag',
             external_task_id=None,
-            allowed_states=[State.Failed],
-            failed_states=[State.Success],
+            allowed_states=[State.FAILED],
+            failed_states=[State.SUCCESS],
             soft_fail=True,
             dag=self.dag,
         )

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -493,7 +493,9 @@ exit 0
 def test_external_task_sensor_templated(dag_maker, app):
     with dag_maker():
         ExternalTaskSensor(
-            task_id='templated_task', external_dag_id='dag_{{ ds }}', external_task_id='task_{{ ds }}',
+            task_id='templated_task',
+            external_dag_id='dag_{{ ds }}',
+            external_task_id='task_{{ ds }}',
         )
 
     dagrun = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, execution_date=DEFAULT_DATE)
@@ -684,14 +686,24 @@ def assert_ti_state_equal(task_instance, state):
 
 @provide_session
 def clear_tasks(
-    dag_bag, dag, task, session, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, dry_run=False,
+    dag_bag,
+    dag,
+    task,
+    session,
+    start_date=DEFAULT_DATE,
+    end_date=DEFAULT_DATE,
+    dry_run=False,
 ):
     """
     Clear the task and its downstream tasks recursively for the dag in the given dagbag.
     """
     partial: DAG = dag.partial_subset(task_ids_or_regex=[task.task_id], include_downstream=True)
     return partial.clear(
-        start_date=start_date, end_date=end_date, dag_bag=dag_bag, dry_run=dry_run, session=session,
+        start_date=start_date,
+        end_date=end_date,
+        dag_bag=dag_bag,
+        dry_run=dry_run,
+        session=session,
     )
 
 
@@ -817,7 +829,9 @@ def dag_bag_cyclic():
             with DAG(f"dag_{n}", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
                 dags.append(dag)
                 task_a = ExternalTaskSensor(
-                    task_id=f"task_a_{n}", external_dag_id=f"dag_{n-1}", external_task_id=f"task_b_{n-1}",
+                    task_id=f"task_a_{n}",
+                    external_dag_id=f"dag_{n-1}",
+                    external_task_id=f"task_b_{n-1}",
                 )
                 task_b = ExternalTaskMarker(
                     task_id=f"task_b_{n}",
@@ -997,7 +1011,10 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
     assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
     assert (
         dag.clear(
-            start_date=DEFAULT_DATE, end_date=execution_date, dag_bag=dag_bag_head_tail, session=session,
+            start_date=DEFAULT_DATE,
+            end_date=execution_date,
+            dag_bag=dag_bag_head_tail,
+            session=session,
         )
         == 30
     )


### PR DESCRIPTION
# Problem

You have an external task which may "skip". When that happens, you want the external task sensor to also skip. This PR enables that behaviour.

# Solution

The "right" way to do this is:
1. Set `failed_states` to `[State.SKIPPED]` (by default it is `None`)
2. Set `soft_fail=True`

With the above settings, when the target task enters the SKIPPED state, the ExternalTaskSensor will see this as a failed state and immediately react to the failure. Because of the `soft_fail` flag, it should not mark as failed, but instead as skipped.

# Effect of change

Prior to this change, the `ExternalTaskSensor` ignored the `soft_fail` setting, and always marked it as an error. With this change in place, the `ExternalTaskSensor` will instead mark the task as skipped, as desired.

# Other comments

`soft_fail` would already kick in if the ExternalTaskSensors timed out (i.e. if the external task did not enter an allowed_state or failed_state in the time. That means a possible workaround for the above is to set a timeout on the ExternalTaskSensor which you believe is long enough that the external task should have completed.

However (in my experience at least) ExternalTaskSensors are often run without timeouts. This is because if the target task hangs on upstream dependencies, having the external sensor timeout means cascading failures throughout the system which normally means more cleanup. It's usually easier to have the ExternalTaskSensors not timeout and thus only fail if there's an actual problem.

Additionally, soft_fail + execution timeouts is not perfect. If the task skips you may want the skip to propagate immediately; under the workaround, the skip would only kick in after the timeout. And of course, there are obvious goldilocks issues with finessing the timeout to be not too short nor too long.

# Related Issues

closes: #19754 

