### PR TITLE
Modify db clean to also catch the ProgrammingError exception

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pendulum import DateTime
 from sqlalchemy import and_, false, func
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, ProgrammingError
 
 from airflow.cli.simple_table import AirflowConsole
 from airflow.jobs.base_job import BaseJob
@@ -260,7 +260,7 @@ class _warn_if_missing(AbstractContextManager):
         return self
 
     def __exit__(self, exctype, excinst, exctb):
-        caught_error = exctype is not None and issubclass(exctype, OperationalError)
+        caught_error = exctype is not None and issubclass(exctype, (OperationalError, ProgrammingError))
         if caught_error:
             logger.warning("Table %r not found.  Skipping.", self.table)
         return caught_error


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #23698

This PR modifies the `_warn_if_missing` context manager in the `db clean` action to also catch the `sqlalchemy.exc.ProgrammingError` exception which is raised when tables do not exist (Certainly in PostgreSQL/psycopg2).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
