### PR TITLE
Retrieve airflow branch/constraints from env variables

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -256,6 +256,13 @@ def get_changed_files(commit_ref: Optional[str], dry_run: bool, verbose: bool) -
     show_default=True,
 )
 @click.option(
+    '--default-constraints-branch',
+    help="Constraints Branch against which the PR should be run",
+    default="constraints-main",
+    envvar="DEFAULT_CONSTRAINTS_BRANCH",
+    show_default=True,
+)
+@click.option(
     '--github-event-name',
     type=BetterChoice(github_events()),
     default=github_events()[0],
@@ -269,6 +276,7 @@ def selective_check(
     commit_ref: Optional[str],
     pr_labels: str,
     default_branch: str,
+    default_constraints_branch: str,
     github_event_name: str,
     verbose: bool,
     dry_run: bool,
@@ -284,6 +292,7 @@ def selective_check(
         commit_ref=commit_ref,
         files=changed_files,
         default_branch=default_branch,
+        default_constraints_branch=default_constraints_branch,
         pr_labels=tuple(ast.literal_eval(pr_labels)) if pr_labels else (),
         github_event=github_event,
     )

--- a/dev/breeze/src/airflow_breeze/params/build_ci_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_ci_params.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
@@ -31,8 +32,10 @@ class BuildCiParams(CommonBuildParams):
     """
 
     airflow_constraints_mode: str = "constraints-source-providers"
-    default_constraints_branch: str = DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
-    airflow_constraints_reference: str = DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
+    default_constraints_branch: str = os.environ.get(
+        'DEFAULT_CONSTRAINTS_BRANCH', DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
+    )
+    airflow_constraints_reference: str = ""
     airflow_extras: str = "devel_ci"
     airflow_pre_cached_pip_packages: bool = True
     force_build: bool = False

--- a/dev/breeze/src/airflow_breeze/params/build_prod_params.py
+++ b/dev/breeze/src/airflow_breeze/params/build_prod_params.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -41,7 +42,9 @@ class BuildProdParams(CommonBuildParams):
     """
 
     airflow_constraints_mode: str = "constraints"
-    default_constraints_branch: str = DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
+    default_constraints_branch: str = os.environ.get(
+        'DEFAULT_CONSTRAINTS_BRANCH', DEFAULT_AIRFLOW_CONSTRAINTS_BRANCH
+    )
     airflow_constraints_reference: str = ""
     airflow_is_in_context: bool = False
     cleanup_context: bool = False

--- a/dev/breeze/src/airflow_breeze/params/common_build_params.py
+++ b/dev/breeze/src/airflow_breeze/params/common_build_params.py
@@ -41,13 +41,13 @@ class CommonBuildParams:
     additional_runtime_apt_command: str = ""
     additional_runtime_apt_deps: str = ""
     additional_runtime_apt_env: str = ""
-    airflow_branch: str = AIRFLOW_BRANCH
+    airflow_branch: str = os.environ.get('DEFAULT_BRANCH', AIRFLOW_BRANCH)
     airflow_constraints_location: str = ""
     answer: Optional[str] = None
     build_id: int = 0
     builder: str = "default"
     constraints_github_repository: str = "apache/airflow"
-    debian_version: str = "bullseye"
+    debian_version: str = os.environ.get('DEBIAN_VERSION', "bullseye")
     dev_apt_command: str = ""
     dev_apt_deps: str = ""
     docker_cache: str = "registry"

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -252,12 +252,14 @@ class SelectiveChecks:
         self,
         files: tuple[str, ...] = (),
         default_branch="main",
+        default_constraints_branch="constraints-main",
         commit_ref: str | None = None,
         pr_labels: tuple[str, ...] = (),
         github_event: GithubEvents = GithubEvents.PULL_REQUEST,
     ):
         self._files = files
         self._default_branch = default_branch
+        self._default_constraints_branch = default_constraints_branch
         self._commit_ref = commit_ref
         self._pr_labels = pr_labels
         self._github_event = github_event
@@ -292,6 +294,10 @@ class SelectiveChecks:
     @cached_property
     def default_branch(self) -> str:
         return self._default_branch
+
+    @cached_property
+    def default_constraints_branch(self) -> str:
+        return self._default_constraints_branch
 
     @cached_property
     def _full_tests_needed(self) -> bool:

--- a/images/breeze/output-commands-hash.txt
+++ b/images/breeze/output-commands-hash.txt
@@ -23,7 +23,7 @@ pull-prod-image:6e8467a2b8c833a392c8bdd65189363e
 regenerate-command-images:4fd2e7ecbfd6eebb18b854f3eb0f29c8
 release-prod-images:8858fe5a13989c7c65a79dc97a880928
 resource-check:0fb929ac3496dbbe97acfe99e35accd7
-selective-check:26b994bff3d703c47380a51789726deb
+selective-check:d4e3c250cd6f2b0040fbe6557fa423f6
 self-upgrade:b5437c0a1a91533a11ee9d0a9692369c
 setup-autocomplete:355b72dee171c2fcba46fc90ac7c97b0
 shell:4680295fdd8a276d51518d29360c365c

--- a/images/breeze/output-selective-check.svg
+++ b/images/breeze/output-selective-check.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1482 513.5999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1482 562.4" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,117 +19,125 @@
         font-weight: 700;
     }
 
-    .terminal-3842717742-matrix {
+    .terminal-1234336166-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3842717742-title {
+    .terminal-1234336166-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3842717742-r1 { fill: #c5c8c6;font-weight: bold }
-.terminal-3842717742-r2 { fill: #c5c8c6 }
-.terminal-3842717742-r3 { fill: #d0b344;font-weight: bold }
-.terminal-3842717742-r4 { fill: #868887 }
-.terminal-3842717742-r5 { fill: #68a0b3;font-weight: bold }
-.terminal-3842717742-r6 { fill: #8d7b39 }
-.terminal-3842717742-r7 { fill: #98a84b;font-weight: bold }
+    .terminal-1234336166-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1234336166-r2 { fill: #c5c8c6 }
+.terminal-1234336166-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1234336166-r4 { fill: #868887 }
+.terminal-1234336166-r5 { fill: #68a0b3;font-weight: bold }
+.terminal-1234336166-r6 { fill: #8d7b39 }
+.terminal-1234336166-r7 { fill: #98a84b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-3842717742-clip-terminal">
-      <rect x="0" y="0" width="1463.0" height="462.59999999999997" />
+    <clipPath id="terminal-1234336166-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="511.4" />
     </clipPath>
-    <clipPath id="terminal-3842717742-line-0">
+    <clipPath id="terminal-1234336166-line-0">
     <rect x="0" y="1.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-1">
+<clipPath id="terminal-1234336166-line-1">
     <rect x="0" y="25.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-2">
+<clipPath id="terminal-1234336166-line-2">
     <rect x="0" y="50.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-3">
+<clipPath id="terminal-1234336166-line-3">
     <rect x="0" y="74.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-4">
+<clipPath id="terminal-1234336166-line-4">
     <rect x="0" y="99.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-5">
+<clipPath id="terminal-1234336166-line-5">
     <rect x="0" y="123.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-6">
+<clipPath id="terminal-1234336166-line-6">
     <rect x="0" y="147.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-7">
+<clipPath id="terminal-1234336166-line-7">
     <rect x="0" y="172.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-8">
+<clipPath id="terminal-1234336166-line-8">
     <rect x="0" y="196.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-9">
+<clipPath id="terminal-1234336166-line-9">
     <rect x="0" y="221.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-10">
+<clipPath id="terminal-1234336166-line-10">
     <rect x="0" y="245.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-11">
+<clipPath id="terminal-1234336166-line-11">
     <rect x="0" y="269.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-12">
+<clipPath id="terminal-1234336166-line-12">
     <rect x="0" y="294.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-13">
+<clipPath id="terminal-1234336166-line-13">
     <rect x="0" y="318.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-14">
+<clipPath id="terminal-1234336166-line-14">
     <rect x="0" y="343.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-15">
+<clipPath id="terminal-1234336166-line-15">
     <rect x="0" y="367.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-16">
+<clipPath id="terminal-1234336166-line-16">
     <rect x="0" y="391.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3842717742-line-17">
+<clipPath id="terminal-1234336166-line-17">
     <rect x="0" y="416.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1234336166-line-18">
+    <rect x="0" y="440.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1234336166-line-19">
+    <rect x="0" y="465.1" width="1464" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="511.6" rx="8"/><text class="terminal-3842717742-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;selective-check</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="560.4" rx="8"/><text class="terminal-1234336166-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;selective-check</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3842717742-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1234336166-clip-terminal)">
     
-    <g class="terminal-3842717742-matrix">
-    <text class="terminal-3842717742-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3842717742-line-0)">
-</text><text class="terminal-3842717742-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-3842717742-line-1)">Usage:&#160;</text><text class="terminal-3842717742-r1" x="97.6" y="44.4" textLength="390.4" clip-path="url(#terminal-3842717742-line-1)">breeze&#160;selective-check&#160;[OPTIONS]</text><text class="terminal-3842717742-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-1)">
-</text><text class="terminal-3842717742-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-2)">
-</text><text class="terminal-3842717742-r2" x="12.2" y="93.2" textLength="768.6" clip-path="url(#terminal-3842717742-line-3)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.</text><text class="terminal-3842717742-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-3)">
-</text><text class="terminal-3842717742-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-4)">
-</text><text class="terminal-3842717742-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-3842717742-line-5)">╭─</text><text class="terminal-3842717742-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-3842717742-line-5)">&#160;Selective&#160;check&#160;flags&#160;─────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3842717742-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-3842717742-line-5)">─╮</text><text class="terminal-3842717742-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3842717742-line-5)">
-</text><text class="terminal-3842717742-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">│</text><text class="terminal-3842717742-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">-</text><text class="terminal-3842717742-r5" x="36.6" y="166.4" textLength="85.4" clip-path="url(#terminal-3842717742-line-6)">-commit</text><text class="terminal-3842717742-r5" x="122" y="166.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-6)">-ref</text><text class="terminal-3842717742-r2" x="305" y="166.4" textLength="695.4" clip-path="url(#terminal-3842717742-line-6)">Commit-ish&#160;reference&#160;to&#160;the&#160;commit&#160;that&#160;should&#160;be&#160;checked</text><text class="terminal-3842717742-r6" x="1012.6" y="166.4" textLength="73.2" clip-path="url(#terminal-3842717742-line-6)">(TEXT)</text><text class="terminal-3842717742-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">│</text><text class="terminal-3842717742-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">
-</text><text class="terminal-3842717742-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">│</text><text class="terminal-3842717742-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">-</text><text class="terminal-3842717742-r5" x="36.6" y="190.8" textLength="36.6" clip-path="url(#terminal-3842717742-line-7)">-pr</text><text class="terminal-3842717742-r5" x="73.2" y="190.8" textLength="85.4" clip-path="url(#terminal-3842717742-line-7)">-labels</text><text class="terminal-3842717742-r2" x="305" y="190.8" textLength="622.2" clip-path="url(#terminal-3842717742-line-7)">Python&#160;array&#160;formatted&#160;PR&#160;labels&#160;assigned&#160;to&#160;the&#160;PR</text><text class="terminal-3842717742-r6" x="939.4" y="190.8" textLength="73.2" clip-path="url(#terminal-3842717742-line-7)">(TEXT)</text><text class="terminal-3842717742-r4" x="1451.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">│</text><text class="terminal-3842717742-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">
-</text><text class="terminal-3842717742-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">│</text><text class="terminal-3842717742-r5" x="24.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">-</text><text class="terminal-3842717742-r5" x="36.6" y="215.2" textLength="97.6" clip-path="url(#terminal-3842717742-line-8)">-default</text><text class="terminal-3842717742-r5" x="134.2" y="215.2" textLength="85.4" clip-path="url(#terminal-3842717742-line-8)">-branch</text><text class="terminal-3842717742-r2" x="305" y="215.2" textLength="500.2" clip-path="url(#terminal-3842717742-line-8)">Branch&#160;against&#160;which&#160;the&#160;PR&#160;should&#160;be&#160;run</text><text class="terminal-3842717742-r6" x="817.4" y="215.2" textLength="73.2" clip-path="url(#terminal-3842717742-line-8)">(TEXT)</text><text class="terminal-3842717742-r4" x="902.8" y="215.2" textLength="183" clip-path="url(#terminal-3842717742-line-8)">[default:&#160;main]</text><text class="terminal-3842717742-r4" x="1451.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">│</text><text class="terminal-3842717742-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">
-</text><text class="terminal-3842717742-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">│</text><text class="terminal-3842717742-r5" x="24.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">-</text><text class="terminal-3842717742-r5" x="36.6" y="239.6" textLength="85.4" clip-path="url(#terminal-3842717742-line-9)">-github</text><text class="terminal-3842717742-r5" x="122" y="239.6" textLength="134.2" clip-path="url(#terminal-3842717742-line-9)">-event-name</text><text class="terminal-3842717742-r2" x="305" y="239.6" textLength="1134.6" clip-path="url(#terminal-3842717742-line-9)">Name&#160;of&#160;the&#160;GitHub&#160;event&#160;that&#160;triggered&#160;the&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">│</text><text class="terminal-3842717742-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">
-</text><text class="terminal-3842717742-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">│</text><text class="terminal-3842717742-r6" x="305" y="264" textLength="1134.6" clip-path="url(#terminal-3842717742-line-10)">(pull_request&#160;|&#160;pull_request_review&#160;|&#160;pull_request_target&#160;|&#160;pull_request_workflow&#160;|&#160;push&#160;|&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">│</text><text class="terminal-3842717742-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">
-</text><text class="terminal-3842717742-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">│</text><text class="terminal-3842717742-r6" x="305" y="288.4" textLength="1134.6" clip-path="url(#terminal-3842717742-line-11)">schedule&#160;|&#160;workflow_dispatch&#160;|&#160;workflow_run)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">│</text><text class="terminal-3842717742-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">
-</text><text class="terminal-3842717742-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">│</text><text class="terminal-3842717742-r4" x="305" y="312.8" textLength="1134.6" clip-path="url(#terminal-3842717742-line-12)">[default:&#160;pull_request]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">│</text><text class="terminal-3842717742-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">
-</text><text class="terminal-3842717742-r4" x="0" y="337.2" textLength="1464" clip-path="url(#terminal-3842717742-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3842717742-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-13)">
-</text><text class="terminal-3842717742-r4" x="0" y="361.6" textLength="24.4" clip-path="url(#terminal-3842717742-line-14)">╭─</text><text class="terminal-3842717742-r4" x="24.4" y="361.6" textLength="1415.2" clip-path="url(#terminal-3842717742-line-14)">&#160;Options&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3842717742-r4" x="1439.6" y="361.6" textLength="24.4" clip-path="url(#terminal-3842717742-line-14)">─╮</text><text class="terminal-3842717742-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-14)">
-</text><text class="terminal-3842717742-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">│</text><text class="terminal-3842717742-r5" x="24.4" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">-</text><text class="terminal-3842717742-r5" x="36.6" y="386" textLength="97.6" clip-path="url(#terminal-3842717742-line-15)">-verbose</text><text class="terminal-3842717742-r7" x="158.6" y="386" textLength="24.4" clip-path="url(#terminal-3842717742-line-15)">-v</text><text class="terminal-3842717742-r2" x="207.4" y="386" textLength="585.6" clip-path="url(#terminal-3842717742-line-15)">Print&#160;verbose&#160;information&#160;about&#160;performed&#160;steps.</text><text class="terminal-3842717742-r4" x="1451.8" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">│</text><text class="terminal-3842717742-r2" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">
-</text><text class="terminal-3842717742-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">│</text><text class="terminal-3842717742-r5" x="24.4" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">-</text><text class="terminal-3842717742-r5" x="36.6" y="410.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-16)">-dry</text><text class="terminal-3842717742-r5" x="85.4" y="410.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-16)">-run</text><text class="terminal-3842717742-r7" x="158.6" y="410.4" textLength="24.4" clip-path="url(#terminal-3842717742-line-16)">-D</text><text class="terminal-3842717742-r2" x="207.4" y="410.4" textLength="719.8" clip-path="url(#terminal-3842717742-line-16)">If&#160;dry-run&#160;is&#160;set,&#160;commands&#160;are&#160;only&#160;printed,&#160;not&#160;executed.</text><text class="terminal-3842717742-r4" x="1451.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">│</text><text class="terminal-3842717742-r2" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">
-</text><text class="terminal-3842717742-r4" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">│</text><text class="terminal-3842717742-r5" x="24.4" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">-</text><text class="terminal-3842717742-r5" x="36.6" y="434.8" textLength="61" clip-path="url(#terminal-3842717742-line-17)">-help</text><text class="terminal-3842717742-r7" x="158.6" y="434.8" textLength="24.4" clip-path="url(#terminal-3842717742-line-17)">-h</text><text class="terminal-3842717742-r2" x="207.4" y="434.8" textLength="329.4" clip-path="url(#terminal-3842717742-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-3842717742-r4" x="1451.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">│</text><text class="terminal-3842717742-r2" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">
-</text><text class="terminal-3842717742-r4" x="0" y="459.2" textLength="1464" clip-path="url(#terminal-3842717742-line-18)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3842717742-r2" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-18)">
+    <g class="terminal-1234336166-matrix">
+    <text class="terminal-1234336166-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1234336166-line-0)">
+</text><text class="terminal-1234336166-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1234336166-line-1)">Usage:&#160;</text><text class="terminal-1234336166-r1" x="97.6" y="44.4" textLength="390.4" clip-path="url(#terminal-1234336166-line-1)">breeze&#160;selective-check&#160;[OPTIONS]</text><text class="terminal-1234336166-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-1)">
+</text><text class="terminal-1234336166-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-2)">
+</text><text class="terminal-1234336166-r2" x="12.2" y="93.2" textLength="768.6" clip-path="url(#terminal-1234336166-line-3)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.</text><text class="terminal-1234336166-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-3)">
+</text><text class="terminal-1234336166-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-4)">
+</text><text class="terminal-1234336166-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-1234336166-line-5)">╭─</text><text class="terminal-1234336166-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-1234336166-line-5)">&#160;Selective&#160;check&#160;flags&#160;─────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1234336166-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-1234336166-line-5)">─╮</text><text class="terminal-1234336166-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1234336166-line-5)">
+</text><text class="terminal-1234336166-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-6)">│</text><text class="terminal-1234336166-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-6)">-</text><text class="terminal-1234336166-r5" x="36.6" y="166.4" textLength="85.4" clip-path="url(#terminal-1234336166-line-6)">-commit</text><text class="terminal-1234336166-r5" x="122" y="166.4" textLength="48.8" clip-path="url(#terminal-1234336166-line-6)">-ref</text><text class="terminal-1234336166-r2" x="305" y="166.4" textLength="695.4" clip-path="url(#terminal-1234336166-line-6)">Commit-ish&#160;reference&#160;to&#160;the&#160;commit&#160;that&#160;should&#160;be&#160;checked</text><text class="terminal-1234336166-r6" x="1012.6" y="166.4" textLength="73.2" clip-path="url(#terminal-1234336166-line-6)">(TEXT)</text><text class="terminal-1234336166-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-6)">│</text><text class="terminal-1234336166-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-6)">
+</text><text class="terminal-1234336166-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-7)">│</text><text class="terminal-1234336166-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-7)">-</text><text class="terminal-1234336166-r5" x="36.6" y="190.8" textLength="36.6" clip-path="url(#terminal-1234336166-line-7)">-pr</text><text class="terminal-1234336166-r5" x="73.2" y="190.8" textLength="85.4" clip-path="url(#terminal-1234336166-line-7)">-labels</text><text class="terminal-1234336166-r2" x="305" y="190.8" textLength="622.2" clip-path="url(#terminal-1234336166-line-7)">Python&#160;array&#160;formatted&#160;PR&#160;labels&#160;assigned&#160;to&#160;the&#160;PR</text><text class="terminal-1234336166-r6" x="939.4" y="190.8" textLength="73.2" clip-path="url(#terminal-1234336166-line-7)">(TEXT)</text><text class="terminal-1234336166-r4" x="1451.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-7)">│</text><text class="terminal-1234336166-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-7)">
+</text><text class="terminal-1234336166-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-8)">│</text><text class="terminal-1234336166-r5" x="24.4" y="215.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-8)">-</text><text class="terminal-1234336166-r5" x="36.6" y="215.2" textLength="97.6" clip-path="url(#terminal-1234336166-line-8)">-default</text><text class="terminal-1234336166-r5" x="134.2" y="215.2" textLength="85.4" clip-path="url(#terminal-1234336166-line-8)">-branch</text><text class="terminal-1234336166-r2" x="305" y="215.2" textLength="500.2" clip-path="url(#terminal-1234336166-line-8)">Branch&#160;against&#160;which&#160;the&#160;PR&#160;should&#160;be&#160;run</text><text class="terminal-1234336166-r6" x="817.4" y="215.2" textLength="73.2" clip-path="url(#terminal-1234336166-line-8)">(TEXT)</text><text class="terminal-1234336166-r4" x="902.8" y="215.2" textLength="183" clip-path="url(#terminal-1234336166-line-8)">[default:&#160;main]</text><text class="terminal-1234336166-r4" x="1451.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-8)">│</text><text class="terminal-1234336166-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-8)">
+</text><text class="terminal-1234336166-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-9)">│</text><text class="terminal-1234336166-r5" x="24.4" y="239.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-9)">-</text><text class="terminal-1234336166-r5" x="36.6" y="239.6" textLength="85.4" clip-path="url(#terminal-1234336166-line-9)">-github</text><text class="terminal-1234336166-r5" x="122" y="239.6" textLength="134.2" clip-path="url(#terminal-1234336166-line-9)">-event-name</text><text class="terminal-1234336166-r2" x="305" y="239.6" textLength="1134.6" clip-path="url(#terminal-1234336166-line-9)">Name&#160;of&#160;the&#160;GitHub&#160;event&#160;that&#160;triggered&#160;the&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1234336166-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-9)">│</text><text class="terminal-1234336166-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-9)">
+</text><text class="terminal-1234336166-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1234336166-line-10)">│</text><text class="terminal-1234336166-r6" x="305" y="264" textLength="1134.6" clip-path="url(#terminal-1234336166-line-10)">(pull_request&#160;|&#160;pull_request_review&#160;|&#160;pull_request_target&#160;|&#160;pull_request_workflow&#160;|&#160;push&#160;|&#160;&#160;&#160;</text><text class="terminal-1234336166-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-1234336166-line-10)">│</text><text class="terminal-1234336166-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1234336166-line-10)">
+</text><text class="terminal-1234336166-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-11)">│</text><text class="terminal-1234336166-r6" x="305" y="288.4" textLength="1134.6" clip-path="url(#terminal-1234336166-line-11)">schedule&#160;|&#160;workflow_dispatch&#160;|&#160;workflow_run)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1234336166-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-11)">│</text><text class="terminal-1234336166-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-11)">
+</text><text class="terminal-1234336166-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-12)">│</text><text class="terminal-1234336166-r4" x="305" y="312.8" textLength="1134.6" clip-path="url(#terminal-1234336166-line-12)">[default:&#160;pull_request]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1234336166-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-12)">│</text><text class="terminal-1234336166-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-12)">
+</text><text class="terminal-1234336166-r4" x="0" y="337.2" textLength="1464" clip-path="url(#terminal-1234336166-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1234336166-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-13)">
+</text><text class="terminal-1234336166-r4" x="0" y="361.6" textLength="24.4" clip-path="url(#terminal-1234336166-line-14)">╭─</text><text class="terminal-1234336166-r4" x="24.4" y="361.6" textLength="1415.2" clip-path="url(#terminal-1234336166-line-14)">&#160;Options&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1234336166-r4" x="1439.6" y="361.6" textLength="24.4" clip-path="url(#terminal-1234336166-line-14)">─╮</text><text class="terminal-1234336166-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-14)">
+</text><text class="terminal-1234336166-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1234336166-line-15)">│</text><text class="terminal-1234336166-r5" x="24.4" y="386" textLength="12.2" clip-path="url(#terminal-1234336166-line-15)">-</text><text class="terminal-1234336166-r5" x="36.6" y="386" textLength="97.6" clip-path="url(#terminal-1234336166-line-15)">-default</text><text class="terminal-1234336166-r5" x="134.2" y="386" textLength="231.8" clip-path="url(#terminal-1234336166-line-15)">-constraints-branch</text><text class="terminal-1234336166-r2" x="439.2" y="386" textLength="646.6" clip-path="url(#terminal-1234336166-line-15)">Constraints&#160;Branch&#160;against&#160;which&#160;the&#160;PR&#160;should&#160;be&#160;run</text><text class="terminal-1234336166-r6" x="1098" y="386" textLength="73.2" clip-path="url(#terminal-1234336166-line-15)">(TEXT)</text><text class="terminal-1234336166-r4" x="1451.8" y="386" textLength="12.2" clip-path="url(#terminal-1234336166-line-15)">│</text><text class="terminal-1234336166-r2" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1234336166-line-15)">
+</text><text class="terminal-1234336166-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-16)">│</text><text class="terminal-1234336166-r4" x="439.2" y="410.4" textLength="646.6" clip-path="url(#terminal-1234336166-line-16)">[default:&#160;constraints-main]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1234336166-r4" x="1451.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-16)">│</text><text class="terminal-1234336166-r2" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1234336166-line-16)">
+</text><text class="terminal-1234336166-r4" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-17)">│</text><text class="terminal-1234336166-r5" x="24.4" y="434.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-17)">-</text><text class="terminal-1234336166-r5" x="36.6" y="434.8" textLength="97.6" clip-path="url(#terminal-1234336166-line-17)">-verbose</text><text class="terminal-1234336166-r7" x="390.4" y="434.8" textLength="24.4" clip-path="url(#terminal-1234336166-line-17)">-v</text><text class="terminal-1234336166-r2" x="439.2" y="434.8" textLength="585.6" clip-path="url(#terminal-1234336166-line-17)">Print&#160;verbose&#160;information&#160;about&#160;performed&#160;steps.</text><text class="terminal-1234336166-r4" x="1451.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-17)">│</text><text class="terminal-1234336166-r2" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-1234336166-line-17)">
+</text><text class="terminal-1234336166-r4" x="0" y="459.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-18)">│</text><text class="terminal-1234336166-r5" x="24.4" y="459.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-18)">-</text><text class="terminal-1234336166-r5" x="36.6" y="459.2" textLength="48.8" clip-path="url(#terminal-1234336166-line-18)">-dry</text><text class="terminal-1234336166-r5" x="85.4" y="459.2" textLength="48.8" clip-path="url(#terminal-1234336166-line-18)">-run</text><text class="terminal-1234336166-r7" x="390.4" y="459.2" textLength="24.4" clip-path="url(#terminal-1234336166-line-18)">-D</text><text class="terminal-1234336166-r2" x="439.2" y="459.2" textLength="719.8" clip-path="url(#terminal-1234336166-line-18)">If&#160;dry-run&#160;is&#160;set,&#160;commands&#160;are&#160;only&#160;printed,&#160;not&#160;executed.</text><text class="terminal-1234336166-r4" x="1451.8" y="459.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-18)">│</text><text class="terminal-1234336166-r2" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-1234336166-line-18)">
+</text><text class="terminal-1234336166-r4" x="0" y="483.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-19)">│</text><text class="terminal-1234336166-r5" x="24.4" y="483.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-19)">-</text><text class="terminal-1234336166-r5" x="36.6" y="483.6" textLength="61" clip-path="url(#terminal-1234336166-line-19)">-help</text><text class="terminal-1234336166-r7" x="390.4" y="483.6" textLength="24.4" clip-path="url(#terminal-1234336166-line-19)">-h</text><text class="terminal-1234336166-r2" x="439.2" y="483.6" textLength="329.4" clip-path="url(#terminal-1234336166-line-19)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-1234336166-r4" x="1451.8" y="483.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-19)">│</text><text class="terminal-1234336166-r2" x="1464" y="483.6" textLength="12.2" clip-path="url(#terminal-1234336166-line-19)">
+</text><text class="terminal-1234336166-r4" x="0" y="508" textLength="1464" clip-path="url(#terminal-1234336166-line-20)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1234336166-r2" x="1464" y="508" textLength="12.2" clip-path="url(#terminal-1234336166-line-20)">
 </text>
     </g>
     </g>


### PR DESCRIPTION
We are using the "main" breeze to build even v2-3 images and
it has to retrieve the branch and constraints not from the
Python constants but from environment variables that are
set by build-image.yaml. Otherwise "main" is used to push/pull
image and constraints.

This pr changes the retrieval in build image to retrieve
branch, constraints branch (and debian version) from env
variables if they are set.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
