### PR TITLE
Use `get_hostname` instead of `socket.getfqdn`

### DIFF
--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -34,13 +34,13 @@
 """Kerberos security provider"""
 import logging
 import shlex
-import socket
 import subprocess
 import sys
 import time
 from typing import List, Optional
 
 from airflow.configuration import conf
+from airflow.utils.net import get_hostname
 
 NEED_KRB181_WORKAROUND = None  # type: Optional[bool]
 
@@ -60,7 +60,7 @@ def renew_from_kt(principal: Optional[str], keytab: str, exit_on_fail: bool = Tr
     renewal_lifetime = f"{conf.getint('kerberos', 'reinit_frequency')}m"
 
     cmd_principal = principal or conf.get_mandatory_value('kerberos', 'principal').replace(
-        "_HOST", socket.getfqdn()
+        "_HOST", get_hostname()
     )
 
     if conf.getboolean('kerberos', 'forwardable'):
@@ -143,7 +143,7 @@ def perform_krb181_workaround(principal: str):
     ret = subprocess.call(cmdv, close_fds=True)
 
     if ret != 0:
-        principal = f"{principal or conf.get('kerberos', 'principal')}/{socket.getfqdn()}"
+        principal = f"{principal or conf.get('kerberos', 'principal')}/{get_hostname()}"
         ccache = conf.get('kerberos', 'ccache')
         log.error(
             "Couldn't renew kerberos ticket in order to work around Kerberos 1.8.1 issue. Please check that "

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import socket
 from functools import wraps
 from typing import Callable, Optional, Sequence, Tuple, TypeVar, cast
 
 from flask import current_app, flash, g, redirect, render_template, request, url_for
 
 from airflow.configuration import conf
+from airflow.utils.net import get_hostname
 
 T = TypeVar("T", bound=Callable)
 
@@ -45,7 +45,7 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
                 return (
                     render_template(
                         'airflow/no_roles_permissions.html',
-                        hostname=socket.getfqdn()
+                        hostname=get_hostname
                         if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
                         else 'redact',
                         logout_url=appbuilder.get_url_for_logout,

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -45,7 +45,7 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
                 return (
                     render_template(
                         'airflow/no_roles_permissions.html',
-                        hostname=get_hostname
+                        hostname=get_hostname()
                         if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
                         else 'redact',
                         logout_url=appbuilder.get_url_for_logout,

--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -16,13 +16,13 @@
 # under the License.
 
 import logging
-import socket
 
 import pendulum
 
 import airflow
 from airflow.configuration import conf
 from airflow.settings import IS_K8S_OR_K8SCELERY_EXECUTOR, STATE_COLORS
+from airflow.utils.net import get_hostname
 from airflow.utils.platform import get_airflow_git_version
 
 
@@ -43,7 +43,7 @@ def init_jinja_globals(app):
         default_ui_timezone = server_timezone
 
     expose_hostname = conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
-    hostname = socket.getfqdn() if expose_hostname else 'redact'
+    hostname = get_hostname() if expose_hostname else 'redact'
 
     try:
         airflow_version = airflow.__version__

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -23,7 +23,6 @@ import json
 import logging
 import math
 import re
-import socket
 import sys
 import traceback
 import warnings
@@ -126,6 +125,7 @@ from airflow.utils.docs import get_doc_url_for_provider, get_docs_url
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils.log import secrets_masker
 from airflow.utils.log.log_reader import TaskLogReader
+from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.strings import to_boolean
@@ -641,7 +641,7 @@ def not_found(error):
     return (
         render_template(
             'airflow/not_found.html',
-            hostname=socket.getfqdn()
+            hostname=get_hostname()
             if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
             else 'redact',
         ),
@@ -656,7 +656,7 @@ def show_traceback(error):
             'airflow/traceback.html',
             python_version=sys.version.split(" ")[0],
             airflow_version=version,
-            hostname=socket.getfqdn()
+            hostname=get_hostname()
             if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
             else 'redact',
             info=traceback.format_exc()

--- a/tests/security/test_kerberos.py
+++ b/tests/security/test_kerberos.py
@@ -285,7 +285,7 @@ class TestKerberosUnit(unittest.TestCase):
     @mock.patch('airflow.security.kerberos.subprocess')
     @mock.patch('airflow.security.kerberos.NEED_KRB181_WORKAROUND', None)
     @mock.patch('airflow.security.kerberos.open', mock.mock_open(read_data=b'X-CACHECONF:'))
-    @mock.patch('airflow.security.kerberos.socket.getfqdn', return_value="HOST")
+    @mock.patch('airflow.security.kerberos.get_hostname', return_value="HOST")
     @mock.patch('time.sleep', return_value=None)
     def test_renew_from_kt_failed_workaround(self, mock_sleep, mock_getfqdn, mock_subprocess):
         mock_subprocess.Popen.return_value.__enter__.return_value.returncode = 0


### PR DESCRIPTION
We allow users to configure a different function to determine the
hostname, so we should use that consistently when we need the hostname.