### PR TITLE
Show 'Dataset' as schedule interval for dataset-triggered dags

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2495,11 +2495,15 @@ class DAG(LoggingMixin):
             orm_dag.last_parsed_time = timezone.utcnow()
             orm_dag.default_view = dag.default_view
             orm_dag.description = dag.description
-            orm_dag.schedule_interval = dag.schedule_interval
             orm_dag.max_active_tasks = dag.max_active_tasks
             orm_dag.max_active_runs = dag.max_active_runs
             orm_dag.has_task_concurrency_limits = any(t.max_active_tis_per_dag is not None for t in dag.tasks)
-            orm_dag.timetable_description = dag.timetable.description
+            if dag.schedule_on:
+                orm_dag.schedule_interval = 'dataset-triggered'
+                orm_dag.timetable_description = 'Triggered by datasets.'
+            else:
+                orm_dag.schedule_interval = dag.schedule_interval
+                orm_dag.timetable_description = dag.timetable.description
 
             run: Optional[DagRun] = most_recent_runs.get(dag.dag_id)
             if run is None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -78,7 +78,7 @@ from airflow.security import permissions
 from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
-from airflow.timetables.simple import NullTimetable, OnceTimetable, _DatasetTimetable
+from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.typing_compat import Literal
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
@@ -433,7 +433,7 @@ class DAG(LoggingMixin):
             if not isinstance(schedule_on, Sequence):
                 raise ValueError("Param `schedule_on` must be Sequence[Dataset]")
             self.schedule_interval = None
-            self.timetable = _DatasetTimetable()
+            self.timetable = NullTimetable()
         elif timetable:
             self.timetable = timetable
             self.schedule_interval = self.timetable.summary
@@ -2498,8 +2498,12 @@ class DAG(LoggingMixin):
             orm_dag.max_active_tasks = dag.max_active_tasks
             orm_dag.max_active_runs = dag.max_active_runs
             orm_dag.has_task_concurrency_limits = any(t.max_active_tis_per_dag is not None for t in dag.tasks)
-            orm_dag.schedule_interval = dag.timetable.summary
-            orm_dag.timetable_description = dag.timetable.description
+            if dag.schedule_on:
+                orm_dag.schedule_interval = 'dataset-triggered'
+                orm_dag.timetable_description = 'Triggered by datasets.'
+            else:
+                orm_dag.schedule_interval = dag.schedule_interval
+                orm_dag.timetable_description = dag.timetable.description
 
             run: Optional[DagRun] = most_recent_runs.get(dag.dag_id)
             if run is None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2499,7 +2499,7 @@ class DAG(LoggingMixin):
             orm_dag.max_active_runs = dag.max_active_runs
             orm_dag.has_task_concurrency_limits = any(t.max_active_tis_per_dag is not None for t in dag.tasks)
             if dag.schedule_on:
-                orm_dag.schedule_interval = 'dataset-triggered'
+                orm_dag.schedule_interval = 'Dataset'
                 orm_dag.timetable_description = 'Triggered by datasets.'
             else:
                 orm_dag.schedule_interval = dag.schedule_interval

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2498,7 +2498,7 @@ class DAG(LoggingMixin):
             orm_dag.max_active_tasks = dag.max_active_tasks
             orm_dag.max_active_runs = dag.max_active_runs
             orm_dag.has_task_concurrency_limits = any(t.max_active_tis_per_dag is not None for t in dag.tasks)
-            orm_dag.schedule_interval = dag.timetable.schedule_interval
+            orm_dag.schedule_interval = dag.timetable.summary
             orm_dag.timetable_description = dag.timetable.description
 
             run: Optional[DagRun] = most_recent_runs.get(dag.dag_id)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -78,7 +78,7 @@ from airflow.security import permissions
 from airflow.stats import Stats
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
 from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
-from airflow.timetables.simple import NullTimetable, OnceTimetable
+from airflow.timetables.simple import NullTimetable, OnceTimetable, _DatasetTimetable
 from airflow.typing_compat import Literal
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
@@ -433,7 +433,7 @@ class DAG(LoggingMixin):
             if not isinstance(schedule_on, Sequence):
                 raise ValueError("Param `schedule_on` must be Sequence[Dataset]")
             self.schedule_interval = None
-            self.timetable = NullTimetable()
+            self.timetable = _DatasetTimetable()
         elif timetable:
             self.timetable = timetable
             self.schedule_interval = self.timetable.summary
@@ -2498,12 +2498,8 @@ class DAG(LoggingMixin):
             orm_dag.max_active_tasks = dag.max_active_tasks
             orm_dag.max_active_runs = dag.max_active_runs
             orm_dag.has_task_concurrency_limits = any(t.max_active_tis_per_dag is not None for t in dag.tasks)
-            if dag.schedule_on:
-                orm_dag.schedule_interval = 'dataset-triggered'
-                orm_dag.timetable_description = 'Triggered by datasets.'
-            else:
-                orm_dag.schedule_interval = dag.schedule_interval
-                orm_dag.timetable_description = dag.timetable.description
+            orm_dag.schedule_interval = dag.timetable.schedule_interval
+            orm_dag.timetable_description = dag.timetable.description
 
             run: Optional[DagRun] = most_recent_runs.get(dag.dag_id)
             if run is None:

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -69,16 +69,6 @@ class NullTimetable(_TrivialTimetable):
         return None
 
 
-class _DatasetTimetable(NullTimetable):
-    """Timetable that never schedules anything.  Used for dataset-triggered dags."""
-
-    description: str = "Triggered by datasets"
-
-    @property
-    def summary(self) -> str:
-        return "dataset"
-
-
 class OnceTimetable(_TrivialTimetable):
     """Timetable that schedules the execution once as soon as possible.
 

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -69,6 +69,16 @@ class NullTimetable(_TrivialTimetable):
         return None
 
 
+class _DatasetTimetable(NullTimetable):
+    """Timetable that never schedules anything.  Used for dataset-triggered dags."""
+
+    description: str = "Triggered by datasets"
+
+    @property
+    def summary(self) -> str:
+        return "dataset"
+
+
 class OnceTimetable(_TrivialTimetable):
     """Timetable that schedules the execution once as soon as possible.
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -123,12 +123,12 @@
         {{ state_token }}
       {% endif %}
       <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-        Schedule: {{ dag.schedule_interval }}
+        Schedule: {{ dag_model.schedule_interval }}
       </a>
       {% if dag_model is defined and dag_model and dag_model.timetable_description %}
           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Schedule: {{ dag_model.timetable_description|string }}">info</span>
       {% endif %}
-      {% if dag_model is defined and dag_model.next_dagrun is defined %}
+      {% if dag_model is defined and dag_model.next_dagrun is defined and dag_model.schedule_interval != 'dataset-triggered' %}
         <p class="label label-default js-tooltip" style="margin-left: 5px" id="next-run" data-html="true" data-placement="bottom">
           Next Run: <time datetime="{{ dag_model.next_dagrun }}">{{ dag_model.next_dagrun }}</time>
         </p>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -123,7 +123,7 @@
         {{ state_token }}
       {% endif %}
       <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-        Schedule: {{ dag_model is defined and dag_model.schedule_interval or None }}
+        Schedule: {{ dag_model is defined and dag_model and dag_model.schedule_interval }}
       </a>
       {% if dag_model is defined and dag_model and dag_model.timetable_description %}
           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Schedule: {{ dag_model.timetable_description|string }}">info</span>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -123,7 +123,7 @@
         {{ state_token }}
       {% endif %}
       <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-        Schedule: {{ dag_model.schedule_interval }}
+        Schedule: {{ dag_model is defined and dag_model.schedule_interval or None }}
       </a>
       {% if dag_model is defined and dag_model and dag_model.timetable_description %}
           <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Schedule: {{ dag_model.timetable_description|string }}">info</span>


### PR DESCRIPTION
In the DAGs page, in place of schedule interval, show `dataset-triggered` to indicate there is no "schedule interval" per se but this is what will determine the next run.  Update tooltip also (derived from dag_model.timetable_description).

And, in the dag detail page, I just suppress the `next run` text entirely because it's not possible to say.  Later we can put something about deps fulfillment information there.

Note to self / @bbovenzi / @jedcunningham.... it occurs to me that we may have some capability of providing an _estimated_ next run time, based on when we think the upstream datasets will be updated (based on when the tasks that update them are estimated to run).

This is a quick and easy improvement.  In subsequent PR will work on getting information about dataset deps fulfillment.

We might want to rename the attrs on the dag model to be more general.  But leaning towards deferring that.

dags view:
![image](https://user-images.githubusercontent.com/15932138/178634871-67e29410-389d-4840-bfc0-a92a9d88eed0.png)

dag view:
![image](https://user-images.githubusercontent.com/15932138/178634884-159a4411-0e3d-45ed-b831-512e81d1802f.png)




cc @blag
