### PR TITLE
Maintain grid view selection on filtering upstream

### DIFF
--- a/airflow/www/static/js/grid/ResetRoot.jsx
+++ b/airflow/www/static/js/grid/ResetRoot.jsx
@@ -33,7 +33,7 @@ const ResetRoot = () => (
         variant="outline"
         href={url}
         colorScheme="blue"
-        mr={2}
+        mx={2}
         title="Reset root to show the whole DAG"
       >
         Reset Root

--- a/airflow/www/static/js/grid/details/content/taskInstance/Nav.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/Nav.jsx
@@ -26,6 +26,7 @@ import {
 } from '@chakra-ui/react';
 
 import { getMetaValue, appendSearchParams } from '../../../../utils';
+import useSelection from '../../../utils/useSelection';
 
 const dagId = getMetaValue('dag_id');
 const isK8sExecutor = getMetaValue('k8s_or_k8scelery_executor') === 'True';
@@ -47,7 +48,7 @@ const LinkButton = ({ children, ...rest }) => (
 );
 
 const Nav = ({
-  taskId, executionDate, operator, isMapped,
+  runId, taskId, executionDate, operator, isMapped,
 }) => {
   const params = new URLSearchParams({
     task_id: taskId,
@@ -68,6 +69,8 @@ const Nav = ({
   }).toString();
 
   const filterParams = new URLSearchParams({
+    task_id: taskId,
+    dag_run_id: runId,
     base_date: baseDate,
     num_runs: numRuns,
     root: taskId,

--- a/airflow/www/static/js/grid/details/content/taskInstance/Nav.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/Nav.jsx
@@ -26,7 +26,6 @@ import {
 } from '@chakra-ui/react';
 
 import { getMetaValue, appendSearchParams } from '../../../../utils';
-import useSelection from '../../../utils/useSelection';
 
 const dagId = getMetaValue('dag_id');
 const isK8sExecutor = getMetaValue('k8s_or_k8scelery_executor') === 'True';

--- a/airflow/www/static/js/grid/details/content/taskInstance/index.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/index.jsx
@@ -83,6 +83,7 @@ const TaskInstance = ({ taskId, runId }) => {
       {!isGroup && (
         <TaskNav
           taskId={taskId}
+          runId={runId}
           isMapped={isMapped}
           executionDate={executionDate}
           operator={operator}


### PR DESCRIPTION
Clicking filter upstream was not persisting the selected task and run ids.
This PR adds those two params to the filter upstream link.

Also, adds a left margin to the "Reset root" button so it doesn't collide with the expand/collapse group buttons


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
