### PR TITLE
Add cache_ok flag to sqlalchemy TypeDecorators.

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -60,6 +60,8 @@ class UtcDateTime(TypeDecorator):
 
     impl = TIMESTAMP(timezone=True)
 
+    cache_ok = True
+
     def process_bind_param(self, value, dialect):
         if value is not None:
             if not isinstance(value, datetime.datetime):
@@ -109,6 +111,8 @@ class ExtendedJSON(TypeDecorator):
     """
 
     impl = Text
+
+    cache_ok = True
 
     def db_supports_json(self):
         """Checks if the database supports JSON (i.e. is NOT MSSQL)"""
@@ -211,6 +215,8 @@ class Interval(TypeDecorator):
     """Base class representing a time interval."""
 
     impl = Text
+
+    cache_ok = True
 
     attr_keys = {
         datetime.timedelta: ('days', 'seconds', 'microseconds'),


### PR DESCRIPTION
This fixes #22647, which was marked closed due to lack of activity / feedback.

SQLAlchemy added [the `cache_ok` flag](https://docs.sqlalchemy.org/en/14/core/custom_types.html#sqlalchemy.types.TypeDecorator.cache_ok) in 1.4.14. If this is unset in a `TypeDecorator` subclass, it emits a log warning when the class is used. The fix is to set the value to `True` or `False` to suppress the warning.

I've set the value to `True` for the three `TypeDecorator` classes in the `airflow.utils.sqlalchemy` module, as these classes have no state and are safe to cache. Setting it to `False` would also suppress the warning, and leave behavior unchanged.
