### PR TITLE
Add 'reschedule' to the serialized fields for the BaseSensorOperator

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -339,6 +339,10 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         """Define mode rescheduled sensors."""
         return self.mode == 'reschedule'
 
+    @classmethod
+    def get_serialized_fields(cls):
+        return super().get_serialized_fields() | {"reschedule"}
+
 
 def poke_mode_only(cls):
     """

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1462,6 +1462,7 @@ class TestStringifiedDAGs:
         assert "deps" in blob
 
         serialized_op = SerializedBaseOperator.deserialize_operator(blob)
+        assert serialized_op.reschedule == (mode == "reschedule")
         assert op.deps == serialized_op.deps
 
     @pytest.mark.parametrize(

--- a/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
+++ b/tests/ti_deps/deps/test_ready_to_reschedule_dep.py
@@ -31,7 +31,7 @@ from airflow.utils.timezone import utcnow
 class TestNotInReschedulePeriodDep(unittest.TestCase):
     def _get_task_instance(self, state):
         dag = DAG('test_dag')
-        task = Mock(dag=dag)
+        task = Mock(dag=dag, reschedule=True)
         ti = TaskInstance(task=task, state=state, run_id=None)
         return ti
 
@@ -51,6 +51,11 @@ class TestNotInReschedulePeriodDep(unittest.TestCase):
         ti = self._get_task_instance(State.UP_FOR_RESCHEDULE)
         dep_context = DepContext(ignore_in_reschedule_period=True)
         assert ReadyToRescheduleDep().is_met(ti=ti, dep_context=dep_context)
+
+    def test_should_pass_if_not_reschedule_mode(self):
+        ti = self._get_task_instance(State.UP_FOR_RESCHEDULE)
+        del ti.task.reschedule
+        assert ReadyToRescheduleDep().is_met(ti=ti)
 
     def test_should_pass_if_not_in_none_state(self):
         ti = self._get_task_instance(State.UP_FOR_RETRY)


### PR DESCRIPTION
closes: #23411

When checking the `ReadyToRescheduleDep` dependency, the `reschedule` property is checked (as explained in `UPDATING.md` in this commit: https://github.com/apache/airflow/commit/8b276c6fc191254d96451958609faf81db994b94)

https://github.com/apache/airflow/blob/ea15277563c472efe4ef2efaa2424d728a80f987/airflow/ti_deps/deps/ready_to_reschedule.py#L43

But `ti.task` is a `SerializedBaseOperator` object, not the original operator. So this serialized object doesn't have the `mode` or `reschedule` attributes, because they are not explicitly included when serializing.

The effect this had was that the sensor task was executed repeatedly, ignoring any other constraints (`poke_interval` for example). The scheduler would eventually fail the task, but this usually happened in a couple seconds.
