### PR TITLE
Move callback_sink from executor to scheduler

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -19,8 +19,6 @@ import sys
 from collections import OrderedDict
 from typing import Any, Counter, Dict, List, Optional, Set, Tuple, Union
 
-from airflow.callbacks.base_callback_sink import BaseCallbackSink
-from airflow.callbacks.callback_requests import CallbackRequest
 from airflow.configuration import conf
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
@@ -63,7 +61,6 @@ class BaseExecutor(LoggingMixin):
     """
 
     job_id: Union[None, int, str] = None
-    callback_sink: Optional[BaseCallbackSink] = None
 
     def __init__(self, parallelism: int = PARALLELISM):
         super().__init__()
@@ -350,14 +347,3 @@ class BaseExecutor(LoggingMixin):
             len(self.event_buffer),
             "\n\t".join(map(repr, self.event_buffer.items())),
         )
-
-    def send_callback(self, request: CallbackRequest) -> None:
-        """Sends callback for execution.
-
-        Provides a default implementation which sends the callback to the `callback_sink` object.
-
-        :param request: Callback request to be executed.
-        """
-        if not self.callback_sink:
-            raise ValueError("Callback sink is not ready.")
-        self.callback_sink.send(request)

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -17,8 +17,6 @@
 # under the License.
 from typing import Dict, List, Optional, Set, Union
 
-from airflow.callbacks.base_callback_sink import BaseCallbackSink
-from airflow.callbacks.callback_requests import CallbackRequest
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType
 from airflow.executors.celery_executor import CeleryExecutor
@@ -37,7 +35,6 @@ class CeleryKubernetesExecutor(LoggingMixin):
     """
 
     supports_ad_hoc_ti_run: bool = True
-    callback_sink: Optional[BaseCallbackSink] = None
 
     KUBERNETES_QUEUE = conf.get('celery_kubernetes_executor', 'kubernetes_queue')
 
@@ -207,12 +204,3 @@ class CeleryKubernetesExecutor(LoggingMixin):
         self.celery_executor.debug_dump()
         self.log.info("Dumping KubernetesExecutor state")
         self.kubernetes_executor.debug_dump()
-
-    def send_callback(self, request: CallbackRequest) -> None:
-        """Sends callback for execution.
-
-        :param request: Callback request to be executed.
-        """
-        if not self.callback_sink:
-            raise ValueError("Callback sink is not ready.")
-        self.callback_sink.send(request)

--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -17,8 +17,6 @@
 # under the License.
 from typing import Dict, List, Optional, Set, Union
 
-from airflow.callbacks.base_callback_sink import BaseCallbackSink
-from airflow.callbacks.callback_requests import CallbackRequest
 from airflow.configuration import conf
 from airflow.executors.base_executor import CommandType, EventBufferValueType, QueuedTaskInstanceType
 from airflow.executors.kubernetes_executor import KubernetesExecutor
@@ -37,7 +35,6 @@ class LocalKubernetesExecutor(LoggingMixin):
     """
 
     supports_ad_hoc_ti_run: bool = True
-    callback_sink: Optional[BaseCallbackSink] = None
 
     KUBERNETES_QUEUE = conf.get('local_kubernetes_executor', 'kubernetes_queue')
 
@@ -206,12 +203,3 @@ class LocalKubernetesExecutor(LoggingMixin):
         self.local_executor.debug_dump()
         self.log.info("Dumping KubernetesExecutor state")
         self.kubernetes_executor.debug_dump()
-
-    def send_callback(self, request: CallbackRequest) -> None:
-        """Sends callback for execution.
-
-        :param request: Callback request to be executed.
-        """
-        if not self.callback_sink:
-            raise ValueError("Callback sink is not ready.")
-        self.callback_sink.send(request)

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -19,7 +19,6 @@ from unittest import mock
 
 from parameterized import parameterized
 
-from airflow.callbacks.callback_requests import CallbackRequest
 from airflow.configuration import conf
 from airflow.executors.celery_executor import CeleryExecutor
 from airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
@@ -224,14 +223,3 @@ class TestCeleryKubernetesExecutor:
         assert k8s_executor_mock.kubernetes_queue == conf.get(
             'celery_kubernetes_executor', 'kubernetes_queue'
         )
-
-    def test_send_callback(self):
-        cel_exec = CeleryExecutor()
-        k8s_exec = KubernetesExecutor()
-        cel_k8s_exec = CeleryKubernetesExecutor(cel_exec, k8s_exec)
-        cel_k8s_exec.callback_sink = mock.MagicMock()
-
-        callback = CallbackRequest(full_filepath="fake")
-        cel_k8s_exec.send_callback(callback)
-
-        cel_k8s_exec.callback_sink.send.assert_called_once_with(callback)

--- a/tests/executors/test_local_kubernetes_executor.py
+++ b/tests/executors/test_local_kubernetes_executor.py
@@ -17,7 +17,6 @@
 # under the License.
 from unittest import mock
 
-from airflow.callbacks.callback_requests import CallbackRequest
 from airflow.configuration import conf
 from airflow.executors.local_executor import LocalExecutor
 from airflow.executors.local_kubernetes_executor import LocalKubernetesExecutor
@@ -68,14 +67,3 @@ class TestLocalKubernetesExecutor:
         LocalKubernetesExecutor(local_executor_mock, k8s_executor_mock)
 
         assert k8s_executor_mock.kubernetes_queue == conf.get('local_kubernetes_executor', 'kubernetes_queue')
-
-    def test_send_callback(self):
-        local_executor_mock = mock.MagicMock()
-        k8s_executor_mock = mock.MagicMock()
-        local_k8s_exec = LocalKubernetesExecutor(local_executor_mock, k8s_executor_mock)
-        local_k8s_exec.callback_sink = mock.MagicMock()
-
-        callback = CallbackRequest(full_filepath="fake")
-        local_k8s_exec.send_callback(callback)
-
-        local_k8s_exec.callback_sink.send.assert_called_once_with(callback)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1476,7 +1476,6 @@ class TestSchedulerJob:
 
         session = settings.Session()
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.processor_agent = mock.MagicMock()
 
         self.scheduler_job.dagbag = dag_maker.dagbag
@@ -1554,7 +1553,6 @@ class TestSchedulerJob:
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag = dag_maker.dagbag
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job._callback_sink = mock.MagicMock()
 
         session = settings.Session()
@@ -1622,7 +1620,6 @@ class TestSchedulerJob:
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag = dag_maker.dagbag
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job._callback_sink = mock.MagicMock()
 
         # Mock that processor_agent is started
@@ -1665,7 +1662,6 @@ class TestSchedulerJob:
         dag_maker.dag_model.next_dagrun == dr.execution_date
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag = dag_maker.dagbag
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job._callback_sink = mock.Mock()
 
         # Mock that processor_agent is started
@@ -1698,7 +1694,6 @@ class TestSchedulerJob:
             EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.dagbag = dag_maker.dagbag
         self.scheduler_job.processor_agent = mock.Mock()
         self.scheduler_job._callback_sink = mock.MagicMock()
@@ -2891,7 +2886,6 @@ class TestSchedulerJob:
 
         with patch.object(settings, "CHECK_SLAS", False):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
-            self.scheduler_job.executor = MockExecutor()
             self.scheduler_job._callback_sink = mock.MagicMock()
 
             self.scheduler_job._send_sla_callbacks_to_processor(dag)
@@ -2905,7 +2899,6 @@ class TestSchedulerJob:
 
         with patch.object(settings, "CHECK_SLAS", True):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
-            self.scheduler_job.executor = MockExecutor()
             self.scheduler_job._callback_sink = mock.MagicMock()
 
             self.scheduler_job._send_sla_callbacks_to_processor(dag)
@@ -2919,7 +2912,6 @@ class TestSchedulerJob:
 
         with patch.object(settings, "CHECK_SLAS", True):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
-            self.scheduler_job.executor = MockExecutor()
             self.scheduler_job._callback_sink = mock.MagicMock()
 
             self.scheduler_job._send_sla_callbacks_to_processor(dag)
@@ -3181,7 +3173,6 @@ class TestSchedulerJob:
         )
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
         self.scheduler_job._callback_sink = mock.MagicMock()
 
@@ -3826,7 +3817,6 @@ class TestSchedulerJob:
             session.flush()
 
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
-            self.scheduler_job.executor = MockExecutor()
             self.scheduler_job.processor_agent = mock.MagicMock()
             self.scheduler_job._callback_sink = mock.MagicMock()
 
@@ -4077,7 +4067,6 @@ class TestSchedulerJob:
             EmptyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
-        self.scheduler_job.executor = MockExecutor()
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
 
         self.scheduler_job._create_dag_runs([dag_maker.dag_model], session)


### PR DESCRIPTION
A followup PR for #24366 
Simplifies the executor interface.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
