### PR TITLE
[FEATURE] google provider - BigQueryInsertJobOperator log query

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2145,6 +2145,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         job_id = self._job_id(context)
 
         try:
+            self.log.info(f"Executing: {self.configuration}")
             job = self._submit_job(hook, job_id)
             self._handle_job_error(job)
         except Conflict:


### PR DESCRIPTION
the `BigQueryExecuteQueryOperator` is deprecated in favor of `BigQueryInsertJobOperator`

(I just migrated all my code)

`BigQueryExecuteQueryOperator` is logging the SQL query but the `BigQueryInsertJobOperator` is not logging , so I'm proposing to add this feature cause it's disturbing to miss it 

-> https://github.com/raphaelauv/airflow/blob/b63685cb5f422a39d9326adf65b5cf6b6d508520/airflow/providers/google/cloud/operators/bigquery.py#L613

