### PR TITLE
Remove defaults from Airflow test config

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -32,100 +32,35 @@
 unit_test_mode = True
 dags_folder = {TEST_DAGS_FOLDER}
 plugins_folder = {TEST_PLUGINS_FOLDER}
-executor = SequentialExecutor
-load_examples = True
-donot_pickle = True
-max_active_tasks_per_dag = 16
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
-enable_xcom_pickling = False
 killed_task_cleanup_time = 5
-hostname_callable = socket.getfqdn
-default_task_retries = 0
-# This is a hack, too many tests assume DAGs are already in the DB. We need to fix those tests instead
-store_serialized_dags = False
 
 [database]
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
-load_default_connections = True
 
 [logging]
-base_log_folder = {AIRFLOW_HOME}/logs
-logging_level = INFO
 celery_logging_level = WARN
-fab_logging_level = WARN
-log_processor_filename_template = {{{{ filename }}}}.log
-dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
-worker_log_server_port = 8793
-
-[cli]
-api_client = airflow.api.client.local_client
-endpoint_url = http://localhost:8080
 
 [api]
 auth_backends = airflow.api.auth.backend.default
 
-[operators]
-default_owner = airflow
-
-
 [hive]
 default_hive_mapred_queue = airflow
 
-[webserver]
-base_url = http://localhost:8080
-web_server_host = 0.0.0.0
-web_server_port = 8080
-dag_orientation = LR
-dag_default_view = tree
-log_fetch_timeout_sec = 5
-hide_paused_dags_by_default = False
-page_size = 100
-
-[email]
-email_backend = airflow.utils.email.send_email_smtp
-email_conn_id = smtp_default
-
 [smtp]
-smtp_host = localhost
 smtp_user = airflow
-smtp_port = 25
 smtp_password = airflow
-smtp_mail_from = airflow@example.com
-smtp_retry_limit = 5
-smtp_timeout = 30
 
 [celery]
-celery_app_name = airflow.executors.celery_executor
-worker_concurrency = 16
 broker_url = sqla+mysql://airflow:airflow@localhost:3306/airflow
 result_backend = db+mysql://airflow:airflow@localhost:3306/airflow
-flower_host = 0.0.0.0
-flower_port = 5555
-sync_parallelism = 0
-worker_precheck = False
 
 [scheduler]
 job_heartbeat_sec = 1
 schedule_after_task_execution = False
-scheduler_heartbeat_sec = 5
-scheduler_health_check_threshold = 30
 scheduler_health_check_server_port = 8794
-parsing_processes = 2
-catchup_by_default = True
-scheduler_zombie_task_threshold = 300
 dag_dir_list_interval = 0
-max_tis_per_query = 512
 
 [elasticsearch]
-host =
 log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
-end_of_log_mark = end_of_log
-
-[elasticsearch_configs]
-
-use_ssl = False
-verify_certs = True
-
-[kubernetes]
-dags_volume_claim = default

--- a/tests/core/test_config_templates.py
+++ b/tests/core/test_config_templates.py
@@ -60,18 +60,12 @@ DEFAULT_TEST_SECTIONS = [
     'core',
     'database',
     "logging",
-    'cli',
     'api',
-    'operators',
     'hive',
-    'webserver',
-    'email',
     'smtp',
     'celery',
     'scheduler',
     'elasticsearch',
-    'elasticsearch_configs',
-    'kubernetes',
 ]
 
 

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -85,7 +85,12 @@ class TestEmail(unittest.TestCase):
 
     @mock.patch('airflow.utils.email.send_email_smtp')
     def test_custom_backend(self, mock_send_email):
-        with conf_vars({('email', 'email_backend'): 'tests.utils.test_email.send_email_test'}):
+        with conf_vars(
+            {
+                ('email', 'email_backend'): 'tests.utils.test_email.send_email_test',
+                ('email', 'email_conn_id'): 'smtp_default',
+            }
+        ):
             email.send_email('to', 'subject', 'content')
         send_email_test.assert_called_once_with(
             'to',
@@ -107,6 +112,7 @@ class TestEmail(unittest.TestCase):
     @conf_vars(
         {
             ('email', 'email_backend'): 'tests.utils.test_email.send_email_test',
+            ('email', 'email_conn_id'): 'smtp_default',
             ('email', 'from_email'): 'from@test.com',
         }
     )


### PR DESCRIPTION
All of these removed values are the defaults (or in the case of the
`dag_default_view`, the old default) and don't actually do
anything being in this file.

This fixes at least 1 deprecation warning from `dag_default_view`.