### PR TITLE
Upgrade FAB to 4.1.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,7 @@ install_requires =
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/www/fab_security` with their upstream counterparts. In particular, make sure any breaking changes,
     # for example any new methods, are accounted for.
-    flask-appbuilder==4.1.2
+    flask-appbuilder==4.1.3
     flask-caching>=1.5.0
     flask-login>=0.5
     flask-session>=0.4.0


### PR DESCRIPTION
No relevant changes were found when comparing `airflow/www/fab_security` with the FAB source.

See https://github.com/dpgaspar/Flask-AppBuilder/compare/v4.1.2...v4.1.3

Ps.: I think that the constraints-main file needs to be updated somehow. Let me know if I need to handle this on that same PR.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
