### PR TITLE
Fix syntax in mysql setup documentation (#24893

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -325,7 +325,7 @@ You can read more about transaction isolation and snapshot features at
    CREATE LOGIN airflow_user WITH PASSWORD='airflow_pass123%';
    USE airflow;
    CREATE USER airflow_user FROM LOGIN airflow_user;
-   GRANT ALL PRIVILEGES ON DATABASE airflow TO airflow_user;
+   GRANT ALL PRIVILEGES ON DATABASE::airflow TO airflow_user;
 
 
 We recommend using the ``mssql+pyodbc`` driver and specifying it in your SqlAlchemy connection string.


### PR DESCRIPTION
In the 'set-up-databases' documentation the code block was not working on newer versions of mssql. Updated the docs so that the query works on supported 2017 and 2019 versions of mssql

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
