### PR TITLE
Apply flake8-logging-format changes to tests

### DIFF
--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -436,7 +436,7 @@ class TestDagBag:
         actual_found_dag_ids = list(map(lambda dag: dag.dag_id, actual_found_dags))
 
         for dag_id in expected_dag_ids:
-            actual_dagbag.log.info(f'validating {dag_id}')
+            actual_dagbag.log.info('validating %s', dag_id)
             assert (dag_id in actual_found_dag_ids) == should_be_found, (
                 f"dag \"{dag_id}\" should {'' if should_be_found else 'not '}"
                 f"have been found after processing dag \"{expected_parent_dag.dag_id}\""

--- a/tests/providers/apache/hive/transfers/test_s3_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_s3_to_hive.py
@@ -107,8 +107,8 @@ class TestS3ToHiveTransfer(unittest.TestCase):
                 self._set_fn(fn_bz2, '.bz2', False)
                 f_bz2_nh.writelines([line1, line2])
         # Base Exception so it catches Keyboard Interrupt
-        except BaseException as e:
-            logging.error(e)
+        except BaseException:
+            logging.exception("An exception occurred.")
             self.tearDown()
 
     def tearDown(self):

--- a/tests/providers/apache/hive/transfers/test_s3_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_s3_to_hive.py
@@ -41,7 +41,7 @@ except ImportError:
 
 class TestS3ToHiveTransfer:
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_attrs(self):
         self.file_names = {}
         self.task_id = 'S3ToHiveTransferTest'
         self.s3_key = 'S32hive_test_file'

--- a/tests/providers/apache/hive/transfers/test_s3_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_s3_to_hive.py
@@ -21,7 +21,6 @@ import errno
 import filecmp
 import logging
 import shutil
-import unittest
 from collections import OrderedDict
 from gzip import GzipFile
 from itertools import product
@@ -40,9 +39,79 @@ except ImportError:
     mock_s3 = None
 
 
-class TestS3ToHiveTransfer(unittest.TestCase):
-    def setUp(self):
-        self.file_names = {}
+@pytest.fixture
+def tmp_dir():
+    return mkdtemp(prefix='test_tmps32hive_')
+
+
+@pytest.fixture
+def file_names(tmp_dir):
+    file_names = {}
+
+    def _get_key(ext, header):
+        key = ext + "_" + ('h' if header else 'nh')
+        return key
+
+    # Helper method to create a dictionary of file names and
+    # file types (file extension and header)
+    def _set_fn(fn, ext, header):
+        key = _get_key(ext, header)
+        file_names[key] = fn
+
+    # Helper method to fetch a file of a
+    # certain format (file extension and header)
+    def _get_fn(ext, header):
+        key = _get_key(ext, header)
+        return file_names[key]
+
+    header = b"Sno\tSome,Text \n"
+    line1 = b"1\tAirflow Test\n"
+    line2 = b"2\tS32HiveTransfer\n"
+    # create sample txt, gz and bz2 with and without headers
+    with NamedTemporaryFile(mode='wb+', dir=tmp_dir, delete=False) as f_txt_h:
+        _set_fn(f_txt_h.name, '.txt', True)
+        f_txt_h.writelines([header, line1, line2])
+    fn_gz = _get_fn('.txt', True) + ".gz"
+    with GzipFile(filename=fn_gz, mode="wb") as f_gz_h:
+        _set_fn(fn_gz, '.gz', True)
+        f_gz_h.writelines([header, line1, line2])
+    fn_gz_upper = _get_fn('.txt', True) + ".GZ"
+    with GzipFile(filename=fn_gz_upper, mode="wb") as f_gz_upper_h:
+        _set_fn(fn_gz_upper, '.GZ', True)
+        f_gz_upper_h.writelines([header, line1, line2])
+    fn_bz2 = _get_fn('.txt', True) + '.bz2'
+    with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2_h:
+        _set_fn(fn_bz2, '.bz2', True)
+        f_bz2_h.writelines([header, line1, line2])
+    # create sample txt, bz and bz2 without header
+    with NamedTemporaryFile(mode='wb+', dir=tmp_dir, delete=False) as f_txt_nh:
+        _set_fn(f_txt_nh.name, '.txt', False)
+        f_txt_nh.writelines([line1, line2])
+    fn_gz = _get_fn('.txt', False) + ".gz"
+    with GzipFile(filename=fn_gz, mode="wb") as f_gz_nh:
+        _set_fn(fn_gz, '.gz', False)
+        f_gz_nh.writelines([line1, line2])
+    fn_gz_upper = _get_fn('.txt', False) + ".GZ"
+    with GzipFile(filename=fn_gz_upper, mode="wb") as f_gz_upper_nh:
+        _set_fn(fn_gz_upper, '.GZ', False)
+        f_gz_upper_nh.writelines([line1, line2])
+    fn_bz2 = _get_fn('.txt', False) + '.bz2'
+    with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2_nh:
+        _set_fn(fn_bz2, '.bz2', False)
+        f_bz2_nh.writelines([line1, line2])
+
+    yield file_names
+
+    try:
+        shutil.rmtree(tmp_dir)
+    except OSError as e:
+        # ENOENT - no such file or directory
+        if e.errno != errno.ENOENT:
+            raise e
+
+
+class TestS3ToHiveTransfer:
+    def setup(self):
         self.task_id = 'S3ToHiveTransferTest'
         self.s3_key = 'S32hive_test_file'
         self.field_dict = OrderedDict([('Sno', 'BIGINT'), ('Some,Text', 'STRING')])
@@ -69,72 +138,6 @@ class TestS3ToHiveTransfer(unittest.TestCase):
             'wildcard_match': self.wildcard_match,
             'input_compressed': self.input_compressed,
         }
-        try:
-            header = b"Sno\tSome,Text \n"
-            line1 = b"1\tAirflow Test\n"
-            line2 = b"2\tS32HiveTransfer\n"
-            self.tmp_dir = mkdtemp(prefix='test_tmps32hive_')
-            # create sample txt, gz and bz2 with and without headers
-            with NamedTemporaryFile(mode='wb+', dir=self.tmp_dir, delete=False) as f_txt_h:
-                self._set_fn(f_txt_h.name, '.txt', True)
-                f_txt_h.writelines([header, line1, line2])
-            fn_gz = self._get_fn('.txt', True) + ".gz"
-            with GzipFile(filename=fn_gz, mode="wb") as f_gz_h:
-                self._set_fn(fn_gz, '.gz', True)
-                f_gz_h.writelines([header, line1, line2])
-            fn_gz_upper = self._get_fn('.txt', True) + ".GZ"
-            with GzipFile(filename=fn_gz_upper, mode="wb") as f_gz_upper_h:
-                self._set_fn(fn_gz_upper, '.GZ', True)
-                f_gz_upper_h.writelines([header, line1, line2])
-            fn_bz2 = self._get_fn('.txt', True) + '.bz2'
-            with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2_h:
-                self._set_fn(fn_bz2, '.bz2', True)
-                f_bz2_h.writelines([header, line1, line2])
-            # create sample txt, bz and bz2 without header
-            with NamedTemporaryFile(mode='wb+', dir=self.tmp_dir, delete=False) as f_txt_nh:
-                self._set_fn(f_txt_nh.name, '.txt', False)
-                f_txt_nh.writelines([line1, line2])
-            fn_gz = self._get_fn('.txt', False) + ".gz"
-            with GzipFile(filename=fn_gz, mode="wb") as f_gz_nh:
-                self._set_fn(fn_gz, '.gz', False)
-                f_gz_nh.writelines([line1, line2])
-            fn_gz_upper = self._get_fn('.txt', False) + ".GZ"
-            with GzipFile(filename=fn_gz_upper, mode="wb") as f_gz_upper_nh:
-                self._set_fn(fn_gz_upper, '.GZ', False)
-                f_gz_upper_nh.writelines([line1, line2])
-            fn_bz2 = self._get_fn('.txt', False) + '.bz2'
-            with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2_nh:
-                self._set_fn(fn_bz2, '.bz2', False)
-                f_bz2_nh.writelines([line1, line2])
-        # Base Exception so it catches Keyboard Interrupt
-        except BaseException:
-            logging.exception("An exception occurred.")
-            self.tearDown()
-
-    def tearDown(self):
-        try:
-            shutil.rmtree(self.tmp_dir)
-        except OSError as e:
-            # ENOENT - no such file or directory
-            if e.errno != errno.ENOENT:
-                raise e
-
-    # Helper method to create a dictionary of file names and
-    # file types (file extension and header)
-    def _set_fn(self, fn, ext, header):
-        key = self._get_key(ext, header)
-        self.file_names[key] = fn
-
-    # Helper method to fetch a file of a
-    # certain format (file extension and header)
-    def _get_fn(self, ext, header):
-        key = self._get_key(ext, header)
-        return self.file_names[key]
-
-    @staticmethod
-    def _get_key(ext, header):
-        key = ext + "_" + ('h' if header else 'nh')
-        return key
 
     @staticmethod
     def _check_file_equality(fn_1, fn_2, ext):
@@ -152,15 +155,20 @@ class TestS3ToHiveTransfer(unittest.TestCase):
         else:
             return filecmp.cmp(fn_1, fn_2, shallow=False)
 
+    @staticmethod
+    def _load_file_side_effect(args, op_fn, ext):
+        check = TestS3ToHiveTransfer._check_file_equality(args[0], op_fn, ext)
+        assert check, f'{ext} output file not as expected'
+
     def test_bad_parameters(self):
         self.kwargs['check_headers'] = True
         self.kwargs['headers'] = False
         with pytest.raises(AirflowException, match="To check_headers.*"):
             S3ToHiveOperator(**self.kwargs)
 
-    def test__get_top_row_as_list(self):
+    def test__get_top_row_as_list(self, file_names):
         self.kwargs['delimiter'] = '\t'
-        fn_txt = self._get_fn('.txt', True)
+        fn_txt = file_names['.txt_h']
         header_list = S3ToHiveOperator(**self.kwargs)._get_top_row_as_list(fn_txt)
         assert header_list == ['Sno', 'Some,Text'], "Top row from file doesn't matched expected value"
 
@@ -182,23 +190,23 @@ class TestS3ToHiveTransfer(unittest.TestCase):
             ['Sno', 'Some,Text', 'ExtraColumn']
         ), "Header row doesn't match expected value"
 
-    def test__delete_top_row_and_compress(self):
+    def test__delete_top_row_and_compress(self, tmp_dir, file_names):
         s32hive = S3ToHiveOperator(**self.kwargs)
         # Testing gz file type
-        fn_txt = self._get_fn('.txt', True)
-        gz_txt_nh = s32hive._delete_top_row_and_compress(fn_txt, '.gz', self.tmp_dir)
-        fn_gz = self._get_fn('.gz', False)
+        fn_txt = file_names['.txt_h']
+        gz_txt_nh = s32hive._delete_top_row_and_compress(fn_txt, '.gz', tmp_dir)
+        fn_gz = file_names['.gz_nh']
         assert self._check_file_equality(gz_txt_nh, fn_gz, '.gz'), "gz Compressed file not as expected"
         # Testing bz2 file type
-        bz2_txt_nh = s32hive._delete_top_row_and_compress(fn_txt, '.bz2', self.tmp_dir)
-        fn_bz2 = self._get_fn('.bz2', False)
+        bz2_txt_nh = s32hive._delete_top_row_and_compress(fn_txt, '.bz2', tmp_dir)
+        fn_bz2 = file_names['.bz2_nh']
         assert self._check_file_equality(bz2_txt_nh, fn_bz2, '.bz2'), "bz2 Compressed file not as expected"
 
-    @unittest.skipIf(mock is None, 'mock package not present')
-    @unittest.skipIf(mock_s3 is None, 'moto package not present')
+    @pytest.mark.skipif(mock is None, reason='mock package not present')
+    @pytest.mark.skipif(mock_s3 is None, reason='moto package not present')
     @mock.patch('airflow.providers.apache.hive.transfers.s3_to_hive.HiveCliHook')
     @mock_s3
-    def test_execute(self, mock_hiveclihook):
+    def test_execute(self, mock_hiveclihook, file_names):
         conn = boto3.client('s3')
         conn.create_bucket(Bucket='bucket')
 
@@ -209,27 +217,26 @@ class TestS3ToHiveTransfer(unittest.TestCase):
             logging.info("Testing %s format %s header", ext, 'with' if has_header else 'without')
             self.kwargs['input_compressed'] = ext.lower() != '.txt'
             self.kwargs['s3_key'] = 's3://bucket/' + self.s3_key + ext
-            ip_fn = self._get_fn(ext, self.kwargs['headers'])
-            op_fn = self._get_fn(ext, False)
+            ip_fn = file_names[f"{ext}_h" if has_header else f"{ext}_nh"]
+            op_fn = file_names[f"{ext}_nh"]
 
             # Upload the file into the Mocked S3 bucket
             conn.upload_file(ip_fn, 'bucket', self.s3_key + ext)
 
             # file parameter to HiveCliHook.load_file is compared
             # against expected file output
-            mock_hiveclihook().load_file.side_effect = lambda *args, **kwargs: self.assertTrue(
-                self._check_file_equality(args[0], op_fn, ext),
-                f'{ext} output file not as expected',
+            mock_hiveclihook().load_file.side_effect = lambda *args, **kwargs: self._load_file_side_effect(
+                args, op_fn, ext
             )
             # Execute S3ToHiveTransfer
             s32hive = S3ToHiveOperator(**self.kwargs)
             s32hive.execute(None)
 
-    @unittest.skipIf(mock is None, 'mock package not present')
-    @unittest.skipIf(mock_s3 is None, 'moto package not present')
+    @pytest.mark.skipif(mock is None, reason='mock package not present')
+    @pytest.mark.skipif(mock_s3 is None, reason='moto package not present')
     @mock.patch('airflow.providers.apache.hive.transfers.s3_to_hive.HiveCliHook')
     @mock_s3
-    def test_execute_with_select_expression(self, mock_hiveclihook):
+    def test_execute_with_select_expression(self, mock_hiveclihook, file_names):
         conn = boto3.client('s3')
         conn.create_bucket(Bucket='bucket')
 
@@ -249,7 +256,7 @@ class TestS3ToHiveTransfer(unittest.TestCase):
             self.kwargs['select_expression'] = select_expression
             self.kwargs['s3_key'] = f's3://{bucket}/{key}'
 
-            ip_fn = self._get_fn(ext, has_header)
+            ip_fn = file_names[f"{ext}_h" if has_header else f"{ext}_nh"]
 
             # Upload the file into the Mocked S3 bucket
             conn.upload_file(ip_fn, bucket, key)

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -96,8 +96,7 @@ class GcpAuthenticator(CommandExecutor):
         key path
         :return: None
         """
-        session = settings.Session()
-        try:
+        with settings.Session() as session:
             conn = session.query(Connection).filter(Connection.conn_id == 'google_cloud_default')[0]
             extras = conn.extra_dejson
             extras[KEYPATH_EXTRA] = self.full_key_path
@@ -106,13 +105,6 @@ class GcpAuthenticator(CommandExecutor):
             extras[SCOPE_EXTRA] = 'https://www.googleapis.com/auth/cloud-platform'
             extras[PROJECT_EXTRA] = self.project_extra if self.project_extra else self.project_id
             conn.extra = json.dumps(extras)
-            session.commit()
-        except BaseException:
-            self.log.error('Airflow DB Session error.')
-            session.rollback()
-            raise
-        finally:
-            session.close()
 
     def set_dictionary_in_airflow_connection(self):
         """
@@ -120,8 +112,7 @@ class GcpAuthenticator(CommandExecutor):
         of the json service account file.
         :return: None
         """
-        session = settings.Session()
-        try:
+        with settings.Session() as session:
             conn = session.query(Connection).filter(Connection.conn_id == 'google_cloud_default')[0]
             extras = conn.extra_dejson
             with open(self.full_key_path) as path_file:
@@ -132,13 +123,6 @@ class GcpAuthenticator(CommandExecutor):
             extras[SCOPE_EXTRA] = 'https://www.googleapis.com/auth/cloud-platform'
             extras[PROJECT_EXTRA] = self.project_extra
             conn.extra = json.dumps(extras)
-            session.commit()
-        except BaseException:
-            self.log.error('Airflow DB Session error.')
-            session.rollback()
-            raise
-        finally:
-            session.close()
 
     def _set_key_path(self):
         """

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -107,8 +107,8 @@ class GcpAuthenticator(CommandExecutor):
             extras[PROJECT_EXTRA] = self.project_extra if self.project_extra else self.project_id
             conn.extra = json.dumps(extras)
             session.commit()
-        except BaseException as ex:
-            self.log.error('Airflow DB Session error: %s', str(ex))
+        except BaseException:
+            self.log.error('Airflow DB Session error.')
             session.rollback()
             raise
         finally:
@@ -133,8 +133,8 @@ class GcpAuthenticator(CommandExecutor):
             extras[PROJECT_EXTRA] = self.project_extra
             conn.extra = json.dumps(extras)
             session.commit()
-        except BaseException as ex:
-            self.log.error('Airflow DB Session error: %s', str(ex))
+        except BaseException:
+            self.log.error('Airflow DB Session error.')
             session.rollback()
             raise
         finally:

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -232,7 +232,7 @@ class TestStandardTaskRunner:
                     time.sleep(0.01)
             logging.info("Task started. Give the task some time to settle")
             time.sleep(3)
-            logging.info(f"Terminating processes {processes} belonging to {runner_pgid} group")
+            logging.info("Terminating processes %s belonging to %s group", processes, runner_pgid)
             runner.terminate()
             session.close()  # explicitly close as `create_session`s commit will blow up otherwise
 

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -20,74 +20,75 @@ import bz2
 import errno
 import filecmp
 import gzip
-import logging
 import shutil
 import tempfile
-import unittest
 
 import pytest
 
 from airflow.utils import compression
 
 
-class TestCompression(unittest.TestCase):
-    def setUp(self):
-        self.file_names = {}
-        try:
-            header = b"Sno\tSome,Text \n"
-            line1 = b"1\tAirflow Test\n"
-            line2 = b"2\tCompressionUtil\n"
-            self.tmp_dir = tempfile.mkdtemp(prefix='test_utils_compression_')
-            # create sample txt, gz and bz2 files
-            with tempfile.NamedTemporaryFile(mode='wb+', dir=self.tmp_dir, delete=False) as f_txt:
-                self._set_fn(f_txt.name, '.txt')
-                f_txt.writelines([header, line1, line2])
+@pytest.fixture
+def tmp_dir():
+    return tempfile.mkdtemp(prefix='test_utils_compression_')
 
-            fn_gz = self._get_fn('.txt') + ".gz"
-            with gzip.GzipFile(filename=fn_gz, mode="wb") as f_gz:
-                self._set_fn(fn_gz, '.gz')
-                f_gz.writelines([header, line1, line2])
 
-            fn_bz2 = self._get_fn('.txt') + '.bz2'
-            with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2:
-                self._set_fn(fn_bz2, '.bz2')
-                f_bz2.writelines([header, line1, line2])
-
-        # Base Exception so it catches Keyboard Interrupt
-        except BaseException:
-            logging.exception("An exception has occurred.")
-            self.tearDown()
-
-    def tearDown(self):
-        try:
-            shutil.rmtree(self.tmp_dir)
-        except OSError as e:
-            # ENOENT - no such file or directory
-            if e.errno != errno.ENOENT:
-                raise e
+@pytest.fixture
+def file_names(tmp_dir):
+    file_names = {}
 
     # Helper method to create a dictionary of file names and
     # file extension
-    def _set_fn(self, fn, ext):
-        self.file_names[ext] = fn
+    def _set_fn(fn, ext):
+        file_names[ext] = fn
 
     # Helper method to fetch a file of a
     # certain extension
-    def _get_fn(self, ext):
-        return self.file_names[ext]
+    def _get_fn(ext):
+        return file_names[ext]
 
-    def test_uncompress_file(self):
+    header = b"Sno\tSome,Text \n"
+    line1 = b"1\tAirflow Test\n"
+    line2 = b"2\tCompressionUtil\n"
+
+    # create sample txt, gz and bz2 files
+    with tempfile.NamedTemporaryFile(mode='wb+', dir=tmp_dir, delete=False) as f_txt:
+        _set_fn(f_txt.name, '.txt')
+        f_txt.writelines([header, line1, line2])
+
+    fn_gz = _get_fn('.txt') + ".gz"
+    with gzip.GzipFile(filename=fn_gz, mode="wb") as f_gz:
+        _set_fn(fn_gz, '.gz')
+        f_gz.writelines([header, line1, line2])
+
+    fn_bz2 = _get_fn('.txt') + '.bz2'
+    with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2:
+        _set_fn(fn_bz2, '.bz2')
+        f_bz2.writelines([header, line1, line2])
+
+    yield file_names
+
+    try:
+        shutil.rmtree(tmp_dir)
+    except OSError as e:
+        # ENOENT - no such file or directory
+        if e.errno != errno.ENOENT:
+            raise e
+
+
+class TestCompression:
+    def test_uncompress_file(self, tmp_dir, file_names):
         # Testing txt file type
         with pytest.raises(NotImplementedError, match="^Received .txt format. Only gz and bz2.*"):
             compression.uncompress_file(
                 **{'input_file_name': None, 'file_extension': '.txt', 'dest_dir': None},
             )
         # Testing gz file type
-        fn_txt = self._get_fn('.txt')
-        fn_gz = self._get_fn('.gz')
-        txt_gz = compression.uncompress_file(fn_gz, '.gz', self.tmp_dir)
+        fn_txt = file_names['.txt']
+        fn_gz = file_names['.gz']
+        txt_gz = compression.uncompress_file(fn_gz, '.gz', tmp_dir)
         assert filecmp.cmp(txt_gz, fn_txt, shallow=False), "Uncompressed file doest match original"
         # Testing bz2 file type
-        fn_bz2 = self._get_fn('.bz2')
-        txt_bz2 = compression.uncompress_file(fn_bz2, '.bz2', self.tmp_dir)
+        fn_bz2 = file_names['.bz2']
+        txt_bz2 = compression.uncompress_file(fn_bz2, '.bz2', tmp_dir)
         assert filecmp.cmp(txt_bz2, fn_txt, shallow=False), "Uncompressed file doest match original"

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -29,7 +29,7 @@ from airflow.utils import compression
 
 class TestCompression:
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup_attrs(self):
         self.file_names = {}
         header = b"Sno\tSome,Text \n"
         line1 = b"1\tAirflow Test\n"

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -28,67 +27,60 @@ import pytest
 from airflow.utils import compression
 
 
-@pytest.fixture
-def tmp_dir():
-    return tempfile.mkdtemp(prefix='test_utils_compression_')
+class TestCompression:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.file_names = {}
+        header = b"Sno\tSome,Text \n"
+        line1 = b"1\tAirflow Test\n"
+        line2 = b"2\tCompressionUtil\n"
+        self.tmp_dir = tempfile.mkdtemp(prefix='test_utils_compression_')
+        # create sample txt, gz and bz2 files
+        with tempfile.NamedTemporaryFile(mode='wb+', dir=self.tmp_dir, delete=False) as f_txt:
+            self._set_fn(f_txt.name, '.txt')
+            f_txt.writelines([header, line1, line2])
 
+        fn_gz = self._get_fn('.txt') + ".gz"
+        with gzip.GzipFile(filename=fn_gz, mode="wb") as f_gz:
+            self._set_fn(fn_gz, '.gz')
+            f_gz.writelines([header, line1, line2])
 
-@pytest.fixture
-def file_names(tmp_dir):
-    file_names = {}
+        fn_bz2 = self._get_fn('.txt') + '.bz2'
+        with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2:
+            self._set_fn(fn_bz2, '.bz2')
+            f_bz2.writelines([header, line1, line2])
+
+        yield
+
+        try:
+            shutil.rmtree(self.tmp_dir)
+        except OSError as e:
+            # ENOENT - no such file or directory
+            if e.errno != errno.ENOENT:
+                raise e
 
     # Helper method to create a dictionary of file names and
     # file extension
-    def _set_fn(fn, ext):
-        file_names[ext] = fn
+    def _set_fn(self, fn, ext):
+        self.file_names[ext] = fn
 
     # Helper method to fetch a file of a
     # certain extension
-    def _get_fn(ext):
-        return file_names[ext]
+    def _get_fn(self, ext):
+        return self.file_names[ext]
 
-    header = b"Sno\tSome,Text \n"
-    line1 = b"1\tAirflow Test\n"
-    line2 = b"2\tCompressionUtil\n"
-
-    # create sample txt, gz and bz2 files
-    with tempfile.NamedTemporaryFile(mode='wb+', dir=tmp_dir, delete=False) as f_txt:
-        _set_fn(f_txt.name, '.txt')
-        f_txt.writelines([header, line1, line2])
-
-    fn_gz = _get_fn('.txt') + ".gz"
-    with gzip.GzipFile(filename=fn_gz, mode="wb") as f_gz:
-        _set_fn(fn_gz, '.gz')
-        f_gz.writelines([header, line1, line2])
-
-    fn_bz2 = _get_fn('.txt') + '.bz2'
-    with bz2.BZ2File(filename=fn_bz2, mode="wb") as f_bz2:
-        _set_fn(fn_bz2, '.bz2')
-        f_bz2.writelines([header, line1, line2])
-
-    yield file_names
-
-    try:
-        shutil.rmtree(tmp_dir)
-    except OSError as e:
-        # ENOENT - no such file or directory
-        if e.errno != errno.ENOENT:
-            raise e
-
-
-class TestCompression:
-    def test_uncompress_file(self, tmp_dir, file_names):
+    def test_uncompress_file(self):
         # Testing txt file type
         with pytest.raises(NotImplementedError, match="^Received .txt format. Only gz and bz2.*"):
             compression.uncompress_file(
                 **{'input_file_name': None, 'file_extension': '.txt', 'dest_dir': None},
             )
         # Testing gz file type
-        fn_txt = file_names['.txt']
-        fn_gz = file_names['.gz']
-        txt_gz = compression.uncompress_file(fn_gz, '.gz', tmp_dir)
+        fn_txt = self._get_fn('.txt')
+        fn_gz = self._get_fn('.gz')
+        txt_gz = compression.uncompress_file(fn_gz, '.gz', self.tmp_dir)
         assert filecmp.cmp(txt_gz, fn_txt, shallow=False), "Uncompressed file doest match original"
         # Testing bz2 file type
-        fn_bz2 = file_names['.bz2']
-        txt_bz2 = compression.uncompress_file(fn_bz2, '.bz2', tmp_dir)
+        fn_bz2 = self._get_fn('.bz2')
+        txt_bz2 = compression.uncompress_file(fn_bz2, '.bz2', self.tmp_dir)
         assert filecmp.cmp(txt_bz2, fn_txt, shallow=False), "Uncompressed file doest match original"

--- a/tests/utils/test_compression.py
+++ b/tests/utils/test_compression.py
@@ -54,8 +54,8 @@ class TestCompression(unittest.TestCase):
                 f_bz2.writelines([header, line1, line2])
 
         # Base Exception so it catches Keyboard Interrupt
-        except BaseException as e:
-            logging.error(e)
+        except BaseException:
+            logging.exception("An exception has occurred.")
             self.tearDown()
 
     def tearDown(self):


### PR DESCRIPTION
Related: #23597 #24910

This is some pre-work for hopefully including the [flake8-logging-format](https://github.com/globality-corp/flake8-logging-format) extension in CI. There are roughly 88 file changes so splitting these up into smaller chunks.

After the initial sweeps are completed we can do a final pass when formally implementing the extension in CI.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
