### PR TITLE
Fix the link to google workplace

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -26,7 +26,7 @@ description: |
       - `Google Firebase <https://firebase.google.com/>`__
       - `Google LevelDB <https://github.com/google/leveldb/>`__
       - `Google Marketing Platform <https://marketingplatform.google.com/>`__
-      - `Google Workspace <https://workspace.google.pl/>`__ (formerly Google Suite)
+      - `Google Workspace <https://workspace.google.com/>`__ (formerly Google Suite)
 
 versions:
   - 7.0.0


### PR DESCRIPTION
The link to google workplace was the polish version instead of the global one.