### PR TITLE
Added small health check server and endpoint in scheduler and updated…

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1943,6 +1943,22 @@
       type: string
       example: ~
       default: "30"
+    - name: enable_health_check
+      description: |
+        When you start a scheduler, airflow starts a tiny web server
+        subprocess to serve a health check if this is set to True
+      version_added: 2.4.0
+      type: boolean
+      example: ~
+      default: "False"
+    - name: scheduler_health_check_server_port
+      description: |
+        When you start a scheduler, airflow starts a tiny web server
+        subprocess to serve a health check on this port
+      version_added: 2.4.0
+      type: string
+      example: ~
+      default: "8974"
     - name: orphaned_tasks_check_interval
       description: |
         How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -980,6 +980,14 @@ pool_metrics_interval = 5.0
 # This is used by the health check in the "/health" endpoint
 scheduler_health_check_threshold = 30
 
+# When you start a scheduler, airflow starts a tiny web server
+# subprocess to serve a health check if this is set to True
+enable_health_check = False
+
+# When you start a scheduler, airflow starts a tiny web server
+# subprocess to serve a health check on this port
+scheduler_health_check_server_port = 8974
+
 # How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs
 orphaned_tasks_check_interval = 300.0
 child_process_log_directory = {AIRFLOW_HOME}/logs/scheduler

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -110,6 +110,7 @@ job_heartbeat_sec = 1
 schedule_after_task_execution = False
 scheduler_heartbeat_sec = 5
 scheduler_health_check_threshold = 30
+scheduler_health_check_server_port = 8794
 parsing_processes = 2
 catchup_by_default = True
 scheduler_zombie_task_threshold = 300

--- a/airflow/utils/scheduler_health.py
+++ b/airflow/utils/scheduler_health.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from airflow.configuration import conf
+from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.utils.net import get_hostname
+from airflow.utils.session import create_session
+
+
+class HealthServer(BaseHTTPRequestHandler):
+    """Small webserver to serve scheduler health check"""
+
+    def do_GET(self):
+        if self.path == '/health':
+            try:
+                with create_session() as session:
+                    scheduler_job = (
+                        session.query(SchedulerJob)
+                        .filter_by(hostname=get_hostname())
+                        .order_by(SchedulerJob.latest_heartbeat.desc())
+                        .limit(1)
+                        .first()
+                    )
+                if scheduler_job and scheduler_job.is_alive():
+                    self.send_response(200)
+                    self.end_headers()
+                else:
+                    self.send_error(503)
+            except Exception:
+                self.send_error(503)
+        else:
+            self.send_error(404)
+
+
+def serve_health_check():
+    health_check_port = conf.getint('scheduler', 'SCHEDULER_HEALTH_CHECK_SERVER_PORT')
+    httpd = HTTPServer(("0.0.0.0", health_check_port), HealthServer)
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    serve_health_check()

--- a/docs/apache-airflow/logging-monitoring/check-health.rst
+++ b/docs/apache-airflow/logging-monitoring/check-health.rst
@@ -66,11 +66,25 @@ To check the health status of your Airflow instance, you can simply access the e
 Please keep in mind that the HTTP response code of ``/health`` endpoint **should not** be used to determine the health
 status of the application. The return code is only indicative of the state of the rest call (200 for success).
 
+Served by the web server, this health check endpoint is independent of the newer :ref:`Scheduler Health Check Server <check-health/scheduler-health-check-server>`, which optionally runs on each scheduler.
+
 .. note::
 
   For this check to work, at least one working web server is required. Suppose you use this check for scheduler
   monitoring, then in case of failure of the web server, you will lose the ability to monitor scheduler, which means
-  that it can be restarted even if it is in good condition. For greater confidence, consider using :ref:`CLI Check for Scheduler <check-health/cli-checks-for-scheduler>`.
+  that it can be restarted even if it is in good condition. For greater confidence, consider using :ref:`CLI Check for Scheduler <check-health/cli-checks-for-scheduler>` or  :ref:`Scheduler Health Check Server <check-health/scheduler-health-check-server>`.
+
+.. _check-health/scheduler-health-check-server:
+
+Scheduler Health Check Server
+-------------------------
+
+In order to check scheduler health independent of the web server, Airflow optionally starts a small HTTP server
+in each scheduler to serve a scheduler ``\health`` endpoint. It returns status code ``200`` when the scheduler
+is healthy and status code ``503`` when the scheduler is unhealthy. To run this server in each scheduler, set
+``[scheduler]enable_health_check`` to ``True``. By default, it is ``False``. The server is running on the port
+specified by the ``[scheduler]scheduler_health_check_server_port`` option. By default, it is ``8974``. We are
+using `http.server.BaseHTTPRequestHandler <https://docs.python.org/3/library/http.server.html#http.server.BaseHTTPRequestHandler>`__ as a small server.
 
 .. _check-health/cli-checks-for-scheduler:
 

--- a/docs/apache-airflow/logging-monitoring/check-health.rst
+++ b/docs/apache-airflow/logging-monitoring/check-health.rst
@@ -32,8 +32,8 @@ For an example for a Docker Compose environment, see the ``docker-compose.yaml``
 
 .. _check-health/http-endpoint:
 
-Health Check Endpoint
----------------------
+Webserver Health Check Endpoint
+-------------------------------
 
 To check the health status of your Airflow instance, you can simply access the endpoint
 ``/health``. It will return a JSON object in which a high-level glance is provided.
@@ -77,7 +77,7 @@ Served by the web server, this health check endpoint is independent of the newer
 .. _check-health/scheduler-health-check-server:
 
 Scheduler Health Check Server
--------------------------
+-----------------------------
 
 In order to check scheduler health independent of the web server, Airflow optionally starts a small HTTP server
 in each scheduler to serve a scheduler ``\health`` endpoint. It returns status code ``200`` when the scheduler


### PR DESCRIPTION
To help resolve [this issue](https://github.com/apache/airflow/issues/22895), I added a new health check endpoint in the scheduler with a "small" webserver.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
