### PR TITLE
Sort operator extra links

### DIFF
--- a/airflow/api_connexion/endpoints/extra_link_endpoint.py
+++ b/airflow/api_connexion/endpoints/extra_link_endpoint.py
@@ -73,6 +73,6 @@ def get_extra_links(
         (link_name, task.get_extra_links(ti, link_name)) for link_name in task.extra_links
     )
     all_extra_links = {
-        link_name: link_url if link_url else None for link_name, link_url in all_extra_link_pairs
+        link_name: link_url if link_url else None for link_name, link_url in sorted(all_extra_link_pairs)
     }
     return all_extra_links


### PR DESCRIPTION
Today, every time webserver is restarted, the order of the
operator extra links are randomized due to Python sets being
unordered.

This change will sort the links according to their name.
No particular thought has been given to customizing this sort
order, except to make it consistent so that extra links always
appear at the same place for the users.