### PR TITLE
Revert "Fix error in seeding elastic `log_id` template (#24960)"

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -835,15 +835,10 @@ def synchronize_log_template(*, session: Session = NEW_SESSION) -> None:
             session.add(
                 LogTemplate(
                     filename="{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log",
-                    elasticsearch_id="{dag_id}_{task_id}_{execution_date}_{try_number}",
+                    elasticsearch_id="{dag_id}-{task_id}-{execution_date}-{try_number}",
                 )
             )
             session.flush()
-    wrong_log_id = "{dag_id}-{task_id}-{execution_date}-{try_number}"
-    correct_log_id = "{dag_id}_{task_id}_{execution_date}_{try_number}"
-    session.query(LogTemplate).filter(LogTemplate.elasticsearch_id == wrong_log_id).update(
-        {LogTemplate.elasticsearch_id: correct_log_id}, synchronize_session='fetch'
-    )
 
     # Before checking if the _current_ value exists, we need to check if the old config value we upgraded in
     # place exists!


### PR DESCRIPTION
This reverts commit c97f0b3da09079778dc9317030cfacc5df01e88c from #24960.

The 2.2 `log_id_template` was with -'s: https://github.com/apache/airflow/blob/2.2.5/airflow/config_templates/default_airflow.cfg#L1004

It was even that way in 1.10's.