### PR TITLE
Cleanup `BranchDayOfWeekOperator` example dag

### DIFF
--- a/airflow/example_dags/example_branch_day_of_week_operator.py
+++ b/airflow/example_dags/example_branch_day_of_week_operator.py
@@ -33,8 +33,8 @@ with DAG(
     schedule_interval="@daily",
 ) as dag:
     # [START howto_operator_day_of_week_branch]
-    empty_task_1 = EmptyOperator(task_id='branch_true', dag=dag)
-    empty_task_2 = EmptyOperator(task_id='branch_false', dag=dag)
+    empty_task_1 = EmptyOperator(task_id='branch_true')
+    empty_task_2 = EmptyOperator(task_id='branch_false')
 
     branch = BranchDayOfWeekOperator(
         task_id="make_choice",

--- a/airflow/example_dags/example_branch_day_of_week_operator.py
+++ b/airflow/example_dags/example_branch_day_of_week_operator.py
@@ -31,7 +31,7 @@ with DAG(
     catchup=False,
     tags=["example"],
     schedule_interval="@daily",
-) as dag:
+):
     # [START howto_operator_day_of_week_branch]
     empty_task_1 = EmptyOperator(task_id='branch_true')
     empty_task_2 = EmptyOperator(task_id='branch_false')

--- a/airflow/example_dags/example_branch_day_of_week_operator.py
+++ b/airflow/example_dags/example_branch_day_of_week_operator.py
@@ -31,7 +31,7 @@ with DAG(
     catchup=False,
     tags=["example"],
     schedule_interval="@daily",
-):
+) as dag:
     # [START howto_operator_day_of_week_branch]
     empty_task_1 = EmptyOperator(task_id='branch_true')
     empty_task_2 = EmptyOperator(task_id='branch_false')


### PR DESCRIPTION
There is no need for `dag=dag` when using context manager.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
