### PR TITLE
Fix docs build errors for Sphinx 5

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/operators/hdfs.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/operators/hdfs.rst
@@ -31,7 +31,7 @@ system data. HDFS is now an Apache Hadoop sub project.
 Prerequisite
 ------------
 
-To use operators, you must configure a :doc:`HDFS Connection <connections>`.
+To use operators, you must configure a :doc:`HDFS Connection </connections>`.
 
 .. _howto/operator:HdfsFolderSensor:
 

--- a/docs/apache-airflow-providers-google/configurations-ref.rst
+++ b/docs/apache-airflow-providers-google/configurations-ref.rst
@@ -23,7 +23,7 @@ This page contains the list of all the provider configurations that you
 can set in ``airflow.cfg`` file or using environment variables.
 
 .. note::
-    For more information on setting the configuration, see :doc:`howto/set-config`
+    For more information on setting the configuration, see :doc:`apache-airflow:howto/set-config`
 
 .. contents:: Sections:
    :local:

--- a/docs/apache-airflow-providers/index.rst
+++ b/docs/apache-airflow-providers/index.rst
@@ -223,7 +223,7 @@ Exposing customized functionality to the Airflow's core:
 
 When your providers are installed you can query the installed providers and their capabilities with the
 ``airflow providers`` command. This way you can verify if your providers are properly recognized and whether
-they define the extensions properly. See :doc:`cli-and-env-variables-ref` for details of available CLI
+they define the extensions properly. See :doc:`apache-airflow:cli-and-env-variables-ref` for details of available CLI
 sub-commands.
 
 When you write your own provider, consider following the

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
@@ -19,7 +19,7 @@
 Operators and Hooks Reference
 =============================
 
-Here is a list of operators and hooks that are released independently of the Airflow core. A list of core operators is available in the documentation for ``apache-airflow``: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`.
+Here is a list of operators and hooks that are released independently of the Airflow core. A list of core operators is available in the documentation for ``apache-airflow``: :doc:`Core Operators and Hooks Reference <apache-airflow:operators-and-hooks-ref>`.
 
 .. toctree::
     :maxdepth: 3

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -59,7 +59,7 @@ Those are "reference" regular images. They contain the most common set of extras
 often used by the users and they are good to "try-things-out" when you want to just take Airflow for a spin,
 
 You can also use "slim" images that contain only core airflow and are about half the size of the "regular" images
-but you need to add all the :doc:`extra-packages-ref` and providers that you need separately
+but you need to add all the :doc:`apache-airflow:extra-packages-ref` and providers that you need separately
 via :ref:`Building the image <build:build_image>`.
 
 * :subst-code:`apache/airflow:slim-latest`              - the latest released Airflow image with default Python version (3.7 currently)
@@ -69,7 +69,7 @@ via :ref:`Building the image <build:build_image>`.
 
 The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases
-you want to either extend or customize the image. You can see all possible extras in :doc:`extra-packages-ref`.
+you want to either extend or customize the image. You can see all possible extras in :doc:`apache-airflow:extra-packages-ref`.
 The set of extras used in Airflow Production image are available in the
 `Dockerfile <https://github.com/apache/airflow/blob/2c6c7fdb2308de98e142618836bdf414df9768c8/Dockerfile#L37>`_.
 


### PR DESCRIPTION
Sphinx 5 is a little bit more picky about docuementation link
errors that Sphinx 4 had. Due to lack of job dependency (fixed now
via #24866), we accidentally upgraded to Sphinx 5 in constraints
and it started to fail our builds. Fortunately the errors in docs
are very few and we can easily fix it without reverting the
constraint change.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
