### PR TITLE
Fix deprecated log_id_template value

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -256,7 +256,7 @@ class AirflowConfigParser(ConfigParser):
         },
         'elasticsearch': {
             'log_id_template': (
-                re.compile('^' + re.escape('{dag_id}-{task_id}-{run_id}-{try_number}') + '$'),
+                re.compile('^' + re.escape('{dag_id}-{task_id}-{execution_date}-{try_number}') + '$'),
                 '{dag_id}-{task_id}-{run_id}-{map_index}-{try_number}',
                 '3.0',
             )


### PR DESCRIPTION
We had the wrong old default in our deprecated value upgrading logic, so
2.2.5 default wasn't actually being upgraded.


