### PR TITLE
Preparing buildx cache is allowed without --push-image flag

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -441,9 +441,14 @@ def build_ci_image(verbose: bool, dry_run: bool, ci_image_params: BuildCiParams)
     :param dry_run: do not execute "write" commands - just print what would happen
     :param ci_image_params: CI image parameters
     """
-    if not ci_image_params.push_image and ci_image_params.is_multi_platform():
+    if (
+        ci_image_params.is_multi_platform()
+        and not ci_image_params.push_image
+        and not ci_image_params.prepare_buildx_cache
+    ):
         get_console().print(
-            "\n[red]You cannot use multi-platform build without using --push-image flag![/]\n"
+            "\n[red]You cannot use multi-platform build without using --push-image flag or "
+            "preparing buildx cache![/]\n"
         )
         return 1, "Error: building multi-platform image without --push-image."
     fix_group_permissions(verbose=verbose)

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -480,9 +480,14 @@ def build_production_image(
     :param dry_run: do not execute "write" commands - just print what would happen
     :param prod_image_params: PROD image parameters
     """
-    if not prod_image_params.push_image and prod_image_params.is_multi_platform():
+    if (
+        prod_image_params.is_multi_platform()
+        and not prod_image_params.push_image
+        and not prod_image_params.prepare_buildx_cache
+    ):
         get_console().print(
-            "\n[red]You cannot use multi-platform build without using --push-image flag![/]\n"
+            "\n[red]You cannot use multi-platform build without using --push-image flag"
+            " or preparing buildx cache![/]\n"
         )
         return 1, "Error: building multi-platform image without --push-image."
     fix_group_permissions(verbose=verbose)


### PR DESCRIPTION
The previous version of buildx cache preparation implied --push-image
flag, but now this is completely separated (we do not push image,
we just prepare cache), so when mutli-platform buildx preparation is
run we should also allow the cache to run without --push-image flag.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
