### PR TITLE
Add project_id as a templated variable in two BQ operators

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1853,6 +1853,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
         'dataset_id',
         'table_resource',
         'impersonation_chain',
+        'project_id'
     )
     template_fields_renderers = {"table_resource": "json"}
     ui_color = BigQueryUIColors.TABLE.value
@@ -2068,6 +2069,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         "configuration",
         "job_id",
         "impersonation_chain",
+        'project_id'
     )
     template_ext: Sequence[str] = (
         ".json",

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1853,7 +1853,7 @@ class BigQueryUpsertTableOperator(BaseOperator):
         'dataset_id',
         'table_resource',
         'impersonation_chain',
-        'project_id'
+        'project_id',
     )
     template_fields_renderers = {"table_resource": "json"}
     ui_color = BigQueryUIColors.TABLE.value

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2069,7 +2069,7 @@ class BigQueryInsertJobOperator(BaseOperator):
         "configuration",
         "job_id",
         "impersonation_chain",
-        'project_id'
+        "project_id",
     )
     template_ext: Sequence[str] = (
         ".json",


### PR DESCRIPTION
Hi all! This is related to #23129. In BigQuery, fully qualified dataset names can be made using the GCP project ID even if the project ID isn't needed for the underlying API to work. It's not unusual to make `project_id` a default arg and to have it be templated, especially if you're using many BQ operators together. I've added it to two operators where I have used it to construct a dataset name. 

I'm not 100% sure how we test templated fields - I looked at the BQ operator test and didn't see any kind of validation, and the test values we're passing to the mocked calls are not templated. Any recommendations for how to handle that are appreciated!