### PR TITLE
Add missing types to FSHook

### DIFF
--- a/airflow/hooks/filesystem.py
+++ b/airflow/hooks/filesystem.py
@@ -33,13 +33,13 @@ class FSHook(BaseHook):
     Extra: {"path": "/tmp"}
     """
 
-    def __init__(self, conn_id='fs_default'):
+    def __init__(self, conn_id: str = 'fs_default'):
         super().__init__()
         conn = self.get_connection(conn_id)
         self.basepath = conn.extra_dejson.get('path', '')
         self.conn = conn
 
-    def get_conn(self):
+    def get_conn(self) -> None:
         pass
 
     def get_path(self) -> str:


### PR DESCRIPTION
Fix mypy error :
```
error: Call to untyped function "FSHook" in typed context  [no-untyped-call]
```

When using :
```python
fs_hook = FSHook(fs_conn_id)
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
