### PR TITLE
Helm logo no longer a link

### DIFF
--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -17,6 +17,7 @@
 
 .. image:: /img/helm-logo.svg
     :width: 100
+    :class: no-scaled-link
 
 Helm Chart for Apache Airflow
 =============================


### PR DESCRIPTION
I accidentally clicked on the helm logo the other day and was surprised it linked out to a bigger version of the logo. We don't need that link.