### PR TITLE
Don't add init.py files to __pycache__ folders.

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_check_init_in_tests.py
+++ b/scripts/ci/pre_commit/pre_commit_check_init_in_tests.py
@@ -39,11 +39,12 @@ errors: List[str] = []
 added = False
 
 if __name__ == '__main__':
-    for dir, sub_dirs, files in os.walk(str(ROOT_DIR / "tests")):
+    for dirname, sub_dirs, files in os.walk(ROOT_DIR / "tests"):
+        dir = Path(dirname)
+        sub_dirs[:] = [subdir for subdir in sub_dirs if subdir not in {"__pycache__", "test_logs"}]
         for sub_dir in sub_dirs:
-            dir_to_check = dir + os.sep + sub_dir
-            init_py_path = Path(dir_to_check) / "__init__.py"
-            if not init_py_path.exists() and "/test_logs/" not in str(init_py_path):
+            init_py_path = dir / sub_dir / "__init__.py"
+            if not init_py_path.exists():
                 init_py_path.touch()
                 console.print(f"[yellow] Created {init_py_path}[/]")
                 added = True


### PR DESCRIPTION
For instance, after running pytest I had these files created by this step:

```
Create missing init.py files in tests..................................................Failed
- hook id: create-missing-init-py-files-tests
- exit code: 1

 Created /home/ash/code/airflow/airflow/tests/__pycache__/__init__.py
 Created /home/ash/code/airflow/airflow/tests/models/__pycache__/__init__.py
 Created /home/ash/code/airflow/airflow/tests/test_utils/__pycache__/__init__.py
 Created /home/ash/code/airflow/airflow/tests/test_utils/perf/__pycache__/__init__.py
 Created /home/ash/code/airflow/airflow/tests/test_utils/perf/perf_kit/__pycache__/__init__.py
```

(This change also stops the `os.walkdir` from needlessly recursing in to
test_logs folder as well.)