### PR TITLE
WIP: Task mapping against a list-of-dicts

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -113,12 +113,26 @@ class XComForMappingNotPushed(AirflowException):
 class UnmappableXComTypePushed(AirflowException):
     """Raise when an unmappable type is pushed as a mapped downstream's dependency."""
 
-    def __init__(self, value: Any) -> None:
-        super().__init__(value)
-        self.value = value
+    def __init__(self, value: Any, *values: Any) -> None:
+        super().__init__(value, *values)
 
     def __str__(self) -> str:
-        return f"unmappable return type {type(self.value).__qualname__!r}"
+        typename = type(self.args[0]).__qualname__
+        for arg in self.args[1:]:
+            typename = f"{typename}[{type(arg).__qualname__}]"
+        return f"unmappable return type {typename!r}"
+
+
+class UnmappableXComValuePushed(AirflowException):
+    """Raise when an invalid value is pushed as a mapped downstream's dependency."""
+
+    def __init__(self, value: Any, reason: str) -> None:
+        super().__init__(value, reason)
+        self.value = value
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"unmappable return value {self.value!r} ({self.reason})"
 
 
 class UnmappableXComLengthPushed(AirflowException):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -756,6 +756,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
         super().__init__()
 
+        kwargs.pop("_airflow_mapped_validation_only", None)
         if kwargs:
             if not conf.getboolean('operators', 'ALLOW_ILLEGAL_ARGUMENTS'):
                 raise AirflowException(
@@ -1509,7 +1510,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def validate_mapped_arguments(cls, **kwargs: Any) -> None:
         """Validate arguments when this operator is being mapped."""
         if cls.mapped_arguments_validated_by_init:
-            cls(**kwargs, _airflow_from_mapped=True)
+            cls(**kwargs, _airflow_from_mapped=True, _airflow_mapped_validation_only=True)
 
     def unmap(self, ctx: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """:meta private:"""

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1511,7 +1511,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if cls.mapped_arguments_validated_by_init:
             cls(**kwargs, _airflow_from_mapped=True)
 
-    def unmap(self) -> "BaseOperator":
+    def unmap(self, ctx: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """:meta private:"""
         return self
 

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 # mapping since we need the value to be ordered).
 Mappable = Union["XComArg", Sequence, dict]
 
-MappedKwargs = Union["DictOfListsMappedKwargs", "ListOfDictsMappedKwargs"]
+ExpandInput = Union["DictOfListsExpandInput", "ListOfDictsExpandInput"]
 
 MAPPABLE_LITERAL_TYPES = (dict, list)
 
@@ -57,7 +57,7 @@ class NotFullyPopulated(RuntimeError):
         return f"Failed to populate all mapping metadata; missing: {keys}"
 
 
-class DictOfListsMappedKwargs(NamedTuple):
+class DictOfListsExpandInput(NamedTuple):
     """Storage type of a mapped operator's mapped kwargs.
 
     This is created from ``expand(**kwargs)``.
@@ -187,7 +187,7 @@ class DictOfListsMappedKwargs(NamedTuple):
         return {k: self._expand_mapped_field(k, v, context, session=session) for k, v in self.value.items()}
 
 
-class ListOfDictsMappedKwargs(NamedTuple):
+class ListOfDictsExpandInput(NamedTuple):
     """Storage type of a mapped operator's mapped kwargs.
 
     This is created from ``expand_kwargs(xcom_arg)``.
@@ -242,17 +242,17 @@ class ListOfDictsMappedKwargs(NamedTuple):
         return self.value.resolve(context, session)[map_index]
 
 
-MAPPED_KWARGS_UNUSED = DictOfListsMappedKwargs({})  # Sentinel value.
+EXPAND_INPUT_EMPTY = DictOfListsExpandInput({})  # Sentinel value.
 
-_MAPPED_KWARGS_TYPES = {
-    "dict-of-lists": DictOfListsMappedKwargs,
-    "list-of-dicts": ListOfDictsMappedKwargs,
+_EXPAND_INPUT_TYPES = {
+    "dict-of-lists": DictOfListsExpandInput,
+    "list-of-dicts": ListOfDictsExpandInput,
 }
 
 
-def get_map_type_key(mapped_kwargs: MappedKwargs) -> str:
-    return next(k for k, v in _MAPPED_KWARGS_TYPES.items() if v == type(mapped_kwargs))
+def get_map_type_key(expand_input: ExpandInput) -> str:
+    return next(k for k, v in _EXPAND_INPUT_TYPES.items() if v == type(expand_input))
 
 
-def create_mapped_kwargs(key: str, value: Any) -> MappedKwargs:
-    return _MAPPED_KWARGS_TYPES[key](value)
+def create_expand_input(kind: str, value: Any) -> ExpandInput:
+    return _EXPAND_INPUT_TYPES[kind](value)

--- a/airflow/models/mappedkwargs.py
+++ b/airflow/models/mappedkwargs.py
@@ -1,0 +1,240 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import collections
+import collections.abc
+import functools
+import operator
+from typing import TYPE_CHECKING, Any, NamedTuple, Sequence, Union
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from airflow.utils.context import Context
+
+if TYPE_CHECKING:
+    from airflow.models.xcom_arg import XComArg
+
+# BaseOperator.expand() can be called on an XComArg, sequence, or dict (not any
+# mapping since we need the value to be ordered).
+Mappable = Union["XComArg", Sequence, dict]
+
+MappedKwargs = Union["DictOfListsMappedKwargs", "ListOfDictsMappedKwargs"]
+
+MAPPABLE_LITERAL_TYPES = (dict, list)
+
+
+class NotFullyPopulated(RuntimeError):
+    """Raise when ``get_map_lengths`` cannot populate all mapping metadata.
+
+    This is generally due to not all upstream tasks have finished when the
+    function is called.
+    """
+
+    def __init__(self, missing: set[str]) -> None:
+        self.missing = missing
+
+    def __str__(self) -> str:
+        keys = ", ".join(repr(k) for k in sorted(self.missing))
+        return f"Failed to populate all mapping metadata; missing: {keys}"
+
+
+class DictOfListsMappedKwargs(NamedTuple):
+    """Storage type of a mapped operator's mapped kwargs.
+
+    This is created from ``expand(**kwargs)``.
+    """
+
+    value: dict[str, Mappable]
+
+    def get_parse_time_mapped_ti_count(self) -> int | None:
+        if not self.value:
+            return 0
+        literal_values = [len(v) for v in self.value.values() if isinstance(v, MAPPABLE_LITERAL_TYPES)]
+        if len(literal_values) != len(self.value):
+            return None  # None-literal type encountered, so give up.
+        return functools.reduce(operator.mul, literal_values, 1)
+
+    def _get_map_lengths(self, run_id: str, *, session: Session) -> dict[str, int]:
+        """Return dict of argument name to map length.
+
+        If any arguments are not known right now (upstream task not finished),
+        they will not be present in the dict.
+        """
+        from airflow.models.taskmap import TaskMap
+        from airflow.models.xcom import XCom
+        from airflow.models.xcom_arg import XComArg
+
+        # Populate literal mapped arguments first.
+        map_lengths: dict[str, int] = collections.defaultdict(int)
+        map_lengths.update((k, len(v)) for k, v in self.value.items() if not isinstance(v, XComArg))
+
+        try:
+            dag_id = next(v.operator.dag_id for v in self.value.values() if isinstance(v, XComArg))
+        except StopIteration:  # All mapped arguments are literal. We're done.
+            return map_lengths
+
+        # Build a reverse mapping of what arguments each task contributes to.
+        mapped_dep_keys: dict[str, set[str]] = collections.defaultdict(set)
+        non_mapped_dep_keys: dict[str, set[str]] = collections.defaultdict(set)
+        for k, v in self.value.items():
+            if not isinstance(v, XComArg):
+                continue
+            assert v.operator.dag_id == dag_id
+            if v.operator.is_mapped:
+                mapped_dep_keys[v.operator.task_id].add(k)
+            else:
+                non_mapped_dep_keys[v.operator.task_id].add(k)
+            # TODO: It's not possible now, but in the future we may support
+            # depending on one single mapped task instance. When that happens,
+            # we need to further analyze the mapped case to contain only tasks
+            # we depend on "as a whole", and put those we only depend on
+            # individually to the non-mapped lookup.
+
+        # Collect lengths from unmapped upstreams.
+        taskmap_query = session.query(TaskMap.task_id, TaskMap.length).filter(
+            TaskMap.dag_id == dag_id,
+            TaskMap.run_id == run_id,
+            TaskMap.task_id.in_(non_mapped_dep_keys),
+            TaskMap.map_index < 0,
+        )
+        for task_id, length in taskmap_query:
+            for mapped_arg_name in non_mapped_dep_keys[task_id]:
+                map_lengths[mapped_arg_name] += length
+
+        # Collect lengths from mapped upstreams.
+        xcom_query = (
+            session.query(XCom.task_id, func.count(XCom.map_index))
+            .group_by(XCom.task_id)
+            .filter(
+                XCom.dag_id == dag_id,
+                XCom.run_id == run_id,
+                XCom.task_id.in_(mapped_dep_keys),
+                XCom.map_index >= 0,
+            )
+        )
+        for task_id, length in xcom_query:
+            for mapped_arg_name in mapped_dep_keys[task_id]:
+                map_lengths[mapped_arg_name] += length
+
+        if len(map_lengths) < len(self.value):
+            raise NotFullyPopulated(set(self.value).difference(map_lengths))
+        return map_lengths
+
+    def get_total_map_length(self, run_id: str, *, session: Session) -> int:
+        if not self.value:
+            return 0
+        lengths = self._get_map_lengths(run_id, session=session)
+        return functools.reduce(operator.mul, (lengths[name] for name in self.value), 1)
+
+    def _expand_mapped_field(self, key: str, value: Any, context: Context, *, session: Session) -> Any:
+        from airflow.models.xcom_arg import XComArg
+
+        if isinstance(value, XComArg):
+            value = value.resolve(context, session=session)
+        map_index = context["ti"].map_index
+        if map_index < 0:
+            return value
+        all_lengths = self._get_map_lengths(context["run_id"], session=session)
+
+        def _find_index_for_this_field(index: int) -> int:
+            # Need to use the original user input to retain argument order.
+            for mapped_key in reversed(list(self.value)):
+                mapped_length = all_lengths[mapped_key]
+                if mapped_length < 1:
+                    raise RuntimeError(f"cannot expand field mapped to length {mapped_length!r}")
+                if mapped_key == key:
+                    return index % mapped_length
+                index //= mapped_length
+            return -1
+
+        found_index = _find_index_for_this_field(map_index)
+        if found_index < 0:
+            return value
+        if isinstance(value, collections.abc.Sequence):
+            return value[found_index]
+        if not isinstance(value, dict):
+            raise TypeError(f"can't map over value of type {type(value)}")
+        for i, (k, v) in enumerate(value.items()):
+            if i == found_index:
+                return k, v
+        raise IndexError(f"index {map_index} is over mapped length")
+
+    def resolve(self, context: Context, session: Session) -> dict[str, Any]:
+        return {k: self._expand_mapped_field(k, v, context, session=session) for k, v in self.value.items()}
+
+
+class ListOfDictsMappedKwargs(NamedTuple):
+    """Storage type of a mapped operator's mapped kwargs.
+
+    This is created from ``expand_kwargs(xcom_arg)``.
+    """
+
+    value: XComArg
+
+    def get_parse_time_mapped_ti_count(self) -> int | None:
+        return None
+
+    def get_total_map_length(self, run_id: str, *, session: Session) -> int:
+        from airflow.models.taskmap import TaskMap
+        from airflow.models.xcom import XCom
+
+        task = self.value.operator
+        if task.is_mapped:
+            query = session.query(func.count(XCom.map_index)).filter(
+                XCom.dag_id == task.dag_id,
+                XCom.run_id == run_id,
+                XCom.task_id == task.task_id,
+                XCom.map_index >= 0,
+            )
+        else:
+            query = session.query(TaskMap.length).filter(
+                TaskMap.dag_id == task.dag_id,
+                TaskMap.run_id == run_id,
+                TaskMap.task_id == task.task_id,
+                TaskMap.map_index < 0,
+            )
+        value = query.scalar()
+        if value is None:
+            raise NotFullyPopulated({"expand_kwargs() argument"})
+        return value
+
+    def resolve(self, context: Context, session: Session) -> dict[str, Any]:
+        map_index = context["ti"].map_index
+        if map_index < 0:
+            raise RuntimeError("can't resolve task-mapping argument without expanding")
+        # Validation should be done when the upstream returns.
+        return self.value.resolve(context, session)[map_index]
+
+
+MAPPED_KWARGS_UNUSED = DictOfListsMappedKwargs({})  # Sentinel value.
+
+_MAPPED_KWARGS_TYPES = {
+    "dict-of-lists": DictOfListsMappedKwargs,
+    "list-of-dicts": ListOfDictsMappedKwargs,
+}
+
+
+def get_map_type_key(mapped_kwargs: MappedKwargs) -> str:
+    return next(k for k, v in _MAPPED_KWARGS_TYPES.items() if v == type(mapped_kwargs))
+
+
+def create_mapped_kwargs(key: str, value: Any) -> MappedKwargs:
+    return _MAPPED_KWARGS_TYPES[key](value)

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -19,8 +19,6 @@
 import collections
 import collections.abc
 import datetime
-import functools
-import operator
 import warnings
 from typing import (
     TYPE_CHECKING,
@@ -61,6 +59,13 @@ from airflow.models.abstractoperator import (
     AbstractOperator,
     TaskStateChangeCallback,
 )
+from airflow.models.mappedkwargs import (
+    MAPPABLE_LITERAL_TYPES,
+    DictOfListsMappedKwargs,
+    ListOfDictsMappedKwargs,
+    MappedKwargs,
+    NotFullyPopulated,
+)
 from airflow.models.pool import Pool
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
@@ -78,19 +83,13 @@ if TYPE_CHECKING:
 
     from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
     from airflow.models.dag import DAG
+    from airflow.models.mappedkwargs import Mappable
     from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
     from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
-    # BaseOperator.expand() can be called on an XComArg, sequence, or dict (not
-    # any mapping since we need the value to be ordered).
-    Mappable = Union[XComArg, Sequence, dict]
-
 ValidationSource = Union[Literal["expand"], Literal["partial"]]
-
-
-MAPPABLE_LITERAL_TYPES = (dict, list)
 
 
 # For isinstance() check.
@@ -194,16 +193,25 @@ class OperatorPartial:
     def expand(self, **mapped_kwargs: "Mappable") -> "MappedOperator":
         if not mapped_kwargs:
             raise TypeError("no arguments to expand against")
-        return self._expand(**mapped_kwargs)
-
-    def _expand(self, **mapped_kwargs: "Mappable") -> "MappedOperator":
         self._expand_called = True
-
-        from airflow.operators.empty import EmptyOperator
-
         validate_mapping_kwargs(self.operator_class, "expand", mapped_kwargs)
         prevent_duplicates(self.kwargs, mapped_kwargs, fail_reason="unmappable or already specified")
-        ensure_xcomarg_return_value(mapped_kwargs)
+        return self._expand(DictOfListsMappedKwargs(mapped_kwargs))
+
+    def expand_kwargs(self, mapped_kwargs: "XComArg") -> "MappedOperator":
+        from airflow.models.xcom_arg import XComArg
+
+        self._expand_called = True
+
+        # We need to validate each dict literal in the list.
+        if not isinstance(mapped_kwargs, XComArg):
+            raise TypeError(f"expected XComArg object, not {type(mapped_kwargs).__name__}")
+        return self._expand(ListOfDictsMappedKwargs(mapped_kwargs))
+
+    def _expand(self, mapped_kwargs: MappedKwargs) -> "MappedOperator":
+        from airflow.operators.empty import EmptyOperator
+
+        ensure_xcomarg_return_value(mapped_kwargs.value)
 
         partial_kwargs = self.kwargs.copy()
         task_id = partial_kwargs.pop("task_id")
@@ -261,7 +269,7 @@ class MappedOperator(AbstractOperator):
     # that can be used to unmap this into a SerializedBaseOperator.
     operator_class: Union[Type["BaseOperator"], Dict[str, Any]]
 
-    mapped_kwargs: Dict[str, "Mappable"]
+    mapped_kwargs: MappedKwargs
     partial_kwargs: Dict[str, Any]
 
     # Needed for serialization.
@@ -315,8 +323,7 @@ class MappedOperator(AbstractOperator):
             self.task_group.add(self)
         if self.dag:
             self.dag.add_task(self)
-        for k, v in self.mapped_kwargs.items():
-            XComArg.apply_upstream_relationship(self, v)
+        XComArg.apply_upstream_relationship(self, self.mapped_kwargs.value)
         for k, v in self.partial_kwargs.items():
             if k in self.template_fields:
                 XComArg.apply_upstream_relationship(self, v)
@@ -361,7 +368,8 @@ class MappedOperator(AbstractOperator):
         """
         if not isinstance(self.operator_class, type):
             return  # No need to validate deserialized operator.
-        self.operator_class.validate_mapped_arguments(**self._get_unmap_kwargs())
+        kwargs = self._get_unmap_kwargs(self._get_mapped_kwargs(None))
+        self.operator_class.validate_mapped_arguments(**kwargs)
 
     @property
     def task_type(self) -> str:
@@ -520,7 +528,23 @@ class MappedOperator(AbstractOperator):
         """Implementing DAGNode."""
         return DagAttributeTypes.OP, self.task_id
 
-    def _get_unmap_kwargs(self) -> Dict[str, Any]:
+    def _get_mapped_kwargs(self, resolve: Optional[Tuple[Context, Session]]) -> Dict[str, Any]:
+        kwargs = self._get_expansion_kwargs()
+        if resolve is not None:
+            return kwargs.resolve(*resolve)
+        if isinstance(kwargs, DictOfListsMappedKwargs):
+            return kwargs.value
+        return {}
+
+    def _get_unmap_kwargs(self, mapped_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Get init kwargs to unmap the underlying operator class.
+
+        This also optionally resolve the mapped arguments, depending on what is
+        passed as the argument.
+        """
+        # Ordering is significant; we want a chance for mapped kwargs to
+        # override others. This is important for e.g. @task since it needs to
+        # "partially map" against op_kwargs.
         return {
             "task_id": self.task_id,
             "dag": self.dag,
@@ -529,29 +553,34 @@ class MappedOperator(AbstractOperator):
             "start_date": self.start_date,
             "end_date": self.end_date,
             **self.partial_kwargs,
-            **self.mapped_kwargs,
+            **mapped_kwargs,
         }
 
-    def unmap(self, unmap_kwargs: Optional[Dict[str, Any]] = None) -> "BaseOperator":
-        """
-        Get the "normal" Operator after applying the current mapping.
+    def unmap(self, resolve: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
+        """Get the "normal" Operator after applying the current mapping.
 
-        If ``operator_class`` is not a class (i.e. this DAG has been deserialized) then this will return a
-        SerializedBaseOperator that aims to "look like" the real operator.
+        If ``operator_class`` is not a class (i.e. this DAG has been
+        deserialized), this returns a SerializedBaseOperator that aims to
+        "look like" the real operator.
 
-        :param unmap_kwargs: Override the args to pass to the Operator constructor. Only used when
-            ``operator_class`` is still an actual class.
+        :param resolve: Only used if ``operator_class`` is a real class. If this
+            is a two-tuple (context, session), the information is used to
+            resolve the mapped arguments into init arguments. If this is a
+            mapping, no resolving happens, the mapping directly provides those
+            init arguments resolved from mapped kwargs.
 
         :meta private:
         """
         if isinstance(self.operator_class, type):
-            # We can't simply specify task_id here because BaseOperator further
+            if isinstance(resolve, collections.abc.Mapping):
+                mapped_kwargs = resolve
+            else:
+                mapped_kwargs = self._get_mapped_kwargs(resolve)
+            op = self.operator_class(**self._get_unmap_kwargs(mapped_kwargs), _airflow_from_mapped=True)
+            # We need to overwrite task_id here because BaseOperator further
             # mangles the task_id based on the task hierarchy (namely, group_id
-            # is prepended, and '__N' appended to deduplicate). Instead of
-            # recreating the whole logic here, we just overwrite task_id later.
-            if unmap_kwargs is None:
-                unmap_kwargs = self._get_unmap_kwargs()
-            op = self.operator_class(**unmap_kwargs, _airflow_from_mapped=True)
+            # is prepended, and '__N' appended to deduplicate). This is hacky,
+            # but better than duplicating the whole mangling logic.
             op.task_id = self.task_id
             return op
 
@@ -565,80 +594,9 @@ class MappedOperator(AbstractOperator):
         SerializedBaseOperator.populate_operator(op, self.operator_class)
         return op
 
-    def _get_expansion_kwargs(self) -> Dict[str, "Mappable"]:
+    def _get_expansion_kwargs(self) -> MappedKwargs:
         """The kwargs to calculate expansion length against."""
         return getattr(self, self._expansion_kwargs_attr)
-
-    def _get_map_lengths(self, run_id: str, *, session: Session) -> Dict[str, int]:
-        """Return dict of argument name to map length.
-
-        If any arguments are not known right now (upstream task not finished) they will not be present in the
-        dict.
-        """
-        # TODO: Find a way to cache this.
-        from airflow.models.taskmap import TaskMap
-        from airflow.models.xcom import XCom
-        from airflow.models.xcom_arg import XComArg
-
-        expansion_kwargs = self._get_expansion_kwargs()
-
-        # Populate literal mapped arguments first.
-        map_lengths: Dict[str, int] = collections.defaultdict(int)
-        map_lengths.update((k, len(v)) for k, v in expansion_kwargs.items() if not isinstance(v, XComArg))
-
-        # Build a reverse mapping of what arguments each task contributes to.
-        mapped_dep_keys: Dict[str, Set[str]] = collections.defaultdict(set)
-        non_mapped_dep_keys: Dict[str, Set[str]] = collections.defaultdict(set)
-        for k, v in expansion_kwargs.items():
-            if not isinstance(v, XComArg):
-                continue
-            if v.operator.is_mapped:
-                mapped_dep_keys[v.operator.task_id].add(k)
-            else:
-                non_mapped_dep_keys[v.operator.task_id].add(k)
-            # TODO: It's not possible now, but in the future (AIP-42 Phase 2)
-            # we will add support for depending on one single mapped task
-            # instance. When that happens, we need to further analyze the mapped
-            # case to contain only tasks we depend on "as a whole", and put
-            # those we only depend on individually to the non-mapped lookup.
-
-        # Collect lengths from unmapped upstreams.
-        taskmap_query = session.query(TaskMap.task_id, TaskMap.length).filter(
-            TaskMap.dag_id == self.dag_id,
-            TaskMap.run_id == run_id,
-            TaskMap.task_id.in_(non_mapped_dep_keys),
-            TaskMap.map_index < 0,
-        )
-        for task_id, length in taskmap_query:
-            for mapped_arg_name in non_mapped_dep_keys[task_id]:
-                map_lengths[mapped_arg_name] += length
-
-        # Collect lengths from mapped upstreams.
-        xcom_query = (
-            session.query(XCom.task_id, func.count(XCom.map_index))
-            .group_by(XCom.task_id)
-            .filter(
-                XCom.dag_id == self.dag_id,
-                XCom.run_id == run_id,
-                XCom.task_id.in_(mapped_dep_keys),
-                XCom.map_index >= 0,
-            )
-        )
-        for task_id, length in xcom_query:
-            for mapped_arg_name in mapped_dep_keys[task_id]:
-                map_lengths[mapped_arg_name] += length
-        return map_lengths
-
-    @cache
-    def _resolve_map_lengths(self, run_id: str, *, session: Session) -> Dict[str, int]:
-        """Return dict of argument name to map length, or throw if some are not resolvable"""
-        expansion_kwargs = self._get_expansion_kwargs()
-        map_lengths = self._get_map_lengths(run_id, session=session)
-        if len(map_lengths) < len(expansion_kwargs):
-            keys = ", ".join(repr(k) for k in sorted(set(expansion_kwargs).difference(map_lengths)))
-            raise RuntimeError(f"Failed to populate all mapping metadata; missing: {keys}")
-
-        return map_lengths
 
     def expand_mapped_task(self, run_id: str, *, session: Session) -> Tuple[Sequence["TaskInstance"], int]:
         """Create the mapped task instances for mapped task.
@@ -649,9 +607,7 @@ class MappedOperator(AbstractOperator):
         from airflow.models.taskinstance import TaskInstance
         from airflow.settings import task_instance_mutation_hook
 
-        total_length = functools.reduce(
-            operator.mul, self._resolve_map_lengths(run_id, session=session).values()
-        )
+        total_length = self._get_expansion_kwargs().get_total_map_length(run_id, session=session)
 
         state: Optional[TaskInstanceState] = None
         unmapped_ti: Optional[TaskInstance] = (
@@ -728,96 +684,6 @@ class MappedOperator(AbstractOperator):
         # we don't need to create a copy of the MappedOperator here.
         return self
 
-    def render_template_fields(
-        self,
-        context: Context,
-        jinja_env: Optional["jinja2.Environment"] = None,
-    ) -> Optional["BaseOperator"]:
-        """Template all attributes listed in template_fields.
-
-        Different from the BaseOperator implementation, this renders the
-        template fields on the *unmapped* BaseOperator.
-
-        :param context: Dict with values to apply on content
-        :param jinja_env: Jinja environment
-        :return: The unmapped, populated BaseOperator
-        """
-        if not jinja_env:
-            jinja_env = self.get_template_env()
-        # Before we unmap we have to resolve the mapped arguments, otherwise the real operator constructor
-        # could be called with an XComArg, rather than the value it resolves to.
-        #
-        # We also need to resolve _all_ mapped arguments, even if they aren't marked as templated
-        kwargs = self._get_unmap_kwargs()
-
-        template_fields = set(self.template_fields)
-
-        # Ideally we'd like to pass in session as an argument to this function, but since operators _could_
-        # override this we can't easily change this function signature.
-        # We can't use @provide_session, as that closes and expunges everything, which we don't want to do
-        # when we are so "deep" in the weeds here.
-        #
-        # Nor do we want to close the session -- that would expunge all the things from the internal cache
-        # which we don't want to do either
-        session = settings.Session()
-        self._resolve_expansion_kwargs(kwargs, template_fields, context, session)
-
-        unmapped_task = self.unmap(unmap_kwargs=kwargs)
-        self._do_render_template_fields(
-            parent=unmapped_task,
-            template_fields=template_fields,
-            context=context,
-            jinja_env=jinja_env,
-            seen_oids=set(),
-            session=session,
-        )
-        return unmapped_task
-
-    def _resolve_expansion_kwargs(
-        self, kwargs: Dict[str, Any], template_fields: Set[str], context: Context, session: Session
-    ) -> None:
-        """Update mapped fields in place in kwargs dict"""
-        from airflow.models.xcom_arg import XComArg
-
-        expansion_kwargs = self._get_expansion_kwargs()
-
-        for k, v in expansion_kwargs.items():
-            if isinstance(v, XComArg):
-                v = v.resolve(context, session=session)
-            v = self._expand_mapped_field(k, v, context, session=session)
-            template_fields.discard(k)
-            kwargs[k] = v
-
-    def _expand_mapped_field(self, key: str, value: Any, context: Context, *, session: Session) -> Any:
-        map_index = context["ti"].map_index
-        if map_index < 0:
-            return value
-        expansion_kwargs = self._get_expansion_kwargs()
-        all_lengths = self._resolve_map_lengths(context["run_id"], session=session)
-
-        def _find_index_for_this_field(index: int) -> int:
-            # Need to use self.mapped_kwargs for the original argument order.
-            for mapped_key in reversed(list(expansion_kwargs)):
-                mapped_length = all_lengths[mapped_key]
-                if mapped_length < 1:
-                    raise RuntimeError(f"cannot expand field mapped to length {mapped_length!r}")
-                if mapped_key == key:
-                    return index % mapped_length
-                index //= mapped_length
-            return -1
-
-        found_index = _find_index_for_this_field(map_index)
-        if found_index < 0:
-            return value
-        if isinstance(value, collections.abc.Sequence):
-            return value[found_index]
-        if not isinstance(value, dict):
-            raise TypeError(f"can't map over value of type {type(value)}")
-        for i, (k, v) in enumerate(value.items()):
-            if i == found_index:
-                return k, v
-        raise IndexError(f"index {map_index} is over mapped length")
-
     def iter_mapped_dependencies(self) -> Iterator["Operator"]:
         """Upstream dependencies that provide XComs used by this task for task mapping."""
         from airflow.models.xcom_arg import XComArg
@@ -827,44 +693,54 @@ class MappedOperator(AbstractOperator):
 
     @cached_property
     def parse_time_mapped_ti_count(self) -> Optional[int]:
-        """
-        Number of mapped TaskInstances that can be created at DagRun create time.
+        """Number of mapped TaskInstances that can be created at DagRun create time.
 
-        :return: None if non-literal mapped arg encountered, or else total number of mapped TIs this task
-            should have
+        :return: None if non-literal mapped arg encountered, or the total
+            number of mapped TIs this task should have.
         """
-        total = 0
-
-        for value in self._get_expansion_kwargs().values():
-            if not isinstance(value, MAPPABLE_LITERAL_TYPES):
-                # None literal type encountered, so give up
-                return None
-            if total == 0:
-                total = len(value)
-            else:
-                total *= len(value)
-        return total
+        return self._get_expansion_kwargs().get_parse_time_mapped_ti_count()
 
     @cache
     def run_time_mapped_ti_count(self, run_id: str, *, session: Session) -> Optional[int]:
-        """
-        Number of mapped TaskInstances that can be created at run time, or None if upstream tasks are not
-        complete yet.
+        """Number of mapped TaskInstances that can be created at run time.
 
-        :return: None if upstream tasks are not complete yet, or else total number of mapped TIs this task
-            should have
+        :return: None if upstream tasks are not complete yet, or the total
+            number of mapped TIs this task should have.
         """
-        lengths = self._get_map_lengths(run_id, session=session)
-        expansion_kwargs = self._get_expansion_kwargs()
-
-        if not lengths or not expansion_kwargs:
+        try:
+            return self._get_expansion_kwargs().get_total_map_length(run_id, session=session)
+        except NotFullyPopulated:
             return None
 
-        total = 1
-        for name in expansion_kwargs:
-            val = lengths.get(name)
-            if val is None:
-                return None
-            total *= val
+    def _get_template_fields_to_render(self, expanded: Iterable[str]) -> Iterable[str]:
+        # Since the mapped kwargs are already resolved during unmapping,
+        # they must be removed from the list of templated fields to avoid
+        # be rendered again (which breaks escaping).
+        return set(self.template_fields).difference(expanded)
 
-        return total
+    def render_template_fields(
+        self,
+        context: Context,
+        jinja_env: Optional["jinja2.Environment"] = None,
+    ) -> Optional["BaseOperator"]:
+        if not jinja_env:
+            jinja_env = self.get_template_env()
+
+        # Ideally we'd like to pass in session as an argument to this function,
+        # but we can't easily change this function signature since operators
+        # could override this. We can't use @provide_session since it closes and
+        # expunges everything, which we don't want to do when we are so "deep"
+        # in the weeds here. We don't close this session for the same reason.
+        session = settings.Session()
+
+        mapped_kwargs = self._get_mapped_kwargs((context, session))
+        unmapped_task = self.unmap(mapped_kwargs)
+        self._do_render_template_fields(
+            parent=unmapped_task,
+            template_fields=self._get_template_fields_to_render(mapped_kwargs),
+            context=context,
+            jinja_env=jinja_env,
+            seen_oids=set(),
+            session=session,
+        )
+        return unmapped_task

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -23,6 +23,7 @@ import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     ClassVar,
     Collection,
     Dict,
@@ -597,6 +598,14 @@ class MappedOperator(AbstractOperator):
     def _get_expansion_kwargs(self) -> MappedKwargs:
         """The kwargs to calculate expansion length against."""
         return getattr(self, self._expansion_kwargs_attr)
+
+    @property
+    def validate_upstream_return_value(self) -> Callable[[Any], None]:
+        """Validate an upstream's return value satisfies this task's needs.
+
+        :meta private:
+        """
+        return self._get_expansion_kwargs().validate_xcom
 
     def expand_mapped_task(self, run_id: str, *, session: Session) -> Tuple[Sequence["TaskInstance"], int]:
         """Create the mapped task instances for mapped task.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -91,7 +91,6 @@ from airflow.exceptions import (
     TaskDeferralError,
     TaskDeferred,
     UnmappableXComLengthPushed,
-    UnmappableXComTypePushed,
     XComForMappingNotPushed,
 )
 from airflow.models.base import Base, StringID
@@ -2306,18 +2305,20 @@ class TaskInstance(Base, LoggingMixin):
         self.log.debug("Task Duration set to %s", self.duration)
 
     def _record_task_map_for_downstreams(self, task: "Operator", value: Any, *, session: Session) -> None:
-        # TODO: We don't push TaskMap for mapped task instances because it's not
-        # currently possible for a downstream to depend on one individual mapped
-        # task instance, only a task as a whole. This will change in AIP-42
-        # Phase 2, and we'll need to further analyze the mapped task case.
-        if next(task.iter_mapped_dependants(), None) is None:
+        validators = {m.validate_upstream_return_value for m in task.iter_mapped_dependants()}
+        if not validators:  # No mapped dependants, not need to validate.
             return
         if value is None:
             raise XComForMappingNotPushed()
+        # TODO: We don't push TaskMap for mapped task instances because it's not
+        # currently possible for a downstream to depend on one individual mapped
+        # task instance. This will change when we implement task group mapping,
+        # and we'll need to further analyze the mapped task case.
         if task.is_mapped:
             return
-        if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
-            raise UnmappableXComTypePushed(value)
+        for validator in validators:
+            validator(value)
+        assert isinstance(value, collections.abc.Collection)  # The validators type-guard this.
         task_map = TaskMap.from_task_instance_xcom(self, value)
         max_map_length = conf.getint("core", "max_map_length", fallback=1024)
         if task_map.length > max_map_length:

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -251,13 +251,13 @@
         "doc_yaml":  { "type": "string" },
         "doc_rst":  { "type": "string" },
         "_is_mapped": { "const": true, "$comment": "only present when True" },
-        "mapped_kwargs": { "type": "object" },
+        "expand_input": { "type": "object" },
         "partial_kwargs": { "type": "object" }
       },
       "dependencies": {
-        "mapped_kwargs": ["partial_kwargs", "_is_mapped"],
-        "partial_kwargs": ["mapped_kwargs", "_is_mapped"],
-        "_is_mapped": ["mapped_kwargs", "partial_kwargs"]
+        "expand_input": ["partial_kwargs", "_is_mapped"],
+        "partial_kwargs": ["expand_input", "_is_mapped"],
+        "_is_mapped": ["expand_input", "partial_kwargs"]
       },
       "additionalProperties": true
     },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -100,8 +100,8 @@ def _get_default_mapped_partial() -> Dict[str, Any]:
     don't need to store them.
     """
     # Use the private _expand() method to avoid the empty kwargs check.
-    default_partial_kwargs = BaseOperator.partial(task_id="_")._expand(EXPAND_INPUT_EMPTY).partial_kwargs
-    return BaseSerialization._serialize(default_partial_kwargs)[Encoding.VAR]
+    default = BaseOperator.partial(task_id="_")._expand(EXPAND_INPUT_EMPTY, strict=False).partial_kwargs
+    return BaseSerialization._serialize(default)[Encoding.VAR]
 
 
 def encode_relativedelta(var: relativedelta.relativedelta) -> Dict[str, Any]:
@@ -827,6 +827,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 task_group=None,
                 start_date=None,
                 end_date=None,
+                disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
                 expand_input_attr=encoded_op["_expand_input_attr"],
             )
         else:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1372,7 +1372,7 @@ class Airflow(AirflowBaseView):
         # only matters if get_rendered_template_fields() raised an exception.
         # The following rendering won't show useful values in this case anyway,
         # but we'll display some quasi-meaingful field names.
-        task = ti.task.unmap()
+        task = ti.task.unmap(None)
 
         title = "Rendered Template"
         html_dict = {}

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -720,6 +720,7 @@ deduplicate
 deduplication
 deepcopy
 deepcopying
+defaultdict
 deferrable
 deidentify
 del

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -52,6 +52,7 @@ IGNORED = {
     # Only on MappedOperator.
     "mapped_kwargs",
     "partial_kwargs",
+    "validate_upstream_return_value",
 }
 
 

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -50,7 +50,7 @@ IGNORED = {
     "partial",
     "shallow_copy_attrs",
     # Only on MappedOperator.
-    "mapped_kwargs",
+    "expand_input",
     "partial_kwargs",
     "validate_upstream_return_value",
 }

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -71,7 +71,7 @@ class TestTaskEndpoint:
             EmptyOperator(task_id=self.task_id3)
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(EXPAND_INPUT_EMPTY)
+            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(EXPAND_INPUT_EMPTY, strict=False)
 
         task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -22,6 +22,7 @@ import pytest
 
 from airflow import DAG
 from airflow.models import DagBag
+from airflow.models.mappedkwargs import MAPPED_KWARGS_UNUSED
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
@@ -70,7 +71,7 @@ class TestTaskEndpoint:
             EmptyOperator(task_id=self.task_id3)
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            EmptyOperator.partial(task_id=self.mapped_task_id)._expand()
+            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(MAPPED_KWARGS_UNUSED)
 
         task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -22,7 +22,7 @@ import pytest
 
 from airflow import DAG
 from airflow.models import DagBag
-from airflow.models.mappedkwargs import MAPPED_KWARGS_UNUSED
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
@@ -71,7 +71,7 @@ class TestTaskEndpoint:
             EmptyOperator(task_id=self.task_id3)
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(MAPPED_KWARGS_UNUSED)
+            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(EXPAND_INPUT_EMPTY)
 
         task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -28,7 +28,7 @@ from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.mappedoperator import DictOfListsMappedKwargs
+from airflow.models.mappedoperator import DictOfListsExpandInput
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XCOM_RETURN_KEY
@@ -614,7 +614,7 @@ def test_mapped_decorator():
     assert isinstance(t2, XComArg)
     assert isinstance(t2.operator, DecoratedMappedOperator)
     assert t2.operator.task_id == "print_everything"
-    assert t2.operator.mapped_op_kwargs == DictOfListsMappedKwargs({"any_key": [1, 2], "works": t1})
+    assert t2.operator.op_kwargs_expand_input == DictOfListsExpandInput({"any_key": [1, 2], "works": t1})
 
     assert t0.operator.task_id == "print_info"
     assert t1.operator.task_id == "print_info__1"
@@ -657,7 +657,7 @@ def test_partial_mapped_decorator() -> None:
 
     assert isinstance(doubled, XComArg)
     assert isinstance(doubled.operator, DecoratedMappedOperator)
-    assert doubled.operator.mapped_op_kwargs == DictOfListsMappedKwargs({"number": literal})
+    assert doubled.operator.op_kwargs_expand_input == DictOfListsExpandInput({"number": literal})
     assert doubled.operator.partial_kwargs["op_kwargs"] == {"multiple": 2}
 
     assert isinstance(trippled.operator, DecoratedMappedOperator)  # For type-checking on partial_kwargs.

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -28,6 +28,7 @@ from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.mappedoperator import DictOfListsMappedKwargs
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XCOM_RETURN_KEY
@@ -613,7 +614,7 @@ def test_mapped_decorator():
     assert isinstance(t2, XComArg)
     assert isinstance(t2.operator, DecoratedMappedOperator)
     assert t2.operator.task_id == "print_everything"
-    assert t2.operator.mapped_op_kwargs == {"any_key": [1, 2], "works": t1}
+    assert t2.operator.mapped_op_kwargs == DictOfListsMappedKwargs({"any_key": [1, 2], "works": t1})
 
     assert t0.operator.task_id == "print_info"
     assert t1.operator.task_id == "print_info__1"
@@ -656,7 +657,7 @@ def test_partial_mapped_decorator() -> None:
 
     assert isinstance(doubled, XComArg)
     assert isinstance(doubled.operator, DecoratedMappedOperator)
-    assert doubled.operator.mapped_op_kwargs == {"number": literal}
+    assert doubled.operator.mapped_op_kwargs == DictOfListsMappedKwargs({"number": literal})
     assert doubled.operator.partial_kwargs["op_kwargs"] == {"multiple": 2}
 
     assert isinstance(trippled.operator, DecoratedMappedOperator)  # For type-checking on partial_kwargs.
@@ -678,7 +679,7 @@ def test_mapped_decorator_unmap_merge_op_kwargs():
 
         task2.partial(arg1=1).expand(arg2=task1())
 
-    unmapped = dag.get_task("task2").unmap()
+    unmapped = dag.get_task("task2").unmap(None)
     assert set(unmapped.op_kwargs) == {"arg1", "arg2"}
 
 
@@ -697,11 +698,11 @@ def test_mapped_decorator_converts_partial_kwargs():
 
     mapped_task2 = dag.get_task("task2")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)
-    assert mapped_task2.unmap().retry_delay == timedelta(seconds=30)
+    assert mapped_task2.unmap(None).retry_delay == timedelta(seconds=30)
 
     mapped_task1 = dag.get_task("task1")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)  # Operator default.
-    mapped_task1.unmap().retry_delay == timedelta(seconds=300)  # Operator default.
+    mapped_task1.unmap(None).retry_delay == timedelta(seconds=300)  # Operator default.
 
 
 def test_mapped_render_template_fields(dag_maker, session):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -1165,7 +1165,7 @@ def test_mapped_literal_length_reduction_adds_removed_state(dag_maker, session):
     ]
 
 
-def test_mapped_literal_length_increase_at_runtime_adds_additional_tis(dag_maker, session):
+def test_mapped_length_increase_at_runtime_adds_additional_tis(dag_maker, session):
     """Test that when the length of mapped literal increases at runtime, additional ti is added"""
     from airflow.models import Variable
 
@@ -1422,3 +1422,24 @@ def test_schedule_tis_map_index(dag_maker, session):
     assert ti0.state == TaskInstanceState.SUCCESS
     assert ti1.state == TaskInstanceState.SCHEDULED
     assert ti2.state == TaskInstanceState.SUCCESS
+
+
+def test_mapped_expand_kwargs(dag_maker):
+    with dag_maker() as dag:
+
+        @task
+        def task_1():
+            return [{"arg1": "a", "arg2": "b"}, {"arg1": "y"}, {"arg2": "z"}]
+
+        MockOperator.partial(task_id="task_2").expand_kwargs(task_1())
+
+    dr: DagRun = dag_maker.create_dagrun()
+    assert len([ti for ti in dr.get_task_instances() if ti.task_id == "task_2"]) == 1
+
+    ti1 = dr.get_task_instance("task_1")
+    ti1.refresh_from_task(dag.get_task("task_1"))
+    ti1.run()
+
+    dr.task_instance_scheduling_decisions()
+    ti_states = {ti.map_index: ti.state for ti in dr.get_task_instances() if ti.task_id == "task_2"}
+    assert ti_states == {0: None, 1: None, 2: None}

--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -102,9 +102,7 @@ def test_map_xcom_arg():
 def test_partial_on_instance() -> None:
     """`.partial` on an instance should fail -- it's only designed to be called on classes"""
     with pytest.raises(TypeError):
-        MockOperator(
-            task_id='a',
-        ).partial()
+        MockOperator(task_id='a').partial()
 
 
 def test_partial_on_class() -> None:
@@ -275,4 +273,109 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
 
     assert op.value == "{{ ds }}", "Should not be templated!"
     assert op.arg1 == "{{ ds }}", "Should not be templated!"
+    assert op.arg2 == "a"
+
+
+@pytest.mark.parametrize(
+    ["num_existing_tis", "expected"],
+    (
+        pytest.param(0, [(0, None), (1, None), (2, None)], id='only-unmapped-ti-exists'),
+        pytest.param(
+            3,
+            [(0, 'success'), (1, 'success'), (2, 'success')],
+            id='all-tis-exist',
+        ),
+        pytest.param(
+            5,
+            [
+                (0, 'success'),
+                (1, 'success'),
+                (2, 'success'),
+                (3, TaskInstanceState.REMOVED),
+                (4, TaskInstanceState.REMOVED),
+            ],
+            id="tis-to-be-removed",
+        ),
+    ),
+)
+def test_expand_kwargs_mapped_task_instance(dag_maker, session, num_existing_tis, expected):
+    literal = [{"arg1": "a"}, {"arg1": "b"}, {"arg1": "c"}]
+    with dag_maker(session=session):
+        task1 = BaseOperator(task_id="op1")
+        mapped = MockOperator.partial(task_id='task_2').expand_kwargs(XComArg(task1))
+
+    dr = dag_maker.create_dagrun()
+
+    session.add(
+        TaskMap(
+            dag_id=dr.dag_id,
+            task_id=task1.task_id,
+            run_id=dr.run_id,
+            map_index=-1,
+            length=len(literal),
+            keys=None,
+        )
+    )
+
+    if num_existing_tis:
+        # Remove the map_index=-1 TI when we're creating other TIs
+        session.query(TaskInstance).filter(
+            TaskInstance.dag_id == mapped.dag_id,
+            TaskInstance.task_id == mapped.task_id,
+            TaskInstance.run_id == dr.run_id,
+        ).delete()
+
+    for index in range(num_existing_tis):
+        # Give the existing TIs a state to make sure we don't change them
+        ti = TaskInstance(mapped, run_id=dr.run_id, map_index=index, state=TaskInstanceState.SUCCESS)
+        session.add(ti)
+    session.flush()
+
+    mapped.expand_mapped_task(dr.run_id, session=session)
+
+    indices = (
+        session.query(TaskInstance.map_index, TaskInstance.state)
+        .filter_by(task_id=mapped.task_id, dag_id=mapped.dag_id, run_id=dr.run_id)
+        .order_by(TaskInstance.map_index)
+        .all()
+    )
+
+    assert indices == expected
+
+
+@pytest.mark.parametrize(
+    "map_index, expected",
+    [
+        pytest.param(0, "{{ ds }}", id="0"),
+        pytest.param(1, 2, id="1"),
+    ],
+)
+def test_expand_kwargs_render_template_fields_validating_operator(dag_maker, session, map_index, expected):
+    with dag_maker(session=session):
+        task1 = BaseOperator(task_id="op1")
+        mapped = MockOperator.partial(task_id='a', arg2='{{ ti.task_id }}').expand_kwargs(XComArg(task1))
+
+    dr = dag_maker.create_dagrun()
+    ti: TaskInstance = dr.get_task_instance(task1.task_id, session=session)
+
+    ti.xcom_push(key=XCOM_RETURN_KEY, value=[{"arg1": '{{ ds }}'}, {"arg1": 2}], session=session)
+
+    session.add(
+        TaskMap(
+            dag_id=dr.dag_id,
+            task_id=task1.task_id,
+            run_id=dr.run_id,
+            map_index=-1,
+            length=2,
+            keys=None,
+        )
+    )
+    session.flush()
+
+    ti: TaskInstance = dr.get_task_instance(mapped.task_id, session=session)
+    ti.refresh_from_task(mapped)
+    ti.map_index = map_index
+    op = mapped.render_template_fields(context=ti.get_template_context(session=session))
+    assert isinstance(op, MockOperator)
+    assert op.arg1 == expected
     assert op.arg2 == "a"

--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -274,5 +274,5 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
     assert isinstance(op, MyOperator)
 
     assert op.value == "{{ ds }}", "Should not be templated!"
-    assert op.arg1 == "{{ ds }}"
+    assert op.arg1 == "{{ ds }}", "Should not be templated!"
     assert op.arg2 == "a"

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -59,7 +59,7 @@ from airflow.models import (
     XCom,
 )
 from airflow.models.dataset import DatasetDagRunQueue, DatasetTaskRef
-from airflow.models.mappedkwargs import MAPPED_KWARGS_UNUSED
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskinstance import TaskInstance
@@ -1061,7 +1061,7 @@ class TestTaskInstance:
         with dag_maker(dag_id="test_xcom", session=session):
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            task_1 = EmptyOperator.partial(task_id="task_1")._expand(MAPPED_KWARGS_UNUSED)
+            task_1 = EmptyOperator.partial(task_id="task_1")._expand(EXPAND_INPUT_EMPTY)
             EmptyOperator(task_id="task_2")
 
         dagrun = dag_maker.create_dagrun(start_date=timezone.datetime(2016, 6, 1, 0, 0, 0))
@@ -2823,7 +2823,7 @@ def test_ti_xcom_pull_on_mapped_operator_return_lazy_iterable(mock_deserialize_v
     with dag_maker(dag_id="test_xcom", session=session):
         # Use the private _expand() method to avoid the empty kwargs check.
         # We don't care about how the operator runs here, only its presence.
-        task_1 = EmptyOperator.partial(task_id="task_1")._expand(MAPPED_KWARGS_UNUSED)
+        task_1 = EmptyOperator.partial(task_id="task_1")._expand(EXPAND_INPUT_EMPTY)
         EmptyOperator(task_id="task_2")
 
     dagrun = dag_maker.create_dagrun()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -43,6 +43,7 @@ from airflow.exceptions import (
     AirflowSkipException,
     UnmappableXComLengthPushed,
     UnmappableXComTypePushed,
+    UnmappableXComValuePushed,
     XComForMappingNotPushed,
 )
 from airflow.models import (
@@ -86,6 +87,7 @@ from tests.models import DEFAULT_DATE, TEST_DAGS_FOLDER
 from tests.test_utils import db
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_connections, clear_db_runs
+from tests.test_utils.mock_operators import MockOperator
 
 
 @pytest.fixture
@@ -2463,9 +2465,9 @@ class TestTaskInstanceRecordTaskMapXComPush:
             (None, XComForMappingNotPushed, "did not push XCom for task mapping"),
         ],
     )
-    def test_error_if_unmappable_type(self, dag_maker, return_value, exception_type, error_message):
-        """If an unmappable return value is used to map, fail the task that pushed the XCom."""
-        with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
+    def test_expand_error_if_unmappable_type(self, dag_maker, return_value, exception_type, error_message):
+        """If an unmappable return value is used for expand(), fail the task that pushed the XCom."""
+        with dag_maker(dag_id="test_expand_error_if_unmappable_type") as dag:
 
             @dag.task()
             def push_something():
@@ -2478,6 +2480,39 @@ class TestTaskInstanceRecordTaskMapXComPush:
             pull_something.expand(value=push_something())
 
         ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push_something")
+        with pytest.raises(exception_type) as ctx:
+            ti.run()
+
+        assert dag_maker.session.query(TaskMap).count() == 0
+        assert ti.state == TaskInstanceState.FAILED
+        assert str(ctx.value) == error_message
+
+    @pytest.mark.parametrize(
+        "return_value, exception_type, error_message",
+        [
+            (123, UnmappableXComTypePushed, "unmappable return type 'int'"),
+            ([123], UnmappableXComTypePushed, "unmappable return type 'list[int]'"),
+            ([{1: 3}], UnmappableXComValuePushed, "unmappable return value [{1: 3}] (dict keys must be str)"),
+            (None, XComForMappingNotPushed, "did not push XCom for task mapping"),
+        ],
+    )
+    def test_expand_kwargs_error_if_unmappable_type(
+        self,
+        dag_maker,
+        return_value,
+        exception_type,
+        error_message,
+    ):
+        """If an unmappable return value is used for expand_kwargs(), fail the task that pushed the XCom."""
+        with dag_maker(dag_id="test_expand_kwargs_error_if_unmappable_type") as dag:
+
+            @dag.task()
+            def push():
+                return return_value
+
+            MockOperator.partial(task_id="pull").expand_kwargs(push())
+
+        ti = next(ti for ti in dag_maker.create_dagrun().task_instances if ti.task_id == "push")
         with pytest.raises(exception_type) as ctx:
             ti.run()
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -58,6 +58,7 @@ from airflow.models import (
     XCom,
 )
 from airflow.models.dataset import DatasetDagRunQueue, DatasetTaskRef
+from airflow.models.mappedkwargs import MAPPED_KWARGS_UNUSED
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskinstance import TaskInstance
@@ -1058,7 +1059,7 @@ class TestTaskInstance:
         with dag_maker(dag_id="test_xcom", session=session):
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            task_1 = EmptyOperator.partial(task_id="task_1")._expand()
+            task_1 = EmptyOperator.partial(task_id="task_1")._expand(MAPPED_KWARGS_UNUSED)
             EmptyOperator(task_id="task_2")
 
         dagrun = dag_maker.create_dagrun(start_date=timezone.datetime(2016, 6, 1, 0, 0, 0))
@@ -2787,7 +2788,7 @@ def test_ti_xcom_pull_on_mapped_operator_return_lazy_iterable(mock_deserialize_v
     with dag_maker(dag_id="test_xcom", session=session):
         # Use the private _expand() method to avoid the empty kwargs check.
         # We don't care about how the operator runs here, only its presence.
-        task_1 = EmptyOperator.partial(task_id="task_1")._expand()
+        task_1 = EmptyOperator.partial(task_id="task_1")._expand(MAPPED_KWARGS_UNUSED)
         EmptyOperator(task_id="task_2")
 
     dagrun = dag_maker.create_dagrun()


### PR DESCRIPTION
This involves mostly refactoring to make mapped_kwargs be able to hold two forms of mapped arguments, either a dict-of-lists (from `expand()`) and list-of-dicts (from `expand_kwargs()`).

The `expand_kwargs()` function has been implemented, but it definitely does not in the actual
worker since unmapping has not been implemented.

This is currently submitted for CI to make sure I’ve made the correct changes to keep existing functionalities working. The code structure is mostly there, so feel free to review if you want to.