### PR TITLE
Add imports to deferring code samples

### DIFF
--- a/docs/apache-airflow/concepts/deferring.rst
+++ b/docs/apache-airflow/concepts/deferring.rst
@@ -82,6 +82,12 @@ You are free to set ``method_name`` to ``execute`` if you want your Operator to 
 
 Here's a basic example of how a sensor might trigger deferral::
 
+    from datetime import timedelta
+
+    from airflow.sensors.base import BaseSensorOperator
+    from airflow.triggers.temporal import TimeDeltaTrigger
+
+
     class WaitOneHourSensor(BaseSensorOperator):
         def execute(self, context):
             self.defer(trigger=TimeDeltaTrigger(timedelta(hours=1)), method_name="execute_complete")
@@ -120,6 +126,12 @@ There's also some design constraints to be aware of:
 
 
 Here's the structure of a basic Trigger::
+
+
+    import asyncio
+
+    from airflow.triggers.base import BaseTrigger, TriggerEvent
+    from airflow.utils import timezone
 
 
     class DateTimeTrigger(BaseTrigger):


### PR DESCRIPTION
Following [this Stack Overflow post](https://stackoverflow.com/questions/72674355/airflow-deferred-operator-example-where-are-basetrigger-and-triggerevent-from/72674723), I think it'd be good to have example code in the deferrable docs include imports so that the code is copy-pasteable without having to search for the correct import paths.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
