### PR TITLE
Fix UnboundLocalError when sql is empty list in ExasolHook

### DIFF
--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -132,6 +132,11 @@ class TestExasolHook(unittest.TestCase):
         self.conn.execute.assert_called_with(sql[1], None)
         self.conn.commit.assert_not_called()
 
+    def test_run_no_queries(self):
+        with pytest.raises(ValueError) as err:
+            self.db_hook.run(sql=[])
+        assert err.value.args[0] == "List of SQL statements is empty"
+
     def test_bulk_load(self):
         with pytest.raises(NotImplementedError):
             self.db_hook.bulk_load('table', '/tmp/file')


### PR DESCRIPTION
Raises `ValueError` if the SQL parameter is an empty list in ExasolHook.

related: #23767
