### PR TITLE
Add on_kill() to kill Trino query if Airflow task is killed

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -93,6 +93,7 @@ class TrinoHook(DbApiHook):
     default_conn_name = 'trino_default'
     conn_type = 'trino'
     hook_name = 'Trino'
+    query_id = ''
 
     def get_conn(self) -> Connection:
         """Returns a connection object"""
@@ -301,6 +302,7 @@ class TrinoHook(DbApiHook):
                 results = []
                 for sql_statement in sql:
                     self._run_command(cur, self._strip_sql(sql_statement), parameters)
+                    self.query_id = cur.stats["queryId"]
                     if handler is not None:
                         result = handler(cur)
                         results.append(result)

--- a/tests/system/providers/trino/example_trino.py
+++ b/tests/system/providers/trino/example_trino.py
@@ -45,7 +45,7 @@ with models.DAG(
     )
     trino_create_table = TrinoOperator(
         task_id="trino_create_table",
-        sql=f"""CREATE TABLE {SCHEMA}.{TABLE}(
+        sql=f"""CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE}(
         cityid bigint,
         cityname varchar
         )""",
@@ -60,9 +60,9 @@ with models.DAG(
 
     trino_multiple_queries = TrinoOperator(
         task_id="trino_multiple_queries",
-        sql=f"""CREATE TABLE {SCHEMA}.{TABLE1}(cityid bigint,cityname varchar);
+        sql=f"""CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE1}(cityid bigint,cityname varchar);
         INSERT INTO {SCHEMA}.{TABLE1} VALUES (2, 'San Jose');
-        CREATE TABLE {SCHEMA}.{TABLE2}(cityid bigint,cityname varchar);
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.{TABLE2}(cityid bigint,cityname varchar);
         INSERT INTO {SCHEMA}.{TABLE2} VALUES (3, 'San Diego');""",
         handler=list,
     )


### PR DESCRIPTION
This PR is a follow up to PR #24415. 
It adds on_kill method to the TrinoOperator to kill Trino query if Airflow task is killed

cc @kaxil @eladkal 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
