### PR TITLE
set color to operators in cloud_sql.py

### DIFF
--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -318,6 +318,7 @@ class CloudSQLCreateInstanceOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_create_template_fields]
+    ui_color = '#FADBDA'
     operator_extra_links = (CloudSQLInstanceLink(),)
 
     def __init__(
@@ -421,6 +422,7 @@ class CloudSQLInstancePatchOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_patch_template_fields]
+    ui_color = '#FBDAC8'
     operator_extra_links = (CloudSQLInstanceLink(),)
 
     def __init__(
@@ -503,6 +505,7 @@ class CloudSQLDeleteInstanceOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_delete_template_fields]
+    ui_color = '#FEECD2'
 
     def execute(self, context: 'Context') -> Optional[bool]:
         hook = CloudSQLHook(
@@ -553,6 +556,7 @@ class CloudSQLCreateInstanceDatabaseOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_db_create_template_fields]
+    ui_color = '#FFFCDB'
     operator_extra_links = (CloudSQLInstanceDatabaseLink(),)
 
     def __init__(
@@ -660,6 +664,7 @@ class CloudSQLPatchInstanceDatabaseOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_db_patch_template_fields]
+    ui_color = '#ECF4D9'
     operator_extra_links = (CloudSQLInstanceDatabaseLink(),)
 
     def __init__(
@@ -758,6 +763,7 @@ class CloudSQLDeleteInstanceDatabaseOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_db_delete_template_fields]
+    ui_color = '#D5EAD8'
 
     def __init__(
         self,
@@ -843,6 +849,7 @@ class CloudSQLExportInstanceOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_export_template_fields]
+    ui_color = '#D4ECEA'
     operator_extra_links = (CloudSQLInstanceLink(), FileDetailsLink())
 
     def __init__(
@@ -953,6 +960,7 @@ class CloudSQLImportInstanceOperator(CloudSQLBaseOperator):
         'impersonation_chain',
     )
     # [END gcp_sql_import_template_fields]
+    ui_color = '#D3EDFB'
     operator_extra_links = (CloudSQLInstanceLink(), FileDetailsLink())
 
     def __init__(
@@ -1041,6 +1049,7 @@ class CloudSQLExecuteQueryOperator(BaseOperator):
     template_ext: Sequence[str] = ('.sql',)
     template_fields_renderers = {'sql': 'sql'}
     # [END gcp_sql_query_template_fields]
+    ui_color = '#D3DEF1'
 
     def __init__(
         self,


### PR DESCRIPTION
closes: #23999
related: #23999

It looks like the following.

<img width="970" alt="set-colors" src="https://user-images.githubusercontent.com/12693596/170856877-8ea05f2a-9f5d-419f-8c78-257e4b512ef6.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
