### PR TITLE
Fix KubernetesPodOperator await_container_completion condition

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -256,7 +256,7 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
-        while not self.container_is_running(pod=pod, container_name=container_name):
+        while self.container_is_running(pod=pod, container_name=container_name):
             time.sleep(1)
 
     def await_pod_completion(self, pod: V1Pod) -> V1Pod:


### PR DESCRIPTION
KubernetesPodOperator await_container_condition has reverse condition.

But this code does not makes problem, because await_pod_condition works well.

However if the Pod is terminated very fast(between await_pod_start and await_container_time maximum 1seconds?), the DAG will not be terminated forever.

Also if get_logs option is False, xcom_push does not works well properly.