### PR TITLE
Add parameter to turn off SQL query logging

### DIFF
--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -70,7 +70,7 @@ class DbApiHook(BaseHook):
     # Override with db-specific query to check connection
     _test_connection_sql = "select 1"
 
-    def __init__(self, *args, schema: Optional[str] = None, log_sql: Optional[bool] = True, **kwargs):
+    def __init__(self, *args, schema: Optional[str] = None, log_sql: bool = True, **kwargs):
         super().__init__()
         if not self.conn_name_attr:
             raise AirflowException("conn_name_attr is not defined")

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -84,6 +84,7 @@ class DbApiHook(BaseHook):
         # from kwargs and store it on its own. We do not run "pop" here as we want to give the
         # Hook deriving from the DBApiHook to still have access to the field in it's constructor
         self.__schema = schema
+        self.log_sql = kwargs.get('log_sql', True)
 
     def get_conn(self):
         """Returns a connection object"""
@@ -228,7 +229,9 @@ class DbApiHook(BaseHook):
 
     def _run_command(self, cur, sql_statement, parameters):
         """Runs a statement using an already open cursor."""
-        self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
+        if self.log_sql:
+            self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
+
         if parameters:
             cur.execute(sql_statement, parameters)
         else:

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -56,6 +56,7 @@ class DbApiHook(BaseHook):
     :param schema: Optional DB schema that overrides the schema specified in the connection. Make sure that
         if you change the schema parameter value in the constructor of the derived Hook, such change
         should be done before calling the ``DBApiHook.__init__()``.
+    :param log_sql: Whether to log SQL query during `run`. Defaults to True.
     """
 
     # Override to provide the connection name.
@@ -69,7 +70,7 @@ class DbApiHook(BaseHook):
     # Override with db-specific query to check connection
     _test_connection_sql = "select 1"
 
-    def __init__(self, *args, schema: Optional[str] = None, **kwargs):
+    def __init__(self, *args, schema: Optional[str] = None, log_sql: Optional[bool] = True, **kwargs):
         super().__init__()
         if not self.conn_name_attr:
             raise AirflowException("conn_name_attr is not defined")
@@ -84,7 +85,7 @@ class DbApiHook(BaseHook):
         # from kwargs and store it on its own. We do not run "pop" here as we want to give the
         # Hook deriving from the DBApiHook to still have access to the field in it's constructor
         self.__schema = schema
-        self.log_sql = kwargs.get('log_sql', True)
+        self.log_sql = log_sql
 
     def get_conn(self):
         """Returns a connection object"""

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -56,7 +56,7 @@ class DbApiHook(BaseHook):
     :param schema: Optional DB schema that overrides the schema specified in the connection. Make sure that
         if you change the schema parameter value in the constructor of the derived Hook, such change
         should be done before calling the ``DBApiHook.__init__()``.
-    :param log_sql: Whether to log SQL query during `run`. Defaults to True.
+    :param log_sql: Whether to log SQL query when it's executed. Defaults to *True*.
     """
 
     # Override to provide the connection name.

--- a/newsfragments/24570.feature.rst
+++ b/newsfragments/24570.feature.rst
@@ -1,0 +1,1 @@
+DbApiHook accepts log_sql to turn off logging SQL queries.

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -44,7 +44,7 @@ class TestDbApiHook(unittest.TestCase):
                 return conn
 
         self.db_hook = UnitTestDbApiHook()
-        self.db_hook_log_sql = UnitTestDbApiHook(log_sql=False)
+        self.db_hook_no_log_sql = UnitTestDbApiHook(log_sql=False)
         self.db_hook_schema_override = UnitTestDbApiHook(schema='schema-override')
 
     def test_get_records(self):

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -349,8 +349,8 @@ class TestDbApiHook(unittest.TestCase):
 
     def test_run_no_log(self):
         statement = 'SQL'
-        self.db_hook_log_sql.run(statement)
-        assert self.db_hook_log_sql.log.info.call_count == 1
+        self.db_hook_no_log_sql.run(statement)
+        assert self.db_hook_no_log_sql.log.info.call_count == 1
 
     def test_run_with_handler(self):
         sql = 'SQL'

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -44,6 +44,7 @@ class TestDbApiHook(unittest.TestCase):
                 return conn
 
         self.db_hook = UnitTestDbApiHook()
+        self.db_hook_log_sql = UnitTestDbApiHook(log_sql=False)
         self.db_hook_schema_override = UnitTestDbApiHook(schema='schema-override')
 
     def test_get_records(self):
@@ -345,6 +346,11 @@ class TestDbApiHook(unittest.TestCase):
         statement = 'SQL'
         self.db_hook.run(statement)
         assert self.db_hook.log.info.call_count == 2
+
+    def test_run_no_log(self):
+        statement = 'SQL'
+        self.db_hook_log_sql.run(statement)
+        assert self.db_hook_log_sql.log.info.call_count == 1
 
     def test_run_with_handler(self):
         sql = 'SQL'

--- a/tests/operators/test_sql.py
+++ b/tests/operators/test_sql.py
@@ -97,12 +97,14 @@ class TestSQLCheckOperatorDbHook:
             'database': 'database',
             'role': 'role',
             'schema': 'schema',
+            'log_sql': False,
         }
         assert self._operator._hook.conn_type == 'snowflake'
         assert self._operator._hook.warehouse == 'warehouse'
         assert self._operator._hook.database == 'database'
         assert self._operator._hook.role == 'role'
         assert self._operator._hook.schema == 'schema'
+        assert not self._operator._hook.log_sql
 
     def test_sql_operator_hook_params_biguery(self, mock_get_conn):
         mock_get_conn.return_value = Connection(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #11618

`DbApiHook` accepts `log_sql` kwarg to turn off logging the SQL query. In `BaseSQLOperator`, `hook_kwargs` flows through to the hook, including `log_sql`.
