### PR TITLE
Stop failing image refreshing on "warm-up" failure

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -703,11 +703,11 @@ LABEL description="test warmup image"
         dry_run=dry_run,
         cwd=AIRFLOW_SOURCES_ROOT,
         text=True,
+        check=False,
         enabled_output_group=True,
     )
     if warm_up_command_result.returncode != 0:
         get_console().print(
-            f"[error]Error {warm_up_command_result.returncode} when warming up builder:"
+            f"[warning]Warning {warm_up_command_result.returncode} when warming up builder:"
             f" {warm_up_command_result.stdout} {warm_up_command_result.stderr}"
         )
-        sys.exit(warm_up_command_result.returncode)


### PR DESCRIPTION
The "warm-up" buld for parallel images might fail when you run
it locally, but this should be ignored, because it is really only
needed at the CI when we want to make sure that several parallel
builds do not try to create the same buildx container.

It's safe to ignore any failure at the warm-up stage.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
