### PR TITLE
Fix HttpHook.run_with_advanced_retry document error

### DIFF
--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -203,7 +203,7 @@ class HttpHook(BaseHook):
             retry_args = dict(
                 wait=tenacity.wait_exponential(),
                 stop=tenacity.stop_after_attempt(10),
-                retry=requests.exceptions.ConnectionError,
+                retry=tenacity.retry_if_exception_type(Exception),
             )
             hook.run_with_advanced_retry(endpoint="v1/test", _retry_args=retry_args)
 


### PR DESCRIPTION
Closes: #9569

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
