### PR TITLE
Credit image used in tutorial.py

### DIFF
--- a/airflow/example_dags/tutorial.py
+++ b/airflow/example_dags/tutorial.py
@@ -93,7 +93,7 @@ with DAG(
     `doc` (plain text), `doc_rst`, `doc_json`, `doc_yaml` which gets
     rendered in the UI's Task Instance Details page.
     ![img](http://montcs.bloomu.edu/~bobmon/Semesters/2012-01/491/import%20soul.png)
-
+    **Image Credit:** Randall Munroe, [XKCD](https://xkcd.com/license.html)
     """
     )
 


### PR DESCRIPTION
The image used in the example task documentation is [licensed under the Creative Commons license](https://xkcd.com/license.html). This change adds a mention of the author and a link to the license under the image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

