### PR TITLE
Helper exactly_one should treat NOTSET as None

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -39,6 +39,7 @@ from typing import (
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.utils.module_loading import import_string
+from airflow.utils.types import ArgNotSet
 
 if TYPE_CHECKING:
     import jinja2
@@ -311,7 +312,14 @@ def exactly_one(*args) -> bool:
         raise ValueError(
             "Not supported for iterable args. Use `*` to unpack your iterable in the function call."
         )
-    return sum(map(bool, args)) == 1
+
+    def is_set(val):
+        if isinstance(val, ArgNotSet):
+            return False
+        else:
+            return bool(val)
+
+    return sum(map(is_set, args)) == 1
 
 
 def prune_dict(val: Any, mode='strict'):

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -30,6 +30,7 @@ from airflow.utils.helpers import (
     validate_group_key,
     validate_key,
 )
+from airflow.utils.types import NOTSET
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs
 
@@ -248,16 +249,23 @@ class TestHelpers:
         they can safely be used in any combination.
         """
 
-        def assert_exactly_one(true=0, truthy=0, false=0, falsy=0):
+        def assert_exactly_one(true=0, truthy=0, false=0, falsy=0, notset=0):
             sample = []
-            for truth_value, num in [(True, true), (False, false), ('a', truthy), ('', falsy)]:
+            for truth_value, num in [
+                (True, true),
+                (False, false),
+                ('a', truthy),
+                ('', falsy),
+                (NOTSET, notset),
+            ]:
                 if num:
                     sample.extend([truth_value] * num)
             if sample:
                 expected = True if true + truthy == 1 else False
                 assert exactly_one(*sample) is expected
 
-        for row in product(range(4), range(4), range(4), range(4)):
+        for row in product(range(4), range(4), range(4), range(4), range(4)):
+            print(row)
             assert_exactly_one(*row)
 
     def test_exactly_one_should_fail(self):


### PR DESCRIPTION
This is maybe technically breaking but I would wager 0% chance of breaking anything in the real world.

The way this helper is intended, and the way it is used, I think it makes sense to treat NOTSET the same as None.

WDYT @jedcunningham @uranusjr @ashb 