### PR TITLE
Fix ``SqliteHook`` compatibility with SQLAlchemy engine

### DIFF
--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -36,6 +36,12 @@ class SqliteHook(DbApiHook):
         conn = sqlite3.connect(airflow_conn.host)
         return conn
 
+    def get_uri(self) -> str:
+        """Override DbApiHook get_uri method for get_sqlalchemy_engine()"""
+        conn_id = getattr(self, self.conn_name_attr)
+        airflow_conn = self.get_connection(conn_id)
+        return f"sqlite:///{airflow_conn.host}"
+
     @staticmethod
     def _generate_insert_sql(table, values, target_fields, replace, **kwargs):
         """

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -21,6 +21,8 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 
+import sqlalchemy
+
 from airflow.models import Connection
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 
@@ -126,3 +128,13 @@ class TestSqliteHook(unittest.TestCase):
         )
 
         assert sql == expected_sql
+
+    def test_sqlalchemy_engine(self):
+        """Test that the sqlalchemy engine is initialized"""
+        conn_id = 'sqlite_default'
+        hook = SqliteHook(sqlite_conn_id=conn_id)
+        engine = hook.get_sqlalchemy_engine()
+        assert isinstance(engine, sqlalchemy.engine.Engine)
+        assert engine.name == 'sqlite'
+        # Assert filepath of the sqliate DB is correct
+        assert engine.url.database == hook.get_connection(conn_id).host


### PR DESCRIPTION
Same as https://github.com/apache/airflow/pull/19508 but for Sqlite as described in https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#connect-strings to be able to create a Sqlalchemy engine from the URI itself.

Without this, it currently fails with the following error due to how we create URI in Connections. An absolute path is denoted by starting with a slash, means you need four slashes:

```
url = sqlite://%2Ftmp%2Fsqlite.db

    def create_connect_args(self, url):
        if url.username or url.password or url.host or url.port:
>           raise exc.ArgumentError(
                "Invalid SQLite URL: %s\n"
                "Valid SQLite URL forms are:\n"
                " sqlite:///:memory: (or, sqlite://)\n"
                " sqlite:///relative/path/to/file.db\n"
                " sqlite:////absolute/path/to/file.db" % (url,)
            )
E           sqlalchemy.exc.ArgumentError: Invalid SQLite URL: sqlite://%2Ftmp%2Fsqlite.db
E           Valid SQLite URL forms are:
E            sqlite:///:memory: (or, sqlite://)
E            sqlite:///relative/path/to/file.db
E            sqlite:////absolute/path/to/file.db
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
