### PR TITLE
Add better feedback to Breeze users about expected action timing

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -380,17 +380,21 @@ def should_we_run_the_build(build_ci_params: BuildCiParams, verbose: bool) -> bo
         return False
     try:
         answer = user_confirm(
-            message="Do you want to build the image?", timeout=STANDARD_TIMEOUT, default_answer=Answer.NO
+            message="Do you want to build the image (this works best when you have good connection and "
+            "can take usually from 20 seconds to few minutes depending how old your image is)?",
+            timeout=STANDARD_TIMEOUT,
+            default_answer=Answer.NO,
         )
         if answer == answer.YES:
             if is_repo_rebased(build_ci_params.github_repository, build_ci_params.airflow_branch):
                 return True
             else:
                 get_console().print(
-                    "\n[warning]This might take a lot of time, we think you should rebase first.[/]\n"
+                    "\n[warning]This might take a lot of time (more than 10 minutes) even if you have"
+                    "a good network connection. We think you should attempt to rebase first.[/]\n"
                 )
                 answer = user_confirm(
-                    "But if you really, really want - you can do it. Are you really sure?",
+                    "But if you really, really want - you can attempt it. Are you really sure?",
                     timeout=STANDARD_TIMEOUT,
                     default_answer=Answer.NO,
                 )
@@ -398,8 +402,8 @@ def should_we_run_the_build(build_ci_params: BuildCiParams, verbose: bool) -> bo
                     return True
                 else:
                     get_console().print(
-                        "[info]Please rebase your code before continuing.[/]\n"
-                        "Check this link to know more "
+                        f"[info]Please rebase your code to latest {build_ci_params.airflow_branch} "
+                        "before continuing.[/]\nCheck this link to find out how "
                         "https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#id15\n"
                     )
                     get_console().print('[error]Exiting the process[/]\n')
@@ -535,6 +539,9 @@ def rebuild_ci_image_if_needed(
         if verbose:
             get_console().print(f'[info]{build_params.image_type} image already built locally.[/]')
     else:
-        get_console().print(f'[warning]{build_params.image_type} image not built locally. Forcing build.[/]')
+        get_console().print(
+            f'[warning]{build_params.image_type} image was never built locally or deleted. '
+            'Forcing build.[/]'
+        )
         ci_image_params.force_build = True
     build_ci_image(verbose, dry_run=dry_run, ci_image_params=ci_image_params)

--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -50,7 +50,8 @@ def ask_to_reinstall_breeze(breeze_sources: Path, timeout: Optional[int] = STAND
          otherwise it is yes
     """
     answer = user_confirm(
-        f"Do you want to reinstall Breeze from {breeze_sources.parent.parent}?",
+        f"Do you want to reinstall Breeze from {breeze_sources.parent.parent} "
+        "(This should usually take couple of seconds)?",
         default_answer=Answer.NO if timeout else Answer.YES,
         timeout=timeout,
     )
@@ -77,7 +78,8 @@ def warn_different_location(installation_airflow_sources: Path, current_airflow_
         f"Current Airflow sources : {current_airflow_sources}\n\n"
         f"[warning]This might cause various problems!![/]\n\n"
         f"If you experience problems - reinstall Breeze with:\n\n"
-        f"    {NAME} self-upgrade --force --use-current-airflow-sources\n\n"
+        f"    {NAME} self-upgrade --force --use-current-airflow-sources\n"
+        f"\nThis should usually take couple of seconds.\n"
     )
 
 
@@ -86,5 +88,6 @@ def warn_dependencies_changed():
         f"\n[warning]Breeze dependencies changed since the installation![/]\n\n"
         f"[warning]This might cause various problems!![/]\n\n"
         f"If you experience problems - reinstall Breeze with:\n\n"
-        f"    {NAME} self-upgrade --force\n\n"
+        f"    {NAME} self-upgrade --force\n"
+        "\nThis should usually take couple of seconds.\n"
     )


### PR DESCRIPTION
There are a few actions in Breeze that might take more or less time
when invoked. This is mostly when you need to upgrade Breeze or
update to latest version of the image because some dependedncies
were added or image was modified.

While we have improved significantly the waiting time involved
now (and caching problems have been fixed to make it as fast
possible), there are still a few situations that you need to have
a good connectivity and a little time to run the upgrade. Which
is often not something you would like to loose your time on in
a number of cases when you need to do things fast.

Usually Breeeze does not force the user to perform such long
actions - it allows to continue without doing them (either by
timeout or by letting user answer "no" to question asked.

Previously Breeze have not informed the user about the exepcted
time of running such operation, but with this change it tells
what is the expected delay - thus allowing the user to make
informed action whether they want to run the upgrade or not.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
