### PR TITLE
Use sql_alchemy_conn for celery result backend when result_backend is not set

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1670,7 +1670,7 @@
         or insert it into a database (depending of the backend)
         This status is used by the scheduler to update the state of the task
         The use of a database is highly recommended
-        When not specified, sql_alchemy_conn with db+ prefix will be used for connection
+        When not specified, sql_alchemy_conn with a db+ scheme prefix will be used
         http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
       version_added: ~
       type: string

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1670,12 +1670,13 @@
         or insert it into a database (depending of the backend)
         This status is used by the scheduler to update the state of the task
         The use of a database is highly recommended
+        When not specified, sql_alchemy_conn with db+ prefix will be used for connection
         http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
       version_added: ~
       type: string
       sensitive: true
-      example: ~
-      default: "db+postgresql://postgres:airflow@postgres/airflow"
+      example: "db+postgresql://postgres:airflow@postgres/airflow"
+      default: ~
     - name: flower_host
       description: |
         Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -846,7 +846,7 @@ broker_url = redis://redis:6379/0
 # or insert it into a database (depending of the backend)
 # This status is used by the scheduler to update the state of the task
 # The use of a database is highly recommended
-# When not specified, sql_alchemy_conn with db+ prefix will be used for connection
+# When not specified, sql_alchemy_conn with a db+ scheme prefix will be used
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
 # Example: result_backend = db+postgresql://postgres:airflow@postgres/airflow
 # result_backend =

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -846,8 +846,10 @@ broker_url = redis://redis:6379/0
 # or insert it into a database (depending of the backend)
 # This status is used by the scheduler to update the state of the task
 # The use of a database is highly recommended
+# When not specified, sql_alchemy_conn with db+ prefix will be used for connection
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
-result_backend = db+postgresql://postgres:airflow@postgres/airflow
+# Example: result_backend = db+postgresql://postgres:airflow@postgres/airflow
+# result_backend =
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
 # it ``airflow celery flower``. This defines the IP that Celery Flower runs on

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -37,9 +37,9 @@ if 'visibility_timeout' not in broker_transport_options:
         broker_transport_options['visibility_timeout'] = 21600
 
 if conf.has_option("celery", 'RESULT_BACKEND'):
-    result_backend = str(conf.get('celery', 'RESULT_BACKEND'))
+    result_backend = conf.get_mandatory_value('celery', 'RESULT_BACKEND')
 else:
-    log.info("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
+    log.debug("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
     result_backend = f'db+{conf.get("database", "SQL_ALCHEMY_CONN")}'
 
 DEFAULT_CELERY_CONFIG = {

--- a/airflow/config_templates/default_celery.py
+++ b/airflow/config_templates/default_celery.py
@@ -36,6 +36,12 @@ if 'visibility_timeout' not in broker_transport_options:
     if _broker_supports_visibility_timeout(broker_url):
         broker_transport_options['visibility_timeout'] = 21600
 
+if conf.has_option("celery", 'RESULT_BACKEND'):
+    result_backend = str(conf.get('celery', 'RESULT_BACKEND'))
+else:
+    log.info("Value for celery result_backend not found. Using sql_alchemy_conn with db+ prefix.")
+    result_backend = f'db+{conf.get("database", "SQL_ALCHEMY_CONN")}'
+
 DEFAULT_CELERY_CONFIG = {
     'accept_content': ['json'],
     'event_serializer': 'json',
@@ -46,7 +52,7 @@ DEFAULT_CELERY_CONFIG = {
     'task_track_started': conf.getboolean('celery', 'task_track_started'),
     'broker_url': broker_url,
     'broker_transport_options': broker_transport_options,
-    'result_backend': conf.get('celery', 'RESULT_BACKEND'),
+    'result_backend': result_backend,
     'worker_concurrency': conf.getint('celery', 'WORKER_CONCURRENCY'),
     'worker_enable_remote_control': conf.getboolean('celery', 'worker_enable_remote_control'),
 }
@@ -92,7 +98,6 @@ except Exception as e:
         f'all necessary certs and key ({e}).'
     )
 
-result_backend = str(DEFAULT_CELERY_CONFIG['result_backend'])
 if 'amqp://' in result_backend or 'redis://' in result_backend or 'rpc://' in result_backend:
     log.warning(
         "You have configured a result_backend of %s, it is highly recommended "

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -74,6 +74,7 @@ If release name contains chart name it will be used as a full name.
         key: webserver-secret-key
   {{- end }}
   {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+    {{- if or (semverCompare "<=2.3.2" .Values.airflowVersion) (.Values.data.resultBackendSecretName) (.Values.data.resultBackendConnection) }}
     {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CELERY__CELERY_RESULT_BACKEND }}
   # (Airflow 1.10.* variant)
   - name: AIRFLOW__CELERY__CELERY_RESULT_BACKEND
@@ -88,6 +89,7 @@ If release name contains chart name it will be used as a full name.
       secretKeyRef:
         name: {{ template "airflow_result_backend_secret" . }}
         key: connection
+    {{- end }}
     {{- end }}
     {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CELERY__BROKER_URL }}
   - name: AIRFLOW__CELERY__BROKER_URL

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -74,7 +74,7 @@ If release name contains chart name it will be used as a full name.
         key: webserver-secret-key
   {{- end }}
   {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-    {{- if or (semverCompare "<=2.3.2" .Values.airflowVersion) (.Values.data.resultBackendSecretName) (.Values.data.resultBackendConnection) }}
+    {{- if or (semverCompare "<2.4.0" .Values.airflowVersion) (.Values.data.resultBackendSecretName) (.Values.data.resultBackendConnection) }}
     {{- if .Values.enableBuiltInSecretEnvVars.AIRFLOW__CELERY__CELERY_RESULT_BACKEND }}
   # (Airflow 1.10.* variant)
   - name: AIRFLOW__CELERY__CELERY_RESULT_BACKEND

--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -20,6 +20,7 @@
 #################################
 {{- if not .Values.data.resultBackendSecretName }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+{{- if or (semverCompare "<=2.3.2" .Values.airflowVersion) (.Values.data.resultBackendSecretName) (.Values.data.resultBackendConnection) }}
 {{- $connection := .Values.data.resultBackendConnection | default .Values.data.metadataConnection }}
 
 {{- $resultBackendHost := $connection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
@@ -43,5 +44,6 @@ metadata:
 type: Opaque
 data:
   connection: {{ urlJoin (dict "scheme" (printf "db+%s" $connection.protocol) "userinfo" (printf "%s:%s" ($connection.user|urlquery) ($connection.pass | urlquery)) "host" (printf "%s:%s" $host $port) "path" (printf "/%s" $database) "query" $query) | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -20,7 +20,7 @@
 #################################
 {{- if not .Values.data.resultBackendSecretName }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-{{- if or (semverCompare "<=2.3.2" .Values.airflowVersion) (.Values.data.resultBackendSecretName) (.Values.data.resultBackendConnection) }}
+{{- if or (semverCompare "<2.4.0" .Values.airflowVersion) (and (semverCompare ">=2.4.0" .Values.airflowVersion) .Values.data.resultBackendConnection) }}
 {{- $connection := .Values.data.resultBackendConnection | default .Values.data.metadataConnection }}
 
 {{- $resultBackendHost := $connection.host | default (printf "%s-%s" .Release.Name "postgresql") }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -330,6 +330,11 @@ data:
   #   connection: base64_encoded_connection_string
 
   metadataSecretName: ~
+  # When providing secret names and using the same database for metadata and
+  # result backend, for Airflow < 2.4.0 it is necessary to create a separate
+  # secret for result backend but with a db+ scheme prefix.
+  # For Airflow >= 2.4.0 it is possible to not specify the secret again,
+  # as Airflow will use sql_alchemy_conn with a db+ scheme prefix by default.
   resultBackendSecretName: ~
   brokerUrlSecretName: ~
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -319,6 +319,16 @@ extraEnvFrom: ~
 # Airflow database & redis config
 data:
   # If secret names are provided, use those secrets
+  # These secrets must be created manually, eg:
+  #
+  # kind: Secret
+  # apiVersion: v1
+  # metadata:
+  #   name: custom-airflow-metadata-secret
+  # type: Opaque
+  # data:
+  #   connection: base64_encoded_connection_string
+
   metadataSecretName: ~
   resultBackendSecretName: ~
   brokerUrlSecretName: ~

--- a/tests/charts/test_basic_helm_chart.py
+++ b/tests/charts/test_basic_helm_chart.py
@@ -40,7 +40,7 @@ class TestBaseChartTest(unittest.TestCase):
             return OBJECT_COUNT_IN_BASIC_DEPLOYMENT + 1
         return OBJECT_COUNT_IN_BASIC_DEPLOYMENT
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_basic_deployments(self, version):
         expected_object_count_in_basic_deployment = self._get_object_count(version)
         k8s_objects = render_chart(
@@ -113,7 +113,7 @@ class TestBaseChartTest(unittest.TestCase):
                 "TEST-LABEL"
             ), f"Missing label TEST-LABEL on {k8s_name}. Current labels: {labels}"
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_basic_deployment_without_default_users(self, version):
         expected_object_count_in_basic_deployment = self._get_object_count(version)
         k8s_objects = render_chart(

--- a/tests/charts/test_basic_helm_chart.py
+++ b/tests/charts/test_basic_helm_chart.py
@@ -25,24 +25,44 @@ from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
-OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 35
+OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 34
 
 
 class TestBaseChartTest(unittest.TestCase):
-    def test_basic_deployments(self):
+    def _get_values_with_version(self, values, version):
+        if version != "default":
+            values["airflowVersion"] = version
+        return values
+
+    def _get_object_count(self, version):
+        # TODO remove default from condition after airflow update
+        if version == "2.3.2" or version == "default":
+            return OBJECT_COUNT_IN_BASIC_DEPLOYMENT + 1
+        return OBJECT_COUNT_IN_BASIC_DEPLOYMENT
+
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_basic_deployments(self, version):
+        expected_object_count_in_basic_deployment = self._get_object_count(version)
         k8s_objects = render_chart(
             "TEST-BASIC",
-            values={
-                "chart": {
-                    'metadata': 'AA',
+            self._get_values_with_version(
+                values={
+                    "chart": {
+                        'metadata': 'AA',
+                    },
+                    'labels': {"TEST-LABEL": "TEST-VALUE"},
+                    "fullnameOverride": "TEST-BASIC",
                 },
-                'labels': {"TEST-LABEL": "TEST-VALUE"},
-                "fullnameOverride": "TEST-BASIC",
-            },
+                version=version,
+            ),
         )
         list_of_kind_names_tuples = {
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         }
+        # TODO remove default from condition after airflow update
+        if version == "2.3.2" or version == "default":
+            assert ('Secret', 'TEST-BASIC-airflow-result-backend') in list_of_kind_names_tuples
+            list_of_kind_names_tuples.remove(('Secret', 'TEST-BASIC-airflow-result-backend'))
         assert list_of_kind_names_tuples == {
             ('ServiceAccount', 'TEST-BASIC-create-user-job'),
             ('ServiceAccount', 'TEST-BASIC-migrate-database-job'),
@@ -53,7 +73,6 @@ class TestBaseChartTest(unittest.TestCase):
             ('ServiceAccount', 'TEST-BASIC-webserver'),
             ('ServiceAccount', 'TEST-BASIC-worker'),
             ('Secret', 'TEST-BASIC-airflow-metadata'),
-            ('Secret', 'TEST-BASIC-airflow-result-backend'),
             ('Secret', 'TEST-BASIC-broker-url'),
             ('Secret', 'TEST-BASIC-fernet-key'),
             ('Secret', 'TEST-BASIC-webserver-secret-key'),
@@ -80,7 +99,7 @@ class TestBaseChartTest(unittest.TestCase):
             ('Job', 'TEST-BASIC-create-user'),
             ('Job', 'TEST-BASIC-run-airflow-migrations'),
         }
-        assert OBJECT_COUNT_IN_BASIC_DEPLOYMENT == len(k8s_objects)
+        assert expected_object_count_in_basic_deployment == len(k8s_objects)
         for k8s_object in k8s_objects:
             labels = jmespath.search('metadata.labels', k8s_object) or {}
             if 'helm.sh/chart' in labels:
@@ -94,16 +113,20 @@ class TestBaseChartTest(unittest.TestCase):
                 "TEST-LABEL"
             ), f"Missing label TEST-LABEL on {k8s_name}. Current labels: {labels}"
 
-    def test_basic_deployment_without_default_users(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_basic_deployment_without_default_users(self, version):
+        expected_object_count_in_basic_deployment = self._get_object_count(version)
         k8s_objects = render_chart(
             "TEST-BASIC",
-            values={"webserver": {"defaultUser": {'enabled': False}}},
+            values=self._get_values_with_version(
+                values={"webserver": {"defaultUser": {'enabled': False}}}, version=version
+            ),
         )
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
         assert ('Job', 'TEST-BASIC-create-user') not in list_of_kind_names_tuples
-        assert OBJECT_COUNT_IN_BASIC_DEPLOYMENT - 2 == len(k8s_objects)
+        assert expected_object_count_in_basic_deployment - 2 == len(k8s_objects)
 
     def test_network_policies_are_valid(self):
         k8s_objects = render_chart(
@@ -139,6 +162,17 @@ class TestBaseChartTest(unittest.TestCase):
             values={
                 "labels": {"label1": "value1", "label2": "value2"},
                 "executor": "CeleryExecutor",
+                "data": {
+                    "resultBackendConnection": {
+                        "user": "someuser",
+                        "pass": "somepass",
+                        "host": "somehost",
+                        "protocol": "postgresql",
+                        "port": 7777,
+                        "db": "somedb",
+                        "sslmode": "allow",
+                    }
+                },
                 "pgbouncer": {"enabled": True},
                 "redis": {"enabled": True},
                 "ingress": {"enabled": True},

--- a/tests/charts/test_rbac.py
+++ b/tests/charts/test_rbac.py
@@ -18,13 +18,13 @@
 import unittest
 
 import jmespath
+from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
 DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES = [
     ('Secret', 'TEST-RBAC-postgresql'),
     ('Secret', 'TEST-RBAC-airflow-metadata'),
-    ('Secret', 'TEST-RBAC-airflow-result-backend'),
     ('Secret', 'TEST-RBAC-pgbouncer-config'),
     ('Secret', 'TEST-RBAC-pgbouncer-stats'),
     ('ConfigMap', 'TEST-RBAC-airflow-config'),
@@ -105,34 +105,51 @@ CUSTOM_SERVICE_ACCOUNT_NAMES = (
 
 
 class RBACTest(unittest.TestCase):
-    def test_deployments_no_rbac_no_sa(self):
+    def _get_values_with_version(self, values, version):
+        if version != "default":
+            values["airflowVersion"] = version
+        return values
+
+    def _get_object_count(self, version):
+        # TODO remove default from condition after airflow update
+        if version == "2.3.2" or version == "default":
+            return [
+                ('Secret', 'TEST-RBAC-airflow-result-backend')
+            ] + DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
+        return DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
+
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_deployments_no_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
-            values={
-                "fullnameOverride": "TEST-RBAC",
-                "rbac": {"create": False},
-                "cleanup": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "create": False,
+            values=self._get_values_with_version(
+                values={
+                    "fullnameOverride": "TEST-RBAC",
+                    "rbac": {"create": False},
+                    "cleanup": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "create": False,
+                        },
                     },
-                },
-                "pgbouncer": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "create": False,
+                    "pgbouncer": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "create": False,
+                        },
                     },
+                    "redis": {"serviceAccount": {"create": False}},
+                    "scheduler": {"serviceAccount": {"create": False}},
+                    "webserver": {"serviceAccount": {"create": False}},
+                    "workers": {"serviceAccount": {"create": False}},
+                    "triggerer": {"serviceAccount": {"create": False}},
+                    "statsd": {"serviceAccount": {"create": False}},
+                    "createUserJob": {"serviceAccount": {"create": False}},
+                    "migrateDatabaseJob": {"serviceAccount": {"create": False}},
+                    "flower": {"enabled": True, "serviceAccount": {"create": False}},
                 },
-                "redis": {"serviceAccount": {"create": False}},
-                "scheduler": {"serviceAccount": {"create": False}},
-                "webserver": {"serviceAccount": {"create": False}},
-                "workers": {"serviceAccount": {"create": False}},
-                "triggerer": {"serviceAccount": {"create": False}},
-                "statsd": {"serviceAccount": {"create": False}},
-                "createUserJob": {"serviceAccount": {"create": False}},
-                "migrateDatabaseJob": {"serviceAccount": {"create": False}},
-                "flower": {"enabled": True, "serviceAccount": {"create": False}},
-            },
+                version=version,
+            ),
         )
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
@@ -140,83 +157,93 @@ class RBACTest(unittest.TestCase):
 
         self.assertCountEqual(
             list_of_kind_names_tuples,
-            DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES,
+            self._get_object_count(version),
         )
 
-    def test_deployments_no_rbac_with_sa(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_deployments_no_rbac_with_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
-            values={
-                "fullnameOverride": "TEST-RBAC",
-                "rbac": {"create": False},
-                "cleanup": {"enabled": True},
-                "flower": {"enabled": True},
-                "pgbouncer": {"enabled": True},
-            },
+            values=self._get_values_with_version(
+                values={
+                    "fullnameOverride": "TEST-RBAC",
+                    "rbac": {"create": False},
+                    "cleanup": {"enabled": True},
+                    "flower": {"enabled": True},
+                    "pgbouncer": {"enabled": True},
+                },
+                version=version,
+            ),
         )
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
-        real_list_of_kind_names = DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES + SERVICE_ACCOUNT_NAME_TUPLES
-        self.assertCountEqual(
-            list_of_kind_names_tuples,
-            real_list_of_kind_names,
-        )
-
-    def test_deployments_with_rbac_no_sa(self):
-        k8s_objects = render_chart(
-            "TEST-RBAC",
-            values={
-                "fullnameOverride": "TEST-RBAC",
-                "cleanup": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "create": False,
-                    },
-                },
-                "scheduler": {"serviceAccount": {"create": False}},
-                "webserver": {"serviceAccount": {"create": False}},
-                "workers": {"serviceAccount": {"create": False}},
-                "triggerer": {"serviceAccount": {"create": False}},
-                "flower": {"enabled": True, "serviceAccount": {"create": False}},
-                "statsd": {"serviceAccount": {"create": False}},
-                "redis": {"serviceAccount": {"create": False}},
-                "pgbouncer": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "create": False,
-                    },
-                },
-                "createUserJob": {"serviceAccount": {"create": False}},
-                "migrateDatabaseJob": {"serviceAccount": {"create": False}},
-            },
-        )
-        list_of_kind_names_tuples = [
-            (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
-        ]
-        real_list_of_kind_names = DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES + RBAC_ENABLED_KIND_NAME_TUPLES
+        real_list_of_kind_names = self._get_object_count(version) + SERVICE_ACCOUNT_NAME_TUPLES
         self.assertCountEqual(
             list_of_kind_names_tuples,
             real_list_of_kind_names,
         )
 
-    def test_deployments_with_rbac_with_sa(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_deployments_with_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
-            values={
-                "fullnameOverride": "TEST-RBAC",
-                "cleanup": {"enabled": True},
-                "flower": {"enabled": True},
-                "pgbouncer": {"enabled": True},
-            },
+            values=self._get_values_with_version(
+                values={
+                    "fullnameOverride": "TEST-RBAC",
+                    "cleanup": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "create": False,
+                        },
+                    },
+                    "scheduler": {"serviceAccount": {"create": False}},
+                    "webserver": {"serviceAccount": {"create": False}},
+                    "workers": {"serviceAccount": {"create": False}},
+                    "triggerer": {"serviceAccount": {"create": False}},
+                    "flower": {"enabled": True, "serviceAccount": {"create": False}},
+                    "statsd": {"serviceAccount": {"create": False}},
+                    "redis": {"serviceAccount": {"create": False}},
+                    "pgbouncer": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "create": False,
+                        },
+                    },
+                    "createUserJob": {"serviceAccount": {"create": False}},
+                    "migrateDatabaseJob": {"serviceAccount": {"create": False}},
+                },
+                version=version,
+            ),
+        )
+        list_of_kind_names_tuples = [
+            (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
+        ]
+        real_list_of_kind_names = self._get_object_count(version) + RBAC_ENABLED_KIND_NAME_TUPLES
+        self.assertCountEqual(
+            list_of_kind_names_tuples,
+            real_list_of_kind_names,
+        )
+
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_deployments_with_rbac_with_sa(self, version):
+        k8s_objects = render_chart(
+            "TEST-RBAC",
+            values=self._get_values_with_version(
+                values={
+                    "fullnameOverride": "TEST-RBAC",
+                    "cleanup": {"enabled": True},
+                    "flower": {"enabled": True},
+                    "pgbouncer": {"enabled": True},
+                },
+                version=version,
+            ),
         )
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
         real_list_of_kind_names = (
-            DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
-            + SERVICE_ACCOUNT_NAME_TUPLES
-            + RBAC_ENABLED_KIND_NAME_TUPLES
+            self._get_object_count(version) + SERVICE_ACCOUNT_NAME_TUPLES + RBAC_ENABLED_KIND_NAME_TUPLES
         )
         self.assertCountEqual(
             list_of_kind_names_tuples,

--- a/tests/charts/test_rbac.py
+++ b/tests/charts/test_rbac.py
@@ -118,7 +118,7 @@ class RBACTest(unittest.TestCase):
             ] + DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
         return DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_deployments_no_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
@@ -160,7 +160,7 @@ class RBACTest(unittest.TestCase):
             self._get_object_count(version),
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_deployments_no_rbac_with_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
@@ -184,7 +184,7 @@ class RBACTest(unittest.TestCase):
             real_list_of_kind_names,
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_deployments_with_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",
@@ -225,7 +225,7 @@ class RBACTest(unittest.TestCase):
             real_list_of_kind_names,
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_deployments_with_rbac_with_sa(self, version):
         k8s_objects = render_chart(
             "TEST-RBAC",

--- a/tests/charts/test_result_backend_connection_secret.py
+++ b/tests/charts/test_result_backend_connection_secret.py
@@ -17,6 +17,7 @@
 
 import base64
 import unittest
+from typing import Union
 
 import jmespath
 from parameterized import parameterized
@@ -25,6 +26,17 @@ from tests.charts.helm_template_generator import render_chart
 
 
 class ResultBackendConnectionSecretTest(unittest.TestCase):
+    def _get_values_with_version(self, values, version):
+        if version != "default":
+            values["airflowVersion"] = version
+        return values
+
+    def _assert_for_old_version(self, version, value, expected_value):
+        # TODO remove default from condition after airflow update
+        if version == "2.3.2" or version == "default":
+            assert value == expected_value
+        else:
+            assert value is None
 
     non_chart_database_values = {
         "user": "someuser",
@@ -53,49 +65,69 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
     )
     def test_should_a_document_be_generated_for_executor(self, executor, expected_doc_count):
         docs = render_chart(
-            values={"executor": executor},
+            values={
+                "executor": executor,
+                "data": {
+                    "metadataConnection": {**self.non_chart_database_values},
+                    "resultBackendConnection": {
+                        **self.non_chart_database_values,
+                        "user": "anotheruser",
+                        "pass": "anotherpass",
+                    },
+                },
+            },
             show_only=["templates/secrets/result-backend-connection-secret.yaml"],
         )
 
         assert expected_doc_count == len(docs)
 
-    def _get_connection(self, values: dict) -> str:
+    def _get_connection(self, values: dict) -> Union[str, None]:
         docs = render_chart(
             values=values,
             show_only=["templates/secrets/result-backend-connection-secret.yaml"],
         )
+        if len(docs) == 0:
+            return None
         encoded_connection = jmespath.search("data.connection", docs[0])
         return base64.b64decode(encoded_connection).decode()
 
-    def test_default_connection(self):
-        connection = self._get_connection({})
-
-        assert (
-            "db+postgresql://postgres:postgres@RELEASE-NAME-postgresql:5432/postgres?sslmode=disable"
-            == connection
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_default_connection_old_version(self, version):
+        connection = self._get_connection(self._get_values_with_version(version=version, values={}))
+        self._assert_for_old_version(
+            version,
+            value=connection,
+            expected_value="db+postgresql://postgres:postgres@RELEASE-NAME"
+            "-postgresql:5432/postgres?sslmode=disable",
         )
 
-    def test_should_default_to_custom_metadata_db_connection_with_pgbouncer_overrides(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_should_default_to_custom_metadata_db_connection_with_pgbouncer_overrides(self, version):
         values = {
             "pgbouncer": {"enabled": True},
             "data": {"metadataConnection": {**self.non_chart_database_values}},
         }
-        connection = self._get_connection(values)
+        connection = self._get_connection(self._get_values_with_version(values=values, version=version))
 
         # host, port, dbname still get overridden
-        assert (
-            "db+postgresql://someuser:somepass@RELEASE-NAME-pgbouncer:6543"
-            "/RELEASE-NAME-result-backend?sslmode=allow" == connection
+        self._assert_for_old_version(
+            version,
+            value=connection,
+            expected_value="db+postgresql://someuser:somepass@RELEASE-NAME-pgbouncer"
+            ":6543/RELEASE-NAME-result-backend?sslmode=allow",
         )
 
-    def test_should_set_pgbouncer_overrides_when_enabled(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_should_set_pgbouncer_overrides_when_enabled(self, version):
         values = {"pgbouncer": {"enabled": True}}
-        connection = self._get_connection(values)
+        connection = self._get_connection(self._get_values_with_version(values=values, version=version))
 
         # host, port, dbname get overridden
-        assert (
-            "db+postgresql://postgres:postgres@RELEASE-NAME-pgbouncer:6543"
-            "/RELEASE-NAME-result-backend?sslmode=disable" == connection
+        self._assert_for_old_version(
+            version,
+            value=connection,
+            expected_value="db+postgresql://postgres:postgres@RELEASE-NAME-pgbouncer"
+            ":6543/RELEASE-NAME-result-backend?sslmode=disable",
         )
 
     def test_should_set_pgbouncer_overrides_with_non_chart_database_when_enabled(self):
@@ -111,13 +143,17 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             "/RELEASE-NAME-result-backend?sslmode=allow" == connection
         )
 
-    def test_should_default_to_custom_metadata_db_connection(self):
+    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    def test_should_default_to_custom_metadata_db_connection_in_old_version(self, version):
         values = {
             "data": {"metadataConnection": {**self.non_chart_database_values}},
         }
-        connection = self._get_connection(values)
-
-        assert "db+postgresql://someuser:somepass@somehost:7777/somedb?sslmode=allow" == connection
+        connection = self._get_connection(self._get_values_with_version(values=values, version=version))
+        self._assert_for_old_version(
+            version,
+            value=connection,
+            expected_value="db+postgresql://someuser:somepass@somehost:7777/somedb?sslmode=allow",
+        )
 
     def test_should_correctly_use_non_chart_database(self):
         values = {"data": {"resultBackendConnection": {**self.non_chart_database_values}}}

--- a/tests/charts/test_result_backend_connection_secret.py
+++ b/tests/charts/test_result_backend_connection_secret.py
@@ -91,7 +91,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
         encoded_connection = jmespath.search("data.connection", docs[0])
         return base64.b64decode(encoded_connection).decode()
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_default_connection_old_version(self, version):
         connection = self._get_connection(self._get_values_with_version(version=version, values={}))
         self._assert_for_old_version(
@@ -101,7 +101,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             "-postgresql:5432/postgres?sslmode=disable",
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_should_default_to_custom_metadata_db_connection_with_pgbouncer_overrides(self, version):
         values = {
             "pgbouncer": {"enabled": True},
@@ -117,7 +117,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             ":6543/RELEASE-NAME-result-backend?sslmode=allow",
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_should_set_pgbouncer_overrides_when_enabled(self, version):
         values = {"pgbouncer": {"enabled": True}}
         connection = self._get_connection(self._get_values_with_version(values=values, version=version))
@@ -143,7 +143,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             "/RELEASE-NAME-result-backend?sslmode=allow" == connection
         )
 
-    @parameterized.expand(["2.3.2", "2.3.3", "default"])
+    @parameterized.expand(["2.3.2", "2.4.0", "default"])
     def test_should_default_to_custom_metadata_db_connection_in_old_version(self, version):
         values = {
             "data": {"metadataConnection": {**self.non_chart_database_values}},


### PR DESCRIPTION
This PR adds possibility to use the same connection for celery result_backend and metadata by automatically adding `db+` for result_backend connection.

closes #18283

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).


@wip ready for review