### PR TITLE
Less verbose logging in ssh operator

### DIFF
--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -195,5 +195,5 @@ class TestSSHOperator:
             command=command,
         )
         self.exec_ssh_client_command.return_value = (1, b'', b'Error here')
-        with pytest.raises(AirflowException, match=f"SSH operator error: exit status = 1"):
+        with pytest.raises(AirflowException, match="SSH operator error: exit status = 1"):
             task.execute(None)

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -195,5 +195,5 @@ class TestSSHOperator:
             command=command,
         )
         self.exec_ssh_client_command.return_value = (1, b'', b'Error here')
-        with pytest.raises(AirflowException, match=f"error running cmd: {command}, error: Error here"):
+        with pytest.raises(AirflowException, match=f"SSH operator error: exit status = 1"):
             task.execute(None)


### PR DESCRIPTION
Current logs of `SSHOperator` are too verbose. `SSHHook` already logs stdout and stderr of the running command in task logs, so there is no need for including stderr in `AirflowException` message returned by `run_ssh_client_command`. Also there is no need to catch and then raise the same exception in `execute` method of `SSHOperator`.

Example of current logs:
```
**<combined stderr & stdout of command>**

Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/providers/ssh/operators/ssh.py", line 173, in execute
    result = self.run_ssh_client_command(ssh_client, self.command)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/providers/ssh/operators/ssh.py", line 160, in run_ssh_client_command
    self.raise_for_status(exit_status, agg_stderr)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/providers/ssh/operators/ssh.py", line 153, in raise_for_status
    raise AirflowException(f"error running cmd: {self.command}, error: {error_msg}")
airflow.exceptions.AirflowException: error running cmd: **<ssh command>**, error: **<stderr of command>**

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.7/site-packages/divar_airflow/operators/spark_operator/ssh/spark_operator.py", line 199, in execute
    return super().execute(**context)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/providers/ssh/operators/ssh.py", line 175, in execute
    raise AirflowException(f"SSH operator error: {str(e)}")
airflow.exceptions.AirflowException: SSH operator error: error running cmd: **<ssh command>**, error: error running cmd: **<ssh command>**, error: **<stderr of command>**
```