### PR TITLE
Fix property name in breeze Shell Params

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/shell_params.py
+++ b/dev/breeze/src/airflow_breeze/params/shell_params.py
@@ -131,13 +131,12 @@ class ShellParams:
         return enabled_integration
 
     @property
-    def the_image_type(self) -> str:
-        the_image_type = 'CI'
-        return the_image_type
+    def image_type(self) -> str:
+        return 'CI'
 
     @property
     def md5sum_cache_dir(self) -> Path:
-        cache_dir = Path(BUILD_CACHE_DIR, self.airflow_branch, self.python, self.the_image_type)
+        cache_dir = Path(BUILD_CACHE_DIR, self.airflow_branch, self.python, self.image_type)
         return cache_dir
 
     @property
@@ -158,7 +157,7 @@ class ShellParams:
 
     def print_badge_info(self):
         if self.verbose:
-            get_console().print(f'[info]Use {self.the_image_type} image[/]')
+            get_console().print(f'[info]Use {self.image_type} image[/]')
             get_console().print(f'[info]Branch Name: {self.airflow_branch}[/]')
             get_console().print(f'[info]Docker Image: {self.airflow_image_name_with_tag}[/]')
             get_console().print(f'[info]Airflow source version:{self.airflow_version}[/]')


### PR DESCRIPTION
The rename from #23562 missed few shell_parms usage where it
also should be replaced.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
