### PR TITLE
Unify DbApiHook.run() method with the methods which override it

### DIFF
--- a/airflow/operators/sql.py
+++ b/airflow/operators/sql.py
@@ -496,7 +496,7 @@ class BranchSQLOperator(BaseSQLOperator, SkipMixin):
         follow_task_ids_if_false: List[str],
         conn_id: str = "default_conn_id",
         database: Optional[str] = None,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         **kwargs,
     ) -> None:
         super().__init__(conn_id=conn_id, database=database, **kwargs)

--- a/airflow/providers/amazon/aws/operators/redshift_sql.py
+++ b/airflow/providers/amazon/aws/operators/redshift_sql.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING, Iterable, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
@@ -55,7 +55,7 @@ class RedshiftSQLOperator(BaseOperator):
         *,
         sql: Union[str, Iterable[str]],
         redshift_conn_id: str = 'redshift_default',
-        parameters: Optional[dict] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         autocommit: bool = True,
         **kwargs,
     ) -> None:

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -93,7 +93,7 @@ class RedshiftToS3Operator(BaseOperator):
         unload_options: Optional[List] = None,
         autocommit: bool = False,
         include_header: bool = False,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         table_as_file_name: bool = True,  # Set to True by default for not breaking current workflows
         **kwargs,
     ) -> None:

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import warnings
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -140,7 +140,7 @@ class S3ToRedshiftOperator(BaseOperator):
 
         copy_statement = self._build_copy_query(copy_destination, credentials_block, copy_options)
 
-        sql: Union[list, str]
+        sql: Union[str, Iterable[str]]
 
         if self.method == 'REPLACE':
             sql = ["BEGIN;", f"DELETE FROM {destination};", copy_statement, "COMMIT"]

--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -17,8 +17,6 @@
 # under the License.
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
-import sqlparse
-
 from airflow.models import BaseOperator
 from airflow.providers.apache.drill.hooks.drill import DrillHook
 
@@ -64,6 +62,4 @@ class DrillOperator(BaseOperator):
     def execute(self, context: 'Context'):
         self.log.info('Executing: %s on %s', self.sql, self.drill_conn_id)
         self.hook = DrillHook(drill_conn_id=self.drill_conn_id)
-        sql = sqlparse.split(sqlparse.format(self.sql, strip_comments=True))
-        no_term_sql = [s[:-1] for s in sql if s[-1] == ';']
-        self.hook.run(no_term_sql, parameters=self.parameters)
+        self.hook.run(DrillHook.split_sql_string(self.sql), parameters=self.parameters)

--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -62,4 +62,4 @@ class DrillOperator(BaseOperator):
     def execute(self, context: 'Context'):
         self.log.info('Executing: %s on %s', self.sql, self.drill_conn_id)
         self.hook = DrillHook(drill_conn_id=self.drill_conn_id)
-        self.hook.run(DrillHook.split_sql_string(self.sql), parameters=self.parameters)
+        self.hook.run(self.sql, parameters=self.parameters, split_statements=True)

--- a/airflow/providers/apache/drill/operators/drill.py
+++ b/airflow/providers/apache/drill/operators/drill.py
@@ -52,7 +52,7 @@ class DrillOperator(BaseOperator):
         *,
         sql: str,
         drill_conn_id: str = 'drill_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -34,7 +34,6 @@ dependencies:
   - apache-airflow>=2.2.0
   - apache-airflow-providers-common-sql
   - sqlalchemy-drill>=1.1.0
-  - sqlparse>=0.4.1
 
 integrations:
   - integration-name: Apache Drill

--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -18,7 +18,7 @@
 
 import os
 import subprocess
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable, List, Mapping, Optional, Union
 
 from pinotdb import connect
 
@@ -275,7 +275,7 @@ class PinotDbApiHook(DbApiHook):
         endpoint = conn.extra_dejson.get('endpoint', 'query/sql')
         return f'{conn_type}://{host}/{endpoint}'
 
-    def get_records(self, sql: str, parameters: Optional[Union[Dict[str, Any], Iterable[Any]]] = None) -> Any:
+    def get_records(self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
         """
         Executes the sql and returns a set of records.
 
@@ -287,7 +287,7 @@ class PinotDbApiHook(DbApiHook):
             cur.execute(sql)
             return cur.fetchall()
 
-    def get_first(self, sql: str, parameters: Optional[Union[Dict[str, Any], Iterable[Any]]] = None) -> Any:
+    def get_first(self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
         """
         Executes the sql and returns the first resulting row.
 

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -236,7 +236,8 @@ class DbApiHook(BaseHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
-    ) -> Optional[list]:
+        return_last: bool = True,
+    ) -> Optional[Union[Any, List[Any]]]:
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -249,6 +250,7 @@ class DbApiHook(BaseHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
+        :param return_last: Whether to return handler result for only last statement or for all
         :return: return only result of the ALL SQL expressions if handler was provided.
         """
         if isinstance(sql, str):
@@ -281,6 +283,8 @@ class DbApiHook(BaseHook):
 
         if handler is None:
             return None
+        elif return_last:
+            return results[-1]
         else:
             return results
 

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -258,7 +258,7 @@ class DbApiHook(BaseHook):
             if split_statements:
                 sql = self.split_sql_string(sql)
             else:
-                sql = [sql]
+                sql = [self.strip_sql_string(sql)]
 
         if sql:
             self.log.debug("Executing following statements against DB: %s", list(sql))

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -235,6 +235,7 @@ class DbApiHook(BaseHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
     ) -> Optional[list]:
         """
         Runs a command or a list of commands. Pass a list of sql
@@ -247,10 +248,14 @@ class DbApiHook(BaseHook):
             before executing the query.
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
+        :param split_statements: Whether to split a single SQL string into statements and run separately
         :return: return only result of the ALL SQL expressions if handler was provided.
         """
         if isinstance(sql, str):
-            sql = [sql]
+            if split_statements:
+                sql = self.split_sql_string(sql)
+            else:
+                sql = [sql]
 
         if sql:
             self.log.debug("Executing following statements against DB: %s", list(sql))

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -250,9 +250,10 @@ class DbApiHook(BaseHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
-        :param return_last: Whether to return handler result for only last statement or for all
+        :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the ALL SQL expressions if handler was provided.
         """
+        scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -283,7 +284,7 @@ class DbApiHook(BaseHook):
 
         if handler is None:
             return None
-        elif return_last:
+        elif scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -24,7 +24,8 @@ description: |
 versions:
   - 1.0.0
 
-dependencies: []
+dependencies:
+  - sqlparse>=0.4.2
 
 additional-extras:
   - name: pandas

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -159,9 +159,10 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
-        :param return_last: Whether to return handler result for only last statement or for all
+        :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
+        scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -191,7 +192,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
         if handler is None:
             return None
-        elif return_last:
+        elif scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -144,6 +144,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = True,
     ) -> Optional[List[Tuple[Any, Any]]]:
         """
         Runs a command or a list of commands. Pass a list of sql
@@ -156,10 +157,14 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
             before executing the query.
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
+        :param split_statements: Whether to split a single SQL string into statements and run separately
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         if isinstance(sql, str):
-            sql = self.split_sql_string(sql)
+            if split_statements:
+                sql = self.split_sql_string(sql)
+            else:
+                sql = [sql]
 
         if sql:
             self.log.debug("Executing following statements against Databricks DB: %s", list(sql))

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -145,7 +145,8 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = True,
-    ) -> Optional[List[Tuple[Any, Any]]]:
+        return_last: bool = True,
+    ) -> Optional[Union[Tuple[str, Any], List[Tuple[str, Any]]]]:
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -158,6 +159,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
+        :param return_last: Whether to return handler result for only last statement or for all
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         if isinstance(sql, str):
@@ -189,6 +191,8 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
         if handler is None:
             return None
+        elif return_last:
+            return results[-1]
         else:
             return results
 

--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -167,7 +167,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
             if split_statements:
                 sql = self.split_sql_string(sql)
             else:
-                sql = [sql]
+                sql = [self.strip_sql_string(sql)]
 
         if sql:
             self.log.debug("Executing following statements against Databricks DB: %s", list(sql))

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -134,6 +134,7 @@ class ExasolHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
     ) -> Optional[list]:
         """
         Runs a command or a list of commands. Pass a list of sql
@@ -146,10 +147,14 @@ class ExasolHook(DbApiHook):
             before executing the query.
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
+        :param split_statements: Whether to split a single SQL string into statements and run separately
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         if isinstance(sql, str):
-            sql = self.split_sql_string(sql)
+            if split_statements:
+                sql = self.split_sql_string(sql)
+            else:
+                sql = [sql]
 
         if sql:
             self.log.debug("Executing following statements against Exasol DB: %s", list(sql))

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -135,7 +135,8 @@ class ExasolHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
-    ) -> Optional[list]:
+        return_last: bool = True,
+    ) -> Optional[Union[Any, List[Any]]]:
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -148,6 +149,7 @@ class ExasolHook(DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
+        :param return_last: Whether to return handler result for only last statement or for all
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         if isinstance(sql, str):
@@ -179,6 +181,8 @@ class ExasolHook(DbApiHook):
 
         if handler is None:
             return None
+        elif return_last:
+            return results[-1]
         else:
             return results
 

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -17,7 +17,7 @@
 # under the License.
 
 from contextlib import closing
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import pandas as pd
 import pyexasol
@@ -64,9 +64,7 @@ class ExasolHook(DbApiHook):
         conn = pyexasol.connect(**conn_args)
         return conn
 
-    def get_pandas_df(
-        self, sql: Union[str, list], parameters: Optional[dict] = None, **kwargs
-    ) -> pd.DataFrame:
+    def get_pandas_df(self, sql: str, parameters: Optional[dict] = None, **kwargs) -> pd.DataFrame:
         """
         Executes the sql and returns a pandas dataframe
 
@@ -79,9 +77,7 @@ class ExasolHook(DbApiHook):
             df = conn.export_to_pandas(sql, query_params=parameters, **kwargs)
             return df
 
-    def get_records(
-        self, sql: Union[str, list], parameters: Optional[dict] = None
-    ) -> List[Union[dict, Tuple[Any, ...]]]:
+    def get_records(self, sql: str, parameters: Optional[dict] = None) -> List[Union[dict, Tuple[Any, ...]]]:
         """
         Executes the sql and returns a set of records.
 
@@ -93,7 +89,7 @@ class ExasolHook(DbApiHook):
             with closing(conn.execute(sql, parameters)) as cur:
                 return cur.fetchall()
 
-    def get_first(self, sql: Union[str, list], parameters: Optional[dict] = None) -> Optional[Any]:
+    def get_first(self, sql: str, parameters: Optional[dict] = None) -> Optional[Any]:
         """
         Executes the sql and returns the first resulting row.
 
@@ -133,7 +129,11 @@ class ExasolHook(DbApiHook):
         self.log.info("Data saved to %s", filename)
 
     def run(
-        self, sql: Union[str, list], autocommit: bool = False, parameters: Optional[dict] = None, handler=None
+        self,
+        sql: Union[str, Iterable[str]],
+        autocommit: bool = False,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        handler: Optional[Callable] = None,
     ) -> Optional[list]:
         """
         Runs a command or a list of commands. Pass a list of sql
@@ -146,38 +146,36 @@ class ExasolHook(DbApiHook):
             before executing the query.
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
+        :return: return only result of the LAST SQL expression if handler was provided.
         """
         if isinstance(sql, str):
-            sql = [sql]
+            sql = self.split_sql_string(sql)
 
         if sql:
-            self.log.debug("Executing %d statements against Exasol DB", len(sql))
+            self.log.debug("Executing following statements against Exasol DB: %s", list(sql))
         else:
             raise ValueError("List of SQL statements is empty")
 
         with closing(self.get_conn()) as conn:
-            if self.supports_autocommit:
-                self.set_autocommit(conn, autocommit)
-
-            for query in sql:
-                self.log.info(query)
-                with closing(conn.execute(query, parameters)) as cur:
-                    results = []
-
+            self.set_autocommit(conn, autocommit)
+            results = []
+            for sql_statement in sql:
+                with closing(conn.execute(sql_statement, parameters)) as cur:
+                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
                     if handler is not None:
-                        cur = handler(cur)
+                        result = handler(cur)
+                        results.append(result)
 
-                    for row in cur:
-                        self.log.info("Statement execution info - %s", row)
-                        results.append(row)
+                    self.log.info("Rows affected: %s", cur.rowcount)
 
-                    self.log.info(cur.row_count)
-            # If autocommit was set to False for db that supports autocommit,
-            # or if db does not support autocommit, we do a manual commit.
+            # If autocommit was set to False or db does not support autocommit, we do a manual commit.
             if not self.get_autocommit(conn):
                 conn.commit()
 
-        return results
+        if handler is None:
+            return None
+        else:
+            return results
 
     def set_autocommit(self, conn, autocommit: bool) -> None:
         """

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -149,9 +149,10 @@ class ExasolHook(DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
-        :param return_last: Whether to return handler result for only last statement or for all
+        :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
+        scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -181,7 +182,7 @@ class ExasolHook(DbApiHook):
 
         if handler is None:
             return None
-        elif return_last:
+        elif scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -157,7 +157,7 @@ class ExasolHook(DbApiHook):
             if split_statements:
                 sql = self.split_sql_string(sql)
             else:
-                sql = [sql]
+                sql = [self.strip_sql_string(sql)]
 
         if sql:
             self.log.debug("Executing following statements against Exasol DB: %s", list(sql))

--- a/airflow/providers/exasol/operators/exasol.py
+++ b/airflow/providers/exasol/operators/exasol.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Optional, Sequence
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.exasol.hooks.exasol import ExasolHook
@@ -46,10 +46,10 @@ class ExasolOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: str,
+        sql: Union[str, Iterable[str]],
         exasol_conn_id: str = 'exasol_default',
         autocommit: bool = False,
-        parameters: Optional[dict] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         schema: Optional[str] = None,
         **kwargs,
     ) -> None:

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -550,7 +550,7 @@ class BigQueryExecuteQueryOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, Iterable],
+        sql: Union[str, Iterable[str]],
         destination_dataset_table: Optional[str] = None,
         write_disposition: str = 'WRITE_EMPTY',
         allow_large_results: bool = False,

--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains Google Cloud SQL operators."""
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from googleapiclient.errors import HttpError
 
@@ -1054,9 +1054,9 @@ class CloudSQLExecuteQueryOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[List[str], str],
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[Union[Dict, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         gcp_conn_id: str = 'google_cloud_default',
         gcp_cloudsql_conn_id: str = 'google_cloud_sql_default',
         **kwargs,

--- a/airflow/providers/google/suite/transfers/sql_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/sql_to_sheets.py
@@ -68,7 +68,7 @@ class SQLToGoogleSheetsOperator(BaseSQLOperator):
         sql: str,
         spreadsheet_id: str,
         sql_conn_id: str,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         database: Optional[str] = None,
         spreadsheet_range: str = "Sheet1",
         gcp_conn_id: str = "google_cloud_default",

--- a/airflow/providers/jdbc/operators/jdbc.py
+++ b/airflow/providers/jdbc/operators/jdbc.py
@@ -16,18 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.jdbc.hooks.jdbc import JdbcHook
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
-
-
-def fetch_all_handler(cursor):
-    """Handler for DbApiHook.run() to return results"""
-    return cursor.fetchall()
 
 
 class JdbcOperator(BaseOperator):
@@ -57,10 +53,10 @@ class JdbcOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, List[str]],
+        sql: Union[str, Iterable[str]],
         jdbc_conn_id: str = 'jdbc_default',
         autocommit: bool = False,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -70,7 +66,7 @@ class JdbcOperator(BaseOperator):
         self.autocommit = autocommit
         self.hook = None
 
-    def execute(self, context: 'Context') -> None:
+    def execute(self, context: 'Context'):
         self.log.info('Executing: %s', self.sql)
         hook = JdbcHook(jdbc_conn_id=self.jdbc_conn_id)
         return hook.run(self.sql, self.autocommit, parameters=self.parameters, handler=fetch_all_handler)

--- a/airflow/providers/microsoft/mssql/operators/mssql.py
+++ b/airflow/providers/microsoft/mssql/operators/mssql.py
@@ -57,9 +57,9 @@ class MsSqlOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: str,
+        sql: Union[str, Iterable[str]],
         mssql_conn_id: str = 'mssql_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         autocommit: bool = False,
         database: Optional[str] = None,
         **kwargs,

--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import ast
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
@@ -59,9 +59,9 @@ class MySqlOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, List[str]],
+        sql: Union[str, Iterable[str]],
         mysql_conn_id: str = 'mysql_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         autocommit: bool = False,
         database: Optional[str] = None,
         **kwargs,

--- a/airflow/providers/neo4j/operators/neo4j.py
+++ b/airflow/providers/neo4j/operators/neo4j.py
@@ -44,7 +44,7 @@ class Neo4jOperator(BaseOperator):
         *,
         sql: str,
         neo4j_conn_id: str = 'neo4j_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/oracle/operators/oracle.py
+++ b/airflow/providers/oracle/operators/oracle.py
@@ -50,9 +50,9 @@ class OracleOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, List[str]],
+        sql: Union[str, Iterable[str]],
         oracle_conn_id: str = 'oracle_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         autocommit: bool = False,
         **kwargs,
     ) -> None:
@@ -98,7 +98,7 @@ class OracleStoredProcedureOperator(BaseOperator):
         self.procedure = procedure
         self.parameters = parameters
 
-    def execute(self, context: 'Context') -> Optional[Union[List, Dict]]:
+    def execute(self, context: 'Context'):
         self.log.info('Executing: %s', self.procedure)
         hook = OracleHook(oracle_conn_id=self.oracle_conn_id)
         return hook.callproc(self.procedure, autocommit=True, parameters=self.parameters)

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
 from psycopg2.sql import SQL, Identifier
 
@@ -53,10 +53,10 @@ class PostgresOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, List[str]],
+        sql: Union[str, Iterable[str]],
         postgres_conn_id: str = 'postgres_default',
         autocommit: bool = False,
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         database: Optional[str] = None,
         runtime_parameters: Optional[Mapping] = None,
         **kwargs,

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -241,6 +241,7 @@ class PrestoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
     ) -> Optional[list]:
         """Execute the statement against Presto. Can be used to create views."""
 
@@ -251,6 +252,7 @@ class PrestoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
         hql: str = "",
     ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
@@ -261,6 +263,7 @@ class PrestoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
         hql: str = "",
     ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
@@ -275,7 +278,13 @@ class PrestoHook(DbApiHook):
         if isinstance(sql, str):
             sql = self.strip_sql_string(sql)
 
-        return super().run(sql=sql, autocommit=autocommit, parameters=parameters, handler=handler)
+        return super().run(
+            sql=sql,
+            autocommit=autocommit,
+            parameters=parameters,
+            handler=handler,
+            split_statements=split_statements,
+        )
 
     def insert_rows(
         self,

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -278,15 +278,13 @@ class PrestoHook(DbApiHook):
             )
             sql = hql
 
-        if isinstance(sql, str):
-            sql = self.strip_sql_string(sql)
-
         return super().run(
             sql=sql,
             autocommit=autocommit,
             parameters=parameters,
             handler=handler,
             split_statements=split_statements,
+            return_last=return_last,
         )
 
     def insert_rows(

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -18,7 +18,7 @@
 import json
 import os
 import warnings
-from typing import Any, Callable, Iterable, Optional, overload
+from typing import Any, Callable, Iterable, Mapping, Optional, Union, overload
 
 import prestodb
 from prestodb.exceptions import DatabaseError
@@ -142,10 +142,6 @@ class PrestoHook(DbApiHook):
         isolation_level = db.extra_dejson.get('isolation_level', 'AUTOCOMMIT').upper()
         return getattr(IsolationLevel, isolation_level, IsolationLevel.AUTOCOMMIT)
 
-    @staticmethod
-    def _strip_sql(sql: str) -> str:
-        return sql.strip().rstrip(';')
-
     @overload
     def get_records(self, sql: str = "", parameters: Optional[dict] = None):
         """Get a set of records from Presto
@@ -169,7 +165,7 @@ class PrestoHook(DbApiHook):
             sql = hql
 
         try:
-            return super().get_records(self._strip_sql(sql), parameters)
+            return super().get_records(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise PrestoException(e)
 
@@ -196,7 +192,7 @@ class PrestoHook(DbApiHook):
             sql = hql
 
         try:
-            return super().get_first(self._strip_sql(sql), parameters)
+            return super().get_first(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise PrestoException(e)
 
@@ -226,7 +222,7 @@ class PrestoHook(DbApiHook):
 
         cursor = self.get_cursor()
         try:
-            cursor.execute(self._strip_sql(sql), parameters)
+            cursor.execute(self.strip_sql_string(sql), parameters)
             data = cursor.fetchall()
         except DatabaseError as e:
             raise PrestoException(e)
@@ -241,32 +237,32 @@ class PrestoHook(DbApiHook):
     @overload
     def run(
         self,
-        sql: str = "",
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[dict] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
-    ) -> None:
+    ) -> Optional[list]:
         """Execute the statement against Presto. Can be used to create views."""
 
     @overload
     def run(
         self,
-        sql: str = "",
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[dict] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         hql: str = "",
-    ) -> None:
+    ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
 
     def run(
         self,
-        sql: str = "",
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[dict] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         hql: str = "",
-    ) -> None:
+    ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(
@@ -276,7 +272,10 @@ class PrestoHook(DbApiHook):
             )
             sql = hql
 
-        return super().run(sql=self._strip_sql(sql), parameters=parameters, handler=handler)
+        if isinstance(sql, str):
+            sql = self.strip_sql_string(sql)
+
+        return super().run(sql=sql, autocommit=autocommit, parameters=parameters, handler=handler)
 
     def insert_rows(
         self,

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -18,7 +18,7 @@
 import json
 import os
 import warnings
-from typing import Any, Callable, Iterable, Mapping, Optional, Union, overload
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union, overload
 
 import prestodb
 from prestodb.exceptions import DatabaseError
@@ -242,7 +242,8 @@ class PrestoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
-    ) -> Optional[list]:
+        return_last: bool = True,
+    ) -> Optional[Union[Any, List[Any]]]:
         """Execute the statement against Presto. Can be used to create views."""
 
     @overload
@@ -253,8 +254,9 @@ class PrestoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
+        return_last: bool = True,
         hql: str = "",
-    ) -> Optional[list]:
+    ) -> Optional[Union[Any, List[Any]]]:
         """:sphinx-autoapi-skip:"""
 
     def run(
@@ -264,8 +266,9 @@ class PrestoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
+        return_last: bool = True,
         hql: str = "",
-    ) -> Optional[list]:
+    ) -> Optional[Union[Any, List[Any]]]:
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -318,7 +318,7 @@ class SnowflakeHook(DbApiHook):
                 split_statements_tuple = util_text.split_statements(StringIO(sql))
                 sql = [sql_string for sql_string, _ in split_statements_tuple if sql_string]
             else:
-                sql = [sql]
+                sql = [self.strip_sql_string(sql)]
 
         if sql:
             self.log.debug("Executing following statements against Snowflake DB: %s", list(sql))

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -290,7 +290,8 @@ class SnowflakeHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = True,
-    ):
+        return_last: bool = True,
+    ) -> Optional[Union[Any, List[Any]]]:
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -306,6 +307,7 @@ class SnowflakeHook(DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
+        :param return_last: Whether to return handler result for only last statement or for all
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         self.query_ids = []
@@ -346,6 +348,8 @@ class SnowflakeHook(DbApiHook):
 
         if handler is None:
             return None
+        elif return_last:
+            return results[-1]
         else:
             return results
 

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -307,11 +307,12 @@ class SnowflakeHook(DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :param handler: The result handler which is called with the result of each statement.
         :param split_statements: Whether to split a single SQL string into statements and run separately
-        :param return_last: Whether to return handler result for only last statement or for all
+        :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
         self.query_ids = []
 
+        scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 split_statements_tuple = util_text.split_statements(StringIO(sql))
@@ -348,7 +349,7 @@ class SnowflakeHook(DbApiHook):
 
         if handler is None:
             return None
-        elif return_last:
+        elif scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/sqlite/operators/sqlite.py
+++ b/airflow/providers/sqlite/operators/sqlite.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, Union
+from typing import Any, Iterable, Mapping, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
@@ -45,9 +45,9 @@ class SqliteOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: Union[str, List[str]],
+        sql: Union[str, Iterable[str]],
         sqlite_conn_id: str = 'sqlite_default',
-        parameters: Optional[Union[Mapping, Iterable]] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -298,15 +298,13 @@ class TrinoHook(DbApiHook):
             )
             sql = hql
 
-        if isinstance(sql, str):
-            sql = self.strip_sql_string(sql)
-
         return super().run(
             sql=sql,
             autocommit=autocommit,
             parameters=parameters,
             handler=handler,
             split_statements=split_statements,
+            return_last=return_last,
         )
 
     def insert_rows(

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -19,10 +19,8 @@ import json
 import os
 import warnings
 from contextlib import closing
-from itertools import chain
-from typing import Any, Callable, Iterable, Optional, Tuple, overload
+from typing import Any, Callable, Iterable, Mapping, Optional, Union, overload
 
-import sqlparse
 import trino
 from trino.exceptions import DatabaseError
 from trino.transaction import IsolationLevel
@@ -150,12 +148,8 @@ class TrinoHook(DbApiHook):
         isolation_level = db.extra_dejson.get('isolation_level', 'AUTOCOMMIT').upper()
         return getattr(IsolationLevel, isolation_level, IsolationLevel.AUTOCOMMIT)
 
-    @staticmethod
-    def _strip_sql(sql: str) -> str:
-        return sql.strip().rstrip(';')
-
     @overload
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None):
+    def get_records(self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None):
         """Get a set of records from Trino
 
         :param sql: SQL statement to be executed.
@@ -163,10 +157,14 @@ class TrinoHook(DbApiHook):
         """
 
     @overload
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None, hql: str = ""):
+    def get_records(
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+    ):
         """:sphinx-autoapi-skip:"""
 
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None, hql: str = ""):
+    def get_records(
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+    ):
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(
@@ -177,12 +175,12 @@ class TrinoHook(DbApiHook):
             sql = hql
 
         try:
-            return super().get_records(self._strip_sql(sql), parameters)
+            return super().get_records(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise TrinoException(e)
 
     @overload
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None) -> Any:
+    def get_first(self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
         """Returns only the first row, regardless of how many rows the query returns.
 
         :param sql: SQL statement to be executed.
@@ -190,10 +188,14 @@ class TrinoHook(DbApiHook):
         """
 
     @overload
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None, hql: str = "") -> Any:
+    def get_first(
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+    ) -> Any:
         """:sphinx-autoapi-skip:"""
 
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None, hql: str = "") -> Any:
+    def get_first(
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+    ) -> Any:
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(
@@ -204,13 +206,13 @@ class TrinoHook(DbApiHook):
             sql = hql
 
         try:
-            return super().get_first(self._strip_sql(sql), parameters)
+            return super().get_first(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise TrinoException(e)
 
     @overload
     def get_pandas_df(
-        self, sql: str = "", parameters: Optional[dict] = None, **kwargs
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, **kwargs
     ):  # type: ignore[override]
         """Get a pandas dataframe from a sql query.
 
@@ -220,12 +222,12 @@ class TrinoHook(DbApiHook):
 
     @overload
     def get_pandas_df(
-        self, sql: str = "", parameters: Optional[dict] = None, hql: str = "", **kwargs
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = "", **kwargs
     ):  # type: ignore[override]
         """:sphinx-autoapi-skip:"""
 
     def get_pandas_df(
-        self, sql: str = "", parameters: Optional[dict] = None, hql: str = "", **kwargs
+        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = "", **kwargs
     ):  # type: ignore[override]
         """:sphinx-autoapi-skip:"""
         if hql:
@@ -240,7 +242,7 @@ class TrinoHook(DbApiHook):
 
         cursor = self.get_cursor()
         try:
-            cursor.execute(self._strip_sql(sql), parameters)
+            cursor.execute(self.strip_sql_string(sql), parameters)
             data = cursor.fetchall()
         except DatabaseError as e:
             raise TrinoException(e)
@@ -255,32 +257,32 @@ class TrinoHook(DbApiHook):
     @overload
     def run(
         self,
-        sql,
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[Tuple] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
-    ) -> None:
+    ) -> Optional[list]:
         """Execute the statement against Trino. Can be used to create views."""
 
     @overload
     def run(
         self,
-        sql,
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[Tuple] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         hql: str = "",
-    ) -> None:
+    ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
 
     def run(
         self,
-        sql,
+        sql: Union[str, Iterable[str]],
         autocommit: bool = False,
-        parameters: Optional[Tuple] = None,
+        parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         hql: str = "",
-    ):
+    ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(
@@ -289,38 +291,11 @@ class TrinoHook(DbApiHook):
                 stacklevel=2,
             )
             sql = hql
-        scalar = isinstance(sql, str)
 
-        with closing(self.get_conn()) as conn:
-            if self.supports_autocommit:
-                self.set_autocommit(conn, autocommit)
+        if isinstance(sql, str):
+            sql = self.strip_sql_string(sql)
 
-            if scalar:
-                sql = sqlparse.split(sql)
-
-            with closing(conn.cursor()) as cur:
-                results = []
-                for sql_statement in sql:
-                    self._run_command(cur, self._strip_sql(sql_statement), parameters)
-                    self.query_id = cur.stats["queryId"]
-                    if handler is not None:
-                        result = handler(cur)
-                        results.append(result)
-
-            # If autocommit was set to False for db that supports autocommit,
-            # or if db does not supports autocommit, we do a manual commit.
-            if not self.get_autocommit(conn):
-                conn.commit()
-
-        self.log.info("Query Execution Result: %s", str(list(chain.from_iterable(results))))
-
-        if handler is None:
-            return None
-
-        if scalar:
-            return results[0]
-
-        return results
+        return super().run(sql=sql, autocommit=autocommit, parameters=parameters, handler=handler)
 
     def insert_rows(
         self,

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -19,7 +19,7 @@ import json
 import os
 import warnings
 from contextlib import closing
-from typing import Any, Callable, Iterable, Mapping, Optional, Union, overload
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union, overload
 
 import trino
 from trino.exceptions import DatabaseError
@@ -262,7 +262,8 @@ class TrinoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
-    ) -> Optional[list]:
+        return_last: bool = True,
+    ) -> Optional[Union[Any, List[Any]]]:
         """Execute the statement against Trino. Can be used to create views."""
 
     @overload
@@ -273,8 +274,9 @@ class TrinoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
+        return_last: bool = True,
         hql: str = "",
-    ) -> Optional[list]:
+    ) -> Optional[Union[Any, List[Any]]]:
         """:sphinx-autoapi-skip:"""
 
     def run(
@@ -284,8 +286,9 @@ class TrinoHook(DbApiHook):
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
         split_statements: bool = False,
+        return_last: bool = True,
         hql: str = "",
-    ) -> Optional[list]:
+    ) -> Optional[Union[Any, List[Any]]]:
         """:sphinx-autoapi-skip:"""
         if hql:
             warnings.warn(

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -261,6 +261,7 @@ class TrinoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
     ) -> Optional[list]:
         """Execute the statement against Trino. Can be used to create views."""
 
@@ -271,6 +272,7 @@ class TrinoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
         hql: str = "",
     ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
@@ -281,6 +283,7 @@ class TrinoHook(DbApiHook):
         autocommit: bool = False,
         parameters: Optional[Union[Iterable, Mapping]] = None,
         handler: Optional[Callable] = None,
+        split_statements: bool = False,
         hql: str = "",
     ) -> Optional[list]:
         """:sphinx-autoapi-skip:"""
@@ -295,7 +298,13 @@ class TrinoHook(DbApiHook):
         if isinstance(sql, str):
             sql = self.strip_sql_string(sql)
 
-        return super().run(sql=sql, autocommit=autocommit, parameters=parameters, handler=handler)
+        return super().run(
+            sql=sql,
+            autocommit=autocommit,
+            parameters=parameters,
+            handler=handler,
+            split_statements=split_statements,
+        )
 
     def insert_rows(
         self,

--- a/airflow/providers/vertica/operators/vertica.py
+++ b/airflow/providers/vertica/operators/vertica.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Any, List, Sequence, Union
+from typing import TYPE_CHECKING, Any, Iterable, Sequence, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.vertica.hooks.vertica import VerticaHook
@@ -40,7 +40,7 @@ class VerticaOperator(BaseOperator):
     ui_color = '#b4e0ff'
 
     def __init__(
-        self, *, sql: Union[str, List[str]], vertica_conn_id: str = 'vertica_default', **kwargs: Any
+        self, *, sql: Union[str, Iterable[str]], vertica_conn_id: str = 'vertica_default', **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
         self.vertica_conn_id = vertica_conn_id

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -62,8 +62,7 @@
     "deps": [
       "apache-airflow-providers-common-sql",
       "apache-airflow>=2.2.0",
-      "sqlalchemy-drill>=1.1.0",
-      "sqlparse>=0.4.1"
+      "sqlalchemy-drill>=1.1.0"
     ],
     "cross-providers-deps": [
       "common.sql"
@@ -191,7 +190,9 @@
     "cross-providers-deps": []
   },
   "common.sql": {
-    "deps": [],
+    "deps": [
+      "sqlparse>=0.4.2"
+    ],
     "cross-providers-deps": []
   },
   "databricks": {

--- a/tests/providers/common/sql/hooks/test_dbapi.py
+++ b/tests/providers/common/sql/hooks/test_dbapi.py
@@ -367,7 +367,7 @@ class TestDbApiHook(unittest.TestCase):
         result = self.db_hook.run(sql, parameters=param, handler=handler)
         assert called == 1
         assert self.conn.commit.called
-        assert result == obj
+        assert result == [obj]
 
     def test_run_with_handler_multiple(self):
         sql = ['SQL', 'SQL']

--- a/tests/providers/common/sql/hooks/test_dbapi.py
+++ b/tests/providers/common/sql/hooks/test_dbapi.py
@@ -367,7 +367,7 @@ class TestDbApiHook(unittest.TestCase):
         result = self.db_hook.run(sql, parameters=param, handler=handler)
         assert called == 1
         assert self.conn.commit.called
-        assert result == [obj]
+        assert result == obj
 
     def test_run_with_handler_multiple(self):
         sql = ['SQL', 'SQL']

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -23,6 +23,7 @@ from unittest import mock
 import pytest
 
 from airflow.models import Connection
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.databricks.hooks.databricks_sql import DatabricksSqlHook
 from airflow.utils.session import provide_session
 
@@ -72,17 +73,17 @@ class TestDatabricksSqlHookQueryByName(unittest.TestCase):
         test_schema = [(field,) for field in test_fields]
 
         conn = mock_conn.return_value
-        cur = mock.MagicMock(rowcount=0)
+        cur = mock.MagicMock(rowcount=0, description=test_schema)
+        cur.fetchall.return_value = []
         conn.cursor.return_value = cur
-        type(cur).description = mock.PropertyMock(return_value=test_schema)
 
-        query = "select * from test.test"
-        schema, results = self.hook.run(sql=query)
+        query = "select * from test.test;"
+        schema, results = self.hook.run(sql=query, handler=fetch_all_handler)[0]
 
         assert schema == test_schema
         assert results == []
 
-        cur.execute.assert_has_calls([mock.call(q) for q in [query]])
+        cur.execute.assert_has_calls([mock.call(q) for q in [query.rstrip(';')]])
         cur.close.assert_called()
 
     def test_no_query(self):

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -78,7 +78,7 @@ class TestDatabricksSqlHookQueryByName(unittest.TestCase):
         conn.cursor.return_value = cur
 
         query = "select * from test.test;"
-        schema, results = self.hook.run(sql=query, handler=fetch_all_handler)[0]
+        schema, results = self.hook.run(sql=query, handler=fetch_all_handler)
 
         assert schema == test_schema
         assert results == []

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -25,6 +25,7 @@ import pytest
 from databricks.sql.types import Row
 
 from airflow import AirflowException
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 from airflow.providers.databricks.operators.databricks_sql import (
     DatabricksCopyIntoOperator,
     DatabricksSqlOperator,
@@ -47,7 +48,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         db_mock = db_mock_class.return_value
         mock_schema = [('id',), ('value',)]
         mock_results = [Row(id=1, value='value1')]
-        db_mock.run.return_value = (mock_schema, mock_results)
+        db_mock.run.return_value = [(mock_schema, mock_results)]
 
         results = op.execute(None)
 
@@ -61,7 +62,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
             catalog=None,
             schema=None,
         )
-        db_mock.run.assert_called_once_with(sql, parameters=None)
+        db_mock.run.assert_called_once_with(sql, parameters=None, handler=fetch_all_handler)
 
     @mock.patch('airflow.providers.databricks.operators.databricks_sql.DatabricksSqlHook')
     def test_exec_write_file(self, db_mock_class):
@@ -74,7 +75,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         db_mock = db_mock_class.return_value
         mock_schema = [('id',), ('value',)]
         mock_results = [Row(id=1, value='value1')]
-        db_mock.run.return_value = (mock_schema, mock_results)
+        db_mock.run.return_value = [(mock_schema, mock_results)]
 
         try:
             op.execute(None)
@@ -92,7 +93,7 @@ class TestDatabricksSqlOperator(unittest.TestCase):
             catalog=None,
             schema=None,
         )
-        db_mock.run.assert_called_once_with(sql, parameters=None)
+        db_mock.run.assert_called_once_with(sql, parameters=None, handler=fetch_all_handler)
 
 
 class TestDatabricksSqlCopyIntoOperator(unittest.TestCase):

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -95,29 +95,29 @@ class TestExasolHook(unittest.TestCase):
         assert not self.db_hook.get_autocommit(self.conn)
 
     def test_run_without_autocommit(self):
-        sql = 'SQL'
+        sql = 'SELECT 1;'
         setattr(self.conn, 'attr', {'autocommit': False})
 
         # Default autocommit setting should be False.
         # Testing default autocommit value as well as run() behavior.
         self.db_hook.run(sql, autocommit=False)
         self.conn.set_autocommit.assert_called_once_with(False)
-        self.conn.execute.assert_called_once_with(sql, None)
+        self.conn.execute.assert_called_once_with(sql.rstrip(';'), None)
         self.conn.commit.assert_called_once()
 
     def test_run_with_autocommit(self):
-        sql = 'SQL'
+        sql = 'SELECT 1;'
         self.db_hook.run(sql, autocommit=True)
         self.conn.set_autocommit.assert_called_once_with(True)
-        self.conn.execute.assert_called_once_with(sql, None)
+        self.conn.execute.assert_called_once_with(sql.rstrip(';'), None)
         self.conn.commit.assert_not_called()
 
     def test_run_with_parameters(self):
-        sql = 'SQL'
+        sql = 'SELECT 1;'
         parameters = ('param1', 'param2')
         self.db_hook.run(sql, autocommit=True, parameters=parameters)
         self.conn.set_autocommit.assert_called_once_with(True)
-        self.conn.execute.assert_called_once_with(sql, parameters)
+        self.conn.execute.assert_called_once_with(sql.rstrip(';'), parameters)
         self.conn.commit.assert_not_called()
 
     def test_run_multi_queries(self):

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -95,29 +95,29 @@ class TestExasolHook(unittest.TestCase):
         assert not self.db_hook.get_autocommit(self.conn)
 
     def test_run_without_autocommit(self):
-        sql = 'SELECT 1;'
+        sql = 'SQL'
         setattr(self.conn, 'attr', {'autocommit': False})
 
         # Default autocommit setting should be False.
         # Testing default autocommit value as well as run() behavior.
         self.db_hook.run(sql, autocommit=False)
         self.conn.set_autocommit.assert_called_once_with(False)
-        self.conn.execute.assert_called_once_with(sql.rstrip(';'), None)
+        self.conn.execute.assert_called_once_with(sql, None)
         self.conn.commit.assert_called_once()
 
     def test_run_with_autocommit(self):
-        sql = 'SELECT 1;'
+        sql = 'SQL'
         self.db_hook.run(sql, autocommit=True)
         self.conn.set_autocommit.assert_called_once_with(True)
-        self.conn.execute.assert_called_once_with(sql.rstrip(';'), None)
+        self.conn.execute.assert_called_once_with(sql, None)
         self.conn.commit.assert_not_called()
 
     def test_run_with_parameters(self):
-        sql = 'SELECT 1;'
+        sql = 'SQL'
         parameters = ('param1', 'param2')
         self.db_hook.run(sql, autocommit=True, parameters=parameters)
         self.conn.set_autocommit.assert_called_once_with(True)
-        self.conn.execute.assert_called_once_with(sql.rstrip(';'), parameters)
+        self.conn.execute.assert_called_once_with(sql, parameters)
         self.conn.commit.assert_not_called()
 
     def test_run_multi_queries(self):

--- a/tests/providers/jdbc/operators/test_jdbc.py
+++ b/tests/providers/jdbc/operators/test_jdbc.py
@@ -19,7 +19,8 @@
 import unittest
 from unittest.mock import patch
 
-from airflow.providers.jdbc.operators.jdbc import JdbcOperator, fetch_all_handler
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.jdbc.operators.jdbc import JdbcOperator
 
 
 class TestJdbcOperator(unittest.TestCase):

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -268,7 +268,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = None
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END;')]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END')]
         assert result == parameters
 
     def test_callproc_dict(self):
@@ -280,7 +280,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = {k: bindvar(v) for k, v in parameters.items()}
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END;', parameters)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END', parameters)]
         assert result == parameters
 
     def test_callproc_list(self):
@@ -292,7 +292,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = list(map(bindvar, parameters))
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END;', parameters)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END', parameters)]
         assert result == parameters
 
     def test_callproc_out_param(self):
@@ -306,7 +306,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = [bindvar(p() if type(p) is type else p) for p in parameters]
         result = self.db_hook.callproc('proc', True, parameters)
         expected = [1, 0, 0.0, False, '']
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END;', expected)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END', expected)]
         assert result == expected
 
     def test_test_connection_use_dual_table(self):

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -269,7 +269,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = None
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END;')]
-        assert result == parameters
+        assert result == [parameters]
 
     def test_callproc_dict(self):
         parameters = {"a": 1, "b": 2, "c": 3}
@@ -281,7 +281,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = {k: bindvar(v) for k, v in parameters.items()}
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END;', parameters)]
-        assert result == parameters
+        assert result == [parameters]
 
     def test_callproc_list(self):
         parameters = [1, 2, 3]
@@ -293,7 +293,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = list(map(bindvar, parameters))
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END;', parameters)]
-        assert result == parameters
+        assert result == [parameters]
 
     def test_callproc_out_param(self):
         parameters = [1, int, float, bool, str]
@@ -307,7 +307,7 @@ class TestOracleHook(unittest.TestCase):
         result = self.db_hook.callproc('proc', True, parameters)
         expected = [1, 0, 0.0, False, '']
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END;', expected)]
-        assert result == expected
+        assert result == [expected]
 
     def test_test_connection_use_dual_table(self):
         status, message = self.db_hook.test_connection()

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -269,7 +269,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = None
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END;')]
-        assert result == [parameters]
+        assert result == parameters
 
     def test_callproc_dict(self):
         parameters = {"a": 1, "b": 2, "c": 3}
@@ -281,7 +281,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = {k: bindvar(v) for k, v in parameters.items()}
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END;', parameters)]
-        assert result == [parameters]
+        assert result == parameters
 
     def test_callproc_list(self):
         parameters = [1, 2, 3]
@@ -293,7 +293,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = list(map(bindvar, parameters))
         result = self.db_hook.callproc('proc', True, parameters)
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END;', parameters)]
-        assert result == [parameters]
+        assert result == parameters
 
     def test_callproc_out_param(self):
         parameters = [1, int, float, bool, str]
@@ -307,7 +307,7 @@ class TestOracleHook(unittest.TestCase):
         result = self.db_hook.callproc('proc', True, parameters)
         expected = [1, 0, 0.0, False, '']
         assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END;', expected)]
-        assert result == [expected]
+        assert result == expected
 
     def test_test_connection_use_dual_table(self):
         status, message = self.db_hook.test_connection()


### PR DESCRIPTION
Now we have [DbApiHook.run()](https://github.com/apache/airflow/blob/637a8b8af132e6231756160a3f6ce7ed789abaf6/airflow/hooks/dbapi.py#L163) method that is used by many other hooks.

Also there are following hooks that overrides this method:
* [DatabricksSqlHook.run()](https://github.com/apache/airflow/blob/ec6761a5c0d031221d53ce213c0e42813606c55d/airflow/providers/databricks/hooks/databricks_sql.py#L154)
* [ExasolHook.run()](https://github.com/apache/airflow/blob/ec6761a5c0d031221d53ce213c0e42813606c55d/airflow/providers/exasol/hooks/exasol.py#L135)
* [SnowflakeHook.run()](https://github.com/apache/airflow/blob/ec6761a5c0d031221d53ce213c0e42813606c55d/airflow/providers/snowflake/hooks/snowflake.py#L287)
* [PrestoHook.run()](https://github.com/apache/airflow/blob/ec6761a5c0d031221d53ce213c0e42813606c55d/airflow/providers/presto/hooks/presto.py#L242)
* [TrinoHook.run()](https://github.com/apache/airflow/blob/ec6761a5c0d031221d53ce213c0e42813606c55d/airflow/providers/trino/hooks/trino.py#L272)

I did all possible to make them as similar as possible, but some of them have peculiarities:
* SnowflakeHook could split a string into a few statements
* DatabricksSqlHook could split a string into a few statements, and each statement is run using a separate connection
* ExasolHook uses `pyexasol` which doesn't have a reusable cursor
* PrestoHook takes additional deprecated `hql` parameter and runs `_strip_sql(sql)`
* TrinoHook also takes additional deprecated `hql` parameter and runs `_strip_sql(sql)`