### PR TITLE
Remove full provider's specification from TEST_TYPES

### DIFF
--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -107,7 +107,8 @@ function run_all_test_types_in_parallel() {
             # Those tests will run in `main` anyway.
             if [[ ${test_types_to_run} == *"Providers"* ]]; then
                 echo "${COLOR_YELLOW}Remove Providers from tests_types_to_run and skip running them altogether (mysql/mssql case).${COLOR_RESET}"
-                test_types_to_run="${test_types_to_run//Providers/}"
+                # shellcheck disable=SC2001
+                test_types_to_run=$(echo "${test_types_to_run}" | sed 's/Providers[^ ]* *//')
             fi
         fi
     fi


### PR DESCRIPTION
The new provider's selective tests introduce option to specify
which providers should be tested (which is automatically
used in CI). This works fine but in case when we remove
Provider's tests from the list (MySQL/MsSQL) the removal was
done only for the Provider's part, not for the detailed list
of providers. That led to test attempting to run
```
[amazon,apache.hive,google,mysql,postgres]
```

for example.

This PR fixes it by removing full Provider's specification.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
