### PR TITLE
Remove escaping which is wrong in latest rich version

### DIFF
--- a/dev/system_tests/update_issue_status.py
+++ b/dev/system_tests/update_issue_status.py
@@ -211,14 +211,14 @@ def update_issue_status(
             all = per_issue_num_all[issue.id]
             done = per_issue_num_done[issue.id]
             console.print(
-                fr" * \[[yellow]{issue.title}[/]]({issue.html_url}): "
+                fr" * [[yellow]{issue.title}[/]]({issue.html_url}): "
                 f"{done}/{all} : {done * 100 / all:.2f}%"
             )
         console.print()
     if completed_open_issues:
         console.print("[yellow] Issues that are completed and should be closed:[/]\n")
         for issue in completed_open_issues:
-            console.print(fr" * \[[yellow]{issue.title}[/]]({issue.html_url})")
+            console.print(fr" * [[yellow]{issue.title}[/]]({issue.html_url})")
         console.print()
     if not_completed_opened_issues:
         console.print("[yellow] Issues that are not completed and are still opened:[/]\n")
@@ -226,14 +226,14 @@ def update_issue_status(
             all = per_issue_num_all[issue.id]
             done = per_issue_num_done[issue.id]
             console.print(
-                fr" * \[[yellow]{issue.title}[/]]({issue.html_url}): "
+                fr" * [[yellow]{issue.title}[/]]({issue.html_url}): "
                 f"{done}/{all} : {done * 100 / all:.2f}%"
             )
         console.print()
     if completed_closed_issues:
         console.print("[green] Issues that are completed and are already closed:[/]\n")
         for issue in completed_closed_issues:
-            console.print(fr" * \[[green]{issue.title}[/]]({issue.html_url})")
+            console.print(fr" * [[green]{issue.title}[/]]({issue.html_url})")
         console.print()
     console.print()
 


### PR DESCRIPTION
Latest rich makes escaping not needed for extra `[` needed in
Markdown URLs.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
