### PR TITLE
Refactoring EmrClusterLink and add it for other AWS EMR Operators

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -37,6 +37,7 @@ import botocore
 import botocore.session
 import requests
 import tenacity
+from botocore.client import ClientMeta
 from botocore.config import Config
 from botocore.credentials import ReadOnlyCredentials
 from slugify import slugify
@@ -520,6 +521,21 @@ class AwsBaseHook(BaseHook):
         else:
             # Rare possibility - subclasses have not specified a client_type or resource_type
             raise NotImplementedError('Could not get boto3 connection!')
+
+    @cached_property
+    def conn_client_meta(self) -> ClientMeta:
+        conn = self.conn
+        if isinstance(conn, botocore.client.BaseClient):
+            return conn.meta
+        return conn.meta.client.meta
+
+    @property
+    def conn_region_name(self) -> str:
+        return self.conn_client_meta.region_name
+
+    @property
+    def conn_partition(self) -> str:
+        return self.conn_client_meta.partition
 
     def get_conn(self) -> Union[boto3.client, boto3.resource]:
         """

--- a/airflow/providers/amazon/aws/links/__init__.py
+++ b/airflow/providers/amazon/aws/links/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/amazon/aws/links/base_aws.py
+++ b/airflow/providers/amazon/aws/links/base_aws.py
@@ -1,0 +1,100 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from typing import TYPE_CHECKING, ClassVar, Optional
+from urllib.parse import quote_plus
+
+from airflow.models import BaseOperatorLink, XCom
+
+if TYPE_CHECKING:
+    from airflow.models import BaseOperator
+    from airflow.models.taskinstance import TaskInstanceKey
+    from airflow.utils.context import Context
+
+
+BASE_AWS_CONSOLE_LINK = "https://console.{aws_domain}"
+
+
+class BaseAwsLink(BaseOperatorLink):
+    """Base Helper class for constructing AWS Console Link"""
+
+    name: ClassVar[str]
+    key: ClassVar[str]
+    format_str: ClassVar[str]
+
+    @staticmethod
+    def get_aws_domain(aws_partition) -> Optional[str]:
+        if aws_partition == "aws":
+            return "aws.amazon.com"
+        elif aws_partition == "aws-cn":
+            return "amazonaws.cn"
+        elif aws_partition == "aws-us-gov":
+            return "amazonaws-us-gov.com"
+
+        return None
+
+    def get_link(
+        self,
+        operator,
+        dttm: Optional[datetime] = None,
+        ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
+        """
+        Link to Amazon Web Services Console.
+
+        :param operator: airflow operator
+        :param ti_key: TaskInstance ID to return link for
+        :param dttm: execution date. Uses for compatibility with Airflow 2.2
+        :return: link to external system
+        """
+        if ti_key is not None:
+            conf = XCom.get_value(key=self.key, ti_key=ti_key)
+        elif not dttm:
+            conf = {}
+        else:
+            conf = XCom.get_one(
+                key=self.key,
+                dag_id=operator.dag.dag_id,
+                task_id=operator.task_id,
+                execution_date=dttm,
+            )
+        if not conf:
+            return ""
+
+        # urlencode special characters, e.g.: CloudWatch links contains `/` character.
+        quoted_conf = {k: quote_plus(v) if isinstance(v, str) else v for k, v in conf.items()}
+        return self.format_str.format(**quoted_conf)
+
+    @classmethod
+    def persist(
+        cls, context: "Context", operator: "BaseOperator", region_name: str, aws_partition: str, **kwargs
+    ) -> None:
+        """Store link information into XCom"""
+        if not operator.do_xcom_push:
+            return
+
+        operator.xcom_push(
+            context,
+            key=cls.key,
+            value={
+                "region_name": region_name,
+                "aws_domain": cls.get_aws_domain(aws_partition),
+                **kwargs,
+            },
+        )

--- a/airflow/providers/amazon/aws/links/emr.py
+++ b/airflow/providers/amazon/aws/links/emr.py
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.providers.amazon.aws.links.base_aws import BASE_AWS_CONSOLE_LINK, BaseAwsLink
+
+
+class EmrClusterLink(BaseAwsLink):
+    """Helper class for constructing AWS EMR Cluster Link"""
+
+    name = "EMR Cluster"
+    key = "emr_cluster"
+    format_str = (
+        BASE_AWS_CONSOLE_LINK + "/elasticmapreduce/home?region={region_name}#cluster-details:{job_flow_id}"
+    )

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -556,7 +556,7 @@ hook-class-names:  # deprecated - to be removed after providers add dependency o
   - airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook
 
 extra-links:
-  - airflow.providers.amazon.aws.operators.emr.EmrClusterLink
+  - airflow.providers.amazon.aws.links.emr.EmrClusterLink
   - airflow.providers.amazon.aws.operators.emr_create_job_flow.EmrClusterLink
 
 connection-types:

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -114,7 +114,7 @@ class CustomSessionFactory(BaseSessionFactory):
         return mock.MagicMock()
 
 
-class TestAwsBaseHook(unittest.TestCase):
+class TestAwsBaseHook:
     @conf_vars(
         {("aws", "session_factory"): "tests.providers.amazon.aws.hooks.test_base_aws.CustomSessionFactory"}
     )
@@ -646,6 +646,60 @@ class TestAwsBaseHook(unittest.TestCase):
             client.get_caller_identity()
             assert mock_refresh.call_count == 2
             assert len(expire_on_calls) == 0
+
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
+    @mock_dynamodb2
+    @pytest.mark.parametrize("conn_type", ["client", "resource"])
+    @pytest.mark.parametrize(
+        "connection_uri,region_name,env_region,expected_region_name",
+        [
+            ("aws://?region_name=eu-west-1", None, "", "eu-west-1"),
+            ("aws://?region_name=eu-west-1", "cn-north-1", "", "cn-north-1"),
+            ("aws://?region_name=eu-west-1", None, "us-east-2", "eu-west-1"),
+            ("aws://?region_name=eu-west-1", "cn-north-1", "us-gov-east-1", "cn-north-1"),
+            ("aws://?", "cn-north-1", "us-gov-east-1", "cn-north-1"),
+            ("aws://?", None, "us-gov-east-1", "us-gov-east-1"),
+        ],
+    )
+    def test_connection_region_name(
+        self, conn_type, connection_uri, region_name, env_region, expected_region_name
+    ):
+        with unittest.mock.patch.dict(
+            'os.environ', AIRFLOW_CONN_TEST_CONN=connection_uri, AWS_DEFAULT_REGION=env_region
+        ):
+            if conn_type == "client":
+                hook = AwsBaseHook(aws_conn_id='test_conn', region_name=region_name, client_type='dynamodb')
+            elif conn_type == "resource":
+                hook = AwsBaseHook(aws_conn_id='test_conn', region_name=region_name, resource_type='dynamodb')
+            else:
+                raise ValueError(f"Unsupported conn_type={conn_type!r}")
+
+            assert hook.conn_region_name == expected_region_name
+
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
+    @mock_dynamodb2
+    @pytest.mark.parametrize("conn_type", ["client", "resource"])
+    @pytest.mark.parametrize(
+        "connection_uri,expected_partition",
+        [
+            ("aws://?region_name=eu-west-1", "aws"),
+            ("aws://?region_name=cn-north-1", "aws-cn"),
+            ("aws://?region_name=us-gov-east-1", "aws-us-gov"),
+        ],
+    )
+    def test_connection_aws_partition(self, conn_type, connection_uri, expected_partition):
+        with unittest.mock.patch.dict(
+            'os.environ',
+            AIRFLOW_CONN_TEST_CONN=connection_uri,
+        ):
+            if conn_type == "client":
+                hook = AwsBaseHook(aws_conn_id='test_conn', client_type='dynamodb')
+            elif conn_type == "resource":
+                hook = AwsBaseHook(aws_conn_id='test_conn', resource_type='dynamodb')
+            else:
+                raise ValueError(f"Unsupported conn_type={conn_type!r}")
+
+            assert hook.conn_partition == expected_partition
 
 
 class ThrowErrorUntilCount:

--- a/tests/providers/amazon/aws/links/__init__.py
+++ b/tests/providers/amazon/aws/links/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/amazon/aws/links/test_base.py
+++ b/tests/providers/amazon/aws/links/test_base.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.amazon.aws.links.base_aws import BaseAwsLink
+from tests.test_utils.mock_operators import MockOperator
+
+XCOM_KEY = "test_xcom_key"
+CUSTOM_KEYS = {
+    "foo": "bar",
+    "spam": "egg",
+}
+
+
+class SimpleBaseAwsLink(BaseAwsLink):
+    key = XCOM_KEY
+
+
+class TestBaseAwsLink:
+    @pytest.mark.parametrize(
+        "region_name, aws_partition,keywords,expected_value",
+        [
+            ("eu-central-1", "aws", {}, {"region_name": "eu-central-1", "aws_domain": "aws.amazon.com"}),
+            ("cn-north-1", "aws-cn", {}, {"region_name": "cn-north-1", "aws_domain": "amazonaws.cn"}),
+            (
+                "us-gov-east-1",
+                "aws-us-gov",
+                {},
+                {"region_name": "us-gov-east-1", "aws_domain": "amazonaws-us-gov.com"},
+            ),
+            (
+                "eu-west-1",
+                "aws",
+                CUSTOM_KEYS,
+                {"region_name": "eu-west-1", "aws_domain": "aws.amazon.com", **CUSTOM_KEYS},
+            ),
+        ],
+    )
+    def test_persist(self, region_name, aws_partition, keywords, expected_value):
+        mock_context = MagicMock()
+
+        SimpleBaseAwsLink.persist(
+            context=mock_context,
+            operator=MockOperator(task_id="test_task_id"),
+            region_name=region_name,
+            aws_partition=aws_partition,
+            **keywords,
+        )
+
+        ti = mock_context["ti"]
+        ti.xcom_push.assert_called_once_with(
+            execution_date=None,
+            key=XCOM_KEY,
+            value=expected_value,
+        )
+
+    def test_disable_xcom_push(self):
+        mock_context = MagicMock()
+        SimpleBaseAwsLink.persist(
+            context=mock_context,
+            operator=MockOperator(task_id="test_task_id", do_xcom_push=False),
+            region_name="eu-east-1",
+            aws_partition="aws",
+        )
+        ti = mock_context["ti"]
+        ti.xcom_push.assert_not_called()

--- a/tests/providers/amazon/aws/links/test_emr.py
+++ b/tests/providers/amazon/aws/links/test_emr.py
@@ -1,0 +1,103 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.amazon.aws.links.emr import EmrClusterLink
+from airflow.serialization.serialized_objects import SerializedDAG
+from tests.providers.amazon.aws.utils.links_test_utils import link_test_operator
+
+DAG_ID = "test_dag_id"
+TASK_ID = "test_task_id"
+JOB_FLOW_ID = "j-test-flow-id"
+REGION_NAME = "eu-west-1"
+
+
+@pytest.fixture(scope="module")
+def operator_class():
+    return link_test_operator(EmrClusterLink)
+
+
+@pytest.fixture(scope="module")
+def mock_task(operator_class):
+    return operator_class(task_id=TASK_ID)
+
+
+@pytest.fixture()
+def mock_ti(create_task_instance_of_operator, operator_class):
+    return create_task_instance_of_operator(operator_class, dag_id=DAG_ID, task_id=TASK_ID)
+
+
+@pytest.mark.need_serialized_dag
+class TestEmrClusterLink:
+    def test_link_serialize(self, dag_maker, mock_ti):
+        serialized_dag = dag_maker.get_serialized_data()
+
+        assert serialized_dag["dag"]["tasks"][0]["_operator_extra_links"] == [
+            {"airflow.providers.amazon.aws.links.emr.EmrClusterLink": {}}
+        ], "Operator links should exist for serialized DAG"
+
+    @pytest.mark.parametrize(
+        "region_name,aws_partition,aws_domain",
+        [
+            ("eu-west-1", "aws", "aws.amazon.com"),
+            ("cn-north-1", "aws-cn", "amazonaws.cn"),
+            ("us-gov-east-1", "aws-us-gov", "amazonaws-us-gov.com"),
+        ],
+    )
+    def test_emr_custer_link(self, dag_maker, mock_task, mock_ti, region_name, aws_partition, aws_domain):
+        mock_context = MagicMock()
+        mock_context.__getitem__.side_effect = {"ti": mock_ti}.__getitem__
+
+        EmrClusterLink.persist(
+            context=mock_context,
+            operator=mock_task,
+            region_name=region_name,
+            aws_partition=aws_partition,
+            job_flow_id=JOB_FLOW_ID,
+        )
+
+        expected = (
+            f"https://console.{aws_domain}/elasticmapreduce/home?region={region_name}"
+            f"#cluster-details:{JOB_FLOW_ID}"
+        )
+        assert (
+            mock_ti.task.get_extra_links(mock_ti, EmrClusterLink.name) == expected
+        ), "Operator link should be preserved after execution"
+
+        serialized_dag = dag_maker.get_serialized_data()
+        deserialized_dag = SerializedDAG.from_dict(serialized_dag)
+        deserialized_task = deserialized_dag.task_dict[TASK_ID]
+
+        assert (
+            deserialized_task.get_extra_links(mock_ti, EmrClusterLink.name) == expected
+        ), "Operator link should be preserved in deserialized tasks after execution"
+
+    def test_empty_xcom(self, dag_maker, mock_ti):
+        serialized_dag = dag_maker.get_serialized_data()
+        deserialized_dag = SerializedDAG.from_dict(serialized_dag)
+        deserialized_task = deserialized_dag.task_dict[TASK_ID]
+
+        assert (
+            mock_ti.task.get_extra_links(mock_ti, EmrClusterLink.name) == ""
+        ), "Operator link should only be added if job id is available in XCom"
+
+        assert (
+            deserialized_task.get_extra_links(mock_ti, EmrClusterLink.name) == ""
+        ), "Operator link should be empty for deserialized task with no XCom push"

--- a/tests/providers/amazon/aws/operators/test_emr_add_steps.py
+++ b/tests/providers/amazon/aws/operators/test_emr_add_steps.py
@@ -20,7 +20,7 @@ import json
 import os
 import unittest
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from jinja2 import StrictUndefined
@@ -170,8 +170,7 @@ class TestEmrAddStepsOperator(unittest.TestCase):
                 operator.execute(self.mock_context)
 
         ti = self.mock_context['ti']
-
-        ti.xcom_push.assert_called_once_with(key='job_flow_id', value=expected_job_flow_id)
+        ti.assert_has_calls(calls=[call.xcom_push(key='job_flow_id', value=expected_job_flow_id)])
 
     def test_init_with_nonexistent_cluster_name(self):
         cluster_name = 'test_cluster'

--- a/tests/providers/amazon/aws/operators/test_emr_terminate_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_terminate_job_flow.py
@@ -42,4 +42,4 @@ class TestEmrTerminateJobFlowOperator(unittest.TestCase):
                 task_id='test_task', job_flow_id='j-8989898989', aws_conn_id='aws_default'
             )
 
-            operator.execute(None)
+            operator.execute(MagicMock())

--- a/tests/providers/amazon/aws/utils/links_test_utils.py
+++ b/tests/providers/amazon/aws/utils/links_test_utils.py
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tests.test_utils.mock_operators import MockOperator
+
+
+def link_test_operator(*links):
+    class LinkTestOperator(MockOperator):
+        operator_extra_links = tuple(c() for c in links)
+
+    return LinkTestOperator


### PR DESCRIPTION
Amazon provider at that moment has only one External link for `EmrClusterLink`.

The idea was taken from Google Cloud Provider.

Extend:
- Hook: Return region and aws partition from current connection/session
- Console link based on aws partition now
- Link contains region_name now

Add:
- AwsBaseLink for further Links (Batch, Glue, Cloudwatch, etc.)
- `EmrClusterLink` links to  `EmrAddStepsOperator`, `EmrModifyClusterOperator`,  `EmrTerminateJobFlowOperator`