### PR TITLE
 feat: add an operator to run a transfer job

### DIFF
--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -215,6 +215,19 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
+    def run_transfer_job(self, job_name: str, body: dict) -> None:
+        """
+        Runs a transfer job in Google Storage Transfer Service.
+
+        :param job_name: (Required) Name of the transfer job to be run.
+        :param body: (Required) A request body, as described in
+            https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/run#request-body
+        """
+        self.get_conn().transferJobs().run(
+            jobName=job_name,
+            body=body,
+        ).execute(num_retries=self.num_retries)    
+
     def list_transfer_job(self, request_filter: Optional[dict] = None, **kwargs) -> List[dict]:
         """
         Lists long-running operations in Google Storage Transfer

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -215,18 +215,20 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
             .execute(num_retries=self.num_retries)
         )
 
-    def run_transfer_job(self, job_name: str, body: dict) -> None:
+    @GoogleBaseHook.fallback_to_default_project_id
+    def run_transfer_job(self, job_name: str, project_id: str) -> None:
         """
         Runs a transfer job in Google Storage Transfer Service.
 
         :param job_name: (Required) Name of the transfer job to be run.
-        :param body: (Required) A request body, as described in
-            https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/run#request-body
+        :param project_id: (Optional) the ID of the project that owns the Transfer
+            Job. If set to None or missing, the default project_id from the Google Cloud
+            connection is used.
         """
         self.get_conn().transferJobs().run(
             jobName=job_name,
-            body=body,
-        ).execute(num_retries=self.num_retries)    
+            body={PROJECT_ID: project_id},
+        ).execute(num_retries=self.num_retries)
 
     def list_transfer_job(self, request_filter: Optional[dict] = None, **kwargs) -> List[dict]:
         """

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -348,10 +348,11 @@ class CloudDataTransferServiceRunJobOperator(BaseOperator):
 
     # [START gcp_transfer_job_run_template_fields]
     template_fields: Sequence[str] = (
-        "job_name",
-        "gcp_conn_id",
-        "api_version",
-        "google_impersonation_chain",
+        'job_name',
+        'project_id',
+        'gcp_conn_id',
+        'api_version',
+        'google_impersonation_chain',
     )
     # [END gcp_transfer_job_run_template_fields]
 

--- a/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/operators/cloud_storage_transfer_service.py
@@ -331,6 +331,9 @@ class CloudDataTransferServiceRunJobOperator(BaseOperator):
     Runs a transfer job in Google Storage Transfer Service.
 
     :param job_name: (Required) Name of the transfer job.
+    :param project_id: (Optional) the ID of the project that owns the Transfer
+        Job. If set to None or missing, the default project_id from the Google Cloud
+        connection is used.
     :param gcp_conn_id: The connection ID used to connect to Google Cloud.
     :param api_version: API version used (e.g. v1).
     :param google_impersonation_chain: Optional Google service account to impersonate using
@@ -356,9 +359,9 @@ class CloudDataTransferServiceRunJobOperator(BaseOperator):
         self,
         *,
         job_name: str,
-        project_id: str,
         gcp_conn_id: str = "google_cloud_default",
         api_version: str = "v1",
+        project_id: Optional[str] = None,
         google_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ) -> None:
@@ -367,7 +370,6 @@ class CloudDataTransferServiceRunJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.api_version = api_version
         self.google_impersonation_chain = google_impersonation_chain
-        self.body = {PROJECT_ID: project_id}
         self._validate_inputs()
         super().__init__(**kwargs)
 
@@ -381,7 +383,7 @@ class CloudDataTransferServiceRunJobOperator(BaseOperator):
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.google_impersonation_chain,
         )
-        hook.run_transfer_job(job_name=self.job_name, body=self.body)
+        hook.run_transfer_job(job_name=self.job_name, project_id=self.project_id)
 
 
 class CloudDataTransferServiceDeleteJobOperator(BaseOperator):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add an operator in google storage transfer service  to directly run a pre-configured transfer job. The storage transfer service provides the API for this use case, here the [link](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs/run) to the API. Corresponding to this API the `cloud_transfer_service` hook has been changed and an operator has been added.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
