### PR TITLE
Add TCP_KEEPALIVE option to http provider

### DIFF
--- a/airflow/providers/http/CHANGELOG.rst
+++ b/airflow/providers/http/CHANGELOG.rst
@@ -24,6 +24,16 @@
 Changelog
 ---------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+The SimpleHTTPOperator, HttpSensor and HttpHook use now TCP_KEEPALIVE by default.
+You can disable it by setting ``tcp_keep_alive`` to False and you can control keepalive parameters
+by new ``tcp_keep_alive_*`` parameters added to constructor of the Hook, Operator and Sensor. Setting the
+TCP_KEEPALIVE prevents some firewalls from closing a long-running connection that has long periods of
+inactivity by sending empty TCP packets periodically. This has a very small impact on network traffic,
+and potentially prevents the idle/hanging connections from being closed automatically by the firewalls.
+
 3.0.0
 .....
 

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -54,6 +54,11 @@ class SimpleHttpOperator(BaseOperator):
         'requests' documentation (options to modify timeout, ssl, etc.)
     :param log_response: Log the response (default: False)
     :param auth_type: The auth type for the service
+    :param tcp_keep_alive: Enable TCP Keep Alive for the connection.
+    :param tcp_keep_alive_idle: The TCP Keep Alive Idle parameter (corresponds to ``socket.TCP_KEEPIDLE``).
+    :param tcp_keep_alive_count: The TCP Keep Alive count parameter (corresponds to ``socket.TCP_KEEPCNT``)
+    :param tcp_keep_alive_interval: The TCP Keep Alive interval parameter (corresponds to
+        ``socket.TCP_KEEPINTVL``)
     """
 
     template_fields: Sequence[str] = (
@@ -78,6 +83,10 @@ class SimpleHttpOperator(BaseOperator):
         http_conn_id: str = 'http_default',
         log_response: bool = False,
         auth_type: Type[AuthBase] = HTTPBasicAuth,
+        tcp_keep_alive: bool = True,
+        tcp_keep_alive_idle: int = 120,
+        tcp_keep_alive_count: int = 20,
+        tcp_keep_alive_interval: int = 30,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -91,11 +100,23 @@ class SimpleHttpOperator(BaseOperator):
         self.extra_options = extra_options or {}
         self.log_response = log_response
         self.auth_type = auth_type
+        self.tcp_keep_alive = tcp_keep_alive
+        self.tcp_keep_alive_idle = tcp_keep_alive_idle
+        self.tcp_keep_alive_count = tcp_keep_alive_count
+        self.tcp_keep_alive_interval = tcp_keep_alive_interval
 
     def execute(self, context: 'Context') -> Any:
         from airflow.utils.operator_helpers import determine_kwargs
 
-        http = HttpHook(self.method, http_conn_id=self.http_conn_id, auth_type=self.auth_type)
+        http = HttpHook(
+            self.method,
+            http_conn_id=self.http_conn_id,
+            auth_type=self.auth_type,
+            tcp_keep_alive=self.tcp_keep_alive,
+            tcp_keep_alive_idle=self.tcp_keep_alive_idle,
+            tcp_keep_alive_count=self.tcp_keep_alive_count,
+            tcp_keep_alive_interval=self.tcp_keep_alive_interval,
+        )
 
         self.log.info("Calling HTTP method")
 

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -38,6 +38,7 @@ dependencies:
   # The 2.26.0 release of requests got rid of the chardet LGPL mandatory dependency, allowing us to
   # release it as a requirement for airflow
   - requests>=2.26.0
+  - requests_toolbelt
 
 integrations:
   - integration-name: Hypertext Transfer Protocol (HTTP)

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -376,7 +376,8 @@
   },
   "http": {
     "deps": [
-      "requests>=2.26.0"
+      "requests>=2.26.0",
+      "requests_toolbelt"
     ],
     "cross-providers-deps": []
   },

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -169,18 +169,18 @@ class TestHttpSensor:
             poke_interval=1,
         )
 
-        with mock.patch.object(task.hook.log, 'error') as mock_errors:
+        with mock.patch('airflow.providers.http.hooks.http.HttpHook.log') as mock_log:
             with pytest.raises(AirflowSensorTimeout):
                 task.execute(None)
 
-            assert mock_errors.called
+            assert mock_log.error.called
             calls = [
                 mock.call('HTTP error: %s', 'Not Found'),
                 mock.call("This endpoint doesn't exist"),
                 mock.call('HTTP error: %s', 'Not Found'),
                 mock.call("This endpoint doesn't exist"),
             ]
-            mock_errors.assert_has_calls(calls)
+            mock_log.error.assert_has_calls(calls)
 
 
 class FakeSession:
@@ -199,6 +199,9 @@ class FakeSession:
 
     def merge_environment_settings(self, _url, **kwargs):
         return kwargs
+
+    def mount(self, prefix, adapter):
+        pass
 
 
 class TestHttpOpSensor(unittest.TestCase):


### PR DESCRIPTION
Enabling TCP_KEEPALIVE allows to keep the idle connections opened
when there are firewalls in-betweeen that close such connections.

TCP_KEEPALIVE sends a "no-data" packet regularly (and expects
ACK from the server). This should not be mistaken with Python
requests "keep alive" feature - which reuses opened HTTP connections
if you perform several requests to the same server (both are named
keep alive but they both mean two completely different things and
are implemented at differen layers of the OSI network stack. The
Requests Keep Alive is Layer 7 (application) and TCP Keep Alive
is at Layer 4 (transport).

The "Requests" keep alive is enabled by default in the requests
library while the TCP Keep Alive requires a TCPKeepAliveAdapter
to be used (from requests_toolbelt library).

Fixes: #21365

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
