### PR TITLE
add option to not encode UUID when upload from Cassandra to GCS

### DIFF
--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -79,6 +79,8 @@ class CassandraToGCSOperator(BaseOperator):
     :param query_timeout: (Optional) The amount of time, in seconds, used to execute the Cassandra query.
         If not set, the timeout value will be set in Session.execute() by Cassandra driver.
         If set to None, there is no timeout.
+    :param encode_uuid: (Optional) Option to encode UUID or not when upload from Cassandra to GCS.
+        Default is to encode UUID.
     """
 
     template_fields: Sequence[str] = (
@@ -105,6 +107,7 @@ class CassandraToGCSOperator(BaseOperator):
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         query_timeout: Union[float, None, NotSetType] = NOT_SET,
+        encode_uuid: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -120,6 +123,7 @@ class CassandraToGCSOperator(BaseOperator):
         self.gzip = gzip
         self.impersonation_chain = impersonation_chain
         self.query_timeout = query_timeout
+        self.encode_uuid = encode_uuid
 
     # Default Cassandra to BigQuery type mapping
     CQL_TYPE_MAP = {
@@ -256,13 +260,11 @@ class CassandraToGCSOperator(BaseOperator):
             gzip=self.gzip,
         )
 
-    @classmethod
-    def generate_data_dict(cls, names: Iterable[str], values: Any) -> Dict[str, Any]:
+    def generate_data_dict(self, names: Iterable[str], values: Any) -> Dict[str, Any]:
         """Generates data structure that will be stored as file in GCS."""
-        return {n: cls.convert_value(v) for n, v in zip(names, values)}
+        return {n: self.convert_value(v) for n, v in zip(names, values)}
 
-    @classmethod
-    def convert_value(cls, value: Optional[Any]) -> Optional[Any]:
+    def convert_value(self, value: Optional[Any]) -> Optional[Any]:
         """Convert value to BQ type."""
         if not value:
             return value
@@ -271,7 +273,10 @@ class CassandraToGCSOperator(BaseOperator):
         elif isinstance(value, bytes):
             return b64encode(value).decode('ascii')
         elif isinstance(value, UUID):
-            return b64encode(value.bytes).decode('ascii')
+            if self.encode_uuid:
+                return b64encode(value.bytes).decode('ascii')
+            else:
+                return str(value)
         elif isinstance(value, (datetime, Date)):
             return str(value)
         elif isinstance(value, Decimal):
@@ -279,51 +284,48 @@ class CassandraToGCSOperator(BaseOperator):
         elif isinstance(value, Time):
             return str(value).split('.')[0]
         elif isinstance(value, (list, SortedSet)):
-            return cls.convert_array_types(value)
+            return self.convert_array_types(value)
         elif hasattr(value, '_fields'):
-            return cls.convert_user_type(value)
+            return self.convert_user_type(value)
         elif isinstance(value, tuple):
-            return cls.convert_tuple_type(value)
+            return self.convert_tuple_type(value)
         elif isinstance(value, OrderedMapSerializedKey):
-            return cls.convert_map_type(value)
+            return self.convert_map_type(value)
         else:
             raise AirflowException('Unexpected value: ' + str(value))
 
-    @classmethod
-    def convert_array_types(cls, value: Union[List[Any], SortedSet]) -> List[Any]:
+    def convert_array_types(self, value: Union[List[Any], SortedSet]) -> List[Any]:
         """Maps convert_value over array."""
-        return [cls.convert_value(nested_value) for nested_value in value]
+        return [self.convert_value(nested_value) for nested_value in value]
 
-    @classmethod
-    def convert_user_type(cls, value: Any) -> Dict[str, Any]:
+    def convert_user_type(self, value: Any) -> Dict[str, Any]:
         """
         Converts a user type to RECORD that contains n fields, where n is the
         number of attributes. Each element in the user type class will be converted to its
         corresponding data type in BQ.
         """
         names = value._fields
-        values = [cls.convert_value(getattr(value, name)) for name in names]
-        return cls.generate_data_dict(names, values)
+        values = [self.convert_value(getattr(value, name)) for name in names]
+        return self.generate_data_dict(names, values)
 
-    @classmethod
-    def convert_tuple_type(cls, values: Tuple[Any]) -> Dict[str, Any]:
+    def convert_tuple_type(self, values: Tuple[Any]) -> Dict[str, Any]:
         """
         Converts a tuple to RECORD that contains n fields, each will be converted
         to its corresponding data type in bq and will be named 'field_<index>', where
         index is determined by the order of the tuple elements defined in cassandra.
         """
         names = ['field_' + str(i) for i in range(len(values))]
-        return cls.generate_data_dict(names, values)
+        return self.generate_data_dict(names, values)
 
-    @classmethod
-    def convert_map_type(cls, value: OrderedMapSerializedKey) -> List[Dict[str, Any]]:
+    def convert_map_type(self, value: OrderedMapSerializedKey) -> List[Dict[str, Any]]:
         """
         Converts a map to a repeated RECORD that contains two fields: 'key' and 'value',
         each will be converted to its corresponding data type in BQ.
         """
         converted_map = []
         for k, v in zip(value.keys(), value.values()):
-            converted_map.append({'key': cls.convert_value(k), 'value': cls.convert_value(v)})
+            converted_map.append({'key': self.convert_value(k),
+                                  'value': self.convert_value(v)})
         return converted_map
 
     @classmethod

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -71,6 +71,7 @@ class TestCassandraToGCS(unittest.TestCase):
 
     def test_convert_value(self):
         op = CassandraToGCSOperator
+        unencoded_uuid_op = CassandraToGCSOperator(encoded_uuid=False)
         assert op.convert_value(None) is None
         assert op.convert_value(1) == 1
         assert op.convert_value(1.0) == 1.0
@@ -95,6 +96,8 @@ class TestCassandraToGCS(unittest.TestCase):
         test_uuid = uuid.uuid4()
         encoded_uuid = b64encode(test_uuid.bytes).decode("ascii")
         assert op.convert_value(test_uuid) == encoded_uuid
+        unencoded_uuid = str(test_uuid)
+        assert unencoded_uuid_op.convert_value(test_uuid) == unencoded_uuid
 
         byte_str = b"abc"
         encoded_b = b64encode(byte_str).decode("ascii")


### PR DESCRIPTION
Issue#22846 -- allow option to encode or not encode UUID when upload from Cassandra to GCS.
As discussed in issue #22846, a new parameter 'encode_uuid' is added to allow user to choose not to encode UUID, while ensures backward compatibility. However, some class methods becomes instance methods as they need to intake this instance parameter. Please feel free to make changes and let me know if you find any issues or concerns by making this change. Thanks!

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
