### PR TITLE
Prevent dag dependencies page from crashing

### DIFF
--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -198,8 +198,14 @@ const renderGraph = () => {
     g.setNode(node.id, node.value);
   });
 
+  // filter out edges that point to non-existent nodes
+  const realEdges = edges.filter((e) => {
+    const edgeNodes = nodes.filter((n) => n.id === e.u || n.id === e.v);
+    return edgeNodes.length === 2;
+  });
+
   // Set edges
-  edges.forEach((edge) => {
+  realEdges.forEach((edge) => {
     g.setEdge(edge.u, edge.v, {
       curve: d3.curveBasis,
       arrowheadClass: 'arrowhead',


### PR DESCRIPTION
Sometimes the nodes and edges that are given to the DAG dependencies view are not in-sync. There are edges that point to nodes that do not exist. At least one case where this happens is if the webserver is running but the scheduler is not. This PR fixes this by filtering out edges that point to a node that doesn't exist.

Fixes: https://github.com/apache/airflow/issues/16610

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
