### PR TITLE
Fix UnboundLocalError when sql is empty list in DbApiHook

### DIFF
--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -178,6 +178,11 @@ class DbApiHook(BaseHook):
         if scalar:
             sql = [sql]
 
+        if sql:
+            self.log.debug("Executing %d statements", len(sql))
+        else:
+            raise ValueError("List of SQL statements is empty")
+
         with closing(self.get_conn()) as conn:
             if self.supports_autocommit:
                 self.set_autocommit(conn, autocommit)

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -273,3 +273,8 @@ class TestDbApiHook(unittest.TestCase):
         assert called == 2
         assert self.conn.commit.called
         assert result == [obj, obj]
+
+    def test_run_no_queries(self):
+        with pytest.raises(ValueError) as err:
+            self.db_hook.run(sql=[])
+        assert err.value.args[0] == "List of SQL statements is empty"


### PR DESCRIPTION
Fixes UnboundLocalError: local variable 'results' referenced before assignment if the SQL parameter is an empty list in DbApiHook.

related: #23767