### PR TITLE
KubernetesPodOperator can get namespace from hook

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -147,16 +147,16 @@ class KubernetesHook(BaseHook):
             extras = {}
         return extras
 
-    def _get_field(self, field_name):
+    def _get_field(self, field_name, default=None):
         if field_name.startswith('extra_'):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the 'extra__kubernetes__' prefix "
                 f"when using this method."
             )
         if field_name in self.conn_extras:
-            return self.conn_extras[field_name] or None
+            return self.conn_extras[field_name] or default
         prefixed_name = f"extra__kubernetes__{field_name}"
-        return self.conn_extras.get(prefixed_name) or None
+        return self.conn_extras.get(prefixed_name) or default
 
     @staticmethod
     def _deprecation_warning_core_param(deprecation_warnings):
@@ -359,11 +359,9 @@ class KubernetesHook(BaseHook):
     def get_namespace(self) -> Optional[str]:
         """Returns the namespace that defined in the connection"""
         if self.conn_id:
-            connection = self.get_connection(self.conn_id)
-            extras = connection.extra_dejson
-            namespace = extras.get("extra__kubernetes__namespace", "default")
-            return namespace
-        return None
+            return self._get_field('namespace', 'default')
+        else:
+            return None
 
     def get_pod_log_stream(
         self,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -532,7 +532,7 @@ class KubernetesPodOperator(BaseOperator):
             api_version="v1",
             kind="Pod",
             metadata=k8s.V1ObjectMeta(
-                namespace=self.namespace,
+                namespace=self.namespace or self.hook.get_namespace(),
                 labels=self.labels,
                 name=self.name,
                 annotations=self.annotations,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -385,7 +385,7 @@ class KubernetesPodOperator(BaseOperator):
 
     def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: 'Context') -> k8s.V1Pod:
         if self.reattach_on_restart:
-            pod = self.find_pod(self.namespace or pod_request_obj.metadata.namespace, context=context)
+            pod = self.find_pod(pod_request_obj.metadata.namespace, context=context)
             if pod:
                 return pod
         self.log.debug("Starting pod:\n%s", yaml.safe_dump(pod_request_obj.to_dict()))

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -211,6 +211,19 @@ class TestKubernetesPodOperator:
         pod = self.run_pod(k)
         assert pod.metadata.namespace == 'hihi'
 
+    def test_hook_get_namespace_call(self):
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            do_xcom_push=False,
+            in_cluster=False,
+        )
+        k.build_pod_request_obj()
+        self.hook_mock.return_value.get_namespace.assert_called_once_with(default=None)
+
     def test_labels_mapped(self):
         k = KubernetesPodOperator(
             namespace="default",
@@ -383,7 +396,7 @@ class TestKubernetesPodOperator:
     @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
     def test_full_pod_spec(self, randomize_name, pod_spec):
         pod_spec_name_base = pod_spec.metadata.name
-
+        self.hook_mock.return_value.get_namespace.return_value = None  # true since no conn_id provided
         k = KubernetesPodOperator(
             task_id="task",
             random_name_suffix=randomize_name,
@@ -418,6 +431,7 @@ class TestKubernetesPodOperator:
     @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
     def test_full_pod_spec_kwargs(self, randomize_name, pod_spec):
         # kwargs take precedence, however
+        self.hook_mock.return_value.get_namespace.return_value = None  # true since no conn_id provided
         image = "some.custom.image:andtag"
         name_base = "world"
         k = KubernetesPodOperator(
@@ -500,6 +514,7 @@ class TestKubernetesPodOperator:
 
     @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
     def test_pod_template_file(self, randomize_name, pod_template_file):
+        self.hook_mock.return_value.get_namespace.return_value = None  # true since no conn_id provided
         k = KubernetesPodOperator(
             task_id="task",
             random_name_suffix=randomize_name,
@@ -562,6 +577,7 @@ class TestKubernetesPodOperator:
     @pytest.mark.parametrize(("randomize_name",), ([True], [False]))
     def test_pod_template_file_kwargs_override(self, randomize_name, pod_template_file):
         # kwargs take precedence, however
+        self.hook_mock.return_value.get_namespace.return_value = None  # true since no conn_id provided
         image = "some.custom.image:andtag"
         name_base = "world"
         k = KubernetesPodOperator(

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -211,19 +211,6 @@ class TestKubernetesPodOperator:
         pod = self.run_pod(k)
         assert pod.metadata.namespace == 'hihi'
 
-    def test_hook_get_namespace_call(self):
-        k = KubernetesPodOperator(
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            labels={"foo": "bar"},
-            name="test",
-            task_id="task",
-            do_xcom_push=False,
-            in_cluster=False,
-        )
-        k.build_pod_request_obj()
-        self.hook_mock.return_value.get_namespace.assert_called_once_with(default=None)
-
     def test_labels_mapped(self):
         k = KubernetesPodOperator(
             namespace="default",

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -197,6 +197,20 @@ class TestKubernetesPodOperator:
             "airflow_kpo_in_cluster": str(in_cluster),
         }
 
+    def test_hook_namespace(self):
+        self.hook_mock.return_value.get_namespace.return_value = 'hihi'
+        k = KubernetesPodOperator(
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            do_xcom_push=False,
+            in_cluster=False,
+        )
+        pod = self.run_pod(k)
+        assert pod.metadata.namespace == 'hihi'
+
     def test_labels_mapped(self):
         k = KubernetesPodOperator(
             namespace="default",


### PR DESCRIPTION
Currently you have to set namespace in KPO init but we can get it from airflow connection if we're using one.