### PR TITLE
Breeze must create `hooks\` and `dags\` directories for bind mounts

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -121,7 +121,7 @@ def get_extra_docker_flags(mount_sources: str) -> List[str]:
         for (src, dst) in NECESSARY_HOST_VOLUMES:
             if (AIRFLOW_SOURCES_ROOT / src).exists():
                 extra_docker_flags.extend(
-                    ["--mount", f'type=bind,src={AIRFLOW_SOURCES_ROOT / src},dst={dst}']
+                    ["--volume", f'type=bind,src={AIRFLOW_SOURCES_ROOT / src},dst={dst}']
                 )
         extra_docker_flags.extend(
             ['--mount', "type=volume,src=docker-compose_mypy-cache-volume,dst=/opt/airflow/.mypy_cache"]

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -121,7 +121,7 @@ def get_extra_docker_flags(mount_sources: str) -> List[str]:
         for (src, dst) in NECESSARY_HOST_VOLUMES:
             if (AIRFLOW_SOURCES_ROOT / src).exists():
                 extra_docker_flags.extend(
-                    ["--volume", f'type=bind,src={AIRFLOW_SOURCES_ROOT / src},dst={dst}']
+                    ["--mount", f'type=bind,src={AIRFLOW_SOURCES_ROOT / src},dst={dst}']
                 )
         extra_docker_flags.extend(
             ['--mount', "type=volume,src=docker-compose_mypy-cache-volume,dst=/opt/airflow/.mypy_cache"]

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -237,7 +237,9 @@ def find_airflow_sources_root_to_operate_on() -> Path:
 
 AIRFLOW_SOURCES_ROOT = find_airflow_sources_root_to_operate_on().resolve()
 BUILD_CACHE_DIR = AIRFLOW_SOURCES_ROOT / '.build'
+DAGS_DIR = AIRFLOW_SOURCES_ROOT / 'dags'
 FILES_DIR = AIRFLOW_SOURCES_ROOT / 'files'
+HOOKS_DIR = AIRFLOW_SOURCES_ROOT / 'hooks'
 MSSQL_DATA_VOLUME = AIRFLOW_SOURCES_ROOT / 'tmp_mssql_volume'
 KUBE_DIR = AIRFLOW_SOURCES_ROOT / ".kube"
 LOGS_DIR = AIRFLOW_SOURCES_ROOT / 'logs'
@@ -255,7 +257,9 @@ def create_directories_and_files() -> None:
     Checks if setup has been updates since last time and proposes to upgrade if so.
     """
     BUILD_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    DAGS_DIR.mkdir(parents=True, exist_ok=True)
     FILES_DIR.mkdir(parents=True, exist_ok=True)
+    HOOKS_DIR.mkdir(parents=True, exist_ok=True)
     MSSQL_DATA_VOLUME.mkdir(parents=True, exist_ok=True)
     KUBE_DIR.mkdir(parents=True, exist_ok=True)
     LOGS_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
As of #23985 and #24026 Breeze now uses `--mount` instead of `--volume` (the former of which does not create missing mount dirs like the latter does, see explanation in the Docker docs [here](https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior)) we need to create these directories explicitly. If not, a fresh clone of Airflow (which you need to notice this issue because if you've run an older version of Breeze the `hooks` and `dags` folders were created for you before the switch to `--mount`) will show you this error when running breeze:
```
$ breeze
Good version of Docker: 20.10.16.
Good version of docker-compose: 1.29.1
.
.
.
Docker image build is not needed for CI build as no important files are changed! You can add --force-build to force it
WARNING: The AIRFLOW_CONSTRAINTS_REFERENCE variable is not set. Defaulting to a blank string.
WARNING: The DEFAULT_CONSTRAINTS_BRANCH variable is not set. Defaulting to a blank string.
Creating docker-compose_airflow_run ... error

ERROR: for docker-compose_airflow_run  Cannot create container for service airflow: invalid mount config for type "bind": bind source path does not exist: /home/onikolas/code/airflow/hooks

```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
