### PR TITLE
GCSDeleteObjectsOperator empty prefix bug fix

### DIFF
--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -306,7 +306,9 @@ class GCSDeleteObjectsOperator(BaseOperator):
         self.impersonation_chain = impersonation_chain
 
         if objects is None and prefix is None:
-            raise ValueError("Either object or prefix should be set. Both are None")
+            err_message = "(Task {task_id})".format(**kwargs) + \
+                " Either object or prefix should be set. Both are None."
+            raise ValueError(err_message)
 
         super().__init__(**kwargs)
 

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -305,7 +305,7 @@ class GCSDeleteObjectsOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
 
-        if not objects and not prefix:
+        if objects is None and prefix is None:
             raise ValueError("Either object or prefix should be set. Both are None")
 
         super().__init__(**kwargs)

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -306,8 +306,9 @@ class GCSDeleteObjectsOperator(BaseOperator):
         self.impersonation_chain = impersonation_chain
 
         if objects is None and prefix is None:
-            err_message = "(Task {task_id})".format(**kwargs) + \
-                " Either object or prefix should be set. Both are None."
+            err_message = "(Task {task_id}) Either object or prefix should be set. Both are None.".format(
+                **kwargs
+            )
             raise ValueError(err_message)
 
         super().__init__(**kwargs)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #24352 
This PR solves the Issue #24352 for a bug found in GCSDeleteObjectsOperator, where an error was thrown if the parameter `prefix` was set to an empty string, which should be a valid input.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
