### PR TITLE
Fix pid check

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -195,7 +195,7 @@ class LocalTaskJob(BaseJob):
             recorded_pid = ti.pid
             same_process = recorded_pid == current_pid
 
-            if recorded_pid is not None and ti.run_as_user or self.task_runner.run_as_user:
+            if recorded_pid is not None and (ti.run_as_user or self.task_runner.run_as_user):
                 # when running as another user, compare the task runner pid to the parent of 
                 # the recorded pid because user delegation becomes an extra process level.
                 # However, if recorded_pid is None, pass that through as it signals the task 

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -190,12 +190,12 @@ class LocalTaskJob(BaseJob):
                     ti.hostname,
                     fqdn,
                 )
-                raise AirflowException("Hostname of job runner does not match")            
+                raise AirflowException("Hostname of job runner does not match")
             current_pid = self.task_runner.process.pid
             recorded_pid = ti.pid
             same_process = recorded_pid == current_pid
 
-            if recorded_pid is not None and ti.run_as_user or self.task_runner.run_as_user:                
+            if recorded_pid is not None and ti.run_as_user or self.task_runner.run_as_user:
                 # when running as another user, compare the task runner pid to the parent of 
                 # the recorded pid because user delegation becomes an extra process level.
                 
@@ -203,7 +203,7 @@ class LocalTaskJob(BaseJob):
                 recorded_pid = psutil.Process(ti.pid).ppid()
                 same_process = recorded_pid == current_pid
 
-            if recorded_pid is not None and not same_process:                
+            if recorded_pid is not None and not same_process:
                 self.log.warning(
                     "Recorded pid %s does not match the current pid %s", recorded_pid, current_pid
                 )

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -196,12 +196,12 @@ class LocalTaskJob(BaseJob):
             same_process = recorded_pid == current_pid
 
             if recorded_pid is not None and (ti.run_as_user or self.task_runner.run_as_user):
-                # when running as another user, compare the task runner pid to the parent of 
+                # when running as another user, compare the task runner pid to the parent of
                 # the recorded pid because user delegation becomes an extra process level.
-                # However, if recorded_pid is None, pass that through as it signals the task 
-                # runner process has already completed and been cleared out. `psutil.Process` 
-                # uses the current process if the parameter is None, which is not what is intended 
-                # for comparison.                
+                # However, if recorded_pid is None, pass that through as it signals the task
+                # runner process has already completed and been cleared out. `psutil.Process`
+                # uses the current process if the parameter is None, which is not what is intended
+                # for comparison.
                 recorded_pid = psutil.Process(ti.pid).ppid()
                 same_process = recorded_pid == current_pid
 

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -190,16 +190,20 @@ class LocalTaskJob(BaseJob):
                     ti.hostname,
                     fqdn,
                 )
-                raise AirflowException("Hostname of job runner does not match")
+                raise AirflowException("Hostname of job runner does not match")            
             current_pid = self.task_runner.process.pid
             recorded_pid = ti.pid
             same_process = recorded_pid == current_pid
 
-            if ti.run_as_user or self.task_runner.run_as_user:
+            if recorded_pid is not None and ti.run_as_user or self.task_runner.run_as_user:                
+                # when running as another user, compare the task runner pid to the parent of 
+                # the recorded pid because user delegation becomes an extra process level.
+                
+                # However, if recorded_pid is None, pass that through as it signals the task runner process has already completed and been cleared out. `psutil.Process` uses the current process if the parameter is None, which is not what is intended for comparison.                
                 recorded_pid = psutil.Process(ti.pid).ppid()
                 same_process = recorded_pid == current_pid
 
-            if recorded_pid is not None and not same_process:
+            if recorded_pid is not None and not same_process:                
                 self.log.warning(
                     "Recorded pid %s does not match the current pid %s", recorded_pid, current_pid
                 )

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -198,8 +198,10 @@ class LocalTaskJob(BaseJob):
             if recorded_pid is not None and ti.run_as_user or self.task_runner.run_as_user:
                 # when running as another user, compare the task runner pid to the parent of 
                 # the recorded pid because user delegation becomes an extra process level.
-                
-                # However, if recorded_pid is None, pass that through as it signals the task runner process has already completed and been cleared out. `psutil.Process` uses the current process if the parameter is None, which is not what is intended for comparison.                
+                # However, if recorded_pid is None, pass that through as it signals the task 
+                # runner process has already completed and been cleared out. `psutil.Process` 
+                # uses the current process if the parameter is None, which is not what is intended 
+                # for comparison.                
                 recorded_pid = psutil.Process(ti.pid).ppid()
                 same_process = recorded_pid == current_pid
 


### PR DESCRIPTION
related: #17507 
related: #20992

This fixes issues in which running a task with impersonation leads to the error `Recorded pid {PID1} does not match the current pid {PID2}`, which then triggers a SIGTERM call to all processes in the group. The issue appears to be that in some cases the recorded pid (which is also the taskinstance pid) is None, which leads the ensuing `psutils.Process(ti.pid).ppid()` call to return the parent of the current running process instead of the parent of the taskinstance - and the parent is the long running Worker, which is not the desired process to identify. 

I was able to reproduce this error regularly and separately traced all processes to try to identify what they were. The "current pid" is the task runner, and in most cases the relevant call was so short lived I couldn't even get it in my tracing - which would explain why it was no longer registered to the task instance. 