### PR TITLE
[23945] Icons in grid view for different dag types

### DIFF
--- a/airflow/www/static/js/grid/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/grid/dagRuns/Bar.jsx
@@ -29,7 +29,8 @@ import {
   VStack,
   useTheme,
 } from '@chakra-ui/react';
-import { MdPlayArrow } from 'react-icons/md';
+import { MdPlayArrow, MdOutlineSchedule } from 'react-icons/md';
+import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import DagRunTooltip from './Tooltip';
 import { useContainerRef } from '../context/containerRef';
@@ -101,6 +102,7 @@ const DagRunBar = ({
             data-testid="run"
           >
             {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
+            {run.runType === 'backfill' && <RiArrowGoBackFill size="8px" color="white" data-testid="backfill-run" />}
           </Flex>
         </Tooltip>
       </Flex>

--- a/airflow/www/static/js/grid/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/grid/dagRuns/Bar.jsx
@@ -29,7 +29,7 @@ import {
   VStack,
   useTheme,
 } from '@chakra-ui/react';
-import { MdPlayArrow, MdOutlineSchedule } from 'react-icons/md';
+import { MdPlayArrow } from 'react-icons/md';
 import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import DagRunTooltip from './Tooltip';

--- a/airflow/www/static/js/grid/dagRuns/Tooltip.jsx
+++ b/airflow/www/static/js/grid/dagRuns/Tooltip.jsx
@@ -25,7 +25,7 @@ import Time from '../components/Time';
 
 const DagRunTooltip = ({
   dagRun: {
-    state, duration, dataIntervalStart, executionDate,
+    state, duration, dataIntervalStart, executionDate, runType,
   },
 }) => (
   <Box py="2px">
@@ -43,6 +43,11 @@ const DagRunTooltip = ({
       Duration:
       {' '}
       {formatDuration(duration)}
+    </Text>
+    <Text>
+      Type:
+      {' '}
+      {runType}
     </Text>
   </Box>
 );

--- a/airflow/www/static/js/grid/details/Header.jsx
+++ b/airflow/www/static/js/grid/details/Header.jsx
@@ -26,7 +26,8 @@ import {
   Heading,
   Text,
 } from '@chakra-ui/react';
-import { MdPlayArrow } from 'react-icons/md';
+import { MdPlayArrow, MdOutlineSchedule } from 'react-icons/md';
+import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import { getMetaValue } from '../../utils';
 import useSelection from '../utils/useSelection';
@@ -68,6 +69,20 @@ const Header = () => {
       runLabel = (
         <>
           <MdPlayArrow style={{ display: 'inline' }} />
+          {runLabel}
+        </>
+      );
+    } else if (dagRun.runType === 'backfill') {
+      runLabel = (
+        <>
+          <RiArrowGoBackFill style={{ display: 'inline' }} />
+          {runLabel}
+        </>
+      );
+    } else if (dagRun.runType === 'scheduled') {
+      runLabel = (
+        <>
+          <MdOutlineSchedule style={{ display: 'inline' }} />
           {runLabel}
         </>
       );

--- a/airflow/www/static/js/grid/details/content/dagRun/index.jsx
+++ b/airflow/www/static/js/grid/details/content/dagRun/index.jsx
@@ -25,7 +25,9 @@ import {
   Link,
   Divider,
 } from '@chakra-ui/react';
-import { MdPlayArrow, MdOutlineAccountTree } from 'react-icons/md';
+
+import { MdPlayArrow, MdOutlineSchedule, MdOutlineAccountTree } from 'react-icons/md';
+import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import { SimpleStatus } from '../../../components/StatusBox';
 import { ClipboardText } from '../../../components/Clipboard';
@@ -97,6 +99,8 @@ const DagRun = ({ runId }) => {
         Run Type:
         {' '}
         {runType === 'manual' && <MdPlayArrow style={{ display: 'inline' }} />}
+        {runType === 'backfill' && <RiArrowGoBackFill style={{ display: 'inline' }} />}
+        {runType === 'scheduled' && <MdOutlineSchedule style={{ display: 'inline' }} />}
         {runType}
       </Text>
       <Text>


### PR DESCRIPTION
closes: #23945 
---

In the grid view, added icons for both "backfill" and "scheduled" dag run types. Additionally, updated the dag run tooltip to include the type. 

## Screenshots

Scheduled, before the change (Notice the missing icons in all 3 locations - same was applicable to backfilled type):

![scheduled_before](https://user-images.githubusercontent.com/3412571/170732226-36534d1d-3592-4b09-a14e-0d2aae3bdbad.png)


Manual run (icons were already present, screenshot to show consistency): 

![manual](https://user-images.githubusercontent.com/3412571/170731690-2dd2d5fc-7598-46b1-aed6-b9f8c9a16de0.png)

Scheduled run (notice not present on bar):

![no icon on scheduled bar](https://user-images.githubusercontent.com/3412571/170742586-548b2dbe-2469-4b77-8bc4-94eef0dcf745.png)

Backfilled run:

![backfill](https://user-images.githubusercontent.com/3412571/170731778-a248f90b-2e14-4c7a-9100-0d6caa77ddd0.png)



