### PR TITLE
Run the `check_migration` loop at least once

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -691,6 +691,7 @@ def check_migrations(timeout):
     :param timeout: Timeout for the migration in seconds
     :return: None
     """
+    timeout = timeout or 1  # run the loop at least 1
     with _configured_alembic_environment() as env:
         context = env.get_context()
         source_heads = None

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -96,6 +96,7 @@ class TestDb:
 
     def test_check_migrations(self):
         # Should run without error. Can't easily test the behaviour, but we can check it works
+        check_migrations(0)
         check_migrations(1)
 
     @mock.patch('alembic.command')


### PR DESCRIPTION
This is broken since 2.3.0. that's if a user specifies a migration_timeout
of 0 then no migration is run at all.

Closes: https://github.com/apache/airflow/issues/24060