### PR TITLE
Fix tag link on dag detail page when setting base_url with url prefix

### DIFF
--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -105,7 +105,7 @@
         {% if tags is defined and tags %}
           {% for tag in tags | sort(attribute='name') %}
             <a class="label label-info"
-               href="/home?tags={{ tag.name }}"
+               href="{{ url_for('Airflow.index', tags=tag.name) }}"
                style="margin: 3px 6px 3px 0;"
                title="All DAGs tagged &ldquo;{{ tag.name }}&rdquo;"
             >


### PR DESCRIPTION
This PR simply fix the tag link on dag detail page.
If use reverse proxy and set webserver.base_url with url prefix, these tag links will point to wrong locations.
Here just replace the direct link with `url_for` function.