### PR TITLE
Better instances for ARM building.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -370,7 +370,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
 
 
   build-ci-images-arm:
-    timeout-minutes: 120
+    timeout-minutes: 50
     name: "Build ARM CI images ${{ needs.build-info.outputs.all-python-versions-list-as-string }}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
     needs: [build-info, build-prod-images]
@@ -426,8 +426,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           Build ARM CI images ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
         run: >
-          breeze build-image --run-in-parallel --parallelism 1
-          --builder airflow_cache --platform "linux/arm64"
+          breeze build-image --run-in-parallel --builder airflow_cache --platform "linux/arm64"
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1677,7 +1677,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   push-buildx-cache-to-github-registry:
     permissions:
       packages: write
-    timeout-minutes: 120
+    timeout-minutes: 50
     name: "Push Image Cache"
     runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
     needs:
@@ -1688,7 +1688,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJson(needs.build-info.outputs.python-versions) }}
         platform: ["linux/amd64", "linux/arm64"]
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
@@ -1738,6 +1737,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           breeze build-image
           --builder airflow_cache
           --prepare-buildx-cache
+          --run-in-parallel
           --force-build
           --platform ${{ matrix.platform }}
         env:
@@ -1763,7 +1763,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: always()
 
   build-ci-arm-images:
-    timeout-minutes: 120
+    timeout-minutes: 50
     name: >
       ${{needs.build-info.outputs.build-job-description}} CI ARM images
       ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
@@ -1782,7 +1782,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}
       DEBIAN_VERSION: ${{ needs.build-info.outputs.debian-version }}
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on)[0] }}
-    if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
+    if: >
+      needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1810,8 +1811,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           Build CI ARM images ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
         run: >
-          breeze build-image --run-in-parallel --parallelism 1
-          --builder airflow_cache --platform "linux/arm64"
+          breeze build-image
+          --run-in-parallel
+          --builder airflow_cache
+          --platform "linux/arm64"
         env:
           UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgrade-to-newer-dependencies }}
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}

--- a/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
+++ b/scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
@@ -22,12 +22,12 @@ SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # This is an AMI that is based on Basic Amazon Linux AMI with installed and configured docker service
 WORKING_DIR="/tmp/armdocker"
 INSTANCE_INFO="${WORKING_DIR}/instance_info.json"
-ARM_AMI="ami-06b8158ea372d3259"
-INSTANCE_TYPE="c6g.xlarge"
-MARKET_OPTIONS="MarketType=spot,SpotOptions={MaxPrice=0.1,SpotInstanceType=one-time}"
+ARM_AMI="ami-0e43196369d299715"  # AMI ID of latest arm-docker-ami-v*
+INSTANCE_TYPE="m6g.2xlarge"  # m6g.2xlarge -> 8 vCPUS 32 GB RAM
+MARKET_OPTIONS="MarketType=spot,SpotOptions={MaxPrice=0.2,SpotInstanceType=one-time}"
 REGION="us-east-2"
 EC2_USER="ec2-user"
-USER_DATA_FILE="${SCRIPTS_DIR}/self_terminate.sh"
+USER_DATA_FILE="${SCRIPTS_DIR}/initialize.sh"
 METADATA_ADDRESS="http://169.254.169.254/latest/meta-data"
 MAC_ADDRESS=$(curl -s "${METADATA_ADDRESS}/network/interfaces/macs/" | head -n1 | tr -d '/')
 CIDR=$(curl -s "${METADATA_ADDRESS}/network/interfaces/macs/${MAC_ADDRESS}/vpc-ipv4-cidr-block/")

--- a/scripts/ci/images/initialize.sh
+++ b/scripts/ci/images/initialize.sh
@@ -16,7 +16,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# This instance will run for maximum 100 minutes and
+# We are mounting /var/lib/docker and /tmp as tmpfs in order
+# to gain speed when building the images The docker storage
+# is ephemeral anyway and will be removed when instance stops
+
+sudo service docker stop || true
+
+sudo mount -t tmpfs -o size=10% tmpfs /tmp
+sudo mount -t tmpfs -o size=66% tmpfs /var/lib/docker
+
+sudo service docker start
+
+# This instance will run for maximum 40 minutes and
 # It will terminate itself after that (it can also
 # be terminated immediately when the job finishes)
-echo "sudo shutdown -h now" | at now +100 min
+echo "sudo shutdown -h now" | at now +40 min

--- a/setup.py
+++ b/setup.py
@@ -399,6 +399,8 @@ devel_only = [
     'yamllint',
 ]
 
+# just to test
+
 
 def get_provider_dependencies(provider_name: str) -> List[str]:
     return PROVIDER_DEPENDENCIES[provider_name][DEPS]


### PR DESCRIPTION
Since we are now building ARM images in parallel, We need more powerful
machines. The c6gd.2xlarge are quite a bit better than c6g.xlarge for
our case:

1) They have 2x more vCPUs
2) They have fast local NVME disks attached which we are switching
   to be used by docker enging so they should be way faster

We are also building image cache in parallel - similarly as main images

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragement file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
