### PR TITLE
Improve documentation to add path of Breeze in a Mac with Python

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -174,6 +174,11 @@ environments. This can be done automatically by the following command (follow in
 
     pipx ensurepath
 
+In Mac
+.. code-block:: bash
+
+    python -m pipx ensurepath
+
 
 Resources required
 ==================

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -175,6 +175,7 @@ environments. This can be done automatically by the following command (follow in
     pipx ensurepath
 
 In Mac
+
 .. code-block:: bash
 
     python -m pipx ensurepath


### PR DESCRIPTION
I was testing Breeze on a Mac and It will be better to specify how to add the path in Macs too because pix doesn´t work on it.

