### PR TITLE
Fix put-secret-value example

### DIFF
--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
@@ -62,7 +62,7 @@ console or through Amazon CLI as shown below:
 
     aws secretsmanager put-secret-value \
         --secret-id airflow/connections/smtp_default \
-        --secret-string [{"user": "nice_user"}, {"pass": "this_is_the_password"}, {"host": "ec2.8399.com"}, {"port": "999"}]
+        --secret-string '{"user": "nice_user","pass": "this_is_the_password","host": "ec2.8399.com","port": "999"}'
 
 Verify that you can get the secret:
 


### PR DESCRIPTION
To set the secret string so it is considered a list of key/value pairs we need to send a JSON object with keys and values, not an array with and object per key/value. 

The command as it is this will throw an error on zsh as the JSON is not escaped. 

`zsh: bad pattern: [{user:`

After escaping with single quotes the json it will update the secret as plain text and the value will simply be a JSON string. 

```
# value is saved a string, not key/value
aws secretsmanager put-secret-value \
    --secret-id staging/airflow/connections/smtp_default \
    --secret-binary '[{"user": "nice_user"}, {"pass": "this_is_the_password"}, {"host": "ec2.8399.com"}, {"port": "999"}]'
```

 change remedies both of these issues by updating the example to the following:

```
aws secretsmanager put-secret-value \
    --secret-id staging/airflow/connections/smtp_default \
    --secret-string '{"user": "nice_user","pass": "this_is_the_password","host": "ec2.8399.com","port": "999"}'
```

Tested with `aws-cli/2.7.0`