### PR TITLE
Fix PR label detection in CI

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Selective checks
         id: selective-checks
         env:
-          PR_LABELS: "$${{ steps.get-latest-pr-labels.outputs.pull-request-labels }}"
+          PR_LABELS: "${{ steps.get-latest-pr-labels.outputs.pull-request-labels }}"
           COMMIT_REF: "${{ env.TARGET_COMMIT_SHA }}"
         run: breeze selective-check
       - name: env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Selective checks
         id: selective-checks
         env:
-          PR_LABELS: "${{ steps.source-run-info.outputs.pull-request-labels }}"
+          PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
           COMMIT_REF: "${{ github.sha }}"
         run: breeze selective-check
       # Avoid having to specify the runs-on logic every time. We use the custom
@@ -239,7 +239,7 @@ jobs:
       - name: Set runs-on
         id: set-runs-on
         env:
-          PR_LABELS: "${{ steps.source-run-info.outputs.pull-request-labels }}"
+          PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
         run: |
           if [[ ${PR_LABELS=} == *"use public runners"* ]]; then
             echo "Forcing running on Public Runners via `use public runners` label"
@@ -290,7 +290,7 @@ jobs:
       - name: env
         run: printenv
         env:
-          PR_LABELS: ${{ steps.get-latest-pr-labels.outputs.pull-request-labels }}
+          PR_LABELS: ${{ steps.source-run-info.outputs.pullRequestLabels }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
 
   build-ci-images:

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import ast
 import os
 import platform
 import subprocess
@@ -243,7 +244,7 @@ def get_changed_files(commit_ref: Optional[str], dry_run: bool, verbose: bool) -
 )
 @click.option(
     '--pr-labels',
-    help="Space-separate list of labels which are valid for the PR",
+    help="Python array formatted PR labels assigned to the PR",
     default="",
     envvar="PR_LABELS",
 )
@@ -283,7 +284,7 @@ def selective_check(
         commit_ref=commit_ref,
         files=changed_files,
         default_branch=default_branch,
-        pr_labels=tuple(" ".split(pr_labels)) if pr_labels else (),
+        pr_labels=tuple(ast.literal_eval(pr_labels)) if pr_labels else (),
         github_event=github_event,
     )
     print(str(sc))

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -299,7 +299,10 @@ class SelectiveChecks:
             get_console().print(f"[warning]Full tests needed because event is {self._github_event}[/]")
             return True
         if FULL_TESTS_NEEDED_LABEL in self._pr_labels:
-            get_console().print(f"[warning]Full tests needed because labels are {self._pr_labels}[/]")
+            get_console().print(
+                "[warning]Full tests needed because "
+                f"label '{FULL_TESTS_NEEDED_LABEL}' is in  {self._pr_labels}[/]"
+            )
             return True
         return False
 

--- a/images/breeze/output-commands-hash.txt
+++ b/images/breeze/output-commands-hash.txt
@@ -23,7 +23,7 @@ pull-prod-image:6e8467a2b8c833a392c8bdd65189363e
 regenerate-command-images:4fd2e7ecbfd6eebb18b854f3eb0f29c8
 release-prod-images:8858fe5a13989c7c65a79dc97a880928
 resource-check:0fb929ac3496dbbe97acfe99e35accd7
-selective-check:43272e6ccc8443c4303ccd092e0829f9
+selective-check:26b994bff3d703c47380a51789726deb
 self-upgrade:b5437c0a1a91533a11ee9d0a9692369c
 setup-autocomplete:355b72dee171c2fcba46fc90ac7c97b0
 shell:4680295fdd8a276d51518d29360c365c

--- a/images/breeze/output-selective-check.svg
+++ b/images/breeze/output-selective-check.svg
@@ -19,117 +19,117 @@
         font-weight: 700;
     }
 
-    .terminal-1596602645-matrix {
+    .terminal-3842717742-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1596602645-title {
+    .terminal-3842717742-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1596602645-r1 { fill: #c5c8c6;font-weight: bold }
-.terminal-1596602645-r2 { fill: #c5c8c6 }
-.terminal-1596602645-r3 { fill: #d0b344;font-weight: bold }
-.terminal-1596602645-r4 { fill: #868887 }
-.terminal-1596602645-r5 { fill: #68a0b3;font-weight: bold }
-.terminal-1596602645-r6 { fill: #8d7b39 }
-.terminal-1596602645-r7 { fill: #98a84b;font-weight: bold }
+    .terminal-3842717742-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-3842717742-r2 { fill: #c5c8c6 }
+.terminal-3842717742-r3 { fill: #d0b344;font-weight: bold }
+.terminal-3842717742-r4 { fill: #868887 }
+.terminal-3842717742-r5 { fill: #68a0b3;font-weight: bold }
+.terminal-3842717742-r6 { fill: #8d7b39 }
+.terminal-3842717742-r7 { fill: #98a84b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-1596602645-clip-terminal">
+    <clipPath id="terminal-3842717742-clip-terminal">
       <rect x="0" y="0" width="1463.0" height="462.59999999999997" />
     </clipPath>
-    <clipPath id="terminal-1596602645-line-0">
+    <clipPath id="terminal-3842717742-line-0">
     <rect x="0" y="1.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-1">
+<clipPath id="terminal-3842717742-line-1">
     <rect x="0" y="25.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-2">
+<clipPath id="terminal-3842717742-line-2">
     <rect x="0" y="50.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-3">
+<clipPath id="terminal-3842717742-line-3">
     <rect x="0" y="74.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-4">
+<clipPath id="terminal-3842717742-line-4">
     <rect x="0" y="99.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-5">
+<clipPath id="terminal-3842717742-line-5">
     <rect x="0" y="123.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-6">
+<clipPath id="terminal-3842717742-line-6">
     <rect x="0" y="147.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-7">
+<clipPath id="terminal-3842717742-line-7">
     <rect x="0" y="172.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-8">
+<clipPath id="terminal-3842717742-line-8">
     <rect x="0" y="196.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-9">
+<clipPath id="terminal-3842717742-line-9">
     <rect x="0" y="221.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-10">
+<clipPath id="terminal-3842717742-line-10">
     <rect x="0" y="245.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-11">
+<clipPath id="terminal-3842717742-line-11">
     <rect x="0" y="269.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-12">
+<clipPath id="terminal-3842717742-line-12">
     <rect x="0" y="294.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-13">
+<clipPath id="terminal-3842717742-line-13">
     <rect x="0" y="318.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-14">
+<clipPath id="terminal-3842717742-line-14">
     <rect x="0" y="343.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-15">
+<clipPath id="terminal-3842717742-line-15">
     <rect x="0" y="367.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-16">
+<clipPath id="terminal-3842717742-line-16">
     <rect x="0" y="391.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1596602645-line-17">
+<clipPath id="terminal-3842717742-line-17">
     <rect x="0" y="416.3" width="1464" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="511.6" rx="8"/><text class="terminal-1596602645-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;selective-check</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="511.6" rx="8"/><text class="terminal-3842717742-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;selective-check</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1596602645-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3842717742-clip-terminal)">
     
-    <g class="terminal-1596602645-matrix">
-    <text class="terminal-1596602645-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1596602645-line-0)">
-</text><text class="terminal-1596602645-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1596602645-line-1)">Usage:&#160;</text><text class="terminal-1596602645-r1" x="97.6" y="44.4" textLength="390.4" clip-path="url(#terminal-1596602645-line-1)">breeze&#160;selective-check&#160;[OPTIONS]</text><text class="terminal-1596602645-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-1)">
-</text><text class="terminal-1596602645-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-2)">
-</text><text class="terminal-1596602645-r2" x="12.2" y="93.2" textLength="768.6" clip-path="url(#terminal-1596602645-line-3)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.</text><text class="terminal-1596602645-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-3)">
-</text><text class="terminal-1596602645-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-4)">
-</text><text class="terminal-1596602645-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-1596602645-line-5)">╭─</text><text class="terminal-1596602645-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-1596602645-line-5)">&#160;Selective&#160;check&#160;flags&#160;─────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1596602645-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-1596602645-line-5)">─╮</text><text class="terminal-1596602645-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1596602645-line-5)">
-</text><text class="terminal-1596602645-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-6)">│</text><text class="terminal-1596602645-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-6)">-</text><text class="terminal-1596602645-r5" x="36.6" y="166.4" textLength="85.4" clip-path="url(#terminal-1596602645-line-6)">-commit</text><text class="terminal-1596602645-r5" x="122" y="166.4" textLength="48.8" clip-path="url(#terminal-1596602645-line-6)">-ref</text><text class="terminal-1596602645-r2" x="305" y="166.4" textLength="695.4" clip-path="url(#terminal-1596602645-line-6)">Commit-ish&#160;reference&#160;to&#160;the&#160;commit&#160;that&#160;should&#160;be&#160;checked</text><text class="terminal-1596602645-r6" x="1012.6" y="166.4" textLength="73.2" clip-path="url(#terminal-1596602645-line-6)">(TEXT)</text><text class="terminal-1596602645-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-6)">│</text><text class="terminal-1596602645-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-6)">
-</text><text class="terminal-1596602645-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-7)">│</text><text class="terminal-1596602645-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-7)">-</text><text class="terminal-1596602645-r5" x="36.6" y="190.8" textLength="36.6" clip-path="url(#terminal-1596602645-line-7)">-pr</text><text class="terminal-1596602645-r5" x="73.2" y="190.8" textLength="85.4" clip-path="url(#terminal-1596602645-line-7)">-labels</text><text class="terminal-1596602645-r2" x="305" y="190.8" textLength="683.2" clip-path="url(#terminal-1596602645-line-7)">Space-separate&#160;list&#160;of&#160;labels&#160;which&#160;are&#160;valid&#160;for&#160;the&#160;PR</text><text class="terminal-1596602645-r6" x="1000.4" y="190.8" textLength="73.2" clip-path="url(#terminal-1596602645-line-7)">(TEXT)</text><text class="terminal-1596602645-r4" x="1451.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-7)">│</text><text class="terminal-1596602645-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-7)">
-</text><text class="terminal-1596602645-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-8)">│</text><text class="terminal-1596602645-r5" x="24.4" y="215.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-8)">-</text><text class="terminal-1596602645-r5" x="36.6" y="215.2" textLength="97.6" clip-path="url(#terminal-1596602645-line-8)">-default</text><text class="terminal-1596602645-r5" x="134.2" y="215.2" textLength="85.4" clip-path="url(#terminal-1596602645-line-8)">-branch</text><text class="terminal-1596602645-r2" x="305" y="215.2" textLength="500.2" clip-path="url(#terminal-1596602645-line-8)">Branch&#160;against&#160;which&#160;the&#160;PR&#160;should&#160;be&#160;run</text><text class="terminal-1596602645-r6" x="817.4" y="215.2" textLength="73.2" clip-path="url(#terminal-1596602645-line-8)">(TEXT)</text><text class="terminal-1596602645-r4" x="902.8" y="215.2" textLength="183" clip-path="url(#terminal-1596602645-line-8)">[default:&#160;main]</text><text class="terminal-1596602645-r4" x="1451.8" y="215.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-8)">│</text><text class="terminal-1596602645-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-8)">
-</text><text class="terminal-1596602645-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-9)">│</text><text class="terminal-1596602645-r5" x="24.4" y="239.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-9)">-</text><text class="terminal-1596602645-r5" x="36.6" y="239.6" textLength="85.4" clip-path="url(#terminal-1596602645-line-9)">-github</text><text class="terminal-1596602645-r5" x="122" y="239.6" textLength="134.2" clip-path="url(#terminal-1596602645-line-9)">-event-name</text><text class="terminal-1596602645-r2" x="305" y="239.6" textLength="1134.6" clip-path="url(#terminal-1596602645-line-9)">Name&#160;of&#160;the&#160;GitHub&#160;event&#160;that&#160;triggered&#160;the&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1596602645-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-9)">│</text><text class="terminal-1596602645-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-9)">
-</text><text class="terminal-1596602645-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1596602645-line-10)">│</text><text class="terminal-1596602645-r6" x="305" y="264" textLength="1134.6" clip-path="url(#terminal-1596602645-line-10)">(pull_request&#160;|&#160;pull_request_review&#160;|&#160;pull_request_target&#160;|&#160;pull_request_workflow&#160;|&#160;push&#160;|&#160;&#160;&#160;</text><text class="terminal-1596602645-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-1596602645-line-10)">│</text><text class="terminal-1596602645-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1596602645-line-10)">
-</text><text class="terminal-1596602645-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-11)">│</text><text class="terminal-1596602645-r6" x="305" y="288.4" textLength="1134.6" clip-path="url(#terminal-1596602645-line-11)">schedule&#160;|&#160;workflow_dispatch&#160;|&#160;workflow_run)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1596602645-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-11)">│</text><text class="terminal-1596602645-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-11)">
-</text><text class="terminal-1596602645-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-12)">│</text><text class="terminal-1596602645-r4" x="305" y="312.8" textLength="1134.6" clip-path="url(#terminal-1596602645-line-12)">[default:&#160;pull_request]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1596602645-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-12)">│</text><text class="terminal-1596602645-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-12)">
-</text><text class="terminal-1596602645-r4" x="0" y="337.2" textLength="1464" clip-path="url(#terminal-1596602645-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1596602645-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-13)">
-</text><text class="terminal-1596602645-r4" x="0" y="361.6" textLength="24.4" clip-path="url(#terminal-1596602645-line-14)">╭─</text><text class="terminal-1596602645-r4" x="24.4" y="361.6" textLength="1415.2" clip-path="url(#terminal-1596602645-line-14)">&#160;Options&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1596602645-r4" x="1439.6" y="361.6" textLength="24.4" clip-path="url(#terminal-1596602645-line-14)">─╮</text><text class="terminal-1596602645-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1596602645-line-14)">
-</text><text class="terminal-1596602645-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1596602645-line-15)">│</text><text class="terminal-1596602645-r5" x="24.4" y="386" textLength="12.2" clip-path="url(#terminal-1596602645-line-15)">-</text><text class="terminal-1596602645-r5" x="36.6" y="386" textLength="97.6" clip-path="url(#terminal-1596602645-line-15)">-verbose</text><text class="terminal-1596602645-r7" x="158.6" y="386" textLength="24.4" clip-path="url(#terminal-1596602645-line-15)">-v</text><text class="terminal-1596602645-r2" x="207.4" y="386" textLength="585.6" clip-path="url(#terminal-1596602645-line-15)">Print&#160;verbose&#160;information&#160;about&#160;performed&#160;steps.</text><text class="terminal-1596602645-r4" x="1451.8" y="386" textLength="12.2" clip-path="url(#terminal-1596602645-line-15)">│</text><text class="terminal-1596602645-r2" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1596602645-line-15)">
-</text><text class="terminal-1596602645-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-16)">│</text><text class="terminal-1596602645-r5" x="24.4" y="410.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-16)">-</text><text class="terminal-1596602645-r5" x="36.6" y="410.4" textLength="48.8" clip-path="url(#terminal-1596602645-line-16)">-dry</text><text class="terminal-1596602645-r5" x="85.4" y="410.4" textLength="48.8" clip-path="url(#terminal-1596602645-line-16)">-run</text><text class="terminal-1596602645-r7" x="158.6" y="410.4" textLength="24.4" clip-path="url(#terminal-1596602645-line-16)">-D</text><text class="terminal-1596602645-r2" x="207.4" y="410.4" textLength="719.8" clip-path="url(#terminal-1596602645-line-16)">If&#160;dry-run&#160;is&#160;set,&#160;commands&#160;are&#160;only&#160;printed,&#160;not&#160;executed.</text><text class="terminal-1596602645-r4" x="1451.8" y="410.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-16)">│</text><text class="terminal-1596602645-r2" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1596602645-line-16)">
-</text><text class="terminal-1596602645-r4" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-17)">│</text><text class="terminal-1596602645-r5" x="24.4" y="434.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-17)">-</text><text class="terminal-1596602645-r5" x="36.6" y="434.8" textLength="61" clip-path="url(#terminal-1596602645-line-17)">-help</text><text class="terminal-1596602645-r7" x="158.6" y="434.8" textLength="24.4" clip-path="url(#terminal-1596602645-line-17)">-h</text><text class="terminal-1596602645-r2" x="207.4" y="434.8" textLength="329.4" clip-path="url(#terminal-1596602645-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-1596602645-r4" x="1451.8" y="434.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-17)">│</text><text class="terminal-1596602645-r2" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-1596602645-line-17)">
-</text><text class="terminal-1596602645-r4" x="0" y="459.2" textLength="1464" clip-path="url(#terminal-1596602645-line-18)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1596602645-r2" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-1596602645-line-18)">
+    <g class="terminal-3842717742-matrix">
+    <text class="terminal-3842717742-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3842717742-line-0)">
+</text><text class="terminal-3842717742-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-3842717742-line-1)">Usage:&#160;</text><text class="terminal-3842717742-r1" x="97.6" y="44.4" textLength="390.4" clip-path="url(#terminal-3842717742-line-1)">breeze&#160;selective-check&#160;[OPTIONS]</text><text class="terminal-3842717742-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-1)">
+</text><text class="terminal-3842717742-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-2)">
+</text><text class="terminal-3842717742-r2" x="12.2" y="93.2" textLength="768.6" clip-path="url(#terminal-3842717742-line-3)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.</text><text class="terminal-3842717742-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-3)">
+</text><text class="terminal-3842717742-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-4)">
+</text><text class="terminal-3842717742-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-3842717742-line-5)">╭─</text><text class="terminal-3842717742-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-3842717742-line-5)">&#160;Selective&#160;check&#160;flags&#160;─────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3842717742-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-3842717742-line-5)">─╮</text><text class="terminal-3842717742-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3842717742-line-5)">
+</text><text class="terminal-3842717742-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">│</text><text class="terminal-3842717742-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">-</text><text class="terminal-3842717742-r5" x="36.6" y="166.4" textLength="85.4" clip-path="url(#terminal-3842717742-line-6)">-commit</text><text class="terminal-3842717742-r5" x="122" y="166.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-6)">-ref</text><text class="terminal-3842717742-r2" x="305" y="166.4" textLength="695.4" clip-path="url(#terminal-3842717742-line-6)">Commit-ish&#160;reference&#160;to&#160;the&#160;commit&#160;that&#160;should&#160;be&#160;checked</text><text class="terminal-3842717742-r6" x="1012.6" y="166.4" textLength="73.2" clip-path="url(#terminal-3842717742-line-6)">(TEXT)</text><text class="terminal-3842717742-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">│</text><text class="terminal-3842717742-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-6)">
+</text><text class="terminal-3842717742-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">│</text><text class="terminal-3842717742-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">-</text><text class="terminal-3842717742-r5" x="36.6" y="190.8" textLength="36.6" clip-path="url(#terminal-3842717742-line-7)">-pr</text><text class="terminal-3842717742-r5" x="73.2" y="190.8" textLength="85.4" clip-path="url(#terminal-3842717742-line-7)">-labels</text><text class="terminal-3842717742-r2" x="305" y="190.8" textLength="622.2" clip-path="url(#terminal-3842717742-line-7)">Python&#160;array&#160;formatted&#160;PR&#160;labels&#160;assigned&#160;to&#160;the&#160;PR</text><text class="terminal-3842717742-r6" x="939.4" y="190.8" textLength="73.2" clip-path="url(#terminal-3842717742-line-7)">(TEXT)</text><text class="terminal-3842717742-r4" x="1451.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">│</text><text class="terminal-3842717742-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-7)">
+</text><text class="terminal-3842717742-r4" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">│</text><text class="terminal-3842717742-r5" x="24.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">-</text><text class="terminal-3842717742-r5" x="36.6" y="215.2" textLength="97.6" clip-path="url(#terminal-3842717742-line-8)">-default</text><text class="terminal-3842717742-r5" x="134.2" y="215.2" textLength="85.4" clip-path="url(#terminal-3842717742-line-8)">-branch</text><text class="terminal-3842717742-r2" x="305" y="215.2" textLength="500.2" clip-path="url(#terminal-3842717742-line-8)">Branch&#160;against&#160;which&#160;the&#160;PR&#160;should&#160;be&#160;run</text><text class="terminal-3842717742-r6" x="817.4" y="215.2" textLength="73.2" clip-path="url(#terminal-3842717742-line-8)">(TEXT)</text><text class="terminal-3842717742-r4" x="902.8" y="215.2" textLength="183" clip-path="url(#terminal-3842717742-line-8)">[default:&#160;main]</text><text class="terminal-3842717742-r4" x="1451.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">│</text><text class="terminal-3842717742-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-8)">
+</text><text class="terminal-3842717742-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">│</text><text class="terminal-3842717742-r5" x="24.4" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">-</text><text class="terminal-3842717742-r5" x="36.6" y="239.6" textLength="85.4" clip-path="url(#terminal-3842717742-line-9)">-github</text><text class="terminal-3842717742-r5" x="122" y="239.6" textLength="134.2" clip-path="url(#terminal-3842717742-line-9)">-event-name</text><text class="terminal-3842717742-r2" x="305" y="239.6" textLength="1134.6" clip-path="url(#terminal-3842717742-line-9)">Name&#160;of&#160;the&#160;GitHub&#160;event&#160;that&#160;triggered&#160;the&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">│</text><text class="terminal-3842717742-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-9)">
+</text><text class="terminal-3842717742-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">│</text><text class="terminal-3842717742-r6" x="305" y="264" textLength="1134.6" clip-path="url(#terminal-3842717742-line-10)">(pull_request&#160;|&#160;pull_request_review&#160;|&#160;pull_request_target&#160;|&#160;pull_request_workflow&#160;|&#160;push&#160;|&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">│</text><text class="terminal-3842717742-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3842717742-line-10)">
+</text><text class="terminal-3842717742-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">│</text><text class="terminal-3842717742-r6" x="305" y="288.4" textLength="1134.6" clip-path="url(#terminal-3842717742-line-11)">schedule&#160;|&#160;workflow_dispatch&#160;|&#160;workflow_run)&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">│</text><text class="terminal-3842717742-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-11)">
+</text><text class="terminal-3842717742-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">│</text><text class="terminal-3842717742-r4" x="305" y="312.8" textLength="1134.6" clip-path="url(#terminal-3842717742-line-12)">[default:&#160;pull_request]&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3842717742-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">│</text><text class="terminal-3842717742-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-12)">
+</text><text class="terminal-3842717742-r4" x="0" y="337.2" textLength="1464" clip-path="url(#terminal-3842717742-line-13)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3842717742-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-13)">
+</text><text class="terminal-3842717742-r4" x="0" y="361.6" textLength="24.4" clip-path="url(#terminal-3842717742-line-14)">╭─</text><text class="terminal-3842717742-r4" x="24.4" y="361.6" textLength="1415.2" clip-path="url(#terminal-3842717742-line-14)">&#160;Options&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3842717742-r4" x="1439.6" y="361.6" textLength="24.4" clip-path="url(#terminal-3842717742-line-14)">─╮</text><text class="terminal-3842717742-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-3842717742-line-14)">
+</text><text class="terminal-3842717742-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">│</text><text class="terminal-3842717742-r5" x="24.4" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">-</text><text class="terminal-3842717742-r5" x="36.6" y="386" textLength="97.6" clip-path="url(#terminal-3842717742-line-15)">-verbose</text><text class="terminal-3842717742-r7" x="158.6" y="386" textLength="24.4" clip-path="url(#terminal-3842717742-line-15)">-v</text><text class="terminal-3842717742-r2" x="207.4" y="386" textLength="585.6" clip-path="url(#terminal-3842717742-line-15)">Print&#160;verbose&#160;information&#160;about&#160;performed&#160;steps.</text><text class="terminal-3842717742-r4" x="1451.8" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">│</text><text class="terminal-3842717742-r2" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-3842717742-line-15)">
+</text><text class="terminal-3842717742-r4" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">│</text><text class="terminal-3842717742-r5" x="24.4" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">-</text><text class="terminal-3842717742-r5" x="36.6" y="410.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-16)">-dry</text><text class="terminal-3842717742-r5" x="85.4" y="410.4" textLength="48.8" clip-path="url(#terminal-3842717742-line-16)">-run</text><text class="terminal-3842717742-r7" x="158.6" y="410.4" textLength="24.4" clip-path="url(#terminal-3842717742-line-16)">-D</text><text class="terminal-3842717742-r2" x="207.4" y="410.4" textLength="719.8" clip-path="url(#terminal-3842717742-line-16)">If&#160;dry-run&#160;is&#160;set,&#160;commands&#160;are&#160;only&#160;printed,&#160;not&#160;executed.</text><text class="terminal-3842717742-r4" x="1451.8" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">│</text><text class="terminal-3842717742-r2" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-3842717742-line-16)">
+</text><text class="terminal-3842717742-r4" x="0" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">│</text><text class="terminal-3842717742-r5" x="24.4" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">-</text><text class="terminal-3842717742-r5" x="36.6" y="434.8" textLength="61" clip-path="url(#terminal-3842717742-line-17)">-help</text><text class="terminal-3842717742-r7" x="158.6" y="434.8" textLength="24.4" clip-path="url(#terminal-3842717742-line-17)">-h</text><text class="terminal-3842717742-r2" x="207.4" y="434.8" textLength="329.4" clip-path="url(#terminal-3842717742-line-17)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-3842717742-r4" x="1451.8" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">│</text><text class="terminal-3842717742-r2" x="1464" y="434.8" textLength="12.2" clip-path="url(#terminal-3842717742-line-17)">
+</text><text class="terminal-3842717742-r4" x="0" y="459.2" textLength="1464" clip-path="url(#terminal-3842717742-line-18)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3842717742-r2" x="1464" y="459.2" textLength="12.2" clip-path="url(#terminal-3842717742-line-18)">
 </text>
     </g>
     </g>


### PR DESCRIPTION
Label detection for incoming PR had few bugs:

* wrong name of output was used for Build Info
* assumption in selective checks was that PR labels are
  space separated, but they were really array formatted.
* there was a $ typo in build-images.yaml

This PR fixes all that:
* output name and typo is corrected
* we use ast.literal_eval now to parse the PR labels.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
