### PR TITLE
Remove redundant register exit signals in `dag-processor` command

### DIFF
--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -70,11 +70,9 @@ def dag_processor(args):
             )
             with ctx:
                 try:
-                    manager.register_exit_signals()
                     manager.start()
                 finally:
                     manager.terminate()
                     manager.end()
     else:
-        manager.register_exit_signals()
         manager.start()


### PR DESCRIPTION
Remove redundant call `register_exit_signals()` in **dag-processor** cli command

This method call in `start` method of class `airflow.dag_processing.manager.DagFileProcessorManager`
https://github.com/apache/airflow/blob/f352ee63a5d09546a7997ba8f2f8702a1ddb4af7/airflow/dag_processing/manager.py#L465-L473

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
