### PR TITLE
Grid fix details button truncated and small UI tweaks

### DIFF
--- a/airflow/www/static/js/grid/AutoRefresh.jsx
+++ b/airflow/www/static/js/grid/AutoRefresh.jsx
@@ -33,7 +33,13 @@ const AutoRefresh = () => {
   return (
     <FormControl display="flex" width="auto" mr={2}>
       <Spinner color="blue.500" speed="1s" mr="4px" visibility={isRefreshOn ? 'visible' : 'hidden'} />
-      <FormLabel htmlFor="auto-refresh" mb={0} fontWeight="normal">
+      <FormLabel
+        htmlFor="auto-refresh"
+        mb={0}
+        fontWeight="normal"
+        display="flex"
+        alignItems="center"
+      >
         Auto-refresh
       </FormLabel>
       <Switch

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -34,7 +34,6 @@ import ResetRoot from './ResetRoot';
 import DagRuns from './dagRuns';
 import ToggleGroups from './ToggleGroups';
 import { getMetaValue } from '../utils';
-import AutoRefresh from './AutoRefresh';
 
 const dagId = getMetaValue('dag_id');
 
@@ -85,7 +84,6 @@ const Grid = ({ isPanelOpen = false, hoveredTaskState }) => {
       minWidth={isPanelOpen && '300px'}
     >
       <Flex alignItems="center" position="sticky" top={0} left={0}>
-        <AutoRefresh />
         <ToggleGroups
           groups={groups}
           openGroupIds={openGroupIds}

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -110,6 +110,8 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }) => {
           title={`${isPanelOpen ? 'Hide ' : 'Show '} Details Panel`}
           aria-label={isPanelOpen ? 'Show Details' : 'Hide Details'}
           icon={<MdReadMore />}
+          transform={!isPanelOpen && 'rotateZ(180deg)'}
+          transitionProperty="none"
         />
       </Flex>
       <Table>

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -26,9 +26,10 @@ import {
   Box,
   Thead,
   Flex,
-  Button,
+  IconButton,
 } from '@chakra-ui/react';
 
+import { MdReadMore } from 'react-icons/md';
 import { useGridData } from './api';
 import renderTaskRows from './renderTaskRows';
 import ResetRoot from './ResetRoot';
@@ -83,7 +84,7 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }) => {
       overflow="auto"
       ref={scrollRef}
       flexGrow={1}
-      minWidth={isPanelOpen && '300px'}
+      minWidth={isPanelOpen && '350px'}
     >
       <Flex
         alignItems="center"
@@ -103,14 +104,13 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }) => {
           />
           <ResetRoot />
         </Flex>
-        <Button
+        <IconButton
+          fontSize="2xl"
           onClick={onPanelToggle}
+          title={`${isPanelOpen ? 'Hide ' : 'Show '} Details Panel`}
           aria-label={isPanelOpen ? 'Show Details' : 'Hide Details'}
-          variant={isPanelOpen ? 'solid' : 'outline'}
-        >
-          {isPanelOpen ? 'Hide ' : 'Show '}
-          Details Panel
-        </Button>
+          icon={<MdReadMore />}
+        />
       </Flex>
       <Table>
         <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">

--- a/airflow/www/static/js/grid/Grid.jsx
+++ b/airflow/www/static/js/grid/Grid.jsx
@@ -26,6 +26,7 @@ import {
   Box,
   Thead,
   Flex,
+  Button,
 } from '@chakra-ui/react';
 
 import { useGridData } from './api';
@@ -34,10 +35,11 @@ import ResetRoot from './ResetRoot';
 import DagRuns from './dagRuns';
 import ToggleGroups from './ToggleGroups';
 import { getMetaValue } from '../utils';
+import AutoRefresh from './AutoRefresh';
 
 const dagId = getMetaValue('dag_id');
 
-const Grid = ({ isPanelOpen = false, hoveredTaskState }) => {
+const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }) => {
   const scrollRef = useRef();
   const tableRef = useRef();
 
@@ -83,13 +85,32 @@ const Grid = ({ isPanelOpen = false, hoveredTaskState }) => {
       flexGrow={1}
       minWidth={isPanelOpen && '300px'}
     >
-      <Flex alignItems="center" position="sticky" top={0} left={0}>
-        <ToggleGroups
-          groups={groups}
-          openGroupIds={openGroupIds}
-          onToggleGroups={onToggleGroups}
-        />
-        <ResetRoot />
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        position="sticky"
+        top={0}
+        left={0}
+        mb={2}
+        p={1}
+      >
+        <Flex alignItems="center">
+          <AutoRefresh />
+          <ToggleGroups
+            groups={groups}
+            openGroupIds={openGroupIds}
+            onToggleGroups={onToggleGroups}
+          />
+          <ResetRoot />
+        </Flex>
+        <Button
+          onClick={onPanelToggle}
+          aria-label={isPanelOpen ? 'Show Details' : 'Hide Details'}
+          variant={isPanelOpen ? 'solid' : 'outline'}
+        >
+          {isPanelOpen ? 'Hide ' : 'Show '}
+          Details Panel
+        </Button>
       </Flex>
       <Table>
         <Thead display="block" pr="10px" position="sticky" top={0} zIndex={2} bg="white">

--- a/airflow/www/static/js/grid/LegendRow.jsx
+++ b/airflow/www/static/js/grid/LegendRow.jsx
@@ -44,7 +44,7 @@ const StatusBadge = ({
 
 const LegendRow = ({ setHoveredTaskState }) => (
   <Flex p={4} flexWrap="wrap" justifyContent="end">
-    <HStack spacing={2}>
+    <HStack spacing={2} wrap="wrap">
       {
       Object.entries(stateColors).map(([state, stateColor]) => (
         <StatusBadge

--- a/airflow/www/static/js/grid/Main.jsx
+++ b/airflow/www/static/js/grid/Main.jsx
@@ -33,6 +33,7 @@ import useSelection from './utils/useSelection';
 import Grid from './Grid';
 import FilterBar from './FilterBar';
 import LegendRow from './LegendRow';
+import AutoRefresh from './AutoRefresh';
 
 const detailsPanelKey = 'hideDetailsPanel';
 
@@ -57,20 +58,20 @@ const Main = () => {
       <FilterBar />
       <LegendRow setHoveredTaskState={setHoveredTaskState} />
       <Divider mb={5} borderBottomWidth={2} />
-      <Flex flexDirection="row" justifyContent="space-between">
+      <Flex justifyContent="space-between" mb={2}>
+        <AutoRefresh />
+        <Button
+          onClick={toggleDetailsPanel}
+          aria-label={isOpen ? 'Show Details' : 'Hide Details'}
+          variant={isOpen ? 'solid' : 'outline'}
+        >
+          {isOpen ? 'Hide ' : 'Show '}
+          Details Panel
+        </Button>
+      </Flex>
+      <Flex justifyContent="space-between">
         <Grid isPanelOpen={isOpen} hoveredTaskState={hoveredTaskState} />
         <Box borderLeftWidth={isOpen ? 1 : 0} position="relative">
-          <Button
-            position="absolute"
-            top={0}
-            right={0}
-            onClick={toggleDetailsPanel}
-            aria-label={isOpen ? 'Show Details' : 'Hide Details'}
-            variant={isOpen ? 'solid' : 'outline'}
-          >
-            {isOpen ? 'Hide ' : 'Show '}
-            Details Panel
-          </Button>
           {isOpen && (<Details />)}
         </Box>
       </Flex>

--- a/airflow/www/static/js/grid/Main.jsx
+++ b/airflow/www/static/js/grid/Main.jsx
@@ -24,7 +24,6 @@ import {
   Box,
   Flex,
   useDisclosure,
-  Button,
   Divider,
 } from '@chakra-ui/react';
 
@@ -33,7 +32,6 @@ import useSelection from './utils/useSelection';
 import Grid from './Grid';
 import FilterBar from './FilterBar';
 import LegendRow from './LegendRow';
-import AutoRefresh from './AutoRefresh';
 
 const detailsPanelKey = 'hideDetailsPanel';
 
@@ -43,7 +41,7 @@ const Main = () => {
   const { clearSelection } = useSelection();
   const [hoveredTaskState, setHoveredTaskState] = useState();
 
-  const toggleDetailsPanel = () => {
+  const onPanelToggle = () => {
     if (!isOpen) {
       localStorage.setItem(detailsPanelKey, false);
     } else {
@@ -58,19 +56,12 @@ const Main = () => {
       <FilterBar />
       <LegendRow setHoveredTaskState={setHoveredTaskState} />
       <Divider mb={5} borderBottomWidth={2} />
-      <Flex justifyContent="space-between" mb={2}>
-        <AutoRefresh />
-        <Button
-          onClick={toggleDetailsPanel}
-          aria-label={isOpen ? 'Show Details' : 'Hide Details'}
-          variant={isOpen ? 'solid' : 'outline'}
-        >
-          {isOpen ? 'Hide ' : 'Show '}
-          Details Panel
-        </Button>
-      </Flex>
       <Flex justifyContent="space-between">
-        <Grid isPanelOpen={isOpen} hoveredTaskState={hoveredTaskState} />
+        <Grid
+          isPanelOpen={isOpen}
+          onPanelToggle={onPanelToggle}
+          hoveredTaskState={hoveredTaskState}
+        />
         <Box borderLeftWidth={isOpen ? 1 : 0} position="relative">
           {isOpen && (<Details />)}
         </Box>


### PR DESCRIPTION
Hello,

Really small PR to suggest minor tweaks in the grid view UI.

Just noticed that the `details button` was truncated on my side when the detail panel is hidden. Looking closer, it has an absolute position, and appears after the Grid component in the dom, making it hard to align with the AutoRefresh. Changed that to make it part of a common flex container with the `AutoRefresh`.

Also took the opportunity to add wrapping to the `LegendRow` for a more responsive UI.

![image_buttton_issue](https://user-images.githubusercontent.com/14861206/170482035-e9704663-4ae7-4b6d-9aef-e3a2ce01f3e7.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
