### PR TITLE
handle exception when resolving XComArg

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -396,10 +396,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
             return render_template_to_string(template, context)
 
         if isinstance(value, (DagParam, XComArg)):
-            try:
-                return value.resolve(context)
-            except AirflowException:
-                return None
+            return value.resolve(context)
 
         # Fast path for common built-in collections.
         if value.__class__ is tuple:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -396,7 +396,10 @@ class AbstractOperator(LoggingMixin, DAGNode):
             return render_template_to_string(template, context)
 
         if isinstance(value, (DagParam, XComArg)):
-            return value.resolve(context)
+            try:
+                return value.resolve(context)
+            except AirflowException:
+                return None
 
         # Fast path for common built-in collections.
         if value.__class__ is tuple:

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -149,10 +149,7 @@ class XComArg(DependencyMixin):
             task_ids=self.operator.task_id, key=str(self.key), default=NOTSET, session=session
         )
         if result is NOTSET:
-            raise AirflowException(
-                f'XComArg result from {self.operator.task_id} at {context["ti"].dag_id} '
-                f'with key="{self.key}" is not found!'
-            )
+            return None
         return result
 
     @staticmethod


### PR DESCRIPTION
related: #24338 

Since TaskFlow API resloves the XComArg automatically, it also should handle the exception. If there is a exception when resloving the XComArg, it should just return None, means nothing there.

When it comes to #24338 
![图片](https://user-images.githubusercontent.com/20011800/173233198-9645f848-290d-4e05-984c-8a8fc8346468.png)
Task 2 is skipped, downstream_task's trigger rule is NONE_FAILED_MIN_ONE_SUCCESS, so I think downstream_task should not fail.

Please kindly review. :)