### PR TITLE
Breeze: Improve version check for kubectl

### DIFF
--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -69,7 +69,7 @@ function kind::make_sure_kubernetes_tools_are_installed() {
     kubectl_url="https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${system}/${machine}/kubectl"
     if [[ -f "${KUBECTL_BINARY_PATH}" ]]; then
         local downloaded_kubectl_version
-        downloaded_kubectl_version="$(${KUBECTL_BINARY_PATH} version --client=true | awk '{ print $3 }')"
+        downloaded_kubectl_version="$(${KUBECTL_BINARY_PATH} version --client --output yaml | grep gitVersion | awk '{ print $2 }')"
         echo "Currently downloaded kubectl version = ${downloaded_kubectl_version}"
     fi
     if [[ ! -f "${KUBECTL_BINARY_PATH}" || ${downloaded_kubectl_version} != "${KUBECTL_VERSION}" ]]; then


### PR DESCRIPTION
kubectl 1.24.0 added a warning that broke the version detection.
It leads to redownload kubectl every time we run a breeze-legacy command.

The change in how the version detection works should be backward
compatible with at least kubectl 1.20, see [command reference](https://v1-20.docs.kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#version).

It should benefit other processes because the `_kind.sh` script is used in
breeze-legacy and the CI tests as well.

Before:

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/1991286/177624209-2d5f1460-731c-46b8-a8fa-cb45c8565f62.png">

After:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/1991286/177624262-0102d7fc-dc68-4cf8-852a-74f5d30d2a21.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
