### PR TITLE
Deprecate remaining occurrences of `bigquery_conn_id` in favor of `gcp_conn_id`

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -812,6 +812,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         gcs_schema_object: Optional[str] = None,
         time_partitioning: Optional[Dict] = None,
         gcp_conn_id: str = 'google_cloud_default',
+        bigquery_conn_id: Optional[str] = None,
         google_cloud_storage_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         labels: Optional[Dict] = None,
@@ -824,6 +825,14 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         exists_ok: bool = False,
         **kwargs,
     ) -> None:
+        if bigquery_conn_id:
+            warnings.warn(
+                "The bigquery_conn_id parameter has been deprecated. Use the gcp_conn_id parameter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            gcp_conn_id = bigquery_conn_id
+
         super().__init__(**kwargs)
 
         self.project_id = project_id
@@ -1007,6 +1016,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         allow_quoted_newlines: bool = False,
         allow_jagged_rows: bool = False,
         gcp_conn_id: str = 'google_cloud_default',
+        bigquery_conn_id: Optional[str] = None,
         google_cloud_storage_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         src_fmt_configs: Optional[dict] = None,
@@ -1016,6 +1026,14 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
+        if bigquery_conn_id:
+            warnings.warn(
+                "The bigquery_conn_id parameter has been deprecated. Use the gcp_conn_id parameter instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            gcp_conn_id = bigquery_conn_id
+
         super().__init__(**kwargs)
 
         # BQ config

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -709,7 +709,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
 
         .. seealso::
             https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#timePartitioning
-    :param bigquery_conn_id: [Optional] The connection ID used to connect to Google Cloud and
+    :param gcp_conn_id: [Optional] The connection ID used to connect to Google Cloud and
         interact with the Bigquery service.
     :param google_cloud_storage_conn_id: [Optional] The connection ID used to connect to Google Cloud.
         and interact with the Google Cloud Storage service.
@@ -726,7 +726,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 table_id='Employees',
                 project_id='internal-gcp-project',
                 gcs_schema_object='gs://schema-bucket/employee_schema.json',
-                bigquery_conn_id='airflow-conn-id',
+                gcp_conn_id='airflow-conn-id',
                 google_cloud_storage_conn_id='airflow-conn-id'
             )
 
@@ -754,7 +754,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
                 project_id='internal-gcp-project',
                 schema_fields=[{"name": "emp_name", "type": "STRING", "mode": "REQUIRED"},
                                {"name": "salary", "type": "INTEGER", "mode": "NULLABLE"}],
-                bigquery_conn_id='airflow-conn-id-account',
+                gcp_conn_id='airflow-conn-id-account',
                 google_cloud_storage_conn_id='airflow-conn-id'
             )
     :param view: [Optional] A dictionary containing definition for the view.
@@ -811,7 +811,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         schema_fields: Optional[List] = None,
         gcs_schema_object: Optional[str] = None,
         time_partitioning: Optional[Dict] = None,
-        bigquery_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = 'google_cloud_default',
         google_cloud_storage_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         labels: Optional[Dict] = None,
@@ -831,7 +831,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
         self.table_id = table_id
         self.schema_fields = schema_fields
         self.gcs_schema_object = gcs_schema_object
-        self.bigquery_conn_id = bigquery_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
         self.time_partitioning = {} if time_partitioning is None else time_partitioning
@@ -847,7 +847,7 @@ class BigQueryCreateEmptyTableOperator(BaseOperator):
 
     def execute(self, context: 'Context') -> None:
         bq_hook = BigQueryHook(
-            gcp_conn_id=self.bigquery_conn_id,
+            gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,
@@ -949,7 +949,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         columns are treated as bad records, and if there are too many bad records, an
         invalid error is returned in the job result. Only applicable to CSV, ignored
         for other formats.
-    :param bigquery_conn_id: (Optional) The connection ID used to connect to Google Cloud and
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud and
         interact with the Bigquery service.
     :param google_cloud_storage_conn_id: (Optional) The connection ID used to connect to Google Cloud
         and interact with the Google Cloud Storage service.
@@ -1006,7 +1006,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         quote_character: Optional[str] = None,
         allow_quoted_newlines: bool = False,
         allow_jagged_rows: bool = False,
-        bigquery_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = 'google_cloud_default',
         google_cloud_storage_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         src_fmt_configs: Optional[dict] = None,
@@ -1085,7 +1085,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         self.quote_character = quote_character
         self.allow_quoted_newlines = allow_quoted_newlines
         self.allow_jagged_rows = allow_jagged_rows
-        self.bigquery_conn_id = bigquery_conn_id
+        self.gcp_conn_id = gcp_conn_id
         self.google_cloud_storage_conn_id = google_cloud_storage_conn_id
         self.delegate_to = delegate_to
         self.autodetect = autodetect
@@ -1098,7 +1098,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
 
     def execute(self, context: 'Context') -> None:
         bq_hook = BigQueryHook(
-            gcp_conn_id=self.bigquery_conn_id,
+            gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             location=self.location,
             impersonation_chain=self.impersonation_chain,


### PR DESCRIPTION
closes: #24343 

Deprecated remaining occurrences of `bigquery_conn_id` arg in google cloud providers in favor of `gcp_conn_id`
