### PR TITLE
Add "no-issue-needed" rule directly in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -71,7 +71,7 @@ fix an issue or make an enhancement, without needing to open an issue first.
 This is intended to make it as easy as possible to contribute to the project.
 
 If you however feel the need to open an issue (usually a bug or feature request)
-consider first to start `GitHub Discussion <https://github.com/apache/airflow/discussions>`_.
+consider starting with a `GitHub Discussion <https://github.com/apache/airflow/discussions>`_ instead.
 In vast majority of cases, discussions are better than issues - you should only open
 issues if you are sure you found a bug and have reproducible case to make the
 maintainers aware of it, or when you want to raise a feature request which you think

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,6 +66,18 @@ implement it.
 Issue reporting and resolution process
 --------------------------------------
 
+An unusual element of the Apache Airflow project is that you can open a PR to
+fix an issue or make an enhancement, without needing to open an issue first.
+This is intended to make it as easy as possible to contribute to the project.
+
+If you however feel the need to open an issue (usually a bug or feature request)
+consider first to start `GitHub Discussion <https://github.com/apache/airflow/discussions>`_.
+In vast majority of cases, discussions are better than issues - you should only open
+issues if you are sure you found a bug and have reproducible case to make the
+maintainers aware of it, or when you want to raise a feature request which you think
+does not require a lot of discussion. In case you have a very important topic
+to discuss - start a discussion on the `Devlist <https://lists.apache.org/list.html?dev@airflow.apache.org>`_.
+
 The Apache Airflow project uses a set of labels for tracking and triaging issues, as
 well as a set of priorities and milestones to track how and when the enhancements and bug
 fixes make it into an Airflow release. This is documented as part of

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,7 +72,7 @@ This is intended to make it as easy as possible to contribute to the project.
 
 If you however feel the need to open an issue (usually a bug or feature request)
 consider starting with a `GitHub Discussion <https://github.com/apache/airflow/discussions>`_ instead.
-In vast majority of cases, discussions are better than issues - you should only open
+In the vast majority of cases discussions are better than issues - you should only open
 issues if you are sure you found a bug and have reproducible case to make the
 maintainers aware of it, or when you want to raise a feature request which you think
 does not require a lot of discussion. In case you have a very important topic

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,10 +73,10 @@ This is intended to make it as easy as possible to contribute to the project.
 If you however feel the need to open an issue (usually a bug or feature request)
 consider starting with a `GitHub Discussion <https://github.com/apache/airflow/discussions>`_ instead.
 In the vast majority of cases discussions are better than issues - you should only open
-issues if you are sure you found a bug and have reproducible case to make the
-maintainers aware of it, or when you want to raise a feature request which you think
-does not require a lot of discussion. In case you have a very important topic
-to discuss - start a discussion on the `Devlist <https://lists.apache.org/list.html?dev@airflow.apache.org>`_.
+issues if you are sure you found a bug and have a reproducible case,
+or when you want to raise a feature request that will not require a lot of discussion.
+If you have a very important topic to discuss, start a discussion on the
+`Devlist <https://lists.apache.org/list.html?dev@airflow.apache.org>`_ instead.
 
 The Apache Airflow project uses a set of labels for tracking and triaging issues, as
 well as a set of priorities and milestones to track how and when the enhancements and bug


### PR DESCRIPTION
The rule was not really explained directly where you'd expect it,
it was hidden deeply in "triage" process where many contributors
would not even get to.

This PR adds appropriate explanation and also explains that
discussions is the preferred way to discuss things in Airflow
rather than issues.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
