### PR TITLE
Support `service_account_email` pipeline option for Dataflow jobs in Python or Go

### DIFF
--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -90,8 +90,18 @@ class BeamDataflowMixin(metaclass=ABCMeta):
         pipeline_options = copy.deepcopy(pipeline_options)
         if job_name_key is not None:
             pipeline_options[job_name_key] = job_name
+
+        # Used for pipeline options in Java. See "Security and networking" section in
+        # https://cloud.google.com/dataflow/docs/reference/pipeline-options#java
         if self.dataflow_config.service_account:
             pipeline_options["serviceAccount"] = self.dataflow_config.service_account
+
+        # Used for pipeline options in Python or Go. See "Security and networking" section in
+        # https://cloud.google.com/dataflow/docs/reference/pipeline-options#python (Python) or
+        # https://cloud.google.com/dataflow/docs/reference/pipeline-options#go (Go)
+        if self.dataflow_config.service_account_email:
+            pipeline_options["service_account_email"] = self.dataflow_config.service_account
+
         if self.dataflow_support_impersonation and self.dataflow_config.impersonation_chain:
             if isinstance(self.dataflow_config.impersonation_chain, list):
                 pipeline_options["impersonateServiceAccount"] = ",".join(

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -124,7 +124,10 @@ class DataflowConfiguration:
         WaitForRun = wait until job finished and the run job.
         Supported only by:
         :py:class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`
-    :param service_account: Run the job as a specific service account, instead of the default GCE robot.
+    :param service_account: Run the Java job as a specific service account, instead of the default Compute Engine service account.
+        See: https://cloud.google.com/dataflow/docs/reference/pipeline-options#java
+    :param service_account_email: Run the Python or Go job as a specific service account for Python or Go, instead of the default Compute Engine service account.
+        See: https://cloud.google.com/dataflow/docs/reference/pipeline-options#python or https://cloud.google.com/dataflow/docs/reference/pipeline-options#go
     """
 
     template_fields: Sequence[str] = ("job_name", "location")
@@ -146,6 +149,7 @@ class DataflowConfiguration:
         multiple_jobs: Optional[bool] = None,
         check_if_running: CheckJobRunning = CheckJobRunning.WaitForRun,
         service_account: Optional[str] = None,
+        service_account_email: Optional[str] = None,
     ) -> None:
         self.job_name = job_name
         self.append_job_name = append_job_name
@@ -161,6 +165,7 @@ class DataflowConfiguration:
         self.multiple_jobs = multiple_jobs
         self.check_if_running = check_if_running
         self.service_account = service_account
+        self.service_account_email = service_account_email
 
 
 class DataflowCreateJavaJobOperator(BaseOperator):


### PR DESCRIPTION
PR #23078 introduced the `service_account` parameter for Dataflow jobs, but this parameter only works for jobs written in Java. See [Java pipeline options](https://cloud.google.com/dataflow/docs/reference/pipeline-options#java) for Dataflow.

To support Dataflow jobs written in Python or Go, the parameter to use is `service_account_email`. See [Python pipeline options](https://cloud.google.com/dataflow/docs/reference/pipeline-options#python) and [Go pipeline options](https://cloud.google.com/dataflow/docs/reference/pipeline-options#go) for Dataflow.

Additional references:
- [Parameter name differences](https://stackoverflow.com/a/68621714).
- [Recent bug reported on SO](https://stackoverflow.com/questions/72910801/beamrunpythonpipelineoperator-on-dataflowrunner-keeps-throwing-error-missing-ser)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
