### PR TITLE
Make extra_args in S3Hook immutable between calls

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -23,6 +23,7 @@ import gzip as gz
 import io
 import re
 import shutil
+from copy import deepcopy
 from datetime import datetime
 from functools import wraps
 from inspect import signature
@@ -97,6 +98,15 @@ class S3Hook(AwsBaseHook):
     """
     Interact with AWS S3, using the boto3 library.
 
+    :param transfer_config_args: Configuration object for managed S3 transfers.
+    :param extra_args: Extra arguments that may be passed to the download/upload operations.
+
+    .. seealso::
+        https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#s3-transfers
+
+        - For allowed upload extra arguments see ``boto3.s3.transfer.S3Transfer.ALLOWED_UPLOAD_ARGS``.
+        - For allowed download extra arguments see ``boto3.s3.transfer.S3Transfer.ALLOWED_DOWNLOAD_ARGS``.
+
     Additional arguments (such as ``aws_conn_id``) may be specified and
     are passed down to the underlying AwsBaseHook.
 
@@ -107,25 +117,31 @@ class S3Hook(AwsBaseHook):
     conn_type = 's3'
     hook_name = 'Amazon S3'
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self,
+        aws_conn_id: Optional[str] = AwsBaseHook.default_conn_name,
+        transfer_config_args: Optional[Dict] = None,
+        extra_args: Optional[Dict] = None,
+        *args,
+        **kwargs,
+    ) -> None:
         kwargs['client_type'] = 's3'
+        kwargs['aws_conn_id'] = aws_conn_id
 
-        self.extra_args = {}
-        if 'extra_args' in kwargs:
-            self.extra_args = kwargs['extra_args']
-            if not isinstance(self.extra_args, dict):
-                raise ValueError(f"extra_args '{self.extra_args!r}' must be of type {dict}")
-            del kwargs['extra_args']
+        if extra_args and not isinstance(extra_args, dict):
+            raise ValueError(f"transfer_config_args '{extra_args!r}' must be of type {dict}")
+        self.transfer_config = TransferConfig(**transfer_config_args or {})
 
-        self.transfer_config = TransferConfig()
-        if 'transfer_config_args' in kwargs:
-            transport_config_args = kwargs['transfer_config_args']
-            if not isinstance(transport_config_args, dict):
-                raise ValueError(f"transfer_config_args '{transport_config_args!r} must be of type {dict}")
-            self.transfer_config = TransferConfig(**transport_config_args)
-            del kwargs['transfer_config_args']
+        if extra_args and not isinstance(extra_args, dict):
+            raise ValueError(f"extra_args '{extra_args!r}' must be of type {dict}")
+        self._extra_args = extra_args or {}
 
         super().__init__(*args, **kwargs)
+
+    @property
+    def extra_args(self):
+        """Return hook's extra arguments (immutable)."""
+        return deepcopy(self._extra_args)
 
     @staticmethod
     def parse_s3_url(s3url: str) -> Tuple[str, str]:
@@ -867,7 +883,11 @@ class S3Hook(AwsBaseHook):
                 raise e
 
         with NamedTemporaryFile(dir=local_path, prefix='airflow_tmp_', delete=False) as local_tmp_file:
-            s3_obj.download_fileobj(local_tmp_file)
+            s3_obj.download_fileobj(
+                local_tmp_file,
+                ExtraArgs=self.extra_args,
+                Config=self.transfer_config,
+            )
 
         return local_tmp_file.name
 


### PR DESCRIPTION
At that moment in S3Hooks methods: `load_file`, `load_string`, `load_bytes`, `load_file_obj` might change `extra_args` argument.

And if user call this methods multiple times in single operator with different arguments the result could be unexpected. 