### PR TITLE
Remove upper-binding for SQLAlchemy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -142,11 +142,7 @@ install_requires =
     rich>=12.4.4
     rich-click>=1.3.1
     setproctitle>=1.1.8
-    # SQL Alchemy 1.4.10 introduces a bug where for PyODBC driver UTCDateTime fields get wrongly converted
-    # as string and fail to be converted back to datetime. It was supposed to be fixed in
-    # https://github.com/sqlalchemy/sqlalchemy/issues/6366 (released in 1.4.12) but apparently our case
-    # is different. Opened https://github.com/sqlalchemy/sqlalchemy/issues/7660 to track it
-    sqlalchemy>=1.4,<1.4.10
+    sqlalchemy>=1.4
     sqlalchemy_jsonfield>=1.0
     tabulate>=0.7.5
     tenacity>=6.2.0

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -73,6 +73,9 @@ class TestDb:
             lambda t: (t[0] == 'remove_table' and t[1].name == 'spt_fallback_usg'),
             lambda t: (t[0] == 'remove_table' and t[1].name == 'MSreplication_options'),
             lambda t: (t[0] == 'remove_table' and t[1].name == 'spt_fallback_dev'),
+            # MSSQL foreign keys where CASCADE has been removed
+            lambda t: (t[0] == 'remove_fk' and t[1].name == 'task_reschedule_dr_fkey'),
+            lambda t: (t[0] == 'add_fk' and t[1].name == 'task_reschedule_dr_fkey'),
             # Ignore flask-session table/index
             lambda t: (t[0] == 'remove_table' and t[1].name == 'session'),
             lambda t: (t[0] == 'remove_index' and t[1].name == 'session_id'),


### PR DESCRIPTION
There was a problem with custom classes for SQLAlchemy that
prevented it to work on MySQL. This PR removes the SQLAlchemy
upper binding.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
