### PR TITLE
Only return non-None task summaries for grid view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -258,7 +258,7 @@ def task_group_to_grid(task_item_or_group, dag, dag_runs, session):
     if isinstance(task_item_or_group, AbstractOperator):
         return {
             'id': task_item_or_group.task_id,
-            'instances': [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs],
+            'instances': [ts for ts in [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs] if ts is not None],
             'label': task_item_or_group.label,
             'extra_links': task_item_or_group.extra_links,
             'is_mapped': task_item_or_group.is_mapped,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -260,7 +260,7 @@ def task_group_to_grid(task_item_or_group, dag, dag_runs, session):
             'id': task_item_or_group.task_id,
             'instances': [
                 ts
-                for ts in [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs]
+                for ts in (wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs)
                 if ts is not None
             ],
             'label': task_item_or_group.label,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -258,7 +258,11 @@ def task_group_to_grid(task_item_or_group, dag, dag_runs, session):
     if isinstance(task_item_or_group, AbstractOperator):
         return {
             'id': task_item_or_group.task_id,
-            'instances': [ts for ts in [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs] if ts is not None],
+            'instances': [
+                ts
+                for ts in [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs]
+                if ts is not None
+            ],
             'label': task_item_or_group.label,
             'extra_links': task_item_or_group.extra_links,
             'is_mapped': task_item_or_group.is_mapped,


### PR DESCRIPTION
If we do return None's, it breaks the grid view when a new task is added
to a DAG.

Fixes: #23908