### PR TITLE
Implement Azure Service Bus (Update and Receive) Subscription Operator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/asb.py
+++ b/airflow/providers/microsoft/azure/operators/asb.py
@@ -314,6 +314,122 @@ class AzureServiceBusSubscriptionCreateOperator(BaseOperator):
             self.log.info("Created subscription %s", subscription.name)
 
 
+class AzureServiceBusUpdateSubscriptionOperator(BaseOperator):
+    """
+    Update an Azure ServiceBus Topic Subscription under a ServiceBus Namespace
+    by using ServiceBusAdministrationClient
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:AzureServiceBusUpdateSubscriptionOperator`
+
+    :param topic_name: The topic that will own the to-be-created subscription.
+    :param subscription_name: Name of the subscription that need to be created.
+    :param max_delivery_count: The maximum delivery count. A message is automatically dead lettered
+        after this number of deliveries. Default value is 10.
+    :param dead_lettering_on_message_expiration: A value that indicates whether this subscription
+        has dead letter support when a message expires.
+    :param enable_batched_operations: Value that indicates whether server-side batched
+        operations are enabled.
+    :param azure_service_bus_conn_id: Reference to the
+        :ref:`Azure Service Bus connection<howto/connection:azure_service_bus>`.
+    """
+
+    template_fields: Sequence[str] = ("topic_name", "subscription_name")
+    ui_color = "#e4f0e8"
+
+    def __init__(
+        self,
+        *,
+        topic_name: str,
+        subscription_name: str,
+        max_delivery_count: Optional[int] = None,
+        dead_lettering_on_message_expiration: Optional[bool] = None,
+        enable_batched_operations: Optional[bool] = None,
+        azure_service_bus_conn_id: str = 'azure_service_bus_default',
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.topic_name = topic_name
+        self.subscription_name = subscription_name
+        self.max_delivery_count = max_delivery_count
+        self.dl_on_message_expiration = dead_lettering_on_message_expiration
+        self.enable_batched_operations = enable_batched_operations
+        self.azure_service_bus_conn_id = azure_service_bus_conn_id
+
+    def execute(self, context: "Context") -> None:
+        """Updates Subscription properties, by connecting to Service Bus Admin client"""
+        hook = AdminClientHook(azure_service_bus_conn_id=self.azure_service_bus_conn_id)
+
+        with hook.get_conn() as service_mgmt_conn:
+            subscription_prop = service_mgmt_conn.get_subscription(self.topic_name, self.subscription_name)
+            if self.max_delivery_count:
+                subscription_prop.max_delivery_count = self.max_delivery_count
+            if self.dl_on_message_expiration is not None:
+                subscription_prop.dead_lettering_on_message_expiration = self.dl_on_message_expiration
+            if self.enable_batched_operations is not None:
+                subscription_prop.enable_batched_operations = self.enable_batched_operations
+            # update by updating the properties in the model
+            service_mgmt_conn.update_subscription(self.topic_name, subscription_prop)
+            updated_subscription = service_mgmt_conn.get_subscription(self.topic_name, self.subscription_name)
+            self.log.info("Subscription Updated successfully %s", updated_subscription)
+
+
+class ASBReceiveSubscriptionMessageOperator(BaseOperator):
+    """
+    Receive a Batch messages from a Service Bus Subscription under specific Topic.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:ASBReceiveSubscriptionMessageOperator`
+
+    :param subscription_name: The subscription name that will own the rule in topic
+    :param topic_name: The topic that will own the subscription rule.
+    :param max_message_count: Maximum number of messages in the batch.
+        Actual number returned will depend on prefetch_count and incoming stream rate.
+        Setting to None will fully depend on the prefetch config. The default value is 1.
+    :param max_wait_time: Maximum time to wait in seconds for the first message to arrive. If no
+        messages arrive, and no timeout is specified, this call will not return until the
+        connection is closed. If specified, an no messages arrive within the timeout period,
+        an empty list will be returned.
+    :param azure_service_bus_conn_id: Reference to the
+        :ref:`Azure Service Bus connection <howto/connection:azure_service_bus>`.
+    """
+
+    template_fields: Sequence[str] = ("topic_name", "subscription_name")
+    ui_color = "#e4f0e8"
+
+    def __init__(
+        self,
+        *,
+        topic_name: str,
+        subscription_name: str,
+        max_message_count: Optional[int] = 1,
+        max_wait_time: Optional[float] = 5,
+        azure_service_bus_conn_id: str = 'azure_service_bus_default',
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.topic_name = topic_name
+        self.subscription_name = subscription_name
+        self.max_message_count = max_message_count
+        self.max_wait_time = max_wait_time
+        self.azure_service_bus_conn_id = azure_service_bus_conn_id
+
+    def execute(self, context: "Context") -> None:
+        """
+        Receive Message in specific queue in Service Bus namespace,
+        by connecting to Service Bus client
+        """
+        # Create the hook
+        hook = MessageHook(azure_service_bus_conn_id=self.azure_service_bus_conn_id)
+
+        # Receive message
+        hook.receive_subscription_message(
+            self.topic_name, self.subscription_name, self.max_message_count, self.max_wait_time
+        )
+
+
 class AzureServiceBusSubscriptionDeleteOperator(BaseOperator):
     """
     Deletes the topic subscription in the Azure ServiceBus namespace

--- a/docs/apache-airflow-providers-microsoft-azure/operators/asb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/asb.rst
@@ -119,6 +119,38 @@ Below is an example of using this operator to execute an Azure Service Bus Creat
     :start-after: [START howto_operator_create_service_bus_subscription]
     :end-before: [END howto_operator_create_service_bus_subscription]
 
+.. _howto/operator:AzureServiceBusUpdateSubscriptionOperator:
+
+Update Azure Service Bus Subscription
+======================================
+
+To Update the Azure service bus topic Subscription which is already created, with specific Parameter you can use
+:class:`~airflow.providers.microsoft.azure.operators.asb.AzureServiceBusUpdateSubscriptionOperator`.
+
+Below is an example of using this operator to execute an Azure Service Bus Update Subscription.
+
+.. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_azure_service_bus.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_update_service_bus_subscription]
+    :end-before: [END howto_operator_update_service_bus_subscription]
+
+.. _howto/operator:ASBReceiveSubscriptionMessageOperator:
+
+Receive Azure Service Bus Subscription Message
+===============================================
+
+To Receive a Batch messages from a Service Bus Subscription under specific Topic, you can use
+:class:`~airflow.providers.microsoft.azure.operators.asb.ASBReceiveSubscriptionMessageOperator`.
+
+Below is an example of using this operator to execute an Azure Service Bus Receive Subscription Message.
+
+.. exampleinclude:: /../../tests/system/providers/microsoft/azure/example_azure_service_bus.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_receive_message_service_bus_subscription]
+    :end-before: [END howto_operator_receive_message_service_bus_subscription]
+
 .. _howto/operator:AzureServiceBusSubscriptionDeleteOperator:
 
 Delete Azure Service Bus Subscription

--- a/tests/system/providers/microsoft/azure/example_azure_service_bus.py
+++ b/tests/system/providers/microsoft/azure/example_azure_service_bus.py
@@ -21,12 +21,14 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.providers.microsoft.azure.operators.asb import (
+    ASBReceiveSubscriptionMessageOperator,
     AzureServiceBusCreateQueueOperator,
     AzureServiceBusDeleteQueueOperator,
     AzureServiceBusReceiveMessageOperator,
     AzureServiceBusSendMessageOperator,
     AzureServiceBusSubscriptionCreateOperator,
     AzureServiceBusSubscriptionDeleteOperator,
+    AzureServiceBusUpdateSubscriptionOperator,
 )
 
 EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
@@ -100,6 +102,24 @@ with DAG(
     )
     # [END howto_operator_create_service_bus_subscription]
 
+    # [START howto_operator_update_service_bus_subscription]
+    update_service_bus_subscription = AzureServiceBusUpdateSubscriptionOperator(
+        task_id="update_service_bus_subscription",
+        topic_name=TOPIC_NAME,
+        subscription_name=SUBSCRIPTION_NAME,
+        max_delivery_count=5,
+    )
+    # [END howto_operator_update_service_bus_subscription]
+
+    # [START howto_operator_receive_message_service_bus_subscription]
+    receive_message_service_bus_subscription = ASBReceiveSubscriptionMessageOperator(
+        task_id="receive_message_service_bus_subscription",
+        topic_name=TOPIC_NAME,
+        subscription_name=SUBSCRIPTION_NAME,
+        max_message_count=10,
+    )
+    # [END howto_operator_receive_message_service_bus_subscription]
+
     # [START howto_operator_delete_service_bus_subscription]
     delete_service_bus_subscription = AzureServiceBusSubscriptionDeleteOperator(
         task_id="delete_service_bus_subscription",
@@ -122,6 +142,8 @@ with DAG(
         send_list_message_to_service_bus_queue,
         send_batch_message_to_service_bus_queue,
         receive_message_service_bus_queue,
+        update_service_bus_subscription,
+        receive_message_service_bus_subscription,
         delete_service_bus_subscription,
         delete_service_bus_queue,
     )


### PR DESCRIPTION
- Added AzureServiceBusUpdateSubscriptionOperator to update the subscription properties
- Added ASBReceiveSubscriptionMessageOperator to receive a Batch messages from a Service Bus Subscription under 
   specific Topic.
- Added sample example to update and receive message subscription in Example DAG
- Added unit Test case for operator and hook
- Added Docs