### PR TITLE
Limit azure-servicebus to not be used on ARM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,8 @@ azure = [
     'azure-storage-blob>=12.7.0,<12.9.0',
     'azure-storage-common>=2.1.0',
     'azure-storage-file>=2.1.0',
-    'azure-servicebus>=7.6.1',
+    # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191
+    'azure-servicebus>=7.6.1; platform_machine != "aarch64"',
 ]
 cassandra = [
     'cassandra-driver>=3.13.0',


### PR DESCRIPTION
Azure service bus uses uamqp which does not build for ARM architecture
and we need to disable it as a dependency for ARM.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
