### PR TITLE
Update tutorial docs to include a definition of operators

### DIFF
--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -107,7 +107,7 @@ Operators
 
 An operator defines a unit of work for Airflow to complete. Using operators is the classic approach
 to defining work in Airflow. For some use cases, it's better to use the TaskFlow API to define
-work in a Pythonic context as described in :doc:`/tutorial_taskflow_api`. In this tutorial, using operators helps to
+work in a Pythonic context as described in :doc:`/tutorial_taskflow_api`. For now, using operators helps to
 illustrate the upstream and downstream dependencies between tasks.
 
 All operators inherit from the BaseOperator, which includes all of the required arguments for

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -115,19 +115,6 @@ KubernetesPodOperator.
 Airflow completes work based on the arguments you pass to your operators. In this tutorial, we
 use the BashOperator to run a few bash scripts.
 
-Operators
----------
-
-An operator defines a unit of work for Airflow to complete. They are the most basic building blocks of DAGs.
-
-All operators inherit from the BaseOperator, which includes all of the required arguments for
-running work in Airflow. From here, each operator includes unique arguments for
-the type of work it's completing. Some of the most popular operators are the PythonOperator, the BashOperator, and the
-KubernetesPodOperator.
-
-Airflow completes work based on the arguments you pass to your operators. In this tutorial, we
-use the BashOperator to run a few bash scripts.
-
 Tasks
 -----
 
@@ -568,7 +555,7 @@ Completing our DAG:
 ~~~~~~~~~~~~~~~~~~~
 We've developed our tasks, now we need to wrap them in a DAG, which enables us to define when and how tasks should run, and state any dependencies that tasks have on other tasks. The DAG below is configured to:
 
-* run every day a midnight starting on Jan 1, 2021,
+* run every day at midnight starting on Jan 1, 2021,
 * only run once in the event that days are missed, and
 * timeout after 60 minutes
 

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -108,7 +108,7 @@ Operators
 An operator defines a unit of work for Airflow to complete. Using operators is the classic approach
 to defining work in Airflow. For some use cases, it's better to use the TaskFlow API to define
 work in a Pythonic context as described in :doc:`/tutorial_taskflow_api`. For now, using operators helps to
-illustrate the upstream and downstream dependencies between tasks.
+visualize task dependencies in our DAG code.
 
 All operators inherit from the BaseOperator, which includes all of the required arguments for
 running work in Airflow. From here, each operator includes unique arguments for

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -119,7 +119,7 @@ Tasks
 -----
 
 To use an operator in a DAG, you have to instantiate it as a task. Tasks
-determine how to execute your operators' work within the context of a DAG.
+determine how to execute your operator's work within the context of a DAG.
 
 In the following example, we instantiate the BashOperator as two separate tasks in order to run two
 separate bash scripts. The first argument for each instantiation, ``task_id``,

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -115,6 +115,19 @@ KubernetesPodOperator.
 Airflow completes work based on the arguments you pass to your operators. In this tutorial, we
 use the BashOperator to run a few bash scripts.
 
+Operators
+---------
+
+An operator defines a unit of work for Airflow to complete. They are the most basic building blocks of DAGs.
+
+All operators inherit from the BaseOperator, which includes all of the required arguments for
+running work in Airflow. From here, each operator includes unique arguments for
+the type of work it's completing. Some of the most popular operators are the PythonOperator, the BashOperator, and the
+KubernetesPodOperator.
+
+Airflow completes work based on the arguments you pass to your operators. In this tutorial, we
+use the BashOperator to run a few bash scripts.
+
 Tasks
 -----
 

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -1,19 +1,19 @@
-.. Licensed to the Apache Software Foundation (ASF) under one
-   or more contributor license agreements.  See the NOTICE file
-   distributed with this work for additional information
-   regarding copyright ownership.  The ASF licenses this file
-   to you under the Apache License, Version 2.0 (the
-   "License"); you may not use this file except in compliance
-   with the License.  You may obtain a copy of the License at
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
 
-..   http://www.apache.org/licenses/LICENSE-2.0
+ ..   http://www.apache.org/licenses/LICENSE-2.0
 
-.. Unless required by applicable law or agreed to in writing,
-   software distributed under the License is distributed on an
-   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-   KIND, either express or implied.  See the License for the
-   specific language governing permissions and limitations
-   under the License.
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
 
 
 
@@ -31,9 +31,9 @@ Here is an example of a basic pipeline definition. Do not worry if this looks
 complicated, a line by line explanation follows below.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :start-after: [START tutorial]
-   :end-before: [END tutorial]
+    :language: python
+    :start-after: [START tutorial]
+    :end-before: [END tutorial]
 
 It's a DAG definition file
 --------------------------
@@ -61,9 +61,9 @@ An Airflow pipeline is just a Python script that happens to define an
 Airflow DAG object. Let's start by importing the libraries we will need.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :start-after: [START import_module]
-   :end-before: [END import_module]
+    :language: python
+    :start-after: [START import_module]
+    :end-before: [END import_module]
 
 
 See :doc:`modules_management` for details on how Python and Airflow manage modules.
@@ -76,10 +76,10 @@ explicitly pass a set of arguments to each task's constructor
 of default parameters that we can use when creating tasks.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :dedent: 4
-   :start-after: [START default_args]
-   :end-before: [END default_args]
+    :language: python
+    :dedent: 4
+    :start-after: [START default_args]
+    :end-before: [END default_args]
 
 For more information about the BaseOperator's parameters and what they do,
 refer to the :py:class:`airflow.models.BaseOperator` documentation.
@@ -98,9 +98,9 @@ We also pass the default argument dictionary that we just defined and
 define a ``schedule_interval`` of 1 day for the DAG.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :start-after: [START instantiate_dag]
-   :end-before: [END instantiate_dag]
+    :language: python
+    :start-after: [START instantiate_dag]
+    :end-before: [END instantiate_dag]
 
 Operators
 ---------
@@ -126,10 +126,10 @@ separate bash scripts. The first argument for each instantiation, ``task_id``,
 acts as a unique identifier for the task.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :dedent: 4
-   :start-after: [START basic_task]
-   :end-before: [END basic_task]
+    :language: python
+    :dedent: 4
+    :start-after: [START basic_task]
+    :end-before: [END basic_task]
 
 Notice how we pass a mix of operator specific arguments (``bash_command``) and
 an argument common to all operators (``retries``) inherited
@@ -162,10 +162,10 @@ point to the most common template variable: ``{{ ds }}`` (today's "date
 stamp").
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :dedent: 4
-   :start-after: [START jinja_template]
-   :end-before: [END jinja_template]
+    :language: python
+    :dedent: 4
+    :start-after: [START jinja_template]
+    :end-before: [END jinja_template]
 
 Notice that the ``templated_command`` contains code logic in ``{% %}`` blocks,
 references parameters like ``{{ ds }}``, and calls a function as in
@@ -202,10 +202,10 @@ of the DAG file (recommended), or anywhere else in the file. Below you can find 
 on how to implement task and DAG docs, as well as screenshots:
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :dedent: 4
-   :start-after: [START documentation]
-   :end-before: [END documentation]
+    :language: python
+    :dedent: 4
+    :start-after: [START documentation]
+    :end-before: [END documentation]
 
 .. image:: img/task_doc.png
 .. image:: img/dag_doc.png
@@ -217,31 +217,31 @@ you can define dependencies between them:
 
 .. code-block:: python
 
-   t1.set_downstream(t2)
+    t1.set_downstream(t2)
 
-   # This means that t2 will depend on t1
-   # running successfully to run.
-   # It is equivalent to:
-   t2.set_upstream(t1)
+    # This means that t2 will depend on t1
+    # running successfully to run.
+    # It is equivalent to:
+    t2.set_upstream(t1)
 
-   # The bit shift operator can also be
-   # used to chain operations:
-   t1 >> t2
+    # The bit shift operator can also be
+    # used to chain operations:
+    t1 >> t2
 
-   # And the upstream dependency with the
-   # bit shift operator:
-   t2 << t1
+    # And the upstream dependency with the
+    # bit shift operator:
+    t2 << t1
 
-   # Chaining multiple dependencies becomes
-   # concise with the bit shift operator:
-   t1 >> t2 >> t3
+    # Chaining multiple dependencies becomes
+    # concise with the bit shift operator:
+    t1 >> t2 >> t3
 
-   # A list of tasks can also be set as
-   # dependencies. These operations
-   # all have the same effect:
-   t1.set_downstream([t2, t3])
-   t1 >> [t2, t3]
-   [t2, t3] << t1
+    # A list of tasks can also be set as
+    # dependencies. These operations
+    # all have the same effect:
+    t1.set_downstream([t2, t3])
+    t1 >> [t2, t3]
+    [t2, t3] << t1
 
 Note that when executing your script, Airflow will raise exceptions when
 it finds cycles in your DAG or when a dependency is referenced more
@@ -261,9 +261,9 @@ Alright, so we have a pretty basic DAG. At this point your code should look
 something like this:
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-   :language: python
-   :start-after: [START tutorial]
-   :end-before: [END tutorial]
+    :language: python
+    :start-after: [START tutorial]
+    :end-before: [END tutorial]
 
 .. _testing:
 
@@ -282,7 +282,7 @@ The default location for your DAGs is ``~/airflow/dags``.
 
 .. code-block:: bash
 
-   python ~/airflow/dags/tutorial.py
+    python ~/airflow/dags/tutorial.py
 
 If the script does not raise an exception it means that you have not done
 anything horribly wrong, and that your Airflow environment is somewhat
@@ -294,17 +294,17 @@ Let's run a few commands to validate this script further.
 
 .. code-block:: bash
 
-   # initialize the database tables
-   airflow db init
+    # initialize the database tables
+    airflow db init
 
-   # print the list of active DAGs
-   airflow dags list
+    # print the list of active DAGs
+    airflow dags list
 
-   # prints the list of tasks in the "tutorial" DAG
-   airflow tasks list tutorial
+    # prints the list of tasks in the "tutorial" DAG
+    airflow tasks list tutorial
 
-   # prints the hierarchy of tasks in the "tutorial" DAG
-   airflow tasks list tutorial --tree
+    # prints the hierarchy of tasks in the "tutorial" DAG
+    airflow tasks list tutorial --tree
 
 
 Testing
@@ -323,21 +323,21 @@ its data interval.
 
 .. code-block:: bash
 
-   # command layout: command subcommand dag_id task_id date
+    # command layout: command subcommand dag_id task_id date
 
-   # testing print_date
-   airflow tasks test tutorial print_date 2015-06-01
+    # testing print_date
+    airflow tasks test tutorial print_date 2015-06-01
 
-   # testing sleep
-   airflow tasks test tutorial sleep 2015-06-01
+    # testing sleep
+    airflow tasks test tutorial sleep 2015-06-01
 
 Now remember what we did with templating earlier? See how this template
 gets rendered and executed by running this command:
 
 .. code-block:: bash
 
-   # testing templated
-   airflow tasks test tutorial templated 2015-06-01
+    # testing templated
+    airflow tasks test tutorial templated 2015-06-01
 
 This should result in displaying a verbose log of events and ultimately
 running your bash command and printing the result.
@@ -378,13 +378,13 @@ which are used to populate the run schedule with task instances from this dag.
 
 .. code-block:: bash
 
-   # optional, start a web server in debug mode in the background
-   # airflow webserver --debug &
+    # optional, start a web server in debug mode in the background
+    # airflow webserver --debug &
 
-   # start your backfill on a date range
-   airflow dags backfill tutorial \
-       --start-date 2015-06-01 \
-       --end-date 2015-06-07
+    # start your backfill on a date range
+    airflow dags backfill tutorial \
+        --start-date 2015-06-01 \
+        --end-date 2015-06-07
 
 
 Pipeline Example
@@ -399,18 +399,18 @@ The steps below should be sufficient, but see the quick-start documentation for 
 
 .. code-block:: bash
 
- # Download the docker-compose.yaml file
- curl -Lf0 'https://airflow.apache.org/docs/apache-airflow/stable/docker-compose.yaml'
+  # Download the docker-compose.yaml file
+  curl -Lf0 'https://airflow.apache.org/docs/apache-airflow/stable/docker-compose.yaml'
 
- # Make expected directories and set an expected environment variable
- mkdir -p ./dags ./logs ./plugins
- echo -e "AIRFLOW_UID=$(id -u)" > .env
+  # Make expected directories and set an expected environment variable
+  mkdir -p ./dags ./logs ./plugins
+  echo -e "AIRFLOW_UID=$(id -u)" > .env
 
- # Initialize the database
- docker-compose up airflow-init
+  # Initialize the database
+  docker-compose up airflow-init
 
- # Start up all services
- docker-compose up
+  # Start up all services
+  docker-compose up
 
 After all services have started up, the web UI will be available at: ``http://localhost:8080``. The default account has the username ``airflow`` and the password ``airflow``.
 
@@ -437,34 +437,34 @@ We'll create one table to facilitate data cleaning steps (``employees_temp``) an
 
 .. code-block:: python
 
- from airflow.providers.postgres.operators.postgres import PostgresOperator
+  from airflow.providers.postgres.operators.postgres import PostgresOperator
 
- create_employees_table = PostgresOperator(
-     task_id="create_employees_table",
-     postgres_conn_id="tutorial_pg_conn",
-     sql="""
-         CREATE TABLE IF NOT EXISTS employees (
-             "Serial Number" NUMERIC PRIMARY KEY,
-             "Company Name" TEXT,
-             "Employee Markme" TEXT,
-             "Description" TEXT,
-             "Leave" INTEGER
-         );""",
- )
+  create_employees_table = PostgresOperator(
+      task_id="create_employees_table",
+      postgres_conn_id="tutorial_pg_conn",
+      sql="""
+          CREATE TABLE IF NOT EXISTS employees (
+              "Serial Number" NUMERIC PRIMARY KEY,
+              "Company Name" TEXT,
+              "Employee Markme" TEXT,
+              "Description" TEXT,
+              "Leave" INTEGER
+          );""",
+  )
 
- create_employees_temp_table = PostgresOperator(
-     task_id="create_employees_temp_table",
-     postgres_conn_id="tutorial_pg_conn",
-     sql="""
-         DROP TABLE IF EXISTS employees_temp;
-         CREATE TABLE employees_temp (
-             "Serial Number" NUMERIC PRIMARY KEY,
-             "Company Name" TEXT,
-             "Employee Markme" TEXT,
-             "Description" TEXT,
-             "Leave" INTEGER
-         );""",
- )
+  create_employees_temp_table = PostgresOperator(
+      task_id="create_employees_temp_table",
+      postgres_conn_id="tutorial_pg_conn",
+      sql="""
+          DROP TABLE IF EXISTS employees_temp;
+          CREATE TABLE employees_temp (
+              "Serial Number" NUMERIC PRIMARY KEY,
+              "Company Name" TEXT,
+              "Employee Markme" TEXT,
+              "Description" TEXT,
+              "Leave" INTEGER
+          );""",
+  )
 
 Optional Note:
 """"""""""""""
@@ -472,11 +472,11 @@ If you want to abstract these sql statements out of your DAG, you can move the s
 
 .. code-block:: python
 
- create_employees_table = PostgresOperator(
-     task_id="create_employees_table",
-     postgres_conn_id="tutorial_pg_conn",
-     sql="sql/employees_schema.sql",
- )
+  create_employees_table = PostgresOperator(
+      task_id="create_employees_table",
+      postgres_conn_id="tutorial_pg_conn",
+      sql="sql/employees_schema.sql",
+  )
 
 and repeat for the ``employees_temp`` table.
 
@@ -487,34 +487,34 @@ Here we retrieve data, save it to a file on our Airflow instance, and load the d
 
 .. code-block:: python
 
- import os
- import requests
- from airflow.decorators import task
- from airflow.providers.postgres.hooks.postgres import PostgresHook
+  import os
+  import requests
+  from airflow.decorators import task
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
- @task
- def get_data():
-     # NOTE: configure this as appropriate for your airflow environment
-     data_path = "/opt/airflow/dags/files/employees.csv"
-     os.makedirs(os.path.dirname(data_path), exist_ok=True)
+  @task
+  def get_data():
+      # NOTE: configure this as appropriate for your airflow environment
+      data_path = "/opt/airflow/dags/files/employees.csv"
+      os.makedirs(os.path.dirname(data_path), exist_ok=True)
 
-     url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
+      url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
 
-     response = requests.request("GET", url)
+      response = requests.request("GET", url)
 
-     with open(data_path, "w") as file:
-         file.write(response.text)
+      with open(data_path, "w") as file:
+          file.write(response.text)
 
-     postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-     conn = postgres_hook.get_conn()
-     cur = conn.cursor()
-     with open(data_path, "r") as file:
-         cur.copy_expert(
-             "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
-             file,
-         )
-     conn.commit()
+      postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+      conn = postgres_hook.get_conn()
+      cur = conn.cursor()
+      with open(data_path, "r") as file:
+          cur.copy_expert(
+              "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
+              file,
+          )
+      conn.commit()
 
 Data Merge Task
 ~~~~~~~~~~~~~~~
@@ -523,31 +523,31 @@ Here we select completely unique records from the retrieved data, then we check 
 
 .. code-block:: python
 
- from airflow.decorators import task
- from airflow.providers.postgres.hooks.postgres import PostgresHook
+  from airflow.decorators import task
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
- @task
- def merge_data():
-     query = """
-         INSERT INTO employees
-         SELECT *
-         FROM (
-             SELECT DISTINCT *
-             FROM employees_temp
-         )
-         ON CONFLICT ("Serial Number") DO UPDATE
-         SET "Serial Number" = excluded."Serial Number";
-     """
-     try:
-         postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-         conn = postgres_hook.get_conn()
-         cur = conn.cursor()
-         cur.execute(query)
-         conn.commit()
-         return 0
-     except Exception as e:
-         return 1
+  @task
+  def merge_data():
+      query = """
+          INSERT INTO employees
+          SELECT *
+          FROM (
+              SELECT DISTINCT *
+              FROM employees_temp
+          )
+          ON CONFLICT ("Serial Number") DO UPDATE
+          SET "Serial Number" = excluded."Serial Number";
+      """
+      try:
+          postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+          conn = postgres_hook.get_conn()
+          cur = conn.cursor()
+          cur.execute(query)
+          conn.commit()
+          return 0
+      except Exception as e:
+          return 1
 
 
 
@@ -563,7 +563,7 @@ And from the last line in the definition of the ``Etl`` DAG, we see:
 
 .. code-block:: python
 
-     [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+      [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
 
 * the ``merge_data()`` task depends on the ``get_data()`` task,
 * the ``get_data()`` depends on both the ``create_employees_table`` and ``create_employees_temp_table`` tasks, and
@@ -573,99 +573,99 @@ Putting all of the pieces together, we have our completed DAG.
 
 .. code-block:: python
 
- import datetime
- import pendulum
- import os
+  import datetime
+  import pendulum
+  import os
 
- import requests
- from airflow.decorators import dag, task
- from airflow.providers.postgres.hooks.postgres import PostgresHook
- from airflow.providers.postgres.operators.postgres import PostgresOperator
-
-
- @dag(
-     schedule_interval="0 0 * * *",
-     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-     catchup=False,
-     dagrun_timeout=datetime.timedelta(minutes=60),
- )
- def Etl():
-     create_employees_table = PostgresOperator(
-         task_id="create_employees_table",
-         postgres_conn_id="tutorial_pg_conn",
-         sql="""
-             CREATE TABLE IF NOT EXISTS employees (
-                 "Serial Number" NUMERIC PRIMARY KEY,
-                 "Company Name" TEXT,
-                 "Employee Markme" TEXT,
-                 "Description" TEXT,
-                 "Leave" INTEGER
-             );""",
-     )
-
-     create_employees_temp_table = PostgresOperator(
-         task_id="create_employees_temp_table",
-         postgres_conn_id="tutorial_pg_conn",
-         sql="""
-             DROP TABLE IF EXISTS employees_temp;
-             CREATE TABLE employees_temp (
-                 "Serial Number" NUMERIC PRIMARY KEY,
-                 "Company Name" TEXT,
-                 "Employee Markme" TEXT,
-                 "Description" TEXT,
-                 "Leave" INTEGER
-             );""",
-     )
-
-     @task
-     def get_data():
-         # NOTE: configure this as appropriate for your airflow environment
-         data_path = "/opt/airflow/dags/files/employees.csv"
-         os.makedirs(os.path.dirname(data_path), exist_ok=True)
-
-         url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
-
-         response = requests.request("GET", url)
-
-         with open(data_path, "w") as file:
-             file.write(response.text)
-
-         postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-         conn = postgres_hook.get_conn()
-         cur = conn.cursor()
-         with open(data_path, "r") as file:
-             cur.copy_expert(
-                 "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
-                 file,
-             )
-         conn.commit()
-
-     @task
-     def merge_data():
-         query = """
-             INSERT INTO employees
-             SELECT *
-             FROM (
-                 SELECT DISTINCT *
-                 FROM employees_temp
-             )
-             ON CONFLICT ("Serial Number") DO UPDATE
-             SET "Serial Number" = excluded."Serial Number";
-         """
-         try:
-             postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-             conn = postgres_hook.get_conn()
-             cur = conn.cursor()
-             cur.execute(query)
-             conn.commit()
-             return 0
-         except Exception as e:
-             return 1
-
-     [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+  import requests
+  from airflow.decorators import dag, task
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
+  from airflow.providers.postgres.operators.postgres import PostgresOperator
 
 
- dag = Etl()
+  @dag(
+      schedule_interval="0 0 * * *",
+      start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+      catchup=False,
+      dagrun_timeout=datetime.timedelta(minutes=60),
+  )
+  def Etl():
+      create_employees_table = PostgresOperator(
+          task_id="create_employees_table",
+          postgres_conn_id="tutorial_pg_conn",
+          sql="""
+              CREATE TABLE IF NOT EXISTS employees (
+                  "Serial Number" NUMERIC PRIMARY KEY,
+                  "Company Name" TEXT,
+                  "Employee Markme" TEXT,
+                  "Description" TEXT,
+                  "Leave" INTEGER
+              );""",
+      )
+
+      create_employees_temp_table = PostgresOperator(
+          task_id="create_employees_temp_table",
+          postgres_conn_id="tutorial_pg_conn",
+          sql="""
+              DROP TABLE IF EXISTS employees_temp;
+              CREATE TABLE employees_temp (
+                  "Serial Number" NUMERIC PRIMARY KEY,
+                  "Company Name" TEXT,
+                  "Employee Markme" TEXT,
+                  "Description" TEXT,
+                  "Leave" INTEGER
+              );""",
+      )
+
+      @task
+      def get_data():
+          # NOTE: configure this as appropriate for your airflow environment
+          data_path = "/opt/airflow/dags/files/employees.csv"
+          os.makedirs(os.path.dirname(data_path), exist_ok=True)
+
+          url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
+
+          response = requests.request("GET", url)
+
+          with open(data_path, "w") as file:
+              file.write(response.text)
+
+          postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+          conn = postgres_hook.get_conn()
+          cur = conn.cursor()
+          with open(data_path, "r") as file:
+              cur.copy_expert(
+                  "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
+                  file,
+              )
+          conn.commit()
+
+      @task
+      def merge_data():
+          query = """
+              INSERT INTO employees
+              SELECT *
+              FROM (
+                  SELECT DISTINCT *
+                  FROM employees_temp
+              )
+              ON CONFLICT ("Serial Number") DO UPDATE
+              SET "Serial Number" = excluded."Serial Number";
+          """
+          try:
+              postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+              conn = postgres_hook.get_conn()
+              cur = conn.cursor()
+              cur.execute(query)
+              conn.commit()
+              return 0
+          except Exception as e:
+              return 1
+
+      [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+
+
+  dag = Etl()
 
 Save this code to a python file in the ``/dags`` folder (e.g. ``dags/etl.py``) and (after a `brief delay <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#dag-dir-list-interval>`_), the ``Etl`` DAG will be included in the list of available DAGs on the web UI.
 
@@ -687,12 +687,12 @@ running against it should get it to get triggered and run every day.
 Here's a few things you might want to do next:
 
 .. seealso::
-   - Read the :doc:`/concepts/index` section for detailed explanation of Airflow concepts such as DAGs, Tasks, Operators, and more.
-   - Take an in-depth tour of the UI - click all the things!
-   - Keep reading the docs!
+    - Read the :doc:`/concepts/index` section for detailed explanation of Airflow concepts such as DAGs, Tasks, Operators, and more.
+    - Take an in-depth tour of the UI - click all the things!
+    - Keep reading the docs!
 
-     - Review the :doc:`how-to guides<howto/index>`, which include a guide to writing your own operator
-     - Review the :ref:`Command Line Interface Reference<cli>`
-     - Review the :ref:`List of operators <pythonapi:operators>`
-     - Review the :ref:`Macros reference<macros>`
-   - Write your first pipeline!
+      - Review the :doc:`how-to guides<howto/index>`, which include a guide to writing your own operator
+      - Review the :ref:`Command Line Interface Reference<cli>`
+      - Review the :ref:`List of operators <pythonapi:operators>`
+      - Review the :ref:`Macros reference<macros>`
+    - Write your first pipeline!

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -105,7 +105,10 @@ define a ``schedule_interval`` of 1 day for the DAG.
 Operators
 ---------
 
-An operator defines a unit of work for Airflow to complete. They are the most basic building blocks of DAGs.
+An operator defines a unit of work for Airflow to complete. Using operators is the classic approach
+to defining work in Airflow. For some use cases, it's better to use the TaskFlow API to define
+work in a Pythonic context as described in :doc:`/tutorial_taskflow_api`. In this tutorial, using operators helps to
+illustrate the upstream and downstream dependencies between tasks.
 
 All operators inherit from the BaseOperator, which includes all of the required arguments for
 running work in Airflow. From here, each operator includes unique arguments for

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -1,19 +1,19 @@
- .. Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
 
- ..   http://www.apache.org/licenses/LICENSE-2.0
+..   http://www.apache.org/licenses/LICENSE-2.0
 
- .. Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+.. Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
 
 
 
@@ -31,9 +31,9 @@ Here is an example of a basic pipeline definition. Do not worry if this looks
 complicated, a line by line explanation follows below.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :start-after: [START tutorial]
-    :end-before: [END tutorial]
+   :language: python
+   :start-after: [START tutorial]
+   :end-before: [END tutorial]
 
 It's a DAG definition file
 --------------------------
@@ -61,9 +61,9 @@ An Airflow pipeline is just a Python script that happens to define an
 Airflow DAG object. Let's start by importing the libraries we will need.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :start-after: [START import_module]
-    :end-before: [END import_module]
+   :language: python
+   :start-after: [START import_module]
+   :end-before: [END import_module]
 
 
 See :doc:`modules_management` for details on how Python and Airflow manage modules.
@@ -76,10 +76,10 @@ explicitly pass a set of arguments to each task's constructor
 of default parameters that we can use when creating tasks.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :dedent: 4
-    :start-after: [START default_args]
-    :end-before: [END default_args]
+   :language: python
+   :dedent: 4
+   :start-after: [START default_args]
+   :end-before: [END default_args]
 
 For more information about the BaseOperator's parameters and what they do,
 refer to the :py:class:`airflow.models.BaseOperator` documentation.
@@ -98,21 +98,38 @@ We also pass the default argument dictionary that we just defined and
 define a ``schedule_interval`` of 1 day for the DAG.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :start-after: [START instantiate_dag]
-    :end-before: [END instantiate_dag]
+   :language: python
+   :start-after: [START instantiate_dag]
+   :end-before: [END instantiate_dag]
+
+Operators
+---------
+
+An operator defines a unit of work for Airflow to complete. They are the most basic building blocks of DAGs.
+
+All operators inherit from the BaseOperator, which includes all of the required arguments for
+running work in Airflow. From here, each operator includes unique arguments for
+the type of work it's completing. Some of the most popular operators are the PythonOperator, the BashOperator, and the
+KubernetesPodOperator.
+
+Airflow completes work based on the arguments you pass to your operators. In this tutorial, we
+use the BashOperator to run a few bash scripts.
 
 Tasks
 -----
-Tasks are generated when instantiating operator objects. An object
-instantiated from an operator is called a task. The first argument
-``task_id`` acts as a unique identifier for the task.
+
+To use an operator in a DAG, you have to instantiate it as a task. Tasks
+determine how to execute your operators' work within the context of a DAG.
+
+In the following example, we instantiate the BashOperator as two separate tasks in order to run two
+separate bash scripts. The first argument for each instantiation, ``task_id``,
+acts as a unique identifier for the task.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :dedent: 4
-    :start-after: [START basic_task]
-    :end-before: [END basic_task]
+   :language: python
+   :dedent: 4
+   :start-after: [START basic_task]
+   :end-before: [END basic_task]
 
 Notice how we pass a mix of operator specific arguments (``bash_command``) and
 an argument common to all operators (``retries``) inherited
@@ -145,10 +162,10 @@ point to the most common template variable: ``{{ ds }}`` (today's "date
 stamp").
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :dedent: 4
-    :start-after: [START jinja_template]
-    :end-before: [END jinja_template]
+   :language: python
+   :dedent: 4
+   :start-after: [START jinja_template]
+   :end-before: [END jinja_template]
 
 Notice that the ``templated_command`` contains code logic in ``{% %}`` blocks,
 references parameters like ``{{ ds }}``, and calls a function as in
@@ -185,10 +202,10 @@ of the DAG file (recommended), or anywhere else in the file. Below you can find 
 on how to implement task and DAG docs, as well as screenshots:
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :dedent: 4
-    :start-after: [START documentation]
-    :end-before: [END documentation]
+   :language: python
+   :dedent: 4
+   :start-after: [START documentation]
+   :end-before: [END documentation]
 
 .. image:: img/task_doc.png
 .. image:: img/dag_doc.png
@@ -200,31 +217,31 @@ you can define dependencies between them:
 
 .. code-block:: python
 
-    t1.set_downstream(t2)
+   t1.set_downstream(t2)
 
-    # This means that t2 will depend on t1
-    # running successfully to run.
-    # It is equivalent to:
-    t2.set_upstream(t1)
+   # This means that t2 will depend on t1
+   # running successfully to run.
+   # It is equivalent to:
+   t2.set_upstream(t1)
 
-    # The bit shift operator can also be
-    # used to chain operations:
-    t1 >> t2
+   # The bit shift operator can also be
+   # used to chain operations:
+   t1 >> t2
 
-    # And the upstream dependency with the
-    # bit shift operator:
-    t2 << t1
+   # And the upstream dependency with the
+   # bit shift operator:
+   t2 << t1
 
-    # Chaining multiple dependencies becomes
-    # concise with the bit shift operator:
-    t1 >> t2 >> t3
+   # Chaining multiple dependencies becomes
+   # concise with the bit shift operator:
+   t1 >> t2 >> t3
 
-    # A list of tasks can also be set as
-    # dependencies. These operations
-    # all have the same effect:
-    t1.set_downstream([t2, t3])
-    t1 >> [t2, t3]
-    [t2, t3] << t1
+   # A list of tasks can also be set as
+   # dependencies. These operations
+   # all have the same effect:
+   t1.set_downstream([t2, t3])
+   t1 >> [t2, t3]
+   [t2, t3] << t1
 
 Note that when executing your script, Airflow will raise exceptions when
 it finds cycles in your DAG or when a dependency is referenced more
@@ -244,9 +261,9 @@ Alright, so we have a pretty basic DAG. At this point your code should look
 something like this:
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial.py
-    :language: python
-    :start-after: [START tutorial]
-    :end-before: [END tutorial]
+   :language: python
+   :start-after: [START tutorial]
+   :end-before: [END tutorial]
 
 .. _testing:
 
@@ -265,7 +282,7 @@ The default location for your DAGs is ``~/airflow/dags``.
 
 .. code-block:: bash
 
-    python ~/airflow/dags/tutorial.py
+   python ~/airflow/dags/tutorial.py
 
 If the script does not raise an exception it means that you have not done
 anything horribly wrong, and that your Airflow environment is somewhat
@@ -277,17 +294,17 @@ Let's run a few commands to validate this script further.
 
 .. code-block:: bash
 
-    # initialize the database tables
-    airflow db init
+   # initialize the database tables
+   airflow db init
 
-    # print the list of active DAGs
-    airflow dags list
+   # print the list of active DAGs
+   airflow dags list
 
-    # prints the list of tasks in the "tutorial" DAG
-    airflow tasks list tutorial
+   # prints the list of tasks in the "tutorial" DAG
+   airflow tasks list tutorial
 
-    # prints the hierarchy of tasks in the "tutorial" DAG
-    airflow tasks list tutorial --tree
+   # prints the hierarchy of tasks in the "tutorial" DAG
+   airflow tasks list tutorial --tree
 
 
 Testing
@@ -306,21 +323,21 @@ its data interval.
 
 .. code-block:: bash
 
-    # command layout: command subcommand dag_id task_id date
+   # command layout: command subcommand dag_id task_id date
 
-    # testing print_date
-    airflow tasks test tutorial print_date 2015-06-01
+   # testing print_date
+   airflow tasks test tutorial print_date 2015-06-01
 
-    # testing sleep
-    airflow tasks test tutorial sleep 2015-06-01
+   # testing sleep
+   airflow tasks test tutorial sleep 2015-06-01
 
 Now remember what we did with templating earlier? See how this template
 gets rendered and executed by running this command:
 
 .. code-block:: bash
 
-    # testing templated
-    airflow tasks test tutorial templated 2015-06-01
+   # testing templated
+   airflow tasks test tutorial templated 2015-06-01
 
 This should result in displaying a verbose log of events and ultimately
 running your bash command and printing the result.
@@ -361,13 +378,13 @@ which are used to populate the run schedule with task instances from this dag.
 
 .. code-block:: bash
 
-    # optional, start a web server in debug mode in the background
-    # airflow webserver --debug &
+   # optional, start a web server in debug mode in the background
+   # airflow webserver --debug &
 
-    # start your backfill on a date range
-    airflow dags backfill tutorial \
-        --start-date 2015-06-01 \
-        --end-date 2015-06-07
+   # start your backfill on a date range
+   airflow dags backfill tutorial \
+       --start-date 2015-06-01 \
+       --end-date 2015-06-07
 
 
 Pipeline Example
@@ -382,18 +399,18 @@ The steps below should be sufficient, but see the quick-start documentation for 
 
 .. code-block:: bash
 
-  # Download the docker-compose.yaml file
-  curl -Lf0 'https://airflow.apache.org/docs/apache-airflow/stable/docker-compose.yaml'
+ # Download the docker-compose.yaml file
+ curl -Lf0 'https://airflow.apache.org/docs/apache-airflow/stable/docker-compose.yaml'
 
-  # Make expected directories and set an expected environment variable
-  mkdir -p ./dags ./logs ./plugins
-  echo -e "AIRFLOW_UID=$(id -u)" > .env
+ # Make expected directories and set an expected environment variable
+ mkdir -p ./dags ./logs ./plugins
+ echo -e "AIRFLOW_UID=$(id -u)" > .env
 
-  # Initialize the database
-  docker-compose up airflow-init
+ # Initialize the database
+ docker-compose up airflow-init
 
-  # Start up all services
-  docker-compose up
+ # Start up all services
+ docker-compose up
 
 After all services have started up, the web UI will be available at: ``http://localhost:8080``. The default account has the username ``airflow`` and the password ``airflow``.
 
@@ -420,34 +437,34 @@ We'll create one table to facilitate data cleaning steps (``employees_temp``) an
 
 .. code-block:: python
 
-  from airflow.providers.postgres.operators.postgres import PostgresOperator
+ from airflow.providers.postgres.operators.postgres import PostgresOperator
 
-  create_employees_table = PostgresOperator(
-      task_id="create_employees_table",
-      postgres_conn_id="tutorial_pg_conn",
-      sql="""
-          CREATE TABLE IF NOT EXISTS employees (
-              "Serial Number" NUMERIC PRIMARY KEY,
-              "Company Name" TEXT,
-              "Employee Markme" TEXT,
-              "Description" TEXT,
-              "Leave" INTEGER
-          );""",
-  )
+ create_employees_table = PostgresOperator(
+     task_id="create_employees_table",
+     postgres_conn_id="tutorial_pg_conn",
+     sql="""
+         CREATE TABLE IF NOT EXISTS employees (
+             "Serial Number" NUMERIC PRIMARY KEY,
+             "Company Name" TEXT,
+             "Employee Markme" TEXT,
+             "Description" TEXT,
+             "Leave" INTEGER
+         );""",
+ )
 
-  create_employees_temp_table = PostgresOperator(
-      task_id="create_employees_temp_table",
-      postgres_conn_id="tutorial_pg_conn",
-      sql="""
-          DROP TABLE IF EXISTS employees_temp;
-          CREATE TABLE employees_temp (
-              "Serial Number" NUMERIC PRIMARY KEY,
-              "Company Name" TEXT,
-              "Employee Markme" TEXT,
-              "Description" TEXT,
-              "Leave" INTEGER
-          );""",
-  )
+ create_employees_temp_table = PostgresOperator(
+     task_id="create_employees_temp_table",
+     postgres_conn_id="tutorial_pg_conn",
+     sql="""
+         DROP TABLE IF EXISTS employees_temp;
+         CREATE TABLE employees_temp (
+             "Serial Number" NUMERIC PRIMARY KEY,
+             "Company Name" TEXT,
+             "Employee Markme" TEXT,
+             "Description" TEXT,
+             "Leave" INTEGER
+         );""",
+ )
 
 Optional Note:
 """"""""""""""
@@ -455,11 +472,11 @@ If you want to abstract these sql statements out of your DAG, you can move the s
 
 .. code-block:: python
 
-  create_employees_table = PostgresOperator(
-      task_id="create_employees_table",
-      postgres_conn_id="tutorial_pg_conn",
-      sql="sql/employees_schema.sql",
-  )
+ create_employees_table = PostgresOperator(
+     task_id="create_employees_table",
+     postgres_conn_id="tutorial_pg_conn",
+     sql="sql/employees_schema.sql",
+ )
 
 and repeat for the ``employees_temp`` table.
 
@@ -470,34 +487,34 @@ Here we retrieve data, save it to a file on our Airflow instance, and load the d
 
 .. code-block:: python
 
-  import os
-  import requests
-  from airflow.decorators import task
-  from airflow.providers.postgres.hooks.postgres import PostgresHook
+ import os
+ import requests
+ from airflow.decorators import task
+ from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
-  @task
-  def get_data():
-      # NOTE: configure this as appropriate for your airflow environment
-      data_path = "/opt/airflow/dags/files/employees.csv"
-      os.makedirs(os.path.dirname(data_path), exist_ok=True)
+ @task
+ def get_data():
+     # NOTE: configure this as appropriate for your airflow environment
+     data_path = "/opt/airflow/dags/files/employees.csv"
+     os.makedirs(os.path.dirname(data_path), exist_ok=True)
 
-      url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
+     url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
 
-      response = requests.request("GET", url)
+     response = requests.request("GET", url)
 
-      with open(data_path, "w") as file:
-          file.write(response.text)
+     with open(data_path, "w") as file:
+         file.write(response.text)
 
-      postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-      conn = postgres_hook.get_conn()
-      cur = conn.cursor()
-      with open(data_path, "r") as file:
-          cur.copy_expert(
-              "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
-              file,
-          )
-      conn.commit()
+     postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+     conn = postgres_hook.get_conn()
+     cur = conn.cursor()
+     with open(data_path, "r") as file:
+         cur.copy_expert(
+             "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
+             file,
+         )
+     conn.commit()
 
 Data Merge Task
 ~~~~~~~~~~~~~~~
@@ -506,31 +523,31 @@ Here we select completely unique records from the retrieved data, then we check 
 
 .. code-block:: python
 
-  from airflow.decorators import task
-  from airflow.providers.postgres.hooks.postgres import PostgresHook
+ from airflow.decorators import task
+ from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
-  @task
-  def merge_data():
-      query = """
-          INSERT INTO employees
-          SELECT *
-          FROM (
-              SELECT DISTINCT *
-              FROM employees_temp
-          )
-          ON CONFLICT ("Serial Number") DO UPDATE
-          SET "Serial Number" = excluded."Serial Number";
-      """
-      try:
-          postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-          conn = postgres_hook.get_conn()
-          cur = conn.cursor()
-          cur.execute(query)
-          conn.commit()
-          return 0
-      except Exception as e:
-          return 1
+ @task
+ def merge_data():
+     query = """
+         INSERT INTO employees
+         SELECT *
+         FROM (
+             SELECT DISTINCT *
+             FROM employees_temp
+         )
+         ON CONFLICT ("Serial Number") DO UPDATE
+         SET "Serial Number" = excluded."Serial Number";
+     """
+     try:
+         postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+         conn = postgres_hook.get_conn()
+         cur = conn.cursor()
+         cur.execute(query)
+         conn.commit()
+         return 0
+     except Exception as e:
+         return 1
 
 
 
@@ -538,7 +555,7 @@ Completing our DAG:
 ~~~~~~~~~~~~~~~~~~~
 We've developed our tasks, now we need to wrap them in a DAG, which enables us to define when and how tasks should run, and state any dependencies that tasks have on other tasks. The DAG below is configured to:
 
-* run every day at midnight starting on Jan 1, 2021,
+* run every day a midnight starting on Jan 1, 2021,
 * only run once in the event that days are missed, and
 * timeout after 60 minutes
 
@@ -546,7 +563,7 @@ And from the last line in the definition of the ``Etl`` DAG, we see:
 
 .. code-block:: python
 
-      [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+     [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
 
 * the ``merge_data()`` task depends on the ``get_data()`` task,
 * the ``get_data()`` depends on both the ``create_employees_table`` and ``create_employees_temp_table`` tasks, and
@@ -556,99 +573,99 @@ Putting all of the pieces together, we have our completed DAG.
 
 .. code-block:: python
 
-  import datetime
-  import pendulum
-  import os
+ import datetime
+ import pendulum
+ import os
 
-  import requests
-  from airflow.decorators import dag, task
-  from airflow.providers.postgres.hooks.postgres import PostgresHook
-  from airflow.providers.postgres.operators.postgres import PostgresOperator
-
-
-  @dag(
-      schedule_interval="0 0 * * *",
-      start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
-      catchup=False,
-      dagrun_timeout=datetime.timedelta(minutes=60),
-  )
-  def Etl():
-      create_employees_table = PostgresOperator(
-          task_id="create_employees_table",
-          postgres_conn_id="tutorial_pg_conn",
-          sql="""
-              CREATE TABLE IF NOT EXISTS employees (
-                  "Serial Number" NUMERIC PRIMARY KEY,
-                  "Company Name" TEXT,
-                  "Employee Markme" TEXT,
-                  "Description" TEXT,
-                  "Leave" INTEGER
-              );""",
-      )
-
-      create_employees_temp_table = PostgresOperator(
-          task_id="create_employees_temp_table",
-          postgres_conn_id="tutorial_pg_conn",
-          sql="""
-              DROP TABLE IF EXISTS employees_temp;
-              CREATE TABLE employees_temp (
-                  "Serial Number" NUMERIC PRIMARY KEY,
-                  "Company Name" TEXT,
-                  "Employee Markme" TEXT,
-                  "Description" TEXT,
-                  "Leave" INTEGER
-              );""",
-      )
-
-      @task
-      def get_data():
-          # NOTE: configure this as appropriate for your airflow environment
-          data_path = "/opt/airflow/dags/files/employees.csv"
-          os.makedirs(os.path.dirname(data_path), exist_ok=True)
-
-          url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
-
-          response = requests.request("GET", url)
-
-          with open(data_path, "w") as file:
-              file.write(response.text)
-
-          postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-          conn = postgres_hook.get_conn()
-          cur = conn.cursor()
-          with open(data_path, "r") as file:
-              cur.copy_expert(
-                  "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
-                  file,
-              )
-          conn.commit()
-
-      @task
-      def merge_data():
-          query = """
-              INSERT INTO employees
-              SELECT *
-              FROM (
-                  SELECT DISTINCT *
-                  FROM employees_temp
-              )
-              ON CONFLICT ("Serial Number") DO UPDATE
-              SET "Serial Number" = excluded."Serial Number";
-          """
-          try:
-              postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
-              conn = postgres_hook.get_conn()
-              cur = conn.cursor()
-              cur.execute(query)
-              conn.commit()
-              return 0
-          except Exception as e:
-              return 1
-
-      [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+ import requests
+ from airflow.decorators import dag, task
+ from airflow.providers.postgres.hooks.postgres import PostgresHook
+ from airflow.providers.postgres.operators.postgres import PostgresOperator
 
 
-  dag = Etl()
+ @dag(
+     schedule_interval="0 0 * * *",
+     start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+     catchup=False,
+     dagrun_timeout=datetime.timedelta(minutes=60),
+ )
+ def Etl():
+     create_employees_table = PostgresOperator(
+         task_id="create_employees_table",
+         postgres_conn_id="tutorial_pg_conn",
+         sql="""
+             CREATE TABLE IF NOT EXISTS employees (
+                 "Serial Number" NUMERIC PRIMARY KEY,
+                 "Company Name" TEXT,
+                 "Employee Markme" TEXT,
+                 "Description" TEXT,
+                 "Leave" INTEGER
+             );""",
+     )
+
+     create_employees_temp_table = PostgresOperator(
+         task_id="create_employees_temp_table",
+         postgres_conn_id="tutorial_pg_conn",
+         sql="""
+             DROP TABLE IF EXISTS employees_temp;
+             CREATE TABLE employees_temp (
+                 "Serial Number" NUMERIC PRIMARY KEY,
+                 "Company Name" TEXT,
+                 "Employee Markme" TEXT,
+                 "Description" TEXT,
+                 "Leave" INTEGER
+             );""",
+     )
+
+     @task
+     def get_data():
+         # NOTE: configure this as appropriate for your airflow environment
+         data_path = "/opt/airflow/dags/files/employees.csv"
+         os.makedirs(os.path.dirname(data_path), exist_ok=True)
+
+         url = "https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/pipeline_example.csv"
+
+         response = requests.request("GET", url)
+
+         with open(data_path, "w") as file:
+             file.write(response.text)
+
+         postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+         conn = postgres_hook.get_conn()
+         cur = conn.cursor()
+         with open(data_path, "r") as file:
+             cur.copy_expert(
+                 "COPY employees_temp FROM STDIN WITH CSV HEADER DELIMITER AS ',' QUOTE '\"'",
+                 file,
+             )
+         conn.commit()
+
+     @task
+     def merge_data():
+         query = """
+             INSERT INTO employees
+             SELECT *
+             FROM (
+                 SELECT DISTINCT *
+                 FROM employees_temp
+             )
+             ON CONFLICT ("Serial Number") DO UPDATE
+             SET "Serial Number" = excluded."Serial Number";
+         """
+         try:
+             postgres_hook = PostgresHook(postgres_conn_id="tutorial_pg_conn")
+             conn = postgres_hook.get_conn()
+             cur = conn.cursor()
+             cur.execute(query)
+             conn.commit()
+             return 0
+         except Exception as e:
+             return 1
+
+     [create_employees_table, create_employees_temp_table] >> get_data() >> merge_data()
+
+
+ dag = Etl()
 
 Save this code to a python file in the ``/dags`` folder (e.g. ``dags/etl.py``) and (after a `brief delay <https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#dag-dir-list-interval>`_), the ``Etl`` DAG will be included in the list of available DAGs on the web UI.
 
@@ -670,12 +687,12 @@ running against it should get it to get triggered and run every day.
 Here's a few things you might want to do next:
 
 .. seealso::
-    - Read the :doc:`/concepts/index` section for detailed explanation of Airflow concepts such as DAGs, Tasks, Operators, and more.
-    - Take an in-depth tour of the UI - click all the things!
-    - Keep reading the docs!
+   - Read the :doc:`/concepts/index` section for detailed explanation of Airflow concepts such as DAGs, Tasks, Operators, and more.
+   - Take an in-depth tour of the UI - click all the things!
+   - Keep reading the docs!
 
-      - Review the :doc:`how-to guides<howto/index>`, which include a guide to writing your own operator
-      - Review the :ref:`Command Line Interface Reference<cli>`
-      - Review the :ref:`List of operators <pythonapi:operators>`
-      - Review the :ref:`Macros reference<macros>`
-    - Write your first pipeline!
+     - Review the :doc:`how-to guides<howto/index>`, which include a guide to writing your own operator
+     - Review the :ref:`Command Line Interface Reference<cli>`
+     - Review the :ref:`List of operators <pythonapi:operators>`
+     - Review the :ref:`Macros reference<macros>`
+   - Write your first pipeline!


### PR DESCRIPTION
The basic [Tutorial](http://localhost:8000/docs/apache-airflow/latest/tutorial.html#operators) in docs introduces tasks without first introducing the concept of operators. I tried to document a basic definition of operators for this tutorial, and I updated the definition of tasks to more clearly relate to operators.