### PR TITLE
Speed up grid_data endpoint by 10x

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -21,6 +21,8 @@ from decimal import Decimal
 
 from flask.json import JSONEncoder
 
+from airflow.utils.timezone import convert_to_utc, is_naive
+
 try:
     import numpy as np
 except ImportError:
@@ -45,7 +47,9 @@ class AirflowJsonEncoder(JSONEncoder):
     def _default(obj):
         """Convert dates and numpy objects in a json serializable format."""
         if isinstance(obj, datetime):
-            return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+            if is_naive(obj):
+                obj = convert_to_utc(obj)
+            return obj.isoformat()
         elif isinstance(obj, date):
             return obj.strftime('%Y-%m-%d')
         elif isinstance(obj, Decimal):

--- a/airflow/www/static/js/grid/components/InstanceTooltip.jsx
+++ b/airflow/www/static/js/grid/components/InstanceTooltip.jsx
@@ -45,7 +45,7 @@ const InstanceTooltip = ({
       }
     });
   } else if (isMapped && mappedStates) {
-    Object.keys(mappedStates).forEach(stateKey => {
+    Object.keys(mappedStates).forEach((stateKey) => {
       const num = mappedStates[stateKey];
       numMapped += num;
       numMap.set(stateKey || 'no_status', num);

--- a/airflow/www/static/js/grid/components/InstanceTooltip.jsx
+++ b/airflow/www/static/js/grid/components/InstanceTooltip.jsx
@@ -35,6 +35,7 @@ const InstanceTooltip = ({
   const summary = [];
 
   const numMap = finalStatesMap();
+  let numMapped = 0;
   if (isGroup) {
     group.children.forEach((child) => {
       const taskInstance = child.instances.find((ti) => ti.runId === runId);
@@ -44,9 +45,10 @@ const InstanceTooltip = ({
       }
     });
   } else if (isMapped && mappedStates) {
-    mappedStates.forEach((s) => {
-      const stateKey = s || 'no_status';
-      if (numMap.has(stateKey)) numMap.set(stateKey, numMap.get(stateKey) + 1);
+    Object.keys(mappedStates).forEach(stateKey => {
+      const num = mappedStates[stateKey];
+      numMapped += num;
+      numMap.set(stateKey || 'no_status', num);
     });
   }
 
@@ -68,12 +70,12 @@ const InstanceTooltip = ({
       {group.tooltip && (
         <Text>{group.tooltip}</Text>
       )}
-      {isMapped && !!mappedStates.length && (
+      {isMapped && numMapped > 0 && (
         <Text>
-          {mappedStates.length}
+          {numMapped}
           {' '}
           mapped task
-          {mappedStates.length > 1 && 's'}
+          {numMapped > 1 && 's'}
         </Text>
       )}
       <Text>

--- a/airflow/www/static/js/grid/components/InstanceTooltip.test.jsx
+++ b/airflow/www/static/js/grid/components/InstanceTooltip.test.jsx
@@ -49,7 +49,7 @@ describe('Test Task InstanceTooltip', () => {
     const { getByText } = render(
       <InstanceTooltip
         group={{ isMapped: true }}
-        instance={{ ...instance, mappedStates: {'success': 2} }}
+        instance={{ ...instance, mappedStates: { success: 2 } }}
       />,
       { wrapper: Wrapper },
     );

--- a/airflow/www/static/js/grid/components/InstanceTooltip.test.jsx
+++ b/airflow/www/static/js/grid/components/InstanceTooltip.test.jsx
@@ -49,7 +49,7 @@ describe('Test Task InstanceTooltip', () => {
     const { getByText } = render(
       <InstanceTooltip
         group={{ isMapped: true }}
-        instance={{ ...instance, mappedStates: ['success', 'success'] }}
+        instance={{ ...instance, mappedStates: {'success': 2} }}
       />,
       { wrapper: Wrapper },
     );

--- a/airflow/www/static/js/grid/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/Details.jsx
@@ -60,7 +60,7 @@ const Details = ({ instance, group, operator }) => {
       }
     });
   } else if (isMapped && mappedStates) {
-    Object.keys(mappedStates).forEach(stateKey => {
+    Object.keys(mappedStates).forEach((stateKey) => {
       const num = mappedStates[stateKey];
       numMapped += num;
       numMap.set(stateKey || 'no_status', num);

--- a/airflow/www/static/js/grid/details/content/taskInstance/Details.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/Details.jsx
@@ -50,6 +50,7 @@ const Details = ({ instance, group, operator }) => {
   } = group;
 
   const numMap = finalStatesMap();
+  let numMapped = 0;
   if (isGroup) {
     children.forEach((child) => {
       const taskInstance = child.instances.find((ti) => ti.runId === runId);
@@ -59,9 +60,10 @@ const Details = ({ instance, group, operator }) => {
       }
     });
   } else if (isMapped && mappedStates) {
-    mappedStates.forEach((s) => {
-      const stateKey = s || 'no_status';
-      if (numMap.has(stateKey)) numMap.set(stateKey, numMap.get(stateKey) + 1);
+    Object.keys(mappedStates).forEach(stateKey => {
+      const num = mappedStates[stateKey];
+      numMapped += num;
+      numMap.set(stateKey || 'no_status', num);
     });
   }
 
@@ -92,11 +94,11 @@ const Details = ({ instance, group, operator }) => {
             <br />
           </>
         )}
-        {mappedStates && mappedStates.length > 0 && (
+        {mappedStates && numMapped > 0 && (
         <Text>
-          {mappedStates.length}
+          {numMapped}
           {' '}
-          {mappedStates.length === 1 ? 'Task ' : 'Tasks '}
+          {numMapped === 1 ? 'Task ' : 'Tasks '}
           Mapped
         </Text>
         )}

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -36,11 +36,9 @@ from pendulum.datetime import DateTime
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
 from sqlalchemy.ext.associationproxy import AssociationProxy
-from sqlalchemy.orm import Session
 
 from airflow import models
 from airflow.models import errors
-from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.code_utils import get_python_source
@@ -127,53 +125,6 @@ def get_mapped_summary(parent_instance, task_instances):
         'mapped_states': mapped_states,
         'try_number': try_count,
     }
-
-
-def get_task_summaries(task, dag_runs: List[DagRun], session: Session) -> List[Dict[str, Any]]:
-    tis = (
-        session.query(
-            TaskInstance.dag_id,
-            TaskInstance.task_id,
-            TaskInstance.run_id,
-            TaskInstance.map_index,
-            TaskInstance.state,
-            TaskInstance.start_date,
-            TaskInstance.end_date,
-            TaskInstance._try_number,
-        )
-        .filter(
-            TaskInstance.dag_id == task.dag_id,
-            TaskInstance.run_id.in_([dag_run.run_id for dag_run in dag_runs]),
-            TaskInstance.task_id == task.task_id,
-            # Only get normal task instances or the first mapped task
-            TaskInstance.map_index <= 0,
-        )
-        .order_by(TaskInstance.run_id.asc())
-    )
-
-    def _get_summary(task_instance):
-        if task_instance.map_index > -1:
-            return get_mapped_summary(
-                task_instance, task_instances=get_mapped_instances(task_instance, session)
-            )
-
-        try_count = (
-            task_instance._try_number
-            if task_instance._try_number != 0 or task_instance.state in State.running
-            else task_instance._try_number + 1
-        )
-
-        return {
-            'task_id': task_instance.task_id,
-            'run_id': task_instance.run_id,
-            'map_index': task_instance.map_index,
-            'state': task_instance.state,
-            'start_date': datetime_to_string(task_instance.start_date),
-            'end_date': datetime_to_string(task_instance.end_date),
-            'try_number': try_count,
-        }
-
-    return [_get_summary(ti) for ti in tis]
 
 
 def encode_dag_run(dag_run: Optional[models.DagRun]) -> Optional[Dict[str, Any]]:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -330,8 +330,12 @@ def dag_to_grid(dag, dag_runs, session):
                             'state': None,  # We change this before yielding
                         }
                         continue
-                    record['start_date'] = min(record['start_date'], ti_summary.start_date)
-                    record['end_date'] = max(record['end_date'], ti_summary.end_date)
+                    record['start_date'] = min(
+                        filter(None, [record['start_date'], ti_summary.start_date]), default=None
+                    )
+                    record['end_date'] = max(
+                        filter(None, [record['end_date'], ti_summary.end_date]), default=None
+                    )
                     record['mapped_states'][ti_summary.state] = ti_summary.state_count
                 if record:
                     set_overall_state(record)

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -23,6 +23,7 @@ from datetime import date, datetime
 
 import numpy as np
 import parameterized
+import pendulum
 import pytest
 
 from airflow.utils import json as utils_json
@@ -31,7 +32,11 @@ from airflow.utils import json as utils_json
 class TestAirflowJsonEncoder(unittest.TestCase):
     def test_encode_datetime(self):
         obj = datetime.strptime('2017-05-21 00:00:00', '%Y-%m-%d %H:%M:%S')
-        assert json.dumps(obj, cls=utils_json.AirflowJsonEncoder) == '"2017-05-21T00:00:00Z"'
+        assert json.dumps(obj, cls=utils_json.AirflowJsonEncoder) == '"2017-05-21T00:00:00+00:00"'
+
+    def test_encode_pendulum(self):
+        obj = pendulum.datetime(2017, 5, 21, tz='Asia/Kolkata')
+        assert json.dumps(obj, cls=utils_json.AirflowJsonEncoder) == '"2017-05-21T00:00:00+05:30"'
 
     def test_encode_date(self):
         assert json.dumps(date(2017, 5, 21), cls=utils_json.AirflowJsonEncoder) == '"2017-05-21"'

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -16,17 +16,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import List
+
 import freezegun
 import pendulum
 import pytest
 
 from airflow.models import DagBag
+from airflow.models.dagrun import DagRun
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
 from airflow.utils.types import DagRunType
 from airflow.www.views import dag_to_grid
 from tests.test_utils.asserts import assert_queries_count
+from tests.test_utils.db import clear_db_runs
 from tests.test_utils.mock_operators import MockOperator
 
 DAG_ID = 'test'
@@ -37,6 +41,13 @@ CURRENT_TIME = pendulum.DateTime(2021, 9, 7)
 def examples_dag_bag():
     # Speed up: We don't want example dags for this module
     return DagBag(include_examples=False, read_dags_from_db=True)
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    clear_db_runs()
+    yield
+    clear_db_runs()
 
 
 @pytest.fixture
@@ -50,7 +61,7 @@ def dag_without_runs(dag_maker, session, app, monkeypatch):
         with dag_maker(dag_id=DAG_ID, serialized=True, session=session):
             EmptyOperator(task_id="task1")
             with TaskGroup(group_id='group'):
-                MockOperator.partial(task_id='mapped').expand(arg1=['a', 'b', 'c'])
+                MockOperator.partial(task_id='mapped').expand(arg1=['a', 'b', 'c', 'd'])
 
         m.setattr(app, 'dag_bag', dag_maker.dagbag)
         yield dag_maker
@@ -110,11 +121,29 @@ def test_no_runs(admin_client, dag_without_runs):
     }
 
 
-def test_one_run(admin_client, dag_with_runs, session):
+def test_one_run(admin_client, dag_with_runs: List[DagRun], session):
+    """
+    Test a DAG with complex interaction of states:
+    - One run successful
+    - One run partly success, partly running
+    - One TI not yet finished
+    """
     run1, run2 = dag_with_runs
 
     for ti in run1.task_instances:
         ti.state = TaskInstanceState.SUCCESS
+    for ti in sorted(run2.task_instances, key=lambda ti: (ti.task_id, ti.map_index)):
+        if ti.task_id == "task1":
+            ti.state = TaskInstanceState.SUCCESS
+        elif ti.task_id == "group.mapped":
+            if ti.map_index == 0:
+                ti.state = TaskInstanceState.SUCCESS
+                ti.start_date = pendulum.DateTime(2021, 7, 1, 1, 0, 0, tzinfo=pendulum.UTC)
+                ti.end_date = pendulum.DateTime(2021, 7, 1, 1, 2, 3, tzinfo=pendulum.UTC)
+            elif ti.map_index == 1:
+                ti.state = TaskInstanceState.RUNNING
+                ti.start_date = pendulum.DateTime(2021, 7, 1, 2, 3, 4, tzinfo=pendulum.UTC)
+                ti.end_date = None
 
     session.flush()
 
@@ -152,18 +181,18 @@ def test_one_run(admin_client, dag_with_runs, session):
                     'id': 'task1',
                     'instances': [
                         {
-                            'end_date': None,
                             'run_id': 'run_1',
                             'start_date': None,
+                            'end_date': None,
                             'state': 'success',
                             'task_id': 'task1',
                             'try_number': 1,
                         },
                         {
-                            'end_date': None,
                             'run_id': 'run_2',
                             'start_date': None,
-                            'state': None,
+                            'end_date': None,
+                            'state': 'success',
                             'task_id': 'task1',
                             'try_number': 1,
                         },
@@ -178,19 +207,19 @@ def test_one_run(admin_client, dag_with_runs, session):
                             'id': 'group.mapped',
                             'instances': [
                                 {
-                                    'end_date': None,
-                                    'mapped_states': {'success': 3},
                                     'run_id': 'run_1',
+                                    'mapped_states': {'success': 4},
                                     'start_date': None,
+                                    'end_date': None,
                                     'state': 'success',
                                     'task_id': 'group.mapped',
                                 },
                                 {
-                                    'end_date': None,
-                                    'mapped_states': {'no_status': 3},
                                     'run_id': 'run_2',
-                                    'start_date': None,
-                                    'state': None,
+                                    'mapped_states': {'no_status': 2, 'running': 1, 'success': 1},
+                                    'start_date': '2021-07-01T01:00:00+00:00',
+                                    'end_date': '2021-07-01T01:02:03+00:00',
+                                    'state': 'running',
                                     'task_id': 'group.mapped',
                                 },
                             ],
@@ -208,10 +237,10 @@ def test_one_run(admin_client, dag_with_runs, session):
                             'task_id': 'group',
                         },
                         {
-                            'end_date': None,
                             'run_id': 'run_2',
-                            'start_date': None,
-                            'state': None,
+                            'start_date': '2021-07-01T01:00:00+00:00',
+                            'end_date': '2021-07-01T01:02:03+00:00',
+                            'state': 'running',
                             'task_id': 'group',
                         },
                     ],
@@ -228,7 +257,13 @@ def test_one_run(admin_client, dag_with_runs, session):
                     'state': 'success',
                     'task_id': None,
                 },
-                {'end_date': None, 'run_id': 'run_2', 'start_date': None, 'state': None, 'task_id': None},
+                {
+                    'end_date': '2021-07-01T01:02:03+00:00',
+                    'run_id': 'run_2',
+                    'start_date': '2021-07-01T01:00:00+00:00',
+                    'state': 'running',
+                    'task_id': None,
+                },
             ],
             'label': None,
             'tooltip': '',


### PR DESCRIPTION
These changes make the endpoint go from almost 20s down to 1.5s and the
changes are two fold:

1. Keep datetimes as objects for as long as possible

   Previously we were converting start/end dates for a task group to a
   string, and then in the parent parsing it back to a datetime to find
   the min and max of all the child nodes.

   The fix for that was to leave it as a datetime (or a
   pendulum.DateTime technically) and use the existing
   `AirflowJsonEncoder` class to "correctly" encode these objects on
   output.

2. Reduce the number of DB queries from 1 per task to 1.

   The removed `get_task_summaries` function was called for each task,
   and was making a query to the database to find info for the given
   DagRuns.

   The helper function now makes just a single DB query for all
   tasks/runs and constructs a dict to efficiently look up the ti by
   run_id.