### PR TITLE
Update provider templates for new Airflow 2.2+ req

### DIFF
--- a/dev/provider_packages/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/provider_packages/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -47,7 +47,7 @@ are in ``{{FULL_PACKAGE_NAME}}`` python package.
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2.1+ installation via
+You can install this package on top of an existing Airflow 2.2+ installation via
 ``pip install {{PACKAGE_PIP_NAME}}``
 {%- if PIP_REQUIREMENTS %}
 

--- a/dev/provider_packages/PROVIDER_README_TEMPLATE.rst.jinja2
+++ b/dev/provider_packages/PROVIDER_README_TEMPLATE.rst.jinja2
@@ -44,7 +44,7 @@ in the `documentation <https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{
 Installation
 ------------
 
-You can install this package on top of an existing Airflow 2.1+ installation via
+You can install this package on top of an existing Airflow 2.2+ installation via
 ``pip install {{PACKAGE_PIP_NAME}}``
 
 The package supports the following python versions: {{ ",".join(SUPPORTED_PYTHON_VERSIONS) }}


### PR DESCRIPTION
Otherwise the Installation section doesn't match the PIP requirements on PyPI.
<img width="799" alt="image" src="https://user-images.githubusercontent.com/48934154/172401826-21170328-7843-42e6-bbf0-9bd67d5ff59b.png">

I imagine we could update this somewhat programmatically and/or add this update to instructions somewhere. Let me know what you think.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
