### PR TITLE
Fix link broken after #24082

### DIFF
--- a/docs/apache-airflow-providers-yandex/index.rst
+++ b/docs/apache-airflow-providers-yandex/index.rst
@@ -39,7 +39,7 @@ Content
     :maxdepth: 1
     :caption: Resources
 
-    Example DAGs <https://github.com/apache/airflow/tree/main/airflow/providers/yandex/example_dags>
+    Example DAGs <https://github.com/apache/airflow/tree/main/tests/system/providers/yandex/example_yandexcloud_dataproc.py>
     PyPI Repository <https://pypi.org/project/apache-airflow-providers-yandex/>
     Installing from sources <installing-providers-from-sources>
 


### PR DESCRIPTION
Fixing example dag link in provider doc after https://github.com/apache/airflow/pull/24082

In case of existing issue, reference it using one of the following:

related: #24082
