### PR TITLE
improve grid date tick spacing

### DIFF
--- a/airflow/www/static/js/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/grid/dagRuns/Bar.tsx
@@ -70,8 +70,9 @@ const DagRunBar = ({
   };
 
   // show the tick on the 4th DagRun and then every 10th tick afterwards
-  const shouldShowTick = index === totalRuns - 4
-    || (index < totalRuns - 4 && (index + 4) % 10 === 0);
+  const inverseIndex = totalRuns - index;
+  const shouldShowTick = inverseIndex === 4
+    || (inverseIndex > 4 && (inverseIndex - 4) % 10 === 0);
 
   return (
     <Box

--- a/airflow/www/static/js/grid/dagRuns/index.test.tsx
+++ b/airflow/www/static/js/grid/dagRuns/index.test.tsx
@@ -106,7 +106,7 @@ describe('Test DagRuns', () => {
   test('Show 1 date tick when there are less than 14 runs', () => {
     const data = {
       groups: {},
-      dagRuns: generateRuns(8),
+      dagRuns: generateRuns(11),
     };
     const spy = jest.spyOn(useGridDataModule, 'default').mockImplementation(() => ({
       data,


### PR DESCRIPTION
There was an issue of date tick spacing when there were 11-13 dag runs. This PR fixes that by counting `shouldShowTick` with the inverse of the run index and counting backwards.

Before:
<img width="239" alt="Screen Shot 2022-07-05 at 1 24 50 PM" src="https://user-images.githubusercontent.com/4600967/177382845-bf353ece-0b8c-49aa-8f5d-f0142f5985ab.png">

After:
<img width="240" alt="Screen Shot 2022-07-05 at 1 25 24 PM" src="https://user-images.githubusercontent.com/4600967/177382930-8ab0f788-2aa5-4658-8e0b-95cb4a5e3415.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
