### PR TITLE
fix typo in google provider additional extras

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -930,8 +930,8 @@ extra-links:
 additional-extras:
   apache.beam: apache-beam[gcp]
   leveldb: plyvel
-  facebook: apache-airlfow-providers-facebook>=2.2.0
-  amazon: apache-airlfow-providers-facebook>=2.6.0
+  facebook: apache-airflow-providers-facebook>=2.2.0
+  amazon: apache-airflow-providers-amazon>=2.6.0
 
 secrets-backends:
   - airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend


### PR DESCRIPTION
Typo fix which prevent install extra packages of google provider.

```shell
❯ pip install "apache-airflow-providers-google[amazon]==8.0.0"
Collecting apache-airflow-providers-google[amazon]==8.0.0
...
ERROR: Could not find a version that satisfies the requirement apache-airlfow-providers-facebook>=2.6.0; extra == "amazon" (from apache-airflow-providers-google[amazon]) (from versions: none)
ERROR: No matching distribution found for apache-airlfow-providers-facebook>=2.6.0; extra == "amazon"
```

```
❯ pip install "apache-airflow-providers-google[facebook]==8.0.0"
Collecting apache-airflow-providers-google[facebook]==8.0.0
...
ERROR: Could not find a version that satisfies the requirement apache-airlfow-providers-facebook>=2.2.0; extra == "facebook" (from apache-airflow-providers-google[facebook]) (from versions: none)
ERROR: No matching distribution found for apache-airlfow-providers-facebook>=2.2.0; extra == "facebook"
```

Just curious is someone install provider packages by this way?