### PR TITLE
Fix missing shorthand for docker buildx rm -f

### DIFF
--- a/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
+++ b/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
@@ -69,7 +69,7 @@ function start_arm_instance() {
 
     bash -c 'echo -n "Waiting port 12357 .."; for _ in `seq 1 40`; do echo -n .; sleep 0.25; nc -z localhost 12357 && echo " Open." && exit ; done; echo " Timeout!" >&2; exit 1'
 
-    docker buildx rm -f airflow_cache || true
+    docker buildx rm --force airflow_cache || true
     docker buildx create --name airflow_cache
     docker buildx create --name airflow_cache --append localhost:12357
     docker buildx ls

--- a/scripts/ci/images/ci_stop_arm_instance.sh
+++ b/scripts/ci/images/ci_stop_arm_instance.sh
@@ -25,7 +25,7 @@ AUTOSSH_LOGFILE="${WORKING_DIR}/autossh.log"
 
 function stop_arm_instance() {
     INSTANCE_ID=$(jq < "${INSTANCE_INFO}" ".Instances[0].InstanceId" -r)
-    docker buildx rm -f airflow_cache || true
+    docker buildx rm --force airflow_cache || true
     aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}"
     cat ${AUTOSSH_LOGFILE}
 


### PR DESCRIPTION
Latest version of buildx removed -f as shorthand for --force flag.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
