### PR TITLE
Fix semver compare number for `jobs check` command

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -620,7 +620,7 @@ Create the name of the cleanup service account to use
 
 {{define "scheduler_liveness_check_command"}}
 
-  {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+  {{- if semverCompare ">=2.1.0" .Values.airflowVersion }}
   - sh
   - -c
   - |


### PR DESCRIPTION
From what I can tell this command was added in 2.1.0 not 2.0.0.
