### PR TITLE
Add: #23880 :: Audit log for AirflowModelViews(Variables/Connection)

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -46,9 +46,7 @@ from airflow.www.decorators import action_logging
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
     connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
@@ -99,9 +97,7 @@ def get_connections(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
 def patch_connection(
     *,
     connection_id: str,
@@ -141,9 +137,7 @@ def patch_connection(
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""
     body = request.json

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -43,16 +43,11 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.strings import get_random_string
 from airflow.www.decorators import action_logging
 
-RESOURCE_EVENT_PREFIX = "connection"
-
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_DELETE,
-    ),
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
 )
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
@@ -105,10 +100,7 @@ def get_connections(
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_EDIT,
-    ),
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
 )
 def patch_connection(
     *,
@@ -150,10 +142,7 @@ def patch_connection(
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_CREATE,
-    ),
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
 )
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -45,9 +45,7 @@ from airflow.www.decorators import action_logging
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
     connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
@@ -98,9 +96,7 @@ def get_connections(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
 def patch_connection(
     *,
     connection_id: str,
@@ -140,9 +136,7 @@ def patch_connection(
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(
-    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
-)
+@action_logging(event=f"connection.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""
     body = request.json

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -38,14 +38,22 @@ from airflow.api_connexion.types import APIResponse, UpdateMask
 from airflow.models import Connection
 from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.security import permissions
+from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.strings import get_random_string
 from airflow.www.decorators import action_logging
 
+RESOURCE_EVENT_PREFIX = "connection"
+
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_DELETE,
+    ),
+)
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
     connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
@@ -96,7 +104,12 @@ def get_connections(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_EDIT,
+    ),
+)
 def patch_connection(
     *,
     connection_id: str,
@@ -136,7 +149,12 @@ def patch_connection(
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_CREATE,
+    ),
+)
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""
     body = request.json

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -40,10 +40,14 @@ from airflow.secrets.environment_variables import CONN_ENV_PREFIX
 from airflow.security import permissions
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.strings import get_random_string
+from airflow.www.decorators import action_logging
 
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
+@action_logging(
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
+)
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
     connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
@@ -94,6 +98,9 @@ def get_connections(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
+@action_logging(
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
+)
 def patch_connection(
     *,
     connection_id: str,
@@ -133,6 +140,9 @@ def patch_connection(
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
+@action_logging(
+    event=f"{permissions.RESOURCE_CONNECTION.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
+)
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""
     body = request.json

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -43,10 +43,17 @@ from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.strings import get_random_string
 from airflow.www.decorators import action_logging
 
+RESOURCE_EVENT_PREFIX = "connection"
+
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_DELETE,
+    ),
+)
 def delete_connection(*, connection_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Delete a connection entry"""
     connection = session.query(Connection).filter_by(conn_id=connection_id).one_or_none()
@@ -97,7 +104,12 @@ def get_connections(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_EDIT,
+    ),
+)
 def patch_connection(
     *,
     connection_id: str,
@@ -137,7 +149,12 @@ def patch_connection(
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION)])
 @provide_session
-@action_logging(event=f"connection.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_CREATE,
+    ),
+)
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry"""
     body = request.json

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -35,9 +35,16 @@ from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.www.decorators import action_logging
 
+RESOURCE_EVENT_PREFIX = "variable"
+
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_DELETE,
+    ),
+)
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
     if Variable.delete(variable_key) == 0:
@@ -81,7 +88,12 @@ def get_variables(
 
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_EDIT,
+    ),
+)
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
     try:
@@ -103,7 +115,12 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_CREATE,
+    ),
+)
 def post_variables() -> Response:
     """Create a variable"""
     try:

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -36,9 +36,7 @@ from airflow.www.decorators import action_logging
 
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
     if Variable.delete(variable_key) == 0:
@@ -82,9 +80,7 @@ def get_variables(
 
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
     try:
@@ -106,12 +102,9 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
 def post_variables() -> Response:
     """Create a variable"""
-
     try:
         data = variable_schema.load(get_json_request_dict())
 

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -35,15 +35,10 @@ from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.www.decorators import action_logging
 
-RESOURCE_EVENT_PREFIX = "variable"
-
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_DELETE,
-    ),
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
 )
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
@@ -89,10 +84,7 @@ def get_variables(
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_EDIT,
-    ),
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
 )
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
@@ -116,13 +108,11 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
 @action_logging(
-    event=action_event_from_permission(
-        prefix=RESOURCE_EVENT_PREFIX,
-        permission=permissions.ACTION_CAN_CREATE,
-    ),
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
 )
 def post_variables() -> Response:
     """Create a variable"""
+
     try:
         data = variable_schema.load(get_json_request_dict())
 

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -31,12 +31,20 @@ from airflow.api_connexion.schemas.variable_schema import variable_collection_sc
 from airflow.api_connexion.types import UpdateMask
 from airflow.models import Variable
 from airflow.security import permissions
+from airflow.utils.log.action_logger import action_event_from_permission
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.www.decorators import action_logging
 
+RESOURCE_EVENT_PREFIX = "variable"
+
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_DELETE,
+    ),
+)
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
     if Variable.delete(variable_key) == 0:
@@ -80,7 +88,12 @@ def get_variables(
 
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_EDIT,
+    ),
+)
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
     try:
@@ -102,7 +115,12 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
-@action_logging(event=f"variable.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
+@action_logging(
+    event=action_event_from_permission(
+        prefix=RESOURCE_EVENT_PREFIX,
+        permission=permissions.ACTION_CAN_CREATE,
+    ),
+)
 def post_variables() -> Response:
     """Create a variable"""
     try:

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -32,9 +32,13 @@ from airflow.api_connexion.types import UpdateMask
 from airflow.models import Variable
 from airflow.security import permissions
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.www.decorators import action_logging
 
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
+@action_logging(
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
+)
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
     if Variable.delete(variable_key) == 0:
@@ -78,6 +82,9 @@ def get_variables(
 
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
+@action_logging(
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
+)
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
     try:
@@ -99,8 +106,12 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
+@action_logging(
+    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
+)
 def post_variables() -> Response:
     """Create a variable"""
+
     try:
         data = variable_schema.load(get_json_request_dict())
 

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -37,9 +37,7 @@ from airflow.www.decorators import action_logging
 
 
 @security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_DELETE.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_DELETE.replace('can_','')}")
 def delete_variable(*, variable_key: str) -> Response:
     """Delete variable"""
     if Variable.delete(variable_key) == 0:
@@ -83,9 +81,7 @@ def get_variables(
 
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_EDIT.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_EDIT.replace('can_','')}")
 def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Response:
     """Update a variable by key"""
     try:
@@ -107,12 +103,9 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])
-@action_logging(
-    event=f"{permissions.RESOURCE_VARIABLE.lower()}.{permissions.ACTION_CAN_CREATE.replace('can_','')}"
-)
+@action_logging(event=f"variable.{permissions.ACTION_CAN_CREATE.replace('can_','')}")
 def post_variables() -> Response:
     """Create a variable"""
-
     try:
         data = variable_schema.load(get_json_request_dict())
 

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -71,4 +71,4 @@ class Log(Base):
         self.owner = owner or task_owner
 
     def __str__(self) -> str:
-        return f"Log({self.event}, {self.task_instance}, {self.owner}, {self.extra})"
+        return f"Log({self.event}, {self.task_id}, {self.owner}, {self.extra})"

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -71,4 +71,4 @@ class Log(Base):
         self.owner = owner or task_owner
 
     def __str__(self) -> str:
-        return f"Log({self.event}, {self.task_id}, {self.owner}, {self.extra})"
+        return f"Log({self.event}, {self.task_instance}, {self.owner}, {self.extra})"

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -69,3 +69,6 @@ class Log(Base):
             self.map_index = kwargs["map_index"]
 
         self.owner = owner or task_owner
+
+    def __str__(self) -> str:
+        return f"Log({self.event}, {self.task_instance}, {self.owner}, {self.extra})"

--- a/airflow/utils/log/action_logger.py
+++ b/airflow/utils/log/action_logger.py
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+def action_event_from_permission(prefix: str, permission: str) -> str:
+    if permission.startswith("can_"):
+        permission = permission[4:]
+    if prefix:
+        return f"{prefix}.{permission}"
+    return permission

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -22,7 +22,7 @@ import gzip
 import logging
 from io import BytesIO as IO
 from itertools import chain
-from typing import Callable, TypeVar, cast
+from typing import Callable, Optional, TypeVar, cast
 
 import pendulum
 from flask import after_this_request, g, request
@@ -36,7 +36,7 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(func: Optional[T]=None, event: Optional[str]=None) -> T:
+def action_logging(func: Optional[T] = None, event: Optional[str] = None) -> Callable[[T], T]:
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -36,7 +36,7 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(func: Callable | None = None, event: str | None = None) -> Callable[[T], T]:
+def action_logging(func=None, event=None):
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -22,7 +22,7 @@ import gzip
 import logging
 from io import BytesIO as IO
 from itertools import chain
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, TypeVar, cast
 
 import pendulum
 from flask import after_this_request, g, request
@@ -36,7 +36,7 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(func: Optional[T] = None, event: Optional[str] = None) -> Callable[[T], T]:
+def action_logging(func: Callable | None = None, event: str | None = None) -> Callable[[T], T]:
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -36,51 +36,56 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(f: T) -> T:
+def action_logging(func=None, event=None):
     """Decorator to log user actions"""
 
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        __tracebackhide__ = True  # Hide from pytest traceback.
+    def log_action(f: T) -> T:
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            __tracebackhide__ = True  # Hide from pytest traceback.
 
-        with create_session() as session:
-            if g.user.is_anonymous:
-                user = "anonymous"
-            else:
-                user = g.user.username
+            with create_session() as session:
+                if g.user.is_anonymous:
+                    user = 'anonymous'
+                else:
+                    user = g.user.username
 
-            fields_skip_logging = {"csrf_token", "_csrf_token"}
-            extra_fields = [
-                (k, v)
-                for k, v in chain(request.values.items(multi=True), request.view_args.items())
-                if k not in fields_skip_logging
-            ]
+                fields_skip_logging = {'csrf_token', '_csrf_token'}
+                extra_fields = [
+                    (k, v)
+                    for k, v in chain(request.values.items(multi=True), request.view_args.items())
+                    if k not in fields_skip_logging
+                ]
 
-            params = {k: v for k, v in chain(request.values.items(), request.view_args.items())}
+                params = {k: v for k, v in chain(request.values.items(), request.view_args.items())}
 
-            log = Log(
-                event=f.__name__,
-                task_instance=None,
-                owner=user,
-                extra=str(extra_fields),
-                task_id=params.get("task_id"),
-                dag_id=params.get("dag_id"),
-            )
+                log = Log(
+                    event=event or f.__name__,
+                    task_instance=None,
+                    owner=user,
+                    extra=str(extra_fields),
+                    task_id=params.get('task_id'),
+                    dag_id=params.get('dag_id'),
+                )
 
-            if "execution_date" in request.values:
-                execution_date_value = request.values.get("execution_date")
-                try:
-                    log.execution_date = pendulum.parse(execution_date_value, strict=False)
-                except ParserError:
-                    logger.exception(
-                        "Failed to parse execution_date from the request: %s", execution_date_value
-                    )
+                if 'execution_date' in request.values:
+                    execution_date_value = request.values.get('execution_date')
+                    try:
+                        log.execution_date = pendulum.parse(execution_date_value, strict=False)
+                    except ParserError:
+                        logger.exception(
+                            "Failed to parse execution_date from the request: %s", execution_date_value
+                        )
 
-            session.add(log)
+                session.add(log)
 
-        return f(*args, **kwargs)
+            return f(*args, **kwargs)
 
-    return cast(T, wrapper)
+        return cast(T, wrapper)
+
+    if func:
+        return log_action(func)
+    return log_action
 
 
 def gzipped(f: T) -> T:

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -36,7 +36,7 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(func=None, event=None):
+def action_logging(func: Optional[T]=None, event: Optional[str]=None) -> T:
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -22,7 +22,7 @@ import gzip
 import logging
 from io import BytesIO as IO
 from itertools import chain
-from typing import Callable, Optional, TypeVar, cast
+from typing import Callable, TypeVar, cast
 
 import pendulum
 from flask import after_this_request, g, request
@@ -36,7 +36,7 @@ T = TypeVar("T", bound=Callable)
 logger = logging.getLogger(__name__)
 
 
-def action_logging(func: Optional[T] = None, event: Optional[str] = None) -> Callable[[T], T]:
+def action_logging(func: Callable | None = None, event: str | None = None) -> Callable[[T], T]:
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:
@@ -46,11 +46,11 @@ def action_logging(func: Optional[T] = None, event: Optional[str] = None) -> Cal
 
             with create_session() as session:
                 if g.user.is_anonymous:
-                    user = 'anonymous'
+                    user = "anonymous"
                 else:
                     user = g.user.username
 
-                fields_skip_logging = {'csrf_token', '_csrf_token'}
+                fields_skip_logging = {"csrf_token", "_csrf_token"}
                 extra_fields = [
                     (k, v)
                     for k, v in chain(request.values.items(multi=True), request.view_args.items())
@@ -64,12 +64,12 @@ def action_logging(func: Optional[T] = None, event: Optional[str] = None) -> Cal
                     task_instance=None,
                     owner=user,
                     extra=str(extra_fields),
-                    task_id=params.get('task_id'),
-                    dag_id=params.get('dag_id'),
+                    task_id=params.get("task_id"),
+                    dag_id=params.get("dag_id"),
                 )
 
-                if 'execution_date' in request.values:
-                    execution_date_value = request.values.get('execution_date')
+                if "execution_date" in request.values:
+                    execution_date_value = request.values.get("execution_date")
                     try:
                         log.execution_date = pendulum.parse(execution_date_value, strict=False)
                     except ParserError:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3834,15 +3834,10 @@ class AirflowModelView(ModelView):
 
     def __getattribute__(self, attr):
         attribute = object.__getattribute__(self, attr)
-        if callable(attribute) and attr in [
-            "add",
-            "edit",
-            "delete",
-            "download",
-            "action",
-            "action_post",
-        ]:
-            return action_logging(event=f"{self.route_base.strip('/')}.{attr}")(attribute)
+        if callable(attribute) and hasattr(attribute, "_permission_name"):
+            permission_str = attribute._permission_name
+            if permission_str not in ["show", "list"]:
+                return action_logging(event=f"{self.route_base.strip('/')}.{permission_str}")(attribute)
         return attribute
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3834,9 +3834,13 @@ class AirflowModelView(ModelView):
 
     def __getattribute__(self, attr):
         attribute = object.__getattribute__(self, attr)
-        if callable(attribute) and hasattr(attribute, "_permission_name"):
-            permission_str = attribute._permission_name
-            if permission_str not in ["show", "list"]:
+        if (
+            callable(attribute)
+            and hasattr(attribute, "_permission_name")
+            and attribute._permission_name in self.method_permission_name
+        ):
+            permission_str = self.method_permission_name[attribute._permission_name]
+            if permission_str not in ["show", "list", "read", "get", "get_list"]:
                 return action_logging(event=f"{self.route_base.strip('/')}.{permission_str}")(attribute)
         return attribute
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3822,7 +3822,10 @@ class DagFilter(BaseFilter):
 
 
 class AirflowModelView(ModelView):
-    """Airflow Mode View."""
+    """Airflow Mode View.
+
+    Overridden `__getattribute__` to wraps REST methods with action_logger
+    """
 
     list_widget = AirflowModelListWidget
     page_size = PAGE_SIZE
@@ -3830,6 +3833,14 @@ class AirflowModelView(ModelView):
     CustomSQLAInterface = wwwutils.CustomSQLAInterface
 
     def __getattribute__(self, attr):
+        """Wraps action REST methods with `action_logging` wrapper
+        Overriding enables differentiating resource and generation of event name at the decorator level.
+
+        if attr in ["show", "list", "read", "get", "get_list"]:
+            return action_logging(event="RESOURCE_NAME"."action_name")(attr)
+        else:
+            return attr
+        """
         attribute = object.__getattribute__(self, attr)
         if (
             callable(attribute)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3833,6 +3833,14 @@ class AirflowModelView(ModelView):
     CustomSQLAInterface = wwwutils.CustomSQLAInterface
 
     def __getattribute__(self, attr):
+        """Wraps action REST methods with `action_logging` wrapper
+        Overriding enables differentiating resource and generation of event name at the decorator level.
+
+        if attr in ["show", "list", "read", "get", "get_list"]:
+            return action_logging(event="RESOURCE_NAME"."action_name")(attr)
+        else:
+            return attr
+        """
         attribute = object.__getattribute__(self, attr)
         if (
             callable(attribute)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3829,6 +3829,21 @@ class AirflowModelView(ModelView):
 
     CustomSQLAInterface = wwwutils.CustomSQLAInterface
 
+    def __getattribute__(self, attr):
+        attribute = object.__getattribute__(self, attr)
+        if callable(attribute) and attr in [
+            "list",
+            "show",
+            "add",
+            "edit",
+            "delete",
+            "download",
+            "action",
+            "action_post",
+        ]:
+            return action_logging(event=f"{self.route_base.strip('/')}.{attr}")(attribute)
+        return attribute
+
 
 class AirflowPrivilegeVerifierModelView(AirflowModelView):
     """

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3835,8 +3835,6 @@ class AirflowModelView(ModelView):
     def __getattribute__(self, attr):
         attribute = object.__getattribute__(self, attr)
         if callable(attribute) and attr in [
-            "list",
-            "show",
             "add",
             "edit",
             "delete",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3831,9 +3831,13 @@ class AirflowModelView(ModelView):
 
     def __getattribute__(self, attr):
         attribute = object.__getattribute__(self, attr)
-        if callable(attribute) and hasattr(attribute, "_permission_name"):
-            permission_str = attribute._permission_name
-            if permission_str not in ["show", "list"]:
+        if (
+            callable(attribute)
+            and hasattr(attribute, "_permission_name")
+            and attribute._permission_name in self.method_permission_name
+        ):
+            permission_str = self.method_permission_name[attribute._permission_name]
+            if permission_str not in ["show", "list", "read", "get", "get_list"]:
                 return action_logging(event=f"{self.route_base.strip('/')}.{permission_str}")(attribute)
         return attribute
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3832,8 +3832,6 @@ class AirflowModelView(ModelView):
     def __getattribute__(self, attr):
         attribute = object.__getattribute__(self, attr)
         if callable(attribute) and attr in [
-            "list",
-            "show",
             "add",
             "edit",
             "delete",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3833,23 +3833,18 @@ class AirflowModelView(ModelView):
     CustomSQLAInterface = wwwutils.CustomSQLAInterface
 
     def __getattribute__(self, attr):
-        """Wraps action REST methods with `action_logging` wrapper
-        Overriding enables differentiating resource and generation of event name at the decorator level.
-
-        if attr in ["show", "list", "read", "get", "get_list"]:
-            return action_logging(event="RESOURCE_NAME"."action_name")(attr)
-        else:
-            return attr
-        """
         attribute = object.__getattribute__(self, attr)
-        if (
-            callable(attribute)
-            and hasattr(attribute, "_permission_name")
-            and attribute._permission_name in self.method_permission_name
-        ):
-            permission_str = self.method_permission_name[attribute._permission_name]
-            if permission_str not in ["show", "list", "read", "get", "get_list"]:
-                return action_logging(event=f"{self.route_base.strip('/')}.{permission_str}")(attribute)
+        if callable(attribute) and attr in [
+            "list",
+            "show",
+            "add",
+            "edit",
+            "delete",
+            "download",
+            "action",
+            "action_post",
+        ]:
+            return action_logging(event=f"{self.route_base.strip('/')}.{attr}")(attribute)
         return attribute
 
 

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -26,6 +26,7 @@ from airflow.utils.session import provide_session
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_connections
+from tests.test_utils.www import _check_last_log
 
 
 @pytest.fixture(scope="module")
@@ -81,6 +82,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
         assert response.status_code == 204
         connection = session.query(Connection).all()
         assert len(connection) == 0
+        _check_last_log(session, dag_id=None, event="connections.delete", execution_date=None)
 
     def test_delete_should_respond_404(self):
         response = self.client.delete(
@@ -366,6 +368,7 @@ class TestPatchConnection(TestConnectionEndpoint):
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={"REMOTE_USER": "test"}
         )
         assert response.status_code == 200
+        _check_last_log(session, dag_id=None, event="connections.edit", execution_date=None)
 
     def test_patch_should_respond_200_with_update_mask(self, session):
         self._create_connection(session)
@@ -526,7 +529,8 @@ class TestPostConnection(TestConnectionEndpoint):
         assert response.status_code == 200
         connection = session.query(Connection).all()
         assert len(connection) == 1
-        assert connection[0].conn_id == "test-connection-id"
+        assert connection[0].conn_id == 'test-connection-id'
+        _check_last_log(session, dag_id=None, event="connections.create", execution_date=None)
 
     def test_post_should_respond_200_extra_null(self, session):
         payload = {"connection_id": "test-connection-id", "conn_type": "test_type", "extra": None}

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -82,7 +82,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
         assert response.status_code == 204
         connection = session.query(Connection).all()
         assert len(connection) == 0
-        _check_last_log(session, dag_id=None, event="connection.delete", execution_date=None)
+        _check_last_log(session, dag_id=None, event="connections.delete", execution_date=None)
 
     def test_delete_should_respond_404(self):
         response = self.client.delete(
@@ -368,7 +368,7 @@ class TestPatchConnection(TestConnectionEndpoint):
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={"REMOTE_USER": "test"}
         )
         assert response.status_code == 200
-        _check_last_log(session, dag_id=None, event="connection.edit", execution_date=None)
+        _check_last_log(session, dag_id=None, event="connections.edit", execution_date=None)
 
     def test_patch_should_respond_200_with_update_mask(self, session):
         self._create_connection(session)
@@ -529,8 +529,8 @@ class TestPostConnection(TestConnectionEndpoint):
         assert response.status_code == 200
         connection = session.query(Connection).all()
         assert len(connection) == 1
-        assert connection[0].conn_id == "test-connection-id"
-        _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
+        assert connection[0].conn_id == 'test-connection-id'
+        _check_last_log(session, dag_id=None, event="connections.create", execution_date=None)
 
     def test_post_should_respond_200_extra_null(self, session):
         payload = {"connection_id": "test-connection-id", "conn_type": "test_type", "extra": None}

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -529,7 +529,7 @@ class TestPostConnection(TestConnectionEndpoint):
         assert response.status_code == 200
         connection = session.query(Connection).all()
         assert len(connection) == 1
-        assert connection[0].conn_id == 'test-connection-id'
+        assert connection[0].conn_id == "test-connection-id"
         _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
 
     def test_post_should_respond_200_extra_null(self, session):

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -82,7 +82,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
         assert response.status_code == 204
         connection = session.query(Connection).all()
         assert len(connection) == 0
-        _check_last_log(session, dag_id=None, event="connections.delete", execution_date=None)
+        _check_last_log(session, dag_id=None, event="connection.delete", execution_date=None)
 
     def test_delete_should_respond_404(self):
         response = self.client.delete(
@@ -368,7 +368,7 @@ class TestPatchConnection(TestConnectionEndpoint):
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={"REMOTE_USER": "test"}
         )
         assert response.status_code == 200
-        _check_last_log(session, dag_id=None, event="connections.edit", execution_date=None)
+        _check_last_log(session, dag_id=None, event="connection.edit", execution_date=None)
 
     def test_patch_should_respond_200_with_update_mask(self, session):
         self._create_connection(session)
@@ -530,7 +530,7 @@ class TestPostConnection(TestConnectionEndpoint):
         connection = session.query(Connection).all()
         assert len(connection) == 1
         assert connection[0].conn_id == 'test-connection-id'
-        _check_last_log(session, dag_id=None, event="connections.create", execution_date=None)
+        _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
 
     def test_post_should_respond_200_extra_null(self, session):
         payload = {"connection_id": "test-connection-id", "conn_type": "test_type", "extra": None}

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -293,7 +293,7 @@ class TestPostVariables(TestVariableEndpoint):
         )
         assert response.status_code == 200
         _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
-        response = self.client.get("/api/v1/variables/var_create", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/variables/var_create", environ_overrides={"REMOTE_USER": "test"})
         assert response.json == {
             "key": "var_create",
             "value": "{}",

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -79,7 +79,7 @@ class TestDeleteVariable(TestVariableEndpoint):
         # make sure variable is deleted
         response = self.client.get("/api/v1/variables/delete_var1", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 404
-        _check_last_log(session, dag_id=None, event="variables.delete", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variable.delete", execution_date=None)
 
     def test_should_respond_404_if_key_does_not_exist(self):
         response = self.client.delete(
@@ -233,7 +233,7 @@ class TestPatchVariable(TestVariableEndpoint):
             "key": "var1",
             "value": "updated",
         }
-        _check_last_log(session, dag_id=None, event="variables.edit", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variable.edit", execution_date=None)
 
     def test_should_reject_invalid_update(self):
         Variable.set("var1", "foo")
@@ -292,7 +292,7 @@ class TestPostVariables(TestVariableEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 200
-        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
         response = self.client.get("/api/v1/variables/var_create", environ_overrides={'REMOTE_USER': "test"})
         assert response.json == {
             "key": "var_create",
@@ -316,7 +316,7 @@ class TestPostVariables(TestVariableEndpoint):
             "type": EXCEPTIONS_LINK_MAP[400],
             "detail": "{'value': ['Missing data for required field.'], 'v': ['Unknown field.']}",
         }
-        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
 
     def test_should_raises_401_unauthenticated(self):
         response = self.client.post(

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -27,6 +27,7 @@ from airflow.security import permissions
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_variables
+from tests.test_utils.www import _check_last_log
 
 
 @pytest.fixture(scope="module")
@@ -64,7 +65,7 @@ class TestVariableEndpoint:
 
 
 class TestDeleteVariable(TestVariableEndpoint):
-    def test_should_delete_variable(self):
+    def test_should_delete_variable(self, session):
         Variable.set("delete_var1", 1)
         # make sure variable is added
         response = self.client.get("/api/v1/variables/delete_var1", environ_overrides={"REMOTE_USER": "test"})
@@ -78,6 +79,7 @@ class TestDeleteVariable(TestVariableEndpoint):
         # make sure variable is deleted
         response = self.client.get("/api/v1/variables/delete_var1", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 404
+        _check_last_log(session, dag_id=None, event="variables.delete", execution_date=None)
 
     def test_should_respond_404_if_key_does_not_exist(self):
         response = self.client.delete(
@@ -216,7 +218,7 @@ class TestGetVariables(TestVariableEndpoint):
 
 
 class TestPatchVariable(TestVariableEndpoint):
-    def test_should_update_variable(self):
+    def test_should_update_variable(self, session):
         Variable.set("var1", "foo")
         response = self.client.patch(
             "/api/v1/variables/var1",
@@ -231,6 +233,7 @@ class TestPatchVariable(TestVariableEndpoint):
             "key": "var1",
             "value": "updated",
         }
+        _check_last_log(session, dag_id=None, event="variables.edit", execution_date=None)
 
     def test_should_reject_invalid_update(self):
         Variable.set("var1", "foo")
@@ -279,7 +282,7 @@ class TestPatchVariable(TestVariableEndpoint):
 
 
 class TestPostVariables(TestVariableEndpoint):
-    def test_should_create_variable(self):
+    def test_should_create_variable(self, session):
         response = self.client.post(
             "/api/v1/variables",
             json={
@@ -289,14 +292,15 @@ class TestPostVariables(TestVariableEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 200
-        response = self.client.get("/api/v1/variables/var_create", environ_overrides={"REMOTE_USER": "test"})
+        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
+        response = self.client.get("/api/v1/variables/var_create", environ_overrides={'REMOTE_USER': "test"})
         assert response.json == {
             "key": "var_create",
             "value": "{}",
             "description": None,
         }
 
-    def test_should_reject_invalid_request(self):
+    def test_should_reject_invalid_request(self, session):
         response = self.client.post(
             "/api/v1/variables",
             json={
@@ -312,6 +316,7 @@ class TestPostVariables(TestVariableEndpoint):
             "type": EXCEPTIONS_LINK_MAP[400],
             "detail": "{'value': ['Missing data for required field.'], 'v': ['Unknown field.']}",
         }
+        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
 
     def test_should_raises_401_unauthenticated(self):
         response = self.client.post(

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -79,7 +79,7 @@ class TestDeleteVariable(TestVariableEndpoint):
         # make sure variable is deleted
         response = self.client.get("/api/v1/variables/delete_var1", environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 404
-        _check_last_log(session, dag_id=None, event="variable.delete", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variables.delete", execution_date=None)
 
     def test_should_respond_404_if_key_does_not_exist(self):
         response = self.client.delete(
@@ -233,7 +233,7 @@ class TestPatchVariable(TestVariableEndpoint):
             "key": "var1",
             "value": "updated",
         }
-        _check_last_log(session, dag_id=None, event="variable.edit", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variables.edit", execution_date=None)
 
     def test_should_reject_invalid_update(self):
         Variable.set("var1", "foo")
@@ -292,8 +292,8 @@ class TestPostVariables(TestVariableEndpoint):
             environ_overrides={"REMOTE_USER": "test"},
         )
         assert response.status_code == 200
-        _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
-        response = self.client.get("/api/v1/variables/var_create", environ_overrides={"REMOTE_USER": "test"})
+        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
+        response = self.client.get("/api/v1/variables/var_create", environ_overrides={'REMOTE_USER': "test"})
         assert response.json == {
             "key": "var_create",
             "value": "{}",
@@ -316,7 +316,7 @@ class TestPostVariables(TestVariableEndpoint):
             "type": EXCEPTIONS_LINK_MAP[400],
             "detail": "{'value': ['Missing data for required field.'], 'v': ['Unknown field.']}",
         }
-        _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
+        _check_last_log(session, dag_id=None, event="variables.create", execution_date=None)
 
     def test_should_raises_401_unauthenticated(self):
         response = self.client.post(

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -72,4 +72,5 @@ def _check_last_log(session, dag_id, event, execution_date):
     )
     assert len(logs) >= 1
     assert logs[0].extra
+    print(logs[0].event)
     session.query(Log).delete()

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -72,5 +72,4 @@ def _check_last_log(session, dag_id, event, execution_date):
     )
     assert len(logs) >= 1
     assert logs[0].extra
-    print(logs[0].event)
     session.query(Log).delete()

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+from airflow.models import Log
+
 
 def client_with_login(app, **kwargs):
     patch_path = "airflow.www.fab_security.manager.check_password_hash"
@@ -47,3 +49,28 @@ def check_content_not_in_response(text, resp, resp_code=200):
             assert line not in resp_html
     else:
         assert text not in resp_html
+
+
+def _check_last_log(session, dag_id, event, execution_date):
+    logs = (
+        session.query(
+            Log.dag_id,
+            Log.task_id,
+            Log.event,
+            Log.execution_date,
+            Log.owner,
+            Log.extra,
+        )
+        .filter(
+            Log.dag_id == dag_id,
+            Log.event == event,
+            Log.execution_date == execution_date,
+        )
+        .order_by(Log.dttm.desc())
+        .limit(5)
+        .all()
+    )
+    assert len(logs) >= 1
+    assert logs[0].extra
+    print(logs[0].event)
+    session.query(Log).delete()

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -49,8 +49,8 @@ def clear_connections():
 
 def test_create_connection(admin_client, session):
     init_views.init_connection_form()
-    resp = admin_client.post('/connection/add', data=CONNECTION, follow_redirects=True)
-    check_content_in_response('Added Row', resp)
+    resp = admin_client.post("/connection/add", data=CONNECTION, follow_redirects=True)
+    check_content_in_response("Added Row", resp)
     _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
 
 

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -51,7 +51,7 @@ def test_create_connection(admin_client, session):
     init_views.init_connection_form()
     resp = admin_client.post('/connection/add', data=CONNECTION, follow_redirects=True)
     check_content_in_response('Added Row', resp)
-    _check_last_log(session, dag_id=None, event="connections.add", execution_date=None)
+    _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
 
 
 def test_prefill_form_null_extra():

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -49,9 +49,9 @@ def clear_connections():
 
 def test_create_connection(admin_client, session):
     init_views.init_connection_form()
-    resp = admin_client.post("/connection/add", data=CONNECTION, follow_redirects=True)
-    check_content_in_response("Added Row", resp)
-    _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
+    resp = admin_client.post('/connection/add', data=CONNECTION, follow_redirects=True)
+    check_content_in_response('Added Row', resp)
+    _check_last_log(session, dag_id=None, event="connections.add", execution_date=None)
 
 
 def test_prefill_form_null_extra():

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -28,7 +28,7 @@ from airflow.models import Connection
 from airflow.utils.session import create_session
 from airflow.www.extensions import init_views
 from airflow.www.views import ConnectionFormWidget, ConnectionModelView
-from tests.test_utils.www import check_content_in_response
+from tests.test_utils.www import _check_last_log, check_content_in_response
 
 CONNECTION = {
     "conn_id": "test_conn",
@@ -47,10 +47,11 @@ def clear_connections():
         session.query(Connection).delete()
 
 
-def test_create_connection(admin_client):
+def test_create_connection(admin_client, session):
     init_views.init_connection_form()
-    resp = admin_client.post("/connection/add", data=CONNECTION, follow_redirects=True)
-    check_content_in_response("Added Row", resp)
+    resp = admin_client.post('/connection/add', data=CONNECTION, follow_redirects=True)
+    check_content_in_response('Added Row', resp)
+    _check_last_log(session, dag_id=None, event="connections.add", execution_date=None)
 
 
 def test_prefill_form_null_extra():

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -164,15 +164,6 @@ def test_action_logging_variables_post(session, admin_client):
     delete_variable(session, key="random")
 
 
-def test_action_logging_variables_get(session, admin_client):
-    variable = Variable("random", "random")
-    session.add(variable)
-    session.commit()
-    admin_client.get(f'/variable/show/{variable.id}', follow_redirects=True)
-    _check_last_log(session, dag_id=None, event="variable.show", execution_date=None)
-    delete_variable(session, key="random")
-
-
 def test_calendar(admin_client, dagruns):
     url = "calendar?dag_id=example_bash_operator"
     resp = admin_client.get(url, follow_redirects=True)

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -158,7 +158,6 @@ def delete_variable(session, key):
 def test_action_logging_variables_post(session, admin_client):
     form = dict(key="random", value="random")
     admin_client.post("/variable/add", data=form)
-    session.flush()
     session.commit()
     _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
     delete_variable(session, key="random")

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -160,7 +160,7 @@ def test_action_logging_variables_post(session, admin_client):
     admin_client.post("/variable/add", data=form)
     session.flush()
     session.commit()
-    _check_last_log(session, dag_id=None, event="variable.add", execution_date=None)
+    _check_last_log(session, dag_id=None, event="variables.add", execution_date=None)
     delete_variable(session, key="random")
 
 

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -187,15 +187,6 @@ def test_action_logging_variables_post(session, admin_client):
     delete_variable(session, key="random")
 
 
-def test_action_logging_variables_get(session, admin_client):
-    variable = Variable("random", "random")
-    session.add(variable)
-    session.commit()
-    admin_client.get(f'/variable/show/{variable.id}', follow_redirects=True)
-    _check_last_log(session, dag_id=None, event="variable.show", execution_date=None)
-    delete_variable(session, key="random")
-
-
 def test_calendar(admin_client, dagruns):
     url = "calendar?dag_id=example_bash_operator"
     resp = admin_client.get(url, follow_redirects=True)

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.models import DagBag, DagRun, Log, TaskInstance
+from airflow.models import DagBag, DagRun, Log, TaskInstance, Variable
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -171,6 +171,29 @@ def test_action_logging_post(session, admin_client):
         event="clear",
         execution_date=EXAMPLE_DAG_DEFAULT_DATE,
     )
+
+
+def delete_variable(session, key):
+    session.query(Variable).filter(Variable.key == key).delete()
+    session.commit()
+
+
+def test_action_logging_variables_post(session, admin_client):
+    form = dict(key="random", value="random")
+    admin_client.post("/variable/add", data=form)
+    session.flush()
+    session.commit()
+    _check_last_log(session, dag_id=None, event="variable.add", execution_date=None)
+    delete_variable(session, key="random")
+
+
+def test_action_logging_variables_get(session, admin_client):
+    variable = Variable("random", "random")
+    session.add(variable)
+    session.commit()
+    admin_client.get(f'/variable/show/{variable.id}', follow_redirects=True)
+    _check_last_log(session, dag_id=None, event="variable.show", execution_date=None)
+    delete_variable(session, key="random")
 
 
 def test_calendar(admin_client, dagruns):

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.models import DagBag, DagRun, Log, TaskInstance, Variable
+from airflow.models import DagBag, DagRun, TaskInstance, Variable
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -22,7 +22,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.models import DagBag, DagRun, TaskInstance, Variable
+from airflow.models import DagBag, DagRun, Log, TaskInstance, Variable
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
@@ -158,8 +158,18 @@ def delete_variable(session, key):
 def test_action_logging_variables_post(session, admin_client):
     form = dict(key="random", value="random")
     admin_client.post("/variable/add", data=form)
+    session.flush()
     session.commit()
-    _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
+    _check_last_log(session, dag_id=None, event="variable.add", execution_date=None)
+    delete_variable(session, key="random")
+
+
+def test_action_logging_variables_get(session, admin_client):
+    variable = Variable("random", "random")
+    session.add(variable)
+    session.commit()
+    admin_client.get(f'/variable/show/{variable.id}', follow_redirects=True)
+    _check_last_log(session, dag_id=None, event="variable.show", execution_date=None)
     delete_variable(session, key="random")
 
 

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -160,7 +160,7 @@ def test_action_logging_variables_post(session, admin_client):
     admin_client.post("/variable/add", data=form)
     session.flush()
     session.commit()
-    _check_last_log(session, dag_id=None, event="variables.add", execution_date=None)
+    _check_last_log(session, dag_id=None, event="variable.create", execution_date=None)
     delete_variable(session, key="random")
 
 

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -22,14 +22,14 @@ from unittest import mock
 
 import pytest
 
-from airflow.models import DagBag, DagRun, Log, TaskInstance, Variable
+from airflow.models import DagBag, DagRun, TaskInstance, Variable
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from airflow.www import app
 from airflow.www.views import action_has_dag_edit_access
 from tests.test_utils.db import clear_db_runs
-from tests.test_utils.www import check_content_in_response
+from tests.test_utils.www import _check_last_log, check_content_in_response
 
 EXAMPLE_DAG_DEFAULT_DATE = timezone.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
 
@@ -89,29 +89,6 @@ def dagruns(bash_dag, sub_dag, xcom_dag):
 @action_has_dag_edit_access
 def some_view_action_which_requires_dag_edit_access(*args) -> bool:
     return True
-
-
-def _check_last_log(session, dag_id, event, execution_date):
-    logs = (
-        session.query(
-            Log.dag_id,
-            Log.task_id,
-            Log.event,
-            Log.execution_date,
-            Log.owner,
-            Log.extra,
-        )
-        .filter(
-            Log.dag_id == dag_id,
-            Log.event == event,
-            Log.execution_date == execution_date,
-        )
-        .order_by(Log.dttm.desc())
-        .limit(5)
-        .all()
-    )
-    assert len(logs) >= 1
-    assert logs[0].extra
 
 
 def test_action_logging_get(session, admin_client):

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -26,7 +26,12 @@ from airflow.models import Variable
 from airflow.security import permissions
 from airflow.utils.session import create_session
 from tests.test_utils.api_connexion_utils import create_user
-from tests.test_utils.www import check_content_in_response, check_content_not_in_response, client_with_login
+from tests.test_utils.www import (
+    _check_last_log,
+    check_content_in_response,
+    check_content_not_in_response,
+    client_with_login,
+)
 
 VARIABLE = {
     "key": "test_key",
@@ -118,7 +123,8 @@ def test_import_variables_success(session, admin_client):
     resp = admin_client.post(
         "/variable/varimport", data={"file": (bytes_content, "test.json")}, follow_redirects=True
     )
-    check_content_in_response("4 variable(s) successfully updated.", resp)
+    check_content_in_response('4 variable(s) successfully updated.', resp)
+    _check_last_log(session, dag_id=None, event="variables.varimport", execution_date=None)
 
 
 def test_import_variables_anon(session, app):

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -123,7 +123,7 @@ def test_import_variables_success(session, admin_client):
     resp = admin_client.post(
         "/variable/varimport", data={"file": (bytes_content, "test.json")}, follow_redirects=True
     )
-    check_content_in_response("4 variable(s) successfully updated.", resp)
+    check_content_in_response('4 variable(s) successfully updated.', resp)
     _check_last_log(session, dag_id=None, event="variables.varimport", execution_date=None)
 
 

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -123,7 +123,7 @@ def test_import_variables_success(session, admin_client):
     resp = admin_client.post(
         "/variable/varimport", data={"file": (bytes_content, "test.json")}, follow_redirects=True
     )
-    check_content_in_response('4 variable(s) successfully updated.', resp)
+    check_content_in_response("4 variable(s) successfully updated.", resp)
     _check_last_log(session, dag_id=None, event="variables.varimport", execution_date=None)
 
 


### PR DESCRIPTION
This includes connections, variables, pools, SLA, and xcom. pools
closes #23880 

**Description**

1. Introduced event parameter to `action_logging` decorator to introduce custom naming. Without this the original `action_logging` wouldn't differentiate update between Connection/Variables/SLA
2. Added logging to the following actions 

```
[
            "add",
            "edit",
            "delete",
            "download",
            "action",
            "action_post",
]
```