### PR TITLE
Speed up Kubernetes upgrade tests at least 2x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,13 @@ jobs:
       all-python-versions-list-as-string: >-
         ${{ steps.selective-checks.outputs.all-python-versions-list-as-string }}
       default-python-version: ${{ steps.selective-checks.outputs.default-python-version }}
+      min-max-python-versions-as-string: >-
+        ${{ steps.selective-checks.outputs.min-max-python-versions-as-string }}
       kubernetes-versions-list-as-string: >-
         ${{ steps.selective-checks.outputs.kubernetes-versions-list-as-string }}
+      default-kubernetes-version: ${{ steps.selective-checks.outputs.default-kubernetes-version }}
+      min-max-kubernetes-versions-as-string: >-
+        ${{ steps.selective-checks.outputs.min-max-kubernetes-versions-as-string }}
       postgres-versions: ${{ steps.selective-checks.outputs.postgres-versions }}
       default-postgres-version: ${{ steps.selective-checks.outputs.default-postgres-version }}
       mysql-versions: ${{ steps.selective-checks.outputs.mysql-versions }}
@@ -1524,7 +1529,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
 
   tests-helm-executor-upgrade:
     timeout-minutes: 150
-    name: Helm Chart Executor Upgrade - ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
+    name: Helm Chart Executor Upgrade - ${{needs.build-info.outputs.min-max-kubernetes-versions-as-string}}
     runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
     needs: [build-info, wait-for-prod-images]
     env:
@@ -1536,10 +1541,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       EXECUTOR: "KubernetesExecutor"
       KIND_VERSION: "${{ needs.build-info.outputs.default-kind-version }}"
       HELM_VERSION: "${{ needs.build-info.outputs.default-helm-version }}"
-      CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING: >
-        ${{needs.build-info.outputs.python-versions-list-as-string}}
-      CURRENT_KUBERNETES_VERSIONS_AS_STRING: >
-        ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
+      CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING: >-
+        ${{needs.build-info.outputs.min-max-python-versions-as-string}}
+      CURRENT_KUBERNETES_VERSIONS_AS_STRING: >-
+        ${{needs.build-info.outputs.min-max-kubernetes-versions-as-string}}
     if: >
       needs.build-info.outputs.run-kubernetes-tests == 'true' &&
       needs.build-info.outputs.default-branch == 'main'
@@ -1569,12 +1574,12 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           path: ".build/.kubernetes_venv"
           key: "kubernetes-${{ needs.build-info.outputs.default-python-version }}\
-  -${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
-  -${{needs.build-info.outputs.python-versions-list-as-string}}
+  -${{needs.build-info.outputs.min-max-kubernetes-versions-as-string}}
+  -${{needs.build-info.outputs.min-max-python-versions-as-string}}
   -${{ hashFiles('setup.py','setup.cfg') }}"
           restore-keys: "kubernetes-${{ needs.build-info.outputs.default-python-version }}-\
-  -${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
-  -${{needs.build-info.outputs.python-versions-list-as-string}}"
+  -${{needs.build-info.outputs.min-max-kubernetes-versions-as-string}} \
+  -${{needs.build-info.outputs.min-max-python-versions-as-string}}"
       - name: "Cache bin folder with tools for kubernetes testing"
         uses: actions/cache@v3
         with:

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -325,6 +325,14 @@ class SelectiveChecks:
         return " ".join(self.python_versions)
 
     @cached_property
+    def min_max_python_versions_as_string(self) -> str:
+        return " ".join(
+            [CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[0], CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[-1]]
+            if self._full_tests_needed
+            else [DEFAULT_PYTHON_MAJOR_MINOR_VERSION]
+        )
+
+    @cached_property
     def all_python_versions(self) -> list[str]:
         return (
             ALL_PYTHON_MAJOR_MINOR_VERSIONS
@@ -379,6 +387,14 @@ class SelectiveChecks:
     @cached_property
     def kubernetes_versions(self) -> list[str]:
         return CURRENT_KUBERNETES_VERSIONS if self._full_tests_needed else [DEFAULT_KUBERNETES_VERSION]
+
+    @cached_property
+    def min_max_kubernetes_versions_as_string(self) -> str:
+        return " ".join(
+            [CURRENT_KUBERNETES_VERSIONS[0], CURRENT_KUBERNETES_VERSIONS[-1]]
+            if self._full_tests_needed
+            else [DEFAULT_KUBERNETES_VERSION]
+        )
 
     @cached_property
     def kubernetes_versions_list_as_string(self) -> str:


### PR DESCRIPTION
We do not need to run upgrade kubernetes tests for all python
versions and all kubernetes versions. It is enough to run them
for the minimum and maximum versions. We already run all k8s tests
in main for all executors, so they "generally" work, and it
is very, very unlikely that if it works for Python 3.7, and 3.10,
it will not work for 3.8 or 3.9 (similarly for K8S version).

This will speed up the build at least 2 times.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
