### PR TITLE
Add release cadence information to provider support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,11 +398,13 @@ might decide to add additional limits (and justify them with comment)
 
 ## Support for providers
 
-Providers released by the community have limitation of a minimum supported version of Airflow. The minimum
-version of Airflow is the `MINOR` version (2.2, 2.3 etc.) indicating that the providers might use features
-that appeared in this release. The default support timespan for the minimum version of Airflow
-(there could be justified exceptions) is that we increase the minimum Airflow version, when 12 months passed
-since the first release for the MINOR version of Airflow.
+Providers released by the community (with roughly monthly cadence) have
+limitation of a minimum supported version of Airflow. The minimum version of
+Airflow is the `MINOR` version (2.2, 2.3 etc.) indicating that the providers
+might use features that appeared in this release. The default support timespan
+for the minimum version of Airflow (there could be justified exceptions) is
+that we increase the minimum Airflow version, when 12 months passed since the
+first release for the MINOR version of Airflow.
 
 For example this means that by default we upgrade the minimum version of Airflow supported by providers
 to 2.3.0 in the first Provider's release after 11th of October 2022 (11th of October 2021 is the date when the


### PR DESCRIPTION
I noticed that we have not mentioned anywhere that release cadence
for providers is roughly monthly.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
