### PR TITLE
Add test connection functionality to `GithubHook`

### DIFF
--- a/tests/providers/github/operators/test_github.py
+++ b/tests/providers/github/operators/test_github.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-import unittest
 from unittest.mock import Mock, patch
 
 from airflow.models import Connection
@@ -29,8 +28,8 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 github_client_mock = Mock(name="github_client_for_test")
 
 
-class TestGithubOperator(unittest.TestCase):
-    def setUp(self):
+class TestGithubOperator:
+    def setup_class(self):
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG('test_dag_id', default_args=args)
         self.dag = dag
@@ -38,9 +37,8 @@ class TestGithubOperator(unittest.TestCase):
             Connection(
                 conn_id='github_default',
                 conn_type='github',
-                host='https://localhost/github/',
-                port=443,
-                extra='{"verify": "False", "project": "AIRFLOW"}',
+                password='my-access-token',
+                host='https://mygithub.com/api/v3',
             )
         )
 

--- a/tests/providers/github/sensors/test_github.py
+++ b/tests/providers/github/sensors/test_github.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-import unittest
 from unittest.mock import Mock, patch
 
 from airflow.models import Connection
@@ -29,8 +28,8 @@ DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 github_client_mock = Mock(name="github_client_for_test")
 
 
-class TestGithubSensor(unittest.TestCase):
-    def setUp(self):
+class TestGithubSensor:
+    def setup_class(self):
         args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         dag = DAG('test_dag_id', default_args=args)
         self.dag = dag
@@ -38,9 +37,8 @@ class TestGithubSensor(unittest.TestCase):
             Connection(
                 conn_id='github_default',
                 conn_type='github',
-                host='https://localhost/github/',
-                port=443,
-                extra='{"verify": "False", "project": "AIRFLOW"}',
+                password='my-access-token',
+                host='https://mygithub.com/api/v3',
             )
         )
 


### PR DESCRIPTION
Light refactoring of the UI form and converting unit tests from `unittest` to `pytest` as well.

**Successful connection test**
<img width="1434" alt="image" src="https://user-images.githubusercontent.com/48934154/177855733-24adbfec-bdc3-4cea-bd1e-9857b9d25b6f.png">

**Failed connection test**
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/48934154/177855806-97fa62ac-705f-4c4a-9b64-fee3be9e3505.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
