### PR TITLE
Incorrect definition of parallelism in default_airflow.cfg

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -53,10 +53,9 @@ default_timezone = utc
 # full import path to the class when using a custom executor.
 executor = SequentialExecutor
 
-# This defines the maximum number of task instances that can run concurrently per scheduler in
-# Airflow, regardless of the worker count. Generally this value, multiplied by the number of
-# schedulers in your cluster, is the maximum number of task instances with the running
-# state in the metadata database.
+# This defines the maximum number of task instances that can run concurrently in
+# Airflow, regardless of the worker or scheduler count. This value represents the maximum number
+# of tasks that can be in the running or queued states in the metadata database.
 parallelism = 32
 
 # The maximum number of task instances allowed to run concurrently in each DAG. To calculate


### PR DESCRIPTION
I believe this definition of parallelism is incorrect.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
