### PR TITLE
Make sure builder is created as needed before warming up

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -74,6 +74,7 @@ from airflow_breeze.utils.confirm import STANDARD_TIMEOUT, Answer, user_confirm
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.docker_command_utils import (
     build_cache,
+    make_sure_builder_configured,
     perform_environment_checks,
     prepare_docker_build_command,
     prepare_docker_build_from_input,
@@ -228,6 +229,11 @@ def run_build_in_parallel(
     pool.close()
 
 
+def start_building(params: BuildCiParams, dry_run: bool, verbose: bool):
+    check_if_image_building_is_needed(params, dry_run=dry_run, verbose=verbose)
+    make_sure_builder_configured(parallel=True, params=params, dry_run=dry_run, verbose=verbose)
+
+
 @main.command(name='build-image')
 @option_github_repository
 @option_verbose
@@ -298,7 +304,7 @@ def build_image(
             params.python = python
             params.answer = answer
             params_list.append(params)
-        check_if_image_building_is_needed(params_list[0], dry_run=dry_run, verbose=verbose)
+        start_building(params_list[0], dry_run, verbose)
         run_build_in_parallel(
             image_params_list=params_list,
             python_version_list=python_version_list,
@@ -308,7 +314,7 @@ def build_image(
         )
     else:
         params = BuildCiParams(**parameters_passed)
-        check_if_image_building_is_needed(params, dry_run=dry_run, verbose=verbose)
+        start_building(params, dry_run, verbose)
         run_build(ci_image_params=params)
 
 

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -73,6 +73,7 @@ from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.docker_command_utils import (
     build_cache,
+    make_sure_builder_configured,
     perform_environment_checks,
     prepare_docker_build_command,
     prepare_docker_build_from_input,
@@ -200,7 +201,10 @@ PRODUCTION_IMAGE_TOOLS_PARAMETERS = {
 }
 
 
-def start_building(prod_image_params: BuildProdParams, dry_run: bool, verbose: bool):
+def start_building(parallel: bool, prod_image_params: BuildProdParams, dry_run: bool, verbose: bool):
+    make_sure_builder_configured(
+        parallel=parallel, params=prod_image_params, dry_run=dry_run, verbose=verbose
+    )
     if prod_image_params.cleanup_context:
         clean_docker_context_files(verbose=verbose, dry_run=dry_run)
     check_docker_context_files(prod_image_params.install_packages_from_context)
@@ -346,7 +350,7 @@ def build_prod_image(
             params.python = python
             params.answer = answer
             params_list.append(params)
-        start_building(prod_image_params=params_list[0], dry_run=dry_run, verbose=verbose)
+        start_building(parallel=True, prod_image_params=params_list[0], dry_run=dry_run, verbose=verbose)
         run_build_in_parallel(
             image_params_list=params_list,
             python_version_list=python_version_list,
@@ -356,7 +360,7 @@ def build_prod_image(
         )
     else:
         params = BuildProdParams(**parameters_passed)
-        start_building(prod_image_params=params, dry_run=dry_run, verbose=verbose)
+        start_building(parallel=False, prod_image_params=params, dry_run=dry_run, verbose=verbose)
         run_build(prod_image_params=params)
 
 


### PR DESCRIPTION
In case of parallel cache building, we want to warm-up the builder and make
sure the builder is created. It might or might not be created by
in case of ARM builds (and then it will point to ARM builder) but in
case we run AMD builds, we should attempt to check and re-create it if
needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
