### PR TITLE
Fix backwards incompatible change for group id naming check

### DIFF
--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
 
 KEY_REGEX = re.compile(r'^[\w.-]+$')
-GROUP_KEY_REGEX = re.compile(r'^[\w-]+$')
+GROUP_KEY_REGEX = KEY_REGEX
 CAMELCASE_TO_SNAKE_CASE_REGEX = re.compile(r'(?!^)([A-Z]+)')
 
 T = TypeVar('T')
@@ -75,7 +75,8 @@ def validate_group_key(k: str, max_length: int = 200):
         raise AirflowException(f"The key has to be less than {max_length} characters")
     if not GROUP_KEY_REGEX.match(k):
         raise AirflowException(
-            f"The key {k!r} has to be made of alphanumeric characters, dashes and underscores exclusively"
+            f"The key {k!r} has to be made of alphanumeric characters, dashes, "
+            f"dots and underscores exclusively"
         )
 
 

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -207,12 +207,8 @@ class TestHelpers:
             (None, "The key has to be a string and is <class 'NoneType'>:None", TypeError),
             ("simple_key", None, None),
             ("simple-key", None, None),
-            (
-                "group.simple_key",
-                "The key 'group.simple_key' has to be made of alphanumeric "
-                "characters, dashes and underscores exclusively",
-                AirflowException,
-            ),
+            ("group.simple_key", None, None),
+            ("root.group-name.simple_key", None, None),
             (
                 "root.group-name.simple_key",
                 "The key 'root.group-name.simple_key' has to be made of alphanumeric "
@@ -222,13 +218,13 @@ class TestHelpers:
             (
                 "key with space",
                 "The key 'key with space' has to be made of alphanumeric "
-                "characters, dashes and underscores exclusively",
+                "characters, dashes, dots and underscores exclusively",
                 AirflowException,
             ),
             (
                 "key_with_!",
                 "The key 'key_with_!' has to be made of alphanumeric "
-                "characters, dashes and underscores exclusively",
+                "characters, dashes, dots and underscores exclusively",
                 AirflowException,
             ),
             (' ' * 201, "The key has to be less than 200 characters", AirflowException),

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -210,12 +210,6 @@ class TestHelpers:
             ("group.simple_key", None, None),
             ("root.group-name.simple_key", None, None),
             (
-                "root.group-name.simple_key",
-                "The key 'root.group-name.simple_key' has to be made of alphanumeric "
-                "characters, dashes and underscores exclusively",
-                AirflowException,
-            ),
-            (
                 "key with space",
                 "The key 'key with space' has to be made of alphanumeric "
                 "characters, dashes, dots and underscores exclusively",


### PR DESCRIPTION
This PR addresses a backwards incompatible change introduced with https://github.com/apache/airflow/pull/17578.

Prior to the change a task group id could contain all characters that were valid for a task id. With the additional validation of the group id the dot character was removed from the list of valid characters.
Although I can understand the rationale behind this, it seems inconsistent/arbitrary to me as illustrated by the picture below.
![task_groups](https://user-images.githubusercontent.com/100271696/178501811-1d1e5cb4-a21c-4132-bd49-c0bf94c7411b.png)

The illustrated tasks all have an effective task id of the form "A.B.C". Right now 1.) through 3.) are valid but 4.) is not, which this PR would remedy. Afterwards all 4 cases would be valid.

I would argue that one cannot reverse engineer the groups from an effective task id alone anyway (e.g. by splitting at every dot), so there should ne no reason why a group id cannot contain a dot.

Here is a real world example where this would help:
We use airflow to load our data warehouse. Each table load (of which are more than a thousand) consists of the same steps grouped together in a task group (e.g. truncate, load, refresh_stats). This task group is named after the fully qualified name  of the table, which is "schema.table_name".


At last I would like to thank you all for your work on this great piece of software.
