### PR TITLE
Fix requirements.txt path in Python operator

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -408,7 +408,8 @@ class PythonVirtualenvOperator(PythonOperator):
         if not requirements:
             self.requirements: Union[List[str], str] = []
         elif isinstance(requirements, str):
-            self.requirements = requirements
+            with open(requirements, "r") as file:
+                self.requirements = file.readlines()
         else:
             self.requirements = list(requirements)
         self.string_args = string_args or []
@@ -430,10 +431,7 @@ class PythonVirtualenvOperator(PythonOperator):
         with TemporaryDirectory(prefix='venv') as tmp_dir:
             requirements_file_name = f'{tmp_dir}/requirements.txt'
 
-            if not isinstance(self.requirements, str):
-                requirements_file_contents = "\n".join(str(dependency) for dependency in self.requirements)
-            else:
-                requirements_file_contents = self.requirements
+            requirements_file_contents = "\n".join(str(dependency) for dependency in self.requirements)
 
             if not self.system_site_packages and self.use_dill:
                 requirements_file_contents += '\ndill'

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -408,8 +408,7 @@ class PythonVirtualenvOperator(PythonOperator):
         if not requirements:
             self.requirements: Union[List[str], str] = []
         elif isinstance(requirements, str):
-            with open(requirements, "r") as file:
-                self.requirements = file.readlines()
+            self.requirements = requirements
         else:
             self.requirements = list(requirements)
         self.string_args = string_args or []
@@ -431,7 +430,11 @@ class PythonVirtualenvOperator(PythonOperator):
         with TemporaryDirectory(prefix='venv') as tmp_dir:
             requirements_file_name = f'{tmp_dir}/requirements.txt'
 
-            requirements_file_contents = "\n".join(str(dependency) for dependency in self.requirements)
+            if not isinstance(self.requirements, str):
+                requirements_file_contents = "\n".join(str(dependency) for dependency in self.requirements)
+            else:
+                with open(self.requirements, "r") as file:
+                    requirements_file_contents = "\n".join(file.readlines())
 
             if not self.system_site_packages and self.use_dill:
                 requirements_file_contents += '\ndill'


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The `requirements` parameter in `PythonVirtualEnvOperator` was not read properly in the case it was a string referring to a file path. Rather than the contents of the file, the file path was taken as a requirement, but this gives an error when trying to install with pip.

This PR reads the contents of the requirements file and passes those to pip.

related: #16037