### PR TITLE
Check for run_id for grid task groups

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -271,7 +271,9 @@ def task_group_to_grid(task_item_or_group, dag, dag_runs, session):
 
     def get_summary(dag_run, children):
         child_instances = [child['instances'] for child in children if 'instances' in child]
-        child_instances = [item for sublist in child_instances for item in sublist]
+        child_instances = [
+            item for sublist in child_instances for item in sublist if item['run_id'] == dag_run.run_id
+        ]
 
         children_start_dates = [item['start_date'] for item in child_instances if item]
         children_end_dates = [item['end_date'] for item in child_instances if item]


### PR DESCRIPTION
Task group data in the grid view were broken. All task groups were only showing the information for the latest dag run's task group and not from their own dag run. This becomes particularly noticeable during auto-refresh.

#23813 removed the need for a check on dag run id, but in #23947 we needed it again yet forgot to put it back in.

Before:
<img width="683" alt="Screen Shot 2022-06-08 at 10 18 33 AM" src="https://user-images.githubusercontent.com/4600967/172644368-7fe4fa76-3815-4494-b678-caf671d7bc82.png">


After:
<img width="372" alt="Screen Shot 2022-06-08 at 10 22 15 AM" src="https://user-images.githubusercontent.com/4600967/172644383-a17eccd4-7a96-4aba-8b0a-1e362040ca46.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
