### PR TITLE
Add Kubernetes-related files to trigger helm tests

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -122,6 +122,8 @@ CI_FILE_GROUP_MATCHES = HashableDict(
         ],
         FileGroupForCi.HELM_FILES: [
             "^chart",
+            "^airflow/kubernetes",
+            "^tests/kubernetes",
         ],
         FileGroupForCi.SETUP_FILES: [
             r"^pyproject.toml",


### PR DESCRIPTION
So far, when Kubernetes-related files ware changed, the Helm chart
were not run - which lead to some of the tests failing after merge.
This change adds kubernetes related files in airlfow to list of
files that trigger Helm tets.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
