### PR TITLE
Increase time to build the ARM image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -363,7 +363,7 @@ jobs:
 
 
   build-ci-images-arm:
-    timeout-minutes: 80
+    timeout-minutes: 120
     name: "Build ARM CI images ${{ needs.build-info.outputs.allPythonVersionsListAsString }}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, build-prod-images]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1751,7 +1751,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: always()
 
   build-ci-arm-images:
-    timeout-minutes: 80
+    timeout-minutes: 120
     name: >
       ${{needs.build-info.outputs.buildJobDescription}} CI ARM images
       ${{ needs.build-info.outputs.allPythonVersionsListAsString }}

--- a/scripts/ci/images/self_terminate.sh
+++ b/scripts/ci/images/self_terminate.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This instance will run for maximum 50 minutes and
+# This instance will run for maximum 100 minutes and
 # It will terminate itself after that (it can also
 # be terminated immediately when the job finishes)
-echo "sudo shutdown -h now" | at now +50 min
+echo "sudo shutdown -h now" | at now +100 min


### PR DESCRIPTION
Building ARM image is now done in parallel in case of CI builds
that update dependencies. If the image is not refreshed, then it might
take quite some time - more than the 50 minutes it's been allowed to

This PR increases both timeouts - the self-terminate timeout for
the ARM instance and timeout on the CI job that triggers it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
