### PR TITLE
Fix exception trying to display moved table warnings

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -845,7 +845,7 @@ class Airflow(AirflowBaseView):
                 if segments[0] != settings.AIRFLOW_MOVED_TABLE_PREFIX:
                     continue
                 # Second segment is a version marker that we don't need to show.
-                yield segments[3], table_name
+                yield segments[-1], table_name
 
         if (
             permissions.ACTION_CAN_ACCESS_MENU,


### PR DESCRIPTION
The count argument to str.split is now many times to split, meaning you
get at most n+1 values back.

But more importantly, in a string like `_airflow_moved__2_2__task_fail`
split on `__` we are going to get three values at index 0, 1, and 2. Not
3.

Fixes up #23635
![image](https://user-images.githubusercontent.com/34150/169611299-9e4988e1-d79e-476c-8445-2584b03c3ab3.png)
