### PR TITLE
Disable attrs state management on MappedOperator

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -240,7 +240,17 @@ class OperatorPartial:
         return op
 
 
-@attr.define(kw_only=True)
+@attr.define(
+    kw_only=True,
+    # Disable custom __getstate__ and __setstate__ generation since it interacts
+    # badly with Airflow's DAG serialization and pickling. When a mapped task is
+    # deserialized, subclasses are coerced into MappedOperator, but when it goes
+    # through DAG pickling, all attributes defined in the subclasses are dropped
+    # by attrs's custom state management. Since attrs does not do anything too
+    # special here (the logic is only important for slots=True), we use Python's
+    # built-in implementation, which works (as proven by good old BaseOperator).
+    getstate_setstate=False,
+)
 class MappedOperator(AbstractOperator):
     """Object representing a mapped operator in a DAG."""
 


### PR DESCRIPTION
The custom `__getstate__` and `__setstate__` implementation from attrs interacts badly with Airflow's DAG serialization and pickling. When a mapped task is deserialized, subclasses are coerced to MappedOperator. But when the instances go through DAG pickling, all attributes defined in the subclasses are dropped by attrs's custom state management.

Since attrs does not do anything too special here (the logic is only important for `slots=True`), we can use Python's built-in implementation instead.

I locally ran `airflow scheduler` and this seems to fix the exceptions, but it seems difficult to create a meaningful test for this due to all the components involved. Ideas on test setup are much welcomed.

Fix #23838.