### PR TITLE
Keep grid log scrolling limited to its wrapper div

### DIFF
--- a/airflow/www/static/js/grid/details/content/taskInstance/Logs/index.jsx
+++ b/airflow/www/static/js/grid/details/content/taskInstance/Logs/index.jsx
@@ -85,7 +85,7 @@ const Logs = ({
 
   useEffect(() => {
     if (codeBlockBottomDiv.current) {
-      codeBlockBottomDiv.current.scrollIntoView();
+      codeBlockBottomDiv.current.scrollIntoView({ block: 'nearest', inline: 'nearest' });
     }
   }, [wrap, data]);
 


### PR DESCRIPTION
When navigating around the grid view logs, the page would jump around when going to a new log that needed to auto-scroll to the bottom.

Use `block` and `inline` arguments of `scrollIntoView()` so that auto-scrolling only affects the wrapper div of Logs and not the entire page.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
