### PR TITLE
Rename Permissions to Permission Pairs.

### DIFF
--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -787,7 +787,7 @@ class BaseSecurityManager:
         if self.appbuilder.app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW", True):
             self.appbuilder.add_view(
                 self.permissionmodelview,
-                "Permissions",
+                "Permission Pairs",
                 icon="fa-link",
                 label=_("Permissions"),
                 category="Security",


### PR DESCRIPTION
Fixes #23926.
Fixes #23512.

The issue is that the following code
```
if self.appbuilder.app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEW", True):
            self.appbuilder.add_view(
                self.actionmodelview,
                "Actions",
                icon="fa-lock",
                label=_("Actions"),
                category="Security",
            )
```
https://github.com/apache/airflow/blob/main/airflow/www/fab_security/manager.py#L769-L775

causes the following actions

```
{manager.py:545} INFO - Removed Permission View: menu_access on Permissions
{manager.py:509} INFO - Created Permission View: menu access on Permissions
```

The lines 
```
        if self.appbuilder.app.config.get("FAB_ADD_SECURITY_PERMISSION_VIEWS_VIEW", True):
            self.appbuilder.add_view(
                self.permissionmodelview,
                "Permissions",
                icon="fa-link",
                label=_("Permissions"),
                category="Security",
            )
```
https://github.com/apache/airflow/blob/main/airflow/www/fab_security/manager.py#L785-L792 

cause

```
{manager.py:509} INFO - Created Permission View: menu access on Permissions
{manager.py:571} INFO - Added Permission menu access on Permissions to role Admin
```

This is because in code block 1, `ActionModelView.class_permission_name = "Permissions"`, and the view name used in code block 2 is `"Permissions",`. This causes a conflict where permissions get removed from and then added to `Permissions` every time the app worker loads.

As a solution, I've renamed the view name in the second code block to `Permission Pairs`, which removes the conflict between the two code blocks.