### PR TITLE
Update templates-ref.rst to mention `extras` and format Airflow Vars / Conns

### DIFF
--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -136,7 +136,7 @@ Similarly, Airflow Connections data can be accessed via the ``conn`` template va
 Just like with ``var`` it's possible to fetch a connection by string  (e.g. ``{{ conn.get('my_conn_id_'+index).host }}``
 ) or provide defaults (e.g ``{{ conn.get('my_conn_id', {"host": "host1", "login": "user1"}).host }}``).
 
-Additionally, the `extras` field of a connection can be fetched as a Python Dictionary by the ``extra_dejson`` field, e.g. 
+Additionally, the ``extras`` field of a connection can be fetched as a Python Dictionary with the ``extra_dejson`` field, e.g. 
 ``conn.my_aws_conn_id.extra_dejson.region_name`` would fetch ``region_name`` out of ``extras``.
 
 Filters

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -136,7 +136,7 @@ Similarly, Airflow Connections data can be accessed via the ``conn`` template va
 Just like with ``var`` it's possible to fetch a connection by string  (e.g. ``{{ conn.get('my_conn_id_'+index).host }}``
 ) or provide defaults (e.g ``{{ conn.get('my_conn_id', {"host": "host1", "login": "user1"}).host }}``).
 
-Additionally, the ``extras`` field of a connection can be fetched as a Python Dictionary with the ``extra_dejson`` field, e.g. 
+Additionally, the ``extras`` field of a connection can be fetched as a Python Dictionary with the ``extra_dejson`` field, e.g.
 ``conn.my_aws_conn_id.extra_dejson.region_name`` would fetch ``region_name`` out of ``extras``.
 
 Filters

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -115,6 +115,8 @@ dot notation. Here are some examples of what is possible:
 Refer to the models documentation for more information on the objects'
 attributes and methods.
 
+Airflow Variables in Templates
+---------
 The ``var`` template variable allows you to access variables defined in Airflow's
 UI. You can access them as either plain-text or JSON. If you use JSON, you are
 also able to walk nested structures, such as dictionaries like:
@@ -125,11 +127,17 @@ It is also possible to fetch a variable by string if needed with
 ``{{ var.json.get('my.dict.var', {'key1': 'val1'}) }}``. Defaults can be
 supplied in case the variable does not exist.
 
-Similarly, Airflow Connections data can be accessed via the ``conn`` template variable.
-For example, you could use expressions in your templates like ``{{ conn.my_conn_id.login }}``,
+
+Airflow Connections in Templates
+---------
+Similarly, Airflow Connections data can be accessed via the ``conn`` template variable. For example, you could use expressions in your templates like ``{{ conn.my_conn_id.login }}``,
 ``{{ conn.my_conn_id.password }}``, etc.
+
 Just like with ``var`` it's possible to fetch a connection by string  (e.g. ``{{ conn.get('my_conn_id_'+index).host }}``
-) or provide defaults (e.g ``{{ conn.get('my_conn_id', {"host": "host1", "login": "user1"}).host }}``)
+) or provide defaults (e.g ``{{ conn.get('my_conn_id', {"host": "host1", "login": "user1"}).host }}``).
+
+Additionally, the `extras` field of a connection can be fetched as a Python Dictionary by the ``extra_dejson`` field, e.g. 
+``conn.my_aws_conn_id.extra_dejson.region_name`` would fetch ``region_name`` out of ``extras``.
 
 Filters
 -------

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -116,7 +116,7 @@ Refer to the models documentation for more information on the objects'
 attributes and methods.
 
 Airflow Variables in Templates
----------
+------------------------------
 The ``var`` template variable allows you to access variables defined in Airflow's
 UI. You can access them as either plain-text or JSON. If you use JSON, you are
 also able to walk nested structures, such as dictionaries like:
@@ -129,7 +129,7 @@ supplied in case the variable does not exist.
 
 
 Airflow Connections in Templates
----------
+---------------------------------
 Similarly, Airflow Connections data can be accessed via the ``conn`` template variable. For example, you could use expressions in your templates like ``{{ conn.my_conn_id.login }}``,
 ``{{ conn.my_conn_id.password }}``, etc.
 

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -117,8 +117,8 @@ attributes and methods.
 
 Airflow Variables in Templates
 ------------------------------
-The ``var`` template variable allows you to access variables defined in Airflow's
-UI. You can access them as either plain-text or JSON. If you use JSON, you are
+The ``var`` template variable allows you to access Airflow Variables.
+You can access them as either plain-text or JSON. If you use JSON, you are
 also able to walk nested structures, such as dictionaries like:
 ``{{ var.json.my_dict_var.key1 }}``.
 


### PR DESCRIPTION
Updates the jinja `templates` page with some minor formatting changes:
- added a `Airflow Variables in Templates` subheader
- added a `Airflow Connections in Templates` subheader
- added a note in the above subheader about `extras` and `extra_dejson`