### PR TITLE
make exists() method on GoogleDriveHook return false for files that are trashed

### DIFF
--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -177,7 +177,6 @@ class GoogleDriveHook(GoogleBaseHook):
                 .list(q=query, spaces="drive", fields="files(id, mimeType, trashed)", orderBy="modifiedTime desc")
                 .execute(num_retries=self.num_retries)
             )
-        print(files)
         file_metadata = {}
         if files['files']:
             file_metadata = {"id": files['files'][0]['id'], "mime_type": files['files'][0]['mimeType'], "trashed": files['files'][0]['trashed']}

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -128,7 +128,13 @@ class GoogleDriveHook(GoogleBaseHook):
         request = service.files().get_media(fileId=file_id)
         return request
 
-    def exists(self, folder_id: str, file_name: str, drive_id: Optional[str] = None, include_trashed: Optional[bool] = False):
+    def exists(
+        self,
+        folder_id: str,
+        file_name: str,
+        drive_id: Optional[str] = None,
+        include_trashed: Optional[bool] = False,
+    ):
         """
         Checks to see if a file exists within a Google Drive folder
 
@@ -174,12 +180,21 @@ class GoogleDriveHook(GoogleBaseHook):
         else:
             files = (
                 service.files()
-                .list(q=query, spaces="drive", fields="files(id, mimeType, trashed)", orderBy="modifiedTime desc")
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields="files(id, mimeType, trashed)",
+                    orderBy="modifiedTime desc",
+                )
                 .execute(num_retries=self.num_retries)
             )
         file_metadata = {}
         if files['files']:
-            file_metadata = {"id": files['files'][0]['id'], "mime_type": files['files'][0]['mimeType'], "trashed": files['files'][0]['trashed']}
+            file_metadata = {
+                "id": files['files'][0]['id'],
+                "mime_type": files['files'][0]['mimeType'],
+                "trashed": files['files'][0]['trashed'],
+            }
         return file_metadata
 
     def upload_file(

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -128,18 +128,19 @@ class GoogleDriveHook(GoogleBaseHook):
         request = service.files().get_media(fileId=file_id)
         return request
 
-    def exists(self, folder_id: str, file_name: str, drive_id: Optional[str] = None):
+    def exists(self, folder_id: str, file_name: str, drive_id: Optional[str] = None, include_trashed: Optional[bool] = False):
         """
         Checks to see if a file exists within a Google Drive folder
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
+        :param include_trashed: Optional. Indicates whether a trashed file should count as existing.
         :return: True if the file exists, False otherwise
         :rtype: bool
         """
         file_metadata = self.get_file_id(folder_id=folder_id, file_name=file_name, drive_id=drive_id)
-        return bool(file_metadata) and not file_metadata["trashed"]
+        return bool(file_metadata) and (include_trashed or (not file_metadata["trashed"]))
 
     def get_file_id(self, folder_id: str, file_name: str, drive_id: Optional[str] = None):
         """

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -194,7 +194,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         file_name = "abc123.csv"
 
         mock_get_conn.return_value.files.return_value.list.return_value.execute.side_effect = [
-            {"files": [{"id": "ID_1", "mimeType": "text/plain"}]}
+            {"files": [{"id": "ID_1", "mimeType": "text/plain", "trashed": False}]}
         ]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)
@@ -207,7 +207,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         file_name = "abc123.csv"
 
         mock_get_conn.return_value.files.return_value.list.return_value.execute.side_effect = [
-            {"files": [{"id": "ID_1", "mimeType": "text/plain"}, {"id": "ID_2", "mimeType": "text/plain"}]}
+            {"files": [{"id": "ID_1", "mimeType": "text/plain", "trashed": False}, {"id": "ID_2", "mimeType": "text/plain", "trashed": False}]}
         ]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -207,7 +207,12 @@ class TestGoogleDriveHook(unittest.TestCase):
         file_name = "abc123.csv"
 
         mock_get_conn.return_value.files.return_value.list.return_value.execute.side_effect = [
-            {"files": [{"id": "ID_1", "mimeType": "text/plain", "trashed": False}, {"id": "ID_2", "mimeType": "text/plain", "trashed": False}]}
+            {
+                "files": [
+                    {"id": "ID_1", "mimeType": "text/plain", "trashed": False},
+                    {"id": "ID_2", "mimeType": "text/plain", "trashed": False},
+                ]
+            }
         ]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)


### PR DESCRIPTION
If a file is created in Google Drive and then moved to the Trash, the exists() method will return true for the file.  This change makes the exists() method check whether the file is 'trashed' and returns false if so.