### PR TITLE
Add test_connection method to AzureFileShareHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -286,3 +286,19 @@ class AzureFileShareHook(BaseHook):
         self.get_conn().create_file_from_stream(
             share_name, directory_name, file_name, stream, count, **kwargs
         )
+
+    def test_connection(self):
+        """Test Azure FileShare connection."""
+        success = (True, "Successfully connected to Azure File Share.")
+
+        try:
+            # Attempt to retrieve file share information
+            next(iter(self.get_conn().list_shares()))
+            return success
+        except StopIteration:
+            # If the iterator returned is empty it should still be considered a successful connection since
+            # it's possible to create a storage account without any file share and none could
+            # legitimately exist yet.
+            return success
+        except Exception as e:
+            return False, str(e)

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -255,3 +255,19 @@ class TestAzureFileshareHook(unittest.TestCase):
         hook = AzureFileShareHook(azure_fileshare_conn_id='azure_fileshare_extras')
         hook.delete_share('my_share')
         mock_instance.delete_share.assert_called_once_with('my_share')
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.fileshare.FileService', autospec=True)
+    def test_connection_success(self, mock_service):
+        hook = AzureFileShareHook(azure_fileshare_conn_id='azure_fileshare_extras')
+        hook.get_conn().list_shares.return_value = ["test_container"]
+        status, msg = hook.test_connection()
+        assert status is True
+        assert msg == "Successfully connected to Azure File Share."
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.fileshare.FileService', autospec=True)
+    def test_connection_failure(self, mock_service):
+        hook = AzureFileShareHook(azure_fileshare_conn_id='azure_fileshare_extras')
+        hook.get_conn().list_shares.side_effect = Exception("Test Connection Failure")
+        status, msg = hook.test_connection()
+        assert status is False
+        assert msg == "Test Connection Failure"


### PR DESCRIPTION
This PR enables Test connection button for the Azure FileShare connection type.

cc @kaxil 

<img width="865" alt="Screenshot 2022-07-05 at 5 05 59 PM" src="https://user-images.githubusercontent.com/94376113/177319206-2b98ae18-42e1-4f0d-a8f1-a84a59f80969.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
