### PR TITLE
Remove `hook-class-names` from provider.yaml

### DIFF
--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -194,17 +194,6 @@
         ]
       }
     },
-    "hook-class-names": {
-      "type": "array",
-      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
-      "items": {
-          "type": "string"
-      },
-      "deprecated": {
-        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
-        "deprecatedVersion": "2.2"
-      }
-    },
     "connection-types": {
       "type": "array",
       "description": "Array of connection types mapped to hook class names",

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -14,6 +14,17 @@
       "description": "Information about the package in RST format",
       "type": "string"
     },
+    "hook-class-names": {
+      "type": "array",
+      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
+      "items": {
+        "type": "string"
+      },
+      "deprecated": {
+        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
+        "deprecatedVersion": "2.2.0"
+      }
+    },
     "connection-types": {
       "type": "array",
       "description": "Map of connection types mapped to hook class names.",

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -14,17 +14,6 @@
       "description": "Information about the package in RST format",
       "type": "string"
     },
-    "hook-class-names": {
-      "type": "array",
-      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
-      "items": {
-        "type": "string"
-      },
-      "deprecated": {
-        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
-        "deprecatedVersion": "2.2.0"
-      }
-    },
     "connection-types": {
       "type": "array",
       "description": "Map of connection types mapped to hook class names.",

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -57,9 +57,6 @@ sensors:
     python-modules:
       - airflow.providers.airbyte.sensors.airbyte
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.airbyte.hooks.airbyte.AirbyteHook
-
 connection-types:
   - hook-class-name: airflow.providers.airbyte.hooks.airbyte.AirbyteHook
     connection-type: airbyte

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -54,8 +54,6 @@ hooks:
     python-modules:
       - airflow.providers.alibaba.cloud.hooks.oss
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.alibaba.cloud.hooks.oss.OSSHook
 
 connection-types:
   - hook-class-name: airflow.providers.alibaba.cloud.hooks.oss.OSSHook

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -561,11 +561,6 @@ transfers:
     how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/sql_to_s3.rst
     python-module: airflow.providers.amazon.aws.transfers.sql_to_s3
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.amazon.aws.hooks.s3.S3Hook
-  - airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
-  - airflow.providers.amazon.aws.hooks.emr.EmrHook
-  - airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook
 
 extra-links:
   - airflow.providers.amazon.aws.links.batch.BatchJobDefinitionLink

--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -54,9 +54,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.cassandra.hooks.cassandra
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook
-
 connection-types:
   - hook-class-name: airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook
     connection-type: cassandra

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -50,9 +50,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.drill.hooks.drill
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.drill.hooks.drill.DrillHook
-
 connection-types:
   - hook-class-name: airflow.providers.apache.drill.hooks.drill.DrillHook
     connection-type: drill

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -58,8 +58,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.druid.hooks.druid
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.druid.hooks.druid.DruidDbApiHook
 
 connection-types:
   - hook-class-name: airflow.providers.apache.druid.hooks.druid.DruidDbApiHook

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -67,9 +67,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.hdfs.hooks.webhdfs
 
-hook-class-names:
-  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook
 
 connection-types:
   - hook-class-name: airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -87,12 +87,6 @@ transfers:
     target-integration-name: Apache Hive
     python-module: airflow.providers.apache.hive.transfers.mssql_to_hive
 
-hook-class-names:
-  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.hive.hooks.hive.HiveCliHook
-  - airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
-  - airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook
-
 connection-types:
   - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveCliHook
     connection-type: hive_cli

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -59,9 +59,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.livy.hooks.livy
 
-hook-class-names:
-  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.livy.hooks.livy.LivyHook
 
 connection-types:
   - hook-class-name: airflow.providers.apache.livy.hooks.livy.LivyHook

--- a/airflow/providers/apache/pig/provider.yaml
+++ b/airflow/providers/apache/pig/provider.yaml
@@ -52,10 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.pig.hooks.pig
 
-hook-class-names:
-  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.pig.hooks.pig.PigCliHook
-
 connection-types:
   - connection-type: pig_cli
     hook-class-name: airflow.providers.apache.pig.hooks.pig.PigCliHook

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -62,10 +62,6 @@ hooks:
       - airflow.providers.apache.spark.hooks.spark_sql
       - airflow.providers.apache.spark.hooks.spark_submit
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
-  - airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
-  - airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook
 
 connection-types:
   - hook-class-name: airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -54,9 +54,6 @@ hooks:
     python-modules:
       - airflow.providers.apache.sqoop.hooks.sqoop
 
-hook-class-names:
-  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook
 
 connection-types:
   - hook-class-name: airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook

--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -49,8 +49,6 @@ hooks:
     python-modules:
       - airflow.providers.asana.hooks.asana
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.asana.hooks.asana.AsanaHook
 
 connection-types:
   - hook-class-name: airflow.providers.asana.hooks.asana.AsanaHook

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -45,9 +45,6 @@ hooks:
     python-modules:
       - airflow.providers.cloudant.hooks.cloudant
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.cloudant.hooks.cloudant.CloudantHook
-
 connection-types:
   - hook-class-name: airflow.providers.cloudant.hooks.cloudant.CloudantHook
     connection-type: cloudant

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -75,8 +75,6 @@ hooks:
     python-modules:
       - airflow.providers.cncf.kubernetes.hooks.kubernetes
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook
 
 connection-types:
   - hook-class-name: airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -83,8 +83,6 @@ hooks:
     python-modules:
       - airflow.providers.databricks.hooks.databricks_sql
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.databricks.hooks.databricks.DatabricksHook
 
 connection-types:
   - hook-class-name: airflow.providers.databricks.hooks.databricks.DatabricksHook

--- a/airflow/providers/dbt/cloud/provider.yaml
+++ b/airflow/providers/dbt/cloud/provider.yaml
@@ -52,9 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.dbt.cloud.hooks.dbt
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook
-
 connection-types:
   - hook-class-name: airflow.providers.dbt.cloud.hooks.dbt.DbtCloudHook
     connection-type: dbt_cloud

--- a/airflow/providers/dingding/provider.yaml
+++ b/airflow/providers/dingding/provider.yaml
@@ -53,8 +53,6 @@ hooks:
     python-modules:
       - airflow.providers.dingding.hooks.dingding
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.dingding.hooks.dingding.DingdingHook
 
 connection-types:
   - hook-class-name: airflow.providers.dingding.hooks.dingding.DingdingHook

--- a/airflow/providers/discord/provider.yaml
+++ b/airflow/providers/discord/provider.yaml
@@ -51,9 +51,6 @@ hooks:
     python-modules:
       - airflow.providers.discord.hooks.discord_webhook
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook
-
 connection-types:
   - hook-class-name: airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook
     connection-type: discord

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -67,9 +67,6 @@ hooks:
     python-modules:
       - airflow.providers.docker.hooks.docker
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.docker.hooks.docker.DockerHook
-
 connection-types:
   - hook-class-name: airflow.providers.docker.hooks.docker.DockerHook
     connection-type: docker

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -52,9 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.elasticsearch.hooks.elasticsearch
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchHook
-
 connection-types:
   - hook-class-name: airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchHook
     connection-type: elasticsearch

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -52,9 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.exasol.hooks.exasol
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.exasol.hooks.exasol.ExasolHook
-
 connection-types:
   - hook-class-name: airflow.providers.exasol.hooks.exasol.ExasolHook
     connection-type: exasol

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -48,9 +48,6 @@ hooks:
     python-modules:
       - airflow.providers.facebook.ads.hooks.ads
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook
-
 connection-types:
   - hook-class-name: airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook
     connection-type: facebook_social

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -48,9 +48,6 @@ hooks:
     python-modules:
       - airflow.providers.ftp.hooks.ftp
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.ftp.hooks.ftp.FTPHook
-
 connection-types:
   - hook-class-name: airflow.providers.ftp.hooks.ftp.FTPHook
     connection-type: ftp

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -853,14 +853,6 @@ transfers:
     python-module: airflow.providers.google.cloud.transfers.mssql_to_gcs
     how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/mssql_to_gcs.rst
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.google.common.hooks.base_google.GoogleBaseHook
-  - airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook
-  - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook
-  - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook
-  - airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook
-  - airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
-  - airflow.providers.google.leveldb.hooks.leveldb.LevelDBHook
 
 connection-types:
   - hook-class-name: airflow.providers.google.common.hooks.base_google.GoogleBaseHook

--- a/airflow/providers/grpc/provider.yaml
+++ b/airflow/providers/grpc/provider.yaml
@@ -50,9 +50,6 @@ hooks:
     python-modules:
       - airflow.providers.grpc.hooks.grpc
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.grpc.hooks.grpc.GrpcHook
-
 connection-types:
   - hook-class-name: airflow.providers.grpc.hooks.grpc.GrpcHook
     connection-type: grpc

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -48,9 +48,6 @@ hooks:
     python-modules:
       - airflow.providers.hashicorp.hooks.vault
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.hashicorp.hooks.vault.VaultHook
-
 connection-types:
   - hook-class-name: airflow.providers.hashicorp.hooks.vault.VaultHook
     connection-type: vault

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -56,9 +56,6 @@ hooks:
     python-modules:
       - airflow.providers.http.hooks.http
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.http.hooks.http.HttpHook
-
 connection-types:
   - hook-class-name: airflow.providers.http.hooks.http.HttpHook
     connection-type: http

--- a/airflow/providers/imap/provider.yaml
+++ b/airflow/providers/imap/provider.yaml
@@ -49,9 +49,6 @@ hooks:
     python-modules:
       - airflow.providers.imap.hooks.imap
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.imap.hooks.imap.ImapHook
-
 connection-types:
   - hook-class-name: airflow.providers.imap.hooks.imap.ImapHook
     connection-type: imap

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -52,8 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.jdbc.hooks.jdbc
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.jdbc.hooks.jdbc.JdbcHook
 
 connection-types:
   - hook-class-name: airflow.providers.jdbc.hooks.jdbc.JdbcHook

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -59,9 +59,6 @@ sensors:
     python-modules:
       - 'airflow.providers.jenkins.sensors.jenkins'
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.jenkins.hooks.jenkins.JenkinsHook
-
 connection-types:
   - hook-class-name: airflow.providers.jenkins.hooks.jenkins.JenkinsHook
     connection-type: jenkins

--- a/airflow/providers/jira/provider.yaml
+++ b/airflow/providers/jira/provider.yaml
@@ -57,9 +57,6 @@ hooks:
     python-modules:
       - airflow.providers.jira.hooks.jira
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.jira.hooks.jira.JiraHook
-
 connection-types:
   - hook-class-name: airflow.providers.jira.hooks.jira.JiraHook
     connection-type: jira

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -204,19 +204,6 @@ transfers:
     how-to-guide: /docs/apache-airflow-providers-microsoft-azure/operators/sftp_to_wasb.rst
     python-module: airflow.providers.microsoft.azure.transfers.sftp_to_wasb
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook
-  - airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook
-  - airflow.providers.microsoft.azure.hooks.batch.AzureBatchHook
-  - airflow.providers.microsoft.azure.hooks.cosmos.AzureCosmosDBHook
-  - airflow.providers.microsoft.azure.hooks.data_lake.AzureDataLakeHook
-  - airflow.providers.microsoft.azure.hooks.fileshare.AzureFileShareHook
-  - airflow.providers.microsoft.azure.hooks.container_volume.AzureContainerVolumeHook
-  - airflow.providers.microsoft.azure.hooks.container_instance.AzureContainerInstanceHook
-  - airflow.providers.microsoft.azure.hooks.wasb.WasbHook
-  - airflow.providers.microsoft.azure.hooks.data_factory.AzureDataFactoryHook
-  - airflow.providers.microsoft.azure.hooks.container_registry.AzureContainerRegistryHook
-  - airflow.providers.microsoft.azure.hooks.asb.BaseAzureServiceBusHook
 
 connection-types:
   - hook-class-name: airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -54,9 +54,6 @@ hooks:
     python-modules:
       - airflow.providers.microsoft.mssql.hooks.mssql
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook
-
 connection-types:
   - hook-class-name: airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook
     connection-type: mssql

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -51,9 +51,6 @@ hooks:
     python-modules:
       - airflow.providers.mongo.hooks.mongo
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.mongo.hooks.mongo.MongoHook
-
 connection-types:
   - hook-class-name: airflow.providers.mongo.hooks.mongo.MongoHook
     connection-type: mongo

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -71,8 +71,6 @@ transfers:
     target-integration-name: MySQL
     python-module: airflow.providers.mysql.transfers.trino_to_mysql
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.mysql.hooks.mysql.MySqlHook
 
 connection-types:
   - hook-class-name: airflow.providers.mysql.hooks.mysql.MySqlHook

--- a/airflow/providers/neo4j/provider.yaml
+++ b/airflow/providers/neo4j/provider.yaml
@@ -53,8 +53,6 @@ hooks:
     python-modules:
       - airflow.providers.neo4j.hooks.neo4j
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.neo4j.hooks.neo4j.Neo4jHook
 
 connection-types:
   - hook-class-name: airflow.providers.neo4j.hooks.neo4j.Neo4jHook

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -45,8 +45,6 @@ hooks:
     python-modules:
       - airflow.providers.odbc.hooks.odbc
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.odbc.hooks.odbc.OdbcHook
 
 connection-types:
   - hook-class-name: airflow.providers.odbc.hooks.odbc.OdbcHook

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -57,9 +57,6 @@ hooks:
       - airflow.providers.opsgenie.hooks.opsgenie_alert
       - airflow.providers.opsgenie.hooks.opsgenie
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.opsgenie.hooks.opsgenie.OpsgenieAlertHook
-
 connection-types:
   - hook-class-name: airflow.providers.opsgenie.hooks.opsgenie.OpsgenieAlertHook
     connection-type: opsgenie

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -62,9 +62,6 @@ transfers:
     target-integration-name: Oracle
     python-module: airflow.providers.oracle.transfers.oracle_to_oracle
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.oracle.hooks.oracle.OracleHook
-
 connection-types:
   - hook-class-name: airflow.providers.oracle.hooks.oracle.OracleHook
     connection-type: oracle

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -57,8 +57,6 @@ hooks:
     python-modules:
       - airflow.providers.postgres.hooks.postgres
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.postgres.hooks.postgres.PostgresHook
 
 connection-types:
   - hook-class-name: airflow.providers.postgres.hooks.postgres.PostgresHook

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -59,9 +59,6 @@ transfers:
     how-to-guide: /docs/apache-airflow-providers-presto/operators/transfer/presto_to_slack.rst
     python-module: airflow.providers.presto.transfers.presto_to_slack
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.presto.hooks.presto.PrestoHook
-
 connection-types:
   - hook-class-name: airflow.providers.presto.hooks.presto.PrestoHook
     connection-type: presto

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -62,8 +62,6 @@ hooks:
       - airflow.providers.qubole.hooks.qubole
       - airflow.providers.qubole.hooks.qubole_check
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.qubole.hooks.qubole.QuboleHook
 
 connection-types:
   - hook-class-name: airflow.providers.qubole.hooks.qubole.QuboleHook

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -56,9 +56,6 @@ hooks:
     python-modules:
       - airflow.providers.redis.hooks.redis
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.redis.hooks.redis.RedisHook
-
 connection-types:
   - hook-class-name: airflow.providers.redis.hooks.redis.RedisHook
     connection-type: redis

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -66,9 +66,6 @@ hooks:
     python-modules:
       - airflow.providers.salesforce.hooks.salesforce
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.salesforce.hooks.salesforce.SalesforceHook
-
 connection-types:
   - hook-class-name: airflow.providers.salesforce.hooks.salesforce.SalesforceHook
     connection-type: salesforce

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -46,8 +46,6 @@ hooks:
     python-modules:
       - airflow.providers.samba.hooks.samba
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.samba.hooks.samba.SambaHook
 
 connection-types:
   - hook-class-name: airflow.providers.samba.hooks.samba.SambaHook

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -50,9 +50,6 @@ hooks:
     python-modules:
       - airflow.providers.segment.hooks.segment
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.segment.hooks.segment.SegmentHook
-
 connection-types:
   - hook-class-name: airflow.providers.segment.hooks.segment.SegmentHook
     connection-type: segment

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -64,8 +64,6 @@ hooks:
     python-modules:
       - airflow.providers.sftp.hooks.sftp
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.sftp.hooks.sftp.SFTPHook
 
 connection-types:
   - hook-class-name: airflow.providers.sftp.hooks.sftp.SFTPHook

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -57,9 +57,6 @@ hooks:
       - airflow.providers.slack.hooks.slack
       - airflow.providers.slack.hooks.slack_webhook
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook
-
 connection-types:
   - hook-class-name: airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook
     connection-type: slackwebhook

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -72,9 +72,6 @@ transfers:
     python-module: airflow.providers.snowflake.transfers.snowflake_to_slack
     how-to-guide: /docs/apache-airflow-providers-snowflake/operators/snowflake_to_slack.rst
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.snowflake.hooks.snowflake.SnowflakeHook
-
 connection-types:
   - hook-class-name: airflow.providers.snowflake.hooks.snowflake.SnowflakeHook
     connection-type: snowflake

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -52,9 +52,6 @@ hooks:
     python-modules:
       - airflow.providers.sqlite.hooks.sqlite
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.sqlite.hooks.sqlite.SqliteHook
-
 connection-types:
   - hook-class-name: airflow.providers.sqlite.hooks.sqlite.SqliteHook
     connection-type: sqlite

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -57,9 +57,6 @@ hooks:
     python-modules:
       - airflow.providers.ssh.hooks.ssh
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.ssh.hooks.ssh.SSHHook
-
 connection-types:
   - hook-class-name: airflow.providers.ssh.hooks.ssh.SSHHook
     connection-type: ssh

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -63,9 +63,6 @@ hooks:
     python-modules:
       - airflow.providers.tableau.hooks.tableau
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.tableau.hooks.tableau.TableauHook
-
 connection-types:
   - hook-class-name: airflow.providers.tableau.hooks.tableau.TableauHook
     connection-type: tableau

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -60,9 +60,6 @@ transfers:
     how-to-guide: /docs/apache-airflow-providers-trino/operators/transfer/gcs_to_trino.rst
     python-module: airflow.providers.trino.transfers.gcs_to_trino
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.trino.hooks.trino.TrinoHook
-
 connection-types:
   - hook-class-name: airflow.providers.trino.hooks.trino.TrinoHook
     connection-type: trino

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -51,9 +51,6 @@ hooks:
     python-modules:
       - airflow.providers.vertica.hooks.vertica
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.vertica.hooks.vertica.VerticaHook
-
 connection-types:
   - hook-class-name: airflow.providers.vertica.hooks.vertica.VerticaHook
     connection-type: vertica

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -61,9 +61,6 @@ hooks:
     python-modules:
       - airflow.providers.yandex.hooks.yandexcloud_dataproc
 
-hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook
-
 connection-types:
   - hook-class-name: airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook
     connection-type: yandexcloud


### PR DESCRIPTION
now that providers>=2.2 there is no need for the hook-class-names any longer.
refrence to https://github.com/apache/airflow/pull/17775

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
