### PR TITLE
Pass connection extra parameters to wasb BlobServiceClient

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -123,21 +123,17 @@ class WasbHook(BaseHook):
             # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
             return BlobServiceClient(account_url=conn.host, **extra)
 
-        connection_string = extra.pop('connection_string', None) or extra.pop(
-            'extra__wasb__connection_string', None
-        )
+        connection_string = extra.pop('connection_string', extra.pop('extra__wasb__connection_string', None))
         if connection_string:
             # connection_string auth takes priority
             return BlobServiceClient.from_connection_string(connection_string, **extra)
 
-        shared_access_key = extra.pop('shared_access_key', None) or extra.pop(
-            'extra__wasb__shared_access_key', None
-        )
+        shared_access_key = extra.pop('shared_access_key', extra.pop('extra__wasb__shared_access_key', None))
         if shared_access_key:
             # using shared access key
             return BlobServiceClient(account_url=conn.host, credential=shared_access_key, **extra)
 
-        tenant = extra.pop('tenant_id', None) or extra.pop('extra__wasb__tenant_id', None)
+        tenant = extra.pop('tenant_id', extra.pop('extra__wasb__tenant_id', None))
         if tenant:
             # use Active Directory auth
             app_id = conn.login
@@ -145,7 +141,7 @@ class WasbHook(BaseHook):
             token_credential = ClientSecretCredential(tenant, app_id, app_secret)
             return BlobServiceClient(account_url=conn.host, credential=token_credential, **extra)
 
-        sas_token = extra.pop('sas_token', None) or extra.pop('extra__wasb__sas_token', None)
+        sas_token = extra.pop('sas_token', extra.pop('extra__wasb__sas_token', None))
         if sas_token:
             if sas_token.startswith('https'):
                 return BlobServiceClient(account_url=sas_token, **extra)

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -123,25 +123,21 @@ class WasbHook(BaseHook):
             # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
             return BlobServiceClient(account_url=conn.host, **extra)
 
-        def pop_keys(*keys):
-            res = None
-            for key in keys:
-                value = extra.pop(key, None)
-                res = res or value
-
-            return res
-
-        connection_string = pop_keys('connection_string', 'extra__wasb__connection_string')
+        connection_string = extra.pop('connection_string', None) or extra.pop(
+            'extra__wasb__connection_string', None
+        )
         if connection_string:
             # connection_string auth takes priority
             return BlobServiceClient.from_connection_string(connection_string, **extra)
 
-        shared_access_key = pop_keys('shared_access_key', 'extra__wasb__shared_access_key')
+        shared_access_key = extra.pop('shared_access_key', None) or extra.pop(
+            'extra__wasb__shared_access_key', None
+        )
         if shared_access_key:
             # using shared access key
             return BlobServiceClient(account_url=conn.host, credential=shared_access_key, **extra)
 
-        tenant = pop_keys('tenant_id', 'extra__wasb__tenant_id')
+        tenant = extra.pop('tenant_id', None) or extra.pop('extra__wasb__tenant_id', None)
         if tenant:
             # use Active Directory auth
             app_id = conn.login
@@ -149,7 +145,7 @@ class WasbHook(BaseHook):
             token_credential = ClientSecretCredential(tenant, app_id, app_secret)
             return BlobServiceClient(account_url=conn.host, credential=token_credential, **extra)
 
-        sas_token = pop_keys('sas_token', 'extra__wasb__sas_token')
+        sas_token = extra.pop('sas_token', None) or extra.pop('extra__wasb__sas_token', None)
         if sas_token:
             if sas_token.startswith('https'):
                 return BlobServiceClient(account_url=sas_token, **extra)

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -52,11 +52,14 @@ class TestWasbHook:
         self.public_read_conn_id = 'pub_read_id'
         self.managed_identity_conn_id = 'managed_identity'
 
+        self.proxies = {'http': 'http_proxy_uri', 'https': 'https_proxy_uri'}
+
         db.merge_conn(
             Connection(
                 conn_id=self.public_read_conn_id,
                 conn_type=self.connection_type,
                 host='https://accountname.blob.core.windows.net',
+                extra=json.dumps({'proxies': self.proxies}),
             )
         )
 
@@ -64,7 +67,7 @@ class TestWasbHook:
             Connection(
                 conn_id=self.connection_string_id,
                 conn_type=self.connection_type,
-                extra=json.dumps({'connection_string': CONN_STRING}),
+                extra=json.dumps({'connection_string': CONN_STRING, 'proxies': self.proxies}),
             )
         )
         db.merge_conn(
@@ -72,50 +75,59 @@ class TestWasbHook:
                 conn_id=self.shared_key_conn_id,
                 conn_type=self.connection_type,
                 host='https://accountname.blob.core.windows.net',
-                extra=json.dumps({'shared_access_key': 'token'}),
+                extra=json.dumps({'shared_access_key': 'token', 'proxies': self.proxies}),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.ad_conn_id,
                 conn_type=self.connection_type,
-                extra=json.dumps(
-                    {'tenant_id': 'token', 'application_id': 'appID', 'application_secret': "appsecret"}
-                ),
+                host='conn_host',
+                login='appID',
+                password='appsecret',
+                extra=json.dumps({'tenant_id': 'token', 'proxies': self.proxies}),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.managed_identity_conn_id,
                 conn_type=self.connection_type,
+                extra=json.dumps({'proxies': self.proxies}),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.sas_conn_id,
                 conn_type=self.connection_type,
-                extra=json.dumps({'sas_token': 'token'}),
+                extra=json.dumps({'sas_token': 'token', 'proxies': self.proxies}),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.extra__wasb__sas_conn_id,
                 conn_type=self.connection_type,
-                extra=json.dumps({'extra__wasb__sas_token': 'token'}),
+                extra=json.dumps({'extra__wasb__sas_token': 'token', 'proxies': self.proxies}),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.http_sas_conn_id,
                 conn_type=self.connection_type,
-                extra=json.dumps({'sas_token': 'https://login.blob.core.windows.net/token'}),
+                extra=json.dumps(
+                    {'sas_token': 'https://login.blob.core.windows.net/token', 'proxies': self.proxies}
+                ),
             )
         )
         db.merge_conn(
             Connection(
                 conn_id=self.extra__wasb__http_sas_conn_id,
                 conn_type=self.connection_type,
-                extra=json.dumps({'extra__wasb__sas_token': 'https://login.blob.core.windows.net/token'}),
+                extra=json.dumps(
+                    {
+                        'extra__wasb__sas_token': 'https://login.blob.core.windows.net/token',
+                        'proxies': self.proxies,
+                    }
+                ),
             )
         )
 
@@ -159,6 +171,31 @@ class TestWasbHook:
         sas_token = hook_conn.extra_dejson[extra_key]
         assert isinstance(conn, BlobServiceClient)
         assert conn.url.endswith(sas_token + '/')
+
+    @pytest.mark.parametrize(
+        argnames="conn_id_str",
+        argvalues=[
+            'connection_string_id',
+            'shared_key_conn_id',
+            'ad_conn_id',
+            'managed_identity_conn_id',
+            'sas_conn_id',
+            'extra__wasb__sas_conn_id',
+            'http_sas_conn_id',
+            'extra__wasb__http_sas_conn_id',
+        ],
+    )
+    def test_connection_extra_arguments(self, conn_id_str):
+        conn_id = self.__getattribute__(conn_id_str)
+        hook = WasbHook(wasb_conn_id=conn_id)
+        conn = hook.get_conn()
+        assert conn._config.proxy_policy.proxies == self.proxies
+
+    def test_connection_extra_arguments_public_read(self):
+        conn_id = self.public_read_conn_id
+        hook = WasbHook(wasb_conn_id=conn_id, public_read=True)
+        conn = hook.get_conn()
+        assert conn._config.proxy_policy.proxies == self.proxies
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.BlobServiceClient")
     def test_check_for_blob(self, mock_service):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

`WasbHook` should pass the extra arguments from connections to the underlying `BlobServiceClient`. This for example allows defining proxies in the connection as can be done in [S3 connection](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/aws.html#examples-for-the-extra-field).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
