### PR TITLE
Update flask-appbuilder authlib/oauth dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -309,8 +309,8 @@ exasol = ['pyexasol>=0.5.1', pandas_requirement]
 facebook = [
     'facebook-business>=6.0.2',
 ]
-flask_appbuilder_authlib = [
-    'authlib',
+flask_appbuilder_oauth = [
+    'flask-appbuilder[oauth]',
 ]
 github = [
     'pygithub',
@@ -767,8 +767,8 @@ CORE_EXTRAS_REQUIREMENTS: Dict[str, List[str]] = {
     'cncf.kubernetes': kubernetes,  # also has provider, but it extends the core with the KubernetesExecutor
     'dask': dask,
     'deprecated_api': deprecated_api,
-    'github_enterprise': flask_appbuilder_authlib,
-    'google_auth': flask_appbuilder_authlib,
+    'github_enterprise': flask_appbuilder_oauth,
+    'google_auth': flask_appbuilder_oauth,
     'kerberos': kerberos,
     'ldap': ldap,
     'leveldb': leveldb,


### PR DESCRIPTION
The dependency we have for flask-appbuilder oauth authentication
(for github/google authentication) should follow the limits
that flask-appbuilder current version has. We added authlib there
but apparently FAB currently limits authlib to <= 1.0 - we should
follow fab rather than have our own dependency here.

This has been pointed out in
https://github.com/dpgaspar/Flask-AppBuilder/issues/1861

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
