### PR TITLE
Fix grid date ticks

### DIFF
--- a/airflow/www/static/js/grid/components/LinkButton.tsx
+++ b/airflow/www/static/js/grid/components/LinkButton.tsx
@@ -26,6 +26,7 @@ import {
 
 interface Props extends ButtonProps {
   href?: string;
+  target?: string;
 }
 
 const LinkButton = ({ children, ...rest }: Props) => (<Button as={Link} variant="ghost" colorScheme="blue" {...rest}>{children}</Button>);

--- a/airflow/www/static/js/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/grid/dagRuns/Bar.tsx
@@ -69,6 +69,10 @@ const DagRunBar = ({
     els.forEach((e) => { e.style.backgroundColor = ''; });
   };
 
+  // show the tick on the 4th DagRun and then every 10th tick afterwards
+  const shouldShowTick = index === totalRuns - 4
+    || (index < totalRuns - 4 && (index + 4) % 10 === 0);
+
   return (
     <Box
       className={`js-${run.runId}`}
@@ -118,7 +122,7 @@ const DagRunBar = ({
           </Flex>
         </Tooltip>
       </Flex>
-      {(index === totalRuns - 4 || (index + 4) % 10 === 0) && (
+      {shouldShowTick && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="sm" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
           <Time dateTime={run.executionDate} format="MMM DD, HH:mm" />

--- a/airflow/www/static/js/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/grid/dagRuns/index.test.tsx
@@ -30,7 +30,7 @@ import type { DagRun } from '../types';
 
 const datestring = (new Date()).toISOString();
 const generateRuns = (length: number): DagRun[] => (
-  Array.apply(null, Array(length)).map((_, i) => ({
+  [...Array(length)].map((_, i) => ({
     runId: `run-${i}`,
     dataIntervalStart: datestring,
     dataIntervalEnd: datestring,
@@ -40,7 +40,7 @@ const generateRuns = (length: number): DagRun[] => (
     endDate: '2021-11-08T21:17:13.206426+00:00',
     lastSchedulingDecision: datestring,
     executionDate: datestring,
-  })) as DagRun[]
+  }))
 );
 
 describe('Test DagRuns', () => {
@@ -85,7 +85,7 @@ describe('Test DagRuns', () => {
     expect(queryAllByTestId('manual-run')).toHaveLength(1);
     expect(getByText('00:02:53')).toBeInTheDocument();
     expect(getByText('00:01:26')).toBeInTheDocument();
-    expect(queryByText(moment.utc(datestring).format('MMM DD, HH:mm'))).toBeNull();
+    expect(queryByText(moment.utc(dagRuns[0].executionDate).format('MMM DD, HH:mm'))).toBeNull();
 
     spy.mockRestore();
   });

--- a/airflow/www/static/js/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/grid/dagRuns/index.test.tsx
@@ -26,33 +26,49 @@ import moment from 'moment-timezone';
 import DagRuns from './index';
 import { TableWrapper } from '../utils/testUtils';
 import * as useGridDataModule from '../api/useGridData';
+import type { DagRun } from '../types';
 
-const dagRuns = [
-  {
-    dagId: 'dagId',
-    runId: 'run1',
-    dataIntervalStart: new Date(),
-    dataIntervalEnd: new Date(),
-    startDate: '2021-11-08T21:14:19.704433+00:00',
-    endDate: '2021-11-08T21:17:13.206426+00:00',
-    state: 'failed',
-    runType: 'scheduled',
-    executionDate: '2021-11-08T21:14:19.704433+00:00',
-  },
-  {
-    dagId: 'dagId',
-    runId: 'run2',
-    dataIntervalStart: new Date(),
-    dataIntervalEnd: new Date(),
+const datestring = (new Date()).toISOString();
+const generateRuns = (length: number): DagRun[] => (
+  Array.apply(null, Array(length)).map((_, i) => ({
+    runId: `run-${i}`,
+    dataIntervalStart: datestring,
+    dataIntervalEnd: datestring,
     state: 'success',
     runType: 'manual',
-    startDate: '2021-11-09T00:19:43.023200+00:00',
-    endDate: '2021-11-09T00:22:18.607167+00:00',
-  },
-];
+    startDate: '2021-11-08T21:14:19.704433+00:00',
+    endDate: '2021-11-08T21:17:13.206426+00:00',
+    lastSchedulingDecision: datestring,
+    executionDate: datestring,
+  })) as DagRun[]
+);
 
 describe('Test DagRuns', () => {
   test('Durations and manual run arrow render correctly, but without any date ticks', () => {
+    const dagRuns: DagRun[] = [
+      {
+        runId: 'run1',
+        dataIntervalStart: datestring,
+        dataIntervalEnd: datestring,
+        startDate: '2021-11-08T21:14:19.704433+00:00',
+        endDate: '2021-11-08T21:17:13.206426+00:00',
+        state: 'failed',
+        runType: 'scheduled',
+        executionDate: '2021-11-08T21:14:19.704433+00:00',
+        lastSchedulingDecision: datestring,
+      },
+      {
+        runId: 'run2',
+        dataIntervalStart: datestring,
+        dataIntervalEnd: datestring,
+        state: 'success',
+        runType: 'manual',
+        startDate: '2021-11-09T00:19:43.023200+00:00',
+        endDate: '2021-11-09T00:22:18.607167+00:00',
+        executionDate: '2021-11-08T21:14:19.704433+00:00',
+        lastSchedulingDecision: datestring,
+      },
+    ];
     const data = {
       groups: {},
       dagRuns,
@@ -60,7 +76,7 @@ describe('Test DagRuns', () => {
 
     const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
       data,
-    }));
+    } as any));
     const {
       queryAllByTestId, getByText, queryByText,
     } = render(<DagRuns />, { wrapper: TableWrapper });
@@ -69,7 +85,7 @@ describe('Test DagRuns', () => {
     expect(queryAllByTestId('manual-run')).toHaveLength(1);
     expect(getByText('00:02:53')).toBeInTheDocument();
     expect(getByText('00:01:26')).toBeInTheDocument();
-    expect(queryByText(moment.utc(dagRuns[0].executionDate).format('MMM DD, HH:mm'))).toBeNull();
+    expect(queryByText(moment.utc(datestring).format('MMM DD, HH:mm'))).toBeNull();
 
     spy.mockRestore();
   });
@@ -77,42 +93,46 @@ describe('Test DagRuns', () => {
   test('Top date ticks appear when there are 4 or more runs', () => {
     const data = {
       groups: {},
-      dagRuns: [
-        ...dagRuns,
-        {
-          dagId: 'dagId',
-          runId: 'run3',
-          dataIntervalStart: new Date(),
-          dataIntervalEnd: new Date(),
-          startDate: '2021-11-08T21:14:19.704433+00:00',
-          endDate: '2021-11-08T21:17:13.206426+00:00',
-          state: 'failed',
-          runType: 'scheduled',
-        },
-        {
-          dagId: 'dagId',
-          runId: 'run4',
-          dataIntervalStart: new Date(),
-          dataIntervalEnd: new Date(),
-          state: 'success',
-          runType: 'manual',
-          startDate: '2021-11-09T00:19:43.023200+00:00',
-          endDate: '2021-11-09T00:22:18.607167+00:00',
-        },
-      ],
+      dagRuns: generateRuns(4),
     };
     const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
       data,
-    }));
+    } as any));
     const { getByText } = render(<DagRuns />, { wrapper: TableWrapper });
-    expect(getByText(moment.utc(dagRuns[0].executionDate).format('MMM DD, HH:mm'))).toBeInTheDocument();
+    expect(getByText(moment.utc(datestring).format('MMM DD, HH:mm'))).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  test('Show 1 date tick when there are less than 14 runs', () => {
+    const data = {
+      groups: {},
+      dagRuns: generateRuns(8),
+    };
+    const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
+      data,
+    } as any));
+    const { queryAllByText } = render(<DagRuns />, { wrapper: TableWrapper });
+    expect(queryAllByText(moment.utc(datestring).format('MMM DD, HH:mm'))).toHaveLength(1);
+    spy.mockRestore();
+  });
+
+  test('Show 2 date ticks when there are 14+ runs', () => {
+    const data = {
+      groups: {},
+      dagRuns: generateRuns(14),
+    };
+    const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
+      data,
+    } as any));
+    const { queryAllByText } = render(<DagRuns />, { wrapper: TableWrapper });
+    expect(queryAllByText(moment.utc(datestring).format('MMM DD, HH:mm'))).toHaveLength(2);
     spy.mockRestore();
   });
 
   test('Handles empty data correctly', () => {
     const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
       data: { groups: {}, dagRuns: [] },
-    }));
+    } as any));
 
     const { queryByTestId } = render(<DagRuns />, { wrapper: TableWrapper });
     expect(queryByTestId('run')).toBeNull();


### PR DESCRIPTION
In #24684 I accidentally broke the date ticks above the dag run bars in the grid view. We weren't counting them correctly and this led to some odd scroll overlapping.

Bug:
<img width="198" alt="Screen Shot 2022-06-29 at 11 33 57 AM" src="https://user-images.githubusercontent.com/4600967/176476987-b9ba0e2f-1bd0-4f6f-85a6-f81cbdd0f2d6.png">

This PR adds tests to detect this issue and then fixes it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
