### PR TITLE
Update credentials when using ADC in Compute Engine

### DIFF
--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -29,8 +29,9 @@ from urllib.parse import urlencode
 import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
-from google.auth import impersonated_credentials
+from google.auth import compute_engine, impersonated_credentials
 from google.auth.environment_vars import CREDENTIALS, LEGACY_PROJECT, PROJECT
+from google.auth.transport import _http_client
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -250,6 +251,9 @@ class _CredentialProvider(LoggingMixin):
             )
 
             project_id = _get_project_id_from_service_account_email(self.target_principal)
+
+        if isinstance(credentials, compute_engine.Credentials):
+            credentials.refresh(_http_client.Request())
 
         return credentials, project_id
 

--- a/airflow/providers/google/cloud/utils/credentials_provider.py
+++ b/airflow/providers/google/cloud/utils/credentials_provider.py
@@ -29,10 +29,8 @@ from urllib.parse import urlencode
 import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
-from google.auth import compute_engine, impersonated_credentials
+from google.auth import impersonated_credentials
 from google.auth.environment_vars import CREDENTIALS, LEGACY_PROJECT, PROJECT
-from google.auth.exceptions import RefreshError
-from google.auth.transport import _http_client
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud._internal_client.secret_manager_client import _SecretManagerClient
@@ -252,16 +250,6 @@ class _CredentialProvider(LoggingMixin):
             )
 
             project_id = _get_project_id_from_service_account_email(self.target_principal)
-
-        if isinstance(credentials, compute_engine.Credentials):
-            try:
-                credentials.refresh(_http_client.Request())
-            except RefreshError as msg:
-                """
-                If the Compute Engine metadata service can't be reached in this case the instance has not
-                credentials.
-                """
-                self._log_debug(msg)
 
         return credentials, project_id
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In this PR I have added code for refresh credentials when gcloud runs in Compute Engine and uses ADC. Because in this case google.auth library returns credential object with empty fields and user need to refresh this object.

Co-authored-by: Maksim Yermakou [maksimy@google.com](mailto:maksimy@google.com)
Co-authored-by: Wojciech Januszek [januszek@google.com](mailto:januszek@google.com)
Co-authored-by: Lukasz Wyszomirski [wyszomirski@google.com](mailto:wyszomirski@google.com)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
