### PR TITLE
Bind log server on worker to IPv6 address (#24755)

### DIFF
--- a/newsfragments/24755.improvement.rst
+++ b/newsfragments/24755.improvement.rst
@@ -1,0 +1,1 @@
+Log server on worker binds IPv6 interface.


### PR DESCRIPTION
Bind log server on worker to IPv6 address (#24755)

The worker(s) run a gunicorn web server that serves task logs,
which are displayed on the web-ui (the `Logs`).
Until now the log server did bind the address `0.0.0.0:<port>`, see `airflow/utils/serve_logs.py`.

In a Kubernetes cluster that allows IPv6 traffic only, the worker logs are not reachable,
because the log server does not listen on `[::]:<port>`.
Therefore we bind another address and listen to both IPv4 and IPv6 traffic.

closes: #24755 

