### PR TITLE
add dagRuns/DR-ID/upstreamDatasetEvents endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -148,6 +148,7 @@ def _get_upstream_dataset_events(*, dag_run: DagRun, session: Session) -> List["
         session.query(DatasetEvent)
         .join(DatasetDagRef, DatasetEvent.dataset_id == DatasetDagRef.dataset_id)
         .filter(*dataset_event_filters)
+        .order_by(DatasetEvent.created_at)
         .all()
     )
     return dataset_events

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -95,10 +95,11 @@ def get_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION)
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DATASET),
     ],
 )
 @provide_session
-def get_dataset_event_triggers(
+def get_upstream_dataset_events(
     *, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION
 ) -> APIResponse:
     """Get a DAG Run."""

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -41,12 +41,17 @@ from airflow.api_connexion.schemas.dag_run_schema import (
     dagruns_batch_form_schema,
     set_dagrun_state_form_schema,
 )
+from airflow.api_connexion.schemas.dataset_schema import (
+    DatasetEventCollection,
+    dataset_event_collection_schema,
+)
 from airflow.api_connexion.schemas.task_instance_schema import (
     TaskInstanceReferenceCollection,
     task_instance_reference_collection_schema,
 )
 from airflow.api_connexion.types import APIResponse
 from airflow.models import DagModel, DagRun
+from airflow.models.dataset import DatasetDagRef, DatasetEvent
 from airflow.security import permissions
 from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.session import NEW_SESSION, provide_session
@@ -84,6 +89,54 @@ def get_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION)
             detail=f"DAGRun with DAG ID: '{dag_id}' and DagRun ID: '{dag_run_id}' not found",
         )
     return dagrun_schema.dump(dag_run)
+
+
+@security.requires_access(
+    [
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+    ],
+)
+@provide_session
+def get_dataset_event_triggers(
+    *, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION
+) -> APIResponse:
+    """Get a DAG Run."""
+    dag_run: Optional[DagRun] = (
+        session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.run_id == dag_run_id).one_or_none()
+    )
+    if dag_run is None:
+        raise NotFound(
+            "DAGRun not found",
+            detail=f"DAGRun with DAG ID: '{dag_id}' and DagRun ID: '{dag_run_id}' not found",
+        )
+    if not dag_run.run_type == DagRunType.DATASET_TRIGGERED:
+        return {}
+    previous_dag_run = (
+        session.query(DagRun)
+        .filter(
+            DagRun.dag_id == dag_run.dag_id,
+            DagRun.execution_date < dag_run.execution_date,
+            DagRun.run_type == DagRunType.DATASET_TRIGGERED,
+        )
+        .order_by(DagRun.execution_date.desc())
+        .first()
+    )
+    dataset_event_filters = [
+        DatasetDagRef.dag_id == dag_run.dag_id,
+        DatasetEvent.created_at <= dag_run.execution_date,
+    ]
+    if previous_dag_run:
+        dataset_event_filters.append(DatasetEvent.created_at > previous_dag_run.execution_date)
+    dataset_events = (
+        session.query(DatasetEvent)
+        .join(DatasetDagRef, DatasetEvent.dataset_id == DatasetDagRef.dataset_id)
+        .filter(*dataset_event_filters)
+        .all()
+    )
+    return dataset_event_collection_schema.dump(
+        DatasetEventCollection(dataset_events=dataset_events, total_entries=0)
+    )
 
 
 def _fetch_dag_runs(

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -122,7 +122,7 @@ def get_upstream_dataset_events(
     )
 
 
-def _get_upstream_dataset_events(*, dag_run: DagRun, session: Session = NEW_SESSION) -> List["DagRun"]:
+def _get_upstream_dataset_events(*, dag_run: DagRun, session: Session) -> List["DagRun"]:
     """If dag run is dataset-triggered, return the dataset events that triggered it."""
     if not dag_run.run_type == DagRunType.DATASET_TRIGGERED:
         return []

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3536,19 +3536,19 @@ components:
         source_dag_id:
           type: string
           description: The DAG ID that updated the dataset.
-          nullable: false
+          nullable: true
         source_task_id:
           type: string
           description: The task ID that updated the dataset.
-          nullable: false
+          nullable: true
         source_run_id:
           type: string
           description: The DAG run ID that updated the dataset.
-          nullable: false
+          nullable: true
         source_map_index:
           type: integer
           description: The task map index that updated the dataset.
-          nullable: false
+          nullable: true
         created_at:
           type: string
           description: The dataset event creation time

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -818,6 +818,34 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /dags/{dag_id}/dagRuns/{dag_run_id}/dataset-event-triggers:
+    parameters:
+      - $ref: '#/components/parameters/DAGID'
+      - $ref: '#/components/parameters/DAGRunID'
+    get:
+      summary: Get dataset events for a DAG run
+      description: |
+        Get datasets for a dag run.
+
+        *New in version 2.4.0*
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dag_run_endpoint
+      operationId: get_dataset_event_triggers
+      tags: [DAGRun, Dataset]
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasetEventCollection'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+
   /eventLogs:
     get:
       summary: List log entries

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -818,7 +818,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /dags/{dag_id}/dagRuns/{dag_run_id}/upstream-dataset-events:
+  /dags/{dag_id}/dagRuns/{dag_run_id}/upstreamDatasetEvents:
     parameters:
       - $ref: '#/components/parameters/DAGID'
       - $ref: '#/components/parameters/DAGRunID'

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -818,7 +818,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /dags/{dag_id}/dagRuns/{dag_run_id}/dataset-event-triggers:
+  /dags/{dag_id}/dagRuns/{dag_run_id}/upstream-dataset-events:
     parameters:
       - $ref: '#/components/parameters/DAGID'
       - $ref: '#/components/parameters/DAGRunID'
@@ -829,7 +829,7 @@ paths:
 
         *New in version 2.4.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_run_endpoint
-      operationId: get_dataset_event_triggers
+      operationId: get_upstream_dataset_events
       tags: [DAGRun, Dataset]
       responses:
         '200':

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1661,6 +1661,6 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         session.add(dagrun_model)
         session.commit()
 
-        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/uptsream-dataset-events")
+        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstream-dataset-events")
 
         assert_401(response)

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1614,7 +1614,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         # make sure whatever is returned by this func is what comes out in response.
         mock_get_events.return_value = [DatasetEvent(dataset_id=1, created_at=created_at)]
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstream-dataset-events",
+            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamDatasetEvents",
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 200
@@ -1637,7 +1637,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
 
     def test_should_respond_404(self):
         response = self.client.get(
-            "api/v1/dags/invalid-id/dagRuns/invalid-id/upstream-dataset-events",
+            "api/v1/dags/invalid-id/dagRuns/invalid-id/upstreamDatasetEvents",
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 404
@@ -1661,6 +1661,6 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         session.add(dagrun_model)
         session.commit()
 
-        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstream-dataset-events")
+        response = self.client.get("api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamDatasetEvents")
 
         assert_401(response)


### PR DESCRIPTION
I know we do camel case for objects but is the convention all-camel-case-all-the-time?  or is it just for objects?

if it's all the time i should rename endpoint to 

...dagRuns/DR-ID/upstreamDatasetEvents i guess...

cc @blag 
