### PR TITLE
Fix UnboundLocalError when sql is empty list in DatabricksSqlHook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -167,7 +167,11 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         """
         if isinstance(sql, str):
             sql = self.maybe_split_sql_string(sql)
-        self.log.debug("Executing %d statements", len(sql))
+
+        if sql:
+            self.log.debug("Executing %d statements", len(sql))
+        else:
+            raise ValueError("List of SQL statements is empty")
 
         conn = None
         for sql_statement in sql:

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -20,6 +20,8 @@
 import unittest
 from unittest import mock
 
+import pytest
+
 from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 from airflow.utils.session import provide_session
@@ -82,3 +84,9 @@ class TestDatabricksSqlHookQueryByName(unittest.TestCase):
 
         cur.execute.assert_has_calls([mock.call(q) for q in [query]])
         cur.close.assert_called()
+
+    def test_no_query(self):
+        for empty_statement in ([], '', '\n'):
+            with pytest.raises(ValueError) as err:
+                self.hook.run(sql=empty_statement)
+            assert err.value.args[0] == "List of SQL statements is empty"


### PR DESCRIPTION
Fixes UnboundLocalError: local variable 'schema' referenced before assignment if the SQL parameter is an empty list in DatabricksSqlHook.

related: #23767
