### PR TITLE
Convert sftp hook to use paramiko instead of pysftp

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -305,7 +305,7 @@ class SFTPHook(SSHHook):
     ) -> None:
         """
         Recursively descend, depth first, the directory tree rooted at
-        remotepath, calling discreet callback functions for each regular file,
+        path, calling discreet callback functions for each regular file,
         directory and unknown file type.
 
         :param str path:

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -49,11 +49,8 @@ class SFTPHook(SSHHook):
     Errors that may occur throughout but should be handled downstream.
 
     For consistency reasons with SSHHook, the preferred parameter is "ssh_conn_id".
-    Please note that it is still possible to use the parameter "ftp_conn_id"
-    to initialize the hook, but it will be removed in future Airflow versions.
 
     :param ssh_conn_id: The :ref:`sftp connection id<howto/connection:sftp>`
-    :param ftp_conn_id (Outdated): The :ref:`sftp connection id<howto/connection:sftp>`
     :param ssh_hook: Optional SSH hook (included to support passing of an SSH hook to the SFTP operator)
     """
 
@@ -79,9 +76,16 @@ class SFTPHook(SSHHook):
         **kwargs,
     ) -> None:
         self.conn: Optional[paramiko.SFTPClient] = None
+
+        # TODO: remove support for ssh_hook when it is removed from SFTPOperator
         self.ssh_hook = ssh_hook
 
         if self.ssh_hook is not None:
+            warnings.warn(
+                'Parameter `ssh_hook` is deprecated and will be removed in a future version.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
             if not isinstance(self.ssh_hook, SSHHook):
                 raise AirflowException(
                     f'ssh_hook must be an instance of SSHHook, but got {type(self.ssh_hook)}'
@@ -111,6 +115,7 @@ class SFTPHook(SSHHook):
         :rtype: paramiko.SFTPClient
         """
         if self.conn is None:
+            # TODO: remove support for ssh_hook when it is removed from SFTPOperator
             if self.ssh_hook is not None:
                 self.conn = self.ssh_hook.get_conn().open_sftp()
             else:

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -17,15 +17,15 @@
 # under the License.
 """This module contains SFTP hook."""
 import datetime
+import os
 import stat
 import warnings
 from fnmatch import fnmatch
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-import pysftp
-import tenacity
-from paramiko import SSHException
+import paramiko
 
+from airflow.exceptions import AirflowException
 from airflow.providers.ssh.hooks.ssh import SSHHook
 
 
@@ -54,6 +54,7 @@ class SFTPHook(SSHHook):
 
     :param ssh_conn_id: The :ref:`sftp connection id<howto/connection:sftp>`
     :param ftp_conn_id (Outdated): The :ref:`sftp connection id<howto/connection:sftp>`
+    :param ssh_hook: Optional SSH hook (included to support passing of an SSH hook to the SFTP operator)
     """
 
     conn_name_attr = 'ssh_conn_id'
@@ -73,9 +74,21 @@ class SFTPHook(SSHHook):
     def __init__(
         self,
         ssh_conn_id: Optional[str] = 'sftp_default',
+        ssh_hook: Optional[SSHHook] = None,
         *args,
         **kwargs,
     ) -> None:
+        self.conn: Optional[paramiko.SFTPClient] = None
+        self.ssh_hook = ssh_hook
+
+        if self.ssh_hook is not None:
+            if not isinstance(self.ssh_hook, SSHHook):
+                raise AirflowException(
+                    f'ssh_hook must be an instance of SSHHook, but got {type(self.ssh_hook)}'
+                )
+            self.log.info('ssh_hook is provided. It will be used to generate SFTP connection.')
+            return
+
         ftp_conn_id = kwargs.pop('ftp_conn_id', None)
         if ftp_conn_id:
             warnings.warn(
@@ -84,99 +97,30 @@ class SFTPHook(SSHHook):
                 stacklevel=2,
             )
             ssh_conn_id = ftp_conn_id
-        kwargs['ssh_conn_id'] = ssh_conn_id
 
-        # Default to fail for unverified hosts, unless this is explicitly allowed
-        # SSHHook init will override this if it is set
-        self.no_host_key_check = False
-
+        self.ssh_conn_id = ssh_conn_id
         super().__init__(*args, **kwargs)
 
-        self.conn = None
-        self.private_key_passphrase = None
+    def get_conn(self) -> paramiko.SFTPClient:  # type: ignore[override]
+        """
+        Opens an SFTP connection to the remote host
 
-        # For backward compatibility
-        # TODO: remove in the next major provider release.
-        if self.ssh_conn_id is not None:
-            conn = self.get_connection(self.ssh_conn_id)
-            if conn.extra is not None:
-                extra_options = conn.extra_dejson
-
-                if 'private_key_pass' in extra_options:
-                    warnings.warn(
-                        'Extra option `private_key_pass` is deprecated.'
-                        'Please use `private_key_passphrase` instead.'
-                        '`private_key_passphrase` will precede if both options are specified.'
-                        'The old option `private_key_pass` will be removed in a future release.',
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                self.private_key_passphrase = extra_options.get(
-                    'private_key_passphrase', extra_options.get('private_key_pass')
-                )
-                private_key = extra_options.get('private_key')
-                if private_key:
-                    self.pkey = self._pkey_from_private_key(
-                        private_key, passphrase=self.private_key_passphrase
-                    )
-
-                if 'ignore_hostkey_verification' in extra_options:
-                    warnings.warn(
-                        'Extra option `ignore_hostkey_verification` is deprecated.'
-                        'Please use `no_host_key_check` instead.'
-                        'This option will be removed in a future release.',
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                    self.no_host_key_check = (
-                        str(extra_options['ignore_hostkey_verification']).lower() == 'true'
-                    )
-
-    @tenacity.retry(
-        stop=tenacity.stop_after_delay(10),
-        wait=tenacity.wait_exponential(multiplier=1, max=10),
-        retry=tenacity.retry_if_exception_type(SSHException),
-        reraise=True,
-    )
-    def get_conn(self) -> pysftp.Connection:
-        """Returns an SFTP connection object"""
+        :rtype: paramiko.SFTPClient
+        """
         if self.conn is None:
-            cnopts = pysftp.CnOpts()
-            if self.no_host_key_check:
-                cnopts.hostkeys = None
+            if self.ssh_hook is not None:
+                self.conn = self.ssh_hook.get_conn().open_sftp()
             else:
-                if self.host_key is not None:
-                    cnopts.hostkeys.add(self.remote_host, self.host_key.get_name(), self.host_key)
-                else:
-                    pass  # will fallback to system host keys if none explicitly specified in conn extra
-
-            cnopts.compression = self.compress
-            cnopts.ciphers = self.ciphers
-            conn_params = {
-                'host': self.remote_host,
-                'port': self.port,
-                'username': self.username,
-                'cnopts': cnopts,
-            }
-            if self.password and self.password.strip():
-                conn_params['password'] = self.password
-            if self.pkey:
-                conn_params['private_key'] = self.pkey
-            elif self.key_file:
-                conn_params['private_key'] = self.key_file
-            if self.private_key_passphrase:
-                conn_params['private_key_pass'] = self.private_key_passphrase
-
-            self.conn = pysftp.Connection(**conn_params)
+                self.conn = super().get_conn().open_sftp()
         return self.conn
 
     def close_conn(self) -> None:
-        """Closes the connection"""
+        """Closes the SFTP connection"""
         if self.conn is not None:
             self.conn.close()
             self.conn = None
 
-    def describe_directory(self, path: str) -> Dict[str, Dict[str, str]]:
+    def describe_directory(self, path: str) -> Dict[str, Dict[str, Union[str, int, None]]]:
         """
         Returns a dictionary of {filename: {attributes}} for all files
         on the remote system (where the MLSD command is supported).
@@ -184,13 +128,13 @@ class SFTPHook(SSHHook):
         :param path: full path to the remote directory
         """
         conn = self.get_conn()
-        flist = conn.listdir_attr(path)
+        flist = sorted(conn.listdir_attr(path), key=lambda x: x.filename)
         files = {}
         for f in flist:
-            modify = datetime.datetime.fromtimestamp(f.st_mtime).strftime('%Y%m%d%H%M%S')
+            modify = datetime.datetime.fromtimestamp(f.st_mtime).strftime('%Y%m%d%H%M%S')  # type: ignore
             files[f.filename] = {
                 'size': f.st_size,
-                'type': 'dir' if stat.S_ISDIR(f.st_mode) else 'file',
+                'type': 'dir' if stat.S_ISDIR(f.st_mode) else 'file',  # type: ignore
                 'modify': modify,
             }
         return files
@@ -205,6 +149,42 @@ class SFTPHook(SSHHook):
         files = conn.listdir(path)
         return files
 
+    def mkdir(self, path: str, mode: int = 777) -> None:
+        """
+        Creates a directory on the remote system.
+
+        :param path: full path to the remote directory to create
+        :param mode: permissions to set the directory with
+        """
+        conn = self.get_conn()
+        conn.mkdir(path, mode=int(str(mode), 8))
+
+    def isdir(self, path: str) -> bool:
+        """
+        Checks if the path provided is a directory or not.
+
+        :param path: full path to the remote directory to check
+        """
+        conn = self.get_conn()
+        try:
+            result = stat.S_ISDIR(conn.stat(path).st_mode)  # type: ignore
+        except OSError:
+            result = False
+        return result
+
+    def isfile(self, path: str) -> bool:
+        """
+        Checks if the path provided is a file or not.
+
+        :param path: full path to the remote file to check
+        """
+        conn = self.get_conn()
+        try:
+            result = stat.S_ISREG(conn.stat(path).st_mode)  # type: ignore
+        except OSError:
+            result = False
+        return result
+
     def create_directory(self, path: str, mode: int = 777) -> None:
         """
         Creates a directory on the remote system.
@@ -213,7 +193,18 @@ class SFTPHook(SSHHook):
         :param mode: int representation of octal mode for directory
         """
         conn = self.get_conn()
-        conn.makedirs(path, mode)
+        if self.isdir(path):
+            self.log.info(f"{path} already exists")
+            return
+        elif self.isfile(path):
+            raise AirflowException(f"{path} already exists and is a file")
+        else:
+            dirname, basename = os.path.split(path)
+            if dirname and not self.isdir(dirname):
+                self.create_directory(dirname, mode)
+            if basename:
+                self.log.info(f"Creating {path}")
+                conn.mkdir(path, mode=mode)
 
     def delete_directory(self, path: str) -> None:
         """
@@ -265,7 +256,7 @@ class SFTPHook(SSHHook):
         """
         conn = self.get_conn()
         ftp_mdtm = conn.stat(path).st_mtime
-        return datetime.datetime.fromtimestamp(ftp_mdtm).strftime('%Y%m%d%H%M%S')
+        return datetime.datetime.fromtimestamp(ftp_mdtm).strftime('%Y%m%d%H%M%S')  # type: ignore
 
     def path_exists(self, path: str) -> bool:
         """
@@ -274,7 +265,11 @@ class SFTPHook(SSHHook):
         :param path: full path to the remote file or directory
         """
         conn = self.get_conn()
-        return conn.exists(path)
+        try:
+            conn.stat(path)
+        except OSError:
+            return False
+        return True
 
     @staticmethod
     def _is_path_match(path: str, prefix: Optional[str] = None, delimiter: Optional[str] = None) -> bool:
@@ -292,6 +287,51 @@ class SFTPHook(SSHHook):
             return False
         return True
 
+    def walktree(
+        self,
+        path: str,
+        fcallback: Callable[[str], Optional[Any]],
+        dcallback: Callable[[str], Optional[Any]],
+        ucallback: Callable[[str], Optional[Any]],
+        recurse: bool = True,
+    ) -> None:
+        """
+        Recursively descend, depth first, the directory tree rooted at
+        remotepath, calling discreet callback functions for each regular file,
+        directory and unknown file type.
+
+        :param str path:
+            root of remote directory to descend, use '.' to start at
+            :attr:`.pwd`
+        :param callable fcallback:
+            callback function to invoke for a regular file.
+            (form: ``func(str)``)
+        :param callable dcallback:
+            callback function to invoke for a directory. (form: ``func(str)``)
+        :param callable ucallback:
+            callback function to invoke for an unknown file type.
+            (form: ``func(str)``)
+        :param bool recurse: *Default: True* - should it recurse
+
+        :returns: None
+        """
+        conn = self.get_conn()
+        for entry in self.list_directory(path):
+            pathname = os.path.join(path, entry)
+            mode = conn.stat(pathname).st_mode
+            if stat.S_ISDIR(mode):  # type: ignore
+                # It's a directory, call the dcallback function
+                dcallback(pathname)
+                if recurse:
+                    # now, recurse into it
+                    self.walktree(pathname, fcallback, dcallback, ucallback)
+            elif stat.S_ISREG(mode):  # type: ignore
+                # It's a file, call the fcallback function
+                fcallback(pathname)
+            else:
+                # Unknown file type
+                ucallback(pathname)
+
     def get_tree_map(
         self, path: str, prefix: Optional[str] = None, delimiter: Optional[str] = None
     ) -> Tuple[List[str], List[str], List[str]]:
@@ -305,14 +345,15 @@ class SFTPHook(SSHHook):
         :return: tuple with list of files, dirs and unknown items
         :rtype: Tuple[List[str], List[str], List[str]]
         """
-        conn = self.get_conn()
-        files, dirs, unknowns = [], [], []  # type: List[str], List[str], List[str]
+        files: List[str] = []
+        dirs: List[str] = []
+        unknowns: List[str] = []
 
-        def append_matching_path_callback(list_):
+        def append_matching_path_callback(list_: List[str]) -> Callable:
             return lambda item: list_.append(item) if self._is_path_match(item, prefix, delimiter) else None
 
-        conn.walktree(
-            remotepath=path,
+        self.walktree(
+            path=path,
             fcallback=append_matching_path_callback(files),
             dcallback=append_matching_path_callback(dirs),
             ucallback=append_matching_path_callback(unknowns),
@@ -325,7 +366,7 @@ class SFTPHook(SSHHook):
         """Test the SFTP connection by calling path with directory"""
         try:
             conn = self.get_conn()
-            conn.pwd
+            conn.normalize('.')
             return True, "Connection successfully tested"
         except Exception as e:
             return False, str(e)

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -22,7 +22,7 @@ import warnings
 from base64 import decodebytes
 from io import StringIO
 from select import select
-from typing import Any, Dict, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import paramiko
 from paramiko.config import SSH_PORT
@@ -71,6 +71,7 @@ class SSHHook(BaseHook):
     :param disabled_algorithms: dictionary mapping algorithm type to an
         iterable of algorithm identifiers, which will be disabled for the
         lifetime of the transport
+    :param ciphers: list of ciphers to use in order of preference
     """
 
     # List of classes to try loading private keys as, ordered (roughly) by most common to least common
@@ -116,6 +117,7 @@ class SSHHook(BaseHook):
         keepalive_interval: int = 30,
         banner_timeout: float = 30.0,
         disabled_algorithms: Optional[dict] = None,
+        ciphers: Optional[List[str]] = None,
     ) -> None:
         super().__init__()
         self.ssh_conn_id = ssh_conn_id
@@ -130,6 +132,7 @@ class SSHHook(BaseHook):
         self.keepalive_interval = keepalive_interval
         self.banner_timeout = banner_timeout
         self.disabled_algorithms = disabled_algorithms
+        self.ciphers = ciphers
         self.host_proxy_cmd = None
 
         # Default values, overridable from Connection
@@ -204,6 +207,9 @@ class SSHHook(BaseHook):
 
                 if "disabled_algorithms" in extra_options:
                     self.disabled_algorithms = extra_options.get("disabled_algorithms")
+
+                if "ciphers" in extra_options:
+                    self.ciphers = extra_options.get("ciphers")
 
                 if host_key is not None:
                     if host_key.startswith("ssh-"):
@@ -341,6 +347,11 @@ class SSHHook(BaseHook):
             # MyPy check ignored because "paramiko" isn't well-typed. The `client.get_transport()` returns
             # type "Optional[Transport]" and item "None" has no attribute "set_keepalive".
             client.get_transport().set_keepalive(self.keepalive_interval)  # type: ignore[union-attr]
+
+        if self.ciphers:
+            # MyPy check ignored because "paramiko" isn't well-typed. The `client.get_transport()` returns
+            # type "Optional[Transport]" and item "None" has no method `get_security_options`".
+            client.get_transport().get_security_options().ciphers = self.ciphers  # type: ignore[union-attr]
 
         self.client = client
         return client

--- a/docker_tests/test_prod_image.py
+++ b/docker_tests/test_prod_image.py
@@ -157,7 +157,7 @@ class TestPythonPackages:
         "pyodbc": ["pyodbc"],
         "redis": ["redis"],
         "sendgrid": ["sendgrid"],
-        "sftp/ssh": ["paramiko", "pysftp", "sshtunnel"],
+        "sftp/ssh": ["paramiko", "sshtunnel"],
         "slack": ["slack_sdk"],
         "statsd": ["statsd"],
         "virtualenv": ["virtualenv"],

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -29,10 +29,8 @@ Authenticating to SFTP
 
 There are two ways to connect to SFTP using Airflow.
 
-1. Use `host key
-   <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.CnOpts>`_
-   i.e. host key entered in extras value ``host_key``.
-2. Use ``private_key`` or ``key_file``, along with the optional ``private_key_pass``
+1. Use ``login`` and ``password``.
+2. Use ``private_key`` or ``key_file``, along with the optional ``private_key_passphrase``
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.
@@ -61,17 +59,18 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in sftp connection.
     The following parameters are all optional:
 
-    * ``private_key_pass``: Specify the password to use, if private_key is encrypted.
-    * ``no_host_key_check``: Set to false to restrict connecting to hosts with either no entries in ~/.ssh/known_hosts
-      (Hosts file) or not present in the host_key extra. This provides maximum protection against trojan horse attacks,
-      but can be troublesome when the /etc/ssh/ssh_known_hosts file is poorly maintained or connections to new hosts are
-      frequently made. This option forces the user to manually add all new hosts. Default is true, ssh will automatically
-      add new host keys to the user known hosts files.
-    * ``host_key``: The base64 encoded ssh-rsa public key of the host, as you would find in the known_hosts file.
-      Specifying this, along with no_host_key_check=False allows you to only make the connection if the public key of
-      the endpoint matches this value.
-    * ``private_key`` Specify the content of the private key, the path to the private key file(str) or paramiko.AgentKey
     * ``key_file`` - Full Path of the private SSH Key file that will be used to connect to the remote_host.
+    * ``private_key`` - Content of the private key used to connect to the remote_host.
+    * ``private_key_passphrase`` - Content of the private key passphrase used to decrypt the private key.
+    * ``conn_timeout`` - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
+    * ``timeout`` - Deprecated - use conn_timeout instead.
+    * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
+    * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
+    * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This won't protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
+    * ``look_for_keys`` - Set to ``false`` if you want to disable searching for discoverable private key files in ``~/.ssh/``
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host or "ssh-<key type> <key data>" (as you would find in the ``known_hosts`` file). Specifying this allows making the connection if and only if the public key of the endpoint matches this value.
+    * ``disabled_algorithms`` - A dictionary mapping algorithm type to an iterable of algorithm identifiers, which will be disabled for the lifetime of the transport.
+    * ``ciphers`` - A list of ciphers to use in order of preference.
 
 Example “extras” field using ``host_key``:
 

--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -55,6 +55,7 @@ Extra (optional)
     * ``look_for_keys`` - Set to ``false`` if you want to disable searching for discoverable private key files in ``~/.ssh/``
     * ``host_key`` - The base64 encoded ssh-rsa public key of the host or "ssh-<key type> <key data>" (as you would find in the ``known_hosts`` file). Specifying this allows making the connection if and only if the public key of the endpoint matches this value.
     * ``disabled_algorithms`` - A dictionary mapping algorithm type to an iterable of algorithm identifiers, which will be disabled for the lifetime of the transport.
+    * ``ciphers`` - A list of ciphers to use in order of preference.
 
     Example "extras" field:
 
@@ -66,8 +67,9 @@ Extra (optional)
           "compress": "false",
           "look_for_keys": "false",
           "allow_host_key_change": "false",
-          "host_key": "AAAHD...YDWwq=="
-          "disabled_algorithms": {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]}
+          "host_key": "AAAHD...YDWwq==",
+          "disabled_algorithms": {"pubkeys": ["rsa-sha2-256", "rsa-sha2-512"]},
+          "ciphers": ["aes128-ctr", "aes192-ctr", "aes256-ctr"]
        }
 
     When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -346,6 +346,7 @@ ResourceRequirements
 Roadmap
 Robinhood
 RoleBinding
+SFTPClient
 SIGTERM
 SSHClient
 SSHTunnelForwarder
@@ -1250,6 +1251,7 @@ readme
 readthedocs
 realtime
 rebase
+recurse
 recurses
 redbubble
 redis

--- a/setup.py
+++ b/setup.py
@@ -537,7 +537,6 @@ spark = [
 ]
 ssh = [
     'paramiko>=2.6.0',
-    'pysftp>=0.2.9',
     'sshtunnel>=0.3.2',
 ]
 statsd = [
@@ -640,7 +639,6 @@ devel_only = [
     'pre-commit',
     'pypsrp',
     'pygithub',
-    'pysftp',
     # Pytest 7 has been released in February 2022 and we should attempt to upgrade and remove the limit
     # It contains a number of potential breaking changes but none of them looks breaking our use
     # https://docs.pytest.org/en/latest/changelog.html#pytest-7-0-0-2022-02-03

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -23,7 +23,6 @@ from io import StringIO
 from unittest import mock
 
 import paramiko
-import pysftp
 from parameterized import parameterized
 
 from airflow.models import Connection
@@ -79,7 +78,7 @@ class TestSFTPHook(unittest.TestCase):
 
     def test_get_conn(self):
         output = self.hook.get_conn()
-        assert isinstance(output, pysftp.Connection)
+        assert isinstance(output, paramiko.SFTPClient)
 
     def test_close_conn(self):
         self.hook.conn = self.hook.get_conn()

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -321,7 +321,9 @@ class TestSFTPOperator:
     def test_arg_checking(self):
         dag = DAG(dag_id="unit_tests_sftp_op_arg_checking", default_args={"start_date": DEFAULT_DATE})
         # Exception should be raised if neither ssh_hook nor ssh_conn_id is provided
-        with pytest.raises(AirflowException, match="Cannot operate without ssh_hook or ssh_conn_id."):
+        with pytest.raises(
+            AirflowException, match="Cannot operate without sftp_hook or sftp_conn_id/ssh_conn_id."
+        ):
             task_0 = SFTPOperator(
                 task_id="test_sftp_0",
                 local_filepath=self.test_local_filepath,
@@ -345,7 +347,7 @@ class TestSFTPOperator:
             task_1.execute(None)
         except Exception:
             pass
-        assert task_1.ssh_hook.ssh_conn_id == TEST_CONN_ID
+        assert task_1.sftp_hook.ssh_conn_id == TEST_CONN_ID
 
         task_2 = SFTPOperator(
             task_id="test_sftp_2",
@@ -359,7 +361,7 @@ class TestSFTPOperator:
             task_2.execute(None)
         except Exception:
             pass
-        assert task_2.ssh_hook.ssh_conn_id == TEST_CONN_ID
+        assert task_2.sftp_hook.ssh_conn_id == TEST_CONN_ID
 
         # if both valid ssh_hook and ssh_conn_id are provided, ignore ssh_conn_id
         task_3 = SFTPOperator(
@@ -375,4 +377,4 @@ class TestSFTPOperator:
             task_3.execute(None)
         except Exception:
             pass
-        assert task_3.ssh_hook.ssh_conn_id == self.hook.ssh_conn_id
+        assert task_3.sftp_hook.ssh_conn_id == self.hook.ssh_conn_id

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -322,9 +322,7 @@ class TestSFTPOperator:
     def test_arg_checking(self):
         dag = DAG(dag_id="unit_tests_sftp_op_arg_checking", default_args={"start_date": DEFAULT_DATE})
         # Exception should be raised if neither ssh_hook nor ssh_conn_id is provided
-        with pytest.raises(
-            AirflowException, match="Cannot operate without sftp_hook or sftp_conn_id/ssh_conn_id."
-        ):
+        with pytest.raises(AirflowException, match="Cannot operate without sftp_hook or ssh_conn_id."):
             task_0 = SFTPOperator(
                 task_id="test_sftp_0",
                 local_filepath=self.test_local_filepath,
@@ -337,7 +335,7 @@ class TestSFTPOperator:
         # if ssh_hook is invalid/not provided, use ssh_conn_id to create SSHHook
         task_1 = SFTPOperator(
             task_id="test_sftp_1",
-            ssh_hook="string_rather_than_SSHHook",  # invalid ssh_hook
+            ssh_hook="string_rather_than_SSHHook",  # type: ignore
             ssh_conn_id=TEST_CONN_ID,
             local_filepath=self.test_local_filepath,
             remote_filepath=self.test_remote_filepath,
@@ -391,28 +389,13 @@ class TestSFTPOperator:
             )
             task_4.execute(None)
 
-        # Exception should be raised if both ssh_conn_id and sftp_conn_id are provided
-        with pytest.raises(
-            AirflowException, match="Parameters `ssh_conn_id` and `sftp_conn_id` are both provided."
-        ):
-            task_5 = SFTPOperator(
-                task_id="test_sftp_5",
-                ssh_conn_id=TEST_CONN_ID,
-                sftp_conn_id=TEST_CONN_ID,
-                local_filepath=self.test_local_filepath,
-                remote_filepath=self.test_remote_filepath,
-                operation=SFTPOperation.PUT,
-                dag=dag,
-            )
-            task_5.execute(None)
-
         # Exception should be raised if both ssh_hook and sftp_hook are provided
         with pytest.raises(
             AirflowException,
             match="Both `ssh_hook` and `sftp_hook` are defined. Please use only one of them.",
         ):
-            task_6 = SFTPOperator(
-                task_id="test_sftp_6",
+            task_5 = SFTPOperator(
+                task_id="test_sftp_5",
                 ssh_hook=self.hook,
                 sftp_hook=SFTPHook(),
                 local_filepath=self.test_local_filepath,
@@ -420,10 +403,10 @@ class TestSFTPOperator:
                 operation=SFTPOperation.PUT,
                 dag=dag,
             )
-            task_6.execute(None)
+            task_5.execute(None)
 
-        task_7 = SFTPOperator(
-            task_id="test_sftp_7",
+        task_6 = SFTPOperator(
+            task_id="test_sftp_6",
             ssh_conn_id=TEST_CONN_ID,
             remote_host='remotehost',
             local_filepath=self.test_local_filepath,
@@ -432,7 +415,7 @@ class TestSFTPOperator:
             dag=dag,
         )
         try:
-            task_7.execute(None)
+            task_6.execute(None)
         except Exception:
             pass
-        assert task_7.sftp_hook.remote_host == 'remotehost'
+        assert task_6.sftp_hook.remote_host == 'remotehost'


### PR DESCRIPTION
This PR is a major change to the SFTP provider to remove the dependency on `pysftp` and use `paramiko` via the `SSHHook` instead. The provider was previously inconsistent in its use of `pysftp` vs the `SSHHook`. The `SFTPHook` used `pysftp` to actually create its connection and perform operations, but it inherited from `SSHHook`. The `SFTPOperator` did not use the `SFTPHook` or `pysftp` and instead used the `SSHHook` to create its connection and use the SFTP operations provided by `paramiko`. This PR rewrites the provider so the `SFTPHook` uses the `SSHHook` and `paramiko` (via `SSHHook`) and the `SFTPOperator` uses the `SFTPHook`. This enables support for all of the parameters supported by the `SSHHook` and creates consistency within the SFTP provider. There should be no breaking changes aside from the removal of previously deprecated parameters in the `SFTPHook` since `pysftp` used `paramiko` under the hood anyway.

A number of changes are contained in this PR:

- Minor change to the SSH provider to support `ciphers` as an optional extra parameter, which is used by the `SFTPHook`
- Deprecated parameters in the SFTP provider were completely removed since this is a major change to the provider (seemed appropriate, but let me know if that should not have been done yet)
- Any functionality provided by `pysftp` that was used by the `SFTPHook` has been incorporated directly into the provider
- `SFTPHook` supports passing an `SSHHook` to continue supporting that option in the `SFTPOperator`; however, this is marked as deprecated and should be removed in a future major version.  `SFTPOperator` warns users to pass an `SFTPHook` instead now.
- `_make_intermediate_dirs` was removed from `SFTPOperator` since the `create_directory` method on `SFTPHook` supports creating parent directories of subdirectories (functionally equivalent)
- typing was added to `SFTPOperator`

Tests have been written to achieve 100% code coverage and all tests are passing. Previously existing tests were only modified where required to ensure backward compatibility with the provider's original functionality. Please double-check my tests though as I'm not confident in my test writing abilities yet. Docs have been updated as well.

I will note there was brief discussion with @malthe on Slack to consider using `parallel-ssh` instead but I opted to hold off on that for now. That could be a good future update since some have reported issues with `paramiko` (for example, #16286).