### PR TITLE
Fix BigQuery system tests

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2130,7 +2130,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         if self.job_id:
             return f"{self.job_id}_{uniqueness_suffix}"
 
-        exec_date = context['data_interval_start'].isoformat()
+        exec_date = context['logical_date'].isoformat()
         job_id = f"airflow_{self.dag_id}_{self.task_id}_{exec_date}_{uniqueness_suffix}"
         return re.sub(r"[:\-+.]", "_", job_id)
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2130,7 +2130,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         if self.job_id:
             return f"{self.job_id}_{uniqueness_suffix}"
 
-        exec_date = context['execution_date'].isoformat()
+        exec_date = context['data_interval_start'].isoformat()
         job_id = f"airflow_{self.dag_id}_{self.task_id}_{exec_date}_{uniqueness_suffix}"
         return re.sub(r"[:\-+.]", "_", job_id)
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -1020,7 +1020,7 @@ class TestBigQueryInsertJobOperator:
     def test_job_id_validity(self, mock_md5, test_dag_id, expected_job_id):
         hash_ = "hash"
         mock_md5.return_value.hexdigest.return_value = hash_
-        context = {"execution_date": datetime(2020, 1, 23)}
+        context = {"logical_date": datetime(2020, 1, 23)}
         configuration = {
             "query": {
                 "query": "SELECT * FROM any",

--- a/tests/system/providers/google/bigquery/example_bigquery_queries.py
+++ b/tests/system/providers/google/bigquery/example_bigquery_queries.py
@@ -21,7 +21,6 @@ Example Airflow DAG for Google BigQuery service.
 """
 import os
 from datetime import datetime
-from pathlib import Path
 
 from airflow import models
 from airflow.operators.bash import BashOperator
@@ -40,7 +39,7 @@ from airflow.utils.trigger_rule import TriggerRule
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 LOCATION = "us-east1"
-QUERY_SQL_PATH = str(Path(__file__).parent / "resources" / "example_bigquery_query.sql")
+QUERY_SQL_PATH = "resources/example_bigquery_query.sql"
 
 TABLE_1 = "table1"
 TABLE_2 = "table2"


### PR DESCRIPTION
Two fixes:

- absolute path to Jinja template was failing, relative path works
- ``execution_date`` used in BigQueryInsertJobOperator job_id is deprecated. Replated with ``logical_date``.