### PR TITLE
Network Error on /failed view

### DIFF
--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -34,7 +34,8 @@
     <form method="POST">
   {% endif %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-    <input type="hidden" name="confirmed" value="true">
+    <input type="hidden" name="confirmed" value="true"/>
+    <input type="hidden" name="origin" value="{{ origin or '' }}"/>
     {% for name,val in request.values.items() if name != "csrf_token" %}
       <input type="hidden" name="{{ name }}" value="{{ val }}">
     {% endfor %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2126,6 +2126,7 @@ class Airflow(AirflowBaseView):
             return htmlsafe_json_dumps(details, separators=(',', ':'))
         return self.render_template(
             'airflow/confirm.html',
+            origin=request.headers.get("Referer"),
             endpoint=None,
             message="Task instances you are about to clear:",
             details="\n".join(details),
@@ -2527,6 +2528,7 @@ class Airflow(AirflowBaseView):
 
         response = self.render_template(
             "airflow/confirm.html",
+            origin=request.headers.get("Referer"),
             endpoint=url_for(f'Airflow.{state}'),
             message=f"Task instances you are about to mark as {state}:",
             details=details,


### PR DESCRIPTION
In grid view, when trying to `mark as failed` any task instance, network error will be returned. It is because `origin` property is not set in the calling form and when `/failed` endpoint tries to redirect user back to `origin` it returns response with `http` scheme and it causes [mixed-content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) error in browsers.