### PR TITLE
Fix backwards-compatibility introduced by fixing mypy problems

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -632,7 +632,10 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     # we still attempt to kill the yarn application
                     renew_from_kt(self._principal, self._keytab, exit_on_fail=False)
                     env = os.environ.copy()
-                    env["KRB5CCNAME"] = airflow_conf.get_mandatory_value('kerberos', 'ccache')
+                    ccacche = airflow_conf.get('kerberos', 'ccache')
+                    if ccacche is None:
+                        raise ValueError("The kerberos/ccache config should be set here!")
+                    env["KRB5CCNAME"] = ccacche
 
                 with subprocess.Popen(
                     kill_cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -227,7 +227,10 @@ class QuboleHook(BaseHook):
         """
         if fp is None:
             iso = datetime.datetime.utcnow().isoformat()
-            logpath = os.path.expanduser(conf.get_mandatory_value('logging', 'BASE_LOG_FOLDER'))
+            base_log_folder = conf.get('logging', 'BASE_LOG_FOLDER')
+            if base_log_folder is None:
+                raise ValueError("logging/BASE_LOG_FOLDER config value should be set")
+            logpath = os.path.expanduser(base_log_folder)
             resultpath = logpath + '/' + self.dag_id + '/' + self.task_id + '/results'
             pathlib.Path(resultpath).mkdir(parents=True, exist_ok=True)
             fp = open(resultpath + '/' + iso, 'wb')

--- a/scripts/ci/pre_commit/pre_commit_check_2_1_compatibility.py
+++ b/scripts/ci/pre_commit/pre_commit_check_2_1_compatibility.py
@@ -36,6 +36,7 @@ errors: List[str] = []
 GET_ATTR_MATCHER = re.compile(r".*getattr\((ti|TI), ['\"]run_id['\"]\).*")
 TI_RUN_ID_MATCHER = re.compile(r".*(ti|TI)\.run_id.*")
 TRY_NUM_MATCHER = re.compile(r".*context.*\[[\"']try_number[\"']].*")
+GET_MANDATORY_MATCHER = re.compile(r".*conf\.get_mandatory_value")
 
 
 def _check_file(_file: Path):
@@ -88,6 +89,15 @@ def _check_file(_file: Path):
                 f"(Airflow 2.3+ only):[/]\n\n"
                 f"{lines[index]}\n\n"
                 f"[yellow]You should not expect try_number field for context in providers "
+                f"as it is not available in Airflow 2.2[/]"
+            )
+
+        if GET_MANDATORY_MATCHER.match(line):
+            errors.append(
+                f"[red]In {_file}:{index} there is a forbidden construct "
+                f"(Airflow 2.3+ only):[/]\n\n"
+                f"{lines[index]}\n\n"
+                f"[yellow]You should not use conf.get_mandatory_value "
                 f"as it is not available in Airflow 2.2[/]"
             )
 


### PR DESCRIPTION
There was a backwards-incompatibility introduced by #23716 in
two providers by using get_mandatory_value config method.

This PR corrects that backwards compatibility and updates 2.1
compatibility pre-commit to check for forbidden usage of
get_mandatory_value.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
