### PR TITLE
Fix migration 0080_2_0_2 - Replace null values before setting column not null

### DIFF
--- a/airflow/migrations/versions/0080_2_0_2_change_default_pool_slots_to_1.py
+++ b/airflow/migrations/versions/0080_2_0_2_change_default_pool_slots_to_1.py
@@ -35,24 +35,9 @@ depends_on = None
 airflow_version = '2.0.2'
 
 
-# Minimal required schema
-task_instance = sa.table(
-    'task_instance',
-    sa.column('pool_slots', sa.Integer),
-)
-
-
 def upgrade():
     """Change default ``pool_slots`` to ``1`` and make pool_slots not nullable"""
-    connection = op.get_bind()
-    sessionmaker = sa.orm.sessionmaker()
-    session = sessionmaker(bind=connection)
-
-    session.query(task_instance) \
-        .filter(task_instance.c.pool_slots.is_(None)) \
-        .update({task_instance.c.pool_slots: 1}, synchronize_session=False)
-    session.commit()
-
+    op.execute("UPDATE task_instance SET pool_slots = 1 WHERE pool_slots IS NULL")
     with op.batch_alter_table("task_instance", schema=None) as batch_op:
         batch_op.alter_column("pool_slots", existing_type=sa.Integer, nullable=False, server_default='1')
 

--- a/airflow/migrations/versions/0080_2_0_2_change_default_pool_slots_to_1.py
+++ b/airflow/migrations/versions/0080_2_0_2_change_default_pool_slots_to_1.py
@@ -35,8 +35,24 @@ depends_on = None
 airflow_version = '2.0.2'
 
 
+# Minimal required schema
+task_instance = sa.table(
+    'task_instance',
+    sa.column('pool_slots', sa.Integer),
+)
+
+
 def upgrade():
     """Change default ``pool_slots`` to ``1`` and make pool_slots not nullable"""
+    connection = op.get_bind()
+    sessionmaker = sa.orm.sessionmaker()
+    session = sessionmaker(bind=connection)
+
+    session.query(task_instance) \
+        .filter(task_instance.c.pool_slots.is_(None)) \
+        .update({task_instance.c.pool_slots: 1}, synchronize_session=False)
+    session.commit()
+
     with op.batch_alter_table("task_instance", schema=None) as batch_op:
         batch_op.alter_column("pool_slots", existing_type=sa.Integer, nullable=False, server_default='1')
 


### PR DESCRIPTION
Partially reverts change from #20962 where update to NULL values was dropped.
Default only applies to INSERTs and UPDATEs or newly added columns (at least in postgres), so if the column contained NULLs before, the migration fails.

closes: #24566 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
