### PR TITLE
Use github for postgres chart index

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/index/bitnami
   version: 10.5.3
-digest: sha256:d8ba564b767cbf73a4ca87cb3b97e0a75bc813ba0a58a1b0bd6c7154a608e783
-generated: "2021-07-20T23:05:18.37915+01:00"
+digest: sha256:d5e64d3d4563f3fc69b813202dd99708b682ba7e59172a64841e8597c171de33
+generated: "2022-06-01T14:46:45.798916-06:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -35,7 +35,7 @@ keywords:
 dependencies:
   - name: postgresql
     version: 10.5.3
-    repository: "https://charts.bitnami.com/bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/index/bitnami"
     condition: postgresql.enabled
 maintainers:
   - email: dev@airflow.apache.org


### PR DESCRIPTION
Bitnami's CloudFront CDN is seemingly having issues, so point at github
direct instead until it is resolved.

Related: #24037