### PR TITLE
Allow re-use of decorated task groups

### DIFF
--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -80,6 +80,9 @@ class TaskGroupDecorator(Generic[R]):
         #   start >> tg >> end
         return task_group
 
+    def override(self, **kwargs: Any) -> "TaskGroupDecorator[R]":
+        return attr.evolve(self, kwargs={**self.kwargs, **kwargs})
+
 
 class Group(Generic[F]):
     """Declaration of a @task_group-decorated callable for type-checking.

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.decorators import task_group
+
+
+def test_task_group_with_overridden_kwargs():
+    @task_group(
+        default_args={
+            'params': {
+                'x': 5,
+                'y': 5,
+            },
+        },
+        add_suffix_on_collision=True,
+    )
+    def simple_tg():
+        ...
+
+    tg_with_overridden_kwargs = simple_tg.override(
+        group_id='custom_group_id',
+        default_args={
+            'params': {
+                'x': 10,
+            },
+        },
+    )
+
+    assert tg_with_overridden_kwargs.kwargs == {
+        'group_id': 'custom_group_id',
+        'default_args': {
+            'params': {
+                'x': 10,
+            },
+        },
+        'add_suffix_on_collision': True,
+    }


### PR DESCRIPTION
There is no way to change group_id of `@task_group` decorated function (TaskGroupDecorator) outside of its declaration. 
I am following the same style that was proposed in solving the same problem for `@task` decorated functions #22941:

```python
@task_group
def simple_tg():
   ...

@dag
def simple_dag():
    tg = simple_tg.override(group_id='other_id')()
```

Also this feature allows to change other kwargs of TaskGroup:
```python
@dag
def simple_dag2():
    tg = simple_tg.override(default_args={
        'pool': 'mypool',
    })()
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
