### PR TITLE
Prevent UI from crashing if grid task instances are null

### DIFF
--- a/airflow/www/static/js/grid/renderTaskRows.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.jsx
@@ -53,7 +53,7 @@ const TaskInstances = ({
   <Flex justifyContent="flex-end">
     {dagRunIds.map((runId) => {
       // Check if an instance exists for the run, or return an empty box
-      const instance = task.instances.find((gi) => gi.runId === runId);
+      const instance = task.instances.find((gi) => gi && gi.runId === runId);
       const isSelected = selectedRunId === runId;
       return (
         <Box

--- a/airflow/www/static/js/grid/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.test.jsx
@@ -73,32 +73,43 @@ const mockGroup = {
   instances: [],
 };
 
+const nullMockGroup = {
+  id: null,
+  label: null,
+  children: [
+    {
+      extraLinks: [],
+      id: 'group_1',
+      label: 'group_1',
+      instances: [null],
+      children: [
+        {
+          id: 'group_1.task_1',
+          label: 'group_1.task_1',
+          extraLinks: [],
+          instances: [null],
+        },
+      ],
+    },
+  ],
+  instances: [null],
+};
+
 describe('Test renderTaskRows', () => {
+  test('Renders name and task instance', () => {
+    const task = mockGroup;
+
+    const { queryByTestId, getByText } = render(
+      <>{renderTaskRows({ task, dagRunIds: ['run1'] })}</>,
+      { wrapper: TableWrapper },
+    );
+
+    expect(getByText('group_1')).toBeInTheDocument();
+    expect(queryByTestId('task-instance')).toBeDefined();
+    expect(queryByTestId('blank-task')).toBeNull();
+  });
+
   test('Still renders names if there are no instances', () => {
-    global.gridData = {
-      groups: {
-        id: null,
-        label: null,
-        children: [
-          {
-            extraLinks: [],
-            id: 'group_1',
-            label: 'group_1',
-            instances: [],
-            children: [
-              {
-                id: 'group_1.task_1',
-                label: 'group_1.task_1',
-                extraLinks: [],
-                instances: [],
-              },
-            ],
-          },
-        ],
-        instances: [],
-      },
-      dagRuns: [],
-    };
     const task = mockGroup;
 
     const { queryByTestId, getByText } = render(
@@ -111,31 +122,10 @@ describe('Test renderTaskRows', () => {
   });
 
   test('Still renders correctly if task instance is null', () => {
-    global.gridData = {
-      groups: {
-        id: null,
-        label: null,
-        children: [
-          {
-            extraLinks: [],
-            id: 'group_1',
-            label: 'group_1',
-            instances: [null],
-          },
-        ],
-        instances: [null],
-      },
-      dagRuns: [
-        {
-          state: 'success',
-          runId: 'run_id',
-        },
-      ],
-    };
-    const task = mockGroup;
+    const task = nullMockGroup;
 
     const { queryByTestId, getByText } = render(
-      <>{renderTaskRows({ task, dagRunIds: ['run_id'] })}</>,
+      <>{renderTaskRows({ task, dagRunIds: ['run1'] })}</>,
       { wrapper: TableWrapper },
     );
 

--- a/airflow/www/static/js/grid/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.test.jsx
@@ -25,33 +25,16 @@ import { render } from '@testing-library/react';
 import renderTaskRows from './renderTaskRows';
 import { TableWrapper } from './utils/testUtils';
 
-const mockGroup = {
-  id: null,
-  label: null,
-  children: [
-    {
-      extraLinks: [],
-      id: 'group_1',
-      label: 'group_1',
-      instances: [
-        {
-          dagId: 'dagId',
-          duration: 0,
-          endDate: '2021-10-26T15:42:03.391939+00:00',
-          executionDate: '2021-10-25T15:41:09.726436+00:00',
-          operator: 'DummyOperator',
-          runId: 'run1',
-          startDate: '2021-10-26T15:42:03.391917+00:00',
-          state: 'success',
-          taskId: 'group_1',
-          tryNumber: 1,
-        },
-      ],
+describe('Test renderTaskRows', () => {
+  test('Renders name and task instance', () => {
+    const task = {
+      id: null,
+      label: null,
       children: [
         {
-          id: 'group_1.task_1',
-          label: 'group_1.task_1',
           extraLinks: [],
+          id: 'group_1',
+          label: 'group_1',
           instances: [
             {
               dagId: 'dagId',
@@ -62,42 +45,35 @@ const mockGroup = {
               runId: 'run1',
               startDate: '2021-10-26T15:42:03.391917+00:00',
               state: 'success',
-              taskId: 'group_1.task_1',
+              taskId: 'group_1',
               tryNumber: 1,
+            },
+          ],
+          children: [
+            {
+              id: 'group_1.task_1',
+              label: 'group_1.task_1',
+              extraLinks: [],
+              instances: [
+                {
+                  dagId: 'dagId',
+                  duration: 0,
+                  endDate: '2021-10-26T15:42:03.391939+00:00',
+                  executionDate: '2021-10-25T15:41:09.726436+00:00',
+                  operator: 'DummyOperator',
+                  runId: 'run1',
+                  startDate: '2021-10-26T15:42:03.391917+00:00',
+                  state: 'success',
+                  taskId: 'group_1.task_1',
+                  tryNumber: 1,
+                },
+              ],
             },
           ],
         },
       ],
-    },
-  ],
-  instances: [],
-};
-
-const nullMockGroup = {
-  id: null,
-  label: null,
-  children: [
-    {
-      extraLinks: [],
-      id: 'group_1',
-      label: 'group_1',
-      instances: [null],
-      children: [
-        {
-          id: 'group_1.task_1',
-          label: 'group_1.task_1',
-          extraLinks: [],
-          instances: [null],
-        },
-      ],
-    },
-  ],
-  instances: [null],
-};
-
-describe('Test renderTaskRows', () => {
-  test('Renders name and task instance', () => {
-    const task = mockGroup;
+      instances: [],
+    };
 
     const { queryByTestId, getByText } = render(
       <>{renderTaskRows({ task, dagRunIds: ['run1'] })}</>,
@@ -110,7 +86,19 @@ describe('Test renderTaskRows', () => {
   });
 
   test('Still renders names if there are no instances', () => {
-    const task = mockGroup;
+    const task = {
+      id: null,
+      label: null,
+      children: [
+        {
+          extraLinks: [],
+          id: 'group_1',
+          label: 'group_1',
+          instances: [],
+        },
+      ],
+      instances: [],
+    };
 
     const { queryByTestId, getByText } = render(
       <>{renderTaskRows({ task, dagRunIds: [] })}</>,
@@ -122,7 +110,27 @@ describe('Test renderTaskRows', () => {
   });
 
   test('Still renders correctly if task instance is null', () => {
-    const task = nullMockGroup;
+    const task = {
+      id: null,
+      label: null,
+      children: [
+        {
+          extraLinks: [],
+          id: 'group_1',
+          label: 'group_1',
+          instances: [null],
+          children: [
+            {
+              id: 'group_1.task_1',
+              label: 'group_1.task_1',
+              extraLinks: [],
+              instances: [null],
+            },
+          ],
+        },
+      ],
+      instances: [null],
+    };
 
     const { queryByTestId, getByText } = render(
       <>{renderTaskRows({ task, dagRunIds: ['run1'] })}</>,

--- a/airflow/www/static/js/grid/renderTaskRows.test.jsx
+++ b/airflow/www/static/js/grid/renderTaskRows.test.jsx
@@ -109,4 +109,38 @@ describe('Test renderTaskRows', () => {
     expect(getByText('group_1')).toBeInTheDocument();
     expect(queryByTestId('task-instance')).toBeNull();
   });
+
+  test('Still renders correctly if task instance is null', () => {
+    global.gridData = {
+      groups: {
+        id: null,
+        label: null,
+        children: [
+          {
+            extraLinks: [],
+            id: 'group_1',
+            label: 'group_1',
+            instances: [null],
+          },
+        ],
+        instances: [null],
+      },
+      dagRuns: [
+        {
+          state: 'success',
+          runId: 'run_id',
+        },
+      ],
+    };
+    const task = mockGroup;
+
+    const { queryByTestId, getByText } = render(
+      <>{renderTaskRows({ task, dagRunIds: ['run_id'] })}</>,
+      { wrapper: TableWrapper },
+    );
+
+    expect(getByText('group_1')).toBeInTheDocument();
+    expect(queryByTestId('task-instance')).toBeNull();
+    expect(queryByTestId('blank-task')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
UI-side fix with an additional test.


Fixes: #23908

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
