### PR TITLE
We now need at least Flask-WTF 0.15

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,7 @@ install_requires =
     flask-caching>=1.5.0
     flask-login>=0.5
     flask-session>=0.4.0
-    flask-wtf>=0.14.3
+    flask-wtf>=0.15
     graphviz>=0.12
     gunicorn>=20.1.0
     httpx


### PR DESCRIPTION
We upgraded flask and werkzeug in #24399, and updated the constraints,
but not everyone uses them (such as me in my local virtual environment
when developing) so the min version in setup.cfg has to match as well


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).