### PR TITLE
Add support to specify language name in PapermillOperator

### DIFF
--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -50,7 +50,7 @@ class PapermillOperator(BaseOperator):
 
     supports_lineage = True
 
-    template_fields: Sequence[str] = ('input_nb', 'output_nb', 'parameters', 'kernel_name')
+    template_fields: Sequence[str] = ('input_nb', 'output_nb', 'parameters', 'kernel_name', 'language_name')
 
     def __init__(
         self,
@@ -59,6 +59,7 @@ class PapermillOperator(BaseOperator):
         output_nb: Optional[str] = None,
         parameters: Optional[Dict] = None,
         kernel_name: Optional[str] = None,
+        language_name: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -67,6 +68,7 @@ class PapermillOperator(BaseOperator):
         self.output_nb = output_nb
         self.parameters = parameters
         self.kernel_name = kernel_name
+        self.language_name = language_name
         if input_nb:
             self.inlets.append(NoteBook(url=input_nb, parameters=self.parameters))
         if output_nb:
@@ -84,4 +86,5 @@ class PapermillOperator(BaseOperator):
                 progress_bar=False,
                 report_mode=True,
                 kernel_name=self.kernel_name,
+                language_name=self.language_name,
             )

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -31,6 +31,7 @@ class TestPapermillOperator(unittest.TestCase):
         in_nb = "/tmp/does_not_exist"
         out_nb = "/tmp/will_not_exist"
         kernel_name = "python3"
+        language_name = "python"
         parameters = {"msg": "hello_world", "train": 1}
 
         op = PapermillOperator(
@@ -39,6 +40,7 @@ class TestPapermillOperator(unittest.TestCase):
             parameters=parameters,
             task_id="papermill_operator_test",
             kernel_name=kernel_name,
+            language_name=language_name,
             dag=None,
         )
 
@@ -50,6 +52,7 @@ class TestPapermillOperator(unittest.TestCase):
             out_nb,
             parameters=parameters,
             kernel_name=kernel_name,
+            language_name=language_name,
             progress_bar=False,
             report_mode=True,
         )
@@ -64,6 +67,7 @@ class TestPapermillOperator(unittest.TestCase):
             output_nb="/tmp/out-{{ dag.dag_id }}.ipynb",
             parameters={"msgs": "dag id is {{ dag.dag_id }}!"},
             kernel_name="python3",
+            language_name="python",
             dag=dag,
         )
 
@@ -75,3 +79,4 @@ class TestPapermillOperator(unittest.TestCase):
         assert '/tmp/out-test_render_template.ipynb' == getattr(operator, 'output_nb')
         assert {"msgs": "dag id is test_render_template!"} == getattr(operator, 'parameters')
         assert "python3" == getattr(operator, 'kernel_name')
+        assert "python" == getattr(operator, 'language_name')

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -75,8 +75,8 @@ class TestPapermillOperator(unittest.TestCase):
         ti.dag_run = DagRun(execution_date=DEFAULT_DATE)
         ti.render_templates()
 
-        assert "/tmp/test_render_template.ipynb" == getattr(operator, 'input_nb')
-        assert '/tmp/out-test_render_template.ipynb' == getattr(operator, 'output_nb')
-        assert {"msgs": "dag id is test_render_template!"} == getattr(operator, 'parameters')
-        assert "python3" == getattr(operator, 'kernel_name')
-        assert "python" == getattr(operator, 'language_name')
+        assert "/tmp/test_render_template.ipynb" == operator.input_nb
+        assert '/tmp/out-test_render_template.ipynb' == operator.output_nb
+        assert {"msgs": "dag id is test_render_template!"} == operator.parameters
+        assert "python3" == operator.kernel_name
+        assert "python" == operator.language_name


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds a language_name field to PapermillOperator so we can specify the programming language the notebook uses.
If language_name is specified, papermill ignores language_info.name in the notebook document metadata (if any).

This is based entirely on a previous merged PR which added kernel_name https://github.com/apache/airflow/pull/20035 option.  This feature would be useful to allow the Operator to be used with any ipynb files which having missing language metadata which the python papermill package requires.

---
