### PR TITLE
fix: StepFunctionHook ignores explicit set `region_name`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/step_function.py
+++ b/airflow/providers/amazon/aws/hooks/step_function.py
@@ -32,7 +32,7 @@ class StepFunctionHook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
-    def __init__(self, region_name: Optional[str] = None, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         kwargs["client_type"] = "stepfunctions"
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Parameter `region_name` in `airflow.providers.amazon.aws.hooks.step_function.StepFunctionHook` doesn't do anything, and doesn't propagate to parent AwsBaseHook

**Sample**
```python
import os
from airflow.providers.amazon.aws.hooks.step_function import StepFunctionHook

os.environ["AIRFLOW_CONN_TEST_CONN"] = "aws://?region_name=eu-west-1"

hook = StepFunctionHook(aws_conn_id="test_conn")
conn = hook.conn
assert conn.meta.region_name == "eu-west-1"

hook = StepFunctionHook(aws_conn_id="test_conn", region_name="ap-southeast-2")
conn = hook.conn
assert conn.meta.region_name == "ap-southeast-2"
```