### PR TITLE
Enable clicking on DAG owner in autocomplete dropdown

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -126,10 +126,10 @@ $('.typeahead').typeahead({
   afterSelect(value) {
     const query = new URLSearchParams(window.location.search);
     query.set('search', value.name);
-    if ('owner' == value.type) {
+    if (value.type === 'owner') {
       window.location = `${DAGS_INDEX}?${query}`;
     }
-    if ('dag' == value.type) {
+    if (value.type === 'dag') {
       window.location = `${gridUrl.replace('__DAG_ID__', value.name)}?${query}`;
     }
   },

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -124,10 +124,13 @@ $('.typeahead').typeahead({
   },
   autoSelect: false,
   afterSelect(value) {
-    const dagId = value.trim();
-    if (dagId) {
-      const query = new URLSearchParams(window.location.search);
-      window.location = `${gridUrl.replace('__DAG_ID__', dagId)}?${query}`;
+    const query = new URLSearchParams(window.location.search);
+    query.set('search', value.name);
+    if ('owner' == value.type) {
+      window.location = `${DAGS_INDEX}?${query}`;
+    }
+    if ('dag' == value.type) {
+      window.location = `${gridUrl.replace('__DAG_ID__', value.name)}?${query}`;
     }
   },
 });

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5127,12 +5127,18 @@ class AutocompleteView(AirflowBaseView):
             return wwwutils.json_response([])
 
         # Provide suggestions of dag_ids and owners
-        dag_ids_query = session.query(DagModel.dag_id.label('item')).filter(
-            ~DagModel.is_subdag, DagModel.is_active, DagModel.dag_id.ilike('%' + query + '%')
-        )
+        dag_ids_query = session.query(
+            sqla.literal('dag').label('type'),
+            DagModel.dag_id.label('name'),
+        ).filter(~DagModel.is_subdag, DagModel.is_active, DagModel.dag_id.ilike('%' + query + '%'))
 
-        owners_query = session.query(func.distinct(DagModel.owners).label('item')).filter(
-            ~DagModel.is_subdag, DagModel.is_active, DagModel.owners.ilike('%' + query + '%')
+        owners_query = (
+            session.query(
+                sqla.literal('owner').label('type'),
+                DagModel.owners.label('name'),
+            )
+            .distinct()
+            .filter(~DagModel.is_subdag, DagModel.is_active, DagModel.owners.ilike('%' + query + '%'))
         )
 
         # Hide DAGs if not showing status: "all"
@@ -5149,8 +5155,9 @@ class AutocompleteView(AirflowBaseView):
         dag_ids_query = dag_ids_query.filter(DagModel.dag_id.in_(filter_dag_ids))
         owners_query = owners_query.filter(DagModel.dag_id.in_(filter_dag_ids))
 
-        payload = [row[0] for row in dag_ids_query.union(owners_query).limit(10).all()]
-
+        payload = [
+            row._asdict() for row in dag_ids_query.union(owners_query).order_by('name').limit(10).all()
+        ]
         return wwwutils.json_response(payload)
 
 

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -244,11 +244,15 @@ def test_index_failure(dag_test_client):
 
 def test_dag_autocomplete_success(client_all_dags):
     resp = client_all_dags.get(
-        'dagmodel/autocomplete?query=example_bash',
+        'dagmodel/autocomplete?query=flow',
         follow_redirects=False,
     )
-    check_content_in_response('example_bash_operator', resp)
-    check_content_not_in_response('example_subdag_operator', resp)
+    assert resp.json == [
+        {'name': 'airflow', 'type': 'owner'},
+        {'name': 'test_mapped_taskflow', 'type': 'dag'},
+        {'name': 'tutorial_taskflow_api_etl', 'type': 'dag'},
+        {'name': 'tutorial_taskflow_api_etl_virtualenv', 'type': 'dag'},
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
PR#18991 introduced directly navigating to a DAG when selecting one from the typeahead search results. Unfortunately, the search results also includes DAG owner names, and selecting one of those navigates to a DAG with that name, which almost certainly doesn't exist.

This extends the autocompletion endpoint to return the type of result, and adjusts the typeahead selection to use this to know which way to navigate.

Fixes #23670.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
