### PR TITLE
Fix langauge override in papermill operator

### DIFF
--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -86,5 +86,5 @@ class PapermillOperator(BaseOperator):
                 progress_bar=False,
                 report_mode=True,
                 kernel_name=self.kernel_name,
-                language_name=self.language_name,
+                language=self.language_name,
             )

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -52,7 +52,7 @@ class TestPapermillOperator(unittest.TestCase):
             out_nb,
             parameters=parameters,
             kernel_name=kernel_name,
-            language_name=language_name,
+            language=language_name,
             progress_bar=False,
             report_mode=True,
         )


### PR DESCRIPTION
This fixes an issue I introduced in https://github.com/apache/airflow/pull/23916 which results in the additional feature introduced in this PR not working.

execute_notebook() expects an argument called language rather than language_name.
