### PR TITLE
Synchronize support for Postgres and K8S in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,15 +85,15 @@ Airflow is not a streaming solution, but it is often used to process real-time d
 
 Apache Airflow is tested with:
 
-|                     | Main version (dev)           | Stable version (2.3.0) |
-|---------------------|------------------------------|------------------------|
-| Python              | 3.7, 3.8, 3.9, 3.10          | 3.7, 3.8, 3.9, 3.10    |
-| Platform            | AMD64/ARM64(\*)              | AMD64/ARM64(\*)        |
-| Kubernetes          | 1.20, 1.21, 1.22, 1.23, 1.24 | 1.20, 1.21, 1.22, 1.23 |
-| PostgreSQL          | 10, 11, 12, 13, 14           | 10, 11, 12, 13, 14     |
-| MySQL               | 5.7, 8                       | 5.7, 8                 |
-| SQLite              | 3.15.0+                      | 3.15.0+                |
-| MSSQL               | 2017(\*), 2019 (\*)          | 2017(\*), 2019 (\*)    |
+|                     | Main version (dev)           | Stable version (2.3.0)       |
+|---------------------|------------------------------|------------------------------|
+| Python              | 3.7, 3.8, 3.9, 3.10          | 3.7, 3.8, 3.9, 3.10          |
+| Platform            | AMD64/ARM64(\*)              | AMD64/ARM64(\*)              |
+| Kubernetes          | 1.20, 1.21, 1.22, 1.23, 1.24 | 1.20, 1.21, 1.22, 1.23, 1.24 |
+| PostgreSQL          | 10, 11, 12, 13, 14           | 10, 11, 12, 13, 14           |
+| MySQL               | 5.7, 8                       | 5.7, 8                       |
+| SQLite              | 3.15.0+                      | 3.15.0+                      |
+| MSSQL               | 2017(\*), 2019 (\*)          | 2017(\*), 2019 (\*)          |
 
 \* Experimental
 

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -24,7 +24,7 @@ Airflow is tested with:
 
 * Databases:
 
-  * PostgreSQL: 10, 11, 12, 13
+  * PostgreSQL: 10, 11, 12, 13, 14
   * MySQL: 5.7, 8
   * SQLite: 3.15.0+
   * MSSQL(Experimental): 2017, 2019


### PR DESCRIPTION
We just added support for Postgres 14 and K8S 1.24 and since we
did not have any changes to support either in main we are bringing
the support to 2.3 line as well.

This documentation syncs all remaining places where it should be
updated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
