### PR TITLE
Don't refresh mapped instances list when states are final

### DIFF
--- a/airflow/www/static/js/grid/api/useClearRun.js
+++ b/airflow/www/static/js/grid/api/useClearRun.js
@@ -50,6 +50,7 @@ export default function useClearRun(dagId, runId) {
       onSuccess: () => {
         // Invalidating the query will force a new API request
         queryClient.invalidateQueries('gridData');
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useClearTask.js
+++ b/airflow/www/static/js/grid/api/useClearTask.js
@@ -66,7 +66,7 @@ export default function useClearTask({
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
-        queryClient.invalidateQueries('mappedInstances', dagId, runId, taskId);
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
+++ b/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
@@ -70,7 +70,7 @@ describe('Test useMappedInstances hook', () => {
       taskId: 'task_id',
     }), { wrapper: Wrapper });
 
-    await new Promise((r) => { setTimeout(r, 10); });
+    await new Promise((r) => { setTimeout(r, 50); });
     await waitFor(() => result.current.isSuccess);
     scope.done();
     expect(result.current.data.taskInstances[0].state).toBe('queued');
@@ -97,7 +97,7 @@ describe('Test useMappedInstances hook', () => {
       taskId: 'task_id',
     }), { wrapper: Wrapper });
 
-    await new Promise((r) => { setTimeout(r, 10); });
+    await new Promise((r) => { setTimeout(r, 50); });
     await waitFor(() => result.current.isSuccess);
     scope.done();
     expect(result.current.data.taskInstances[0].state).toBe('success');

--- a/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
+++ b/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
@@ -70,7 +70,7 @@ describe('Test useMappedInstances hook', () => {
       taskId: 'task_id',
     }), { wrapper: Wrapper });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => { setTimeout(r, 10); });
     await waitFor(() => result.current.isSuccess);
     scope.done();
     expect(result.current.data.taskInstances[0].state).toBe('queued');
@@ -80,7 +80,7 @@ describe('Test useMappedInstances hook', () => {
       .query(true)
       .reply(200, { totalEntries: 2, taskInstances: [{ taskId: 'task_id', state: 'failed' }] });
 
-    await new Promise((_) => setTimeout(_, 300));
+    await new Promise((_) => { setTimeout(_, 300); });
     await waitFor(() => result.current.isSuccess);
     scope2.done();
     expect(result.current.data.taskInstances[0].state).toBe('failed');
@@ -97,7 +97,7 @@ describe('Test useMappedInstances hook', () => {
       taskId: 'task_id',
     }), { wrapper: Wrapper });
 
-    await new Promise((r) => setTimeout(r, 10));
+    await new Promise((r) => { setTimeout(r, 10); });
     await waitFor(() => result.current.isSuccess);
     scope.done();
     expect(result.current.data.taskInstances[0].state).toBe('success');
@@ -107,7 +107,7 @@ describe('Test useMappedInstances hook', () => {
       .query(true)
       .reply(200, { totalEntries: 2, taskInstances: [{ taskId: 'task_id', state: 'failed' }] });
 
-    await new Promise((r) => setTimeout(r, 300));
+    await new Promise((r) => { setTimeout(r, 300); });
     await waitFor(() => result.current.isSuccess);
     expect(result.current.data.taskInstances[0].state).toBe('success');
 

--- a/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
+++ b/airflow/www/static/js/grid/api/useMappedInstances.test.jsx
@@ -1,0 +1,133 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect, beforeEach, afterEach, jest */
+
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import nock from 'nock';
+
+import useMappedInstances from './useMappedInstances';
+import { AutoRefreshProvider } from '../context/autorefresh';
+import * as metaUtils from '../../utils';
+
+const pendingGridData = {
+  groups: {},
+  dag_runs: [
+    {
+      dag_id: 'example_python_operator',
+      run_id: 'manual__2021-11-08T21:14:17.170046+00:00',
+      start_date: null,
+      end_date: null,
+      state: 'queued',
+      execution_date: '2021-11-08T21:14:17.170046+00:00',
+      data_interval_start: '2021-11-08T21:14:17.170046+00:00',
+      data_interval_end: '2021-11-08T21:14:17.170046+00:00',
+      run_type: 'manual',
+    },
+  ],
+};
+
+const Wrapper = ({ children }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        cacheTime: Infinity,
+        staleTime: Infinity,
+      },
+    },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AutoRefreshProvider>
+        {children}
+      </AutoRefreshProvider>
+    </QueryClientProvider>
+  );
+};
+
+const fakeUrl = 'http://fake.api';
+
+describe('Test useMappedInstances hook', () => {
+  let spy;
+  beforeEach(() => {
+    global.autoRefreshInterval = 0.5;
+    spy = jest.spyOn(metaUtils, 'getMetaValue').mockReturnValue(`${fakeUrl}/_DAG_RUN_ID_/_TASK_ID_`);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    nock.cleanAll();
+  });
+
+  test('autorefresh works normally', async () => {
+    global.gridData = JSON.stringify(pendingGridData);
+
+    const scope = nock(fakeUrl)
+      .get('/run_id/task_id')
+      .query(true)
+      .reply(200, { totalEntries: 1, taskInstances: [{ taskId: 'task_id', state: 'queued' }] });
+    const { result, waitFor } = renderHook(() => useMappedInstances({
+      dagId: 'dag_id',
+      runId: 'run_id',
+      taskId: 'task_id',
+    }), { wrapper: Wrapper });
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data.taskInstances[0].state).toBe('queued');
+
+    const scope2 = nock(fakeUrl)
+      .get('/run_id/task_id')
+      .query(true)
+      .reply(200, { totalEntries: 2, taskInstances: [{ taskId: 'task_id', state: 'failed' }] });
+    await new Promise((r) => setTimeout(r, 600));
+    await waitFor(() => result.current.isSuccess);
+    scope.done();
+    scope2.done();
+
+    expect(result.current.data.taskInstances[0].state).toBe('failed');
+  });
+
+  test('autorefresh stops if all states are final', async () => {
+    global.gridData = JSON.stringify(pendingGridData);
+
+    const scope = nock(fakeUrl)
+      .get('/run_id/task_id')
+      .query(true)
+      .reply(200, { totalEntries: 1, taskInstances: [{ taskId: 'task_id', state: 'success' }] });
+    const { result, waitFor } = renderHook(() => useMappedInstances({
+      dagId: 'dag_id',
+      runId: 'run_id',
+      taskId: 'task_id',
+    }), { wrapper: Wrapper });
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data.taskInstances[0].state).toBe('success');
+
+    const scope2 = nock(fakeUrl)
+      .get('/run_id/task_id')
+      .query(true)
+      .reply(200, { totalEntries: 2, taskInstances: [{ taskId: 'task_id', state: 'failed' }] });
+    await new Promise((r) => setTimeout(r, 600));
+    await waitFor(() => result.current.isSuccess);
+    expect(result.current.data.taskInstances[0].state).toBe('success');
+
+    scope.done();
+    scope2.pendingMocks();
+  });
+});

--- a/airflow/www/static/js/grid/api/useMarkFailedRun.js
+++ b/airflow/www/static/js/grid/api/useMarkFailedRun.js
@@ -49,6 +49,7 @@ export default function useMarkFailedRun(dagId, runId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useMarkFailedTask.js
+++ b/airflow/www/static/js/grid/api/useMarkFailedTask.js
@@ -62,7 +62,7 @@ export default function useMarkFailedTask({
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
-        queryClient.invalidateQueries('mappedInstances', dagId, runId, taskId);
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useMarkSuccessRun.js
+++ b/airflow/www/static/js/grid/api/useMarkSuccessRun.js
@@ -49,6 +49,7 @@ export default function useMarkSuccessRun(dagId, runId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useMarkSuccessTask.js
+++ b/airflow/www/static/js/grid/api/useMarkSuccessTask.js
@@ -63,7 +63,7 @@ export default function useMarkSuccessTask({
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
-        queryClient.invalidateQueries('mappedInstances', dagId, runId, taskId);
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useQueueRun.js
+++ b/airflow/www/static/js/grid/api/useQueueRun.js
@@ -49,6 +49,7 @@ export default function useQueueRun(dagId, runId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/api/useRunTask.js
+++ b/airflow/www/static/js/grid/api/useRunTask.js
@@ -60,7 +60,7 @@ export default function useRunTask(dagId, runId, taskId) {
     {
       onSuccess: () => {
         queryClient.invalidateQueries('gridData');
-        queryClient.invalidateQueries('mappedInstances', dagId, runId, taskId);
+        queryClient.invalidateQueries('mappedInstances', dagId);
         startRefresh();
       },
       onError: (error) => errorToast({ error }),

--- a/airflow/www/static/js/grid/details/content/taskInstance/MappedInstances.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/MappedInstances.jsx
@@ -59,7 +59,7 @@ const MappedInstances = ({
   const order = sort && (sort.id === 'state' || sort.id === 'mapIndex') ? `${sort.desc ? '-' : ''}${snakeCase(sort.id)}` : '';
 
   const {
-    data: { taskInstances, totalEntries } = { taskInstances: [], totalEntries: 0 },
+    data: { taskInstances, totalEntries },
     isLoading,
   } = useMappedInstances({
     dagId, runId, taskId, limit, offset, order,

--- a/airflow/www/static/js/grid/utils/gridData.js
+++ b/airflow/www/static/js/grid/utils/gridData.js
@@ -17,31 +17,30 @@
  * under the License.
  */
 
-/* global describe, test, expect */
+import camelcaseKeys from 'camelcase-keys';
 
-import { areActiveRuns } from './useGridData';
+export const areActiveRuns = (runs = []) => runs.filter((run) => ['queued', 'running', 'scheduled', null].includes(run.state)).length > 0;
 
-describe('Test areActiveRuns()', () => {
-  test('Correctly detects active runs', () => {
-    const runs = [
-      { state: 'success' },
-      { state: 'queued' },
-    ];
-    expect(areActiveRuns(runs)).toBe(true);
-  });
+export const areActiveTasks = (tasks = []) => tasks.filter((task) => [
+  'queued',
+  'running',
+  'scheduled',
+  'deferred',
+  'up_for_retry',
+  'up_for_reschedule',
+  'sensing',
+  'restarting',
+  null,
+].includes(task.state)).length > 0;
 
-  test('Returns false when all runs are resolved', () => {
-    const runs = [
-      { state: 'success' },
-      { state: 'failed' },
-      { state: 'not_queued' },
-    ];
-    const result = areActiveRuns(runs);
-    expect(result).toBe(false);
-  });
-
-  test('Returns false when there are no runs', () => {
-    const result = areActiveRuns();
-    expect(result).toBe(false);
-  });
-});
+export const formatData = (data, emptyData) => {
+  if (!data || !Object.keys(data).length) {
+    return emptyData;
+  }
+  let formattedData = data;
+  // Convert to json if needed
+  if (typeof data === 'string') formattedData = JSON.parse(data);
+  // change from pascal to camelcase
+  formattedData = camelcaseKeys(formattedData, { deep: true });
+  return formattedData;
+};

--- a/airflow/www/static/js/grid/utils/gridData.test.js
+++ b/airflow/www/static/js/grid/utils/gridData.test.js
@@ -1,0 +1,72 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect */
+
+import { areActiveRuns, areActiveTasks } from './gridData';
+
+describe('Test areActiveRuns()', () => {
+  test('Correctly detects active runs', () => {
+    const runs = [
+      { state: 'success' },
+      { state: 'queued' },
+    ];
+    expect(areActiveRuns(runs)).toBe(true);
+  });
+
+  test('Returns false when all runs are resolved', () => {
+    const runs = [
+      { state: 'success' },
+      { state: 'failed' },
+      { state: 'not_queued' },
+    ];
+    const result = areActiveRuns(runs);
+    expect(result).toBe(false);
+  });
+
+  test('Returns false when there are no runs', () => {
+    const result = areActiveRuns();
+    expect(result).toBe(false);
+  });
+});
+
+describe('Test areActiveTasks()', () => {
+  test('Correctly detects active tasks', () => {
+    const tasks = [
+      { state: 'success' },
+      { state: 'deferred' },
+    ];
+    expect(areActiveTasks(tasks)).toBe(true);
+  });
+
+  test('Returns false when all tasks are resolved', () => {
+    const tasks = [
+      { state: 'success' },
+      { state: 'failed' },
+      { state: 'upstream_failed' },
+    ];
+    const result = areActiveTasks(tasks);
+    expect(result).toBe(false);
+  });
+
+  test('Returns false when there are no tasks', () => {
+    const result = areActiveRuns();
+    expect(result).toBe(false);
+  });
+});


### PR DESCRIPTION
If a user selects a mapped task, both the gridData and mappedInstances will auto-refresh.

To prevent excess API calls, we should stop refreshing mappedInstances if all the currently displayed instances are final. (ie: there are 100 tasks, the first page of 25 are done but the 75 others are still running).

Any run or task actions will invalidate the query and still call the API.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
