### PR TITLE
Revert "KubernetesExecutor: Use user-provided namespace from executor…

### DIFF
--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -414,8 +414,7 @@ class TestPodGenerator:
                         name='', resources=k8s.V1ResourceRequirements(limits={'cpu': '1m', 'memory': '1G'})
                     )
                 ]
-            ),
-            metadata=k8s.V1ObjectMeta(namespace='overridden_namespace'),
+            )
         )
 
         result = PodGenerator.construct_pod(
@@ -436,7 +435,7 @@ class TestPodGenerator:
         expected.metadata.labels['app'] = 'myapp'
         expected.metadata.annotations = self.annotations
         expected.metadata.name = 'pod_id-' + self.static_uuid.hex
-        expected.metadata.namespace = 'overridden_namespace'
+        expected.metadata.namespace = 'test_namespace'
         expected.spec.containers[0].args = ['command']
         expected.spec.containers[0].image = expected_image
         expected.spec.containers[0].resources = {'limits': {'cpu': '1m', 'memory': '1G'}}


### PR DESCRIPTION
…_config arg (#24342)"

This reverts commit 1fe07e5cebac5e8a0b3fe7e88c65f6d2b0c2134d.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
