### PR TITLE
SqlToS3Operator: change column type from object to str in dataframe

### DIFF
--- a/tests/providers/amazon/aws/transfers/test_mysql_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mysql_to_s3.py
@@ -109,10 +109,10 @@ class TestMySqlToS3Operator(unittest.TestCase):
                 filename=f.name, key=s3_key, bucket_name=s3_bucket, replace=False
             )
 
-    def test_fix_int_dtypes(self):
+    def test_fix_dtypes(self):
         from airflow.providers.amazon.aws.transfers.mysql_to_s3 import MySQLToS3Operator
 
         op = MySQLToS3Operator(query="query", s3_bucket="s3_bucket", s3_key="s3_key", task_id="task_id")
         dirty_df = pd.DataFrame({"strings": ["a", "b", "c"], "ints": [1, 2, None]})
-        op._fix_int_dtypes(df=dirty_df)
+        op._fix_dtypes(df=dirty_df)
         assert dirty_df["ints"].dtype.kind == "i"

--- a/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
@@ -144,7 +144,7 @@ class TestSqlToS3Operator(unittest.TestCase):
                 replace=True,
             )
 
-    def test_fix_int_dtypes(self):
+    def test_fix_dtypes(self):
         op = SqlToS3Operator(
             query="query",
             s3_bucket="s3_bucket",
@@ -153,7 +153,7 @@ class TestSqlToS3Operator(unittest.TestCase):
             sql_conn_id="mysql_conn_id",
         )
         dirty_df = pd.DataFrame({"strings": ["a", "b", "c"], "ints": [1, 2, None]})
-        op._fix_int_dtypes(df=dirty_df)
+        op._fix_dtypes(df=dirty_df)
         assert dirty_df["ints"].dtype.kind == "i"
 
     def test_invalid_file_format(self):


### PR DESCRIPTION
When doing the type check in SqlToS3Operator, convert dataframe columns object to str.
This avoids errors when converting from df to parquet, allowing for this simple SQL->S3 operator to be used with most queries - without having to modify the SQL to avoid types pandas doesn't by like by default.