### PR TITLE
Add test_connection method to AWS hook

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -701,6 +701,29 @@ class TestAwsBaseHook:
 
             assert hook.conn_partition == expected_partition
 
+    @pytest.mark.parametrize(
+        "client_type,resource_type",
+        [
+            ("s3", "dynamodb"),
+            (None, None),
+            ("", ""),
+        ],
+    )
+    def test_connection_client_resource_types_check(self, client_type, resource_type):
+        # Should not raise any error during Hook initialisation.
+        hook = AwsBaseHook(aws_conn_id=None, client_type=client_type, resource_type=resource_type)
+
+        with pytest.raises(ValueError, match="Either client_type=.* or resource_type=.* must be provided"):
+            hook.get_conn()
+
+    @unittest.skipIf(mock_sts is None, 'mock_sts package not present')
+    @mock_sts
+    def test_hook_connection_test(self):
+        hook = AwsBaseHook(client_type="s3")
+        result, message = hook.test_connection()
+        assert result
+        assert hook.client_type == "s3"  # Same client_type which defined during initialisation
+
 
 class ThrowErrorUntilCount:
     """Holds counter state for invoking a method several times in a row."""


### PR DESCRIPTION
For test AWS Credentials I move validation `client_type` and `resource_type` to conn property.
General usage of AWS Hooks use `conn` property or `get_conn()` method.

@ferruzzi @o-nikolas

<details>
  <summary>Test Connection Pass</summary>

![image](https://user-images.githubusercontent.com/3998685/175792253-bf93741c-cd6f-427a-83b6-0e998c279286.png)

</details>

<details>
  <summary>Test Connection Failed</summary>

![image](https://user-images.githubusercontent.com/3998685/175792337-a6718532-97e5-4414-a2a0-0fe890283d67.png)

</details>

