### PR TITLE
`DockerOperator` fix cli.logs giving character array instead of string

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -321,9 +321,9 @@ class DockerOperator(BaseOperator):
                     return None
                 try:
                     if self.xcom_all:
-                        return [stringify(line).strip() for line in log_lines]
+                        return log_lines
                     else:
-                        return stringify(log_lines[-1]).strip()
+                        return log_lines[-1]
                 except StopIteration:
                     # handle the case when there is not a single line to iterate on
                     return None

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -317,18 +317,13 @@ class DockerOperator(BaseOperator):
             if self.retrieve_output:
                 return self._attempt_to_retrieve_result()
             elif self.do_xcom_push:
-                log_parameters = {
-                    'container': self.container['Id'],
-                    'stdout': True,
-                    'stderr': True,
-                    'stream': True,
-                }
+                if len(log_lines) == 0:
+                    return None
                 try:
                     if self.xcom_all:
-                        return [stringify(line).strip() for line in self.cli.logs(**log_parameters)]
+                        return [stringify(line).strip() for line in log_lines]
                     else:
-                        lines = [stringify(line).strip() for line in self.cli.logs(**log_parameters, tail=1)]
-                        return lines[-1] if lines else None
+                        return stringify(log_lines[-1]).strip()
                 except StopIteration:
                     # handle the case when there is not a single line to iterate on
                     return None

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -129,9 +129,6 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock.attach.assert_called_once_with(
             container='some_id', stdout=True, stderr=True, stream=True
         )
-        self.client_mock.logs.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True, tail=1
-        )
         self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
         self.client_mock.wait.assert_called_once_with('some_id')
         assert (
@@ -194,9 +191,6 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
         self.client_mock.attach.assert_called_once_with(
             container='some_id', stdout=True, stderr=True, stream=True
-        )
-        self.client_mock.logs.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True, tail=1
         )
         self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
         self.client_mock.wait.assert_called_once_with('some_id')
@@ -303,9 +297,6 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
         self.client_mock.attach.assert_called_once_with(
             container='some_id', stdout=True, stderr=True, stream=True
-        )
-        self.client_mock.logs.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True, tail=1
         )
         self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
         self.client_mock.wait.assert_called_once_with('some_id')
@@ -471,7 +462,7 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock.pull.return_value = [b'{"status":"pull log"}']
         self.client_mock.attach.return_value = iter([b'container log 1 ', b'container log 2'])
         # Make sure the logs side effect is updated after the change
-        self.client_mock.logs.side_effect = (
+        self.client_mock.attach.side_effect = (
             lambda **kwargs: iter(self.log_messages[-kwargs['tail'] :])
             if 'tail' in kwargs
             else iter(self.log_messages)

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -502,8 +502,6 @@ class TestDockerOperator(unittest.TestCase):
         self.log_messages = []
         self.client_mock.pull.return_value = [b'{"status":"pull log"}']
         self.client_mock.attach.return_value = iter([])
-        # Make sure the logs side effect is updated after the change
-        self.client_mock.logs.side_effect = iter([])
 
         kwargs = {
             'api_version': '1.19',


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/24681
Based on ticket [24681](https://github.com/apache/airflow/issues/24681). `cli.logs` behaviour is not fixed sometimes it returns the array of character rather than one single string.  

This changes was brought as part of [change](https://github.com/apache/airflow/commit/2f4a3d4d4008a95fc36971802c514fef68e8a5d4) Before that it was returning the data from log_lines. Reverting to some part of it to get correct line