### PR TITLE
Turn inability of creating mypy-cache into warning

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -262,12 +262,17 @@ def create_volume_if_missing(volume_name: str):
         check=False,
     )
     if res_inspect.returncode != 0:
-        run_command(
+        result = run_command(
             cmd=["docker", "volume", "create", volume_name],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            check=True,
+            check=False,
+            capture_output=True,
         )
+        if result.returncode != 0:
+            get_console().print(
+                "[warning]\nMypy Cache volume could not be created. Continuing, but you "
+                "should make sure your docker works.\n\n"
+                f"Error: {result.stdout}\n"
+            )
 
 
 def create_static_check_volumes():


### PR DESCRIPTION
The mypy cache creation might happen before checking if good
version of docker is installed and it works, so we want to turn
it into a warning rather than error when it is not possible to
create one.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
