### PR TITLE
Fix task log is not captured

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -520,7 +520,8 @@ class TaskInstance(Base, LoggingMixin):
         self.task_id = task.task_id
         self.map_index = map_index
         self.refresh_from_task(task)
-        self._log = logging.getLogger("airflow.task")
+        # init_on_load will config the log
+        self.init_on_load()
 
         if run_id is None and execution_date is not None:
             from airflow.models.dagrun import DagRun  # Avoid circular import
@@ -563,7 +564,6 @@ class TaskInstance(Base, LoggingMixin):
         if state:
             self.state = state
         self.hostname = ''
-        self.init_on_load()
         # Is this TaskInstance being currently running within `airflow tasks run --raw`.
         # Not persisted to the database so only valid for the current process
         self.raw = False
@@ -594,6 +594,8 @@ class TaskInstance(Base, LoggingMixin):
     @reconstructor
     def init_on_load(self):
         """Initialize the attributes that aren't stored in the DB"""
+        # correctly config the ti log
+        self._log = logging.getLogger("airflow.task")
         self.test_mode = False  # can be changed when calling 'run'
 
     @property

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -111,7 +111,7 @@ class TestCliTasks(unittest.TestCase):
 
         args = self.parser.parse_args(["tasks", "test", self.dag_id, task_id, DEFAULT_DATE.isoformat()])
 
-        with self.assertLogs('airflow.models', level='INFO') as cm:
+        with self.assertLogs('airflow.task', level='INFO') as cm:
             task_command.task_test(args)
             assert any(
                 [

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -244,6 +244,12 @@ class TestTaskInstance:
         assert op2 in op1.downstream_list
         assert op2 in op3.downstream_list
 
+    def test_init_on_load(self, create_task_instance):
+        ti = create_task_instance()
+        # ensure log is correctly created for ORM ti
+        assert ti.log.name == 'airflow.task'
+        assert not ti.test_mode
+
     @patch.object(DAG, 'get_concurrency_reached')
     def test_requeue_over_dag_concurrency(self, mock_concurrency_reached, create_task_instance):
         mock_concurrency_reached.return_value = True


### PR DESCRIPTION
when StandardTaskRunner runs tasks with exec

Issue: https://github.com/apache/airflow/issues/23540



## After the fix:

![image](https://user-images.githubusercontent.com/8662365/168185735-21307830-06e6-4c5f-9841-85bfdfa290d0.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
