### PR TITLE
Fix and speed up grid view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -258,7 +258,7 @@ def task_group_to_grid(task_item_or_group, dag, dag_runs, session):
     if isinstance(task_item_or_group, AbstractOperator):
         return {
             'id': task_item_or_group.task_id,
-            'instances': [wwwutils.get_task_summary(dr, task_item_or_group, session) for dr in dag_runs],
+            'instances': wwwutils.get_task_summaries(task_item_or_group, dag_runs, session),
             'label': task_item_or_group.label,
             'extra_links': task_item_or_group.extra_links,
             'is_mapped': task_item_or_group.is_mapped,


### PR DESCRIPTION
This fetches all TIs for a given task across dag runs, leading to
signifincatly faster response times. It also fixes a bug where Nones
were being passed to the UI when a new task was added to a DAG with
exiting runs.

I'm gathering more data points, but with a DAG with ~2k tasks across 100 task groups, 1 "big" dag_run, 2 "small" with <100 task, this brought /grid from ~16s to 7s.

Another data point:
28 runs, 2k tasks across 100 task groups.
Before: I gave up after 18 minutes.
After: 40s

Fixes: https://github.com/apache/airflow/discussions/23908
Closes: #23772