### PR TITLE
Clarify "significant" newsfragment vs significant newsfragment _type_

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -341,13 +341,11 @@ Step 4: Prepare PR
      * `doc`
      * `misc`
 
-     To add a newsfragment, simply create an rst file named ``{pr_number}.{type}.rst`` (e.g. ``1234.bugfix.rst``)
+     To add a newsfragment, create an ``rst`` file named ``{pr_number}.{type}.rst`` (e.g. ``1234.bugfix.rst``)
      and place in either `newsfragments <https://github.com/apache/airflow/blob/main/newsfragments>`__ for core newsfragments,
      or `chart/newsfragments <https://github.com/apache/airflow/blob/main/chart/newsfragments>`__ for helm chart newsfragments.
 
-     For significant newsfragments, similar to git commits, the first line is the summary and optionally a
-     body can be added with an empty line separating it.
-     For other newsfragment types, only use a single summary line.
+     In general newsfragments must be one line.  For newsfragment type ``significant``, you may include summary and body separated by a blank line, similar to ``git`` commit messages.
 
 2. Rebase your fork, squash commits, and resolve all conflicts. See `How to rebase PR <#how-to-rebase-pr>`_
    if you need help with rebasing your change. Remember to rebase often if your PR takes a lot of time to


### PR DESCRIPTION
Previously was tiny bit ambiguous and could make it appear that any newsfragment type could have summary + body.  Also I remove the word "simply" just because it's a pet peeve of mine.
