### PR TITLE
Self upgrade when refreshing images

### DIFF
--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -23,6 +23,8 @@ export ANSWER="yes"
 export CI="true"
 export GITHUB_TOKEN=""
 
+breeze self-upgrade --force
+
 breeze build-image \
      --build-multiple-images \
      --prepare-buildx-cache \


### PR DESCRIPTION
When you have two branches, you should sefl-upgrade breeze to make
sure you use the version that is tied with your branch.

Usually we have two active branches - main and the last released
line, so switching between then is not unlikely for maintainers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
