### PR TITLE
Do not calculate grid root instances

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -391,6 +391,7 @@ def dag_to_grid(dag, dag_runs, session):
         if task_group.group_id is None:
             return {
                 'id': task_group.group_id,
+                'label': task_group.label,
                 'children': children,
                 'instances': [],
             }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -387,6 +387,14 @@ def dag_to_grid(dag, dag_runs, session):
                 'end_date': group_end_date,
             }
 
+        # We don't need to calculate summaries for the root
+        if task_group.group_id is None:
+            return {
+                'id': task_group.group_id,
+                'children': children,
+                'instances': [],
+            }
+
         group_summaries = [get_summary(dr, children) for dr in dag_runs]
 
         return {

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -116,7 +116,6 @@ def test_no_runs(admin_client, dag_without_runs):
             'id': None,
             'instances': [],
             'label': None,
-            'tooltip': '',
         },
     }
 
@@ -249,24 +248,8 @@ def test_one_run(admin_client, dag_with_runs: List[DagRun], session):
                 },
             ],
             'id': None,
-            'instances': [
-                {
-                    'end_date': None,
-                    'run_id': 'run_1',
-                    'start_date': None,
-                    'state': 'success',
-                    'task_id': None,
-                },
-                {
-                    'end_date': '2021-07-01T01:02:03+00:00',
-                    'run_id': 'run_2',
-                    'start_date': '2021-07-01T01:00:00+00:00',
-                    'state': 'running',
-                    'task_id': None,
-                },
-            ],
+            'instances': [],
             'label': None,
-            'tooltip': '',
         },
     }
 


### PR DESCRIPTION
We were calculating `instances` for the root of `grid_data` but we didn't use that information for anything. Instead we should detect when it is the root node and only return what is necessary

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
