### PR TITLE
S3ToSnowflakeOperator: escape single quote in s3_keys

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -125,7 +125,7 @@ class S3ToSnowflakeOperator(BaseOperator):
             f"FROM @{self.stage}/{self.prefix or ''}",
         ]
         if self.s3_keys:
-            files = ", ".join(f"'{key}'" for key in self.s3_keys)
+            files = ", ".join(map(enclose_param, self.s3_keys))
             sql_parts.append(f"files=({files})")
         sql_parts.append(f"file_format={self.file_format}")
         if self.pattern:


### PR DESCRIPTION
Follow up: https://github.com/apache/airflow/pull/24571#pullrequestreview-1013026426

AWS S3 Key might contain `'` character, it is legit (as well as in GCS and Azure Blob Storage).