### PR TITLE
Fix usage of `click.get_terminal_size()`

### DIFF
--- a/dev/send_email.py
+++ b/dev/send_email.py
@@ -20,6 +20,7 @@
 # This tool is based on the Superset send_email script:
 # https://github.com/apache/incubator-superset/blob/master/RELEASING/send_email.py
 import os
+import shutil
 import smtplib
 import ssl
 import sys
@@ -83,7 +84,7 @@ def show_message(entity: str, message: str):
     """
     Show message on the Command Line
     """
-    width, _ = click.get_terminal_size()  # type: ignore[attr-defined]
+    width, _ = shutil.get_terminal_size()
     click.secho("-" * width, fg="blue")
     click.secho(f"{entity} Message:", fg="bright_red", bold=True)
     click.secho("-" * width, fg="blue")


### PR DESCRIPTION
We were ignoring mypy error instead of fixing it.

click had removed `get_terminal_size` and recommend using `shutil.get_terminal_size`


Click Commit: https://github.com/pallets/click/commit/d88e771a004c34e4b863123333a259b28a2bf8f4
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
