### PR TITLE
Rewrite the 'version' command to use Click

### DIFF
--- a/airflow/cli/__main__.py
+++ b/airflow/cli/__main__.py
@@ -18,7 +18,9 @@
 # under the License.
 
 from airflow.cli import airflow_cmd
-from airflow.cli.commands import version  # noqa: F401
+from airflow.cli.commands import version
+
+__all__ = ["version"]
 
 if __name__ == '__main__':
     airflow_cmd(obj={})

--- a/airflow/cli/commands/version.py
+++ b/airflow/cli/commands/version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,9 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Version command"""
+from rich.console import Console
 
+import airflow
 from airflow.cli import airflow_cmd
-from airflow.cli.commands import version  # noqa: F401
 
-if __name__ == '__main__':
-    airflow_cmd(obj={})
+
+@airflow_cmd.command('version')
+def version():
+    """Displays Airflow version at the command line"""
+    console = Console()
+    console.print(airflow.__version__)

--- a/airflow/cli/commands/version.py
+++ b/airflow/cli/commands/version.py
@@ -15,14 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """Version command"""
-from rich.console import Console
-
-import airflow
 from airflow.cli import airflow_cmd
 
 
 @airflow_cmd.command('version')
 def version():
     """Displays Airflow version at the command line"""
+    from rich.console import Console
+
+    import airflow
+
     console = Console()
     console.print(airflow.__version__)

--- a/airflow/cli/commands/version.py
+++ b/airflow/cli/commands/version.py
@@ -25,5 +25,4 @@ def version():
 
     import airflow
 
-    console = Console()
-    console.print(airflow.__version__)
+    Console().print(airflow.__version__)

--- a/tests/cli/commands/test_version.py
+++ b/tests/cli/commands/test_version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,8 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from airflow.cli import airflow_cmd
-from airflow.cli.commands import version  # noqa: F401
+import unittest
 
-if __name__ == '__main__':
-    airflow_cmd(obj={})
+from click.testing import CliRunner
+
+import airflow
+from airflow.cli.commands.version import version
+
+
+class TestCliVersion(unittest.TestCase):
+    def test_cli_version(self):
+        runner = CliRunner()
+        response = runner.invoke(version)
+
+        assert response.exit_code == 0
+        assert airflow.__version__ in response.output


### PR DESCRIPTION
This is part of a series of PRs breaking up #22613 into smaller, more reviewable chunks. The end result will be rewriting the existing `airflow` CLI to use Click instead of argparse. For motivation, please see #22708.

This PR adds `airflow version` subcommand to the `airflow-ng` command. It's exactly the same as the `airflow version` command, it's just implemented with Click. This PR also adds an additional test module for the new command. I opted to copy/add a new test module instead of keeping a single module and making it compatible with both argparse and Click, because that way it will be easier to remove the tests that rely on argparse once all commands are rewritten, the CLI is completely converted to utilize Click, and the `airflow-ng` command replaces the `airflow` command.

~While this incorporates the changes from #24590, I will rebase this once that PR is merged to make the relevant changes in this PR smaller and easier to separate out and review. Until then, you can use GitHub's [compare view](https://github.com/astronomer/airflow/compare/convert-to-click-cli-pr...astronomer:convert-version-command-to-click) to compare this branch to `astronomer:convert-to-click-cli-pr` to see just the diff for this PR.~ I have rebased this against `main`.

For comparison to the modules this supersedes:
* [`airflow/cli/commands/version_command.py`](https://github.com/apache/airflow/blob/main/airflow/cli/commands/version_command.py)
* [`tests/cli/commands/test_version_command.py`](https://github.com/apache/airflow/blob/main/tests/cli/commands/test_version_command.py)