### PR TITLE
Add test_connection method to Azure WasbHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -444,3 +444,14 @@ class WasbHook(BaseHook):
             raise AirflowException(f'Blob(s) not found: {blob_name}')
 
         self.delete_blobs(container_name, *blobs_to_delete, **kwargs)
+
+    def test_connection(self):
+        """Test Azure Blob Storage connection."""
+        success = (True, "Successfully connected to Azure Blob Storage.")
+
+        try:
+            # Attempt to retrieve storage account information
+            self.get_conn().get_account_information()
+            return success
+        except Exception as e:
+            return False, str(e)


### PR DESCRIPTION
This PR enables Test connection button on airflow UI for the Azure Blob Storage connection type.

cc @kaxil 

<img width="1075" alt="image" src="https://user-images.githubusercontent.com/94376113/176822663-395f0208-c9b1-4d95-96c7-85ec63645b5f.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
