### PR TITLE
switching from `cx-Oracle` to `oracledb`

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -21,7 +21,7 @@ import warnings
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-import cx_Oracle
+import oracledb
 
 try:
     import numpy
@@ -57,7 +57,7 @@ class OracleHook(DbApiHook):
 
     supports_autocommit = True
 
-    def get_conn(self) -> 'OracleHook':
+    def get_conn(self) -> oracledb.Connection:
         """
         Returns a oracle connection object
         Optional parameters for using a custom DSN connection
@@ -85,9 +85,7 @@ class OracleHook(DbApiHook):
            }
 
         see more param detail in
-        `cx_Oracle.connect <https://cx-oracle.readthedocs.io/en/latest/module.html#cx_Oracle.connect>`_
-
-
+        `oracledb.connect <https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html>`_
         """
         conn = self.get_connection(self.oracle_conn_id)  # type: ignore[attr-defined]
         conn_config = {'user': conn.login, 'password': conn.password}
@@ -98,9 +96,9 @@ class OracleHook(DbApiHook):
         service_name = conn.extra_dejson.get('service_name')
         port = conn.port if conn.port else 1521
         if conn.host and sid and not service_name:
-            conn_config['dsn'] = cx_Oracle.makedsn(conn.host, port, sid)
+            conn_config['dsn'] = oracledb.makedsn(conn.host, port, sid)
         elif conn.host and service_name and not sid:
-            conn_config['dsn'] = cx_Oracle.makedsn(conn.host, port, service_name=service_name)
+            conn_config['dsn'] = oracledb.makedsn(conn.host, port, service_name=service_name)
         else:
             dsn = conn.extra_dejson.get('dsn')
             if dsn is None:
@@ -119,51 +117,40 @@ class OracleHook(DbApiHook):
                     dsn += "/" + conn.schema
             conn_config['dsn'] = dsn
 
-        if 'encoding' in conn.extra_dejson:
-            conn_config['encoding'] = conn.extra_dejson.get('encoding')
-            # if `encoding` is specific but `nencoding` is not
-            # `nencoding` should use same values as `encoding` to set encoding, inspired by
-            # https://github.com/oracle/python-cx_Oracle/issues/157#issuecomment-371877993
-            if 'nencoding' not in conn.extra_dejson:
-                conn_config['nencoding'] = conn.extra_dejson.get('encoding')
-        if 'nencoding' in conn.extra_dejson:
-            conn_config['nencoding'] = conn.extra_dejson.get('nencoding')
-        if 'threaded' in conn.extra_dejson:
-            conn_config['threaded'] = conn.extra_dejson.get('threaded')
         if 'events' in conn.extra_dejson:
             conn_config['events'] = conn.extra_dejson.get('events')
 
         mode = conn.extra_dejson.get('mode', '').lower()
         if mode == 'sysdba':
-            conn_config['mode'] = cx_Oracle.SYSDBA
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSDBA
         elif mode == 'sysasm':
-            conn_config['mode'] = cx_Oracle.SYSASM
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSASM
         elif mode == 'sysoper':
-            conn_config['mode'] = cx_Oracle.SYSOPER
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSOPER
         elif mode == 'sysbkp':
-            conn_config['mode'] = cx_Oracle.SYSBKP
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSBKP
         elif mode == 'sysdgd':
-            conn_config['mode'] = cx_Oracle.SYSDGD
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSDGD
         elif mode == 'syskmt':
-            conn_config['mode'] = cx_Oracle.SYSKMT
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSKMT
         elif mode == 'sysrac':
-            conn_config['mode'] = cx_Oracle.SYSRAC
+            conn_config['mode'] = oracledb.AUTH_MODE_SYSRAC
 
         purity = conn.extra_dejson.get('purity', '').lower()
         if purity == 'new':
-            conn_config['purity'] = cx_Oracle.ATTR_PURITY_NEW
+            conn_config['purity'] = oracledb.PURITY_NEW
         elif purity == 'self':
-            conn_config['purity'] = cx_Oracle.ATTR_PURITY_SELF
+            conn_config['purity'] = oracledb.PURITY_SELF
         elif purity == 'default':
-            conn_config['purity'] = cx_Oracle.ATTR_PURITY_DEFAULT
+            conn_config['purity'] = oracledb.PURITY_DEFAULT
 
-        conn = cx_Oracle.connect(**conn_config)
+        conn = oracledb.connect(**conn_config)
         if mod is not None:
             conn.module = mod
 
         # if Connection.schema is defined, set schema after connecting successfully
         # cannot be part of conn_config
-        # https://cx-oracle.readthedocs.io/en/latest/api_manual/connection.html?highlight=schema#Connection.current_schema
+        # https://python-oracledb.readthedocs.io/en/latest/api_manual/connection.html#Connection.current_schema
         # Only set schema when not using conn.schema as Service Name
         if schema and service_name:
             conn.current_schema = schema
@@ -184,7 +171,7 @@ class OracleHook(DbApiHook):
         the whole set of inserts is treated as one transaction
         Changes from standard DbApiHook implementation:
 
-        - Oracle SQL queries in cx_Oracle can not be terminated with a semicolon (`;`)
+        - Oracle SQL queries in oracledb can not be terminated with a semicolon (`;`)
         - Replace NaN values with NULL using `numpy.nan_to_num` (not using
           `is_nan()` because of input types error for strings)
         - Coerce datetime cells to Oracle DATETIME format during insert
@@ -245,7 +232,7 @@ class OracleHook(DbApiHook):
         commit_every: int = 5000,
     ):
         """
-        A performant bulk insert for cx_Oracle
+        A performant bulk insert for oracledb
         that uses prepared statements via `executemany()`.
         For best performance, pass in `rows` as an iterator.
 
@@ -307,7 +294,7 @@ class OracleHook(DbApiHook):
         provided `parameters` argument.
 
         See
-        https://cx-oracle.readthedocs.io/en/latest/api_manual/cursor.html#Cursor.var
+        https://python-oracledb.readthedocs.io/en/latest/api_manual/cursor.html#Cursor.var
         for further reference.
         """
         if parameters is None:

--- a/docs/apache-airflow-providers-google/operators/transfer/oracle_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/oracle_to_gcs.rst
@@ -49,5 +49,5 @@ Reference
 ---------
 
 For further information, look at:
-* `cx_Oracle Documentation <https://cx-oracle.readthedocs.io/en/latest/>`__
+* `oracledb Documentation <https://python-oracledb.readthedocs.io>`__
 * `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -42,15 +42,6 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Oracle
     connection. The following parameters are supported:
 
-    * ``encoding`` - The encoding to use for regular database strings. If not specified,
-      the environment variable ``NLS_LANG`` is used. If the environment variable ``NLS_LANG``
-      is not set, ``ASCII`` is used.
-    * ``nencoding`` - The encoding to use for national character set database strings.
-      If not specified, the environment variable ``NLS_NCHAR`` is used. If the environment
-      variable ``NLS_NCHAR`` is not used, the environment variable ``NLS_LANG`` is used instead,
-      and if the environment variable ``NLS_LANG`` is not set, ``ASCII`` is used.
-    * ``threaded`` - Whether or not Oracle should wrap accesses to connections with a mutex.
-      Default value is False.
     * ``events`` - Whether or not to initialize Oracle in events mode.
     * ``mode`` - one of ``sysdba``, ``sysasm``, ``sysoper``, ``sysbkp``, ``sysdgd``, ``syskmt`` or ``sysrac``
       which are defined at the module level, Default mode is connecting.
@@ -82,8 +73,8 @@ Extra (optional)
         Schema = "orcl"
 
 
-    More details on all Oracle connect parameters supported can be found in `cx_Oracle documentation
-    <https://cx-oracle.readthedocs.io/en/latest/api_manual/module.html#cx_Oracle.connect>`_.
+    More details on all Oracle connect parameters supported can be found in `oracledb documentation
+    <https://python-oracledb.readthedocs.io/en/latest/index.html>`_.
 
     Information on creating an Oracle Connection through the web user interface can be found in Airflow's :doc:`Managing Connections Documentation <apache-airflow:howto/connection>`.
 
@@ -93,9 +84,6 @@ Extra (optional)
     .. code-block:: json
 
        {
-          "encoding": "UTF-8",
-          "nencoding": "UTF-8",
-          "threaded": false,
           "events": false,
           "mode": "sysdba",
           "purity": "new"
@@ -109,4 +97,4 @@ Extra (optional)
 
     .. code-block:: bash
 
-        export AIRFLOW_CONN_ORACLE_DEFAULT='oracle://oracle_user:XXXXXXXXXXXX@1.1.1.1:1521?encoding=UTF-8&nencoding=UTF-8&threaded=False&events=False&mode=sysdba&purity=new'
+        export AIRFLOW_CONN_ORACLE_DEFAULT='oracle://oracle_user:XXXXXXXXXXXX@1.1.1.1:1521?events=False&mode=sysdba&purity=new'

--- a/setup.py
+++ b/setup.py
@@ -463,7 +463,7 @@ opsgenie = [
     'opsgenie-sdk>=2.1.5',
 ]
 oracle = [
-    'cx_Oracle>=5.1.2',
+    'oracledb>=1.0.0',
 ]
 pagerduty = [
     'pdpyras>=4.1.2',

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -28,12 +28,12 @@ from airflow.models import Connection
 from airflow.providers.oracle.hooks.oracle import OracleHook
 
 try:
-    import cx_Oracle
+    import oracledb
 except ImportError:
-    cx_Oracle = None
+    oracledb = None
 
 
-@unittest.skipIf(cx_Oracle is None, 'cx_Oracle package not present')
+@unittest.skipIf(oracledb is None, 'oracledb package not present')
 class TestOracleHookConn(unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -75,7 +75,7 @@ class TestOracleHookConn(unittest.TestCase):
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
         assert args == ()
-        assert kwargs['dsn'] == cx_Oracle.makedsn("host", self.connection.port, dsn_sid['sid'])
+        assert kwargs['dsn'] == oracledb.makedsn("host", self.connection.port, dsn_sid['sid'])
 
     @mock.patch('airflow.providers.oracle.hooks.oracle.cx_Oracle.connect')
     def test_get_conn_service_name(self, mock_connect):
@@ -85,7 +85,7 @@ class TestOracleHookConn(unittest.TestCase):
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
         assert args == ()
-        assert kwargs['dsn'] == cx_Oracle.makedsn(
+        assert kwargs['dsn'] == oracledb.makedsn(
             "host", self.connection.port, service_name=dsn_service_name['service_name']
         )
 
@@ -122,12 +122,12 @@ class TestOracleHookConn(unittest.TestCase):
     @mock.patch('airflow.providers.oracle.hooks.oracle.cx_Oracle.connect')
     def test_get_conn_mode(self, mock_connect):
         mode = {
-            'sysdba': cx_Oracle.SYSDBA,
-            'sysasm': cx_Oracle.SYSASM,
-            'sysoper': cx_Oracle.SYSOPER,
-            'sysbkp': cx_Oracle.SYSBKP,
-            'sysdgd': cx_Oracle.SYSDGD,
-            'syskmt': cx_Oracle.SYSKMT,
+            'sysdba': oracledb.SYSDBA,
+            'sysasm': oracledb.SYSASM,
+            'sysoper': oracledb.SYSOPER,
+            'sysbkp': oracledb.SYSBKP,
+            'sysdgd': oracledb.SYSDGD,
+            'syskmt': oracledb.SYSKMT,
         }
         first = True
         for mod in mode:
@@ -161,9 +161,9 @@ class TestOracleHookConn(unittest.TestCase):
     @mock.patch('airflow.providers.oracle.hooks.oracle.cx_Oracle.connect')
     def test_get_conn_purity(self, mock_connect):
         purity = {
-            'new': cx_Oracle.ATTR_PURITY_NEW,
-            'self': cx_Oracle.ATTR_PURITY_SELF,
-            'default': cx_Oracle.ATTR_PURITY_DEFAULT,
+            'new': oracledb.ATTR_PURITY_NEW,
+            'self': oracledb.ATTR_PURITY_SELF,
+            'default': oracledb.ATTR_PURITY_DEFAULT,
         }
         first = True
         for pur in purity:
@@ -183,7 +183,7 @@ class TestOracleHookConn(unittest.TestCase):
         assert self.db_hook.get_conn().current_schema == self.connection.schema
 
 
-@unittest.skipIf(cx_Oracle is None, 'cx_Oracle package not present')
+@unittest.skipIf(oracledb is None, 'oracledb package not present')
 class TestOracleHook(unittest.TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Recently, Oracle introduce a brand new python driver for its database name [`python-oracledb`](https://github.com/oracle/python-oracledb)
In comparison with `cx_Oracle`, `python-oracledb` **is a Thin driver by default that doesn’t need Oracle Client libraries**. That is a good reason to switch from `cx-Oracle` to `oracledb`

For more information, you can read [the bog post here](https://levelup.gitconnected.com/open-source-python-thin-driver-for-oracle-database-e82aac7ecf5a).