### PR TITLE
Speed up Kubernetes tests  30% on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1454,7 +1454,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
 
   tests-kubernetes:
     timeout-minutes: 240
-    name: Helm Chart; ${{matrix.executor}}
+    name: Helm Chart; ${{matrix.executor}} - ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
     runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
     needs: [build-info, wait-for-prod-images]
     strategy:
@@ -1524,7 +1524,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
 
   tests-helm-executor-upgrade:
     timeout-minutes: 150
-    name: Helm Chart Executor Upgrade
+    name: Helm Chart Executor Upgrade - ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
     runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
     needs: [build-info, wait-for-prod-images]
     env:

--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -252,16 +252,10 @@ function parallel::get_maximum_parallel_k8s_jobs() {
         echo
         export MAX_PARALLEL_K8S_JOBS="1"
     else
-        if [[ ${MAX_PARALLEL_K8S_JOBS=} != "" ]]; then
-            echo
-            echo "${COLOR_YELLOW}Maximum parallel k8s jobs forced vi MAX_PARALLEL_K8S_JOBS = ${MAX_PARALLEL_K8S_JOBS}${COLOR_RESET}"
-            echo
-        else
-            MAX_PARALLEL_K8S_JOBS=$((CPUS_AVAILABLE_FOR_DOCKER / 4))
-            echo
-            echo "${COLOR_YELLOW}Maximum parallel k8s jobs set to number of CPUs available for Docker = ${MAX_PARALLEL_K8S_JOBS}${COLOR_RESET}"
-            echo
-        fi
+        echo
+        echo "${COLOR_YELLOW}This is a Self-Hosted runner - forcing max parallel jobs to 5${COLOR_RESET}"
+        echo
+        export MAX_PARALLEL_K8S_JOBS="3"
     fi
     export MAX_PARALLEL_K8S_JOBS
 }


### PR DESCRIPTION
We should have enough resources - we were limiting them to 1/4 of available
CPUs but monitoring shows that ~20% memory and up to 4 CPUs are used
when 2 tests are running in parallel (on a big instance).
We can safely run all 5 parallell tests at the same time with big
instances speeding up the test up to 3 times when full tests are
needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
