### PR TITLE
Fix retrieval of deprecated non-config values 

### DIFF
--- a/airflow/config_templates/config.yml.schema.json
+++ b/airflow/config_templates/config.yml.schema.json
@@ -36,7 +36,7 @@
             },
             "sensitive": {
               "type": "boolean",
-              "description": "When true, this option is sensitive and can be specified using AIRFLOW__{section}___{name}__SECRET or AIRFLOW__{section}___{name}__CMD environment variables. See: airflow.configuration.AirflowConfigParser.sensitive_config_values"
+              "description": "When true, this option is sensitive and can be specified using AIRFLOW__{section}___{name}__SECRET or AIRFLOW__{section}___{name}_CMD environment variables. See: airflow.configuration.AirflowConfigParser.sensitive_config_values"
             }
           },
           "required": [

--- a/tests/config_templates/deprecated.cfg
+++ b/tests/config_templates/deprecated.cfg
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# This is the template for Airflow's unit test configuration. When Airflow runs
+# unit tests, it looks for a configuration file at $AIRFLOW_HOME/unittests.cfg.
+# If it doesn't exist, Airflow uses this template to generate it by replacing
+# variables in curly braces with their global values from configuration.py.
+
+# Users should not modify this file; they should customize the generated
+# unittests.cfg instead.
+[core]
+sql_alchemy_conn = mysql://

--- a/tests/config_templates/deprecated_cmd.cfg
+++ b/tests/config_templates/deprecated_cmd.cfg
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# This is the template for Airflow's unit test configuration. When Airflow runs
+# unit tests, it looks for a configuration file at $AIRFLOW_HOME/unittests.cfg.
+# If it doesn't exist, Airflow uses this template to generate it by replacing
+# variables in curly braces with their global values from configuration.py.
+
+# Users should not modify this file; they should customize the generated
+# unittests.cfg instead.
+
+[core]
+sql_alchemy_conn_cmd = echo -n "postgresql://"

--- a/tests/config_templates/deprecated_secret.cfg
+++ b/tests/config_templates/deprecated_secret.cfg
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# This is the template for Airflow's unit test configuration. When Airflow runs
+# unit tests, it looks for a configuration file at $AIRFLOW_HOME/unittests.cfg.
+# If it doesn't exist, Airflow uses this template to generate it by replacing
+# variables in curly braces with their global values from configuration.py.
+
+# Users should not modify this file; they should customize the generated
+# unittests.cfg instead.
+
+[core]
+sql_alchemy_conn_secret = secret_path

--- a/tests/config_templates/empty.cfg
+++ b/tests/config_templates/empty.cfg
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# This is the template for Airflow's unit test configuration. When Airflow runs
+# unit tests, it looks for a configuration file at $AIRFLOW_HOME/unittests.cfg.
+# If it doesn't exist, Airflow uses this template to generate it by replacing
+# variables in curly braces with their global values from configuration.py.
+
+# Users should not modify this file; they should customize the generated
+# unittests.cfg instead.

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -42,6 +42,14 @@ from airflow.configuration import (
 )
 from tests.test_utils.config import conf_vars
 from tests.test_utils.reset_warning_registry import reset_warning_registry
+from tests.utils.test_config import (
+    remove_all_configurations,
+    set_deprecated_options,
+    set_sensitive_config_values,
+    use_config,
+)
+
+HOME_DIR = os.path.expanduser('~')
 
 
 @unittest.mock.patch.dict(
@@ -511,89 +519,6 @@ AIRFLOW_HOME = /root/airflow
         assert isinstance(section_dict['_test_only_float'], float)
         assert isinstance(section_dict['_test_only_string'], str)
 
-    @conf_vars(
-        {
-            ("celery", "worker_concurrency"): None,
-            ("celery", "celeryd_concurrency"): None,
-        }
-    )
-    def test_deprecated_options(self):
-        # Guarantee we have a deprecated setting, so we test the deprecation
-        # lookup even if we remove this explicit fallback
-        conf.deprecated_options = {
-            ('celery', 'worker_concurrency'): ('celery', 'celeryd_concurrency', '2.0.0'),
-        }
-
-        # Remove it so we are sure we use the right setting
-        conf.remove_option('celery', 'worker_concurrency')
-
-        with pytest.warns(DeprecationWarning):
-            with mock.patch.dict('os.environ', AIRFLOW__CELERY__CELERYD_CONCURRENCY="99"):
-                assert conf.getint('celery', 'worker_concurrency') == 99
-
-        with pytest.warns(DeprecationWarning), conf_vars({('celery', 'celeryd_concurrency'): '99'}):
-            assert conf.getint('celery', 'worker_concurrency') == 99
-
-    @conf_vars(
-        {
-            ('logging', 'logging_level'): None,
-            ('core', 'logging_level'): None,
-        }
-    )
-    def test_deprecated_options_with_new_section(self):
-        # Guarantee we have a deprecated setting, so we test the deprecation
-        # lookup even if we remove this explicit fallback
-        conf.deprecated_options = {
-            ('logging', 'logging_level'): ('core', 'logging_level', '2.0.0'),
-        }
-
-        # Remove it so we are sure we use the right setting
-        conf.remove_option('core', 'logging_level')
-        conf.remove_option('logging', 'logging_level')
-
-        with pytest.warns(DeprecationWarning):
-            with mock.patch.dict('os.environ', AIRFLOW__CORE__LOGGING_LEVEL="VALUE"):
-                assert conf.get('logging', 'logging_level') == "VALUE"
-
-        with pytest.warns(DeprecationWarning), conf_vars({('core', 'logging_level'): 'VALUE'}):
-            assert conf.get('logging', 'logging_level') == "VALUE"
-
-    @conf_vars(
-        {
-            ("celery", "result_backend"): None,
-            ("celery", "celery_result_backend"): None,
-            ("celery", "celery_result_backend_cmd"): None,
-        }
-    )
-    def test_deprecated_options_cmd(self):
-        # Guarantee we have a deprecated setting, so we test the deprecation
-        # lookup even if we remove this explicit fallback
-        conf.deprecated_options[('celery', "result_backend")] = 'celery', 'celery_result_backend', '2.0.0'
-        conf.sensitive_config_values.add(('celery', 'celery_result_backend'))
-
-        conf.remove_option('celery', 'result_backend')
-        with conf_vars({('celery', 'celery_result_backend_cmd'): '/bin/echo 99'}):
-            with pytest.warns(DeprecationWarning):
-                tmp = None
-                if 'AIRFLOW__CELERY__RESULT_BACKEND' in os.environ:
-                    tmp = os.environ.pop('AIRFLOW__CELERY__RESULT_BACKEND')
-                assert conf.getint('celery', 'result_backend') == 99
-                if tmp:
-                    os.environ['AIRFLOW__CELERY__RESULT_BACKEND'] = tmp
-
-    def test_deprecated_values_from_conf(self):
-        test_conf = AirflowConfigParser(default_config='')
-        # Guarantee we have deprecated settings, so we test the deprecation
-        # lookup even if we remove this explicit fallback
-        test_conf.deprecated_values = {
-            'core': {'hostname_callable': (re.compile(r':'), r'.', '2.1')},
-        }
-        test_conf.read_dict({'core': {'hostname_callable': 'socket:getfqdn'}})
-
-        with pytest.warns(FutureWarning):
-            test_conf.validate()
-            assert test_conf.get('core', 'hostname_callable') == 'socket.getfqdn'
-
     def test_auth_backends_adds_session(self):
         test_conf = AirflowConfigParser(default_config='')
         # Guarantee we have deprecated settings, so we test the deprecation
@@ -615,95 +540,6 @@ AIRFLOW_HOME = /root/airflow
                 test_conf.get('api', 'auth_backends')
                 == 'airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session'
             )
-
-    @pytest.mark.parametrize(
-        "old, new",
-        [
-            (
-                ("api", "auth_backend", "airflow.api.auth.backend.basic_auth"),
-                (
-                    "api",
-                    "auth_backends",
-                    "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session",
-                ),
-            ),
-            (
-                ("core", "sql_alchemy_conn", "postgres+psycopg2://localhost/postgres"),
-                ("database", "sql_alchemy_conn", "postgresql://localhost/postgres"),
-            ),
-        ],
-    )
-    def test_deprecated_env_vars_upgraded_and_removed(self, old, new):
-        test_conf = AirflowConfigParser(default_config='')
-        old_section, old_key, old_value = old
-        new_section, new_key, new_value = new
-        old_env_var = test_conf._env_var_name(old_section, old_key)
-        new_env_var = test_conf._env_var_name(new_section, new_key)
-
-        with pytest.warns(FutureWarning):
-            with unittest.mock.patch.dict('os.environ', **{old_env_var: old_value}):
-                # Can't start with the new env var existing...
-                os.environ.pop(new_env_var, None)
-
-                test_conf.validate()
-                assert test_conf.get(new_section, new_key) == new_value
-                # We also need to make sure the deprecated env var is removed
-                # so that any subprocesses don't use it in place of our updated
-                # value.
-                assert old_env_var not in os.environ
-                # and make sure we track the old value as well, under the new section/key
-                assert test_conf.upgraded_values[(new_section, new_key)] == old_value
-
-    @pytest.mark.parametrize(
-        "conf_dict",
-        [
-            {},  # Even if the section is absent from config file, environ still needs replacing.
-            {'core': {'hostname_callable': 'socket:getfqdn'}},
-        ],
-    )
-    def test_deprecated_values_from_environ(self, conf_dict):
-        def make_config():
-            test_conf = AirflowConfigParser(default_config='')
-            # Guarantee we have a deprecated setting, so we test the deprecation
-            # lookup even if we remove this explicit fallback
-            test_conf.deprecated_values = {
-                'core': {'hostname_callable': (re.compile(r':'), r'.', '2.1')},
-            }
-            test_conf.read_dict(conf_dict)
-            test_conf.validate()
-            return test_conf
-
-        with pytest.warns(FutureWarning):
-            with unittest.mock.patch.dict('os.environ', AIRFLOW__CORE__HOSTNAME_CALLABLE='socket:getfqdn'):
-                test_conf = make_config()
-                assert test_conf.get('core', 'hostname_callable') == 'socket.getfqdn'
-
-        with reset_warning_registry():
-            with warnings.catch_warnings(record=True) as warning:
-                with unittest.mock.patch.dict(
-                    'os.environ',
-                    AIRFLOW__CORE__HOSTNAME_CALLABLE='CarrierPigeon',
-                ):
-                    test_conf = make_config()
-                    assert test_conf.get('core', 'hostname_callable') == 'CarrierPigeon'
-                    assert [] == warning
-
-    def test_deprecated_funcs(self):
-        for func in [
-            'load_test_config',
-            'get',
-            'getboolean',
-            'getfloat',
-            'getint',
-            'has_option',
-            'remove_option',
-            'as_dict',
-            'set',
-        ]:
-            with mock.patch(f'airflow.configuration.conf.{func}') as mock_method:
-                with pytest.warns(DeprecationWarning):
-                    getattr(configuration, func)()
-                mock_method.assert_called_once()
 
     def test_command_from_env(self):
         test_cmdenv_config = '''[testcmdenv]
@@ -877,6 +713,20 @@ notacommand = OK
             assert 'sql_alchemy_conn' in conf_maintain_cmds['database']
             assert conf_maintain_cmds['database']['sql_alchemy_conn'] == conf_conn
 
+    @mock.patch.dict(
+        'os.environ', {"AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_CMD": "echo -n 'postgresql://'"}, clear=True
+    )
+    def test_as_dict_respects_sensitive_cmds_from_env(self):
+        test_conf = copy.deepcopy(conf)
+        test_conf.read_string("")
+
+        conf_materialize_cmds = test_conf.as_dict(display_sensitive=True, raw=True, include_cmds=True)
+
+        assert 'sql_alchemy_conn' in conf_materialize_cmds['database']
+        assert 'sql_alchemy_conn_cmd' not in conf_materialize_cmds['database']
+
+        assert conf_materialize_cmds['database']['sql_alchemy_conn'] == 'postgresql://'
+
     def test_gettimedelta(self):
         test_config = '''
 [invalid]
@@ -940,3 +790,474 @@ key7 =
         assert test_conf.gettimedelta('valid', 'key6') == datetime.timedelta(seconds=300)
         assert isinstance(test_conf.gettimedelta('default', 'key7'), type(None))
         assert test_conf.gettimedelta('default', 'key7') is None
+
+
+class TestDeprecatedConf:
+    @conf_vars(
+        {
+            ("celery", "worker_concurrency"): None,
+            ("celery", "celeryd_concurrency"): None,
+        }
+    )
+    def test_deprecated_options(self):
+        # Guarantee we have a deprecated setting, so we test the deprecation
+        # lookup even if we remove this explicit fallback
+        with set_deprecated_options(
+            deprecated_options={('celery', 'worker_concurrency'): ('celery', 'celeryd_concurrency', '2.0.0')}
+        ):
+            # Remove it so we are sure we use the right setting
+            conf.remove_option('celery', 'worker_concurrency')
+
+            with pytest.warns(DeprecationWarning):
+                with mock.patch.dict('os.environ', AIRFLOW__CELERY__CELERYD_CONCURRENCY="99"):
+                    assert conf.getint('celery', 'worker_concurrency') == 99
+
+            with pytest.warns(DeprecationWarning), conf_vars({('celery', 'celeryd_concurrency'): '99'}):
+                assert conf.getint('celery', 'worker_concurrency') == 99
+
+    @conf_vars(
+        {
+            ('logging', 'logging_level'): None,
+            ('core', 'logging_level'): None,
+        }
+    )
+    def test_deprecated_options_with_new_section(self):
+        # Guarantee we have a deprecated setting, so we test the deprecation
+        # lookup even if we remove this explicit fallback
+        with set_deprecated_options(
+            deprecated_options={('logging', 'logging_level'): ('core', 'logging_level', '2.0.0')}
+        ):
+            # Remove it so we are sure we use the right setting
+            conf.remove_option('core', 'logging_level')
+            conf.remove_option('logging', 'logging_level')
+
+            with pytest.warns(DeprecationWarning):
+                with mock.patch.dict('os.environ', AIRFLOW__CORE__LOGGING_LEVEL="VALUE"):
+                    assert conf.get('logging', 'logging_level') == "VALUE"
+
+            with pytest.warns(DeprecationWarning), conf_vars({('core', 'logging_level'): 'VALUE'}):
+                assert conf.get('logging', 'logging_level') == "VALUE"
+
+    @conf_vars(
+        {
+            ("celery", "result_backend"): None,
+            ("celery", "celery_result_backend"): None,
+            ("celery", "celery_result_backend_cmd"): None,
+        }
+    )
+    def test_deprecated_options_cmd(self):
+        # Guarantee we have a deprecated setting, so we test the deprecation
+        # lookup even if we remove this explicit fallback
+        with set_deprecated_options(
+            deprecated_options={('celery', "result_backend"): ('celery', 'celery_result_backend', '2.0.0')}
+        ), set_sensitive_config_values(sensitive_config_values={('celery', 'celery_result_backend')}):
+            conf.remove_option('celery', 'result_backend')
+            with conf_vars({('celery', 'celery_result_backend_cmd'): '/bin/echo 99'}):
+                with pytest.warns(DeprecationWarning):
+                    tmp = None
+                    if 'AIRFLOW__CELERY__RESULT_BACKEND' in os.environ:
+                        tmp = os.environ.pop('AIRFLOW__CELERY__RESULT_BACKEND')
+                    assert conf.getint('celery', 'result_backend') == 99
+                    if tmp:
+                        os.environ['AIRFLOW__CELERY__RESULT_BACKEND'] = tmp
+
+    def test_deprecated_values_from_conf(self):
+        test_conf = AirflowConfigParser(
+            default_config="""
+[core]
+executor=SequentialExecutor
+[database]
+sql_alchemy_conn=sqlite://test
+"""
+        )
+        # Guarantee we have deprecated settings, so we test the deprecation
+        # lookup even if we remove this explicit fallback
+        test_conf.deprecated_values = {
+            'core': {'hostname_callable': (re.compile(r':'), r'.', '2.1')},
+        }
+        test_conf.read_dict({'core': {'hostname_callable': 'socket:getfqdn'}})
+
+        with pytest.warns(FutureWarning):
+            test_conf.validate()
+            assert test_conf.get('core', 'hostname_callable') == 'socket.getfqdn'
+
+    @pytest.mark.parametrize(
+        "old, new",
+        [
+            (
+                ("api", "auth_backend", "airflow.api.auth.backend.basic_auth"),
+                (
+                    "api",
+                    "auth_backends",
+                    "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session",
+                ),
+            ),
+            (
+                ("core", "sql_alchemy_conn", "postgres+psycopg2://localhost/postgres"),
+                ("database", "sql_alchemy_conn", "postgresql://localhost/postgres"),
+            ),
+        ],
+    )
+    def test_deprecated_env_vars_upgraded_and_removed(self, old, new):
+        test_conf = AirflowConfigParser(
+            default_config="""
+[core]
+executor=SequentialExecutor
+[database]
+sql_alchemy_conn=sqlite://test
+"""
+        )
+        old_section, old_key, old_value = old
+        new_section, new_key, new_value = new
+        old_env_var = test_conf._env_var_name(old_section, old_key)
+        new_env_var = test_conf._env_var_name(new_section, new_key)
+
+        with pytest.warns(FutureWarning):
+            with unittest.mock.patch.dict('os.environ', **{old_env_var: old_value}):
+                # Can't start with the new env var existing...
+                os.environ.pop(new_env_var, None)
+
+                test_conf.validate()
+                assert test_conf.get(new_section, new_key) == new_value
+                # We also need to make sure the deprecated env var is removed
+                # so that any subprocesses don't use it in place of our updated
+                # value.
+                assert old_env_var not in os.environ
+                # and make sure we track the old value as well, under the new section/key
+                assert test_conf.upgraded_values[(new_section, new_key)] == old_value
+
+    @pytest.mark.parametrize(
+        "conf_dict",
+        [
+            {},  # Even if the section is absent from config file, environ still needs replacing.
+            {'core': {'hostname_callable': 'socket:getfqdn'}},
+        ],
+    )
+    def test_deprecated_values_from_environ(self, conf_dict):
+        def make_config():
+            test_conf = AirflowConfigParser(
+                default_config="""
+[core]
+executor=SequentialExecutor
+[database]
+sql_alchemy_conn=sqlite://test
+"""
+            )
+            # Guarantee we have a deprecated setting, so we test the deprecation
+            # lookup even if we remove this explicit fallback
+            test_conf.deprecated_values = {
+                'core': {'hostname_callable': (re.compile(r':'), r'.', '2.1')},
+            }
+            test_conf.read_dict(conf_dict)
+            test_conf.validate()
+            return test_conf
+
+        with pytest.warns(FutureWarning):
+            with unittest.mock.patch.dict('os.environ', AIRFLOW__CORE__HOSTNAME_CALLABLE='socket:getfqdn'):
+                test_conf = make_config()
+                assert test_conf.get('core', 'hostname_callable') == 'socket.getfqdn'
+
+        with reset_warning_registry():
+            with warnings.catch_warnings(record=True) as warning:
+                with unittest.mock.patch.dict(
+                    'os.environ',
+                    AIRFLOW__CORE__HOSTNAME_CALLABLE='CarrierPigeon',
+                ):
+                    test_conf = make_config()
+                    assert test_conf.get('core', 'hostname_callable') == 'CarrierPigeon'
+                    assert [] == warning
+
+    def test_deprecated_funcs(self):
+        for func in [
+            'load_test_config',
+            'get',
+            'getboolean',
+            'getfloat',
+            'getint',
+            'has_option',
+            'remove_option',
+            'as_dict',
+            'set',
+        ]:
+            with mock.patch(f'airflow.configuration.conf.{func}') as mock_method:
+                with pytest.warns(DeprecationWarning):
+                    getattr(configuration, func)()
+                mock_method.assert_called_once()
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_config(self, display_source: bool):
+        with use_config(config="deprecated.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=False,
+                include_cmds=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('mysql://', "airflow.cfg") if display_source else 'mysql://'
+            )
+            # database should be None because the deprecated value is set in config
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'mysql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql://"}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_both_env_and_config(self, display_source: bool):
+        with use_config(config="deprecated.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_cmds=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('postgresql://', "env var") if display_source else 'postgresql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'postgresql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql://"}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_both_env_and_config_exclude_env(
+        self, display_source: bool
+    ):
+        with use_config(config="deprecated.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=False,
+                include_cmds=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('mysql://', "airflow.cfg") if display_source else 'mysql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'mysql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN": "postgresql://"}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_env(self, display_source: bool):
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source, raw=True, display_sensitive=True, include_env=True
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('postgresql://', "env var") if display_source else 'postgresql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'postgresql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_conf_as_dict_when_both_conf_and_env_are_empty(self, display_source: bool):
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(display_source=display_source, raw=True, display_sensitive=True)
+            assert cfg_dict['core'].get('sql_alchemy_conn') is None
+            # database should be taken from default because the deprecated value is missing in config
+            assert cfg_dict['database'].get('sql_alchemy_conn') == (
+                (f'sqlite:///{HOME_DIR}/airflow/airflow.db', "default")
+                if display_source
+                else f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+            )
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_cmd_config(self, display_source: bool):
+        with use_config(config="deprecated_cmd.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_cmds=True,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('postgresql://', "cmd") if display_source else 'postgresql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'postgresql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict(
+        'os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD": "echo -n 'postgresql://'"}, clear=True
+    )
+    def test_conf_as_dict_when_deprecated_value_in_cmd_env(self, display_source: bool):
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_cmds=True,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('postgresql://', "cmd") if display_source else 'postgresql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'postgresql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict(
+        'os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD": "echo -n 'postgresql://'"}, clear=True
+    )
+    def test_conf_as_dict_when_deprecated_value_in_cmd_disabled_env(self, display_source: bool):
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_cmds=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') is None
+            assert cfg_dict['database'].get('sql_alchemy_conn') == (
+                (f'sqlite:///{HOME_DIR}/airflow/airflow.db', 'default')
+                if display_source
+                else f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+            )
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_cmd_disabled_config(self, display_source: bool):
+        with use_config(config="deprecated_cmd.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_cmds=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') is None
+            assert cfg_dict['database'].get('sql_alchemy_conn') == (
+                (f'sqlite:///{HOME_DIR}/airflow/airflow.db', 'default')
+                if display_source
+                else f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+            )
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET": "secret_path'"}, clear=True)
+    @mock.patch("airflow.configuration.get_custom_secret_backend")
+    def test_conf_as_dict_when_deprecated_value_in_secrets(
+        self, get_custom_secret_backend, display_source: bool
+    ):
+        get_custom_secret_backend.return_value.get_config.return_value = "postgresql://"
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_secret=True,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') == (
+                ('postgresql://', "secret") if display_source else 'postgresql://'
+            )
+            # database should be None because the deprecated value is set in env value
+            assert cfg_dict['database'].get('sql_alchemy_conn') is None
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == 'postgresql://'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch.dict('os.environ', {"AIRFLOW__CORE__SQL_ALCHEMY_CONN_SECRET": "secret_path'"}, clear=True)
+    @mock.patch("airflow.configuration.get_custom_secret_backend")
+    def test_conf_as_dict_when_deprecated_value_in_secrets_disabled_env(
+        self, get_custom_secret_backend, display_source: bool
+    ):
+        get_custom_secret_backend.return_value.get_config.return_value = "postgresql://"
+        with use_config(config="empty.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_secret=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') is None
+            assert cfg_dict['database'].get('sql_alchemy_conn') == (
+                (f'sqlite:///{HOME_DIR}/airflow/airflow.db', 'default')
+                if display_source
+                else f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+            )
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+
+    @pytest.mark.parametrize("display_source", [True, False])
+    @mock.patch("airflow.configuration.get_custom_secret_backend")
+    @mock.patch.dict('os.environ', {}, clear=True)
+    def test_conf_as_dict_when_deprecated_value_in_secrets_disabled_config(
+        self, get_custom_secret_backend, display_source: bool
+    ):
+        get_custom_secret_backend.return_value.get_config.return_value = "postgresql://"
+        with use_config(config="deprecated_secret.cfg"):
+            cfg_dict = conf.as_dict(
+                display_source=display_source,
+                raw=True,
+                display_sensitive=True,
+                include_env=True,
+                include_secret=False,
+            )
+            assert cfg_dict['core'].get('sql_alchemy_conn') is None
+            assert cfg_dict['database'].get('sql_alchemy_conn') == (
+                (f'sqlite:///{HOME_DIR}/airflow/airflow.db', 'default')
+                if display_source
+                else f'sqlite:///{HOME_DIR}/airflow/airflow.db'
+            )
+            if not display_source:
+                remove_all_configurations()
+                conf.read_dict(dictionary=cfg_dict)
+                os.environ.clear()
+                assert conf.get('database', 'sql_alchemy_conn') == f'sqlite:///{HOME_DIR}/airflow/airflow.db'

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Set, Tuple
+
+from airflow.configuration import conf
+
+log = logging.getLogger(__name__)
+
+# TODO(potiuk) change the tests use better approach sing Pytest fixtures rather than
+#              `unit_test_mode` parameter. It's potentially disruptive so we should not do it **JUST** yet
+
+
+def remove_all_configurations():
+    old_sections, old_proxies = (conf._sections, conf._proxies)
+    conf._sections = {}
+    conf._proxies = {}
+    return old_sections, old_proxies
+
+
+def restore_all_configurations(sections: Dict, proxies: Dict):
+    conf._sections = sections  # type: ignore
+    conf._proxies = proxies  # type: ignore
+
+
+@contextmanager
+def use_config(config: str):
+    """
+    Temporary load the deprecated test configuration.
+    """
+    sections, proxies = remove_all_configurations()
+    conf.read(str(Path(__file__).parents[1] / "config_templates" / config))
+    try:
+        yield
+    finally:
+        restore_all_configurations(sections, proxies)
+
+
+@contextmanager
+def set_deprecated_options(deprecated_options: Dict[Tuple[str, str], Tuple[str, str, str]]):
+    """
+    Temporary replaces deprecated options with the ones provided.
+    """
+    old_deprecated_options = conf.deprecated_options
+    conf.deprecated_options = deprecated_options
+    try:
+        yield
+    finally:
+        conf.deprecated_options = old_deprecated_options
+
+
+@contextmanager
+def set_sensitive_config_values(sensitive_config_values: Set[Tuple[str, str]]):
+    """
+    Temporary replaces sensitive values with the ones provided.
+    """
+    old_sensitive_config_values = conf.sensitive_config_values
+    conf.sensitive_config_values = sensitive_config_values
+    try:
+        yield
+    finally:
+        conf.sensitive_config_values = old_sensitive_config_values


### PR DESCRIPTION
It turned out that deprecation of config values did not work as
intended. While deprecation worked fine when the value was specified
in configuration value it did not work when `run_as_user` was used.

In those cases the "as_dict" option was used to generate temporary
configuratin and this temporary configuration contained default value
for the new configuration value - for example it caused that
the generated temporary value contained:

```
[database]
sql_alchemy_conn=sqlite:///{AIRFLOW_HOME}/airflow.db
```

Even if the deprecated `core/sql_alchemy_conn` was set (and no
new `database/sql_alchemy_conn` was set at the same time.

This effectively rendered the old installation that did not convert
to the new "database" configuration not working for run_as_user, because
the tasks run with "run_as_user" used wrong, empty sqlite database
instaead of the one configured for Airflow.

Also during adding tests, it turned out that the mechanism was also
not working as intended before - in case `_CMD` or `_SECRET` were used
as environment variables rather than configuration. In those cases
both _CMD and _SECRET should be evaluated during as_dict() evaluation,
because the "run_as_user" might have not enough permission to run the
command or retrieve secret. The _cmd and _secret variables were only
evaluated during as_dict() when they were in the config file (note
that this only happens when include_cmd, include_env, include_secret
are set to True).

The changes implemented in this PR fix both problems:

* the _CMD and _SECRET env vars are evaluated during as_dict when the
  respective include_* is set
* the defaults are only set for the values that have deprecations
  in case the deprecations have no values set in either of the ways:
    * in config file
    * in env variable
    * in _cmd (via config file or env variable)
    * in _secret (via config file or env variable)

Fixes: https://github.com/apache/airflow/issues/23679



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
