### PR TITLE
Move Flask hook registration to end of file

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -714,28 +714,6 @@ class AirflowBaseView(BaseView):
         )
 
 
-def add_user_permissions_to_dag(sender, template, context, **extra):
-    """
-    Adds `.can_edit`, `.can_trigger`, and `.can_delete` properties
-    to DAG based on current user's permissions.
-    Located in `views.py` rather than the DAG model to keep
-    permissions logic out of the Airflow core.
-    """
-    if 'dag' in context:
-        dag = context['dag']
-        can_create_dag_run = get_airflow_app().appbuilder.sm.has_access(
-            permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN
-        )
-
-        dag.can_edit = get_airflow_app().appbuilder.sm.can_edit_dag(dag.dag_id)
-        dag.can_trigger = dag.can_edit and can_create_dag_run
-        dag.can_delete = get_airflow_app().appbuilder.sm.can_delete_dag(dag.dag_id)
-        context['dag'] = dag
-
-
-before_render_template.connect(add_user_permissions_to_dag)
-
-
 class Airflow(AirflowBaseView):
     """Main Airflow application."""
 
@@ -5632,3 +5610,29 @@ class CustomUserRemoteUserModelView(MultiResourceUserMixin, UserRemoteUserModelV
         permissions.ACTION_CAN_EDIT,
         permissions.ACTION_CAN_DELETE,
     ]
+
+
+def add_user_permissions_to_dag(sender, template, context, **extra):
+    """
+    Adds `.can_edit`, `.can_trigger`, and `.can_delete` properties
+    to DAG based on current user's permissions.
+    Located in `views.py` rather than the DAG model to keep
+    permissions logic out of the Airflow core.
+    """
+    if 'dag' in context:
+        dag = context['dag']
+        can_create_dag_run = get_airflow_app().appbuilder.sm.has_access(
+            permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN
+        )
+
+        dag.can_edit = get_airflow_app().appbuilder.sm.can_edit_dag(dag.dag_id)
+        dag.can_trigger = dag.can_edit and can_create_dag_run
+        dag.can_delete = get_airflow_app().appbuilder.sm.can_delete_dag(dag.dag_id)
+        context['dag'] = dag
+
+
+# NOTE: Put this at the end of the file. Pylance is too clever and detects that
+# before_render_template.connect() is declared as NoReturn, and marks everything
+# after this line as unreachable code. It's technically correct based on the
+# lint-time information, but that's not what actually happens at runtime.
+before_render_template.connect(add_user_permissions_to_dag)


### PR DESCRIPTION
Pylance is too clever here. It (correctly) detects the `connect()` call is a NoReturn and marks everything after it as unreachable. But this is not correct; Flask does trickery at runtime to make it not the case. The simplest workaround is to just move those registration code to the end of the file.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
