### PR TITLE
Note that yarn dev needs webserver in debug mode

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1253,7 +1253,7 @@ commands:
     yarn run prod
 
     # Starts a web server that manages and updates your assets as you modify them
-    # You'll need to run the webserver in debug mode too: `airflow webserver -d`
+    # You'll need to run the webserver in debug mode too: `airflow webserver -D`
     yarn run dev
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1253,7 +1253,7 @@ commands:
     yarn run prod
 
     # Starts a web server that manages and updates your assets as you modify them
-    # You'll need to run the webserver in debug mode too: `airflow webserver -D`
+    # You'll need to run the webserver in debug mode too: `airflow webserver -d`
     yarn run dev
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1253,6 +1253,7 @@ commands:
     yarn run prod
 
     # Starts a web server that manages and updates your assets as you modify them
+    # You'll need to run the webserver in dev mode too: `airflow webserver -d`
     yarn run dev
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1253,7 +1253,7 @@ commands:
     yarn run prod
 
     # Starts a web server that manages and updates your assets as you modify them
-    # You'll need to run the webserver in dev mode too: `airflow webserver -d`
+    # You'll need to run the webserver in debug mode too: `airflow webserver -d`
     yarn run dev
 
 


### PR DESCRIPTION
Some contributors have been confused on how to iterate quickly with the UI. Often building the UI after every change. But `airflow webserver -d` and `yarn dev` allows for just refreshing the page.
This PR adds a note to the contributing doc to help surface this information for future contributors.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
