### PR TITLE
Add limit for JPype1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -411,6 +411,10 @@ influxdb = [
 ]
 jdbc = [
     'jaydebeapi>=1.1.1',
+    # JPype1 has been published without sdist in PyPI which caused failures when trying to build an
+    # ARM image (JPype1 does not publish binary ARM packages)
+    # The whole line below can be removed when https://github.com/jpype-project/jpype/issues/1069 is solved
+    'jpype1<1.4.0',
 ]
 jenkins = [
     'python-jenkins>=1.0.0',


### PR DESCRIPTION
The JPype1 limit has to be introduced because otherwise the 1.4.0
JPype1 breaks our ARM builds. The 1.4.0 did not release the sdist
version of the package. This made our cache refresh job to fail
as 1.4.0 version cannot be installed on ARM image.

The issue is captured in
https://github.com/jpype-project/jpype/issues/1069

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
