### PR TITLE
Limit astroid version to < 2.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -247,6 +247,9 @@ deprecated_api = [
     'requests>=2.26.0',
 ]
 doc = [
+    # Astroid 2.12.* breaks documentation building
+    # We can remove the limit here after https://github.com/PyCQA/astroid/issues/1708 is solved
+    'astroid<2.12.0',
     'click>=8.0',
     # Docutils 0.17.0 converts generated <div class="section"> into <section> and breaks our doc formatting
     # By adding a lot of whitespace separation. This limit can be lifted when we update our doc to handle


### PR DESCRIPTION
Astroid 2.12 released 9th of July breaks documentation building
with sphinx-autoapi.

Issue about it has been opened in
https://github.com/PyCQA/astroid/issues/1708

Until it is fixed, we should limit astroid.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
