### PR TITLE
Fix breeze build_params attribute access

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -526,8 +526,10 @@ def rebuild_ci_image_if_needed(
     ci_image_params = BuildCiParams(python=build_params.python, upgrade_to_newer_dependencies=False)
     if build_ci_image_check_cache.exists():
         if verbose:
-            get_console().print(f'[info]{build_params.image_type} image already built locally.[/]')
+            get_console().print(f'[info]{build_params.the_image_type} image already built locally.[/]')
     else:
-        get_console().print(f'[warning]{build_params.image_type} image not built locally. Forcing build.[/]')
+        get_console().print(
+            f'[warning]{build_params.the_image_type} image not built locally. Forcing build.[/]'
+        )
         ci_image_params.force_build = True
     build_ci_image(verbose, dry_run=dry_run, ci_image_params=ci_image_params)


### PR DESCRIPTION
While running breeze locally I was getting an exception (see below). It seems to be related to changes made in #23562. The changes in this PR fix the issue.

```
breeze start-airflow --forward-credentials restart --backend postgres --db-reset
...

Resource check successful.

Traceback (most recent call last):
  File "/home/ANT.AMAZON.COM/onikolas/.local/bin/breeze", line 33, in <module>
    sys.exit(load_entry_point('apache-airflow-breeze', 'console_scripts', 'breeze')())
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/rich_click/rich_group.py", line 21, in main
    return super().main(*args, standalone_mode=False, **kwargs)
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ANT.AMAZON.COM/onikolas/.local/pipx/venvs/apache-airflow-breeze/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/ANT.AMAZON.COM/onikolas/code/oss/airflow/airflow/dev/breeze/src/airflow_breeze/commands/developer_commands.py", line 340, in start_airflow
    enter_shell(
  File "/home/ANT.AMAZON.COM/onikolas/code/oss/airflow/airflow/dev/breeze/src/airflow_breeze/commands/developer_commands.py", line 578, in enter_shell
    return run_shell_with_build_image_checks(verbose, dry_run, enter_shell_params)
  File "/home/ANT.AMAZON.COM/onikolas/code/oss/airflow/airflow/dev/breeze/src/airflow_breeze/commands/developer_commands.py", line 598, in run_shell_with_build_image_checks
    rebuild_ci_image_if_needed(build_params=shell_params, dry_run=dry_run, verbose=verbose)
  File "/home/ANT.AMAZON.COM/onikolas/code/oss/airflow/airflow/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py", line 531, in rebuild_ci_image_if_needed
    get_console().print(f'[warning]{build_params.image_type} image not built locally. Forcing build.[/]')
AttributeError: 'ShellParams' object has no attribute 'image_type'
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
