### PR TITLE
Add foldable groups in CI outputs in commands that need it

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/configuration_and_maintenance_commands.py
@@ -177,7 +177,13 @@ def cleanup(verbose: bool, dry_run: bool, github_repository: str, all: bool, ans
     given_answer = user_confirm("Are you sure with the removal?")
     if given_answer == Answer.YES:
         system_prune_command_to_execute = ['docker', 'system', 'prune']
-        run_command(system_prune_command_to_execute, verbose=verbose, dry_run=dry_run, check=False)
+        run_command(
+            system_prune_command_to_execute,
+            verbose=verbose,
+            dry_run=dry_run,
+            check=False,
+            enabled_output_group=True,
+        )
     elif given_answer == Answer.QUIT:
         sys.exit(0)
     get_console().print(f"Removing build cache dir ${BUILD_CACHE_DIR}")
@@ -455,7 +461,9 @@ def fix_ownership(github_repository: str, verbose: bool, dry_run: bool):
         shell_params.airflow_image_name_with_tag,
         "/opt/airflow/scripts/in_container/run_fix_ownership.sh",
     ]
-    run_command(cmd, verbose=verbose, dry_run=dry_run, text=True, env=env, check=False)
+    run_command(
+        cmd, verbose=verbose, dry_run=dry_run, text=True, env=env, check=False, enabled_output_group=True
+    )
     # Always succeed
     sys.exit(0)
 

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -533,6 +533,7 @@ def build_production_image(
                 cwd=AIRFLOW_SOURCES_ROOT,
                 check=False,
                 text=True,
+                enabled_output_group=True,
             )
             if build_command_result.returncode == 0:
                 if prod_image_params.tag_as_latest:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -267,6 +267,7 @@ def prepare_airflow_packages(
         verbose=verbose,
         dry_run=dry_run,
         debug=debug,
+        enabled_output_group=True,
     )
     sys.exit(result_command.returncode)
 
@@ -550,6 +551,7 @@ def verify_provider_packages(
         verbose=verbose,
         dry_run=dry_run,
         debug=debug,
+        enabled_output_group=True,
     )
     sys.exit(result_command.returncode)
 

--- a/dev/breeze/src/airflow_breeze/utils/ci_group.py
+++ b/dev/breeze/src/airflow_breeze/utils/ci_group.py
@@ -37,6 +37,6 @@ def ci_group(title: str, enabled: bool = True):
         get_console().print(f"[info]{title}[/]")
         yield
         return
-    get_console().print(f"::group::<EXPAND>: [info]{title}[/]")
+    get_console().print(f"::group::<CLICK_TO_EXPAND>: [info]{title}[/]")
     yield
     get_console().print("::endgroup::")

--- a/dev/breeze/src/airflow_breeze/utils/image.py
+++ b/dev/breeze/src/airflow_breeze/utils/image.py
@@ -125,7 +125,6 @@ def run_pull_image(
                 dry_run=dry_run,
                 text=True,
                 check=False,
-                enabled_output_group=not parallel,
             )
             if not dry_run:
                 if command_result.returncode == 0:

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -88,7 +88,7 @@ def run_command(
     if verbose or dry_run:
         command_to_print = ' '.join(shlex.quote(c) for c in cmd)
         env_to_print = get_environments_to_print(env)
-        with ci_group(title=f"Running {title}", enabled=enabled_output_group):
+        with ci_group(title=f"Running {title}"):
             get_console().print(f"\n[info]Working directory {workdir} [/]\n")
             # Soft wrap allows to copy&paste and run resulting output as it has no hard EOL
             get_console().print(f"\n[info]{env_to_print}{command_to_print}[/]\n", soft_wrap=True)


### PR DESCRIPTION
This is follow-up after #24026 which added capability of selectively
deciding for each breeze command, whether the output of the command
should be "foldable" group. All CI output has been reviewed, and
the commands which "need" it were identified.

This also fixes a problem introduced there - that the command itself
was not "foldable" group itself.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
