### PR TITLE
Add disabled_algorithms as an extra parameter for SSH connections

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -202,6 +202,9 @@ class SSHHook(BaseHook):
                 ):
                     self.look_for_keys = False
 
+                if "disabled_algorithms" in extra_options:
+                    self.disabled_algorithms = extra_options.get("disabled_algorithms")
+
                 if host_key is not None:
                     if host_key.startswith("ssh-"):
                         key_type, host_key = host_key.split(None)[:2]
@@ -306,7 +309,6 @@ class SSHHook(BaseHook):
             sock=self.host_proxy,
             look_for_keys=self.look_for_keys,
             banner_timeout=self.banner_timeout,
-            disabled_algorithms=self.disabled_algorithms,
         )
 
         if self.password:
@@ -318,6 +320,9 @@ class SSHHook(BaseHook):
 
         if self.key_file:
             connect_kwargs.update(key_filename=self.key_file)
+
+        if self.disabled_algorithms:
+            connect_kwargs.update(disabled_algorithms=self.disabled_algorithms)
 
         log_before_sleep = lambda retry_state: self.log.info(
             "Failed to connect. Sleeping before retry attempt %d", retry_state.attempt_number

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -68,6 +68,9 @@ class SSHHook(BaseHook):
     :param keepalive_interval: send a keepalive packet to remote host every
         keepalive_interval seconds
     :param banner_timeout: timeout to wait for banner from the server in seconds
+    :param disabled_algorithms: dictionary mapping algorithm type to an
+        iterable of algorithm identifiers, which will be disabled for the
+        lifetime of the transport
     """
 
     # List of classes to try loading private keys as, ordered (roughly) by most common to least common
@@ -112,6 +115,7 @@ class SSHHook(BaseHook):
         conn_timeout: Optional[int] = None,
         keepalive_interval: int = 30,
         banner_timeout: float = 30.0,
+        disabled_algorithms: Optional[dict] = None,
     ) -> None:
         super().__init__()
         self.ssh_conn_id = ssh_conn_id
@@ -125,6 +129,7 @@ class SSHHook(BaseHook):
         self.conn_timeout = conn_timeout
         self.keepalive_interval = keepalive_interval
         self.banner_timeout = banner_timeout
+        self.disabled_algorithms = disabled_algorithms
         self.host_proxy_cmd = None
 
         # Default values, overridable from Connection
@@ -301,6 +306,7 @@ class SSHHook(BaseHook):
             sock=self.host_proxy,
             look_for_keys=self.look_for_keys,
             banner_timeout=self.banner_timeout,
+            disabled_algorithms=self.disabled_algorithms,
         )
 
         if self.password:

--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -67,7 +67,7 @@ Extra (optional)
           "look_for_keys": "false",
           "allow_host_key_change": "false",
           "host_key": "AAAHD...YDWwq=="
-          "disabled_algorithms": {'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']}
+          "disabled_algorithms": {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
        }
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it

--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -54,6 +54,7 @@ Extra (optional)
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This won't protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
     * ``look_for_keys`` - Set to ``false`` if you want to disable searching for discoverable private key files in ``~/.ssh/``
     * ``host_key`` - The base64 encoded ssh-rsa public key of the host or "ssh-<key type> <key data>" (as you would find in the ``known_hosts`` file). Specifying this allows making the connection if and only if the public key of the endpoint matches this value.
+    * ``disabled_algorithms`` - A dictionary mapping algorithm type to an iterable of algorithm identifiers, which will be disabled for the lifetime of the transport.
 
     Example "extras" field:
 
@@ -66,6 +67,7 @@ Extra (optional)
           "look_for_keys": "false",
           "allow_host_key_change": "false",
           "host_key": "AAAHD...YDWwq=="
+          "disabled_algorithms": {'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']}
        }
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -774,6 +774,7 @@ class TestSSHHook(unittest.TestCase):
                 hostname='remote_host',
                 username='username',
                 compress=True,
+                timeout=10,
                 port='port',
                 sock=None,
                 look_for_keys=True,

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -76,7 +76,7 @@ TEST_CONN_TIMEOUT = 30
 PASSPHRASE = ''.join(random.choice(string.ascii_letters) for i in range(10))
 TEST_ENCRYPTED_PRIVATE_KEY = generate_key_string(pkey=TEST_PKEY, passphrase=PASSPHRASE)
 
-TEST_DISABLED_ALGORITHMS = {'pubkeys': ['rsa-sha2-256', 'rsa-sha2-512']}
+TEST_DISABLED_ALGORITHMS = {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
 
 
 class TestSSHHook(unittest.TestCase):


### PR DESCRIPTION
related: #22194

Add disabled_algorithms parameter to SSHHook to allow compatibility with older SSH servers that do not support RSA2/SHA2.  Note that this does not solve the issue for the SFTPOperator but I will be working on that in a separate PR.

I _think_ I added the test correctly but would like a second set of eyes to make sure what I did makes sense.  The test passed but I think this is the first test I've written like this on a big project.  Thanks to @potiuk  and @uranusjr for all the help on Slack!
