### PR TITLE
Rewrite the 'celery' command to use Click

### DIFF
--- a/airflow/cli/__main__.py
+++ b/airflow/cli/__main__.py
@@ -18,6 +18,7 @@
 # under the License.
 
 from airflow.cli import airflow_cmd
+from airflow.cli.commands import celery  # noqa: F401
 
 if __name__ == '__main__':
     airflow_cmd(obj={})

--- a/airflow/cli/commands/celery.py
+++ b/airflow/cli/commands/celery.py
@@ -1,0 +1,213 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Celery command"""
+
+from multiprocessing import Process
+from typing import Optional
+
+import daemon
+import psutil
+import sqlalchemy.exc
+from celery import maybe_patch_concurrency  # type: ignore[attr-defined]
+from daemon.pidfile import TimeoutPIDLockFile
+from lockfile.pidlockfile import read_pid_from_pidfile, remove_existing_pidfile
+
+from airflow import settings
+from airflow.configuration import conf
+from airflow.executors.celery_executor import app as celery_app
+from airflow.utils import cli as cli_utils
+from airflow.utils.cli import setup_locations, setup_logging
+from airflow.utils.serve_logs import serve_logs
+
+WORKER_PROCESS_NAME = "worker"
+
+
+@cli_utils.action_cli
+def flower(args):
+    """Starts Flower, Celery monitoring tool"""
+    options = [
+        "flower",
+        conf.get('celery', 'BROKER_URL'),
+        f"--address={args.hostname}",
+        f"--port={args.port}",
+    ]
+
+    if args.broker_api:
+        options.append(f"--broker-api={args.broker_api}")
+
+    if args.url_prefix:
+        options.append(f"--url-prefix={args.url_prefix}")
+
+    if args.basic_auth:
+        options.append(f"--basic-auth={args.basic_auth}")
+
+    if args.flower_conf:
+        options.append(f"--conf={args.flower_conf}")
+
+    if args.daemon:
+        pidfile, stdout, stderr, _ = setup_locations(
+            process="flower",
+            pid=args.pid,
+            stdout=args.stdout,
+            stderr=args.stderr,
+            log=args.log_file,
+        )
+        with open(stdout, "w+") as stdout, open(stderr, "w+") as stderr:
+            ctx = daemon.DaemonContext(
+                pidfile=TimeoutPIDLockFile(pidfile, -1),
+                stdout=stdout,
+                stderr=stderr,
+            )
+            with ctx:
+                celery_app.start(options)
+    else:
+        celery_app.start(options)
+
+
+def _serve_logs(skip_serve_logs: bool = False) -> Optional[Process]:
+    """Starts serve_logs sub-process"""
+    if skip_serve_logs is False:
+        sub_proc = Process(target=serve_logs)
+        sub_proc.start()
+        return sub_proc
+    return None
+
+
+def _run_worker(options, skip_serve_logs):
+    sub_proc = _serve_logs(skip_serve_logs)
+    try:
+        celery_app.worker_main(options)
+    finally:
+        if sub_proc:
+            sub_proc.terminate()
+
+
+@cli_utils.action_cli
+def worker(args):
+    """Starts Airflow Celery worker"""
+    # Disable connection pool so that celery worker does not hold an unnecessary db connection
+    settings.reconfigure_orm(disable_connection_pool=True)
+    if not settings.validate_session():
+        raise SystemExit("Worker exiting, database connection precheck failed.")
+
+    autoscale = args.autoscale
+    skip_serve_logs = args.skip_serve_logs
+
+    if autoscale is None and conf.has_option("celery", "worker_autoscale"):
+        autoscale = conf.get("celery", "worker_autoscale")
+
+    # Setup locations
+    pid_file_path, stdout, stderr, log_file = setup_locations(
+        process=WORKER_PROCESS_NAME,
+        pid=args.pid,
+        stdout=args.stdout,
+        stderr=args.stderr,
+        log=args.log_file,
+    )
+
+    if hasattr(celery_app.backend, 'ResultSession'):
+        # Pre-create the database tables now, otherwise SQLA via Celery has a
+        # race condition where one of the subprocesses can die with "Table
+        # already exists" error, because SQLA checks for which tables exist,
+        # then issues a CREATE TABLE, rather than doing CREATE TABLE IF NOT
+        # EXISTS
+        try:
+            session = celery_app.backend.ResultSession()
+            session.close()
+        except sqlalchemy.exc.IntegrityError:
+            # At least on postgres, trying to create a table that already exist
+            # gives a unique constraint violation or the
+            # "pg_type_typname_nsp_index" table. If this happens we can ignore
+            # it, we raced to create the tables and lost.
+            pass
+
+    # backwards-compatible: https://github.com/apache/airflow/pull/21506#pullrequestreview-879893763
+    celery_log_level = conf.get('logging', 'CELERY_LOGGING_LEVEL')
+    if not celery_log_level:
+        celery_log_level = conf.get('logging', 'LOGGING_LEVEL')
+    # Setup Celery worker
+    options = [
+        'worker',
+        '-O',
+        'fair',
+        '--queues',
+        args.queues,
+        '--concurrency',
+        args.concurrency,
+        '--hostname',
+        args.celery_hostname,
+        '--loglevel',
+        celery_log_level,
+        '--pidfile',
+        pid_file_path,
+    ]
+    if autoscale:
+        options.extend(['--autoscale', autoscale])
+    if args.without_mingle:
+        options.append('--without-mingle')
+    if args.without_gossip:
+        options.append('--without-gossip')
+
+    if conf.has_option("celery", "pool"):
+        pool = conf.get("celery", "pool")
+        options.extend(["--pool", pool])
+        # Celery pools of type eventlet and gevent use greenlets, which
+        # requires monkey patching the app:
+        # https://eventlet.net/doc/patching.html#monkey-patch
+        # Otherwise task instances hang on the workers and are never
+        # executed.
+        maybe_patch_concurrency(['-P', pool])
+
+    if args.daemon:
+        # Run Celery worker as daemon
+        handle = setup_logging(log_file)
+
+        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+            if args.umask:
+                umask = args.umask
+
+            ctx = daemon.DaemonContext(
+                files_preserve=[handle],
+                umask=int(umask, 8),
+                stdout=stdout_handle,
+                stderr=stderr_handle,
+            )
+            with ctx:
+                _run_worker(options=options, skip_serve_logs=skip_serve_logs)
+    else:
+        # Run Celery worker in the same process
+        _run_worker(options=options, skip_serve_logs=skip_serve_logs)
+
+
+@cli_utils.action_cli
+def stop_worker(args):
+    """Sends SIGTERM to Celery worker"""
+    # Read PID from file
+    if args.pid:
+        pid_file_path = args.pid
+    else:
+        pid_file_path, _, _, _ = setup_locations(process=WORKER_PROCESS_NAME)
+    pid = read_pid_from_pidfile(pid_file_path)
+
+    # Send SIGTERM
+    if pid:
+        worker_process = psutil.Process(pid)
+        worker_process.terminate()
+
+    # Remove pid file
+    remove_existing_pidfile(pid_file_path)

--- a/tests/cli/commands/test_celery.py
+++ b/tests/cli/commands/test_celery.py
@@ -1,0 +1,379 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from argparse import Namespace
+from tempfile import NamedTemporaryFile
+from unittest import mock
+
+import pytest
+import sqlalchemy
+
+import airflow
+from airflow.cli import cli_parser
+from airflow.cli.commands import celery_command
+from airflow.configuration import conf
+from tests.test_utils.config import conf_vars
+
+
+class TestWorkerPrecheck(unittest.TestCase):
+    @mock.patch('airflow.settings.validate_session')
+    def test_error(self, mock_validate_session):
+        """
+        Test to verify the exit mechanism of airflow-worker cli
+        by mocking validate_session method
+        """
+        mock_validate_session.return_value = False
+        with pytest.raises(SystemExit) as ctx:
+            celery_command.worker(Namespace(queues=1, concurrency=1))
+        assert str(ctx.value) == "Worker exiting, database connection precheck failed."
+
+    @conf_vars({('celery', 'worker_precheck'): 'False'})
+    def test_worker_precheck_exception(self):
+        """
+        Test to check the behaviour of validate_session method
+        when worker_precheck is absent in airflow configuration
+        """
+        assert airflow.settings.validate_session()
+
+    @mock.patch('sqlalchemy.orm.session.Session.execute')
+    @conf_vars({('celery', 'worker_precheck'): 'True'})
+    def test_validate_session_dbapi_exception(self, mock_session):
+        """
+        Test to validate connection failure scenario on SELECT 1 query
+        """
+        mock_session.side_effect = sqlalchemy.exc.OperationalError("m1", "m2", "m3", "m4")
+        assert airflow.settings.validate_session() is False
+
+
+@pytest.mark.integration("redis")
+@pytest.mark.integration("rabbitmq")
+@pytest.mark.backend("mysql", "postgres")
+class TestWorkerServeLogs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_serve_logs_on_worker_start(self, mock_celery_app):
+        with mock.patch('airflow.cli.commands.celery_command.Process') as mock_process:
+            args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1'])
+
+            with mock.patch('celery.platforms.check_privileges') as mock_privil:
+                mock_privil.return_value = 0
+                celery_command.worker(args)
+                mock_process.assert_called()
+
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_skip_serve_logs_on_worker_start(self, mock_celery_app):
+        with mock.patch('airflow.cli.commands.celery_command.Process') as mock_popen:
+            args = self.parser.parse_args(['celery', 'worker', '--concurrency', '1', '--skip-serve-logs'])
+
+            with mock.patch('celery.platforms.check_privileges') as mock_privil:
+                mock_privil.return_value = 0
+                celery_command.worker(args)
+                mock_popen.assert_not_called()
+
+
+@pytest.mark.backend("mysql", "postgres")
+class TestCeleryStopCommand(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch("airflow.cli.commands.celery_command.setup_locations")
+    @mock.patch("airflow.cli.commands.celery_command.psutil.Process")
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_if_right_pid_is_read(self, mock_process, mock_setup_locations):
+        args = self.parser.parse_args(['celery', 'stop'])
+        pid = "123"
+
+        # Calling stop_worker should delete the temporary pid file
+        with pytest.raises(FileNotFoundError):
+            with NamedTemporaryFile("w+") as f:
+                # Create pid file
+                f.write(pid)
+                f.flush()
+                # Setup mock
+                mock_setup_locations.return_value = (f.name, None, None, None)
+                # Check if works as expected
+                celery_command.stop_worker(args)
+                mock_process.assert_called_once_with(int(pid))
+                mock_process.return_value.terminate.assert_called_once_with()
+
+    @mock.patch("airflow.cli.commands.celery_command.read_pid_from_pidfile")
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @mock.patch("airflow.cli.commands.celery_command.setup_locations")
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_same_pid_file_is_used_in_start_and_stop(
+        self, mock_setup_locations, mock_celery_app, mock_read_pid_from_pidfile
+    ):
+        pid_file = "test_pid_file"
+        mock_setup_locations.return_value = (pid_file, None, None, None)
+        mock_read_pid_from_pidfile.return_value = None
+
+        # Call worker
+        worker_args = self.parser.parse_args(['celery', 'worker', '--skip-serve-logs'])
+        celery_command.worker(worker_args)
+        assert mock_celery_app.worker_main.call_args
+        args, _ = mock_celery_app.worker_main.call_args
+        args_str = ' '.join(map(str, args[0]))
+        assert f'--pidfile {pid_file}' in args_str
+
+        # Call stop
+        stop_args = self.parser.parse_args(['celery', 'stop'])
+        celery_command.stop_worker(stop_args)
+        mock_read_pid_from_pidfile.assert_called_once_with(pid_file)
+
+    @mock.patch("airflow.cli.commands.celery_command.remove_existing_pidfile")
+    @mock.patch("airflow.cli.commands.celery_command.read_pid_from_pidfile")
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @mock.patch("airflow.cli.commands.celery_command.psutil.Process")
+    @mock.patch("airflow.cli.commands.celery_command.setup_locations")
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_custom_pid_file_is_used_in_start_and_stop(
+        self,
+        mock_setup_locations,
+        mock_process,
+        mock_celery_app,
+        mock_read_pid_from_pidfile,
+        mock_remove_existing_pidfile,
+    ):
+        pid_file = "custom_test_pid_file"
+        mock_setup_locations.return_value = (pid_file, None, None, None)
+        # Call worker
+        worker_args = self.parser.parse_args(['celery', 'worker', '--skip-serve-logs', '--pid', pid_file])
+        celery_command.worker(worker_args)
+        assert mock_celery_app.worker_main.call_args
+        args, _ = mock_celery_app.worker_main.call_args
+        args_str = ' '.join(map(str, args[0]))
+        assert f'--pidfile {pid_file}' in args_str
+
+        stop_args = self.parser.parse_args(['celery', 'stop', '--pid', pid_file])
+        celery_command.stop_worker(stop_args)
+
+        mock_read_pid_from_pidfile.assert_called_once_with(pid_file)
+        mock_process.return_value.terminate.assert_called()
+        mock_remove_existing_pidfile.assert_called_once_with(pid_file)
+
+
+@pytest.mark.backend("mysql", "postgres")
+class TestWorkerStart(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch("airflow.cli.commands.celery_command.setup_locations")
+    @mock.patch('airflow.cli.commands.celery_command.Process')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_worker_started_with_required_arguments(self, mock_celery_app, mock_popen, mock_locations):
+        pid_file = "pid_file"
+        mock_locations.return_value = (pid_file, None, None, None)
+        concurrency = '1'
+        celery_hostname = "celery_hostname"
+        queues = "queue"
+        autoscale = "2,5"
+        args = self.parser.parse_args(
+            [
+                'celery',
+                'worker',
+                '--autoscale',
+                autoscale,
+                '--concurrency',
+                concurrency,
+                '--celery-hostname',
+                celery_hostname,
+                '--queues',
+                queues,
+                '--without-mingle',
+                '--without-gossip',
+            ]
+        )
+
+        celery_command.worker(args)
+
+        mock_celery_app.worker_main.assert_called_once_with(
+            [
+                'worker',
+                '-O',
+                'fair',
+                '--queues',
+                queues,
+                '--concurrency',
+                int(concurrency),
+                '--hostname',
+                celery_hostname,
+                '--loglevel',
+                conf.get('logging', 'CELERY_LOGGING_LEVEL'),
+                '--pidfile',
+                pid_file,
+                '--autoscale',
+                autoscale,
+                '--without-mingle',
+                '--without-gossip',
+                '--pool',
+                'prefork',
+            ]
+        )
+
+
+@pytest.mark.backend("mysql", "postgres")
+class TestWorkerFailure(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch('airflow.cli.commands.celery_command.Process')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_worker_failure_gracefull_shutdown(self, mock_celery_app, mock_popen):
+        args = self.parser.parse_args(['celery', 'worker'])
+        mock_celery_app.run.side_effect = Exception('Mock exception to trigger runtime error')
+        try:
+            celery_command.worker(args)
+        finally:
+            mock_popen().terminate.assert_called()
+
+
+@pytest.mark.backend("mysql", "postgres")
+class TestFlowerCommand(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_run_command(self, mock_celery_app):
+        args = self.parser.parse_args(
+            [
+                'celery',
+                'flower',
+                '--basic-auth',
+                'admin:admin',
+                '--broker-api',
+                'http://username:password@rabbitmq-server-name:15672/api/',
+                '--flower-conf',
+                'flower_config',
+                '--hostname',
+                'my-hostname',
+                '--port',
+                '3333',
+                '--url-prefix',
+                'flower-monitoring',
+            ]
+        )
+
+        celery_command.flower(args)
+        mock_celery_app.start.assert_called_once_with(
+            [
+                'flower',
+                'amqp://guest:guest@rabbitmq:5672/',
+                '--address=my-hostname',
+                '--port=3333',
+                '--broker-api=http://username:password@rabbitmq-server-name:15672/api/',
+                '--url-prefix=flower-monitoring',
+                '--basic-auth=admin:admin',
+                '--conf=flower_config',
+            ]
+        )
+
+    @mock.patch('airflow.cli.commands.celery_command.TimeoutPIDLockFile')
+    @mock.patch('airflow.cli.commands.celery_command.setup_locations')
+    @mock.patch('airflow.cli.commands.celery_command.daemon')
+    @mock.patch('airflow.cli.commands.celery_command.celery_app')
+    @conf_vars({("core", "executor"): "CeleryExecutor"})
+    def test_run_command_daemon(self, mock_celery_app, mock_daemon, mock_setup_locations, mock_pid_file):
+        mock_setup_locations.return_value = (
+            mock.MagicMock(name='pidfile'),
+            mock.MagicMock(name='stdout'),
+            mock.MagicMock(name='stderr'),
+            mock.MagicMock(name="INVALID"),
+        )
+        args = self.parser.parse_args(
+            [
+                'celery',
+                'flower',
+                '--basic-auth',
+                'admin:admin',
+                '--broker-api',
+                'http://username:password@rabbitmq-server-name:15672/api/',
+                '--flower-conf',
+                'flower_config',
+                '--hostname',
+                'my-hostname',
+                '--log-file',
+                '/tmp/flower.log',
+                '--pid',
+                '/tmp/flower.pid',
+                '--port',
+                '3333',
+                '--stderr',
+                '/tmp/flower-stderr.log',
+                '--stdout',
+                '/tmp/flower-stdout.log',
+                '--url-prefix',
+                'flower-monitoring',
+                '--daemon',
+            ]
+        )
+        mock_open = mock.mock_open()
+        with mock.patch('airflow.cli.commands.celery_command.open', mock_open):
+            celery_command.flower(args)
+
+        mock_celery_app.start.assert_called_once_with(
+            [
+                'flower',
+                'amqp://guest:guest@rabbitmq:5672/',
+                '--address=my-hostname',
+                '--port=3333',
+                '--broker-api=http://username:password@rabbitmq-server-name:15672/api/',
+                '--url-prefix=flower-monitoring',
+                '--basic-auth=admin:admin',
+                '--conf=flower_config',
+            ]
+        )
+        assert mock_daemon.mock_calls == [
+            mock.call.DaemonContext(
+                pidfile=mock_pid_file.return_value,
+                stderr=mock_open.return_value,
+                stdout=mock_open.return_value,
+            ),
+            mock.call.DaemonContext().__enter__(),
+            mock.call.DaemonContext().__exit__(None, None, None),
+        ]
+
+        assert mock_setup_locations.mock_calls == [
+            mock.call(
+                log='/tmp/flower.log',
+                pid='/tmp/flower.pid',
+                process='flower',
+                stderr='/tmp/flower-stderr.log',
+                stdout='/tmp/flower-stdout.log',
+            )
+        ]
+        mock_pid_file.assert_has_calls([mock.call(mock_setup_locations.return_value[0], -1)])
+        assert mock_open.mock_calls == [
+            mock.call(mock_setup_locations.return_value[1], 'w+'),
+            mock.call().__enter__(),
+            mock.call(mock_setup_locations.return_value[2], 'w+'),
+            mock.call().__enter__(),
+            mock.call().__exit__(None, None, None),
+            mock.call().__exit__(None, None, None),
+        ]


### PR DESCRIPTION
This is part of a series of PRs breaking up #22613 into smaller, more reviewable chunks. The end result will be rewriting the existing `airflow` CLI to use Click instead of argparse. For motivation, please see #22708.

This PR adds the `celery` subcommand to the `airflow-ng` command. It's exactly the same as the `airflow celery` command, it's just implemented with Click. This PR also includes an additional, separate test file for the Click `celery` subcommand. The intent there is to simply remove the test files for the old commands once the Click-based `airflow-ng` command supersedes and replaces the argparse-based `airflow` command.

For comparison to the modules this supersedes:
* [`airflow/cli/commands/celery_command.py`](https://github.com/apache/airflow/blob/main/airflow/cli/commands/celery_command.py)
* [`tests/cli/commands/test_celery_command.py`](https://github.com/apache/airflow/blob/main/tests/cli/commands/test_celery_command.py)

Original author: @hankehly astronomer/airflow#1495