### PR TITLE
Add test_connection method to GoogleBaseHook

### DIFF
--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -31,6 +31,7 @@ import google.auth
 import google.auth.credentials
 import google.oauth2.service_account
 import google_auth_httplib2
+import requests
 import tenacity
 from google.api_core.exceptions import Forbidden, ResourceExhausted, TooManyRequests
 from google.api_core.gapic_v1.client_info import ClientInfo
@@ -270,7 +271,12 @@ class GoogleBaseHook(BaseHook):
 
     def _get_access_token(self) -> str:
         """Returns a valid access token from Google API Credentials"""
-        return self._get_credentials().token
+        credentials = self._get_credentials()
+        auth_req = google.auth.transport.requests.Request()
+        # credentials.token is None
+        # Need to refresh credentials to populate the token
+        credentials.refresh(auth_req)
+        return credentials.token
 
     @functools.lru_cache(maxsize=None)
     def _get_credentials_email(self) -> str:
@@ -585,7 +591,10 @@ class GoogleBaseHook(BaseHook):
         """Test the Google cloud connectivity from UI"""
         status, message = False, ''
         try:
-            if self.project_id:
+            token = self._get_access_token()
+            url = f"https://www.googleapis.com/oauth2/v3/tokeninfo?access_token={token}"
+            response = requests.post(url)
+            if response.status_code == 200:
                 status = True
                 message = 'Connection successfully tested'
         except Exception as e:

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -580,3 +580,16 @@ class GoogleBaseHook(BaseHook):
         while done is False:
             _, done = downloader.next_chunk()
         file_handle.flush()
+
+    def test_connection(self):
+        """Test the Google cloud connectivity from UI"""
+        status, message = False, ''
+        try:
+            if self.project_id:
+                status = True
+                message = 'Connection successfully tested'
+        except Exception as e:
+            status = False
+            message = str(e)
+
+        return status, message

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -342,6 +342,20 @@ class TestGoogleBaseHook(unittest.TestCase):
         assert ('CREDENTIALS', 'PROJECT_ID') == result
 
     @mock.patch(MODULE_NAME + '.get_credentials_and_project_id')
+    def test_connection_success(self, mock_get_creds_and_proj_id):
+        mock_get_creds_and_proj_id.return_value = ("CREDENTIALS", "PROJECT_ID")
+        self.instance.extras = {}
+        result = self.instance.test_connection()
+        assert result == (True, 'Connection successfully tested')
+
+    @mock.patch(MODULE_NAME + '.get_credentials_and_project_id')
+    def test_connection_failure(self, mock_get_creds_and_proj_id):
+        mock_get_creds_and_proj_id.side_effect = AirflowException('Invalid key JSON.')
+        self.instance.extras = {}
+        result = self.instance.test_connection()
+        assert result == (False, 'Invalid key JSON.')
+
+    @mock.patch(MODULE_NAME + '.get_credentials_and_project_id')
     def test_get_credentials_and_project_id_with_service_account_file(self, mock_get_creds_and_proj_id):
         mock_credentials = mock.MagicMock()
         mock_get_creds_and_proj_id.return_value = (mock_credentials, "PROJECT_ID")

--- a/tests/providers/google/common/hooks/test_base_google.py
+++ b/tests/providers/google/common/hooks/test_base_google.py
@@ -341,9 +341,13 @@ class TestGoogleBaseHook(unittest.TestCase):
         )
         assert ('CREDENTIALS', 'PROJECT_ID') == result
 
+    @mock.patch('requests.post')
     @mock.patch(MODULE_NAME + '.get_credentials_and_project_id')
-    def test_connection_success(self, mock_get_creds_and_proj_id):
-        mock_get_creds_and_proj_id.return_value = ("CREDENTIALS", "PROJECT_ID")
+    def test_connection_success(self, mock_get_creds_and_proj_id, requests_post):
+        requests_post.return_value.status_code = 200
+        credentials = mock.MagicMock()
+        type(credentials).token = mock.PropertyMock(return_value="TOKEN")
+        mock_get_creds_and_proj_id.return_value = (credentials, "PROJECT_ID")
         self.instance.extras = {}
         result = self.instance.test_connection()
         assert result == (True, 'Connection successfully tested')


### PR DESCRIPTION
This PR adds test connection functionality to Google Cloud connection type in airflow UI

cc @kaxil @potiuk 

Test connection Pass
<img width="1012" alt="Screenshot 2022-06-27 at 10 05 47 PM" src="https://user-images.githubusercontent.com/94376113/175992096-22b093d0-b193-4a58-bc7e-e33ca9065020.png">


Test connection Failed

<img width="1656" alt="image" src="https://user-images.githubusercontent.com/94376113/175991719-c6c8fbe7-8afb-4bbd-99c0-9dbf7452718a.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
