### PR TITLE
Add `test_connection` method to AzureCosmosDBHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -320,6 +320,25 @@ class AzureCosmosDBHook(BaseHook):
         except CosmosHttpResponseError:
             return None
 
+    def test_connection(self):
+        """Test a configured Azure Cosmos connection."""
+        success = (True, "Successfully connected to Azure Cosmos.")
+        try:
+            # Attempt to list existing databases under the configured subscription and retrieve the first in
+            # the returned iterator. The Azure Cosmos API does allow for creation of a
+            # CosmosClient with incorrect values but then will fail properly once items are
+            # retrieved using the client. We need to _actually_ try to retrieve an object to properly test the
+            # connection.
+            next(iter(self.get_conn().list_databases()))
+            return success
+        except StopIteration:
+            # If the iterator returned is empty it should still be considered a successful connection since
+            # it's possible to create a Cosmos connection via the ``AzureCosmosDBHook`` and no database could
+            # legitimately exist yet.
+            return success
+        except Exception as e:
+            return False, str(e)
+
 
 def get_database_link(database_id: str) -> str:
     """Get Azure CosmosDB database link"""

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -322,22 +322,16 @@ class AzureCosmosDBHook(BaseHook):
 
     def test_connection(self):
         """Test a configured Azure Cosmos connection."""
-        success = (True, "Successfully connected to Azure Cosmos.")
         try:
             # Attempt to list existing databases under the configured subscription and retrieve the first in
             # the returned iterator. The Azure Cosmos API does allow for creation of a
             # CosmosClient with incorrect values but then will fail properly once items are
             # retrieved using the client. We need to _actually_ try to retrieve an object to properly test the
             # connection.
-            next(iter(self.get_conn().list_databases()))
-            return success
-        except StopIteration:
-            # If the iterator returned is empty it should still be considered a successful connection since
-            # it's possible to create a Cosmos connection via the ``AzureCosmosDBHook`` and no database could
-            # legitimately exist yet.
-            return success
+            next(iter(self.get_conn().list_databases()), None)
         except Exception as e:
             return False, str(e)
+        return True, "Successfully connected to Azure Cosmos."
 
 
 def get_database_link(database_id: str) -> str:

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -23,6 +23,7 @@ import logging
 import unittest
 import uuid
 from unittest import mock
+from unittest.mock import PropertyMock
 
 import pytest
 from azure.cosmos.cosmos_client import CosmosClient
@@ -234,3 +235,19 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         ]
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.cosmos.CosmosClient')
+    def test_connection_success(self, mock_cosmos):
+        hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        hook.get_conn().list_databases.return_value = {'id': self.test_database_name}
+        status, msg = hook.test_connection()
+        assert status is True
+        assert msg == "Successfully connected to Azure Cosmos."
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.cosmos.CosmosClient')
+    def test_connection_failure(self, mock_cosmos):
+        hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
+        hook.get_conn().list_databases = PropertyMock(side_effect=Exception("Authentication failed."))
+        status, msg = hook.test_connection()
+        assert status is False
+        assert msg == "Authentication failed."


### PR DESCRIPTION
This PR enables the Test Connection button on the airflow UI for the connection type Azure CosmosDB.

cc @kaxil 

<img width="1020" alt="Screenshot 2022-07-13 at 11 27 15 AM" src="https://user-images.githubusercontent.com/94376113/178697991-2a381574-d1b3-4b20-9be3-b812047b66d6.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
