### PR TITLE
Move mapped kwargs introspection to separate type

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1511,7 +1511,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if cls.mapped_arguments_validated_by_init:
             cls(**kwargs, _airflow_from_mapped=True)
 
-    def unmap(self) -> "BaseOperator":
+    def unmap(self, ctx: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """:meta private:"""
         return self
 

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -1,0 +1,201 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import collections
+import collections.abc
+import functools
+import operator
+from typing import TYPE_CHECKING, Any, NamedTuple, Sequence, Union
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from airflow.exceptions import UnmappableXComTypePushed
+from airflow.utils.context import Context
+
+if TYPE_CHECKING:
+    from airflow.models.xcom_arg import XComArg
+
+# BaseOperator.expand() can be called on an XComArg, sequence, or dict (not any
+# mapping since we need the value to be ordered).
+Mappable = Union["XComArg", Sequence, dict]
+
+MAPPABLE_LITERAL_TYPES = (dict, list)
+
+
+class NotFullyPopulated(RuntimeError):
+    """Raise when ``get_map_lengths`` cannot populate all mapping metadata.
+    This is generally due to not all upstream tasks have finished when the
+    function is called.
+    """
+
+    def __init__(self, missing: set[str]) -> None:
+        self.missing = missing
+
+    def __str__(self) -> str:
+        keys = ", ".join(repr(k) for k in sorted(self.missing))
+        return f"Failed to populate all mapping metadata; missing: {keys}"
+
+
+class DictOfListsExpandInput(NamedTuple):
+    """Storage type of a mapped operator's mapped kwargs.
+
+    This is created from ``expand(**kwargs)``.
+    """
+
+    value: dict[str, Mappable]
+
+    @staticmethod
+    def validate_xcom(value: Any) -> None:
+        if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
+            raise UnmappableXComTypePushed(value)
+
+    def get_parse_time_mapped_ti_count(self) -> int | None:
+        if not self.value:
+            return 0
+        literal_values = [len(v) for v in self.value.values() if isinstance(v, MAPPABLE_LITERAL_TYPES)]
+        if len(literal_values) != len(self.value):
+            return None  # None-literal type encountered, so give up.
+        return functools.reduce(operator.mul, literal_values, 1)
+
+    def _get_map_lengths(self, run_id: str, *, session: Session) -> dict[str, int]:
+        """Return dict of argument name to map length.
+
+        If any arguments are not known right now (upstream task not finished),
+        they will not be present in the dict.
+        """
+        from airflow.models.taskmap import TaskMap
+        from airflow.models.xcom import XCom
+        from airflow.models.xcom_arg import XComArg
+
+        # Populate literal mapped arguments first.
+        map_lengths: dict[str, int] = collections.defaultdict(int)
+        map_lengths.update((k, len(v)) for k, v in self.value.items() if not isinstance(v, XComArg))
+
+        try:
+            dag_id = next(v.operator.dag_id for v in self.value.values() if isinstance(v, XComArg))
+        except StopIteration:  # All mapped arguments are literal. We're done.
+            return map_lengths
+
+        # Build a reverse mapping of what arguments each task contributes to.
+        mapped_dep_keys: dict[str, set[str]] = collections.defaultdict(set)
+        non_mapped_dep_keys: dict[str, set[str]] = collections.defaultdict(set)
+        for k, v in self.value.items():
+            if not isinstance(v, XComArg):
+                continue
+            assert v.operator.dag_id == dag_id
+            if v.operator.is_mapped:
+                mapped_dep_keys[v.operator.task_id].add(k)
+            else:
+                non_mapped_dep_keys[v.operator.task_id].add(k)
+            # TODO: It's not possible now, but in the future we may support
+            # depending on one single mapped task instance. When that happens,
+            # we need to further analyze the mapped case to contain only tasks
+            # we depend on "as a whole", and put those we only depend on
+            # individually to the non-mapped lookup.
+
+        # Collect lengths from unmapped upstreams.
+        taskmap_query = session.query(TaskMap.task_id, TaskMap.length).filter(
+            TaskMap.dag_id == dag_id,
+            TaskMap.run_id == run_id,
+            TaskMap.task_id.in_(non_mapped_dep_keys),
+            TaskMap.map_index < 0,
+        )
+        for task_id, length in taskmap_query:
+            for mapped_arg_name in non_mapped_dep_keys[task_id]:
+                map_lengths[mapped_arg_name] += length
+
+        # Collect lengths from mapped upstreams.
+        xcom_query = (
+            session.query(XCom.task_id, func.count(XCom.map_index))
+            .group_by(XCom.task_id)
+            .filter(
+                XCom.dag_id == dag_id,
+                XCom.run_id == run_id,
+                XCom.task_id.in_(mapped_dep_keys),
+                XCom.map_index >= 0,
+            )
+        )
+        for task_id, length in xcom_query:
+            for mapped_arg_name in mapped_dep_keys[task_id]:
+                map_lengths[mapped_arg_name] += length
+
+        if len(map_lengths) < len(self.value):
+            raise NotFullyPopulated(set(self.value).difference(map_lengths))
+        return map_lengths
+
+    def get_total_map_length(self, run_id: str, *, session: Session) -> int:
+        if not self.value:
+            return 0
+        lengths = self._get_map_lengths(run_id, session=session)
+        return functools.reduce(operator.mul, (lengths[name] for name in self.value), 1)
+
+    def _expand_mapped_field(self, key: str, value: Any, context: Context, *, session: Session) -> Any:
+        from airflow.models.xcom_arg import XComArg
+
+        if isinstance(value, XComArg):
+            value = value.resolve(context, session=session)
+        map_index = context["ti"].map_index
+        if map_index < 0:
+            raise RuntimeError("can't resolve task-mapping argument without expanding")
+        all_lengths = self._get_map_lengths(context["run_id"], session=session)
+
+        def _find_index_for_this_field(index: int) -> int:
+            # Need to use the original user input to retain argument order.
+            for mapped_key in reversed(list(self.value)):
+                mapped_length = all_lengths[mapped_key]
+                if mapped_length < 1:
+                    raise RuntimeError(f"cannot expand field mapped to length {mapped_length!r}")
+                if mapped_key == key:
+                    return index % mapped_length
+                index //= mapped_length
+            return -1
+
+        found_index = _find_index_for_this_field(map_index)
+        if found_index < 0:
+            return value
+        if isinstance(value, collections.abc.Sequence):
+            return value[found_index]
+        if not isinstance(value, dict):
+            raise TypeError(f"can't map over value of type {type(value)}")
+        for i, (k, v) in enumerate(value.items()):
+            if i == found_index:
+                return k, v
+        raise IndexError(f"index {map_index} is over mapped length")
+
+    def resolve(self, context: Context, session: Session) -> dict[str, Any]:
+        return {k: self._expand_mapped_field(k, v, context, session=session) for k, v in self.value.items()}
+
+
+ExpandInput = DictOfListsExpandInput
+
+EXPAND_INPUT_EMPTY = DictOfListsExpandInput({})  # Sentinel value.
+
+_EXPAND_INPUT_TYPES = {
+    "dict-of-lists": DictOfListsExpandInput,
+}
+
+
+def get_map_type_key(expand_input: ExpandInput) -> str:
+    return next(k for k, v in _EXPAND_INPUT_TYPES.items() if v == type(expand_input))
+
+
+def create_expand_input(kind: str, value: Any) -> ExpandInput:
+    return _EXPAND_INPUT_TYPES[kind](value)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -91,7 +91,6 @@ from airflow.exceptions import (
     TaskDeferralError,
     TaskDeferred,
     UnmappableXComLengthPushed,
-    UnmappableXComTypePushed,
     XComForMappingNotPushed,
 )
 from airflow.models.base import Base, StringID
@@ -1854,7 +1853,14 @@ class TaskInstance(Base, LoggingMixin):
         return tb or error.__traceback__
 
     @provide_session
-    def handle_failure(self, error, test_mode=None, context=None, force_fail=False, session=None) -> None:
+    def handle_failure(
+        self,
+        error: Any,
+        test_mode: Optional[bool] = None,
+        context: Optional[Context] = None,
+        force_fail: bool = False,
+        session: Session = NEW_SESSION,
+    ) -> None:
         """Handle Failure for the TaskInstance"""
         if test_mode is None:
             test_mode = self.test_mode
@@ -1898,11 +1904,11 @@ class TaskInstance(Base, LoggingMixin):
         # only mark task instance as FAILED if the next task instance
         # try_number exceeds the max_tries ... or if force_fail is truthy
 
-        task = None
+        task: Optional[BaseOperator] = None
         try:
-            task = self.task.unmap()
+            task = self.task.unmap((context, session))
         except Exception:
-            self.log.error("Unable to unmap task, can't determine if we need to send an alert email or not")
+            self.log.error("Unable to unmap task to determine if we need to send an alert email")
 
         if force_fail or not self.is_eligible_to_retry():
             self.state = State.FAILED
@@ -2135,7 +2141,7 @@ class TaskInstance(Base, LoggingMixin):
 
         rendered_task_instance_fields = RenderedTaskInstanceFields.get_templated_fields(self, session=session)
         if rendered_task_instance_fields:
-            self.task = self.task.unmap()
+            self.task = self.task.unmap(None)
             for field_name, rendered_value in rendered_task_instance_fields.items():
                 setattr(self.task, field_name, rendered_value)
             return
@@ -2311,18 +2317,20 @@ class TaskInstance(Base, LoggingMixin):
         self.log.debug("Task Duration set to %s", self.duration)
 
     def _record_task_map_for_downstreams(self, task: "Operator", value: Any, *, session: Session) -> None:
-        # TODO: We don't push TaskMap for mapped task instances because it's not
-        # currently possible for a downstream to depend on one individual mapped
-        # task instance, only a task as a whole. This will change in AIP-42
-        # Phase 2, and we'll need to further analyze the mapped task case.
-        if next(task.iter_mapped_dependants(), None) is None:
+        validators = {m.validate_upstream_return_value for m in task.iter_mapped_dependants()}
+        if not validators:  # No mapped dependants, no need to validate.
             return
         if value is None:
             raise XComForMappingNotPushed()
+        # TODO: We don't push TaskMap for mapped task instances because it's not
+        # currently possible for a downstream to depend on one individual mapped
+        # task instance. This will change when we implement task group mapping,
+        # and we'll need to further analyze the mapped task case.
         if task.is_mapped:
             return
-        if not isinstance(value, collections.abc.Collection) or isinstance(value, (bytes, str)):
-            raise UnmappableXComTypePushed(value)
+        for validator in validators:
+            validator(value)
+        assert isinstance(value, collections.abc.Collection)  # The validators type-guard this.
         task_map = TaskMap.from_task_instance_xcom(self, value)
         max_map_length = conf.getint("core", "max_map_length", fallback=1024)
         if task_map.length > max_map_length:

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -251,13 +251,13 @@
         "doc_yaml":  { "type": "string" },
         "doc_rst":  { "type": "string" },
         "_is_mapped": { "const": true, "$comment": "only present when True" },
-        "mapped_kwargs": { "type": "object" },
+        "expand_input": { "type": "object" },
         "partial_kwargs": { "type": "object" }
       },
       "dependencies": {
-        "mapped_kwargs": ["partial_kwargs", "_is_mapped"],
-        "partial_kwargs": ["mapped_kwargs", "_is_mapped"],
-        "_is_mapped": ["mapped_kwargs", "partial_kwargs"]
+        "expand_input": ["partial_kwargs", "_is_mapped"],
+        "partial_kwargs": ["expand_input", "_is_mapped"],
+        "_is_mapped": ["expand_input", "partial_kwargs"]
       },
       "additionalProperties": true
     },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -37,6 +37,7 @@ from airflow.models import Dataset
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, create_timetable
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY, ExpandInput, create_expand_input, get_map_type_key
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.operator import Operator
 from airflow.models.param import Param, ParamsDict
@@ -99,8 +100,8 @@ def _get_default_mapped_partial() -> Dict[str, Any]:
     don't need to store them.
     """
     # Use the private _expand() method to avoid the empty kwargs check.
-    default_partial_kwargs = BaseOperator.partial(task_id="_")._expand().partial_kwargs
-    return BaseSerialization._serialize(default_partial_kwargs)[Encoding.VAR]
+    default = BaseOperator.partial(task_id="_")._expand(EXPAND_INPUT_EMPTY, strict=False).partial_kwargs
+    return BaseSerialization._serialize(default)[Encoding.VAR]
 
 
 def encode_relativedelta(var: relativedelta.relativedelta) -> Dict[str, Any]:
@@ -193,15 +194,36 @@ def _decode_timetable(var: Dict[str, Any]) -> Timetable:
 
 
 class _XComRef(NamedTuple):
-    """
-    Used to store info needed to create XComArg when deserializing MappedOperator.
+    """Used to store info needed to create XComArg.
 
-    We can't turn it in to a XComArg until we've loaded _all_ the tasks, so when deserializing an operator we
-    need to create _something_, and then post-process it in deserialize_dag
+    We can't turn it in to a XComArg until we've loaded _all_ the tasks, so when
+    deserializing an operator, we need to create something in its place, and
+    post-process it in ``deserialize_dag``.
     """
 
     task_id: str
     key: str
+
+    def deref(self, dag: DAG) -> XComArg:
+        return XComArg(operator=dag.get_task(self.task_id), key=self.key)
+
+
+class _ExpandInputRef(NamedTuple):
+    """Used to store info needed to create a mapped operator's expand input.
+
+    This references a ``ExpandInput`` type, but replaces ``XComArg`` objects
+    with ``_XComRef`` (see documentation on the latter type for reasoning).
+    """
+
+    key: str
+    value: Union[_XComRef, Dict[str, Any]]
+
+    def deref(self, dag: DAG) -> ExpandInput:
+        if isinstance(self.value, _XComRef):
+            value: Any = self.value.deref(dag)
+        else:
+            value = {k: v.deref(dag) if isinstance(v, _XComRef) else v for k, v in self.value.items()}
+        return create_expand_input(self.key, value)
 
 
 class BaseSerialization:
@@ -598,8 +620,12 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     def serialize_mapped_operator(cls, op: MappedOperator) -> Dict[str, Any]:
         serialized_op = cls._serialize_node(op, include_deps=op.deps is MappedOperator.deps_for(BaseOperator))
 
-        # Handle mapped_kwargs and mapped_op_kwargs.
-        serialized_op[op._expansion_kwargs_attr] = cls._serialize(op._get_expansion_kwargs())
+        # Handle expand_input and op_kwargs_expand_input.
+        expansion_kwargs = op._get_specified_expand_input()
+        serialized_op[op._expand_input_attr] = {
+            "type": get_map_type_key(expansion_kwargs),
+            "value": cls._serialize(expansion_kwargs.value),
+        }
 
         # Simplify partial_kwargs by comparing it to the most barebone object.
         # Remove all entries that are simply default values.
@@ -749,6 +775,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = cls._deserialize_params_dict(v)
             elif k == "partial_kwargs":
                 v = {arg: cls._deserialize(value) for arg, value in v.items()}
+            elif k in {"expand_input", "op_kwargs_expand_input"}:
+                v = _ExpandInputRef(v["type"], cls._deserialize(v["value"]))
             elif k in cls._decorated_fields or k not in op.get_serialized_fields():
                 v = cls._deserialize(v)
             elif k in ("_outlets", "_inlets"):
@@ -781,7 +809,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             op_data = {k: v for k, v in encoded_op.items() if k in BaseOperator.get_serialized_fields()}
             op = MappedOperator(
                 operator_class=op_data,
-                mapped_kwargs={},
+                expand_input=EXPAND_INPUT_EMPTY,
                 partial_kwargs={},
                 task_id=encoded_op["task_id"],
                 params={},
@@ -799,7 +827,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 task_group=None,
                 start_date=None,
                 end_date=None,
-                expansion_kwargs_attr=encoded_op["_expansion_kwargs_attr"],
+                disallow_kwargs_override=encoded_op["_disallow_kwargs_override"],
+                expand_input_attr=encoded_op["_expand_input_attr"],
             )
         else:
             op = SerializedBaseOperator(task_id=encoded_op['task_id'])
@@ -1078,13 +1107,11 @@ class SerializedDAG(DAG, BaseSerialization):
             if task.subdag is not None:
                 setattr(task.subdag, 'parent_dag', dag)
 
-            if isinstance(task, MappedOperator):
-                expansion_kwargs = task._get_expansion_kwargs()
-                for k, v in expansion_kwargs.items():
-                    if not isinstance(v, _XComRef):
-                        continue
-
-                    expansion_kwargs[k] = XComArg(operator=dag.get_task(v.task_id), key=v.key)
+            # Dereference expand_input and op_kwargs_expand_input.
+            for k in ("expand_input", "op_kwargs_expand_input"):
+                kwargs_ref = getattr(task, k, None)
+                if isinstance(kwargs_ref, _ExpandInputRef):
+                    setattr(task, k, kwargs_ref.deref(dag))
 
             for task_id in task.downstream_task_ids:
                 # Bypass set_upstream etc here - it does more than we want

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1372,7 +1372,7 @@ class Airflow(AirflowBaseView):
         # only matters if get_rendered_template_fields() raised an exception.
         # The following rendering won't show useful values in this case anyway,
         # but we'll display some quasi-meaingful field names.
-        task = ti.task.unmap()
+        task = ti.task.unmap(None)
 
         title = "Rendered Template"
         html_dict = {}

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1514,6 +1514,7 @@ unittests
 unix
 unmappable
 unmapped
+unmapping
 unpause
 unpaused
 unpausing

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -50,8 +50,9 @@ IGNORED = {
     "partial",
     "shallow_copy_attrs",
     # Only on MappedOperator.
-    "mapped_kwargs",
+    "expand_input",
     "partial_kwargs",
+    "validate_upstream_return_value",
 }
 
 

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -22,6 +22,7 @@ import pytest
 
 from airflow import DAG
 from airflow.models import DagBag
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
@@ -70,7 +71,7 @@ class TestTaskEndpoint:
             EmptyOperator(task_id=self.task_id3)
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            EmptyOperator.partial(task_id=self.mapped_task_id)._expand()
+            EmptyOperator.partial(task_id=self.mapped_task_id)._expand(EXPAND_INPUT_EMPTY, strict=False)
 
         task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -28,6 +28,7 @@ from airflow.decorators.base import DecoratedMappedOperator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
+from airflow.models.expandinput import DictOfListsExpandInput
 from airflow.models.taskinstance import TaskInstance
 from airflow.models.taskmap import TaskMap
 from airflow.models.xcom import XCOM_RETURN_KEY
@@ -613,7 +614,7 @@ def test_mapped_decorator():
     assert isinstance(t2, XComArg)
     assert isinstance(t2.operator, DecoratedMappedOperator)
     assert t2.operator.task_id == "print_everything"
-    assert t2.operator.mapped_op_kwargs == {"any_key": [1, 2], "works": t1}
+    assert t2.operator.op_kwargs_expand_input == DictOfListsExpandInput({"any_key": [1, 2], "works": t1})
 
     assert t0.operator.task_id == "print_info"
     assert t1.operator.task_id == "print_info__1"
@@ -656,7 +657,7 @@ def test_partial_mapped_decorator() -> None:
 
     assert isinstance(doubled, XComArg)
     assert isinstance(doubled.operator, DecoratedMappedOperator)
-    assert doubled.operator.mapped_op_kwargs == {"number": literal}
+    assert doubled.operator.op_kwargs_expand_input == DictOfListsExpandInput({"number": literal})
     assert doubled.operator.partial_kwargs["op_kwargs"] == {"multiple": 2}
 
     assert isinstance(trippled.operator, DecoratedMappedOperator)  # For type-checking on partial_kwargs.
@@ -678,7 +679,7 @@ def test_mapped_decorator_unmap_merge_op_kwargs():
 
         task2.partial(arg1=1).expand(arg2=task1())
 
-    unmapped = dag.get_task("task2").unmap()
+    unmapped = dag.get_task("task2").unmap(None)
     assert set(unmapped.op_kwargs) == {"arg1", "arg2"}
 
 
@@ -697,11 +698,11 @@ def test_mapped_decorator_converts_partial_kwargs():
 
     mapped_task2 = dag.get_task("task2")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)
-    assert mapped_task2.unmap().retry_delay == timedelta(seconds=30)
+    assert mapped_task2.unmap(None).retry_delay == timedelta(seconds=30)
 
     mapped_task1 = dag.get_task("task1")
     assert mapped_task2.partial_kwargs["retry_delay"] == timedelta(seconds=30)  # Operator default.
-    mapped_task1.unmap().retry_delay == timedelta(seconds=300)  # Operator default.
+    mapped_task1.unmap(None).retry_delay == timedelta(seconds=300)  # Operator default.
 
 
 def test_mapped_render_template_fields(dag_maker, session):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -1165,7 +1165,7 @@ def test_mapped_literal_length_reduction_adds_removed_state(dag_maker, session):
     ]
 
 
-def test_mapped_literal_length_increase_at_runtime_adds_additional_tis(dag_maker, session):
+def test_mapped_length_increase_at_runtime_adds_additional_tis(dag_maker, session):
     """Test that when the length of mapped literal increases at runtime, additional ti is added"""
     from airflow.models import Variable
 

--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -102,9 +102,7 @@ def test_map_xcom_arg():
 def test_partial_on_instance() -> None:
     """`.partial` on an instance should fail -- it's only designed to be called on classes"""
     with pytest.raises(TypeError):
-        MockOperator(
-            task_id='a',
-        ).partial()
+        MockOperator(task_id='a').partial()
 
 
 def test_partial_on_class() -> None:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -58,6 +58,7 @@ from airflow.models import (
     XCom,
 )
 from airflow.models.dataset import Dataset, DatasetDagRunQueue, DatasetEvent, DatasetTaskRef
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
 from airflow.models.taskinstance import TaskInstance
@@ -1058,7 +1059,7 @@ class TestTaskInstance:
         with dag_maker(dag_id="test_xcom", session=session):
             # Use the private _expand() method to avoid the empty kwargs check.
             # We don't care about how the operator runs here, only its presence.
-            task_1 = EmptyOperator.partial(task_id="task_1")._expand()
+            task_1 = EmptyOperator.partial(task_id="task_1")._expand(EXPAND_INPUT_EMPTY, strict=False)
             EmptyOperator(task_id="task_2")
 
         dagrun = dag_maker.create_dagrun(start_date=timezone.datetime(2016, 6, 1, 0, 0, 0))
@@ -2477,9 +2478,9 @@ class TestTaskInstanceRecordTaskMapXComPush:
             (None, XComForMappingNotPushed, "did not push XCom for task mapping"),
         ],
     )
-    def test_error_if_unmappable_type(self, dag_maker, return_value, exception_type, error_message):
-        """If an unmappable return value is used to map, fail the task that pushed the XCom."""
-        with dag_maker(dag_id="test_not_recorded_for_unused") as dag:
+    def test_expand_error_if_unmappable_type(self, dag_maker, return_value, exception_type, error_message):
+        """If an unmappable return value is used for expand(), fail the task that pushed the XCom."""
+        with dag_maker(dag_id="test_expand_error_if_unmappable_type") as dag:
 
             @dag.task()
             def push_something():
@@ -2802,7 +2803,7 @@ def test_ti_xcom_pull_on_mapped_operator_return_lazy_iterable(mock_deserialize_v
     with dag_maker(dag_id="test_xcom", session=session):
         # Use the private _expand() method to avoid the empty kwargs check.
         # We don't care about how the operator runs here, only its presence.
-        task_1 = EmptyOperator.partial(task_id="task_1")._expand()
+        task_1 = EmptyOperator.partial(task_id="task_1")._expand(EXPAND_INPUT_EMPTY, strict=False)
         EmptyOperator(task_id="task_2")
 
     dagrun = dag_maker.create_dagrun()


### PR DESCRIPTION
First part toward #24489.

To support list-of-dicts task-mapping (expand_kwargs), we need different logic in many places of task-mapping to handle the two difference "shapes" of data. Instead of putting conditionals everywhere, we should use polymorphism to switch between different implementations.

This PR lays the foundation to this. A new class DictOfListsExpandInput is added to wrap kwargs received from expand(), and related logic is moved from MappedOperator to that class. It should be quite obvious in various places that I'm "leaving room" for something else; if you feel some abstraction is unnecessary (it's probably not), check #24838 to make sure.

I also included some trivial annotation and code formatting stuffs here since they don't warrant a separate PR and fit as well here as anywhere else.