### PR TITLE
DAG regex flag in backfill command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -351,6 +351,13 @@ ARG_RUN_BACKWARDS = Arg(
     ),
     action="store_true",
 )
+ARG_TREAT_DAG_AS_REGEX = Arg(
+    ("--treat-dag-as-regex",),
+    help=(
+        "if set, dag_id will be treated as regex instead of an exact string"
+    ),
+    action="store_true",
+)
 # test_dag
 ARG_SHOW_DAGRUN = Arg(
     ("--show-dagrun",),
@@ -1135,7 +1142,7 @@ DAGS_COMMANDS = (
             ARG_RESET_DAG_RUN,
             ARG_RERUN_FAILED_TASKS,
             ARG_RUN_BACKWARDS,
-            ARG_DAG_REGEX,
+            ARG_TREAT_DAG_AS_REGEX,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -353,9 +353,7 @@ ARG_RUN_BACKWARDS = Arg(
 )
 ARG_TREAT_DAG_AS_REGEX = Arg(
     ("--treat-dag-as-regex",),
-    help=(
-        "if set, dag_id will be treated as regex instead of an exact string"
-    ),
+    help=("if set, dag_id will be treated as regex instead of an exact string"),
     action="store_true",
 )
 # test_dag

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1135,6 +1135,7 @@ DAGS_COMMANDS = (
             ARG_RESET_DAG_RUN,
             ARG_RERUN_FAILED_TASKS,
             ARG_RUN_BACKWARDS,
+            ARG_DAG_REGEX,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -40,14 +40,16 @@ from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils
-from airflow.utils.cli import get_dag, process_subdir, sigint_handler, suppress_logs_and_warning
+from airflow.utils.cli import get_dag, get_dags, process_subdir, sigint_handler, suppress_logs_and_warning
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
 
+log = logging.getLogger(__name__)
+
 
 @cli_utils.action_cli
-def dag_backfill(args, dag=None):
+def dag_backfill(args, dags=None):
     """Creates backfill job or dry run for a DAG"""
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
 
@@ -66,64 +68,68 @@ def dag_backfill(args, dag=None):
     if not args.start_date and not args.end_date:
         raise AirflowException("Provide a start_date and/or end_date")
 
-    dag = dag or get_dag(args.subdir, args.dag_id)
+    dags = dags or get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.dag_regex)
 
     # If only one date is passed, using same as start and end
     args.end_date = args.end_date or args.start_date
     args.start_date = args.start_date or args.end_date
 
-    if args.task_regex:
-        dag = dag.partial_subset(
-            task_ids_or_regex=args.task_regex, include_upstream=not args.ignore_dependencies
-        )
-        if not dag.task_dict:
-            raise AirflowException(
-                f"There are no tasks that match '{args.task_regex}' regex. Nothing to run, exiting..."
-            )
-
     run_conf = None
     if args.conf:
         run_conf = json.loads(args.conf)
 
-    if args.dry_run:
-        print(f"Dry run of DAG {args.dag_id} on {args.start_date}")
-        dr = DagRun(dag.dag_id, execution_date=args.start_date)
-        for task in dag.tasks:
-            print(f"Task {task.task_id}")
-            ti = TaskInstance(task, run_id=None)
-            ti.dag_run = dr
-            ti.dry_run()
-    else:
-        if args.reset_dagruns:
-            DAG.clear_dags(
-                [dag],
-                start_date=args.start_date,
-                end_date=args.end_date,
-                confirm_prompt=not args.yes,
-                include_subdags=True,
-                dag_run_state=DagRunState.QUEUED,
+    for dag in dags:
+        if args.task_regex:
+            dag = dag.partial_subset(
+                task_ids_or_regex=args.task_regex, include_upstream=not args.ignore_dependencies
             )
+            if not dag.task_dict:
+                raise AirflowException(
+                    f"There are no tasks that match '{args.task_regex}' regex. Nothing to run, exiting..."
+                )
 
-        try:
-            dag.run(
-                start_date=args.start_date,
-                end_date=args.end_date,
-                mark_success=args.mark_success,
-                local=args.local,
-                donot_pickle=(args.donot_pickle or conf.getboolean('core', 'donot_pickle')),
-                ignore_first_depends_on_past=args.ignore_first_depends_on_past,
-                ignore_task_deps=args.ignore_dependencies,
-                pool=args.pool,
-                delay_on_limit_secs=args.delay_on_limit,
-                verbose=args.verbose,
-                conf=run_conf,
-                rerun_failed_tasks=args.rerun_failed_tasks,
-                run_backwards=args.run_backwards,
-                continue_on_failures=args.continue_on_failures,
-            )
-        except ValueError as vr:
-            print(str(vr))
-            sys.exit(1)
+        if args.dry_run:
+            print(f"Dry run of DAG {dag.dag_id} on {args.start_date}")
+            dr = DagRun(dag.dag_id, execution_date=args.start_date)
+            for task in dag.tasks:
+                print(f"Task {task.task_id} located in DAG {dag.dag_id}")
+                ti = TaskInstance(task, run_id=None)
+                ti.dag_run = dr
+                ti.dry_run()
+        else:
+            if args.reset_dagruns:
+                DAG.clear_dags(
+                    [dag],
+                    start_date=args.start_date,
+                    end_date=args.end_date,
+                    confirm_prompt=not args.yes,
+                    include_subdags=True,
+                    dag_run_state=DagRunState.QUEUED,
+                )
+
+            try:
+                dag.run(
+                    start_date=args.start_date,
+                    end_date=args.end_date,
+                    mark_success=args.mark_success,
+                    local=args.local,
+                    donot_pickle=(args.donot_pickle or conf.getboolean('core', 'donot_pickle')),
+                    ignore_first_depends_on_past=args.ignore_first_depends_on_past,
+                    ignore_task_deps=args.ignore_dependencies,
+                    pool=args.pool,
+                    delay_on_limit_secs=args.delay_on_limit,
+                    verbose=args.verbose,
+                    conf=run_conf,
+                    rerun_failed_tasks=args.rerun_failed_tasks,
+                    run_backwards=args.run_backwards,
+                    continue_on_failures=args.continue_on_failures,
+                )
+            except ValueError as vr:
+                print(str(vr))
+                sys.exit(1)
+
+    if len(dags) > 1:
+        log.info("All of the backfills are done.")
 
 
 @cli_utils.action_cli

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -44,7 +44,6 @@ from airflow.utils.cli import get_dag, get_dags, process_subdir, sigint_handler,
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
-from airflow.utils.helpers import ask_yesno
 
 log = logging.getLogger(__name__)
 
@@ -75,15 +74,6 @@ def dag_backfill(args, dag=None):
         dags = dag if type(dag) == list else [dag]
 
     dags.sort(key=lambda d: d.dag_id)
-
-    dag_id_list = "\n".join(str(dag.dag_id) for dag in dags)
-    question = (
-        "You are about to backfill these {count} DAGs:\n{dag_id_list}\n\nAre you sure? [y/n]"
-    ).format(count=len(dags), dag_id_list=dag_id_list)
-    do_it = ask_yesno(question)
-
-    if not do_it:
-        sys.exit(0)
 
     # If only one date is passed, using same as start and end
     args.end_date = args.end_date or args.start_date

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -44,6 +44,7 @@ from airflow.utils.cli import get_dag, get_dags, process_subdir, sigint_handler,
 from airflow.utils.dot_renderer import render_dag, render_dag_dependencies
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
+from airflow.utils.helpers import ask_yesno
 
 log = logging.getLogger(__name__)
 
@@ -69,11 +70,20 @@ def dag_backfill(args, dag=None):
         raise AirflowException("Provide a start_date and/or end_date")
 
     if not dag:
-        dags = get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.dag_regex)
+        dags = get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.treat_dag_as_regex)
     else:
         dags = dag if type(dag) == list else [dag]
 
     dags.sort(key=lambda d: d.dag_id)
+
+    dag_id_list = "\n".join(str(dag.dag_id) for dag in dags)
+    question = (
+        "You are about to backfill these {count} DAGs:\n{dag_id_list}\n\nAre you sure? [y/n]"
+    ).format(count=len(dags), dag_id_list=dag_id_list)
+    do_it = ask_yesno(question)
+
+    if not do_it:
+        sys.exit(0)
 
     # If only one date is passed, using same as start and end
     args.end_date = args.end_date or args.start_date

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -49,8 +49,8 @@ log = logging.getLogger(__name__)
 
 
 @cli_utils.action_cli
-def dag_backfill(args, dags=None):
-    """Creates backfill job or dry run for a DAG"""
+def dag_backfill(args, dag=None):
+    """Creates backfill job or dry run for a DAG or list of DAGs using regex"""
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
 
     signal.signal(signal.SIGTERM, sigint_handler)
@@ -68,7 +68,12 @@ def dag_backfill(args, dags=None):
     if not args.start_date and not args.end_date:
         raise AirflowException("Provide a start_date and/or end_date")
 
-    dags = dags or get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.dag_regex)
+    if not dag:
+        dags = get_dags(args.subdir, dag_id=args.dag_id, use_regex=args.dag_regex)
+    else:
+        dags = dag if type(dag) == list else [dag]
+
+    dags.sort(key=lambda d: d.dag_id)
 
     # If only one date is passed, using same as start and end
     args.end_date = args.end_date or args.start_date

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -876,7 +876,7 @@ class BackfillJob(BaseJob):
             session.commit()
             executor.end()
 
-        self.log.info("Backfill done. Exiting.")
+        self.log.info("Backfill done for DAG %s. Exiting.", self.dag)
 
     @provide_session
     def reset_state_for_orphaned_tasks(self, filter_by_dag_run=None, session=None):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -199,18 +199,9 @@ class TestCliDags(unittest.TestCase):
             f"Dry run of DAG example_branch_python_operator_decorator on "
             f"{DEFAULT_DATE.isoformat()}\n" in output
         )
-        assert (
-            "Task run_this_first located in DAG "
-            "example_branch_python_operator_decorator\n" in output
-        )
-        assert (
-            f"Dry run of DAG example_branch_operator on "
-            f"{DEFAULT_DATE.isoformat()}\n" in output
-        )
-        assert (
-            "Task run_this_first located in DAG "
-            "example_branch_operator\n" in output
-        )
+        assert "Task run_this_first located in DAG example_branch_python_operator_decorator\n" in output
+        assert f"Dry run of DAG example_branch_operator on {DEFAULT_DATE.isoformat()}\n" in output
+        assert "Task run_this_first located in DAG example_branch_operator\n" in output
 
     @mock.patch("airflow.cli.commands.dag_command.get_dag")
     def test_backfill_fails_without_loading_dags(self, mock_get_dag):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -199,9 +199,18 @@ class TestCliDags(unittest.TestCase):
             f"Dry run of DAG example_branch_python_operator_decorator on "
             f"{DEFAULT_DATE.isoformat()}\n" in output
         )
-        assert "Task run_this_first located in DAG " "example_branch_python_operator_decorator\n" in output
-        assert f"Dry run of DAG example_branch_operator on " f"{DEFAULT_DATE.isoformat()}\n" in output
-        assert "Task run_this_first located in DAG " "example_branch_operator\n" in output
+        assert (
+            "Task run_this_first located in DAG "
+            "example_branch_python_operator_decorator\n" in output
+        )
+        assert (
+            f"Dry run of DAG example_branch_operator on "
+            f"{DEFAULT_DATE.isoformat()}\n" in output
+        )
+        assert (
+            "Task run_this_first located in DAG "
+            "example_branch_operator\n" in output
+        )
 
     @mock.patch("airflow.cli.commands.dag_command.get_dag")
     def test_backfill_fails_without_loading_dags(self, mock_get_dag):

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -119,7 +119,7 @@ class TestCliDags(unittest.TestCase):
                         DEFAULT_DATE.isoformat(),
                     ]
                 ),
-                dags=[dag],
+                dag=dag,
             )
 
         output = stdout.getvalue()
@@ -139,7 +139,7 @@ class TestCliDags(unittest.TestCase):
                     DEFAULT_DATE.isoformat(),
                 ]
             ),
-            dags=[dag],
+            dag=dag,
         )
 
         mock_run.assert_not_called()  # Dry run shouldn't run the backfill
@@ -155,7 +155,7 @@ class TestCliDags(unittest.TestCase):
                     DEFAULT_DATE.isoformat(),
                 ]
             ),
-            dags=[dag],
+            dag=dag,
         )
 
         mock_run.assert_called_once_with(
@@ -291,7 +291,7 @@ class TestCliDags(unittest.TestCase):
         ]
         dag = self.dagbag.get_dag(dag_id)
 
-        dag_command.dag_backfill(self.parser.parse_args(args), dags=[dag])
+        dag_command.dag_backfill(self.parser.parse_args(args), dag=dag)
 
         mock_run.assert_called_once_with(
             start_date=run_date,
@@ -332,7 +332,7 @@ class TestCliDags(unittest.TestCase):
         ]
         dag = self.dagbag.get_dag(dag_id)
 
-        dag_command.dag_backfill(self.parser.parse_args(args), dags=[dag])
+        dag_command.dag_backfill(self.parser.parse_args(args), dag=dag)
         mock_run.assert_called_once_with(
             start_date=start_date,
             end_date=end_date,

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -186,7 +186,7 @@ class TestCliDags(unittest.TestCase):
                         '--task-regex',
                         'run_this_first',
                         '--dry-run',
-                        '--dag-regex',
+                        '--treat-dag-as-regex',
                         '--start-date',
                         DEFAULT_DATE.isoformat(),
                     ]


### PR DESCRIPTION
When this parameter is set, the dag_id string will be used as a regular expression to match the available DAGs.
This enables multiple DAG backfills to be consecutively executed under the same backfill session.
This is often used in the DAG factory based approach where more than one DAG have same task names, which are based on some ID, therefore it's commonly combined with task-regex.