### PR TITLE
Document LocalKubernetesExecutor support in chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -36,7 +36,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Features
 
-* Supported executors: ``LocalExecutor``, ``LocalKubernetesExecutor``, ``CeleryExecutor``, ``CeleryKubernetesExecutor``, ``KubernetesExecutor``.
+* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``, ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
 * Supported Airflow version: ``1.10+``, ``2.0+``
 * Supported database backend: ``PostgresSQL``, ``MySQL``
 * Autoscaling for ``CeleryExecutor`` provided by KEDA

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -64,7 +64,7 @@ Requirements
 Features
 --------
 
-* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``CeleryKubernetesExecutor``, ``KubernetesExecutor``.
+* Supported executors: ``LocalExecutor``, ``CeleryExecutor``, ``KubernetesExecutor``, ``LocalKubernetesExecutor``, ``CeleryKubernetesExecutor``
 * Supported Airflow version: ``1.10+``, ``2.0+``
 * Supported database backend: ``PostgresSQL``, ``MySQL``
 * Autoscaling for ``CeleryExecutor`` provided by KEDA


### PR DESCRIPTION
I just noticed we missed adding LocalKubernetesExecutor into the helm chart docs. I've also reordered them to put the "core" executors first, and the "combo" executors last.