### PR TITLE
fix: change disable_verify_ssl behaviour

### DIFF
--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -30,7 +30,7 @@ try:
     has_kubernetes = True
 
     def _disable_verify_ssl() -> None:
-        configuration = Configuration()
+        configuration = Configuration.get_default_copy()
         configuration.verify_ssl = False
         Configuration.set_default(configuration)
 
@@ -100,9 +100,6 @@ def get_kube_client(
     if conf.getboolean('kubernetes', 'enable_tcp_keepalive'):
         _enable_tcp_keepalive()
 
-    if not conf.getboolean('kubernetes', 'verify_ssl'):
-        _disable_verify_ssl()
-
     if in_cluster:
         config.load_incluster_config()
     else:
@@ -111,5 +108,8 @@ def get_kube_client(
         if config_file is None:
             config_file = conf.get('kubernetes', 'config_file', fallback=None)
         config.load_kube_config(config_file=config_file, context=cluster_context)
+
+    if not conf.getboolean('kubernetes', 'verify_ssl'):
+        _disable_verify_ssl()
 
     return client.CoreV1Api()

--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -30,7 +30,10 @@ try:
     has_kubernetes = True
 
     def _disable_verify_ssl() -> None:
-        configuration = Configuration.get_default_copy()
+        if hasattr(Configuration, 'get_default_copy'):
+            configuration = Configuration.get_default_copy()
+        else:
+            configuration = Configuration()
         configuration.verify_ssl = False
         Configuration.set_default(configuration)
 

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -38,6 +38,19 @@ class TestClient(unittest.TestCase):
         assert config.load_incluster_config.not_called
         assert config.load_kube_config.called
 
+    @mock.patch('airflow.kubernetes.kube_client.config')
+    @mock.patch('airflow.kubernetes.kube_client.conf')
+    def test_load_config_disable_ssl(self, conf, config):
+        conf.getboolean.return_value = False
+        get_kube_client(in_cluster=False)
+        conf.getboolean.assert_called_with('kubernetes', 'verify_ssl')
+        # Support wide range of kube client libraries
+        if hasattr(Configuration, 'get_default_copy'):
+            configuration = Configuration.get_default_copy()
+        else:
+            configuration = Configuration()
+        self.assertFalse(configuration.verify_ssl)
+
     def test_enable_tcp_keepalive(self):
         socket_options = [
             (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),


### PR DESCRIPTION
The problem is that verify_ssl is overwritten by the
configuration from the kube_config or load_incluster_config file.
