### PR TITLE
fix document about response_check in HttpSensor

### DIFF
--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -38,15 +38,18 @@ class HttpSensor(BaseSensorOperator):
 
     The response check can access the template context to the operator:
 
+    .. code-block:: python
+
         def response_check(response, task_instance):
             # The task_instance is injected, so you can pull data form xcom
             # Other context variables such as dag, ds, execution_date are also available.
-            xcom_data = task_instance.xcom_pull(task_ids='pushing_task')
+            xcom_data = task_instance.xcom_pull(task_ids="pushing_task")
             # In practice you would do something more sensible with this data..
             print(xcom_data)
             return True
 
-        HttpSensor(task_id='my_http_sensor', ..., response_check=response_check)
+
+        HttpSensor(task_id="my_http_sensor", ..., response_check=response_check)
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:


### PR DESCRIPTION
The layout of response_check is broken.

see: https://airflow.apache.org/docs/apache-airflow-providers-http/stable/_api/airflow/providers/http/sensors/http/index.html

Added code-block for response_check.

<img width="773" alt="image" src="https://user-images.githubusercontent.com/12693596/176213957-8f6f9da1-b0a4-49a2-91dc-fb715971b6e8.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
