### PR TITLE
Fix grid details header text overlap

### DIFF
--- a/airflow/www/static/js/grid/details/Header.jsx
+++ b/airflow/www/static/js/grid/details/Header.jsx
@@ -83,21 +83,21 @@ const Header = () => {
   const isTaskDetails = runId && taskId;
 
   return (
-    <Breadcrumb mt={4} separator={<Text color="gray.300">/</Text>}>
-      <BreadcrumbItem isCurrentPage={isDagDetails}>
+    <Breadcrumb separator={<Text color="gray.300">/</Text>}>
+      <BreadcrumbItem isCurrentPage={isDagDetails} mt={4}>
         <BreadcrumbLink onClick={clearSelection} _hover={isDagDetails ? { cursor: 'default' } : undefined}>
           <LabelValue label="DAG" value={dagId} />
         </BreadcrumbLink>
       </BreadcrumbItem>
       {runId && (
-        <BreadcrumbItem isCurrentPage={isRunDetails}>
+        <BreadcrumbItem isCurrentPage={isRunDetails} mt={4}>
           <BreadcrumbLink onClick={() => onSelect({ runId })} _hover={isRunDetails ? { cursor: 'default' } : undefined}>
             <LabelValue label="Run" value={runLabel} />
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}
       {taskId && (
-        <BreadcrumbItem isCurrentPage>
+        <BreadcrumbItem isCurrentPage mt={4}>
           <BreadcrumbLink _hover={isTaskDetails ? { cursor: 'default' } : undefined}>
             <LabelValue label="Task" value={`${taskName}${isMapped ? ' []' : ''}`} />
           </BreadcrumbLink>


### PR DESCRIPTION
Problem: For long dag, run or task names, the grid details header will wrap and then the text will overlap.
<img width="474" alt="Screen Shot 2022-05-16 at 12 39 25 PM" src="https://user-images.githubusercontent.com/4600967/168642431-b2d0886d-da22-41e8-9885-70eaa27be44a.png">


Solution: Move top margin to each breadcrumb component to make sure that there is no overlap when the header wraps.
<img width="476" alt="Screen Shot 2022-05-16 at 12 39 15 PM" src="https://user-images.githubusercontent.com/4600967/168642442-c0f7ae06-2af9-47d8-a0ea-3c9647f2dbae.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
