### PR TITLE
Move LOAD_DEFAULT_CONNECTIONS env var to database config section in CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -803,7 +803,7 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
     cd "${AIRFLOW_SOURCES}"
 
     if [[ ${START_AIRFLOW:="false"} == "true" || ${START_AIRFLOW} == "True" ]]; then
-        export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
+        export AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
         export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
         # shellcheck source=scripts/in_container/bin/run_tmux
         exec run_tmux

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -211,7 +211,7 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
     cd "${AIRFLOW_SOURCES}"
 
     if [[ ${START_AIRFLOW:="false"} == "true" || ${START_AIRFLOW} == "True" ]]; then
-        export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
+        export AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
         export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
         # shellcheck source=scripts/in_container/bin/run_tmux
         exec run_tmux

--- a/scripts/in_container/airflow_ci.cfg
+++ b/scripts/in_container/airflow_ci.cfg
@@ -23,11 +23,13 @@ sql_alchemy_conn = # overridden by the startup scripts
 #sql_engine_collation_for_ids = overridden by the startup scripts
 unit_test_mode = True
 load_examples = True
-load_default_connections = True
 donot_pickle = False
 dags_are_paused_at_creation = False
 default_impersonation =
 fernet_key = af7CN0q6ag5U3g08IsPsw3K45U7Xa0axgVFhoh-3zB8=
+
+[database]
+load_default_connections = True
 
 [hive]
 default_hive_mapred_queue = airflow

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -129,7 +129,7 @@ function startairflow_if_requested() {
         echo
         echo "Starting Airflow"
         echo
-        export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
+        export AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
         export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
 
         . "$( dirname "${BASH_SOURCE[0]}" )/configure_environment.sh"


### PR DESCRIPTION
As of 2.3 the `load_default_connections` config was moved from "core" to a new "database" section. Currently when spinning up Airflow in Breeze a `DeprecationWarning` is displayed for this config:

```shell
Starting Airflow

DB: postgresql+psycopg2://postgres:***@postgres/airflow
[2022-06-18 03:05:09,528] {db.py:1471} INFO - Creating tables
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
INFO  [alembic.runtime.migration] Will assume transactional DDL.
/opt/airflow/airflow/configuration.py:526 DeprecationWarning: The load_default_connections option in [core] has been moved to the load_default_connections option in [database] - the old setting has been used, but please update your config.
Initialization done
```

Likely not all of the changes in this PR directly affect the `DeprecationWarning` thrown when using the `breeze start-airflow` command, but for the sake of due diligence, the remaining environment variables of `AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS` have been updated to `AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
