### PR TITLE
fix connection extra parameter `auth_mechanism` in `HiveMetastoreHook` and `HiveServer2Hook`

### DIFF
--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -625,7 +625,7 @@ class TestHiveServer2Hook(unittest.TestCase):
 
         with mock.patch.dict(
             'os.environ',
-            {conn_env: "jdbc+hive2://conn_id:conn_pass@localhost:10000/default?authMechanism=LDAP"},
+            {conn_env: "jdbc+hive2://conn_id:conn_pass@localhost:10000/default?auth_mechanism=LDAP"},
         ):
             HiveServer2Hook(hiveserver2_conn_id=conn_id).get_conn()
             mock_connect.assert_called_once_with(


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/24692

I changed the parameter to `auth_mechanism` in order to keep the convention of the other extra parameters:
https://airflow.apache.org/docs/apache-airflow-providers-apache-hive/stable/connections/hiveserver2.html#configuring-the-connection
https://airflow.apache.org/docs/apache-airflow-providers-apache-hive/stable/connections/hive_metastore.html#configuring-the-connection

Part of the fix is also fixing the previous provider docs - see also https://github.com/apache/airflow-site/pull/619

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
