### PR TITLE
Clear one mapped task's state via the REST API

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2893,14 +2893,18 @@ components:
           type: string
           readOnly: true
           description: The DAG ID.
-        execution_date:
-          type: string
-          format: datetime
-          readOnly: true
         dag_run_id:
           type: string
           readOnly: true
           description: The DAG run ID.
+        execution_date:
+          type: string
+          format: datetime
+          readOnly: true
+        map_index:
+          type: integer
+          readOnly: true
+          description: Index of a mapped task, or -1 if the task is not mapped.
 
     TaskInstanceReferenceCollection:
       type: object
@@ -3439,9 +3443,26 @@ components:
           type: boolean
           default: true
 
+        tasks:
+          description: |
+            A list of {task_id, map_index} combinations to clear.
+
+            *New in version 2.4.0*
+          type: array
+          items:
+            type: object
+            properties:
+              task_id:
+                type: string
+              map_index:
+                type: integer
+            required:
+              - "task_id"
+          minItems: 1
+
         task_ids:
           description: |
-            A list of task ids to clear.
+            A list of task IDs to clear.
 
             *New in version 2.1.0*
           type: array

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -88,6 +88,13 @@ class TaskInstanceCollectionSchema(Schema):
     total_entries = fields.Int()
 
 
+class TaskInstanceInRunSchema(Schema):
+    """Schema to specify one task instance in a DAG run."""
+
+    task_id = fields.String()
+    map_index = fields.Integer(load_default=None)
+
+
 class TaskInstanceBatchFormSchema(Schema):
     """Schema for the request form passed to Task Instance Batch endpoint"""
 
@@ -118,6 +125,7 @@ class ClearTaskInstanceFormSchema(Schema):
     include_subdags = fields.Boolean(load_default=False)
     include_parentdag = fields.Boolean(load_default=False)
     reset_dag_runs = fields.Boolean(load_default=False)
+    tasks = fields.List(fields.Nested(TaskInstanceInRunSchema), validate=validate.Length(min=1))
     task_ids = fields.List(fields.String(), validate=validate.Length(min=1))
 
     @validates_schema
@@ -157,6 +165,7 @@ class TaskInstanceReferenceSchema(Schema):
     run_id = fields.Str(data_key="dag_run_id")
     dag_id = fields.Str()
     execution_date = fields.DateTime()
+    map_index = fields.Int()
 
 
 class TaskInstanceReferenceCollection(NamedTuple):

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1444,6 +1444,7 @@ class TestClearDagRun(TestDagRunEndpoint):
                     "dag_run_id": dag_run_id,
                     "execution_date": dr.execution_date.isoformat(),
                     "task_id": "task_id",
+                    "map_index": -1,
                 }
             ]
         }


### PR DESCRIPTION
First part of #24699 (the other would be to fix the web UI). This adds the ability to clear one specific mapped task’s state via the REST API.

This is a bit more complicated than I’d desired. Currently the `clearTaskInstance` endpoint accepts a `task_ids` field that takes a list of strings to filter out specific tasks. To make this support map indexes, I first tried the followings:

```js
{
    "task_ids": [
        "task_1",  // Clearing the entire task, multiple tis if mapped.
        ["task_2", 1],  // Clearing one specific ti.
    ],
}
```

But this does not work since it requires using the new `prefixItems` key to specify an array as tuple, which was added in Open API 3.1, but we’re still on 3.0.

Next I tried

```js
{
    "task_ids": [
        "task_1",
        {"task_id": "task_2", "map_index": 1},
    ],
}
```

I don’t like duplicating `task_id` inside the nested object, but even this does not work, since Open API 3.0 also forbids heterogeneous arrays.

So in the end I added a new field `tasks`, that only accepts the object form, and merge `task_ids` and `tasks` in the backend instead. In the future, once we are able to use heterogeneous arrays, we could merge the two fields back into one property to clean up the interface. For now though, this is what we need to do.

Example request now:

```js
{
    ...,
    "task_ids": ["task_1", ...],
    "tasks": [
        {"task_id": "task_2", "map_index": 1},
        {"task_id": "task_3"},  // Allowed; same as adding task_3 to task_ids.
        ...,
    ]
}
```