### PR TITLE
fix #25149 DAG.access_control can't sync when clean access_control

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -646,7 +646,7 @@ class DagBag(LoggingMixin):
         def needs_perms(dag_id: str) -> bool:
             dag_resource_name = resource_name_for_dag(dag_id)
             for permission_name in DAG_ACTIONS:
-                if not (
+                if (
                     session.query(Permission)
                     .join(Action)
                     .join(Resource)

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -621,8 +621,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         for dag_action_name in self.DAG_ACTIONS:
             self.create_permission(dag_action_name, dag_resource_name)
 
-        if access_control:
-            self._sync_dag_view_permissions(dag_resource_name, access_control)
+        self._sync_dag_view_permissions(dag_resource_name, access_control)
 
     def _sync_dag_view_permissions(self, dag_id, access_control):
         """


### PR DESCRIPTION
closes: #25149

- fix needs_perms logical error.
- we shoud sync dag to db when we clear access_control.
