### PR TITLE
Fix Amazon EKS example DAG raises warning during Imports

### DIFF
--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -289,7 +289,7 @@ class EksCreateNodegroupOperator(BaseOperator):
                         "The nodegroup_subnets should be List or string representing "
                         "Python list and is %s. Defaulting to []",
                         self.nodegroup_subnets,
-                    )   
+                    )
             self.nodegroup_subnets = nodegroup_subnets_list
 
         eks_hook = EksHook(

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -275,23 +275,23 @@ class EksCreateNodegroupOperator(BaseOperator):
         self.create_nodegroup_kwargs = create_nodegroup_kwargs or {}
         self.aws_conn_id = aws_conn_id
         self.region = region
-        nodegroup_subnets_list: List[str] = []
-        if isinstance(nodegroup_subnets, str):
-            if nodegroup_subnets != "":
+        self.nodegroup_subnets = nodegroup_subnets
+        super().__init__(**kwargs)
+
+    def execute(self, context: 'Context'):
+        if isinstance(self.nodegroup_subnets, str):
+            nodegroup_subnets_list: List[str] = []
+            if self.nodegroup_subnets != "":
                 try:
-                    nodegroup_subnets_list = cast(List, literal_eval(nodegroup_subnets))
+                    nodegroup_subnets_list = cast(List, literal_eval(self.nodegroup_subnets))
                 except ValueError:
                     self.log.warning(
                         "The nodegroup_subnets should be List or string representing "
                         "Python list and is %s. Defaulting to []",
-                        nodegroup_subnets,
-                    )
-        else:
-            nodegroup_subnets_list = nodegroup_subnets
-        self.nodegroup_subnets = nodegroup_subnets_list
-        super().__init__(**kwargs)
+                        self.nodegroup_subnets,
+                    )   
+            self.nodegroup_subnets = nodegroup_subnets_list
 
-    def execute(self, context: 'Context'):
         eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Moving the `nodegroup_subnets` out of `__init__` into `execute()`. 
So that string evaluations won't occur during imports.

closes: #23756 
