### PR TITLE
Add disable retry flag on backfill

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -352,7 +352,7 @@ ARG_CONTINUE_ON_FAILURES = Arg(
     action="store_true",
 )
 ARG_DISABLE_RETRY = Arg(
-    ("-dr", "--disable-retry"),
+    ("--disable-retry"),
     help=("if set, the backfill will set tasks as failed without retrying."),
     action="store_true",
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -352,7 +352,7 @@ ARG_CONTINUE_ON_FAILURES = Arg(
     action="store_true",
 )
 ARG_DISABLE_RETRY = Arg(
-    ("--disable-retry"),
+    ("--disable-retry",),
     help=("if set, the backfill will set tasks as failed without retrying."),
     action="store_true",
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -351,6 +351,11 @@ ARG_CONTINUE_ON_FAILURES = Arg(
     help=("if set, the backfill will keep going even if some of the tasks failed"),
     action="store_true",
 )
+ARG_DISABLE_RETRY = Arg(
+    ("-dr", "--disable-retry"),
+    help=("if set, the backfill will set tasks as failed without retrying."),
+    action="store_true",
+)
 ARG_RUN_BACKWARDS = Arg(
     (
         "-B",
@@ -1160,6 +1165,7 @@ DAGS_COMMANDS = (
             ARG_DONOT_PICKLE,
             ARG_YES,
             ARG_CONTINUE_ON_FAILURES,
+            ARG_DISABLE_RETRY,
             ARG_BF_IGNORE_DEPENDENCIES,
             ARG_BF_IGNORE_FIRST_DEPENDS_ON_PAST,
             ARG_SUBDIR,

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -127,6 +127,7 @@ def dag_backfill(args, dag=None):
                     rerun_failed_tasks=args.rerun_failed_tasks,
                     run_backwards=args.run_backwards,
                     continue_on_failures=args.continue_on_failures,
+                    disable_retry=args.disable_retry,
                 )
             except ValueError as vr:
                 print(str(vr))

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -631,7 +631,7 @@ class BackfillJob(BaseJob):
                     new_ti.set_state(TaskInstanceState.SCHEDULED, session=session)
 
             # Set state to failed for running TIs that are set up for retry if disable-retry flag is set
-            for ti in list(ti_status.running.values()):
+            for ti in ti_status.running.values():
                 if self.disable_retry and ti.state == TaskInstanceState.UP_FOR_RETRY:
                     ti.set_state(TaskInstanceState.FAILED, session=session)
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -117,6 +117,7 @@ class BackfillJob(BaseJob):
         run_backwards=False,
         run_at_least_once=False,
         continue_on_failures=False,
+        disable_retry=False,
         *args,
         **kwargs,
     ):
@@ -156,6 +157,7 @@ class BackfillJob(BaseJob):
         self.run_backwards = run_backwards
         self.run_at_least_once = run_at_least_once
         self.continue_on_failures = continue_on_failures
+        self.disable_retry = disable_retry
         super().__init__(*args, **kwargs)
 
     def _update_counters(self, ti_status, session=None):
@@ -627,6 +629,11 @@ class BackfillJob(BaseJob):
 
                 for new_ti in new_mapped_tis:
                     new_ti.set_state(TaskInstanceState.SCHEDULED, session=session)
+
+            # Set state to failed for running TIs that are set up for retry if disable-retry flag is set
+            for ti in list(ti_status.running.values()):
+                if self.disable_retry and ti.state == TaskInstanceState.UP_FOR_RETRY:
+                    ti.set_state(TaskInstanceState.FAILED, session=session)
 
             # update the task counters
             self._update_counters(ti_status=ti_status, session=session)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2396,6 +2396,7 @@ class DAG(LoggingMixin):
         run_backwards=False,
         run_at_least_once=False,
         continue_on_failures=False,
+        disable_retry=False,
     ):
         """
         Runs the DAG.
@@ -2446,6 +2447,7 @@ class DAG(LoggingMixin):
             run_backwards=run_backwards,
             run_at_least_once=run_at_least_once,
             continue_on_failures=continue_on_failures,
+            disable_retry=disable_retry,
         )
         job.run()
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -130,6 +130,7 @@ class TestCliDags:
             run_backwards=False,
             verbose=False,
             continue_on_failures=False,
+            disable_retry=False,
         )
         mock_run.reset_mock()
         dag = self.dagbag.get_dag("example_bash_operator")
@@ -202,6 +203,7 @@ class TestCliDags:
             run_backwards=False,
             verbose=False,
             continue_on_failures=False,
+            disable_retry=False,
         )
         mock_run.reset_mock()
 
@@ -337,6 +339,7 @@ class TestCliDags:
             run_backwards=False,
             verbose=False,
             continue_on_failures=False,
+            disable_retry=False,
         )
 
     @mock.patch("airflow.cli.commands.dag_command.DAG.run")
@@ -377,6 +380,7 @@ class TestCliDags:
             run_backwards=True,
             verbose=False,
             continue_on_failures=False,
+            disable_retry=False,
         )
 
     def test_next_execution(self):

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1838,7 +1838,7 @@ class TestBackfillJob:
             assert State.NONE in states
 
     @pytest.mark.parametrize(
-        ['disable_retry', 'try_number', 'exception'],
+        ["disable_retry", "try_number", "exception"],
         (
             (True, 1, BackfillUnfinished),
             (False, 2, AirflowException),
@@ -1846,11 +1846,11 @@ class TestBackfillJob:
     )
     def test_backfill_disable_retry(self, dag_maker, disable_retry, try_number, exception):
         with dag_maker(
-            dag_id='test_disable_retry',
+            dag_id="test_disable_retry",
             schedule_interval="@daily",
             default_args={
-                'retries': 2,
-                'retry_delay': datetime.timedelta(seconds=3),
+                "retries": 2,
+                "retry_delay": datetime.timedelta(seconds=3),
             },
         ) as dag:
             task1 = EmptyOperator(task_id="task1")


### PR DESCRIPTION
Oftentimes while backfilling the data it's known that some day will fail due to some source being unable to provide the data or due to retention period (on the source). Meaning, backfill take longer than it should.
For that reason `disable_retry` is implemented so the backfill set the states of all TIs to FAILED on a first `UP_FOR_RETRY` show up.