### PR TITLE
Use '--subdir' argument value for standalone dag processor.

### DIFF
--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -22,7 +22,6 @@ from datetime import timedelta
 import daemon
 from daemon.pidfile import TimeoutPIDLockFile
 
-from airflow import settings
 from airflow.configuration import conf
 from airflow.dag_processing.manager import DagFileProcessorManager
 from airflow.utils import cli as cli_utils
@@ -36,7 +35,7 @@ def _create_dag_processor_manager(args) -> DagFileProcessorManager:
     processor_timeout_seconds: int = conf.getint('core', 'dag_file_processor_timeout')
     processor_timeout = timedelta(seconds=processor_timeout_seconds)
     return DagFileProcessorManager(
-        dag_directory=settings.DAGS_FOLDER,
+        dag_directory=args.subdir,
         max_runs=args.num_runs,
         processor_timeout=processor_timeout,
         dag_ids=[],


### PR DESCRIPTION
The value defaults to  `settings.DAGS_FOLDER` if not set:
https://github.com/apache/airflow/blob/637a8b8af132e6231756160a3f6ce7ed789abaf6/airflow/cli/cli_parser.py#L193