### PR TITLE
Revert "Add limit for JPype1 (#23847)"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -412,10 +412,6 @@ influxdb = [
 ]
 jdbc = [
     'jaydebeapi>=1.1.1',
-    # JPype1 has been published without sdist in PyPI which caused failures when trying to build an
-    # ARM image (JPype1 does not publish binary ARM packages)
-    # The whole line below can be removed when https://github.com/jpype-project/jpype/issues/1069 is solved
-    'jpype1<1.4.0',
 ]
 jenkins = [
     'python-jenkins>=1.0.0',


### PR DESCRIPTION
This turned out to be mistake in manual submission. Fixed
on JPype1 side.

This reverts commit 3699be49b24ef5a0a8d8de81a149af2c5a7dc206.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
