### PR TITLE
Move fallible ti.task.dag assignment back inside try/except block (#24533)

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -125,12 +125,13 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             else:
                 log_id_template = self.log_id_template
 
-        dag = ti.task.dag
-        assert dag is not None  # For Mypy.
         try:
-            data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
+            dag = ti.task.dag
         except AttributeError:  # ti.task is not always set.
             data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
+        else:
+            assert dag is not None  # For Mypy.
+            data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
 
         if self.json_format:
             data_interval_start = self._clean_date(data_interval[0])

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -131,7 +131,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
             data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
         else:
             assert dag is not None  # For Mypy.
-            data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
+            data_interval = dag.get_run_data_interval(dag_run)
 
         if self.json_format:
             data_interval_start = self._clean_date(data_interval[0])

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -19,9 +19,8 @@
 import logging
 import os
 import warnings
-from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 from airflow.configuration import AirflowConfigException, conf
 from airflow.utils.context import Context
@@ -99,7 +98,7 @@ class FileTaskHandler(logging.Handler):
                 data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
             else:
                 assert dag is not None  # For Mypy.
-                data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
+                data_interval = dag.get_run_data_interval(dag_run)
             if data_interval[0]:
                 data_interval_start = data_interval[0].isoformat()
             else:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -93,12 +93,13 @@ class FileTaskHandler(logging.Handler):
             context["try_number"] = try_number
             return render_template_to_string(jinja_tpl, context)
         elif str_tpl:
-            dag = ti.task.dag
-            assert dag is not None  # For Mypy.
             try:
-                data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
+                dag = ti.task.dag
             except AttributeError:  # ti.task is not always set.
                 data_interval = (dag_run.data_interval_start, dag_run.data_interval_end)
+            else:
+                assert dag is not None  # For Mypy.
+                data_interval: Tuple[datetime, datetime] = dag.get_run_data_interval(dag_run)
             if data_interval[0]:
                 data_interval_start = data_interval[0].isoformat()
             else:


### PR DESCRIPTION
It looks like ti.task.dag was originally protected inside try/except, but was moved out at commit 7be87d

This causes the "View Logs in Elasticsearch" option to crash in the Airflow UI

related: #24533 