### PR TITLE
Bump typing-extensions and mypy for ParamSpec

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -833,7 +833,7 @@ repos:
       - id: run-mypy
         name: Run mypy for providers
         language: python
-        entry: ./scripts/ci/pre_commit/pre_commit_mypy.py --namespace-packages --show-traceback
+        entry: ./scripts/ci/pre_commit/pre_commit_mypy.py --namespace-packages
         files: ^airflow/providers/.*\.py$
         require_serial: true
         additional_dependencies: ['rich>=12.4.4', 'inputimeout']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -833,7 +833,7 @@ repos:
       - id: run-mypy
         name: Run mypy for providers
         language: python
-        entry: ./scripts/ci/pre_commit/pre_commit_mypy.py --namespace-packages
+        entry: ./scripts/ci/pre_commit/pre_commit_mypy.py --namespace-packages --show-traceback
         files: ^airflow/providers/.*\.py$
         require_serial: true
         additional_dependencies: ['rich>=12.4.4', 'inputimeout']

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -175,7 +175,7 @@ class SchedulerJob(BaseJob):
         signal.signal(signal.SIGTERM, self._exit_gracefully)
         signal.signal(signal.SIGUSR2, self._debug_dump)
 
-    def _exit_gracefully(self, signum: int, frame: "FrameType") -> None:
+    def _exit_gracefully(self, signum: int, frame: Optional["FrameType"]) -> None:
         """Helper method to clean up processor_agent to avoid leaving orphan processes."""
         if not _is_parent_process():
             # Only the parent process should perform the cleanup.
@@ -186,7 +186,7 @@ class SchedulerJob(BaseJob):
             self.processor_agent.end()
         sys.exit(os.EX_OK)
 
-    def _debug_dump(self, signum: int, frame: "FrameType") -> None:
+    def _debug_dump(self, signum: int, frame: Optional["FrameType"]) -> None:
         if not _is_parent_process():
             # Only the parent process should perform the debug dump.
             return

--- a/airflow/mypy/plugin/decorators.py
+++ b/airflow/mypy/plugin/decorators.py
@@ -68,7 +68,10 @@ def _change_decorator_function_type(
     # Mark provided arguments as optional
     decorator.arg_types = copy.copy(decorated.arg_types)
     for argument in provided_arguments:
-        index = decorated.arg_names.index(argument)
+        try:
+            index = decorated.arg_names.index(argument)
+        except ValueError:
+            continue
         decorated_type = decorated.arg_types[index]
         decorator.arg_types[index] = UnionType.make_union([decorated_type, NoneType()])
         decorated.arg_kinds[index] = ARG_NAMED_OPT

--- a/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/dynamodb_to_s3.py
@@ -114,6 +114,7 @@ class DynamoDBToS3Operator(BaseOperator):
 
         scan_kwargs = copy(self.dynamodb_scan_kwargs) if self.dynamodb_scan_kwargs else {}
         err = None
+        f: IO[Any]
         with NamedTemporaryFile() as f:
             try:
                 f = self._scan_dynamodb_and_upload_to_s3(f, scan_kwargs, table)

--- a/airflow/providers/amazon/aws/transfers/sql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/sql_to_s3.py
@@ -16,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import enum
 from collections import namedtuple
-from enum import Enum
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Union
 
@@ -35,10 +35,13 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-FILE_FORMAT = Enum(
-    "FILE_FORMAT",
-    "CSV, JSON, PARQUET",
-)
+class FILE_FORMAT(enum.Enum):
+    """Possible file formats."""
+
+    CSV = enum.auto()
+    JSON = enum.auto()
+    PARQUET = enum.auto()
+
 
 FileOptions = namedtuple('FileOptions', ['mode', 'suffix', 'function'])
 
@@ -118,9 +121,9 @@ class SqlToS3Operator(BaseOperator):
         if "path_or_buf" in self.pd_kwargs:
             raise AirflowException('The argument path_or_buf is not allowed, please remove it')
 
-        self.file_format = getattr(FILE_FORMAT, file_format.upper(), None)
-
-        if self.file_format is None:
+        try:
+            self.file_format = FILE_FORMAT[file_format.upper()]
+        except KeyError:
             raise AirflowException(f"The argument file_format doesn't support {file_format} value.")
 
     @staticmethod

--- a/airflow/providers/google/cloud/operators/cloud_sql.py
+++ b/airflow/providers/google/cloud/operators/cloud_sql.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 SETTINGS = 'settings'
 SETTINGS_VERSION = 'settingsVersion'
 
-CLOUD_SQL_CREATE_VALIDATION = [
+CLOUD_SQL_CREATE_VALIDATION: Sequence[dict] = [
     dict(name="name", allow_empty=False),
     dict(
         name="settings",

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -23,12 +23,12 @@ import copy
 import functools
 import warnings
 from typing import (
-    AbstractSet,
     Any,
     Container,
     Dict,
     ItemsView,
     Iterator,
+    KeysView,
     List,
     Mapping,
     MutableMapping,
@@ -175,7 +175,7 @@ class Context(MutableMapping[str, Any]):
     }
 
     def __init__(self, context: Optional[MutableMapping[str, Any]] = None, **kwargs: Any) -> None:
-        self._context = context or {}
+        self._context: MutableMapping[str, Any] = context or {}
         if kwargs:
             self._context.update(kwargs)
         self._deprecation_replacements = self._DEPRECATION_REPLACEMENTS.copy()
@@ -231,7 +231,7 @@ class Context(MutableMapping[str, Any]):
             return NotImplemented
         return self._context != other._context
 
-    def keys(self) -> AbstractSet[str]:
+    def keys(self) -> KeysView[str]:
         return self._context.keys()
 
     def items(self):

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -197,9 +197,9 @@ def run_with_progress(
 ) -> RunCommandResult:
     title = f"Running tests: {test_type}, Python: {python}, Backend: {backend}:{version}"
     try:
-        with tempfile.NamedTemporaryFile(mode='w+t', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode='w+t', delete=False) as tf:
             get_console().print(f"[info]Starting test = {title}[/]")
-            thread = MonitoringThread(title=title, file_name=f.name)
+            thread = MonitoringThread(title=title, file_name=tf.name)
             thread.start()
             try:
                 result = run_command(
@@ -208,14 +208,14 @@ def run_with_progress(
                     dry_run=dry_run,
                     env=env_variables,
                     check=False,
-                    stdout=f,
+                    stdout=tf,
                     stderr=subprocess.STDOUT,
                 )
             finally:
                 thread.stop()
                 thread.join()
         with ci_group(f"Result of {title}", message_type=message_type_from_return_code(result.returncode)):
-            with open(f.name) as f:
+            with open(tf.name) as f:
                 shutil.copyfileobj(f, sys.stdout)
     finally:
         os.unlink(f.name)

--- a/scripts/in_container/run_migration_reference.py
+++ b/scripts/in_container/run_migration_reference.py
@@ -102,6 +102,7 @@ def revision_suffix(rev: "Script"):
 
 def ensure_airflow_version(revisions: Iterable["Script"]):
     for rev in revisions:
+        assert rev.module.__file__ is not None  # For Mypy.
         file = Path(rev.module.__file__)
         content = file.read_text()
         if not has_version(content):

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,7 +147,7 @@ install_requires =
     tabulate>=0.7.5
     tenacity>=6.2.0
     termcolor>=1.1.0
-    typing-extensions>=3.7.4
+    typing-extensions>=4.0.0
     unicodecsv>=0.14.1
     werkzeug>=2.0
 

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ webhdfs = [
 # mypyd which does not support installing the types dynamically with --install-types
 mypy_dependencies = [
     # TODO: upgrade to newer versions of MyPy continuously as they are released
-    'mypy==0.960',
+    'mypy==0.961',
     'types-boto',
     'types-certifi',
     'types-croniter',

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ webhdfs = [
 # mypyd which does not support installing the types dynamically with --install-types
 mypy_dependencies = [
     # TODO: upgrade to newer versions of MyPy continuously as they are released
-    'mypy==0.961',
+    'mypy==0.950',
     'types-boto',
     'types-certifi',
     'types-croniter',

--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ webhdfs = [
 # mypyd which does not support installing the types dynamically with --install-types
 mypy_dependencies = [
     # TODO: upgrade to newer versions of MyPy continuously as they are released
-    'mypy==0.910',
+    'mypy==0.960',
     'types-boto',
     'types-certifi',
     'types-croniter',

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -91,7 +91,9 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_collection(self.test_collection_name, self.test_database_name)
         expected_calls = [
-            mock.call().get_database_client('test_database_name').create_container('test_collection_name')
+            mock.call()
+            .get_database_client('test_database_name')
+            .create_container('test_collection_name', partition_key=None)
         ]
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)
@@ -101,7 +103,9 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         hook = AzureCosmosDBHook(azure_cosmos_conn_id='azure_cosmos_test_key_id')
         hook.create_collection(self.test_collection_name)
         expected_calls = [
-            mock.call().get_database_client('test_database_name').create_container('test_collection_name')
+            mock.call()
+            .get_database_client('test_database_name')
+            .create_container('test_collection_name', partition_key=None)
         ]
         mock_cosmos.assert_any_call(self.test_end_point, {'masterKey': self.test_master_key})
         mock_cosmos.assert_has_calls(expected_calls)


### PR DESCRIPTION
I want to use them in some `@task` signature improvements. Mypy added this in 0.950, but let's just bump to latest since why not.

Changelog of typing-extensions is spotty before 4.0, but ParamSpec was introduced some time before that (likely some time in 2021), and it seems to be a reasonble minimum to bump to.

See [PEP 612](https://peps.python.org/pep-0612/) for more about ParamSpec if you’re interested. But in short, it solves our problem when typing `@task`—the resulting task should accept the same arguments as the wrapped function inside, but when called should return an XComArg, instead of the wrapped function’s return value.

```python
# This is a Callable[[int, str], str]
def foo(a: int, b: str) -> str:
    return b * a

# How can we type the wrapped task as Callable[[int, str] XComArg]?
# ParamSpec makes this possible.
@task
def foo(a: int, b: str) -> str:
    return b * a
```