### PR TITLE
Ignore deprecation warnings for days ago tests

### DIFF
--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -28,6 +28,7 @@ from airflow.utils import dates, timezone
 
 
 class TestDates(unittest.TestCase):
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_days_ago(self):
         today = pendulum.today()
         today_midnight = pendulum.instance(datetime.fromordinal(today.date().toordinal()))


### PR DESCRIPTION
Decreases the deprecation warnings for this test file from 71 to 19 :)
This function will be removed anyway in Airflow 3, so it's either to delete the test or to remove the deprecation warnings. I was guided to do the latter :) 
