### PR TITLE
Remove unused [github_enterprise] from ref docs

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2168,15 +2168,6 @@
       type: boolean
       example: ~
       default: "True"
-- name: github_enterprise
-  description: ~
-  options:
-    - name: api_rev
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "v3"
 - name: elasticsearch
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1087,9 +1087,6 @@ forwardable = True
 # Allow to remove source IP from token, useful when using token behind NATted Docker host.
 include_ip = True
 
-[github_enterprise]
-api_rev = v3
-
 [elasticsearch]
 # Elasticsearch host
 host =

--- a/tests/core/test_config_templates.py
+++ b/tests/core/test_config_templates.py
@@ -49,7 +49,6 @@ DEFAULT_AIRFLOW_SECTIONS = [
     'scheduler',
     'triggerer',
     'kerberos',
-    'github_enterprise',
     'elasticsearch',
     'elasticsearch_configs',
     'kubernetes',


### PR DESCRIPTION
This option is not used anymore by Airflow.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
