### PR TITLE
Preserve original order of providers' connection extra fields in UI

### DIFF
--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -82,7 +82,7 @@ def hooks_list(args):
 def connection_form_widget_list(args):
     """Lists all custom connection form fields at the command line"""
     AirflowConsole().print_as(
-        data=list(ProvidersManager().connection_form_widgets.items()),
+        data=list(sorted(ProvidersManager().connection_form_widgets.items())),
         output=args.output,
         mapper=lambda x: {
             "connection_parameter_name": x[0],

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -653,6 +653,13 @@ class ProvidersManager(LoggingMixin):
         _ = list(self._hooks_lazy_dict.values())
         self._field_behaviours = OrderedDict(sorted(self._field_behaviours.items()))
 
+        # Widgets for connection forms are currently used in two places:
+        # 1. In the UI Connections, expected same order that it defined in Hook.
+        # 2. cli command - `airflow providers widgets` and expected that it in alphabetical order.
+        # It is not possible to recover original ordering after sorting,
+        # that the main reason why original sorting moved to cli part:
+        # self._connection_form_widgets = OrderedDict(sorted(self._connection_form_widgets.items()))
+
     def _discover_taskflow_decorators(self) -> None:
         for name, info in self._provider_dict.items():
             for taskflow_decorator in info.data.get("task-decorators", []):
@@ -899,7 +906,10 @@ class ProvidersManager(LoggingMixin):
 
     @property
     def connection_form_widgets(self) -> Dict[str, ConnectionFormWidgetInfo]:
-        """Returns widgets for connection forms."""
+        """
+        Returns widgets for connection forms.
+        Dictionary keys in the same order that it defined in Hook.
+        """
         self.initialize_providers_hooks()
         self._import_info_from_all_hooks()
         return self._connection_form_widgets

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -651,7 +651,6 @@ class ProvidersManager(LoggingMixin):
         """Force-import all hooks and initialize the connections/fields"""
         # Retrieve all hooks to make sure that all of them are imported
         _ = list(self._hooks_lazy_dict.values())
-        self._connection_form_widgets = OrderedDict(sorted(self._connection_form_widgets.items()))
         self._field_behaviours = OrderedDict(sorted(self._field_behaviours.items()))
 
     def _discover_taskflow_decorators(self) -> None:


### PR DESCRIPTION
At that moment additional extra fields in Provider Connection always orders in alphabetical order of their keys.
So there is no possible to change this order in UI.

This PR remove sorts original dictionary and keep it stored in original order that it defined in Hook.

Probably I miss idea of this additional transformation dict -> sorted tuples -> OrderedDict, or probably it kept since time when Airflow supported Python 3.5

<details>
  <summary>Snowflake Connection Example</summary>

https://github.com/apache/airflow/blob/6d69dd062f079a8fbf72563fd218017208bfe6c1/airflow/providers/snowflake/hooks/snowflake.py#L86-L110

### Before Changes
![snowflake-before](https://user-images.githubusercontent.com/3998685/173441355-94d7c651-d4b5-4294-990b-b1abf55d951c.jpeg)

### After Changes
![snowflake-after](https://user-images.githubusercontent.com/3998685/173441372-6b209689-b3a5-4df0-8c0d-754658ec62e7.jpeg)

</details>


<details>
  <summary>K8S Connection Example</summary>

https://github.com/apache/airflow/blob/6d69dd062f079a8fbf72563fd218017208bfe6c1/airflow/providers/cncf/kubernetes/hooks/kubernetes.py#L84-L107

### Before Changes
![k8s-before](https://user-images.githubusercontent.com/3998685/173441627-ee68719d-31a4-4a40-824b-5bb0216dab10.jpeg)

### After Changes
![k8s-after](https://user-images.githubusercontent.com/3998685/173442126-91d18a1a-af88-4212-8dc1-6f43808a9ad8.png)

</details>