### PR TITLE
Temporarily fix bitnami index problem

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -35,7 +35,13 @@ keywords:
 dependencies:
   - name: postgresql
     version: 10.5.3
-    repository: "https://raw.githubusercontent.com/bitnami/charts/index/bitnami"
+    # In order to react to a sudden, totally breaking change by bitnami in
+    # https://github.com/bitnami/charts/issues/10539
+    # we need to use the version of index from just before the change. However we hope
+    # it is only temporary change as it breaks all our charts we released so far
+    # see comment here https://github.com/bitnami/charts/issues/10539#issuecomment-1144869092
+    repository: >
+      https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: postgresql.enabled
 maintainers:
   - email: dev@airflow.apache.org


### PR DESCRIPTION
We started to experience "Internal Error" when installing
Helm chart and apperently bitnami "solved" the problem by
removing from their index software older than 6 months(!).

This makes our CI fail but It is much worse. This
renders all our charts useless for people to install
This is terribly wrong, and I raised this in the issue
here:

https://github.com/bitnami/charts/issues/10539#issuecomment-1144869092

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
