### PR TITLE
fix style of example block

### DIFF
--- a/docs/exts/exampleinclude.py
+++ b/docs/exts/exampleinclude.py
@@ -121,7 +121,7 @@ class ExampleInclude(SphinxDirective):
                 extra_args["hl_lines"] = [x + 1 for x in hl_lines if x < lines]
             extra_args["linenostart"] = reader.lineno_start
 
-            container_node = nodes.container("", literal_block=True, classes=["example-block-wrapper"])
+            container_node = nodes.compound(classes=["example-block-wrapper"])
             container_node += ExampleHeader(filename=filename)
             container_node += retnode
             retnode = container_node


### PR DESCRIPTION
closes: #24077
related: #24077

Fixed:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/12693596/171426583-3685ca13-8c96-407f-905a-e8d34d6cd0a0.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
