### PR TITLE
Apply per-run log templates to log handlers

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -82,7 +82,6 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
             'class': 'airflow.utils.log.file_task_handler.FileTaskHandler',
             'formatter': 'airflow',
             'base_log_folder': os.path.expanduser(BASE_LOG_FOLDER),
-            'filename_template': FILENAME_TEMPLATE,
             'filters': ['mask_secrets'],
         },
         'processor': {

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -54,7 +54,6 @@ base_log_folder = {AIRFLOW_HOME}/logs
 logging_level = INFO
 celery_logging_level = WARN
 fab_logging_level = WARN
-log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
 log_processor_filename_template = {{{{ filename }}}}.log
 dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
 worker_log_server_port = 8793

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1065,11 +1065,11 @@ class DagRun(Base, LoggingMixin):
         return count
 
     @provide_session
-    def get_log_filename_template(self, *, session: Session = NEW_SESSION) -> str:
+    def get_log_template(self, *, session: Session = NEW_SESSION) -> LogTemplate:
         if self.log_template_id is None:  # DagRun created before LogTemplate introduction.
-            template = session.query(LogTemplate.filename).order_by(LogTemplate.id).limit(1).scalar()
+            template = session.query(LogTemplate).order_by(LogTemplate.id).first()
         else:
-            template = session.query(LogTemplate.filename).filter_by(id=self.log_template_id).scalar()
+            template = session.query(LogTemplate).filter_by(id=self.log_template_id).one_or_none()
         if template is None:
             raise AirflowException(
                 f"No log_template entry found for ID {self.log_template_id!r}. "

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1069,7 +1069,7 @@ class DagRun(Base, LoggingMixin):
         if self.log_template_id is None:  # DagRun created before LogTemplate introduction.
             template = session.query(LogTemplate).order_by(LogTemplate.id).first()
         else:
-            template = session.query(LogTemplate).filter_by(id=self.log_template_id).one_or_none()
+            template = session.query(LogTemplate).get(self.log_template_id)
         if template is None:
             raise AirflowException(
                 f"No log_template entry found for ID {self.log_template_id!r}. "

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1076,3 +1076,12 @@ class DagRun(Base, LoggingMixin):
                 f"Please make sure you set up the metadatabase correctly."
             )
         return template
+
+    @provide_session
+    def get_log_filename_template(self, *, session: Session = NEW_SESSION) -> str:
+        warnings.warn(
+            "This method is deprecated. Please use get_log_template instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_log_template(session=session).filename

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -38,7 +38,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from OSS remote storage.
     """
 
-    def __init__(self, base_log_folder, oss_log_folder, *, filename_template=None):
+    def __init__(self, base_log_folder, oss_log_folder, filename_template=None):
         self.log.info("Using oss_task_handler for remote logging...")
         super().__init__(base_log_folder, filename_template)
         (self.bucket_name, self.base_folder) = OSSHook.parse_oss_url(oss_log_folder)

--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -38,7 +38,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from OSS remote storage.
     """
 
-    def __init__(self, base_log_folder, oss_log_folder, filename_template):
+    def __init__(self, base_log_folder, oss_log_folder, *, filename_template=None):
         self.log.info("Using oss_task_handler for remote logging...")
         super().__init__(base_log_folder, filename_template)
         (self.bucket_name, self.base_folder) = OSSHook.parse_oss_url(oss_log_folder)

--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -17,6 +17,7 @@
 # under the License.
 import sys
 from datetime import datetime
+from typing import Optional
 
 import watchtower
 
@@ -42,7 +43,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
     :param filename_template: template for file name (local storage) or log stream name (remote)
     """
 
-    def __init__(self, base_log_folder: str, log_group_arn: str, filename_template: str):
+    def __init__(self, base_log_folder: str, log_group_arn: str, filename_template: Optional[str] = None):
         super().__init__(base_log_folder, filename_template)
         split_arn = log_group_arn.split(':')
 

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -18,6 +18,7 @@
 import os
 import pathlib
 import sys
+from typing import Optional
 
 if sys.version_info >= (3, 8):
     from functools import cached_property
@@ -36,7 +37,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from S3 remote storage.
     """
 
-    def __init__(self, base_log_folder: str, s3_log_folder: str, filename_template: str):
+    def __init__(self, base_log_folder: str, s3_log_folder: str, *, filename_template: Optional[str] = None):
         super().__init__(base_log_folder, filename_template)
         self.remote_base = s3_log_folder
         self.log_relative_path = ''

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -37,7 +37,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
     uploads to and reads from S3 remote storage.
     """
 
-    def __init__(self, base_log_folder: str, s3_log_folder: str, *, filename_template: Optional[str] = None):
+    def __init__(self, base_log_folder: str, s3_log_folder: str, filename_template: Optional[str] = None):
         super().__init__(base_log_folder, filename_template)
         self.remote_base = s3_log_folder
         self.log_relative_path = ''

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -99,7 +99,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
 
         if USE_PER_RUN_LOG_ID and log_id_template is not None:
             warnings.warn(
-                "Passing log_id_template to the log handler is deprecated and has not effect",
+                "Passing log_id_template to ElasticsearchTaskHandler is deprecated and has no effect",
                 DeprecationWarning,
             )
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -43,9 +43,9 @@ from airflow.utils.session import create_session
 # Elasticsearch hosted log type
 EsLogMsgType = List[Tuple[str, str]]
 
-# Compatibility: Airflow 2.3.2 uses this method, which accesses the LogTemplate
-# model to record the log ID template used. If this function does not exist, the
-# task handler should use the log_id_template attribute instead.
+# Compatibility: Airflow 2.3.3 and up uses this method, which accesses the
+# LogTemplate model to record the log ID template used. If this function does
+# not exist, the task handler should use the log_id_template attribute instead.
 USE_PER_RUN_LOG_ID = hasattr(DagRun, "get_log_template")
 
 

--- a/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -67,7 +67,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         *,
         base_log_folder: str,
         gcs_log_folder: str,
-        filename_template: str,
+        filename_template: Optional[str] = None,
         gcp_key_path: Optional[str] = None,
         gcp_keyfile_dict: Optional[dict] = None,
         gcp_scopes: Optional[Collection[str]] = _DEFAULT_SCOPESS,

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -44,8 +44,9 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         base_log_folder: str,
         wasb_log_folder: str,
         wasb_container: str,
-        filename_template: str,
         delete_local_copy: str,
+        *,
+        filename_template: Optional[str] = None,
     ) -> None:
         super().__init__(base_log_folder, filename_template)
         self.wasb_container = wasb_container

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -18,6 +18,7 @@
 """File logging handler for tasks."""
 import logging
 import os
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple
@@ -28,6 +29,7 @@ from airflow.configuration import AirflowConfigException, conf
 from airflow.utils.context import Context
 from airflow.utils.helpers import parse_template_string, render_template_to_string
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
+from airflow.utils.session import create_session
 
 if TYPE_CHECKING:
     from airflow.models import TaskInstance
@@ -44,11 +46,15 @@ class FileTaskHandler(logging.Handler):
     :param filename_template: template filename string
     """
 
-    def __init__(self, base_log_folder: str, filename_template: str):
+    def __init__(self, base_log_folder: str, filename_template: Optional[str] = None):
         super().__init__()
         self.handler: Optional[logging.FileHandler] = None
         self.local_base = base_log_folder
-        self.filename_template, self.filename_jinja_template = parse_template_string(filename_template)
+        if filename_template is not None:
+            warnings.warn(
+                "Passing filename_template to FileTaskHandler is deprecated and has not effect",
+                DeprecationWarning,
+            )
 
     def set_context(self, ti: "TaskInstance"):
         """
@@ -75,15 +81,19 @@ class FileTaskHandler(logging.Handler):
             self.handler.close()
 
     def _render_filename(self, ti: "TaskInstance", try_number: int) -> str:
-        if self.filename_jinja_template:
+        with create_session() as session:
+            dag_run = ti.get_dagrun(session=session)
+            template = dag_run.get_log_template(session=session).filename
+        str_tpl, jinja_tpl = parse_template_string(template)
+
+        if jinja_tpl:
             if hasattr(ti, "task"):
                 context = ti.get_template_context()
             else:
-                context = Context(ti=ti, ts=ti.get_dagrun().logical_date.isoformat())
+                context = Context(ti=ti, ts=dag_run.logical_date.isoformat())
             context["try_number"] = try_number
-            return render_template_to_string(self.filename_jinja_template, context)
-        elif self.filename_template:
-            dag_run = ti.get_dagrun()
+            return render_template_to_string(jinja_tpl, context)
+        elif str_tpl:
             dag = ti.task.dag
             assert dag is not None  # For Mypy.
             try:
@@ -98,7 +108,7 @@ class FileTaskHandler(logging.Handler):
                 data_interval_end = data_interval[1].isoformat()
             else:
                 data_interval_end = ""
-            return self.filename_template.format(
+            return str_tpl.format(
                 dag_id=ti.dag_id,
                 task_id=ti.task_id,
                 run_id=ti.run_id,

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -52,7 +52,7 @@ class FileTaskHandler(logging.Handler):
         self.local_base = base_log_folder
         if filename_template is not None:
             warnings.warn(
-                "Passing filename_template to FileTaskHandler is deprecated and has not effect",
+                "Passing filename_template to FileTaskHandler is deprecated and has no effect",
                 DeprecationWarning,
             )
 

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -121,6 +121,6 @@ class TaskLogReader:
         attachment_filename = render_log_filename(
             ti=ti,
             try_number="all" if try_number is None else try_number,
-            filename_template=dagrun.get_log_filename_template(session=session),
+            filename_template=dagrun.get_log_template(session=session).filename,
         )
         return attachment_filename

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -99,7 +99,7 @@ class TestGetLog:
         self.ti.hostname = 'localhost'
 
     @pytest.fixture
-    def configure_loggers(self, tmp_path):
+    def configure_loggers(self, tmp_path, create_log_template):
         self.log_dir = tmp_path
 
         dir_path = tmp_path / self.DAG_ID / self.TASK_ID / self.default_time.replace(':', '.')
@@ -112,9 +112,9 @@ class TestGetLog:
         logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
         logging_config['handlers']['task']['base_log_folder'] = self.log_dir
 
-        logging_config['handlers']['task'][
-            'filename_template'
-        ] = '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(":", ".") }}/{{ try_number }}.log'
+        create_log_template(
+            '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(":", ".") }}/{{ try_number }}.log'
+        )
 
         logging.config.dictConfig(logging_config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,9 @@ os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"] = "True"
 os.environ["AWS_DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 os.environ["CREDENTIALS_DIR"] = os.environ.get('CREDENTIALS_DIR') or "/files/airflow-breeze-config/keys"
 
+from airflow import settings  # noqa: E402
+from airflow.models.tasklog import LogTemplate  # noqa: E402
+
 from tests.test_utils.perf.perf_kit.sqlalchemy import (  # noqa isort:skip
     count_queries,
     trace_queries,
@@ -769,3 +772,21 @@ def get_test_dag():
         return dag
 
     return _get
+
+
+@pytest.fixture()
+def create_log_template(request):
+    session = settings.Session()
+
+    def _create_log_template(filename_template, elasticsearch_id=""):
+        log_template = LogTemplate(filename=filename_template, elasticsearch_id=elasticsearch_id)
+        session.add(log_template)
+        session.commit()
+
+        def _delete_log_template():
+            session.delete(log_template)
+            session.commit()
+
+        request.addfinalizer(_delete_log_template)
+
+    return _create_log_template

--- a/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
+++ b/tests/providers/alibaba/cloud/log/test_oss_task_handler.py
@@ -35,10 +35,7 @@ class TestOSSTaskHandler(unittest.TestCase):
     def setUp(self):
         self.base_log_folder = 'local/airflow/logs/1.log'
         self.oss_log_folder = f'oss://{MOCK_BUCKET_NAME}/airflow/logs'
-        self.filename_template = '{try_number}.log'
-        self.oss_task_handler = OSSTaskHandler(
-            self.base_log_folder, self.oss_log_folder, self.filename_template
-        )
+        self.oss_task_handler = OSSTaskHandler(self.base_log_folder, self.oss_log_folder)
 
     @mock.patch(OSS_TASK_HANDLER_STRING.format('conf.get'))
     @mock.patch(OSS_TASK_HANDLER_STRING.format('OSSHook'))

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -91,9 +91,6 @@ class TestCloudwatchTaskHandler:
 
         yield
 
-        with create_session() as session:
-            session.query(DagRun).delete()
-
         self.cloudwatch_task_handler.handler = None
         with create_session() as session:
             session.query(DagRun).delete()

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -18,7 +18,6 @@
 
 import contextlib
 import os
-import unittest
 from unittest import mock
 from unittest.mock import ANY
 
@@ -29,6 +28,7 @@ from airflow.models import DAG, DagRun, TaskInstance
 from airflow.operators.empty import EmptyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.log.s3_task_handler import S3TaskHandler
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from tests.test_utils.config import conf_vars
@@ -41,32 +41,39 @@ except ImportError:
     mock_s3 = None
 
 
-@unittest.skipIf(mock_s3 is None, "Skipping test because moto.mock_s3 is not available")
-@mock_s3
-class TestS3TaskHandler(unittest.TestCase):
+@pytest.fixture(autouse=True, scope="module")
+def s3mock():
+    with mock_s3():
+        yield
+
+
+@pytest.mark.skipif(mock_s3 is None, reason="Skipping test because moto.mock_s3 is not available")
+class TestS3TaskHandler:
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def setup(self, create_log_template):
         self.remote_log_base = 's3://bucket/remote/log/location'
         self.remote_log_location = 's3://bucket/remote/log/location/1.log'
         self.remote_log_key = 'remote/log/location/1.log'
         self.local_log_location = 'local/log/location'
-        self.filename_template = '{try_number}.log'
-        self.s3_task_handler = S3TaskHandler(
-            self.local_log_location, self.remote_log_base, self.filename_template
-        )
+        create_log_template('{try_number}.log')
+        self.s3_task_handler = S3TaskHandler(self.local_log_location, self.remote_log_base)
         # Vivfy the hook now with the config override
         assert self.s3_task_handler.hook is not None
 
         date = datetime(2016, 1, 1)
         self.dag = DAG('dag_for_testing_s3_task_handler', start_date=date)
         task = EmptyOperator(task_id='task_for_testing_s3_log_handler', dag=self.dag)
-        dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test")
-        self.ti = TaskInstance(task=task)
+        dag_run = DagRun(dag_id=self.dag.dag_id, execution_date=date, run_id="test", run_type="manual")
+        with create_session() as session:
+            session.add(dag_run)
+            session.commit()
+            session.refresh(dag_run)
+
+        self.ti = TaskInstance(task=task, run_id=dag_run.run_id)
         self.ti.dag_run = dag_run
         self.ti.try_number = 1
         self.ti.state = State.RUNNING
-        self.addCleanup(self.dag.clear)
 
         self.conn = boto3.client('s3')
         # We need to create the bucket since this is all in Moto's 'virtual'
@@ -74,7 +81,13 @@ class TestS3TaskHandler(unittest.TestCase):
         moto.moto_api._internal.models.moto_api_backend.reset()
         self.conn.create_bucket(Bucket="bucket")
 
-    def tearDown(self):
+        yield
+
+        self.dag.clear()
+
+        with create_session() as session:
+            session.query(DagRun).delete()
+
         if self.s3_task_handler.handler:
             with contextlib.suppress(Exception):
                 os.remove(self.s3_task_handler.handler.baseFilename)
@@ -85,7 +98,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     def test_hook_raises(self):
-        handler = S3TaskHandler(self.local_log_location, self.remote_log_base, self.filename_template)
+        handler = S3TaskHandler(self.local_log_location, self.remote_log_base)
         with mock.patch.object(handler.log, 'error') as mock_error:
             with mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook:
                 mock_hook.side_effect = Exception('Failed to connect')

--- a/tests/providers/google/cloud/log/test_gcs_task_handler.py
+++ b/tests/providers/google/cloud/log/test_gcs_task_handler.py
@@ -49,13 +49,11 @@ class TestGCSTaskHandler:
             yield td
 
     @pytest.fixture(autouse=True)
-    def gcs_task_handler(self, local_log_location):
-        self.remote_log_base = "gs://bucket/remote/log/location"
-        self.filename_template = "{try_number}.log"
+    def gcs_task_handler(self, create_log_template, local_log_location):
+        create_log_template("{try_number}.log")
         self.gcs_task_handler = GCSTaskHandler(
             base_log_folder=local_log_location,
-            gcs_log_folder=self.remote_log_base,
-            filename_template=self.filename_template,
+            gcs_log_folder="gs://bucket/remote/log/location",
         )
         yield self.gcs_task_handler
 

--- a/tests/task/task_runner/test_task_runner.py
+++ b/tests/task/task_runner/test_task_runner.py
@@ -36,6 +36,7 @@ class GetTaskRunner(unittest.TestCase):
     def test_should_support_core_task_runner(self, mock_subprocess):
         ti = mock.MagicMock(map_index=-1, run_as_user=None)
         ti.get_template_context.return_value = {"ti": ti}
+        ti.get_dagrun.return_value.get_log_template.return_value.filename = "blah"
         local_task_job = mock.MagicMock(task_instance=ti)
         task_runner = get_task_runner(local_task_job)
 

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -29,6 +29,7 @@ import pytest
 from airflow import settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DagRun
+from airflow.models.tasklog import LogTemplate
 from airflow.operators.python import PythonOperator
 from airflow.timetables.base import DataInterval
 from airflow.utils import timezone
@@ -44,6 +45,7 @@ class TestLogView:
     DAG_ID = "dag_log_reader"
     TASK_ID = "task_log_reader"
     DEFAULT_DATE = timezone.datetime(2017, 9, 1)
+    FILENAME_TEMPLATE = "{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(':', '.') }}/{{ try_number }}.log"
 
     @pytest.fixture(autouse=True)
     def log_dir(self):
@@ -70,9 +72,7 @@ class TestLogView:
     def configure_loggers(self, log_dir, settings_folder):
         logging_config = copy.deepcopy(DEFAULT_LOGGING_CONFIG)
         logging_config["handlers"]["task"]["base_log_folder"] = log_dir
-        logging_config["handlers"]["task"][
-            "filename_template"
-        ] = "{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(':', '.') }}/{{ try_number }}.log"
+        logging_config["handlers"]["task"]["filename_template"] = self.FILENAME_TEMPLATE
         settings_file = os.path.join(settings_folder, "airflow_local_settings.py")
         with open(settings_file, "w") as handle:
             new_logging_file = f"LOGGING_CONFIG = {logging_config}"
@@ -93,6 +93,10 @@ class TestLogView:
 
     @pytest.fixture(autouse=True)
     def prepare_db(self, create_task_instance):
+        session = settings.Session()
+        log_template = LogTemplate(filename=self.FILENAME_TEMPLATE, elasticsearch_id="")
+        session.add(log_template)
+        session.commit()
         ti = create_task_instance(
             dag_id=self.DAG_ID,
             task_id=self.TASK_ID,
@@ -107,6 +111,8 @@ class TestLogView:
         yield
         clear_db_runs()
         clear_db_dags()
+        session.delete(log_template)
+        session.commit()
 
     def test_test_read_log_chunks_should_read_one_try(self):
         task_log_reader = TaskLogReader()

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -23,8 +23,10 @@ import re
 
 import pytest
 
+from airflow import settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DAG, DagRun, TaskInstance
+from airflow.models.tasklog import LogTemplate
 from airflow.operators.python import PythonOperator
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import set_context
@@ -219,33 +221,54 @@ class TestFileTaskLogHandler:
 
 
 @pytest.fixture()
-def filename_rendering_ti(session, create_task_instance):
-    return create_task_instance(
-        dag_id='dag_for_testing_filename_rendering',
-        task_id='task_for_testing_filename_rendering',
-        run_type=DagRunType.SCHEDULED,
-        execution_date=DEFAULT_DATE,
-        session=session,
-    )
+def create_log_template(request):
+    session = settings.Session()
+
+    def _create_log_template(filename_template):
+        log_template = LogTemplate(filename=filename_template, elasticsearch_id="")
+        session.add(log_template)
+        session.commit()
+
+        def _delete_log_template():
+            session.delete(log_template)
+            session.commit()
+
+        request.addfinalizer(_delete_log_template)
+
+    return _create_log_template
 
 
 class TestFilenameRendering:
-    def test_python_formatting(self, filename_rendering_ti):
-        expected_filename = (
-            f'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/'
-            f'{DEFAULT_DATE.isoformat()}/42.log'
+    def test_python_formatting(self, create_log_template, create_task_instance):
+        create_log_template("{dag_id}/{task_id}/{execution_date}/{try_number}.log")
+        filename_rendering_ti = create_task_instance(
+            dag_id="dag_for_testing_filename_rendering",
+            task_id="task_for_testing_filename_rendering",
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
         )
 
-        fth = FileTaskHandler('', '{dag_id}/{task_id}/{execution_date}/{try_number}.log')
+        expected_filename = (
+            f"dag_for_testing_filename_rendering/task_for_testing_filename_rendering/"
+            f"{DEFAULT_DATE.isoformat()}/42.log"
+        )
+        fth = FileTaskHandler("")
         rendered_filename = fth._render_filename(filename_rendering_ti, 42)
         assert expected_filename == rendered_filename
 
-    def test_jinja_rendering(self, filename_rendering_ti):
-        expected_filename = (
-            f'dag_for_testing_filename_rendering/task_for_testing_filename_rendering/'
-            f'{DEFAULT_DATE.isoformat()}/42.log'
+    def test_jinja_rendering(self, create_log_template, create_task_instance):
+        create_log_template("{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log")
+        filename_rendering_ti = create_task_instance(
+            dag_id="dag_for_testing_filename_rendering",
+            task_id="task_for_testing_filename_rendering",
+            run_type=DagRunType.SCHEDULED,
+            execution_date=DEFAULT_DATE,
         )
 
-        fth = FileTaskHandler('', '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log')
+        expected_filename = (
+            f"dag_for_testing_filename_rendering/task_for_testing_filename_rendering/"
+            f"{DEFAULT_DATE.isoformat()}/42.log"
+        )
+        fth = FileTaskHandler("")
         rendered_filename = fth._render_filename(filename_rendering_ti, 42)
         assert expected_filename == rendered_filename

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -21,12 +21,8 @@ import logging.config
 import os
 import re
 
-import pytest
-
-from airflow import settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.models import DAG, DagRun, TaskInstance
-from airflow.models.tasklog import LogTemplate
 from airflow.operators.python import PythonOperator
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import set_context
@@ -218,24 +214,6 @@ class TestFileTaskLogHandler:
 
         # Remove the generated tmp log file.
         os.remove(log_filename)
-
-
-@pytest.fixture()
-def create_log_template(request):
-    session = settings.Session()
-
-    def _create_log_template(filename_template):
-        log_template = LogTemplate(filename=filename_template, elasticsearch_id="")
-        session.add(log_template)
-        session.commit()
-
-        def _delete_log_template():
-            session.delete(log_template)
-            session.commit()
-
-        request.addfinalizer(_delete_log_template)
-
-    return _create_log_template
 
 
 class TestFilenameRendering:

--- a/tests/www/test_logs/dag_for_testing_log_view/scheduled__2017-09-01T00:00:00+00:00/task_for_testing_log_view/1.log
+++ b/tests/www/test_logs/dag_for_testing_log_view/scheduled__2017-09-01T00:00:00+00:00/task_for_testing_log_view/1.log
@@ -1,0 +1,1 @@
+Log for testing.

--- a/tests/www/test_logs/dag_id=dag_for_testing_log_view/run_id=scheduled__2017-09-01T00:00:00+00:00/task_id=task_for_testing_log_view/attempt=1.log
+++ b/tests/www/test_logs/dag_id=dag_for_testing_log_view/run_id=scheduled__2017-09-01T00:00:00+00:00/task_id=task_for_testing_log_view/attempt=1.log
@@ -1,0 +1,1 @@
+Log for testing.

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -85,9 +85,6 @@ def log_app(backup_modules):
     logging_config['handlers']['task']['base_log_folder'] = str(
         pathlib.Path(__file__, "..", "..", "test_logs").resolve(),
     )
-    logging_config['handlers']['task'][
-        'filename_template'
-    ] = '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts | replace(":", ".") }}/{{ try_number }}.log'
 
     with tempfile.TemporaryDirectory() as settings_dir:
         local_settings = pathlib.Path(settings_dir, "airflow_local_settings.py")


### PR DESCRIPTION
We implemented _recording_ of per-run templates, but didn’t access them in the log handlers to read the logs out. This fixes that. Since the template values are now dynamic, it no longer makes sense to set a static `filename_template` attribute on the handler object (and for ElasticSearch specifically, `log_id_template`), so I deprecated the attributes.

Note that `FileProcessorHandler` does not use the dynamic template, and thus still accepts a static `filename_template`. We could potentially also deprecate that as well, however (and read from configuration instead).

cc @jedcunningham 