### PR TITLE
Wait for xcom sidecar container to start before sidecar exec

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -429,6 +429,7 @@ class KubernetesPodOperator(BaseOperator):
                 )
 
             if self.do_xcom_push:
+                self.pod_manager.await_xcom_sidecar_container_start(pod=self.pod)
                 result = self.extract_xcom(pod=self.pod)
             remote_pod = self.pod_manager.await_pod_completion(self.pod)
         finally:

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -354,6 +354,18 @@ class PodManager(LoggingMixin):
         except BaseHTTPError as e:
             raise AirflowException(f'There was an error reading the kubernetes API: {e}')
 
+    def await_xcom_sidecar_container_start(self, pod: V1Pod) -> None:
+        self.log.info("Checking if xcom sidecar container is started.")
+        warned = False
+        while True:
+            if self.container_is_running(pod, PodDefaults.SIDECAR_CONTAINER_NAME):
+                self.log.info("The xcom sidecar container is started.")
+                break
+            if not warned:
+                self.log.warning("The xcom sidecar container is not yet started.")
+                warned = True
+            time.sleep(1)
+
     def extract_xcom(self, pod: V1Pod) -> str:
         """Retrieves XCom value and kills xcom sidecar container"""
         with closing(

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -883,12 +883,16 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
+    @mock.patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start")
     @mock.patch(f"{POD_MANAGER_CLASS}.extract_xcom")
     @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion")
     @mock.patch(f"{POD_MANAGER_CLASS}.create_pod", new=MagicMock)
     @mock.patch(HOOK_CLASS)
-    def test_pod_template_file(self, hook_mock, await_pod_completion_mock, extract_xcom_mock):
+    def test_pod_template_file(
+        self, hook_mock, await_pod_completion_mock, extract_xcom_mock, await_xcom_sidecar_container_start_mock
+    ):
         # todo: This isn't really a system test
+        await_xcom_sidecar_container_start_mock.return_value = None
         hook_mock.return_value.is_in_cluster = False
         extract_xcom_mock.return_value = '{}'
         path = sys.path[0] + '/tests/kubernetes/pod.yaml'


### PR DESCRIPTION
According to k8s's docs on pod phase [1], "Running" state means "The Pod has been bound to a node,
and all of the containers have been created. At least one container is still running,
or is in the process of starting or restarting.".

This means there is no guarantee that the xcom sidecar container will have been
running by the time the `extract_xcom` is used by KPO's `execute` even if
we wait for pod to be a "Running" state - this further means if the base container
has completed before the xcom sidecar container is running, the entire
operator fails because you cannot exec against a non-running container.

Fix is to wait for the xcom sidecar container to be in the running state
before we exec against it, which this PR implements.

[1] - https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
[2] - https://github.com/schattian/airflow/blob/86171ff43f8977021708cfa241da64f96c4c15e2/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py#L398

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

