### PR TITLE
Clean up task decorator type hints and docstrings

### DIFF
--- a/airflow/decorators/__init__.py
+++ b/airflow/decorators/__init__.py
@@ -41,11 +41,11 @@ __all__ = [
 class TaskDecoratorCollection:
     """Implementation to provide the ``@task`` syntax."""
 
-    python: Any = staticmethod(python_task)
+    python = staticmethod(python_task)
     virtualenv = staticmethod(virtualenv_task)
     branch = staticmethod(branch_task)
 
-    __call__ = python  # Alias '@task' to '@task.python'.
+    __call__: Any = python  # Alias '@task' to '@task.python'.
 
     def __getattr__(self, name: str) -> TaskDecorator:
         """Dynamically get provider-registered task decorators, e.g. ``@task.docker``."""

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -20,7 +20,7 @@
 # necessarily exist at run time. See "Creating Custom @task Decorators"
 # documentation for more details.
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union, overload
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Union, overload
 
 from airflow.decorators.base import Function, Task, TaskDecorator
 from airflow.decorators.branch_python import branch_task
@@ -60,7 +60,7 @@ class TaskDecoratorCollection:
         :param templates_dict: a dictionary where the values are templates that
             will get templated by the Airflow engine sometime between
             ``__init__`` and ``execute`` takes place and are made available
-            in your callable's context after the template has been applied
+            in your callable's context after the template has been applied.
         :param show_return_value_in_logs: a bool value whether to show return_value
             logs. Defaults to True, which allows return value log output.
             It can be set to False to prevent log output of return value when you return huge data
@@ -115,7 +115,7 @@ class TaskDecoratorCollection:
         :param templates_dict: a dictionary where the values are templates that
             will get templated by the Airflow engine sometime between
             ``__init__`` and ``execute`` takes place and are made available
-            in your callable's context after the template has been applied
+            in your callable's context after the template has been applied.
         :param show_return_value_in_logs: a bool value whether to show return_value
             logs. Defaults to True, which allows return value log output.
             It can be set to False to prevent log output of return value when you return huge data
@@ -124,20 +124,14 @@ class TaskDecoratorCollection:
     @overload
     def virtualenv(self, python_callable: Function) -> Task[Function]: ...
     @overload
-    def branch(
-        self, python_callable: Optional[Callable] = None, multiple_outputs: Optional[bool] = None, **kwargs
-    ) -> TaskDecorator:
-        """Wraps a python function into a BranchPythonOperator
+    def branch(self, *, multiple_outputs: Optional[bool] = None, **kwargs) -> TaskDecorator:
+        """Create a decorator to wrap the decorated callable into a BranchPythonOperator.
 
-        For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:BranchPythonOperator`
-        Accepts kwargs for operator kwarg. Can be reused in a single DAG.
-        :param python_callable: Function to decorate
-        :type python_callable: Optional[Callable]
-        :param multiple_outputs: if set, function return value will be
-            unrolled to multiple XCom values. Dict will unroll to xcom values with keys as XCom keys.
-            Defaults to False.
-        :type multiple_outputs: bool
+        For more information on how to use this decorator, see :ref:`howto/operator:BranchPythonOperator`.
+        Accepts arbitrary for operator kwarg. Can be reused in a single DAG.
+
+        :param multiple_outputs: If set, function return value will be unrolled to multiple XCom values.
+            Dict will unroll to XCom values with keys as XCom keys. Defaults to False.
         """
     @overload
     def branch(self, python_callable: Function) -> Task[Function]: ...

--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -17,7 +17,7 @@
 
 import inspect
 from textwrap import dedent
-from typing import Callable, Optional, Sequence, TypeVar
+from typing import Callable, Optional, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import BranchPythonOperator
@@ -61,9 +61,6 @@ class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
         res = dedent(raw_source)
         res = remove_task_decorator(res, "@task.branch")
         return res
-
-
-T = TypeVar("T", bound=Callable)
 
 
 def branch_task(

--- a/airflow/decorators/python.py
+++ b/airflow/decorators/python.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Callable, Optional, Sequence, TypeVar
+from typing import Callable, Optional, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import PythonOperator
@@ -54,9 +54,6 @@ class _PythonDecoratedOperator(DecoratedOperator, PythonOperator):
             op_kwargs=op_kwargs,
             **kwargs,
         )
-
-
-T = TypeVar("T", bound=Callable)
 
 
 def python_task(

--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -17,7 +17,7 @@
 
 import inspect
 from textwrap import dedent
-from typing import Callable, Optional, Sequence, TypeVar
+from typing import Callable, Optional, Sequence
 
 from airflow.decorators.base import DecoratedOperator, TaskDecorator, task_decorator_factory
 from airflow.operators.python import PythonVirtualenvOperator
@@ -63,9 +63,6 @@ class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOper
         res = dedent(raw_source)
         res = remove_task_decorator(res, "@task.virtualenv")
         return res
-
-
-T = TypeVar("T", bound=Callable)
 
 
 def virtualenv_task(

--- a/airflow/providers/docker/decorators/docker.py
+++ b/airflow/providers/docker/decorators/docker.py
@@ -21,7 +21,7 @@ import os
 import pickle
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import TYPE_CHECKING, Callable, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
 import dill
 
@@ -127,9 +127,6 @@ class _DockerDecoratedOperator(DecoratedOperator, DockerOperator):
         res = dedent(raw_source)
         res = remove_task_decorator(res, "@task.docker")
         return res
-
-
-T = TypeVar("T", bound=Callable)
 
 
 def docker_task(


### PR DESCRIPTION
All those 'T' type vars are no longer needed since we've unified the
typing long ago (all these functions now use the 'Function' type var).

Also slightly fixed up task.branch to match the styles of other
task decorators.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
