### PR TITLE
Move dataset dagrun creation to scheduler main

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -46,7 +46,7 @@ from airflow.models import DAG
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import DatasetDagRef, DatasetDagRunQueue, DatasetEvent, DatasetEventDagRun
+from airflow.models.dataset import DatasetDagRef, DatasetDagRunQueue, DatasetEvent
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
@@ -1129,8 +1129,8 @@ class SchedulerJob(BaseJob):
                     .filter(*dataset_event_filters)
                     .all()
                 )
-                for de in dataset_events:
-                    session.add(DatasetEventDagRun(dag_run_id=dag_run.id, dataset_event_id=de.id))
+
+                dag_run.dataset_events.extend(dataset_events)
                 session.query(DatasetDagRunQueue).filter(
                     DatasetDagRunQueue.target_dag_id == dag_run.dag_id
                 ).delete()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -46,6 +46,7 @@ from airflow.models import DAG
 from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
+from airflow.models.dataset import DatasetDagRef, DatasetDagRunQueue, DatasetEvent, DatasetEventDagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
@@ -981,8 +982,17 @@ class SchedulerJob(BaseJob):
     @retry_db_transaction
     def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
         """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError"""
-        query = DagModel.dags_needing_dagruns(session)
-        self._create_dag_runs(query.all(), session)
+        query, dataset_triggered_dag_info = DagModel.dags_needing_dagruns(session)
+        all_dags_needing_dag_runs = set(query.all())
+        dataset_triggered_dags = [
+            dag for dag in all_dags_needing_dag_runs if dag.dag_id in dataset_triggered_dag_info
+        ]
+        non_dataset_dags = all_dags_needing_dag_runs.difference(dataset_triggered_dags)
+        self._create_dag_runs(non_dataset_dags, session)
+        if dataset_triggered_dags:
+            self._create_dag_runs_dataset_triggered(
+                dataset_triggered_dags, dataset_triggered_dag_info, session
+            )
 
         # commit the session - Release the write lock on DagModel table.
         guard.commit()
@@ -1047,6 +1057,83 @@ class SchedulerJob(BaseJob):
                 dag_model.calculate_dagrun_date_fields(dag, data_interval)
         # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
         # memory for larger dags? or expunge_all()
+
+    def _create_dag_runs_dataset_triggered(
+        self, dag_models: Collection[DagModel], dataset_triggered_dag_info: Dict, session: Session
+    ) -> None:
+        """For DAGs that are triggered by datasets, create dag runs."""
+        # Bulk Fetch DagRuns with dag_id and execution_date same
+        # as DagModel.dag_id and DagModel.next_dagrun
+        # This list is used to verify if the DagRun already exist so that we don't attempt to create
+        # duplicate dag runs
+        exec_dates = {
+            dag_id: last_time for dag_id, (first_time, last_time) in dataset_triggered_dag_info.items()
+        }
+        existing_dagruns = (
+            session.query(DagRun.dag_id, DagRun.execution_date)
+            .filter(
+                tuple_in_condition(
+                    (DagRun.dag_id, DagRun.execution_date),
+                    list(exec_dates.items()),
+                ),
+            )
+            .all()
+        )
+
+        for dag_model in dag_models:
+            dag = self.dagbag.get_dag(dag_model.dag_id, session=session)
+            if not dag:
+                self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
+                continue
+
+            dag_hash = self.dagbag.dags_hash.get(dag.dag_id)
+
+            # Explicitly check if the DagRun already exists. This is an edge case
+            # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
+            # are not updated.
+            # We opted to check DagRun existence instead
+            # of catching an Integrity error and rolling back the session i.e
+            # we need to set dag.next_dagrun_info if the Dag Run already exists or if we
+            # create a new one. This is so that in the next Scheduling loop we try to create new runs
+            # instead of falling in a loop of Integrity Error.
+            exec_date = exec_dates[dag.dag_id]
+            if (dag.dag_id, exec_date) not in existing_dagruns:
+                dag_run = dag.create_dagrun(
+                    run_type=DagRunType.DATASET_TRIGGERED,
+                    execution_date=exec_date,
+                    state=DagRunState.QUEUED,
+                    external_trigger=False,
+                    session=session,
+                    dag_hash=dag_hash,
+                    creating_job_id=self.id,
+                )
+                previous_dag_run = (
+                    session.query(DagRun)
+                    .filter(
+                        DagRun.dag_id == dag_run.dag_id,
+                        DagRun.execution_date < dag_run.execution_date,
+                        DagRun.run_type == DagRunType.DATASET_TRIGGERED,
+                    )
+                    .order_by(DagRun.execution_date.desc())
+                    .first()
+                )
+                dataset_event_filters = [
+                    DatasetDagRef.dag_id == dag.dag_id,
+                    DatasetEvent.timestamp <= dag_run.execution_date,
+                ]
+                if previous_dag_run:
+                    dataset_event_filters.append(DatasetEvent.timestamp > previous_dag_run.execution_date)
+                dataset_events = (
+                    session.query(DatasetEvent)
+                    .join(DatasetDagRef, DatasetEvent.dataset_id == DatasetDagRef.dataset_id)
+                    .filter(*dataset_event_filters)
+                    .all()
+                )
+                for de in dataset_events:
+                    session.add(DatasetEventDagRun(dag_run_id=dag_run.id, dataset_event_id=de.id))
+                session.query(DatasetDagRunQueue).filter(
+                    DatasetDagRunQueue.target_dag_id == dag_run.dag_id
+                ).delete()
 
     def _should_update_dag_next_dagruns(self, dag, dag_model: DagModel, total_active_runs: int) -> bool:
         """Check if the dag's next_dagruns_create_after should be updated."""

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -134,12 +134,22 @@ def _create_dataset_event_table():
     op.create_index('idx_dataset_id_timestamp', 'dataset_event', ['dataset_id', 'timestamp'])
 
 
+def _create_dataset_event_dag_run_table():
+    op.create_table(
+        'dataset_event_dag_run',
+        sa.Column('dataset_event_id', Integer, nullable=False),
+        sa.Column('dag_run_id', Integer, nullable=False),
+        sa.Column('created_at', TIMESTAMP, nullable=False),
+    )
+
+
 def upgrade():
     """Apply Add Dataset model"""
     _create_dataset_table()
     _create_dataset_dag_ref_table()
     _create_dataset_task_ref_table()
     _create_dataset_dag_run_queue_table()
+    _create_dataset_event_dag_run_table()
     _create_dataset_event_table()
 
 
@@ -148,5 +158,6 @@ def downgrade():
     op.drop_table('dataset_dag_ref')
     op.drop_table('dataset_task_ref')
     op.drop_table('dataset_dag_run_queue')
+    op.drop_table('dataset_event_dag_run')
     op.drop_table('dataset_event')
     op.drop_table('dataset')

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -136,11 +136,26 @@ def _create_dataset_event_table():
 
 def _create_dataset_event_dag_run_table():
     op.create_table(
-        'dataset_event_dag_run',
-        sa.Column('dataset_event_id', Integer, nullable=False),
-        sa.Column('dag_run_id', Integer, nullable=False),
-        sa.Column('created_at', TIMESTAMP, nullable=False),
+        'dagrun_dataset_event',
+        sa.Column('dag_run_id', sa.Integer(), nullable=False),
+        sa.Column('event_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['dag_run_id'],
+            ['dag_run.id'],
+            name=op.f('dagrun_dataset_events_dag_run_id_fkey'),
+            ondelete='CASCADE',
+        ),
+        sa.ForeignKeyConstraint(
+            ['event_id'],
+            ['dataset_event.id'],
+            name=op.f('dagrun_dataset_events_event_id_fkey'),
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('dag_run_id', 'event_id', name=op.f('dagrun_dataset_events_pkey')),
     )
+    with op.batch_alter_table('dagrun_dataset_events') as batch_op:
+        batch_op.create_index('idx_dagrun_dataset_events_dag_run_id', ['dag_run_id'], unique=False)
+        batch_op.create_index('idx_dagrun_dataset_events_event_id', ['event_id'], unique=False)
 
 
 def upgrade():
@@ -149,8 +164,8 @@ def upgrade():
     _create_dataset_dag_ref_table()
     _create_dataset_task_ref_table()
     _create_dataset_dag_run_queue_table()
-    _create_dataset_event_dag_run_table()
     _create_dataset_event_table()
+    _create_dataset_event_dag_run_table()
 
 
 def downgrade():
@@ -158,6 +173,6 @@ def downgrade():
     op.drop_table('dataset_dag_ref')
     op.drop_table('dataset_task_ref')
     op.drop_table('dataset_dag_run_queue')
-    op.drop_table('dataset_event_dag_run')
+    op.drop_table('dagrun_dataset_event')
     op.drop_table('dataset_event')
     op.drop_table('dataset')

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -55,7 +55,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import joinedload, relationship, synonym
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.expression import case, false, select, true
+from sqlalchemy.sql.expression import false, select, true
 
 from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest
@@ -634,89 +634,7 @@ class DagRun(Base, LoggingMixin):
         session.merge(self)
         # We do not flush here for performance reasons(It increases queries count by +20)
 
-        self._process_dataset_dagrun_events(session=session)
-
         return schedulable_tis, callback
-
-    def _process_dataset_dagrun_events(self, *, session=NEW_SESSION):
-        """
-        Looks at all outlet datasets that have been updated by this dag,
-        and creates DAG runs that have all dataset deps fulfilled.
-        """
-        from airflow.datasets import Dataset
-        from airflow.models.dataset import DatasetDagRef, DatasetTaskRef
-
-        has_dataset_outlets = False
-        if self.dag:
-            for _, task in self.dag.task_dict.items():
-                if has_dataset_outlets is True:
-                    break
-                for obj in getattr(task, '_outlets', []):
-                    if isinstance(obj, Dataset):
-                        has_dataset_outlets = True
-                        break
-        dependent_dag_ids = {}
-        if self.dag and has_dataset_outlets:
-            subquery = (
-                session.query(DatasetTaskRef.dataset_id)
-                .filter(DatasetTaskRef.dag_id == self.dag_id)
-                .distinct(DatasetTaskRef.dataset_id)
-                .subquery()
-            )
-            dependent_dag_ids = {
-                x.dag_id
-                for x in session.query(DatasetDagRef.dag_id)
-                .join(subquery, subquery.c.dataset_id == DatasetDagRef.dataset_id)
-                .all()
-            }
-
-        from airflow.models.dataset import DatasetDagRunQueue as DDRQ
-        from airflow.models.serialized_dag import SerializedDagModel
-
-        dag_ids_to_trigger = None
-        if dependent_dag_ids:
-            dag_ids_to_trigger = [
-                x.dag_id
-                for x in session.query(
-                    DatasetDagRef.dag_id,
-                )
-                .join(
-                    DDRQ,
-                    and_(
-                        DDRQ.dataset_id == DatasetDagRef.dataset_id,
-                        DDRQ.target_dag_id == DatasetDagRef.dag_id,
-                    ),
-                    isouter=True,
-                )
-                .filter(DatasetDagRef.dag_id.in_(dependent_dag_ids))
-                .group_by(DatasetDagRef.dag_id)
-                .having(func.count() == func.sum(case((DDRQ.target_dag_id.is_not(None), 1), else_=0)))
-                .all()
-            ]
-
-        if dag_ids_to_trigger:
-            dags_to_purge_from_queue = set()
-            for target_dag_id in dag_ids_to_trigger:
-                row = SerializedDagModel.get(target_dag_id, session)
-                if not row:
-                    self.log.warning("Could not find serialized DAG %s", target_dag_id)
-                    continue
-                dag = row.dag
-                if dag.dataset_triggers:
-                    dag.create_dagrun(
-                        run_type=DagRunType.DATASET_TRIGGERED,
-                        run_id=self.generate_run_id(
-                            DagRunType.DATASET_TRIGGERED, execution_date=timezone.utcnow()
-                        ),
-                        state=DagRunState.QUEUED,
-                        session=session,
-                    )
-                else:
-                    self.log.warning(
-                        "DAG %s no longer has a dataset scheduling dep; purging queue records.", dag.dag_id
-                    )
-                dags_to_purge_from_queue.add(target_dag_id)
-            session.query(DDRQ).filter(DDRQ.target_dag_id.in_(dags_to_purge_from_queue)).delete()
 
     @provide_session
     def task_instance_scheduling_decisions(self, session: Session = NEW_SESSION) -> TISchedulingDecision:

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3317,7 +3317,8 @@ class TestSchedulerJob:
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
         session = settings.Session()
         assert session.query(DagRun).count() == 0
-        dag_models = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        dag_models = query.all()
         self.scheduler_job._create_dag_runs(dag_models, session)
         dr = session.query(DagRun).one()
         dr.state == DagRunState.QUEUED
@@ -3325,7 +3326,8 @@ class TestSchedulerJob:
         assert dag_maker.dag_model.next_dagrun_create_after is None
         session.flush()
         # dags_needing_dagruns query should not return any value
-        assert len(DagModel.dags_needing_dagruns(session).all()) == 0
+        query, _ = DagModel.dags_needing_dagruns(session)
+        assert len(query.all()) == 0
         self.scheduler_job._create_dag_runs(dag_models, session)
         assert session.query(DagRun).count() == 1
         assert dag_maker.dag_model.next_dagrun_create_after is None
@@ -3341,7 +3343,8 @@ class TestSchedulerJob:
         # check that next_dagrun is set properly by Schedulerjob._update_dag_next_dagruns
         self.scheduler_job._schedule_dag_run(dr, session)
         session.flush()
-        assert len(DagModel.dags_needing_dagruns(session).all()) == 1
+        query, _ = DagModel.dags_needing_dagruns(session)
+        assert len(query.all()) == 1
         # assert next_dagrun has been updated correctly
         assert dag_maker.dag_model.next_dagrun == DEFAULT_DATE + timedelta(days=1)
         # assert no dagruns is created yet
@@ -3378,7 +3381,8 @@ class TestSchedulerJob:
         self.scheduler_job.executor = MockExecutor(do_update=True)
         self.scheduler_job.processor_agent = mock.MagicMock(spec=DagFileProcessorAgent)
 
-        DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        query.all()
         for _ in range(3):
             self.scheduler_job._do_scheduling(session)
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -27,13 +27,11 @@ from tempfile import mkdtemp
 from typing import Deque, Generator, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
-from uuid import uuid4
 
 import psutil
 import pytest
 from freezegun import freeze_time
 from sqlalchemy import func
-from airflow.datasets import Dataset
 
 import airflow.example_dags
 from airflow import settings
@@ -41,6 +39,7 @@ from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackR
 from airflow.callbacks.database_callback_sink import DatabaseCallbackSink
 from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
 from airflow.dag_processing.manager import DagFileProcessorAgent
+from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
 from airflow.jobs.backfill_job import BackfillJob
@@ -49,7 +48,7 @@ from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest, Pool, TaskInstance
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import DatasetDagRunQueue, DatasetModel
+from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKey
 from airflow.operators.bash import BashOperator
@@ -3028,7 +3027,8 @@ class TestSchedulerJob:
 
         assert dag.get_last_dagrun().creating_job_id == self.scheduler_job.id
 
-    def test_create_dag_runs_datasets(self, dag_maker):
+    @pytest.mark.need_serialized_dag
+    def test_create_dag_runs_datasets(self, session, dag_maker):
         """
         Test various invariants of _create_dag_runs.
 
@@ -3040,22 +3040,32 @@ class TestSchedulerJob:
         dataset1 = Dataset(uri="ds1")
         dataset2 = Dataset(uri="ds2")
 
-        with dag_maker(dag_id="datasets-1", start_date=timezone.utcnow()):
+        with dag_maker(dag_id="datasets-1", start_date=timezone.utcnow(), session=session):
             BashOperator(task_id="task", bash_command="echo 1", outlets=[dataset1])
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.state = TaskInstanceState.SUCCESS
 
-        with dag_maker(dag_id="datasets-2", schedule=[dataset1, dataset2]):
+        ds1_id = session.query(DatasetModel.id).filter_by(uri=dataset1.uri).scalar()
+
+        event = DatasetEvent(
+            dataset_id=ds1_id,
+            source_task_id=ti.task_id,
+            source_dag_id=ti.dag_id,
+            source_run_id=ti.run_id,
+            source_map_index=ti.map_index,
+        )
+        session.add(event)
+
+        with dag_maker(dag_id="datasets-consumer-multiple", schedule=[dataset1, dataset2]):
             pass
         dag2 = dag_maker.dag
-        with dag_maker(dag_id="datasets-3", schedule=[dataset1]):
+        with dag_maker(dag_id="datasets-consumer-single", schedule=[dataset1]):
             pass
         dag3 = dag_maker.dag
 
         session = dag_maker.session
-        ds1_id = session.query(DatasetModel.id).filter_by(uri=dataset1.uri).scalar()
-        session.bulk_save_objects(
+        session.add_all(
             [
                 DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag2.dag_id),
                 DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag3.dag_id),
@@ -3073,6 +3083,7 @@ class TestSchedulerJob:
         created_run = session.query(DagRun).filter(DagRun.dag_id == dag3.dag_id).one()
         assert created_run.state == State.QUEUED
         assert created_run.start_date is None
+        assert created_run.dataset_events == [event]
         # dag3 DDRQ record should still be there since the dag run was *not* triggered
         assert session.query(DatasetDagRunQueue).filter(DagRun.dag_id == dag3.dag_id).one() is not None
         # dag2 should not be triggered since it depends on both dataset 1  and 2

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -27,11 +27,13 @@ from tempfile import mkdtemp
 from typing import Deque, Generator, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import psutil
 import pytest
 from freezegun import freeze_time
 from sqlalchemy import func
+from airflow.datasets import Dataset
 
 import airflow.example_dags
 from airflow import settings
@@ -47,6 +49,7 @@ from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DAG, DagBag, DagModel, DbCallbackRequest, Pool, TaskInstance
 from airflow.models.dagrun import DagRun
+from airflow.models.dataset import DatasetDagRunQueue, DatasetModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKey
 from airflow.operators.bash import BashOperator
@@ -3024,6 +3027,60 @@ class TestSchedulerJob:
         assert dr.start_date is None
 
         assert dag.get_last_dagrun().creating_job_id == self.scheduler_job.id
+
+    def test_create_dag_runs_datasets(self, dag_maker):
+        """
+        Test various invariants of _create_dag_runs.
+
+        - That the run created has the creating_job_id set
+        - That the run created is on QUEUED State
+        - That dag_model has next_dagrun
+        """
+
+        dataset1 = Dataset(uri="ds1")
+        dataset2 = Dataset(uri="ds2")
+
+        with dag_maker(dag_id="datasets-1", start_date=timezone.utcnow()):
+            BashOperator(task_id="task", bash_command="echo 1", outlets=[dataset1])
+        dr = dag_maker.create_dagrun()
+        ti = dr.task_instances[0]
+        ti.state = TaskInstanceState.SUCCESS
+
+        with dag_maker(dag_id="datasets-2", schedule=[dataset1, dataset2]):
+            pass
+        dag2 = dag_maker.dag
+        with dag_maker(dag_id="datasets-3", schedule=[dataset1]):
+            pass
+        dag3 = dag_maker.dag
+
+        session = dag_maker.session
+        ds1_id = session.query(DatasetModel.id).filter_by(uri=dataset1.uri).scalar()
+        session.bulk_save_objects(
+            [
+                DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag2.dag_id),
+                DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag3.dag_id),
+            ]
+        )
+        session.flush()
+
+        self.scheduler_job = SchedulerJob(executor=self.null_exec)
+        self.scheduler_job.processor_agent = mock.MagicMock()
+
+        with create_session() as session:
+            self.scheduler_job._create_dagruns_for_dags(session, session)
+
+        # dag3 should be triggered since it only depends on dataset1, and it's been queued
+        created_run = session.query(DagRun).filter(DagRun.dag_id == dag3.dag_id).one()
+        assert created_run.state == State.QUEUED
+        assert created_run.start_date is None
+        # dag3 DDRQ record should still be there since the dag run was *not* triggered
+        assert session.query(DatasetDagRunQueue).filter(DagRun.dag_id == dag3.dag_id).one() is not None
+        # dag2 should not be triggered since it depends on both dataset 1  and 2
+        assert session.query(DagRun).filter(DagRun.dag_id == dag2.dag_id).one_or_none() is None
+        # dag2 DDRQ record should be deleted since the dag run was triggered
+        assert session.query(DatasetDagRunQueue).filter(DagRun.dag_id == dag2.dag_id).one_or_none() is None
+
+        assert dag3.get_last_dagrun().creating_job_id == self.scheduler_job.id
 
     @freeze_time(DEFAULT_DATE + datetime.timedelta(days=1, seconds=9))
     @mock.patch('airflow.jobs.scheduler_job.Stats.timing')

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2041,7 +2041,8 @@ class TestDagModel:
         session.add(orm_dag)
         session.flush()
 
-        dag_models = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        dag_models = query.all()
         assert dag_models == []
 
         session.rollback()
@@ -2086,13 +2087,15 @@ class TestDagModel:
         session.add(orm_dag)
         session.flush()
 
-        needed = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        needed = query.all()
         assert needed == [orm_dag]
 
         orm_dag.is_paused = True
         session.flush()
 
-        dag_models = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        dag_models = query.all()
         assert dag_models == []
 
         session.rollback()
@@ -2117,12 +2120,14 @@ class TestDagModel:
         session.add(orm_dag)
         session.flush()
 
-        needed = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        needed = query.all()
         assert needed == [orm_dag]
         orm_dag.has_import_errors = True
         session.merge(orm_dag)
         session.flush()
-        needed = DagModel.dags_needing_dagruns(session).all()
+        query, _ = DagModel.dags_needing_dagruns(session)
+        needed = query.all()
         assert needed == []
 
     @pytest.mark.parametrize(

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -27,12 +27,9 @@ from sqlalchemy.orm.session import Session
 
 from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest
-from airflow.datasets import Dataset
 from airflow.decorators import task
 from airflow.models import DAG, DagBag, DagModel, DagRun, TaskInstance as TI, clear_task_instances
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.dataset import DatasetDagRunQueue, DatasetModel
-from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.empty import EmptyOperator

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -32,9 +32,9 @@ from airflow.decorators import task
 from airflow.models import DAG, DagBag, DagModel, DagRun, TaskInstance as TI, clear_task_instances
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dataset import DatasetDagRunQueue, DatasetModel
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom_arg import XComArg
-from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.serialization.serialized_objects import SerializedDAG
@@ -1364,46 +1364,6 @@ def test_mapped_task_upstream_failed(dag_maker, session):
     tis, _ = dr.update_state(execute_callbacks=False, session=session)
     assert tis == []
     assert dr.state == DagRunState.FAILED
-
-
-@pytest.mark.need_serialized_dag
-def test_dataset_dagruns_triggered(dag_maker):
-    dataset1 = Dataset(uri="ds1")
-    dataset2 = Dataset(uri="ds2")
-
-    with dag_maker(dag_id="datasets-1", start_date=timezone.utcnow()):
-        BashOperator(task_id="task", bash_command="echo 1", outlets=[dataset1])
-    dr = dag_maker.create_dagrun()
-    ti = dr.task_instances[0]
-    ti.state = TaskInstanceState.SUCCESS
-
-    with dag_maker(dag_id="datasets-2", schedule=[dataset1, dataset2]):
-        pass
-    dag2 = dag_maker.dag
-    with dag_maker(dag_id="datasets-3", schedule=[dataset1]):
-        pass
-    dag3 = dag_maker.dag
-
-    session = dag_maker.session
-    ds1_id = session.query(DatasetModel.id).filter_by(uri=dataset1.uri).scalar()
-    session.bulk_save_objects(
-        [
-            DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag2.dag_id),
-            DatasetDagRunQueue(dataset_id=ds1_id, target_dag_id=dag3.dag_id),
-        ]
-    )
-    session.flush()
-    dr.update_state(session=session)
-    session.flush()
-
-    # dag3 should be triggered since it only depends on dataset1, and it's been queued
-    assert session.query(DagRun).filter(DagRun.dag_id == dag3.dag_id).one() is not None
-    # dag3 DDRQ record should still be there since the dag run was *not* triggered
-    assert session.query(DatasetDagRunQueue).filter(DagRun.dag_id == dag3.dag_id).one() is not None
-    # dag2 should not be triggered since it depends on both dataset 1  and 2
-    assert session.query(DagRun).filter(DagRun.dag_id == dag2.dag_id).one_or_none() is None
-    # dag2 DDRQ record should be deleted since the dag run was triggered
-    assert session.query(DatasetDagRunQueue).filter(DagRun.dag_id == dag2.dag_id).one_or_none() is None
 
 
 def test_mapped_task_all_finish_before_downstream(dag_maker, session):

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -267,6 +267,7 @@ class TestDBCleanup:
             'dataset_dag_ref',  # leave alone for now
             'dataset_task_ref',  # leave alone for now
             'dataset_dag_run_queue',  # self-managed
+            'dataset_event_dag_run',  # foreign keys
         }
 
         from airflow.utils.db_cleanup import config_dict


### PR DESCRIPTION
Moves dataset-triggered dagrun creation to the main scheduler loop so that the _target_ dag can be locked.

~Makes the run_id of the dataset-triggered dagrun deterministic.~

Adds a table to map dataset events to dagruns.

~Note: if we decide to go this route, we'll be able to remove querying of dataset-dagrun associations which is done elsewhere (not in this PR yet)~
<ins>Will do that in a follow up PR, what is there works right now, so this goes form working to working :)</ins>
