### PR TITLE
Support host_name on Datadog provider

### DIFF
--- a/airflow/providers/datadog/hooks/datadog.py
+++ b/airflow/providers/datadog/hooks/datadog.py
@@ -43,6 +43,7 @@ class DatadogHook(BaseHook, LoggingMixin):
         conn = self.get_connection(datadog_conn_id)
         self.api_key = conn.extra_dejson.get('api_key', None)
         self.app_key = conn.extra_dejson.get('app_key', None)
+        self.api_host = conn.extra_dejson.get('api_host', None)
         self.source_type_name = conn.extra_dejson.get('source_type_name', None)
 
         # If the host is populated, it will use that hostname instead.
@@ -53,7 +54,7 @@ class DatadogHook(BaseHook, LoggingMixin):
             raise AirflowException("api_key must be specified in the Datadog connection details")
 
         self.log.info("Setting up api keys for Datadog")
-        initialize(api_key=self.api_key, app_key=self.app_key)
+        initialize(api_key=self.api_key, app_key=self.app_key, api_host=self.api_host)
 
     def validate_response(self, response: Dict[str, Any]) -> None:
         """Validate Datadog response"""

--- a/tests/providers/datadog/hooks/test_datadog.py
+++ b/tests/providers/datadog/hooks/test_datadog.py
@@ -28,6 +28,7 @@ from airflow.providers.datadog.hooks.datadog import DatadogHook
 
 APP_KEY = 'app_key'
 API_KEY = 'api_key'
+API_HOST = 'api_host'
 METRIC_NAME = 'metric'
 DATAPOINT = 7
 TAGS = ['tag']
@@ -53,6 +54,7 @@ class TestDatadogHook(unittest.TestCase):
                 {
                     'app_key': APP_KEY,
                     'api_key': API_KEY,
+                    'api_host': API_HOST,
                 }
             )
         )


### PR DESCRIPTION
Setting the `api_host` is required `[...]/site-packages/datadog/__init__.py` in Datadog to send metrics/events/etc to other tenants like app.datadoghq.eu.

The tests for the provider do not seem to have any testing regarding `api_key` or `app_key`, but in case we leverage these in the future, I've added the to the `setUp`.


PS: Fixes the PR in https://github.com/apache/airflow/pull/23763 which was incorrectly marked as merged due to a force-pushed by my pull bot before it was merged.