### PR TITLE
Add databricks job sensors

### DIFF
--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -82,6 +82,11 @@ hooks:
     python-modules:
       - airflow.providers.databricks.hooks.databricks_sql
 
+sensors:
+  - integration-name: Databricks
+    python-modules:
+      - airflow.providers.databricks.sensors.databricks
+
 hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
   - airflow.providers.databricks.hooks.databricks.DatabricksHook
 

--- a/airflow/providers/databricks/sensors/__init__.py
+++ b/airflow/providers/databricks/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/databricks/sensors/databricks.py
+++ b/airflow/providers/databricks/sensors/databricks.py
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Databricks sensors"""
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+
+from airflow.exceptions import AirflowException
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.context import Context
+
+if TYPE_CHECKING:
+    from airflow.sensors.base import PokeReturnValue
+
+
+class DatabricksJobRunSensor(BaseSensorOperator):
+    """
+    Check for the state of a submitted Databricks job run or specific task of a job run.
+
+    :param run_id: Id of the submitted Databricks job run or specific task of a job run. (templated)
+    :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
+        By default and in the common case this will be ``databricks_default``. To use
+        token based authentication, provide the key ``token`` in the extra field for the
+        connection and create the key ``host`` and leave the ``host`` field empty.
+    :param retry_limit: Amount of times retry if the Databricks backend is
+        unreachable. Its value must be greater than or equal to 1.
+    :param retry_delay_seconds: Number of seconds to wait between retries (it
+            might be a floating point number).
+    :param databricks_retry_args: An optional dictionary with arguments passed to ``tenacity.Retrying`` class.
+    """
+
+    template_fields: Sequence[str] = ('run_id',)
+
+    # Databricks brand color (blue) under white text
+    ui_color = '#1CB1C2'
+    ui_fgcolor = '#fff'
+
+    def __init__(
+        self,
+        *,
+        run_id: int,
+        databricks_conn_id: str = 'databricks_default',
+        retry_limit: int = 3,
+        retry_delay_seconds: int = 1,
+        databricks_retry_args: Optional[Dict[Any, Any]] = None,
+        **kwargs,
+    ) -> None:
+        """Creates a new ``DatabricksJobSensor`` instance."""
+        super().__init__(**kwargs)
+        self.run_id = run_id
+        self.databricks_conn_id = databricks_conn_id
+        self.retry_limit = retry_limit
+        self.retry_delay_seconds = retry_delay_seconds
+        self.databricks_retry_args = databricks_retry_args
+
+    def poke(self, context: Context) -> Union[bool, 'PokeReturnValue']:
+        hook = self._get_hook()
+        run_state = hook.get_run_state(self.run_id)
+        if run_state.is_terminal:
+            if run_state.is_successful:
+                self.log.info('%s completed successfully.', self.task_id)
+                return True
+            else:
+                run_output = hook.get_run_output(self.run_id)
+                notebook_error = run_output['error']
+                error_message = (
+                    f'{self.task_id} failed with terminal state: {run_state} '
+                    f'and with the error: {notebook_error}'
+                )
+                raise AirflowException(error_message)
+        else:
+            run_page_url = hook.get_run_page_url(self.run_id)
+            self.log.info(
+                'Task %s is in state: %s, Spark UI and logs are available at %s',
+                self.task_id,
+                run_state,
+                run_page_url,
+            )
+            self.log.info('Waiting for run %s to complete.', self.run_id)
+            return False
+
+    def _get_hook(self) -> DatabricksHook:
+        return DatabricksHook(
+            self.databricks_conn_id,
+            retry_limit=self.retry_limit,
+            retry_delay=self.retry_delay_seconds,
+            retry_args=self.databricks_retry_args,
+        )

--- a/tests/providers/databricks/sensors/__init__.py
+++ b/tests/providers/databricks/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/databricks/sensors/test_databricks.py
+++ b/tests/providers/databricks/sensors/test_databricks.py
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from unittest import mock
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.providers.databricks.hooks.databricks import RunState
+from airflow.providers.databricks.sensors.databricks import DatabricksJobRunSensor
+
+RUN_ID = 1
+TASK_ID = 'databricks-sensor'
+RUN_PAGE_URL = 'workspace.databricks.com/jobs/1'
+DEFAULT_CONN_ID = 'databricks_default'
+
+
+class TestDatabricksJobRunSensor(unittest.TestCase):
+    @mock.patch('airflow.providers.databricks.sensors.databricks.DatabricksHook')
+    def test_terminal_state_success(self, db_mock_class):
+        """Test DatabricksJobRunSensor in a successful terminal state"""
+        sensor = DatabricksJobRunSensor(task_id=TASK_ID, run_id=RUN_ID)
+        db_mock = db_mock_class.return_value
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        with self.assertLogs(sensor.log) as logger:
+            sensor.execute(None)
+            self.assertIn(
+                f'INFO:airflow.task.operators:{TASK_ID} completed successfully.',
+                logger.output,
+            )
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=sensor.retry_limit,
+            retry_delay=sensor.retry_delay_seconds,
+            retry_args=sensor.databricks_retry_args,
+        )
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.providers.databricks.sensors.databricks.DatabricksHook')
+    def test_terminal_state_error(self, db_mock_class):
+        """Test DatabricksJobRunSensor in a failed terminal state"""
+        sensor = DatabricksJobRunSensor(task_id=TASK_ID, run_id=RUN_ID)
+        db_mock = db_mock_class.return_value
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'INTERNAL_ERROR', '')
+        db_mock.get_run_output.return_value = {'error': 'internal error'}
+
+        exception_message = (
+            f'{TASK_ID} failed with terminal state: {db_mock.get_run_state.return_value} '
+            f'and with the error: internal error'
+        )
+        with pytest.raises(AirflowException, match=exception_message):
+            sensor.execute(None)
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=sensor.retry_limit,
+            retry_delay=sensor.retry_delay_seconds,
+            retry_args=sensor.databricks_retry_args,
+        )
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        db_mock.get_run_output.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.providers.databricks.sensors.databricks.DatabricksHook')
+    def test_non_terminal_state(self, db_mock_class):
+        """Test DatabricksJobRunSensor in a non terminal state"""
+        sensor = DatabricksJobRunSensor(task_id=TASK_ID, run_id=RUN_ID)
+        db_mock = db_mock_class.return_value
+        db_mock.get_run_state.return_value = RunState('RUNNING', '', '')
+        db_mock.get_run_page_url.return_value = RUN_PAGE_URL
+
+        with self.assertLogs(sensor.log) as logger:
+            sensor.poke(None)
+            self.assertListEqual(
+                [
+                    f'INFO:airflow.task.operators:Task {TASK_ID} is in state: '
+                    f'{db_mock.get_run_state.return_value}, '
+                    f'Spark UI and logs are available at {RUN_PAGE_URL}',
+                    f'INFO:airflow.task.operators:Waiting for run {RUN_ID} to complete.',
+                ],
+                logger.output,
+            )
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=sensor.retry_limit,
+            retry_delay=sensor.retry_delay_seconds,
+            retry_args=sensor.databricks_retry_args,
+        )
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)


### PR DESCRIPTION
This PR adds ``sensors`` sub-package and ``DatabricksJobRunSensor`` class to the Databricks provider. It allows us to wait for the completion of a Databricks job or task.

closes: #21379

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
