### PR TITLE
Correctly classify dag_processing.processes as a gauge

### DIFF
--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -91,7 +91,6 @@ Name                                        Description
 ``previously_succeeded``                    Number of previously succeeded task instances
 ``zombies_killed``                          Zombie tasks killed
 ``scheduler_heartbeat``                     Scheduler heartbeats
-``dag_processing.processes``                Number of currently running DAG parsing processes
 ``dag_processing.processor_timeouts``       Number of file processors that have been killed due to taking too long
 ``dag_processing.manager_stalls``           Number of stalled ``DagFileProcessorManager``
 ``dag_file_refresh_error``                  Number of failures loading any DAG files
@@ -128,6 +127,7 @@ Name                                                Description
 ``dagbag_size``                                     Number of DAGs found when the scheduler ran a scan based on it's
                                                     configuration
 ``dag_processing.import_errors``                    Number of errors from trying to parse DAG files
+``dag_processing.processes``                        Number of currently running DAG parsing processes
 ``dag_processing.total_parse_time``                 Seconds taken to scan and import all DAG files once
 ``dag_processing.last_run.seconds_ago.<dag_file>``  Seconds since ``<dag_file>`` was last processed
 ``scheduler.tasks.running``                         Number of tasks running in executor


### PR DESCRIPTION
Currently, `dag_processing.processes` is classified as a counter in the documentation but in reality it is a gauge with `decr` operations performed on it. While exporting this metric as counter to prometheus, this results in a counter that just keeps on increasing and leads to some confusion.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
