### PR TITLE
Change `log_filename_template` in unittest default template

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -54,7 +54,7 @@ base_log_folder = {AIRFLOW_HOME}/logs
 logging_level = INFO
 celery_logging_level = WARN
 fab_logging_level = WARN
-log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
+log_filename_template = dag_id={{{{ ti.dag_id }}}}/run_id={{{{ ti.run_id }}}}/task_id={{{{ ti.task_id }}}}/{{%% if ti.map_index >= 0 %%}}map_index={{{{ ti.map_index }}}}/{{%% endif %%}}attempt={{{{ try_number }}}}.log
 log_processor_filename_template = {{{{ filename }}}}.log
 dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
 worker_log_server_port = 8793


### PR DESCRIPTION
At that moment if user use unit test mode (`AIRFLOW__CORE__UNIT_TEST_MODE=True`) then got warning:

```
================================================================================= warnings summary ==================================================================================
.nox/tests-airflow_version-2-3-2/lib/python3.9/site-packages/airflow/configuration.py:433
  .nox/tests-airflow_version-2-3-2/lib/python3.9/site-packages/airflow/configuration.py:433: FutureWarning: The 'log_filename_template' setting in [logging] has the old default value of '{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log'. This value has been changed to 'dag_id={{ ti.dag_id }}/run_id={{ ti.run_id }}/task_id={{ ti.task_id }}/{% if ti.map_index >= 0 %}map_index={{ ti.map_index }}/{% endif %}attempt={{ try_number }}.log' in the running config, but please update your config before Apache Airflow 3.0.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```

This change won't affect to already created `unittests.cfg`.