### PR TITLE
Use our yaml util in all providers

### DIFF
--- a/airflow/providers/amazon/aws/hooks/eks.py
+++ b/airflow/providers/amazon/aws/hooks/eks.py
@@ -26,11 +26,11 @@ from enum import Enum
 from functools import partial
 from typing import Callable, Dict, Generator, List, Optional
 
-import yaml
 from botocore.exceptions import ClientError
 from botocore.signers import RequestSigner
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+from airflow.utils import yaml
 from airflow.utils.json import AirflowJsonEncoder
 
 DEFAULT_PAGINATION_TOKEN = ''

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -22,15 +22,10 @@ from kubernetes import client, config, watch
 from kubernetes.config import ConfigException
 
 from airflow.compat.functools import cached_property
-from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
-
-try:
-    import airflow.utils.yaml as yaml
-except ImportError:
-    import yaml  # type: ignore[no-redef]
-
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keepalive
+from airflow.utils import yaml
 
 
 def _load_body_to_dict(body):

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -24,7 +24,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
 from urllib.parse import unquote, urlparse
 
-import yaml
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.api_core.retry import Retry
 from google.cloud.devtools.cloudbuild_v1.types import Build, BuildTrigger, RepoSource
@@ -32,6 +31,7 @@ from google.cloud.devtools.cloudbuild_v1.types import Build, BuildTrigger, RepoS
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildHook
+from airflow.utils import yaml
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context


### PR DESCRIPTION
Our yaml util, which uses libyaml where possible, has been available in
core since 2.0.2. Providers now require 2.2.0+, so we can safely use it
now.