### PR TITLE
[FIX] Scheduler crashloopbackoff when using `hostname_callable`

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -908,8 +908,8 @@ ARG_JOB_HOSTNAME_FILTER = Arg(
 ARG_JOB_HOSTNAME_CALLABLE_FILTER = Arg(
     ("--local",),
     action='store_true',
-    help="If passed, this command will use the `hostname_callable` function"
-    "defined in Airflow configuration.",
+    help="If passed, this command will only show jobs from the local host "
+    "(those with a hostname matching what `hostname_callable` returns).",
 )
 
 ARG_JOB_LIMIT = Arg(
@@ -1797,11 +1797,7 @@ JOBS_COMMANDS = (
             'examples:\n'
             'To check if the local scheduler is still working properly, run:\n'
             '\n'
-            '    $ airflow jobs check --job-type SchedulerJob --hostname "$(hostname)"\n'
-            '\n'
-            'To check if the local scheduler is still working properly with `hostname_callback`, run:\n'
-            '\n'
-            '    $ airflow jobs check --job-type SchedulerJob --local\n'
+            '    $ airflow jobs check --job-type SchedulerJob --local"\n'
             '\n'
             'To check if any scheduler is running when you are using high availability, run:\n'
             '\n'

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -905,6 +905,13 @@ ARG_JOB_HOSTNAME_FILTER = Arg(
     help="The hostname of job(s) that will be checked.",
 )
 
+ARG_JOB_HOSTNAME_CALLABLE_FILTER = Arg(
+    ("--local",),
+    action='store_true',
+    help="If passed, this command will use the `hostname_callable` function"
+    "defined in Airflow configuration.",
+)
+
 ARG_JOB_LIMIT = Arg(
     ("--limit",),
     default=1,
@@ -1779,12 +1786,22 @@ JOBS_COMMANDS = (
         name='check',
         help="Checks if job(s) are still alive",
         func=lazy_load_command('airflow.cli.commands.jobs_command.check'),
-        args=(ARG_JOB_TYPE_FILTER, ARG_JOB_HOSTNAME_FILTER, ARG_JOB_LIMIT, ARG_ALLOW_MULTIPLE),
+        args=(
+            ARG_JOB_TYPE_FILTER,
+            ARG_JOB_HOSTNAME_FILTER,
+            ARG_JOB_HOSTNAME_CALLABLE_FILTER,
+            ARG_JOB_LIMIT,
+            ARG_ALLOW_MULTIPLE,
+        ),
         epilog=(
             'examples:\n'
             'To check if the local scheduler is still working properly, run:\n'
             '\n'
             '    $ airflow jobs check --job-type SchedulerJob --hostname "$(hostname)"\n'
+            '\n'
+            'To check if the local scheduler is still working properly with `hostname_callback`, run:\n'
+            '\n'
+            '    $ airflow jobs check --job-type SchedulerJob --local\n'
             '\n'
             'To check if any scheduler is running when you are using high availability, run:\n'
             '\n'

--- a/airflow/cli/commands/jobs_command.py
+++ b/airflow/cli/commands/jobs_command.py
@@ -18,6 +18,7 @@
 from typing import List
 
 from airflow.jobs.base_job import BaseJob
+from airflow.utils.net import get_hostname
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
@@ -27,6 +28,9 @@ def check(args, session=None):
     """Checks if job(s) are still alive"""
     if args.allow_multiple and not args.limit > 1:
         raise SystemExit("To use option --allow-multiple, you must set the limit to a value greater than 1.")
+    if args.hostname and args.local:
+        raise SystemExit("You can't use --hostname and --local at the same time")
+
     query = (
         session.query(BaseJob)
         .filter(BaseJob.state == State.RUNNING)
@@ -36,6 +40,8 @@ def check(args, session=None):
         query = query.filter(BaseJob.job_type == args.job_type)
     if args.hostname:
         query = query.filter(BaseJob.hostname == args.hostname)
+    if args.local:
+        query = query.filter(BaseJob.hostname == get_hostname())
     if args.limit > 0:
         query = query.limit(args.limit)
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -633,7 +633,7 @@ Create the name of the cleanup service account to use
 
 {{define "scheduler_liveness_check_command"}}
 
-  {{- if semverCompare ">=2.4.0" .Values.airflowVersion }}
+  {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
   - sh
   - -c
   - |
@@ -665,7 +665,7 @@ Create the name of the cleanup service account to use
 {{- end }}
 
 {{define "triggerer_liveness_check_command"}}
-    {{- if semverCompare ">=2.4.0" .Values.airflowVersion }}
+    {{- if semverCompare ">=2.5.0" .Values.airflowVersion }}
     - sh
     - -c
     - |

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -633,7 +633,13 @@ Create the name of the cleanup service account to use
 
 {{define "scheduler_liveness_check_command"}}
 
-  {{- if semverCompare ">=2.1.0" .Values.airflowVersion }}
+  {{- if semverCompare ">=2.4.0" .Values.airflowVersion }}
+  - sh
+  - -c
+  - |
+    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+    airflow jobs check --job-type SchedulerJob --local
+  {{- else if semverCompare ">=2.1.0" .Values.airflowVersion }}
   - sh
   - -c
   - |
@@ -659,11 +665,19 @@ Create the name of the cleanup service account to use
 {{- end }}
 
 {{define "triggerer_liveness_check_command"}}
-  - sh
-  - -c
-  - |
-    CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
-    airflow jobs check --job-type TriggererJob --hostname $(hostname)
+    {{- if semverCompare ">=2.4.0" .Values.airflowVersion }}
+    - sh
+    - -c
+    - |
+      CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+      airflow jobs check --job-type TriggererJob --local
+    {{- else }}
+    - sh
+    - -c
+    - |
+      CONNECTION_CHECK_MAX_COUNT=0 AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR exec /entrypoint \
+      airflow jobs check --job-type TriggererJob  --hostname $(hostname)
+    {{- end }}
 {{- end }}
 
 {{define "dag_processor_liveness_check_command"}}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fix a scheduler `crashLoopBackOff` when `hostname_callable` was defined with a function which returned something different than the [`hostname`](https://linux.die.net/man/1/hostname) command from linux.

## Context
In our production Airflow, I updated the [`hostname_callable`](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#hostname-callable) config with [`airflow.utils.net.get_host_ip_address`](https://github.com/apache/airflow/blob/a3f2df0f45973ddb97990361fdc5caa256c175ca/airflow/utils/net.py#L46-L48) so that we could read the pod logs produced by our celery workers. But this new config was making kubernetes to restart the scheduler pods because the [command defined in helm](https://github.com/apache/airflow/blob/451181f6f2efd8b5e6bd7807e84a17d48a4fe875/chart/templates/_helpers.yaml#L640-L641) was returning a "No alive jobs found."
I therefore updated the cli command jobs to allow the use of `--use-hostname-callable`  in:
```bash
airflow jobs check --job-type SchedulerJob --use-hostname-callable
```
to use the `hostname_callable` that the user defined in its Airflow conf. Also updated the helm chart to with this new conf since I think it will be more reliable than to use linux `hostname` command.