### PR TITLE
cleanup usage of `get_connections()` from test suite

### DIFF
--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -643,13 +643,12 @@ class TestConnection(unittest.TestCase):
         },
     )
     def test_get_connections_env_var(self):
-        conns = SqliteHook.get_connections(conn_id='test_uri')
-        assert len(conns) == 1
-        assert conns[0].host == 'ec2.compute.com'
-        assert conns[0].schema == 'the_database'
-        assert conns[0].login == 'username'
-        assert conns[0].password == 'password'
-        assert conns[0].port == 5432
+        conns = SqliteHook.get_connection(conn_id='test_uri')
+        assert conns.host == 'ec2.compute.com'
+        assert conns.schema == 'the_database'
+        assert conns.login == 'username'
+        assert conns.password == 'password'
+        assert conns.port == 5432
 
     def test_connection_mixed(self):
         with pytest.raises(

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -24,10 +24,9 @@ from airflow.providers.amazon.aws.secrets.secrets_manager import SecretsManagerB
 
 class TestSecretsManagerBackend(TestCase):
     @mock.patch("airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend.get_conn_value")
-    def test_aws_secrets_manager_get_connections(self, mock_get_value):
+    def test_aws_secrets_manager_get_connection(self, mock_get_value):
         mock_get_value.return_value = "scheme://user:pass@host:100"
-        conn_list = SecretsManagerBackend().get_connections("fake_conn")
-        conn = conn_list[0]
+        conn = SecretsManagerBackend().get_connection("fake_conn")
         assert conn.host == 'host'
 
     @mock_secretsmanager
@@ -105,7 +104,7 @@ class TestSecretsManagerBackend(TestCase):
     def test_get_conn_uri_non_existent_key(self):
         """
         Test that if the key with connection ID is not present,
-        SecretsManagerBackend.get_connections should return None
+        SecretsManagerBackend.get_connection should return None
         """
         conn_id = "test_mysql"
 
@@ -124,7 +123,7 @@ class TestSecretsManagerBackend(TestCase):
         secrets_manager_backend.client.put_secret_value(**param)
 
         assert secrets_manager_backend.get_conn_uri(conn_id=conn_id) is None
-        assert [] == secrets_manager_backend.get_connections(conn_id=conn_id)
+        assert secrets_manager_backend.get_connection(conn_id=conn_id) is None
 
     @mock_secretsmanager
     def test_get_variable(self):

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -29,10 +29,9 @@ class TestSsmSecrets(TestCase):
         "airflow.providers.amazon.aws.secrets.systems_manager."
         "SystemsManagerParameterStoreBackend.get_conn_value"
     )
-    def test_aws_ssm_get_connections(self, mock_get_value):
+    def test_aws_ssm_get_connection(self, mock_get_value):
         mock_get_value.return_value = "scheme://user:pass@host:100"
-        conn_list = SystemsManagerParameterStoreBackend().get_connections("fake_conn")
-        conn = conn_list[0]
+        conn = SystemsManagerParameterStoreBackend().get_connection("fake_conn")
         assert conn.host == 'host'
 
     @mock_ssm
@@ -53,7 +52,7 @@ class TestSsmSecrets(TestCase):
     def test_get_conn_uri_non_existent_key(self):
         """
         Test that if the key with connection ID is not present in SSM,
-        SystemsManagerParameterStoreBackend.get_connections should return None
+        SystemsManagerParameterStoreBackend.get_connection should return None
         """
         conn_id = "test_mysql"
         param = {
@@ -66,7 +65,7 @@ class TestSsmSecrets(TestCase):
         ssm_backend.client.put_parameter(**param)
 
         assert ssm_backend.get_conn_uri(conn_id=conn_id) is None
-        assert [] == ssm_backend.get_connections(conn_id=conn_id)
+        assert ssm_backend.get_connection(conn_id=conn_id) is None
 
     @mock_ssm
     def test_get_variable(self):

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -109,12 +109,11 @@ class TestCloudSecretManagerBackend(TestCase):
 
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
     @mock.patch(MODULE_NAME + ".CloudSecretManagerBackend.get_conn_value")
-    def test_get_connections(self, mock_get_value, mock_get_creds):
+    def test_get_connection(self, mock_get_value, mock_get_creds):
         mock_get_creds.return_value = CREDENTIALS, PROJECT_ID
         mock_get_value.return_value = CONN_URI
-        conns = CloudSecretManagerBackend().get_connections(conn_id=CONN_ID)
-        assert isinstance(conns, list)
-        assert isinstance(conns[0], Connection)
+        conn = CloudSecretManagerBackend().get_connection(conn_id=CONN_ID)
+        assert isinstance(conn, Connection)
 
     @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
     @mock.patch(CLIENT_MODULE_NAME + ".SecretManagerServiceClient")
@@ -129,7 +128,7 @@ class TestCloudSecretManagerBackend(TestCase):
         secret_id = secrets_manager_backend.build_path(CONNECTIONS_PREFIX, CONN_ID, SEP)
         with self.assertLogs(secrets_manager_backend.client.log, level="ERROR") as log_output:
             assert secrets_manager_backend.get_conn_uri(conn_id=CONN_ID) is None
-            assert [] == secrets_manager_backend.get_connections(conn_id=CONN_ID)
+            assert secrets_manager_backend.get_connection(conn_id=CONN_ID) is None
             assert re.search(
                 f"Google Cloud API Call Error \\(NotFound\\): Secret ID {secret_id} not found",
                 log_output.output[0],

--- a/tests/providers/hashicorp/secrets/test_vault.py
+++ b/tests/providers/hashicorp/secrets/test_vault.py
@@ -175,7 +175,7 @@ class TestVaultSecrets(TestCase):
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_conn_uri_non_existent_key(self, mock_hvac):
         """
-        Test that if the key with connection ID is not present in Vault, _VaultClient.get_connections
+        Test that if the key with connection ID is not present in Vault, _VaultClient.get_connection
         should return None
         """
         mock_client = mock.MagicMock()
@@ -196,7 +196,7 @@ class TestVaultSecrets(TestCase):
         mock_client.secrets.kv.v2.read_secret_version.assert_called_once_with(
             mount_point='airflow', path='connections/test_mysql', version=None
         )
-        assert [] == test_client.get_connections(conn_id="test_mysql")
+        assert test_client.get_connection(conn_id="test_mysql") is None
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_variable_value(self, mock_hvac):
@@ -273,7 +273,7 @@ class TestVaultSecrets(TestCase):
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_variable_value_non_existent_key(self, mock_hvac):
         """
-        Test that if the key with connection ID is not present in Vault, _VaultClient.get_connections
+        Test that if the key with connection ID is not present in Vault, _VaultClient.get_connection
         should return None
         """
         mock_client = mock.MagicMock()
@@ -311,7 +311,7 @@ class TestVaultSecrets(TestCase):
         }
 
         with pytest.raises(VaultError, match="Vault Authentication Error!"):
-            VaultBackend(**kwargs).get_connections(conn_id='test')
+            VaultBackend(**kwargs).get_connection(conn_id='test')
 
     def test_auth_type_kubernetes_with_unreadable_jwt_raises_error(self):
         path = "/var/tmp/this_does_not_exist/334e918ef11987d3ef2f9553458ea09f"
@@ -323,7 +323,7 @@ class TestVaultSecrets(TestCase):
         }
 
         with pytest.raises(FileNotFoundError, match=path):
-            VaultBackend(**kwargs).get_connections(conn_id='test')
+            VaultBackend(**kwargs).get_connection(conn_id='test')
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_get_config_value(self, mock_hvac):

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -25,10 +25,9 @@ from airflow.providers.microsoft.azure.secrets.key_vault import AzureKeyVaultBac
 
 class TestAzureKeyVaultBackend(TestCase):
     @mock.patch('airflow.providers.microsoft.azure.secrets.key_vault.AzureKeyVaultBackend.get_conn_value')
-    def test_get_connections(self, mock_get_value):
+    def test_get_connection(self, mock_get_value):
         mock_get_value.return_value = 'scheme://user:pass@host:100'
-        conn_list = AzureKeyVaultBackend().get_connections('fake_conn')
-        conn = conn_list[0]
+        conn = AzureKeyVaultBackend().get_connection('fake_conn')
         assert conn.host == 'host'
 
     @mock.patch('airflow.providers.microsoft.azure.secrets.key_vault.DefaultAzureCredential')
@@ -54,14 +53,14 @@ class TestAzureKeyVaultBackend(TestCase):
     def test_get_conn_uri_non_existent_key(self, mock_client):
         """
         Test that if the key with connection ID is not present,
-        AzureKeyVaultBackend.get_connections should return None
+        AzureKeyVaultBackend.get_connection should return None
         """
         conn_id = 'test_mysql'
         mock_client.get_secret.side_effect = ResourceNotFoundError
         backend = AzureKeyVaultBackend(vault_url="https://example-akv-resource-name.vault.azure.net/")
 
         assert backend.get_conn_uri(conn_id=conn_id) is None
-        assert [] == backend.get_connections(conn_id=conn_id)
+        assert backend.get_connection(conn_id=conn_id) is None
 
     @mock.patch('airflow.providers.microsoft.azure.secrets.key_vault.AzureKeyVaultBackend.client')
     def test_get_variable(self, mock_client):
@@ -107,7 +106,7 @@ class TestAzureKeyVaultBackend(TestCase):
     def test_connection_prefix_none_value(self, mock_get_secret):
         """
         Test that if Connections prefix is None,
-        AzureKeyVaultBackend.get_connections should return None
+        AzureKeyVaultBackend.get_connection should return None
         AzureKeyVaultBackend._get_secret should not be called
         """
         kwargs = {'connections_prefix': None}

--- a/tests/secrets/test_secrets_backends.py
+++ b/tests/secrets/test_secrets_backends.py
@@ -62,9 +62,7 @@ class TestBaseSecretsBackend(unittest.TestCase):
         sample_conn_1 = SampleConn("sample_1", "A")
         env_secrets_backend = EnvironmentVariablesBackend()
         os.environ[sample_conn_1.var_name] = sample_conn_1.conn_uri
-        conn_list = env_secrets_backend.get_connections(sample_conn_1.conn_id)
-        assert 1 == len(conn_list)
-        conn = conn_list[0]
+        conn = env_secrets_backend.get_connection(sample_conn_1.conn_id)
 
         # we could make this more precise by defining __eq__ method for Connection
         assert sample_conn_1.host.lower() == conn.host
@@ -75,9 +73,8 @@ class TestBaseSecretsBackend(unittest.TestCase):
             session.add(sample_conn_2.conn)
             session.commit()
         metastore_backend = MetastoreBackend()
-        conn_list = metastore_backend.get_connections("sample_2")
-        host_list = {x.host for x in conn_list}
-        assert {sample_conn_2.host.lower()} == set(host_list)
+        conn = metastore_backend.get_connection("sample_2")
+        assert sample_conn_2.host.lower() == conn.host
 
     @mock.patch.dict(
         'os.environ',


### PR DESCRIPTION
The function is deprecated and raises warnings https://github.com/apache/airflow/pull/10192
Replacing the usage with `get_connection()`

Example:
```
tests/always/test_connection.py::TestConnection::test_get_connections_env_var

  /opt/airflow/tests/always/test_connection.py:646: PendingDeprecationWarning: `BaseHook.get_connections` method will be deprecated in the future.Please use `BaseHook.get_connection` instead.

    conns = SqliteHook.get_connections(conn_id='test_uri')
  
```
    
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
