### PR TITLE
Add note about Docker volume remount issues in WSL 2

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -127,9 +127,17 @@ Docker in WSL 2
 
 - **WSL 2 Docker mount errors**:
     Another reason to use Linux filesystem, is that sometimes - depending on the length of
-    your path, you might get strange errors when you try start ``Breeze``, such us
+    your path, you might get strange errors when you try start ``Breeze``, such as
     ``caused: mount through procfd: not a directory: unknown:``. Therefore checking out
     Airflow in Windows-mounted Filesystem is strongly discouraged.
+
+- **WSL 2 Docker volume remount errors**:
+    If you're experiencing errors such as ``ERROR: for docker-compose_airflow_run
+    Cannot create container for service airflow: not a directory`` when starting Breeze
+    or an error like ``docker: Error response from daemon: not a directory.
+    See 'docker run --help'.`` when running the pre-commit tests, you may need to consider
+    `installing Docker directly in WSL 2 <https://dev.to/bowmanjd/install-docker-on-windows-wsl-without-docker-desktop-34m9>`_
+    instead of using Docker Desktop for Windows.
 
 - **WSL 2 Memory Usage** :
     WSL 2 can consume a lot of memory under the process name "Vmmem". To reclaim the memory after

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -134,7 +134,7 @@ Docker in WSL 2
 - **WSL 2 Docker volume remount errors**:
     If you're experiencing errors such as ``ERROR: for docker-compose_airflow_run
     Cannot create container for service airflow: not a directory`` when starting Breeze
-    or an error like ``docker: Error response from daemon: not a directory.
+    after the first time or an error like ``docker: Error response from daemon: not a directory.
     See 'docker run --help'.`` when running the pre-commit tests, you may need to consider
     `installing Docker directly in WSL 2 <https://dev.to/bowmanjd/install-docker-on-windows-wsl-without-docker-desktop-34m9>`_
     instead of using Docker Desktop for Windows.


### PR DESCRIPTION
Add a note to the Breeze Docker in WSL 2 docs about issues with volumes remounting with a suggestion to install Docker directly in WSL 2 rather than through Docker Desktop for Windows.  Based on a conversation in the Slack development channel with @potiuk.  Everything worked perfectly after installing Docker directly in WSL 2 instead of using Docker Desktop for Windows (even with WSL 2 integration enabled).

