### PR TITLE
Support impersonation service account parameter for Dataflow runner

### DIFF
--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -51,6 +51,7 @@ class BeamDataflowMixin(metaclass=ABCMeta):
     dataflow_config: DataflowConfiguration
     gcp_conn_id: str
     delegate_to: Optional[str]
+    dataflow_support_impersonation: bool = True
 
     def _set_dataflow(
         self,
@@ -91,6 +92,13 @@ class BeamDataflowMixin(metaclass=ABCMeta):
             pipeline_options[job_name_key] = job_name
         if self.dataflow_config.service_account:
             pipeline_options["serviceAccount"] = self.dataflow_config.service_account
+        if self.dataflow_support_impersonation and self.dataflow_config.impersonation_chain:
+            if isinstance(self.dataflow_config.impersonation_chain, list):
+                pipeline_options["impersonateServiceAccount"] = ",".join(
+                    self.dataflow_config.impersonation_chain
+                )
+            else:
+                pipeline_options["impersonateServiceAccount"] = self.dataflow_config.impersonation_chain
         pipeline_options["project"] = self.dataflow_config.project_id
         pipeline_options["region"] = self.dataflow_config.location
         pipeline_options.setdefault("labels", {}).update(
@@ -548,6 +556,13 @@ class BeamRunGoPipelineOperator(BeamBasePipelineOperator):
             dataflow_config=dataflow_config,
             **kwargs,
         )
+
+        if self.dataflow_config.impersonation_chain:
+            self.log.info(
+                "Impersonation chain parameter is not supported for Apache Beam GO SDK and will be skipped "
+                "in the execution"
+            )
+        self.dataflow_support_impersonation = False
 
         self.go_file = go_file
         self.should_init_go_module = False

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ amazon = [
     'xmltodict<0.13.0',
 ]
 apache_beam = [
-    'apache-beam>=2.33.0',
+    'apache-beam>=2.39.0',
 ]
 arangodb = ['python-arango>=7.3.2']
 asana = ['asana>=0.10']

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -47,6 +47,7 @@ EXPECTED_ADDITIONAL_OPTIONS = {
     'output': 'gs://test/output',
     'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
 }
+TEST_IMPERSONATION_ACCOUNT = "test@impersonation.com"
 
 
 class TestBeamRunPythonPipelineOperator(unittest.TestCase):
@@ -104,7 +105,7 @@ class TestBeamRunPythonPipelineOperator(unittest.TestCase):
         """Test DataflowHook is created and the right args are passed to
         start_python_dataflow.
         """
-        dataflow_config = DataflowConfiguration()
+        dataflow_config = DataflowConfiguration(impersonation_chain=TEST_IMPERSONATION_ACCOUNT)
         self.operator.runner = "DataflowRunner"
         self.operator.dataflow_config = dataflow_config
         gcs_provide_file = gcs_hook.return_value.provide_file
@@ -126,6 +127,7 @@ class TestBeamRunPythonPipelineOperator(unittest.TestCase):
             'output': 'gs://test/output',
             'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
             'region': 'us-central1',
+            'impersonate_service_account': TEST_IMPERSONATION_ACCOUNT,
         }
         gcs_provide_file.assert_called_once_with(object_url=PY_FILE)
         persist_link_mock.assert_called_once_with(
@@ -222,7 +224,7 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
         """Test DataflowHook is created and the right args are passed to
         start_java_dataflow.
         """
-        dataflow_config = DataflowConfiguration()
+        dataflow_config = DataflowConfiguration(impersonation_chain="test@impersonation.com")
         self.operator.runner = "DataflowRunner"
         self.operator.dataflow_config = dataflow_config
         gcs_provide_file = gcs_hook.return_value.provide_file
@@ -247,6 +249,7 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
             'region': 'us-central1',
             'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
             'output': 'gs://test/output',
+            'impersonateServiceAccount': TEST_IMPERSONATION_ACCOUNT,
         }
         persist_link_mock.assert_called_once_with(
             self.operator,
@@ -373,7 +376,7 @@ class TestBeamRunGoPipelineOperator(unittest.TestCase):
         """Test DataflowHook is created and the right args are passed to
         start_go_dataflow.
         """
-        dataflow_config = DataflowConfiguration()
+        dataflow_config = DataflowConfiguration(impersonation_chain="test@impersonation.com")
         self.operator.runner = "DataflowRunner"
         self.operator.dataflow_config = dataflow_config
         gcs_provide_file = gcs_hook.return_value.provide_file


### PR DESCRIPTION
The Apache beam team released a new version of SDK for python and JAVA and both started support for impersonation service account parameter.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
