### PR TITLE
fix: update docker-compose.yaml to build

### DIFF
--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -38,7 +38,7 @@
 #
 # Feel free to modify this file to suit your needs.
 ---
-version: '3'
+version: '3.2'
 x-airflow-common:
   &airflow-common
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.


### PR DESCRIPTION
fixes issue where docker compose will not run out of the box when running `docker-compose up airflow-init` using the default docker-compose.yaml and latest docker based on instructions.

closes: #24442
