### PR TITLE
fix: RedshiftDataHook and RdsHook not use cached connection

### DIFF
--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -19,13 +19,13 @@
 
 from typing import TYPE_CHECKING
 
-from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
 if TYPE_CHECKING:
-    from mypy_boto3_rds import RDSClient
+    from mypy_boto3_rds import RDSClient  # noqa
 
 
-class RdsHook(AwsBaseHook):
+class RdsHook(AwsGenericHook['RDSClient']):
     """
     Interact with AWS RDS using proper client from the boto3 library.
 
@@ -39,7 +39,7 @@ class RdsHook(AwsBaseHook):
     are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
 
     :param aws_conn_id: The Airflow connection used for AWS credentials.
     """
@@ -47,13 +47,3 @@ class RdsHook(AwsBaseHook):
     def __init__(self, *args, **kwargs) -> None:
         kwargs["client_type"] = "rds"
         super().__init__(*args, **kwargs)
-
-    @property
-    def conn(self) -> 'RDSClient':
-        """
-        Get the underlying boto3 RDS client (cached)
-
-        :return: boto3 RDS client
-        :rtype: botocore.client.RDS
-        """
-        return super().conn

--- a/airflow/providers/amazon/aws/hooks/redshift_data.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_data.py
@@ -18,13 +18,13 @@
 
 from typing import TYPE_CHECKING
 
-from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
 if TYPE_CHECKING:
-    from mypy_boto3_redshift_data import RedshiftDataAPIServiceClient
+    from mypy_boto3_redshift_data import RedshiftDataAPIServiceClient  # noqa
 
 
-class RedshiftDataHook(AwsBaseHook):
+class RedshiftDataHook(AwsGenericHook['RedshiftDataAPIServiceClient']):
     """
     Interact with AWS Redshift Data, using the boto3 library
     Hook attribute `conn` has all methods that listed in documentation
@@ -37,7 +37,7 @@ class RedshiftDataHook(AwsBaseHook):
         are passed down to the underlying AwsBaseHook.
 
     .. seealso::
-        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
+        :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
 
     :param aws_conn_id: The Airflow connection used for AWS credentials.
     """
@@ -45,8 +45,3 @@ class RedshiftDataHook(AwsBaseHook):
     def __init__(self, *args, **kwargs) -> None:
         kwargs["client_type"] = "redshift-data"
         super().__init__(*args, **kwargs)
-
-    @property
-    def conn(self) -> 'RedshiftDataAPIServiceClient':
-        """Get the underlying boto3 RedshiftDataAPIService client (cached)"""
-        return super().conn

--- a/tests/providers/amazon/aws/hooks/test_rds.py
+++ b/tests/providers/amazon/aws/hooks/test_rds.py
@@ -25,3 +25,6 @@ class TestRdsHook:
         hook = RdsHook(aws_conn_id='aws_default', region_name='us-east-1')
         assert hasattr(hook, 'conn')
         assert hook.conn.__class__.__name__ == 'RDS'
+        conn = hook.conn
+        assert conn is hook.conn  # Cached property
+        assert conn is hook.get_conn()  # Same object as returned by `conn` property

--- a/tests/providers/amazon/aws/hooks/test_redshift_data.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_data.py
@@ -24,3 +24,6 @@ class TestRedshiftDataHook:
         hook = RedshiftDataHook(aws_conn_id='aws_default', region_name='us-east-1')
         assert hasattr(hook, 'conn')
         assert hook.conn.__class__.__name__ == 'RedshiftDataAPIService'
+        conn = hook.conn
+        assert conn is hook.conn  # Cached property
+        assert conn is hook.get_conn()  # Same object as returned by `conn` property


### PR DESCRIPTION
After finding in this PR: https://github.com/apache/airflow/pull/24057#discussion_r894848008 I've checked other AWS Hooks which not use cached `conn` property and found two hooks `RedshiftDataHook` and `RdsHook`

Add to `AwsBaseHook` generic connection, so it won't required anymore overwrite `conn` property

<details>
  <summary>Type hinting still work in IDE (PyCharm) after changes</summary>

 ![out](https://user-images.githubusercontent.com/3998685/173164439-fbf99a81-087e-43d7-b973-e51f378763fe.gif)
</details>


