### PR TITLE
Adding connections for sql operator unit tests so they pass

### DIFF
--- a/tests/operators/test_sql.py
+++ b/tests/operators/test_sql.py
@@ -35,7 +35,7 @@ from airflow.operators.sql import (
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.hooks.base import BaseHook
 from airflow.utils import timezone
-from airflow.utils.session import create_session
+from airflow.utils.session import create_session 
 from airflow.utils.state import State
 from tests.providers.apache.hive import TestHiveEnvironment
 from airflow import settings
@@ -518,6 +518,9 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
             dag=self.dag,
         )
         branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        conn = Connection().get_connection_from_secrets("postgres_default")
+        session = settings.Session()
+        session.delete(conn)
 
     @mock.patch("airflow.operators.sql.BaseSQLOperator.get_db_hook")
     def test_branch_single_value_with_dag_run(self, mock_get_db_hook):
@@ -575,6 +578,10 @@ class TestSqlBranch(TestHiveEnvironment, unittest.TestCase):
                 assert ti.state == State.SKIPPED
             else:
                 raise ValueError(f"Invalid task id {ti.task_id} found!")
+        
+        conn = Connection().get_connection_from_secrets("mysql_default")
+        session = settings.Session()
+        session.delete(conn)
 
     @mock.patch("airflow.operators.sql.BaseSQLOperator.get_db_hook")
     def test_branch_true_with_dag_run(self, mock_get_db_hook):

--- a/tests/operators/test_sql.py
+++ b/tests/operators/test_sql.py
@@ -35,7 +35,7 @@ from airflow.operators.sql import (
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.hooks.base import BaseHook
 from airflow.utils import timezone
-from airflow.utils.session import create_session 
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from tests.providers.apache.hive import TestHiveEnvironment
 from airflow import settings


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
2 of the unit tests in airflow/tests/operators/test_sql.py were failing for postgres and mysql so I fixed them so no connection has to be made before running the tests

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
