### PR TITLE
Add test_connection method to Databricks hook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -52,6 +52,8 @@ WORKSPACE_GET_STATUS_ENDPOINT = ('GET', 'api/2.0/workspace/get-status')
 
 RUN_LIFE_CYCLE_STATES = ['PENDING', 'RUNNING', 'TERMINATING', 'TERMINATED', 'SKIPPED', 'INTERNAL_ERROR']
 
+LIST_ZONES_ENDPOINT = ('GET', 'api/2.0/clusters/list-zones')
+
 
 class RunState:
     """Utility class for the run state concept of Databricks runs."""
@@ -408,3 +410,19 @@ class DatabricksHook(BaseDatabricksHook):
                 raise e
 
         return None
+
+    def test_connection(self):
+        """Test the Databricks connectivity from UI"""
+        status, message = False, ''
+        hook = DatabricksHook(databricks_conn_id=self.databricks_conn_id)
+        try:
+            result = hook._do_api_call(endpoint_info=LIST_ZONES_ENDPOINT).get('zones', [])
+            if result:
+                self.log.info(result)
+                status = True
+                message = 'Connection successfully tested'
+        except Exception as e:
+            status = False
+            message = str(e)
+
+        return status, message

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -418,7 +418,6 @@ class DatabricksHook(BaseDatabricksHook):
         try:
             result = hook._do_api_call(endpoint_info=LIST_ZONES_ENDPOINT).get('zones', [])
             if result:
-                self.log.info(result)
                 status = True
                 message = 'Connection successfully tested'
         except Exception as e:

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -413,13 +413,11 @@ class DatabricksHook(BaseDatabricksHook):
 
     def test_connection(self):
         """Test the Databricks connectivity from UI"""
-        status, message = False, ''
         hook = DatabricksHook(databricks_conn_id=self.databricks_conn_id)
         try:
-            result = hook._do_api_call(endpoint_info=LIST_ZONES_ENDPOINT).get('zones', [])
-            if result:
-                status = True
-                message = 'Connection successfully tested'
+            hook._do_api_call(endpoint_info=LIST_ZONES_ENDPOINT).get('zones')
+            status = True
+            message = 'Connection successfully tested'
         except Exception as e:
             status = False
             message = str(e)

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -185,9 +185,7 @@ def list_jobs_endpoint(host):
 
 
 def list_zones_endpoint(host):
-    """
-    Utility function to generate the list zones endpoint given the host
-    """
+    """Utility function to generate the list zones endpoint given the host"""
     return f'https://{host}/api/2.0/clusters/list-zones'
 
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -104,6 +104,7 @@ LIST_JOBS_RESPONSE = {
     ],
     'has_more': False,
 }
+LIST_ZONES_RESPONSE = {'zones': ['us-east-2b', 'us-east-2c', 'us-east-2a'], 'default_zone': 'us-east-2b'}
 
 
 def run_now_endpoint(host):
@@ -178,9 +179,16 @@ def uninstall_endpoint(host):
 
 def list_jobs_endpoint(host):
     """
-    Utility function to generate the list jobs endpoint giver the host
+    Utility function to generate the list jobs endpoint given the host
     """
     return f'https://{host}/api/2.1/jobs/list'
+
+
+def list_zones_endpoint(host):
+    """
+    Utility function to generate the list zones endpoint given the host
+    """
+    return f'https://{host}/api/2.0/clusters/list-zones'
 
 
 def create_valid_response_mock(content):
@@ -701,6 +709,40 @@ class TestDatabricksHook(unittest.TestCase):
             list_jobs_endpoint(HOST),
             json=None,
             params={'limit': 25, 'offset': 0, 'expand_tasks': False},
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+        )
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks_base.requests')
+    def test_connection_success(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.get.return_value.json.return_value = LIST_ZONES_RESPONSE
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.get.return_value).status_code = status_code_mock
+        response = self.hook.test_connection()
+        assert response == (True, 'Connection successfully tested')
+        mock_requests.get.assert_called_once_with(
+            list_zones_endpoint(HOST),
+            json=None,
+            params=None,
+            auth=HTTPBasicAuth(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+        )
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks_base.requests')
+    def test_connection_failure(self, mock_requests):
+        mock_requests.codes.ok = 404
+        mock_requests.get.side_effect = Exception('Connection Failure')
+        status_code_mock = mock.PropertyMock(return_value=404)
+        type(mock_requests.get.return_value).status_code = status_code_mock
+        response = self.hook.test_connection()
+        assert response == (False, 'Connection Failure')
+        mock_requests.get.assert_called_once_with(
+            list_zones_endpoint(HOST),
+            json=None,
+            params=None,
             auth=HTTPBasicAuth(LOGIN, PASSWORD),
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds,


### PR DESCRIPTION
This PR enables the test button on the airflow UI for testing whether the Databricks connection works using the connection params filled by the user

cc @kaxil @potiuk 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
