### PR TITLE
Dataset event table

### DIFF
--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -124,10 +124,10 @@ def _create_dataset_event_table():
         sa.Column('id', Integer, primary_key=True, autoincrement=True),
         sa.Column('dataset_id', Integer, nullable=False),
         sa.Column('extra', ExtendedJSON, nullable=True),
-        sa.Column('source_task_id', String(250), nullable=True),
-        sa.Column('source_dag_id', String(250), nullable=True),
-        sa.Column('source_run_id', String(250), nullable=True),
-        sa.Column('source_map_index', sa.Integer(), nullable=True, server_default='-1'),
+        sa.Column('task_id', String(250), nullable=True),
+        sa.Column('dag_id', String(250), nullable=True),
+        sa.Column('run_id', String(250), nullable=True),
+        sa.Column('map_index', sa.Integer(), nullable=True, server_default='-1'),
         sa.Column('created_at', TIMESTAMP, nullable=False),
         sqlite_autoincrement=True,  # ensures PK values not reused
     )

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -131,9 +131,7 @@ def _create_dataset_event_table():
         sa.Column('created_at', TIMESTAMP, nullable=False),
         sqlite_autoincrement=True,  # ensures PK values not reused
     )
-    op.create_index(
-        'idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], mssql_clustered=True
-    )
+    op.create_index('idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'])
 
 
 def upgrade():

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -131,16 +131,6 @@ def _create_dataset_event_table():
         sa.Column('created_at', TIMESTAMP, nullable=False),
         sqlite_autoincrement=True,  # ensures PK values not reused
     )
-    sa.ForeignKeyConstraint(
-        ('dataset_id',),
-        ['dataset.id'],
-        name="datasetevent_dataset_fkey",
-    ),
-    sa.ForeignKeyConstraint(
-        ('source_dag_run_id',),
-        ['dag_run.id'],
-        name="datasetevent_dagrun_fkey",
-    ),
     op.create_index(
         'idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], mssql_clustered=True
     )

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -118,12 +118,41 @@ def _create_dataset_dag_run_queue_table():
     )
 
 
+def _create_dataset_event_table():
+    op.create_table(
+        'dataset_event',
+        sa.Column('id', Integer, primary_key=True, autoincrement=True),
+        sa.Column('dataset_id', Integer, nullable=False),
+        sa.Column('extra', ExtendedJSON, nullable=True),
+        sa.Column('source_task_id', String(250), nullable=True),
+        sa.Column('source_dag_id', String(250), nullable=True),
+        sa.Column('source_run_id', String(250), nullable=True),
+        sa.Column('source_map_index', sa.Integer(), nullable=True, server_default='-1'),
+        sa.Column('created_at', TIMESTAMP, nullable=False),
+        sqlite_autoincrement=True,  # ensures PK values not reused
+    )
+    sa.ForeignKeyConstraint(
+        ('dataset_id',),
+        ['dataset.id'],
+        name="datasetevent_dataset_fkey",
+    ),
+    sa.ForeignKeyConstraint(
+        ('source_dag_run_id',),
+        ['dag_run.id'],
+        name="datasetevent_dagrun_fkey",
+    ),
+    op.create_index(
+        'idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], mssql_clustered=True
+    )
+
+
 def upgrade():
     """Apply Add Dataset model"""
     _create_dataset_table()
     _create_dataset_dag_ref_table()
     _create_dataset_task_ref_table()
     _create_dataset_dag_run_queue_table()
+    _create_dataset_event_table()
 
 
 def downgrade():
@@ -131,4 +160,5 @@ def downgrade():
     op.drop_table('dataset_dag_ref')
     op.drop_table('dataset_task_ref')
     op.drop_table('dataset_dag_run_queue')
+    op.drop_table('dataset_event')
     op.drop_table('dataset')

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -207,10 +207,10 @@ class DatasetEvent(Base):
 
     :param dataset_id: reference to Dataset record
     :param extra: JSON field for arbitrary extra info
-    :param source_task_id: the task_id of the TI which updated the dataset
-    :param source_dag_id: the dag_id of the TI which updated the dataset
-    :param source_run_id: the run_id of the TI which updated the dataset
-    :param source_map_index: the map_index of the TI which updated the dataset
+    :param task_id: the task_id of the TI which updated the dataset
+    :param dag_id: the dag_id of the TI which updated the dataset
+    :param run_id: the run_id of the TI which updated the dataset
+    :param map_index: the map_index of the TI which updated the dataset
 
     We use relationships instead of foreign keys so that dataset events are not deleted even
     if the foreign key object is.
@@ -219,10 +219,10 @@ class DatasetEvent(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     dataset_id = Column(Integer, nullable=False)
     extra = Column(ExtendedJSON, nullable=True)
-    source_task_id = Column(StringID(), nullable=True)
-    source_dag_id = Column(StringID(), nullable=True)
-    source_run_id = Column(StringID(), nullable=True)
-    source_map_index = Column(Integer, nullable=True, server_default=text("-1"))
+    task_id = Column(StringID(), nullable=True)
+    dag_id = Column(StringID(), nullable=True)
+    run_id = Column(StringID(), nullable=True)
+    map_index = Column(Integer, nullable=True, server_default=text("-1"))
     created_at = Column(UtcDateTime, default=timezone.utcnow, nullable=False)
 
     __tablename__ = "dataset_event"
@@ -234,10 +234,10 @@ class DatasetEvent(Base):
     source_task_instance = relationship(
         "TaskInstance",
         primaryjoin="""and_(
-            DatasetEvent.source_dag_id == foreign(TaskInstance.dag_id),
-            DatasetEvent.source_run_id == foreign(TaskInstance.run_id),
-            DatasetEvent.source_task_id == foreign(TaskInstance.task_id),
-            DatasetEvent.source_map_index == foreign(TaskInstance.map_index),
+            DatasetEvent.dag_id == foreign(TaskInstance.dag_id),
+            DatasetEvent.run_id == foreign(TaskInstance.run_id),
+            DatasetEvent.task_id == foreign(TaskInstance.task_id),
+            DatasetEvent.map_index == foreign(TaskInstance.map_index),
         )""",
         viewonly=True,
         lazy="select",
@@ -246,8 +246,8 @@ class DatasetEvent(Base):
     source_dag_run = relationship(
         "DagRun",
         primaryjoin="""and_(
-            DatasetEvent.source_dag_id == foreign(DagRun.dag_id),
-            DatasetEvent.source_run_id == foreign(DagRun.run_id),
+            DatasetEvent.dag_id == foreign(DagRun.dag_id),
+            DatasetEvent.run_id == foreign(DagRun.run_id),
         )""",
         viewonly=True,
         lazy="select",
@@ -273,12 +273,13 @@ class DatasetEvent(Base):
     def __repr__(self) -> str:
         args = []
         for attr in [
+            'id',
             'dataset_id',
             'extra',
-            'source_task_id',
-            'source_dag_id',
-            'source_run_id',
-            'source_map_index',
+            'task_id',
+            'dag_id',
+            'run_id',
+            'map_index',
         ]:
             args.append(f"{attr}={getattr(self, attr)!r}")
         return f"{self.__class__.__name__}({', '.join(args)})"

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -261,16 +261,16 @@ class DatasetEvent(Base):
         uselist=False,
     )
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, self.__class__):
             return self.dataset_id == other.dataset_id and self.created_at == other.created_at
         else:
             return NotImplemented
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash((self.dataset_id, self.created_at))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         args = []
         for attr in [
             'dataset_id',

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -227,7 +227,7 @@ class DatasetEvent(Base):
 
     __tablename__ = "dataset_event"
     __table_args__ = (
-        Index('idx_dataset_id_created_at', dataset_id, created_at, mssql_clustered=True),
+        Index('idx_dataset_id_created_at', dataset_id, created_at),
         {'sqlite_autoincrement': True},  # ensures PK values not reused
     )
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1516,7 +1516,7 @@ class TaskInstance(Base, LoggingMixin):
             self._create_dataset_dag_run_queue_records(context=context, session=session)
             session.commit()
 
-    def _create_dataset_dag_run_queue_records(self, *, context=None, session=NEW_SESSION):
+    def _create_dataset_dag_run_queue_records(self, *, context: Context = None, session: Session):
         from airflow.models import Dataset
 
         for obj in getattr(self.task, '_outlets', []):
@@ -1531,7 +1531,6 @@ class TaskInstance(Base, LoggingMixin):
                 session.add(
                     DatasetEvent(
                         dataset_id=dataset.id,
-                        extra=None,
                         source_task_id=self.task_id,
                         source_dag_id=self.dag_id,
                         source_run_id=self.run_id,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1531,10 +1531,10 @@ class TaskInstance(Base, LoggingMixin):
                 session.add(
                     DatasetEvent(
                         dataset_id=dataset.id,
-                        source_task_id=self.task_id,
-                        source_dag_id=self.dag_id,
-                        source_run_id=self.run_id,
-                        source_map_index=self.map_index,
+                        task_id=self.task_id,
+                        dag_id=self.dag_id,
+                        run_id=self.run_id,
+                        map_index=self.map_index,
                     )
                 )
                 for dag_id in downstream_dag_ids:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1516,7 +1516,7 @@ class TaskInstance(Base, LoggingMixin):
             self._create_dataset_dag_run_queue_records(session=session)
             session.commit()
 
-    def _create_dataset_dag_run_queue_records(self, *, context: Context = None, session: Session):
+    def _create_dataset_dag_run_queue_records(self, *, session: Session) -> None:
         from airflow.models import Dataset
 
         for obj in getattr(self.task, '_outlets', []):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1513,7 +1513,7 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(self.state, self))
             session.merge(self)
-            self._create_dataset_dag_run_queue_records(context=context, session=session)
+            self._create_dataset_dag_run_queue_records(session=session)
             session.commit()
 
     def _create_dataset_dag_run_queue_records(self, *, context: Context = None, session: Session):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1531,7 +1531,7 @@ class TaskInstance(Base, LoggingMixin):
                 session.add(
                     DatasetEvent(
                         dataset_id=dataset.id,
-                        extra=dataset_payload,
+                        extra=None,
                         source_task_id=self.task_id,
                         source_dag_id=self.dag_id,
                         source_run_id=self.run_id,

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -94,6 +94,7 @@ config_list: List[_TableConfig] = [
         keep_last_filters=[column('external_trigger') == false()],
         keep_last_group_by=['dag_id'],
     ),
+    _TableConfig(table_name='dataset_event', recency_column_name='created_at'),
     _TableConfig(table_name='import_error', recency_column_name='timestamp'),
     _TableConfig(table_name='log', recency_column_name='dttm'),
     _TableConfig(table_name='rendered_task_instance_fields', recency_column_name='execution_date'),

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1512,14 +1512,11 @@ class TestTaskInstance:
 
         # check that no other dataset events recorded
         assert (
-            len(
                 session.query(Dataset.uri)
                 .join(DatasetEvent.dataset)
                 .filter(DatasetEvent.source_task_instance == ti)
-                .all()
-            )
-            == 1
-        )
+                .count()
+            ) == 1
 
     @staticmethod
     def _test_previous_dates_setup(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1512,11 +1512,11 @@ class TestTaskInstance:
 
         # check that no other dataset events recorded
         assert (
-                session.query(Dataset.uri)
-                .join(DatasetEvent.dataset)
-                .filter(DatasetEvent.source_task_instance == ti)
-                .count()
-            ) == 1
+            session.query(Dataset.uri)
+            .join(DatasetEvent.dataset)
+            .filter(DatasetEvent.source_task_instance == ti)
+            .count()
+        ) == 1
 
     @staticmethod
     def _test_previous_dates_setup(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -57,7 +57,7 @@ from airflow.models import (
     Variable,
     XCom,
 )
-from airflow.models.dataset import DatasetDagRunQueue, DatasetTaskRef
+from airflow.models.dataset import Dataset, DatasetDagRunQueue, DatasetEvent, DatasetTaskRef
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskinstance import TaskInstance
@@ -1499,9 +1499,27 @@ class TestTaskInstance:
         ti._run_raw_task()
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
+
+        # check that one queue record created for each dag that depends on dataset 1
         assert session.query(DatasetDagRunQueue.target_dag_id).filter(
             DatasetTaskRef.dag_id == dag1.dag_id, DatasetTaskRef.task_id == 'upstream_task_1'
         ).all() == [('dag3',), ('dag4',), ('dag5',)]
+
+        # check that one event record created for dataset1 and this TI
+        assert session.query(Dataset.uri).join(DatasetEvent.dataset).filter(
+            DatasetEvent.source_task_instance == ti
+        ).one() == ('s3://dag1/output_1.txt',)
+
+        # check that no other dataset events recorded
+        assert (
+            len(
+                session.query(Dataset.uri)
+                .join(DatasetEvent.dataset)
+                .filter(DatasetEvent.source_task_instance == ti)
+                .all()
+            )
+            == 1
+        )
 
     @staticmethod
     def _test_previous_dates_setup(


### PR DESCRIPTION
Adds dataset event [log] table which records all dataset events, even those which are ignored for purpose of dag run queue records (e.g. say the dataset has already been updated once and the dag run is still waiting on other datasets)

Provides a way to scrutinize / surface / visualize all historical dataset events (the queue table's records are ephemeral)

cc @blag 
