### PR TITLE
Automatically reschedule stalled queued tasks in CeleryExecutor (v2)

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1769,7 +1769,7 @@
     - name: task_adoption_timeout
       description: |
         Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
-        and are automatically cleared. This setting does the same thing as ``stalled_task_timeout`` but
+        and are automatically rescheduled. This setting does the same thing as ``stalled_task_timeout`` but
         applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
         also applies to adopted tasks.
       version_added: 2.0.0
@@ -1779,7 +1779,7 @@
     - name: stalled_task_timeout
       description: |
         Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
-        cleared. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
+        rescheduled. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
         When set to 0, automatic clearing of stalled tasks is disabled.
       version_added: 2.3.1
       type: integer

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1768,12 +1768,23 @@
       default: "True"
     - name: task_adoption_timeout
       description: |
-        Time in seconds after which Adopted tasks are cleared by CeleryExecutor. This is helpful to clear
-        stalled tasks.
+        Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
+        and are automatically cleared. This setting does the same thing as ``stalled_task_timeout`` but
+        applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
+        also applies to adopted tasks.
       version_added: 2.0.0
       type: integer
       example: ~
       default: "600"
+    - name: stalled_task_timeout
+      description: |
+        Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
+        cleared. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
+        When set to 0, automatic clearing of stalled tasks is disabled.
+      version_added: 2.3.1
+      type: integer
+      example: ~
+      default: "0"
     - name: task_publish_max_retries
       description: |
         The Maximum number of retries for publishing task messages to the broker when failing

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -895,7 +895,7 @@ task_track_started = True
 task_adoption_timeout = 600
 
 # Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
-# cleared. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
+# rescheduled. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
 # When set to 0, automatic clearing of stalled tasks is disabled.
 stalled_task_timeout = 0
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -889,7 +889,7 @@ operation_timeout = 1.0
 task_track_started = True
 
 # Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
-# and are automatically cleared. This setting does the same thing as ``stalled_task_timeout`` but
+# and are automatically rescheduled. This setting does the same thing as ``stalled_task_timeout`` but
 # applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
 # also applies to adopted tasks.
 task_adoption_timeout = 600

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -888,9 +888,16 @@ operation_timeout = 1.0
 # or run in HA mode, it can adopt the orphan tasks launched by previous SchedulerJob.
 task_track_started = True
 
-# Time in seconds after which Adopted tasks are cleared by CeleryExecutor. This is helpful to clear
-# stalled tasks.
+# Time in seconds after which adopted tasks which are queued in celery are assumed to be stalled,
+# and are automatically cleared. This setting does the same thing as ``stalled_task_timeout`` but
+# applies specifically to adopted tasks only. When set to 0, the ``stalled_task_timeout`` setting
+# also applies to adopted tasks.
 task_adoption_timeout = 600
+
+# Time in seconds after which tasks queued in celery are assumed to be stalled, and are automatically
+# cleared. Adopted tasks will instead use the ``task_adoption_timeout`` setting if specified.
+# When set to 0, automatic clearing of stalled tasks is disabled.
+stalled_task_timeout = 0
 
 # The Maximum number of retries for publishing task messages to the broker when failing
 # due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -536,6 +536,11 @@ class CeleryExecutor(BaseExecutor):
         return not_adopted_tis
 
     def _set_celery_pending_task_timeout(
+        """
+        We use the fact that dicts maintain insertion order, and the the timeout for a
+        task is always "now + delta" to maintain the property that oldest item = first to
+        time out.
+        """
         self, key: TaskInstanceKey, timeout_type: Optional[_CeleryPendingTaskTimeoutType]
     ) -> None:
         self.adopted_task_timeouts.pop(key, None)

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -357,7 +357,7 @@ class CeleryExecutor(BaseExecutor):
 
         self.log.error(
             "Tasks were still pending after configured timeout (adopted: %s, all: %s), "
-            "assuming they never made it to celery and clearing:\n\t%s",
+            "assuming they never made it to celery and sending back to the scheduler:\n\t%s",
             self.task_adoption_timeout,
             self.stalled_task_timeout,
             "\n\t".join(repr(x) for x in timedout_keys),

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -536,13 +536,13 @@ class CeleryExecutor(BaseExecutor):
         return not_adopted_tis
 
     def _set_celery_pending_task_timeout(
+        self, key: TaskInstanceKey, timeout_type: Optional[_CeleryPendingTaskTimeoutType]
+    ) -> None:
         """
         We use the fact that dicts maintain insertion order, and the the timeout for a
         task is always "now + delta" to maintain the property that oldest item = first to
         time out.
         """
-        self, key: TaskInstanceKey, timeout_type: Optional[_CeleryPendingTaskTimeoutType]
-    ) -> None:
         self.adopted_task_timeouts.pop(key, None)
         self.stalled_task_timeouts.pop(key, None)
         if timeout_type == _CeleryPendingTaskTimeoutType.ADOPTED and self.task_adoption_timeout:

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -29,7 +29,7 @@ import os
 import subprocess
 import time
 import traceback
-from collections import Counter, OrderedDict
+from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import cpu_count
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
@@ -40,6 +40,7 @@ from celery.backends.database import DatabaseBackend, Task as TaskDb, session_cl
 from celery.result import AsyncResult
 from celery.signals import import_modules as celery_import_modules
 from setproctitle import setproctitle
+from sqlalchemy.orm.session import Session
 
 import airflow.settings as settings
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
@@ -50,6 +51,7 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.timezone import utcnow
@@ -230,10 +232,12 @@ class CeleryExecutor(BaseExecutor):
             self._sync_parallelism = max(1, cpu_count() - 1)
         self.bulk_state_fetcher = BulkStateFetcher(self._sync_parallelism)
         self.tasks = {}
-        # Mapping of tasks we've adopted, ordered by the earliest date they timeout
-        self.adopted_task_timeouts: Dict[TaskInstanceKey, datetime.datetime] = OrderedDict()
+        self.stalled_task_timeouts: Dict[TaskInstanceKey, datetime.datetime] = {}
         self.task_adoption_timeout = datetime.timedelta(
             seconds=conf.getint('celery', 'task_adoption_timeout', fallback=600)
+        )
+        self.stalled_task_timeout = datetime.timedelta(
+            seconds=conf.getint('celery', 'stalled_task_timeout', fallback=0)
         )
         self.task_publish_retries: Counter[TaskInstanceKey] = Counter()
         self.task_publish_max_retries = conf.getint('celery', 'task_publish_max_retries', fallback=3)
@@ -285,6 +289,7 @@ class CeleryExecutor(BaseExecutor):
                 result.backend = cached_celery_backend
                 self.running.add(key)
                 self.tasks[key] = result
+                self._set_stalled_task_timeout(key, self.stalled_task_timeout)
 
                 # Store the Celery task_id in the event buffer. This will get "overwritten" if the task
                 # has another event, but that is fine, because the only other events are success/failed at
@@ -315,25 +320,23 @@ class CeleryExecutor(BaseExecutor):
             self.log.debug("No task to query celery, skipping sync")
             return
         self.update_all_task_states()
+        self._check_for_stalled_tasks()
 
-        if self.adopted_task_timeouts:
-            self._check_for_stalled_adopted_tasks()
-
-    def _check_for_stalled_adopted_tasks(self):
+    @provide_session
+    def _check_for_stalled_tasks(self, session: Session = NEW_SESSION):
         """
-        See if any of the tasks we adopted from another Executor run have not
-        progressed after the configured timeout.
+        Check to see if any of our tasks have not progressed in the expected
+        time. This can happen for few different reasons, usually related to
+        race conditions while shutting down schedulers and celery workers.
 
-        If they haven't, they likely never made it to Celery, and we should
-        just resend them. We do that by clearing the state and letting the
-        normal scheduler loop deal with that
+        It is, of course, always possible that these tasks are not actually
+        stalled - they could just be waiting in a long celery queue.
+        Unfortunately there's no way for us to know for sure, so we'll just
+        reschedule them and let the normal scheduler loop requeue them.
         """
         now = utcnow()
-
-        sorted_adopted_task_timeouts = sorted(self.adopted_task_timeouts.items(), key=lambda k: k[1])
-
         timedout_keys = []
-        for key, stalled_after in sorted_adopted_task_timeouts:
+        for key, stalled_after in self.stalled_task_timeouts.items():
             if stalled_after > now:
                 # Since items are stored sorted, if we get to a stalled_after
                 # in the future then we can stop
@@ -343,20 +346,46 @@ class CeleryExecutor(BaseExecutor):
             # already finished, then it will be removed from this list -- so
             # the only time it's still in this list is when it a) never made it
             # to celery in the first place (i.e. race condition somewhere in
-            # the dying executor) or b) a really long celery queue and it just
+            # the dying executor), b) celery lost the task before execution
+            # started, or  c) a really long celery queue and it just
             # hasn't started yet -- better cancel it and let the scheduler
             # re-queue rather than have this task risk stalling for ever
             timedout_keys.append(key)
 
-        if timedout_keys:
-            self.log.error(
-                "Adopted tasks were still pending after %s, assuming they never made it to celery and "
-                "clearing:\n\t%s",
-                self.task_adoption_timeout,
-                "\n\t".join(repr(x) for x in timedout_keys),
-            )
-            for key in timedout_keys:
-                self.change_state(key, State.FAILED)
+        if not timedout_keys:
+            return
+
+        self.log.error(
+            "Tasks were still pending after configured timeout (adopted: %s, all: %s), "
+            "assuming they never made it to celery and clearing:\n\t%s",
+            self.task_adoption_timeout,
+            self.stalled_task_timeout,
+            "\n\t".join(repr(x) for x in timedout_keys),
+        )
+
+        filter_for_tis = TaskInstance.filter_for_tis(timedout_keys)
+        session.query(TaskInstance).filter(
+            filter_for_tis, TaskInstance.state == State.QUEUED, TaskInstance.queued_by_job_id == self.job_id
+        ).update(
+            {
+                TaskInstance.state: State.SCHEDULED,
+                TaskInstance.queued_dttm: None,
+                TaskInstance.queued_by_job_id: None,
+                TaskInstance.external_executor_id: None,
+            },
+            synchronize_session=False,
+        )
+        session.commit()
+
+        for key in timedout_keys:
+            self.stalled_task_timeouts.pop(key, None)
+            self.running.discard(key)
+            celery_async_result = self.tasks.pop(key, None)
+            if celery_async_result:
+                try:
+                    app.control.revoke(celery_async_result.task_id)
+                except Exception as ex:
+                    self.log.error("Error revoking task instance %s from celery: %s", key, ex)
 
     def debug_dump(self) -> None:
         """Called in response to SIGUSR2 by the scheduler"""
@@ -365,9 +394,9 @@ class CeleryExecutor(BaseExecutor):
             "executor.tasks (%d)\n\t%s", len(self.tasks), "\n\t".join(map(repr, self.tasks.items()))
         )
         self.log.info(
-            "executor.adopted_task_timeouts (%d)\n\t%s",
-            len(self.adopted_task_timeouts),
-            "\n\t".join(map(repr, self.adopted_task_timeouts.items())),
+            "executor.stalled_task_timeouts (%d)\n\t%s",
+            len(self.stalled_task_timeouts),
+            "\n\t".join(map(repr, self.stalled_task_timeouts.items())),
         )
 
     def update_all_task_states(self) -> None:
@@ -384,7 +413,7 @@ class CeleryExecutor(BaseExecutor):
     def change_state(self, key: TaskInstanceKey, state: str, info=None) -> None:
         super().change_state(key, state, info)
         self.tasks.pop(key, None)
-        self.adopted_task_timeouts.pop(key, None)
+        self.stalled_task_timeouts.pop(key, None)
 
     def update_task_state(self, key: TaskInstanceKey, state: str, info: Any) -> None:
         """Updates state of a single task."""
@@ -394,8 +423,8 @@ class CeleryExecutor(BaseExecutor):
             elif state in (celery_states.FAILURE, celery_states.REVOKED):
                 self.fail(key, info)
             elif state == celery_states.STARTED:
-                # It's now actually running, so know it made it to celery okay!
-                self.adopted_task_timeouts.pop(key, None)
+                # It's now actually running, so we know it made it to celery okay!
+                self.stalled_task_timeouts.pop(key, None)
             elif state == celery_states.PENDING:
                 pass
             else:
@@ -455,7 +484,7 @@ class CeleryExecutor(BaseExecutor):
 
             # Set the correct elements of the state dicts, then update this
             # like we just queried it.
-            self.adopted_task_timeouts[ti.key] = ti.queued_dttm + self.task_adoption_timeout
+            self._set_stalled_task_timeout(ti.key, self.task_adoption_timeout or self.stalled_task_timeout)
             self.tasks[ti.key] = result
             self.running.add(ti.key)
             self.update_task_state(ti.key, state, info)
@@ -468,6 +497,15 @@ class CeleryExecutor(BaseExecutor):
             )
 
         return not_adopted_tis
+
+    def _set_stalled_task_timeout(self, key: TaskInstanceKey, timeout: datetime.timedelta) -> None:
+        if timeout:
+            self.stalled_task_timeouts[key] = utcnow() + timeout
+            self.stalled_task_timeouts = dict(
+                sorted(self.stalled_task_timeouts.items(), key=lambda item: item[1])
+            )
+        else:
+            self.stalled_task_timeouts.pop(key, None)
 
 
 def fetch_celery_task_state(async_result: AsyncResult) -> Tuple[str, Union[str, ExceptionWithTraceback], Any]:

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -332,6 +332,7 @@ class TestCeleryExecutor:
         tis = [ti1, ti2]
         executor = celery_executor.CeleryExecutor()
         assert executor.running == set()
+        assert executor.adopted_task_timeouts == {}
         assert executor.stalled_task_timeouts == {}
         assert executor.tasks == {}
 
@@ -340,10 +341,11 @@ class TestCeleryExecutor:
         key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, None, try_number)
         key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, None, try_number)
         assert executor.running == {key_1, key_2}
-        assert dict(executor.stalled_task_timeouts) == {
+        assert executor.adopted_task_timeouts == {
             key_1: timezone.utcnow() + executor.task_adoption_timeout,
             key_2: timezone.utcnow() + executor.task_adoption_timeout,
         }
+        assert executor.stalled_task_timeouts == {}
         assert executor.tasks == {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
         assert not_adopted_tis == []
 
@@ -352,6 +354,38 @@ class TestCeleryExecutor:
         with _prepare_app() as app:
             app.control.revoke = mock.MagicMock()
             yield app.control.revoke
+
+    @pytest.mark.backend("mysql", "postgres")
+    def test_check_for_timedout_adopted_tasks(self, create_dummy_dag, dag_maker, session, mock_celery_revoke):
+        create_dummy_dag(dag_id="test_clear_stalled", task_id="task1", with_dagrun_type=None)
+        dag_run = dag_maker.create_dagrun()
+
+        ti = dag_run.task_instances[0]
+        ti.state = State.QUEUED
+        ti.queued_dttm = timezone.utcnow()
+        ti.queued_by_job_id = 1
+        ti.external_executor_id = '231'
+        session.flush()
+
+        executor = celery_executor.CeleryExecutor()
+        executor.job_id = 1
+        executor.adopted_task_timeouts = {
+            ti.key: timezone.utcnow() - timedelta(days=1),
+        }
+        executor.running = {ti.key}
+        executor.tasks = {ti.key: AsyncResult("231")}
+        executor.sync()
+        assert executor.event_buffer == {}
+        assert executor.tasks == {}
+        assert executor.running == set()
+        assert executor.adopted_task_timeouts == {}
+        assert mock_celery_revoke.called_with("231")
+
+        ti.refresh_from_db()
+        assert ti.state == State.SCHEDULED
+        assert ti.queued_by_job_id is None
+        assert ti.queued_dttm is None
+        assert ti.external_executor_id is None
 
     @pytest.mark.backend("mysql", "postgres")
     def test_check_for_stalled_tasks(self, create_dummy_dag, dag_maker, session, mock_celery_revoke):
@@ -387,7 +421,7 @@ class TestCeleryExecutor:
 
     @pytest.mark.backend("mysql", "postgres")
     @freeze_time("2020-01-01")
-    def test_check_for_stalled_tasks_goes_in_ordered_fashion(self):
+    def test_pending_tasks_timeout_with_appropriate_config_setting(self):
         start_date = timezone.utcnow() - timedelta(days=2)
 
         with DAG("test_check_for_stalled_tasks_are_ordered"):
@@ -410,11 +444,13 @@ class TestCeleryExecutor:
             executor._process_tasks([(ti2.key, None, None, mock.MagicMock())])
         assert executor.stalled_task_timeouts == {
             ti2.key: timezone.utcnow() + timedelta(seconds=30),
+        }
+        assert executor.adopted_task_timeouts == {
             ti1.key: timezone.utcnow() + timedelta(seconds=600),
         }
 
     @pytest.mark.backend("mysql", "postgres")
-    def test_no_stalled_task_timeouts_when_configured(self):
+    def test_no_pending_task_timeouts_when_configured(self):
         start_date = timezone.utcnow() - timedelta(days=2)
 
         with DAG("test_check_for_stalled_tasks_are_ordered"):
@@ -435,6 +471,7 @@ class TestCeleryExecutor:
         with mock.patch('airflow.executors.celery_executor.send_task_to_executor') as mock_send_task:
             mock_send_task.return_value = (ti2.key, None, mock.MagicMock())
             executor._process_tasks([(ti2.key, None, None, mock.MagicMock())])
+        assert executor.adopted_task_timeouts == {}
         assert executor.stalled_task_timeouts == {}
 
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -33,6 +33,7 @@ from celery.backends.base import BaseBackend, BaseKeyValueStoreBackend
 from celery.backends.database import DatabaseBackend
 from celery.contrib.testing.worker import start_worker
 from celery.result import AsyncResult
+from freezegun import freeze_time
 from kombu.asynchronous import set_event_loop
 from parameterized import parameterized
 
@@ -311,9 +312,9 @@ class TestCeleryExecutor:
         assert executor.try_adopt_task_instances(tis) == tis
 
     @pytest.mark.backend("mysql", "postgres")
+    @freeze_time("2020-01-01")
     def test_try_adopt_task_instances(self):
         start_date = timezone.utcnow() - timedelta(days=2)
-        queued_dttm = timezone.utcnow() - timedelta(minutes=1)
 
         try_number = 1
 
@@ -323,17 +324,15 @@ class TestCeleryExecutor:
 
         ti1 = TaskInstance(task=task_1, run_id=None)
         ti1.external_executor_id = '231'
-        ti1.queued_dttm = queued_dttm
         ti1.state = State.QUEUED
         ti2 = TaskInstance(task=task_2, run_id=None)
         ti2.external_executor_id = '232'
-        ti2.queued_dttm = queued_dttm
         ti2.state = State.QUEUED
 
         tis = [ti1, ti2]
         executor = celery_executor.CeleryExecutor()
         assert executor.running == set()
-        assert executor.adopted_task_timeouts == {}
+        assert executor.stalled_task_timeouts == {}
         assert executor.tasks == {}
 
         not_adopted_tis = executor.try_adopt_task_instances(tis)
@@ -341,67 +340,102 @@ class TestCeleryExecutor:
         key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, None, try_number)
         key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, None, try_number)
         assert executor.running == {key_1, key_2}
-        assert dict(executor.adopted_task_timeouts) == {
-            key_1: queued_dttm + executor.task_adoption_timeout,
-            key_2: queued_dttm + executor.task_adoption_timeout,
+        assert dict(executor.stalled_task_timeouts) == {
+            key_1: timezone.utcnow() + executor.task_adoption_timeout,
+            key_2: timezone.utcnow() + executor.task_adoption_timeout,
         }
         assert executor.tasks == {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
         assert not_adopted_tis == []
 
+    @pytest.fixture
+    def mock_celery_revoke(self):
+        with _prepare_app() as app:
+            app.control.revoke = mock.MagicMock()
+            yield app.control.revoke
+
     @pytest.mark.backend("mysql", "postgres")
-    def test_check_for_stalled_adopted_tasks(self):
-        start_date = timezone.utcnow() - timedelta(days=2)
-        queued_dttm = timezone.utcnow() - timedelta(minutes=30)
+    def test_check_for_stalled_tasks(self, create_dummy_dag, dag_maker, session, mock_celery_revoke):
+        create_dummy_dag(dag_id="test_clear_stalled", task_id="task1", with_dagrun_type=None)
+        dag_run = dag_maker.create_dagrun()
 
-        try_number = 1
-
-        with DAG("test_check_for_stalled_adopted_tasks") as dag:
-            task_1 = BaseOperator(task_id="task_1", start_date=start_date)
-            task_2 = BaseOperator(task_id="task_2", start_date=start_date)
-
-        key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, "runid", try_number)
-        key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, "runid", try_number)
+        ti = dag_run.task_instances[0]
+        ti.state = State.QUEUED
+        ti.queued_dttm = timezone.utcnow()
+        ti.queued_by_job_id = 1
+        ti.external_executor_id = '231'
+        session.flush()
 
         executor = celery_executor.CeleryExecutor()
-        executor.adopted_task_timeouts = {
-            key_1: queued_dttm + executor.task_adoption_timeout,
-            key_2: queued_dttm + executor.task_adoption_timeout,
+        executor.job_id = 1
+        executor.stalled_task_timeouts = {
+            ti.key: timezone.utcnow() - timedelta(days=1),
         }
-        executor.running = {key_1, key_2}
-        executor.tasks = {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
+        executor.running = {ti.key}
+        executor.tasks = {ti.key: AsyncResult("231")}
         executor.sync()
-        assert executor.event_buffer == {key_1: (State.FAILED, None), key_2: (State.FAILED, None)}
+        assert executor.event_buffer == {}
         assert executor.tasks == {}
         assert executor.running == set()
-        assert executor.adopted_task_timeouts == {}
+        assert executor.stalled_task_timeouts == {}
+        assert mock_celery_revoke.called_with("231")
+
+        ti.refresh_from_db()
+        assert ti.state == State.SCHEDULED
+        assert ti.queued_by_job_id is None
+        assert ti.queued_dttm is None
+        assert ti.external_executor_id is None
 
     @pytest.mark.backend("mysql", "postgres")
-    def test_check_for_stalled_adopted_tasks_goes_in_ordered_fashion(self):
+    @freeze_time("2020-01-01")
+    def test_check_for_stalled_tasks_goes_in_ordered_fashion(self):
         start_date = timezone.utcnow() - timedelta(days=2)
-        queued_dttm = timezone.utcnow() - timedelta(minutes=30)
-        queued_dttm_2 = timezone.utcnow() - timedelta(minutes=4)
 
-        try_number = 1
-
-        with DAG("test_check_for_stalled_adopted_tasks") as dag:
+        with DAG("test_check_for_stalled_tasks_are_ordered"):
             task_1 = BaseOperator(task_id="task_1", start_date=start_date)
             task_2 = BaseOperator(task_id="task_2", start_date=start_date)
 
-        key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, "runid", try_number)
-        key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, "runid", try_number)
+        ti1 = TaskInstance(task=task_1, run_id=None)
+        ti1.external_executor_id = '231'
+        ti1.state = State.QUEUED
+        ti2 = TaskInstance(task=task_2, run_id=None)
+        ti2.external_executor_id = '232'
+        ti2.state = State.QUEUED
 
         executor = celery_executor.CeleryExecutor()
-        executor.adopted_task_timeouts = {
-            key_2: queued_dttm_2 + executor.task_adoption_timeout,
-            key_1: queued_dttm + executor.task_adoption_timeout,
+        executor.stalled_task_timeout = timedelta(seconds=30)
+        executor.queued_tasks[ti2.key] = (None, None, None, None)
+        executor.try_adopt_task_instances([ti1])
+        with mock.patch('airflow.executors.celery_executor.send_task_to_executor') as mock_send_task:
+            mock_send_task.return_value = (ti2.key, None, mock.MagicMock())
+            executor._process_tasks([(ti2.key, None, None, mock.MagicMock())])
+        assert executor.stalled_task_timeouts == {
+            ti2.key: timezone.utcnow() + timedelta(seconds=30),
+            ti1.key: timezone.utcnow() + timedelta(seconds=600),
         }
-        executor.running = {key_1, key_2}
-        executor.tasks = {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
-        executor.sync()
-        assert executor.event_buffer == {key_1: (State.FAILED, None)}
-        assert executor.tasks == {key_2: AsyncResult('232')}
-        assert executor.running == {key_2}
-        assert executor.adopted_task_timeouts == {key_2: queued_dttm_2 + executor.task_adoption_timeout}
+
+    @pytest.mark.backend("mysql", "postgres")
+    def test_no_stalled_task_timeouts_when_configured(self):
+        start_date = timezone.utcnow() - timedelta(days=2)
+
+        with DAG("test_check_for_stalled_tasks_are_ordered"):
+            task_1 = BaseOperator(task_id="task_1", start_date=start_date)
+            task_2 = BaseOperator(task_id="task_2", start_date=start_date)
+
+        ti1 = TaskInstance(task=task_1, run_id=None)
+        ti1.external_executor_id = '231'
+        ti1.state = State.QUEUED
+        ti2 = TaskInstance(task=task_2, run_id=None)
+        ti2.external_executor_id = '232'
+        ti2.state = State.QUEUED
+
+        executor = celery_executor.CeleryExecutor()
+        executor.task_adoption_timeout = timedelta(0)
+        executor.queued_tasks[ti2.key] = (None, None, None, None)
+        executor.try_adopt_task_instances([ti1])
+        with mock.patch('airflow.executors.celery_executor.send_task_to_executor') as mock_send_task:
+            mock_send_task.return_value = (ti2.key, None, mock.MagicMock())
+            executor._process_tasks([(ti2.key, None, None, mock.MagicMock())])
+        assert executor.stalled_task_timeouts == {}
 
 
 def test_operation_timeout_config():


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Celery can lose tasks on worker shutdown, causing airflow to just wait on them indefinitely (may be related to https://github.com/celery/celery/issues/7266). This PR expands the "stalled tasks" functionality which is already in place for adopted tasks, and adds the ability to apply it to all tasks such that these lost/hung tasks can be automatically recovered and queued up again. 

Closes: https://github.com/apache/airflow/issues/19699

This is an alternate approach/implementation of https://github.com/apache/airflow/pull/23432. There are a couple advantages to this approach:
* It is lighter weight - instead of db queries happening on a periodic schedule, it's a simple date comparison happening on each loop
* The code is cleaner - it's not a whole new piece of functionality, rather it's a slight expansion of an existing capability
* Disabled by default - unless the user explicitly sets the `stalled_task_timeout` config setting, there is minimal behavioural change. The only behavioural difference is:
  * in the existing code, stalled adopted tasks are not revoked from celery and they are marked as failed in airflow....which potentially results in:
    * the task being executed multiple times (if it wasn't actually stalled, just in a long celery queue)
    * failing with no error (if the task is set to `retries=0`)
  * in this implementation, stalled adopted tasks are revoked from celery and are re-set to `SCHEDULED` state so they'll get queued back up.

cc: @ephraimbuddy @kristoffern @kaxil @XD-DENG @ashb 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
