### PR TITLE
Don't queue dagruns or create dataset events on skipped task instances

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1518,7 +1518,8 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(self.state, self))
             session.merge(self)
-            self._create_dataset_dag_run_queue_records(session=session)
+            if self.state == TaskInstanceState.SUCCESS:
+                self._create_dataset_dag_run_queue_records(session=session)
             session.commit()
 
     def _create_dataset_dag_run_queue_records(self, *, session: Session) -> None:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1535,7 +1535,7 @@ class TestTaskInstance:
         session.commit()
         ti._run_raw_task()
         ti.refresh_from_db()
-        assert ti.state == State.SUCCESS
+        assert ti.state == TaskInstanceState.SUCCESS
 
         # check that one queue record created for each dag that depends on dataset 1
         assert session.query(DatasetDagRunQueue.target_dag_id).filter(
@@ -1577,13 +1577,13 @@ class TestTaskInstance:
         session.commit()
         ti._run_raw_task()
         ti.refresh_from_db()
-        assert ti.state == State.SKIPPED
+        assert ti.state == TaskInstanceState.SKIPPED
 
         # check that no dagruns were queued
         assert session.query(DatasetDagRunQueue).count() == 0
 
         # check that no dataset events were generated
-        assert (session.query(DatasetEvent).count()) == 0
+        assert session.query(DatasetEvent).count() == 0
 
     @staticmethod
     def _test_previous_dates_setup(


### PR DESCRIPTION
We don't check the task instance state before queuing dagruns and generating dataset events. This PR fixes that, so skipped task instances do not do those things, and adds a test for that case.

Closes #25036.