### PR TITLE
Fix bugs in URI constructor for MySQL connection

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -231,13 +231,9 @@ class Connection(Base, LoggingMixin):
             host_block += quote(self.host, safe='')
 
         if self.port:
-            if host_block > '':
-                host_block += f':{self.port}'
-            else:
-                host_block += f'@:{self.port}'
+            host_block += f':{self.port}'
 
-        if self.schema:
-            host_block += f"/{quote(self.schema, safe='')}"
+        host_block += f"/{quote(self.schema, safe='')}" if self.schema else '/'
 
         uri += host_block
 

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -231,9 +231,13 @@ class Connection(Base, LoggingMixin):
             host_block += quote(self.host, safe='')
 
         if self.port:
-            host_block += f':{self.port}'
+            if host_block == '' and authority_block == '':
+                host_block += f'@:{self.port}'
+            else:
+                host_block += f':{self.port}'
 
-        host_block += f"/{quote(self.schema, safe='')}" if self.schema else '/'
+        if self.schema:
+            host_block += f"/{quote(self.schema, safe='')}"
 
         uri += host_block
 
@@ -243,9 +247,9 @@ class Connection(Base, LoggingMixin):
             except TypeError:
                 query = None
             if query and self.extra_dejson == dict(parse_qsl(query, keep_blank_values=True)):
-                uri += '?' + query
+                uri += ('?' if self.schema else '/?') + query
             else:
-                uri += '?' + urlencode({self.EXTRA_KEY: self.extra})
+                uri += ('?' if self.schema else '/?') + urlencode({self.EXTRA_KEY: self.extra})
 
         return uri
 

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -242,14 +242,14 @@ class TestCliExportConnections:
                 'uri',
                 [
                     "airflow_db=mysql://root:plainpassword@mysql/airflow",
-                    "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql",
+                    "druid_broker_default=druid://druid-broker:8082/?endpoint=druid%2Fv2%2Fsql",
                 ],
             ),
             (
                 None,  # tests that default is URI
                 [
                     "airflow_db=mysql://root:plainpassword@mysql/airflow",
-                    "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql",
+                    "druid_broker_default=druid://druid-broker:8082/?endpoint=druid%2Fv2%2Fsql",
                 ],
             ),
             (
@@ -287,7 +287,7 @@ class TestCliExportConnections:
         connection_command.connections_export(args)
         expected_connections = [
             "airflow_db=mysql://root:plainpassword@mysql/airflow",
-            "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql",
+            "druid_broker_default=druid://druid-broker:8082/?endpoint=druid%2Fv2%2Fsql",
         ]
 
         assert output_filepath.read_text().splitlines() == expected_connections

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+import json
 import unittest
 from unittest import mock
 
@@ -234,6 +235,111 @@ class TestDbApiHook(unittest.TestCase):
             )
         )
         assert "conn-type://host:1/schema" == self.db_hook.get_uri()
+
+    def test_get_uri_extra(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login='login',
+                password='password',
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login:password@host/?charset=utf-8"
+
+    def test_get_uri_extra_with_schema(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login='login',
+                password='password',
+                schema="schema",
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login:password@host/schema?charset=utf-8"
+
+    def test_get_uri_extra_with_port(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login='login',
+                password='password',
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login:password@host:3306/?charset=utf-8"
+
+    def test_get_uri_extra_with_port_and_empty_host(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                login='login',
+                password='password',
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login:password@:3306/?charset=utf-8"
+
+    def test_get_uri_extra_with_port_and_schema(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login='login',
+                password='password',
+                schema="schema",
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login:password@host:3306/schema?charset=utf-8"
+
+    def test_get_uri_without_password(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login='login',
+                password=None,
+                schema="schema",
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://login@host:3306/schema?charset=utf-8"
+
+    def test_get_uri_without_auth(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                host="host",
+                login=None,
+                password=None,
+                schema="schema",
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://host:3306/schema?charset=utf-8"
+
+    def test_get_uri_without_auth_and_empty_host(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn-type",
+                login=None,
+                password=None,
+                schema="schema",
+                port=3306,
+                extra=json.dumps({'charset': 'utf-8'}),
+            )
+        )
+        assert self.db_hook.get_uri() == "conn-type://@:3306/schema?charset=utf-8"
 
     def test_run_log(self):
         statement = 'SQL'

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -45,6 +45,7 @@ class TestMySqlHookConn(unittest.TestCase):
             login='login',
             password='password',
             host='host',
+            schema='schema',
         )
 
         self.db_hook = MySqlHook()
@@ -53,7 +54,6 @@ class TestMySqlHookConn(unittest.TestCase):
 
     @mock.patch('MySQLdb.connect')
     def test_get_conn(self, mock_connect):
-        self.connection.schema = 'schema'
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
@@ -68,82 +68,8 @@ class TestMySqlHookConn(unittest.TestCase):
         self.connection.extra = json.dumps({'charset': 'utf-8'})
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login:password@host/?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_without_extra(self, mock_connect):
-        self.connection.schema = 'schema'
-        self.connection.port = '3306'
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/schema"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_with_schema(self, mock_connect):
-        self.connection.schema = 'schema'
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
         assert self.db_hook.get_uri() == "mysql://login:password@host/schema?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_with_port(self, mock_connect):
-        self.connection.port = '3306'
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_with_port_and_empty_host(self, mock_connect):
-        self.connection.host = None
-        self.connection.port = '3306'
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login:password@:3306/?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_with_port_and_schema(self, mock_connect):
-        self.connection.port = '3306'
-        self.connection.schema = 'schema'
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/schema?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_without_password(self, mock_connect):
-        self.connection.port = '3306'
-        self.connection.schema = 'schema'
-        self.connection._password = None
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://login@host:3306/schema?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_without_auth(self, mock_connect):
-        self.connection.port = '3306'
-        self.connection.schema = 'schema'
-        self.connection.login = None
-        self.connection._password = None
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://host:3306/schema?charset=utf-8"
-
-    @mock.patch('MySQLdb.connect')
-    def test_get_uri_without_auth_and_empty_host(self, mock_connect):
-        self.connection.port = '3306'
-        self.connection.schema = 'schema'
-        self.connection.host = None
-        self.connection.login = None
-        self.connection._password = None
-        self.connection.extra = json.dumps({'charset': 'utf-8'})
-        self.db_hook.get_conn()
-        assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "mysql://:3306/schema?charset=utf-8"
 
     @mock.patch('MySQLdb.connect')
     def test_get_conn_from_connection(self, mock_connect):
@@ -230,7 +156,6 @@ class TestMySqlHookConn(unittest.TestCase):
     @mock.patch('MySQLdb.connect')
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type')
     def test_get_conn_rds_iam(self, mock_client, mock_connect):
-        self.connection.schema = 'schema'
         self.connection.extra = '{"iam":true}'
         mock_client.return_value.generate_db_auth_token.return_value = 'aws_token'
         self.db_hook.get_conn()

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -45,7 +45,6 @@ class TestMySqlHookConn(unittest.TestCase):
             login='login',
             password='password',
             host='host',
-            schema='schema',
         )
 
         self.db_hook = MySqlHook()
@@ -54,6 +53,7 @@ class TestMySqlHookConn(unittest.TestCase):
 
     @mock.patch('MySQLdb.connect')
     def test_get_conn(self, mock_connect):
+        self.connection.schema = 'schema'
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
@@ -68,8 +68,82 @@ class TestMySqlHookConn(unittest.TestCase):
         self.connection.extra = json.dumps({'charset': 'utf-8'})
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
-        args, kwargs = mock_connect.call_args
+        assert self.db_hook.get_uri() == "mysql://login:password@host/?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_without_extra(self, mock_connect):
+        self.connection.schema = 'schema'
+        self.connection.port = '3306'
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/schema"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_with_schema(self, mock_connect):
+        self.connection.schema = 'schema'
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
         assert self.db_hook.get_uri() == "mysql://login:password@host/schema?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_with_port(self, mock_connect):
+        self.connection.port = '3306'
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_with_port_and_empty_host(self, mock_connect):
+        self.connection.host = None
+        self.connection.port = '3306'
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://login:password@:3306/?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_with_port_and_schema(self, mock_connect):
+        self.connection.port = '3306'
+        self.connection.schema = 'schema'
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://login:password@host:3306/schema?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_without_password(self, mock_connect):
+        self.connection.port = '3306'
+        self.connection.schema = 'schema'
+        self.connection._password = None
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://login@host:3306/schema?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_without_auth(self, mock_connect):
+        self.connection.port = '3306'
+        self.connection.schema = 'schema'
+        self.connection.login = None
+        self.connection._password = None
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://host:3306/schema?charset=utf-8"
+
+    @mock.patch('MySQLdb.connect')
+    def test_get_uri_without_auth_and_empty_host(self, mock_connect):
+        self.connection.port = '3306'
+        self.connection.schema = 'schema'
+        self.connection.host = None
+        self.connection.login = None
+        self.connection._password = None
+        self.connection.extra = json.dumps({'charset': 'utf-8'})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        assert self.db_hook.get_uri() == "mysql://:3306/schema?charset=utf-8"
 
     @mock.patch('MySQLdb.connect')
     def test_get_conn_from_connection(self, mock_connect):
@@ -156,6 +230,7 @@ class TestMySqlHookConn(unittest.TestCase):
     @mock.patch('MySQLdb.connect')
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type')
     def test_get_conn_rds_iam(self, mock_client, mock_connect):
+        self.connection.schema = 'schema'
         self.connection.extra = '{"iam":true}'
         mock_client.return_value.generate_db_auth_token.return_value = 'aws_token'
         self.db_hook.get_conn()

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -157,8 +157,8 @@ class TestLoadConnection(unittest.TestCase):
     @parameterized.expand(
         (
             (
-                "CONN_ID=mysql://host_1?param1=val1&param2=val2",
-                {"CONN_ID": "mysql://host_1?param1=val1&param2=val2"},
+                "CONN_ID=mysql://host_1/?param1=val1&param2=val2",
+                {"CONN_ID": "mysql://host_1/?param1=val1&param2=val2"},
             ),
         )
     )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In this PR I have fixed several bugs in the `get_uri` function in connection.py file. And also I have created unit tests for most of the use cases for this function.

Co-authored-by: Maksim Yermakou [maksimy@google.com](mailto:maksimy@google.com)
Co-authored-by: Wojciech Januszek [januszek@google.com](mailto:januszek@google.com)
Co-authored-by: Lukasz Wyszomirski [wyszomirski@google.com](mailto:wyszomirski@google.com)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
