### PR TITLE
Fix BigQuery Sensors system test

### DIFF
--- a/tests/system/providers/google/bigquery/example_bigquery_sensors.py
+++ b/tests/system/providers/google/bigquery/example_bigquery_sensors.py
@@ -48,7 +48,7 @@ INSERT_DATE = datetime.now().strftime("%Y-%m-%d")
 
 PARTITION_NAME = "{{ ds_nodash }}"
 
-INSERT_ROWS_QUERY = f"INSERT {DATASET_NAME}.{TABLE_NAME} VALUES (42, '{{ ds }}')"
+INSERT_ROWS_QUERY = f"INSERT {DATASET_NAME}.{TABLE_NAME} VALUES (42, '{{{{ ds }}}}')"
 
 SCHEMA = [
     {"name": "value", "type": "INTEGER", "mode": "REQUIRED"},


### PR DESCRIPTION
Fix failing system tests after #23873 . 

Initially the string was split by the test author to presumably not use the fstring for the second string (to use a curly bracket without escaping). Then it was modified by black (moved to the same line) and in the end the string was merged into one in linked PR but without escaping curly brackets.

