### PR TITLE
Use target commit SHA for build image workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -121,7 +121,7 @@ jobs:
         id: selective-checks
         env:
           PR_LABELS: "$${{ steps.get-latest-pr-labels.outputs.pullRequestLabels }}"
-          COMMIT_REF: "${{ github.sha }}"
+          COMMIT_REF: "${{ env.TARGET_COMMIT_SHA }}"
         run: breeze selective-check
       - name: Compute dynamic outputs
         id: dynamic-outputs


### PR DESCRIPTION
The build-image workflow should use TARGET_COMMIT_SHA as the
selective check COMMIT_REF otherwise it might not build
image when needed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
