### PR TITLE
Fix ``RedshiftCreateClusterOperator``  for single-node cluster type

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -176,8 +176,8 @@ class RedshiftCreateClusterOperator(BaseOperator):
             params["DBName"] = self.db_name
         if self.cluster_type:
             params["ClusterType"] = self.cluster_type
-        if self.number_of_nodes:
-            params["NumberOfNodes"] = self.number_of_nodes
+            if self.cluster_type == "multi-node":
+                params["NumberOfNodes"] = self.number_of_nodes
         if self.cluster_security_groups:
             params["ClusterSecurityGroups"] = self.cluster_security_groups
         if self.vpc_security_group_ids:


### PR DESCRIPTION
`NumberOfNodes ` param in AWS API requires only when we create a multi-node cluster. The current operator is sending default value 1 even in single-node, so the operator is failing. In this PR I'm modifying the code so that `NumberOfNodes` will be passed to AWS only in case of multi-node cluster type. 