### PR TITLE
KubernetesExecutor: Use user-provided namespace from executor_config arg

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -386,8 +386,8 @@ class PodGenerator:
         )
 
         # Reconcile the pods starting with the first chronologically,
-        # Pod from the pod_template_File -> Pod from executor_config arg -> Pod from the K8s executor
-        pod_list = [base_worker_pod, pod_override_object, dynamic_pod]
+        # Pod from the pod_template_file -> Pod from dynamic arguments -> Pod from executor_config arg
+        pod_list = [base_worker_pod, dynamic_pod, pod_override_object]
 
         try:
             return reduce(PodGenerator.reconcile_pods, pod_list)

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -335,6 +335,10 @@ class PodGenerator:
             - airflow.cfg
             - executor_config
             - dynamic arguments
+
+        If a user provides a `pod_override_object`, that pod should only be able to
+        override the image and namespace, and not arbitrary labels / annotations of
+        the dynamic_pod.
         """
         try:
             image = pod_override_object.spec.containers[0].image  # type: ignore
@@ -342,6 +346,12 @@ class PodGenerator:
                 image = kube_image
         except Exception:
             image = kube_image
+        try:
+            final_namespace = pod_override_object.metadata.namespace  # type: ignore
+            if not final_namespace:
+                final_namespace = namespace
+        except Exception:
+            final_namespace = namespace
 
         annotations = {
             'dag_id': dag_id,
@@ -368,7 +378,7 @@ class PodGenerator:
 
         dynamic_pod = k8s.V1Pod(
             metadata=k8s.V1ObjectMeta(
-                namespace=namespace,
+                namespace=final_namespace,
                 annotations=annotations,
                 name=PodGenerator.make_unique_pod_id(pod_id),
                 labels=labels,
@@ -386,8 +396,8 @@ class PodGenerator:
         )
 
         # Reconcile the pods starting with the first chronologically,
-        # Pod from the pod_template_file -> Pod from dynamic arguments -> Pod from executor_config arg
-        pod_list = [base_worker_pod, dynamic_pod, pod_override_object]
+        # Pod from the pod_template_file -> Pod from executor_config arg -> Pod from dynamic arguments
+        pod_list = [base_worker_pod, pod_override_object, dynamic_pod]
 
         try:
             return reduce(PodGenerator.reconcile_pods, pod_list)

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -414,7 +414,8 @@ class TestPodGenerator:
                         name='', resources=k8s.V1ResourceRequirements(limits={'cpu': '1m', 'memory': '1G'})
                     )
                 ]
-            )
+            ),
+            metadata=k8s.V1ObjectMeta(namespace='overridden_namespace'),
         )
 
         result = PodGenerator.construct_pod(
@@ -435,7 +436,7 @@ class TestPodGenerator:
         expected.metadata.labels['app'] = 'myapp'
         expected.metadata.annotations = self.annotations
         expected.metadata.name = 'pod_id-' + self.static_uuid.hex
-        expected.metadata.namespace = 'test_namespace'
+        expected.metadata.namespace = 'overridden_namespace'
         expected.spec.containers[0].args = ['command']
         expected.spec.containers[0].image = expected_image
         expected.spec.containers[0].resources = {'limits': {'cpu': '1m', 'memory': '1G'}}


### PR DESCRIPTION
closes: #22298 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
