### PR TITLE
Revert "Fix await_container_completion condition (#23883)"

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -256,7 +256,7 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
-        while self.container_is_running(pod=pod, container_name=container_name):
+        while not self.container_is_running(pod=pod, container_name=container_name):
             time.sleep(1)
 
     def await_pod_completion(self, pod: V1Pod) -> V1Pod:


### PR DESCRIPTION
This reverts commit 42abbf0d61f94ec50026af0c0f95eb378e403042.

Trying to determine if this is the source of the failing k8s tests.