### PR TITLE
Make sure that build-images workflow has permissions to read PR info

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -22,6 +22,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   # all other permissions are set to none
   contents: read
+  pull-requests: read
 env:
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   ANSWER: "yes"


### PR DESCRIPTION
For a public repo this information is public so no extra permission is
required, but just in case this workflow ends up against a private repo
we need these permissions explicitly.

(Does no harm for apache/airflow, is just belt-and-brances here)