### PR TITLE
Modify BigQueryCreateExternalTableOperator to use updated hook function

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -33,7 +33,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.xcom import XCom
 from airflow.operators.sql import SQLCheckOperator, SQLIntervalCheckOperator, SQLValueCheckOperator
-from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob, _split_tablename
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook, BigQueryJob
 from airflow.providers.google.cloud.hooks.gcs import GCSHook, _parse_gcs_url
 from airflow.providers.google.cloud.links.bigquery import BigQueryDatasetLink, BigQueryTableLink
 
@@ -1143,7 +1143,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
 
         source_uris = [f"gs://{self.bucket}/{source_object}" for source_object in self.source_objects]
 
-        project_id, dataset_id, table_id = _split_tablename(
+        project_id, dataset_id, table_id = bq_hook.split_tablename(
             table_input=self.destination_project_dataset_table,
             default_project_id=bq_hook.project_id or '',
         )

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -190,7 +190,7 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
     def test_execute(self, mock_hook):
         operator = BigQueryCreateExternalTableOperator(
             task_id=TASK_ID,
-            destination_project_dataset_table=f'{TEST_DATASET}.{TEST_TABLE_ID}',
+            destination_project_dataset_table=f'{TEST_GCP_PROJECT_ID}.{TEST_DATASET}.{TEST_TABLE_ID}',
             schema_fields=[],
             bucket=TEST_GCS_BUCKET,
             source_objects=TEST_GCS_DATA,
@@ -199,22 +199,34 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
         )
 
         operator.execute(context=MagicMock())
-        mock_hook.return_value.create_external_table.assert_called_once_with(
-            external_project_dataset_table=f'{TEST_DATASET}.{TEST_TABLE_ID}',
-            schema_fields=[],
-            source_uris=[f'gs://{TEST_GCS_BUCKET}/{source_object}' for source_object in TEST_GCS_DATA],
-            source_format=TEST_SOURCE_FORMAT,
-            autodetect=True,
-            compression='NONE',
-            skip_leading_rows=0,
-            field_delimiter=',',
-            max_bad_records=0,
-            quote_character=None,
-            allow_quoted_newlines=False,
-            allow_jagged_rows=False,
-            src_fmt_configs={},
-            labels=None,
-            encryption_configuration=None,
+        mock_hook.return_value.create_empty_table.assert_called_once_with(
+            table_resource={
+                "tableReference": {
+                    "projectId": TEST_GCP_PROJECT_ID,
+                    "datasetId": TEST_DATASET,
+                    "tableId": TEST_TABLE_ID,
+                },
+                "labels": None,
+                "schema": {"fields": []},
+                "externalDataConfiguration": {
+                    "source_uris": [
+                        f'gs://{TEST_GCS_BUCKET}/{source_object}' for source_object in TEST_GCS_DATA
+                    ],
+                    "source_format": TEST_SOURCE_FORMAT,
+                    "maxBadRecords": 0,
+                    "autodetect": True,
+                    "compression": 'NONE',
+                    "csvOptions": {
+                        "fieldDelimeter": ',',
+                        "skipLeadingRows": 0,
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "allowJaggedRows": False,
+                    },
+                },
+                "location": None,
+                "encryptionConfiguration": None,
+            }
         )
 
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -198,6 +198,12 @@ class TestBigQueryCreateExternalTableOperator(unittest.TestCase):
             autodetect=True,
         )
 
+        mock_hook.return_value.split_tablename.return_value = (
+            TEST_GCP_PROJECT_ID,
+            TEST_DATASET,
+            TEST_TABLE_ID,
+        )
+
         operator.execute(context=MagicMock())
         mock_hook.return_value.create_empty_table.assert_called_once_with(
             table_resource={


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fixes: #24160 

Modified the unit tests to verify that `create_empty_table` is called at least once.

--- 
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
