### PR TITLE
Improve grid rendering performance with a custom tooltip

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -20,3 +20,10 @@ This product contains a modified portion of 'Flask App Builder' developed by Dan
 (https://github.com/dpgaspar/Flask-AppBuilder).
 
 * Copyright 2013, Daniel Vaz Gaspar
+
+Chakra UI:
+-----
+This product contains a modified portion of 'Chakra UI' developed by Segun Adebayo.
+(https://github.com/chakra-ui/chakra-ui).
+
+* Copyright 2019, Segun Adebayo

--- a/airflow/www/static/js/grid/components/StatusBox.jsx
+++ b/airflow/www/static/js/grid/components/StatusBox.jsx
@@ -23,12 +23,12 @@ import React from 'react';
 import { isEqual } from 'lodash';
 import {
   Box,
-  Tooltip,
   useTheme,
 } from '@chakra-ui/react';
 
 import InstanceTooltip from './InstanceTooltip';
 import { useContainerRef } from '../context/containerRef';
+import Tooltip from './Tooltip';
 
 export const boxSize = 10;
 export const boxSizePx = `${boxSize}px`;
@@ -72,11 +72,11 @@ const StatusBox = ({
 
   return (
     <Tooltip
-      label={<InstanceTooltip instance={instance} group={group} />}
-      portalProps={{ containerRef }}
-      hasArrow
-      placement="top"
-      openDelay={400}
+      content={<InstanceTooltip instance={instance} group={group} />}
+      // portalProps={{ containerRef }}
+      // hasArrow
+      // placement="top"
+      // openDelay={400}
     >
       <Box>
         <SimpleStatus
@@ -88,6 +88,7 @@ const StatusBox = ({
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           opacity={isActive ? 1 : 0.3}
+
         />
       </Box>
     </Tooltip>

--- a/airflow/www/static/js/grid/components/StatusBox.jsx
+++ b/airflow/www/static/js/grid/components/StatusBox.jsx
@@ -26,9 +26,9 @@ import {
   useTheme,
 } from '@chakra-ui/react';
 
+import Tooltip from './Tooltip';
 import InstanceTooltip from './InstanceTooltip';
 import { useContainerRef } from '../context/containerRef';
-import Tooltip from './Tooltip';
 
 export const boxSize = 10;
 export const boxSizePx = `${boxSize}px`;
@@ -72,11 +72,11 @@ const StatusBox = ({
 
   return (
     <Tooltip
-      content={<InstanceTooltip instance={instance} group={group} />}
-      // portalProps={{ containerRef }}
-      // hasArrow
-      // placement="top"
-      // openDelay={400}
+      label={<InstanceTooltip instance={instance} group={group} />}
+      portalProps={{ containerRef }}
+      hasArrow
+      placement="top"
+      openDelay={400}
     >
       <Box>
         <SimpleStatus
@@ -88,7 +88,6 @@ const StatusBox = ({
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           opacity={isActive ? 1 : 0.3}
-
         />
       </Box>
     </Tooltip>

--- a/airflow/www/static/js/grid/components/Tooltip.tsx
+++ b/airflow/www/static/js/grid/components/Tooltip.tsx
@@ -17,57 +17,163 @@
  * under the License.
  */
 
-import React, { ReactNode, useState } from 'react';
-import { Box, chakra } from '@chakra-ui/react';
+/* Simplified version of chakra's Tooltip component for faster rendering but less customization */
 
-interface Props {
-  delay?: number;
-  direction?: 'top' | 'bottom' | 'left' | 'right';
-  content: string | ReactNode;
+import React from 'react';
+import {
+  chakra,
+  forwardRef,
+  HTMLChakraProps,
+  omitThemingProps,
+  ThemingProps,
+  useTheme,
+  useTooltip,
+  UseTooltipProps,
+  Portal,
+  PortalProps,
+} from '@chakra-ui/react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+export interface TooltipProps
+  extends HTMLChakraProps<'div'>,
+  ThemingProps<'Tooltip'>,
+  UseTooltipProps {
+  /**
+   * The React component to use as the
+   * trigger for the tooltip
+   */
+  children: React.ReactNode
+  /**
+   * The label of the tooltip
+   */
+  label?: React.ReactNode
+  /**
+   * The accessible, human friendly label to use for
+   * screen readers.
+   *
+   * If passed, tooltip will show the content `label`
+   * but expose only `aria-label` to assistive technologies
+   */
+  'aria-label'?: string
+  /**
+   * If `true`, the tooltip will wrap its children
+   * in a `<span/>` with `tabIndex=0`
+   */
+  shouldWrapChildren?: boolean
+  /**
+   * If `true`, the tooltip will show an arrow tip
+   */
+  hasArrow?: boolean
+  /**
+   * Props to be forwarded to the portal component
+   */
+  portalProps?: Pick<PortalProps, 'appendToParentPortal' | 'containerRef'>
 }
 
-const Tooltip: React.FC<Props> = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  delay = 400, direction = 'top', content, children,
-}) => {
-  let timeout: any;
-  const [active, setActive] = useState(false);
+const StyledTooltip = chakra(motion.div);
 
-  const showTip = () => {
-    timeout = setTimeout(() => {
-      setActive(true);
-    }, delay);
-  };
+const styles = {
+  '--popper-arrow-bg': ['var(--tooltip-bg)'],
+  '--tooltip-bg': 'colors.gray.700',
+  bg: ['var(--tooltip-bg)'],
+  borderRadius: 'sm',
+  boxShadow: 'md',
+  color: 'whiteAlpha.900',
+  fontSize: 'md',
+  fontWeight: 'medium',
+  maxW: '320px',
+  px: '8px',
+  py: '2px',
+  zIndex: 'tooltip',
+};
 
-  const hideTip = () => {
-    clearInterval(timeout);
-    setActive(false);
+/**
+ * Tooltips display informative text when users hover, focus on, or tap an element.
+ *
+ * @see Docs     https://chakra-ui.com/docs/overlay/tooltip
+ * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices/#tooltip
+ */
+const Tooltip = forwardRef<TooltipProps, 'div'>((props, ref) => {
+  const ownProps = omitThemingProps(props);
+  const theme = useTheme();
+
+  const {
+    children,
+    label,
+    shouldWrapChildren,
+    'aria-label': ariaLabel,
+    hasArrow,
+    bg,
+    portalProps,
+    background,
+    backgroundColor,
+    bgColor,
+    ...rest
+  } = ownProps;
+
+  const tooltip = useTooltip({ ...rest, direction: theme.direction });
+
+  /*
+     * Ensure tooltip has only one child node
+     */
+  const child = React.Children.only(children) as React.ReactElement & {
+    ref?: React.Ref<any>
   };
+  const trigger: React.ReactElement = React.cloneElement(
+    child,
+    tooltip.getTriggerProps(child.props, child.ref),
+  );
+
+  const tooltipProps = tooltip.getTooltipProps({}, ref);
+
+  /**
+   * If the `label` is empty, there's no point showing the tooltip.
+   * Let's simply return the children
+   */
+  if (!label) {
+    return <>{children}</>;
+  }
 
   return (
-    <chakra.span
-      onMouseEnter={showTip}
-      onMouseLeave={hideTip}
-      position="relative"
-    >
-      {children}
-      {active && (
-        <Box
-          position="absolute"
-          borderRadius={2}
-          left="50%"
-          transform="translateX(-50%)"
-          p={3}
-          color="white"
-          backgroundColor="black"
-          zIndex={100}
-          width={200}
-        >
-          {content}
-        </Box>
-      )}
-    </chakra.span>
+    <>
+      {trigger}
+      <AnimatePresence>
+        {tooltip.isOpen && (
+          <Portal {...portalProps}>
+            <chakra.div
+              {...tooltip.getTooltipPositionerProps()}
+              __css={{
+                zIndex: styles.zIndex,
+                pointerEvents: 'none',
+              }}
+            >
+              <StyledTooltip
+                {...(tooltipProps as any)}
+                initial="exit"
+                animate="enter"
+                exit="exit"
+                __css={styles}
+              >
+                {label}
+                {hasArrow && (
+                  <chakra.div
+                    data-popper-arrow
+                    className="chakra-tooltip__arrow-wrapper"
+                  >
+                    <chakra.div
+                      data-popper-arrow-inner
+                      className="chakra-tooltip__arrow"
+                      __css={{ bg: styles.bg }}
+                    />
+                  </chakra.div>
+                )}
+              </StyledTooltip>
+            </chakra.div>
+          </Portal>
+        )}
+      </AnimatePresence>
+    </>
   );
-};
+});
 
 export default Tooltip;

--- a/airflow/www/static/js/grid/components/Tooltip.tsx
+++ b/airflow/www/static/js/grid/components/Tooltip.tsx
@@ -1,0 +1,73 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactNode, useState } from 'react';
+import { Box, chakra } from '@chakra-ui/react';
+
+interface Props {
+  delay?: number;
+  direction?: 'top' | 'bottom' | 'left' | 'right';
+  content: string | ReactNode;
+}
+
+const Tooltip: React.FC<Props> = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  delay = 400, direction = 'top', content, children,
+}) => {
+  let timeout: any;
+  const [active, setActive] = useState(false);
+
+  const showTip = () => {
+    timeout = setTimeout(() => {
+      setActive(true);
+    }, delay);
+  };
+
+  const hideTip = () => {
+    clearInterval(timeout);
+    setActive(false);
+  };
+
+  return (
+    <chakra.span
+      onMouseEnter={showTip}
+      onMouseLeave={hideTip}
+      position="relative"
+    >
+      {children}
+      {active && (
+        <Box
+          position="absolute"
+          borderRadius={2}
+          left="50%"
+          transform="translateX(-50%)"
+          p={3}
+          color="white"
+          backgroundColor="black"
+          zIndex={100}
+          width={200}
+        >
+          {content}
+        </Box>
+      )}
+    </chakra.span>
+  );
+};
+
+export default Tooltip;


### PR DESCRIPTION
We have a tooltip component for every status box we show in the Grid view.

The default Tooltip component in Chakra was taking too much time to load. Particularly do to an expensive call to `useStyleConfig()`. But we weren't actually using that, so I copied the source code for the Tooltip and stripped out a few parts to make it render faster, albeit with less ability to customize everything in the component.

Before:
<img width="1020" alt="Screen Shot 2022-06-13 at 12 40 40 PM" src="https://user-images.githubusercontent.com/4600967/173402877-5e989de4-5493-4ae4-9380-8cdfb9fd70e8.png">


After:
<img width="1023" alt="Screen Shot 2022-06-13 at 12 40 33 PM" src="https://user-images.githubusercontent.com/4600967/173402901-43bc01d4-6894-4cb4-8eff-6552837a0e68.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
