### PR TITLE
WIP Task-level dataset deps

### DIFF
--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.models.dataset_reference import InletDataset, OutletDataset
+from airflow.operators.bash import BashOperator
+
+with DAG(
+    dag_id='upstream_dag',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_interval='@daily',
+) as dag1:
+    BashOperator(
+        outlets=[OutletDataset('s3://abc/dataset3.txt', extra={'hi': 'bye'})],
+        inlets=[
+            InletDataset('s3://abc/dataset1.txt', schedule_on=False),
+            InletDataset('s3://abc/dataset2.txt', schedule_on=False),
+        ],
+        task_id='upstream_task_1',
+        bash_command="sleep 5",
+    )
+
+with DAG(
+    dag_id='some_downstream_dag',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_on_dataset=True,
+    schedule_interval=None,
+) as dag2:
+    BashOperator(
+        outlets=[OutletDataset('s3://abc/dataset_other.txt')],
+        inlets=[
+            InletDataset('s3://abc/dataset3.txt', schedule_on=True),
+            InletDataset('s3://abc/dataset_unknown.txt', schedule_on=False),
+        ],
+        task_id='downstream_1',
+        bash_command="sleep 5",
+    )
+
+with DAG(
+    dag_id='other_downstream_dag',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_on_dataset=True,
+    schedule_interval=None,
+) as dag3:
+    BashOperator(
+        inlets=[
+            InletDataset('s3://abc/dataset3.txt', schedule_on=True),
+            InletDataset('s3://abc/dataset_other_unknown.txt', schedule_on=True),
+        ],
+        task_id='downstream_2',
+        bash_command="sleep 5",
+    )

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -667,7 +667,7 @@ class DagRun(Base, LoggingMixin):
                     isouter=True,
                 )
                 .filter(
-                    DDRE.target_dag_id.in_(dependent_dag_ids),
+                    DatasetReference.dag_id.in_(dependent_dag_ids),
                     DatasetReference.is_scheduling_dep == True,
                     DatasetReference.is_write == False,
                 )

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -68,9 +68,10 @@ class Dataset(Base):
         super().__init__(uri=uri, **kwargs)
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        return self.uri == other.uri
+        if isinstance(other, self.__class__):
+            return self.uri == other.uri
+        else:
+            return NotImplemented
 
     def __hash__(self):
         return hash(self.uri)

--- a/airflow/models/dataset_dag_run_event.py
+++ b/airflow/models/dataset_dag_run_event.py
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy import Column, ForeignKeyConstraint, Integer
+
+from airflow.models.base import Base, StringID
+from airflow.utils import timezone
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+class DatasetDagRunEvent(Base):
+    """Model for storing dataset events that need processing."""
+
+    dataset_id = Column(Integer, primary_key=True, nullable=False)
+    target_dag_id = Column(StringID(), primary_key=True, nullable=False)
+    created_at = Column(UtcDateTime, default=timezone.utcnow, nullable=False)
+
+    __tablename__ = "dataset_dag_run_event"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            (dataset_id,),
+            ["dataset.id"],
+            name='ddre_dataset_fkey',
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            (target_dag_id,),
+            ["dag.dag_id"],
+            name='ddre_dag_fkey',
+            ondelete="CASCADE",
+        ),
+    )
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.dataset_id == other.dataset_id and self.target_dag_id == other.target_dag_id
+
+    def __hash__(self):
+        return hash((self.dataset_id, self.target_dag_id))
+
+    def __repr__(self):
+        args = []
+        for attr in ('dataset_id', 'target_dag_id'):
+            args.append(f"{attr}={getattr(self, attr)!r}")
+        return f"{self.__class__.__name__}({', '.join(args)})"

--- a/airflow/models/dataset_reference.py
+++ b/airflow/models/dataset_reference.py
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from sqlalchemy import Boolean, Column, ForeignKeyConstraint, Integer, String
+
+from airflow.models.base import ID_LEN, Base
+from airflow.utils import timezone
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+class DatasetReference(Base):
+    """References to datasets"""
+
+    dataset_id = Column(Integer, primary_key=True, nullable=False)
+    dag_id = Column(String(ID_LEN), primary_key=True, nullable=False)
+    task_id = Column(String(ID_LEN), primary_key=True, nullable=False)
+    is_write = Column(Boolean, primary_key=True, nullable=False)
+    is_scheduling_dep = Column(Boolean, nullable=False)
+    created_at = Column(UtcDateTime, default=timezone.utcnow, nullable=False)
+    updated_at = Column(UtcDateTime, default=timezone.utcnow(), onupdate=timezone.utcnow, nullable=False)
+
+    __tablename__ = "dataset_reference"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            (dataset_id,),
+            ["dataset.id"],
+            name='dataset_event_dataset_fkey',
+            ondelete="CASCADE",
+        ),
+    )
+
+    def __eq__(self, other):
+        return self.uri == other.uri
+
+    def __hash__(self):
+        return hash((self.uri, self.extra))
+
+    def __repr__(self):
+        args = []
+        for attr in ('dataset_id', 'dag_id', 'task_id', 'is_write'):
+            args.append(f"{attr}={getattr(self, attr)!r}")
+        return f"{self.__class__.__name__}({', '.join(args)})"
+
+
+class InletDataset:
+    """For inbound dataset references"""
+
+    def __init__(self, uri, *, schedule_on: bool = True, **kwargs):
+        self.uri = uri
+        self.schedule_on = schedule_on
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.uri == other.uri
+
+    def __hash__(self):
+        return hash(self.uri)
+
+
+class OutletDataset:
+    """For outbound dataset references"""
+
+    def __init__(self, uri, extra: Optional[dict] = None, **kwargs):
+        self.uri = uri
+        self.extra = extra
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.uri == other.uri
+
+    def __hash__(self):
+        return hash(self.uri)

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -49,3 +49,6 @@ class DagAttributeTypes(str, Enum):
     EDGE_INFO = 'edgeinfo'
     PARAM = 'param'
     XCOM_REF = 'xcomref'
+    DATASET = 'dataset'
+    INLET_DATASET = 'inlet_dataset'
+    OUTLET_DATASET = 'outlet_dataset'

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -90,6 +90,7 @@
             { "$ref": "#/definitions/typed_relativedelta" }
           ]
         },
+        "schedule_on_dataset": { "type": "boolean" },
         "timetable": {
           "type": "object",
           "properties": {

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -39,6 +39,7 @@ from typing import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.utils.module_loading import import_string
+from airflow.utils.types import ArgNotSet
 
 if TYPE_CHECKING:
     import jinja2
@@ -312,6 +313,22 @@ def exactly_one(*args) -> bool:
             "Not supported for iterable args. Use `*` to unpack your iterable in the function call."
         )
     return sum(map(bool, args)) == 1
+
+
+def at_most_one(*args) -> bool:
+    """
+    Returns True if at most one of *args is "truthy", and False otherwise.
+
+    If user supplies an iterable, we raise ValueError and force them to unpack.
+    """
+
+    def is_set(val):
+        if isinstance(val, ArgNotSet):
+            return False
+        else:
+            return bool(val)
+
+    return sum(map(is_set, args)) in (0, 1)
 
 
 def prune_dict(val: Any, mode='strict'):


### PR DESCRIPTION
This is an exploratory PR for AIP-48 defining dataset dependencies at the task level.

In each upstream dataset reference we can define whether it should be considered for scheduling or if it's just lineage info.  This allows us to freely define all dataset relationships while only considering a subset of them for scheduling. 

A dag will be triggered when all of its scheduling dep datasets have been updated.
