### PR TITLE
Choose the right builder when pushing to ghcr.io registry for cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1726,6 +1726,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - name: "Push CI cache ${{ matrix.python-version }} ${{ matrix.platform }}"
         run: >
           breeze build-image
+          --builder airflow_cache
           --prepare-buildx-cache
           --force-build
           --platform ${{ matrix.platform }}
@@ -1736,6 +1737,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - name: "Push PROD cache ${{ matrix.python-version }} ${{ matrix.platform }}"
         run: >
           breeze build-prod-image
+          --builder airflow_cache
           --airflow-is-in-context
           --install-packages-from-context
           --prepare-buildx-cache

--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -23,9 +23,10 @@ export ANSWER="yes"
 export CI="true"
 export GITHUB_TOKEN=""
 
-breeze self-upgrade --force
+breeze self-upgrade --force --use-current-airflow-sources
 
 breeze build-image \
+     --builder airflow_cache \
      --run-in-parallel \
      --prepare-buildx-cache \
      --force-build \
@@ -44,6 +45,7 @@ breeze prepare-airflow-package --package-format wheel --version-suffix-for-pypi 
 mv -v ./dist/*.whl ./docker-context-files
 
 breeze build-prod-image \
+     --builder airflow_cache \
      --run-in-parallel \
      --airflow-is-in-context \
      --install-packages-from-context \


### PR DESCRIPTION
When pushing cache we cannot use default builder because it has
no capability to push cache. We need to use airflow_cache for it,
which has additionally the capacity of forwarding the builds
to a remote ARM instance in case cache is built for ARM images
too. Recently we added a new --builder flag to allow to choose
the builder, but our scripts and CI have not been modified to
account for that (previously builder was chosen automatically but
that has proven to be limiting in some manual operations and it
also allows to choose different names for builders in case
someone wants to build their own pipeline of builds.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
