### PR TITLE
Add default task retry delay config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -249,6 +249,14 @@
       type: string
       example: ~
       default: "0"
+    - name: default_task_retry_delay
+      description: |
+          The number of seconds each task is going to wait by default between retries. Can be overridden at
+          dag or task level.
+      version_added: 2.3.2
+      type: integer
+      example: ~
+      default: 300
     - name: default_task_weight_rule
       description: |
         The weighting method used for the effective total priority weight of the task

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -256,7 +256,7 @@
       version_added: 2.3.2
       type: integer
       example: ~
-      default: 300
+      default: "300"
     - name: default_task_weight_rule
       description: |
         The weighting method used for the effective total priority weight of the task

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -147,7 +147,8 @@ dag_ignore_file_syntax = regexp
 # The number of retries each task is going to have by default. Can be overridden at dag or task level.
 default_task_retries = 0
 
-# The number of seconds each task is going to wait by default between retries. Can be overridden at dag or task level.
+# The number of seconds each task is going to wait by default between retries. Can be overridden at
+# dag or task level.
 default_task_retry_delay = 300
 
 # The weighting method used for the effective total priority weight of the task

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -147,6 +147,9 @@ dag_ignore_file_syntax = regexp
 # The number of retries each task is going to have by default. Can be overridden at dag or task level.
 default_task_retries = 0
 
+# The number of seconds each task is going to wait by default between retries. Can be overridden at dag or task level.
+default_task_retry_delay = 300
+
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -62,7 +62,9 @@ DEFAULT_POOL_SLOTS: int = 1
 DEFAULT_PRIORITY_WEIGHT: int = 1
 DEFAULT_QUEUE: str = conf.get_mandatory_value("operators", "default_queue")
 DEFAULT_RETRIES: int = conf.getint("core", "default_task_retries", fallback=0)
-DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(seconds=300)
+DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(
+    seconds=conf.getint("core", "default_task_retry_delay", fallback=300)
+)
 DEFAULT_WEIGHT_RULE: WeightRule = WeightRule(
     conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
 )

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -994,3 +994,25 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
     assert op.value == "{{ ds }}", "Should not be templated!"
     assert op.arg1 == "{{ ds }}"
     assert op.arg2 == "a"
+
+
+def test_default_retry_delay(dag_maker):
+    with dag_maker(dag_id='test_default_retry_delay'):
+        task1 = BaseOperator(task_id='test_no_explicit_retry_delay')
+
+        assert task1.retry_delay == timedelta(seconds=300)
+
+
+def test_dag_level_retry_delay(dag_maker):
+    with dag_maker(dag_id='test_dag_level_retry_delay', default_args={'retry_delay': timedelta(seconds=100)}):
+        task1 = BaseOperator(task_id='test_no_explicit_retry_delay')
+
+        assert task1.retry_delay == timedelta(seconds=100)
+
+
+def test_task_level_retry_delay(dag_maker):
+    with dag_maker(dag_id='test_task_level_retry_delay',
+                   default_args={'retry_delay': timedelta(seconds=100)}):
+        task1 = BaseOperator(task_id='test_no_explicit_retry_delay', retry_delay=timedelta(seconds=200))
+
+        assert task1.retry_delay == timedelta(seconds=200)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -1011,8 +1011,9 @@ def test_dag_level_retry_delay(dag_maker):
 
 
 def test_task_level_retry_delay(dag_maker):
-    with dag_maker(dag_id='test_task_level_retry_delay',
-                   default_args={'retry_delay': timedelta(seconds=100)}):
+    with dag_maker(
+        dag_id='test_task_level_retry_delay', default_args={'retry_delay': timedelta(seconds=100)}
+    ):
         task1 = BaseOperator(task_id='test_no_explicit_retry_delay', retry_delay=timedelta(seconds=200))
 
         assert task1.retry_delay == timedelta(seconds=200)


### PR DESCRIPTION
Adding a cluster level support for task retry delay, so one doesn't need to specify at each dag or task level if it's different from 300s. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
