### PR TITLE
Pass worker annotations to generated pod_template_file

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -31,9 +31,14 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-  {{- if .Values.airflowPodAnnotations }}
+  {{- if or .Values.airflowPodAnnotations .Values.workers.podAnnotations }}
   annotations:
-  {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}
+    {{- if .Values.airflowPodAnnotations }}
+    {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.workers.podAnnotations }}
+    {{- toYaml .Values.workers.podAnnotations | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   {{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled)) .Values.workers.extraInitContainers }}

--- a/tests/charts/test_pod_template_file.py
+++ b/tests/charts/test_pod_template_file.py
@@ -564,6 +564,30 @@ class PodTemplateFileTest(unittest.TestCase):
         assert "my_annotation" in annotations
         assert "annotated!" in annotations["my_annotation"]
 
+    def test_workers_pod_annotations(self):
+        docs = render_chart(
+            values={"workers": {"podAnnotations": {"my_annotation": "annotated!"}}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert "my_annotation" in annotations
+        assert "annotated!" in annotations["my_annotation"]
+
+    def test_airflow_and_workers_pod_annotations(self):
+        # should give preference to workers.podAnnotations
+        docs = render_chart(
+            values={
+                "airflowPodAnnotations": {"my_annotation": "airflowPodAnnotations"},
+                "workers": {"podAnnotations": {"my_annotation": "workerPodAnnotations"}},
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert "my_annotation" in annotations
+        assert "workerPodAnnotations" in annotations["my_annotation"]
+
     def test_should_add_extra_init_containers(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
Include podAnnotations defined in workers to the generated pod_template_file.

This makes it possible to KubernetesExecutor pods to share the workers pod annotations without needing to overwrite the whole file.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
