### PR TITLE
Don't render child rows for closed groups

### DIFF
--- a/airflow/www/static/js/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/grid/renderTaskRows.tsx
@@ -23,7 +23,6 @@ import {
   Td,
   Box,
   Flex,
-  Collapse,
   useTheme,
 } from '@chakra-ui/react';
 
@@ -140,13 +139,14 @@ const Row = (props: RowProps) => {
     [isGroup, isOpen, task.label, openGroupIds, onToggleGroups],
   );
 
-  const isFullyOpen = level === openParentCount;
+  // check if the group's parents are all open, if not, return null
+  if (level !== openParentCount) return null;
 
   return (
     <>
       <Tr
         bg={isSelected ? 'blue.100' : 'inherit'}
-        borderBottomWidth={isFullyOpen ? 1 : 0}
+        borderBottomWidth={1}
         borderBottomColor={isGroup && isOpen ? 'gray.400' : 'gray.200'}
         role="group"
         _hover={!isSelected ? { bg: hoverBlue } : undefined}
@@ -164,16 +164,14 @@ const Row = (props: RowProps) => {
           width="100%"
           zIndex={1}
         >
-          <Collapse in={isFullyOpen} unmountOnExit>
-            <TaskName
-              onToggle={memoizedToggle}
-              isGroup={isGroup}
-              isMapped={task.isMapped}
-              label={task.label}
-              isOpen={isOpen}
-              level={level}
-            />
-          </Collapse>
+          <TaskName
+            onToggle={memoizedToggle}
+            isGroup={isGroup}
+            isMapped={task.isMapped}
+            label={task.label}
+            isOpen={isOpen}
+            level={level}
+          />
         </Td>
         <Td width={0} p={0} borderBottom={0} />
         <Td
@@ -182,20 +180,18 @@ const Row = (props: RowProps) => {
           width={`${dagRunIds.length * columnWidth}px`}
           borderBottom={0}
         >
-          <Collapse in={isFullyOpen} unmountOnExit>
-            <TaskInstances
-              dagRunIds={dagRunIds}
-              task={task}
-              selectedRunId={selected.runId}
-              onSelect={onSelect}
-              hoveredTaskState={hoveredTaskState}
-            />
-          </Collapse>
+          <TaskInstances
+            dagRunIds={dagRunIds}
+            task={task}
+            selectedRunId={selected.runId}
+            onSelect={onSelect}
+            hoveredTaskState={hoveredTaskState}
+          />
         </Td>
       </Tr>
-      {isGroup && (
+      {isGroup && isOpen && (
         renderTaskRows({
-          ...props, level: level + 1, openParentCount: openParentCount + (isOpen ? 1 : 0),
+          ...props, level: level + 1, openParentCount: openParentCount + 1,
         })
       )}
     </>


### PR DESCRIPTION
On DAGs with many task groups, collapsing/expanding a group or selecting a task instance can take a really long time. This PR doesn't try to render a any child rows is their parent group is closed. This does force us to remove the open/close animation. But the page is quite a bit faster on large DAGs with many closed groups.

Profiles from 6 runs of a DAG 100 groups of 20 tasks each (2000 task * 6 runs):

Before:
<img width="772" alt="Screen Shot 2022-06-24 at 11 17 52 AM" src="https://user-images.githubusercontent.com/4600967/175570442-01a66129-b886-482b-8a8a-9315bcf603db.png">


After:
<img width="550" alt="Screen Shot 2022-06-24 at 11 19 09 AM" src="https://user-images.githubusercontent.com/4600967/175570371-b7c511f9-89a0-47a6-888a-6f498c48716f.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
