### PR TITLE
BREEZE.rst rendering fixes

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -532,7 +532,7 @@ You can regular unit tests with ``breeze`` in two different ways, either interac
 the default ``shell`` command or via the ``tests`` command.
 
 Iterate on tests interactively
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 You can simply enter the ``breeze`` container and run ``pytest`` command there. You can enter the
 container via just ``breeze`` command or ``breeze shell`` command (the latter has more options
@@ -562,7 +562,7 @@ in the ``TESTING.rst <TESTING.rst#>`` where all the test types of our are explai
 on how to run them.
 
 Running group of tests
-~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 You can also run tests via built-in ``breeze tests`` command - similarly as iterative ``pytest`` command
 allows to run test individually, or by class or in any other way pytest allows to test them, but it


### PR DESCRIPTION
The current `BREEZE.rst` file syntax is broken, so it's not opening up rendered in GitHub (or PyCharm for the matter)
https://github.com/apache/airflow/blob/main/BREEZE.rst
I looked it up, and it seems like the squiggly headlines broke the rendering.
Please look at the fixed formatting here. I verified that now it renders in Pycharm, and you can also see it here:
https://github.com/apache/airflow/blob/0e5a153f8691a6b74da9e76a5659181ff8407055/BREEZE.rst