### PR TITLE
Add parsing context to DAG Parsing 

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -251,7 +251,6 @@ class DagFileProcessorAgent(LoggingMixin, MultiprocessingStartMethodMixin):
             signal_conn=signal_conn,
             async_mode=async_mode,
         )
-
         processor_manager.start()
 
     def heartbeat(self) -> None:

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -137,7 +137,6 @@ class DagFileProcessorProcess(LoggingMixin, MultiprocessingStartMethodMixin):
 
         set_context(log, file_path)
         setproctitle(f"airflow scheduler - DagFileProcessor {file_path}")
-
         try:
             # redirect stdout/stderr to log
             with redirect_stdout(StreamLogWriter(log, logging.INFO)), redirect_stderr(

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -16,6 +16,7 @@
 # under the License.
 """Base executor - this is the base class for all the implemented executors."""
 import sys
+import warnings
 from collections import OrderedDict
 from typing import Any, Counter, Dict, List, Optional, Sequence, Set, Tuple, Union
 
@@ -333,9 +334,42 @@ class BaseExecutor(LoggingMixin):
 
     @staticmethod
     def validate_command(command: List[str]) -> None:
-        """Check if the command to execute is airflow command"""
+        """
+        Back-compat method to Check if the command to execute is airflow command
+
+        :param command: command to check
+        :return: None
+        """
+        warnings.warn(
+            """
+            The `validate_command` method is deprecated. Please use ``validate_airflow_tasks_run_command``
+            """,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        BaseExecutor.validate_airflow_tasks_run_command(command)
+
+    @staticmethod
+    def validate_airflow_tasks_run_command(command: List[str]) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Check if the command to execute is airflow command
+
+        Returns tuple (dag_id,task_id) retrieved from the command (replaced with None values if missing)
+        """
         if command[0:3] != ["airflow", "tasks", "run"]:
             raise ValueError('The command must start with ["airflow", "tasks", "run"].')
+        if len(command) > 3 and "--help" not in command:
+            dag_id: Optional[str] = None
+            task_id: Optional[str] = None
+            for arg in command[4:]:
+                if not arg.startswith("--"):
+                    if dag_id is None:
+                        dag_id = arg
+                    else:
+                        task_id = arg
+                        break
+            return dag_id, task_id
+        return None, None
 
     def debug_dump(self):
         """Called in response to SIGUSR2 by the scheduler"""

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -77,7 +77,7 @@ class DaskExecutor(BaseExecutor):
         executor_config: Optional[Any] = None,
     ) -> None:
 
-        self.validate_command(command)
+        self.validate_airflow_tasks_run_command(command)
 
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -368,7 +368,7 @@ class LocalExecutor(BaseExecutor):
         if not self.impl:
             raise AirflowException(NOT_STARTED_MESSAGE)
 
-        self.validate_command(command)
+        self.validate_airflow_tasks_run_command(command)
 
         self.impl.execute_async(key=key, command=command, queue=queue, executor_config=executor_config)
 

--- a/airflow/executors/sequential_executor.py
+++ b/airflow/executors/sequential_executor.py
@@ -51,7 +51,7 @@ class SequentialExecutor(BaseExecutor):
         queue: Optional[str] = None,
         executor_config: Optional[Any] = None,
     ) -> None:
-        self.validate_command(command)
+        self.validate_airflow_tasks_run_command(command)
         self.commands_to_run.append((key, command))
 
     def sync(self) -> None:

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -20,6 +20,7 @@ import os
 import subprocess
 import threading
 
+from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.platform import IS_WINDOWS
 
 if not IS_WINDOWS:
@@ -126,26 +127,29 @@ class BaseTaskRunner(LoggingMixin):
 
         self.log.info("Running on host: %s", get_hostname())
         self.log.info('Running: %s', full_cmd)
-
-        if IS_WINDOWS:
-            proc = subprocess.Popen(
-                full_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                close_fds=True,
-                env=os.environ.copy(),
-            )
-        else:
-            proc = subprocess.Popen(
-                full_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                close_fds=True,
-                env=os.environ.copy(),
-                preexec_fn=os.setsid,
-            )
+        with _airflow_parsing_context_manager(
+            dag_id=self._task_instance.dag_id,
+            task_id=self._task_instance.task_id,
+        ):
+            if IS_WINDOWS:
+                proc = subprocess.Popen(
+                    full_cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    universal_newlines=True,
+                    close_fds=True,
+                    env=os.environ.copy(),
+                )
+            else:
+                proc = subprocess.Popen(
+                    full_cmd,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    universal_newlines=True,
+                    close_fds=True,
+                    env=os.environ.copy(),
+                    preexec_fn=os.setsid,
+                )
 
         # Start daemon thread to read subprocess logging output
         log_reader = threading.Thread(

--- a/airflow/utils/dag_parsing_context.py
+++ b/airflow/utils/dag_parsing_context.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+from contextlib import contextmanager
+from typing import NamedTuple, Optional
+
+
+class AirflowParsingContext(NamedTuple):
+    """Context of parsing for the DAG."""
+
+    dag_id: Optional[str]
+    task_id: Optional[str]
+
+
+_AIRFLOW_PARSING_CONTEXT_DAG_ID = "_AIRFLOW_PARSING_CONTEXT_DAG_ID"
+_AIRFLOW_PARSING_CONTEXT_TASK_ID = "_AIRFLOW_PARSING_CONTEXT_TASK_ID"
+
+
+@contextmanager
+def _airflow_parsing_context_manager(dag_id: Optional[str] = None, task_id: Optional[str] = None):
+    old_dag_id = os.environ.get(_AIRFLOW_PARSING_CONTEXT_DAG_ID)
+    old_task_id = os.environ.get(_AIRFLOW_PARSING_CONTEXT_TASK_ID)
+    if dag_id is not None:
+        os.environ[_AIRFLOW_PARSING_CONTEXT_DAG_ID] = dag_id
+    if task_id is not None:
+        os.environ[_AIRFLOW_PARSING_CONTEXT_TASK_ID] = task_id
+    yield
+    if old_task_id is not None:
+        os.environ[_AIRFLOW_PARSING_CONTEXT_TASK_ID] = old_task_id
+    if old_dag_id is not None:
+        os.environ[_AIRFLOW_PARSING_CONTEXT_DAG_ID] = old_dag_id
+
+
+def get_parsing_context() -> AirflowParsingContext:
+    return AirflowParsingContext(
+        dag_id=os.environ.get(_AIRFLOW_PARSING_CONTEXT_DAG_ID),
+        task_id=os.environ.get(_AIRFLOW_PARSING_CONTEXT_TASK_ID),
+    )

--- a/docs/apache-airflow/howto/dynamic-dag-generation.rst
+++ b/docs/apache-airflow/howto/dynamic-dag-generation.rst
@@ -140,3 +140,61 @@ Each of them can run separately with related configuration
 
 .. warning::
   Using this practice, pay attention to "late binding" behaviour in Python loops. See `that GitHub discussion <https://github.com/apache/airflow/discussions/21278#discussioncomment-2103559>`_ for more details
+
+|experimental|
+
+Optimizing DAG parsing delays during execution
+----------------------------------------------
+
+Sometimes when you generate a lot of Dynamic DAGs from a single DAG file, it might cause unnecessary delays
+when the DAG file is parsed during task execution. The impact is a delay before a task starts.
+
+Why is this happening? You might not be aware but just before your task is executed,
+Airflow parses the Python file the DAG comes from.
+
+The Airflow Scheduler (or rather DAG File Processor) requires loading of a complete DAG file to process
+all metadata. However, task execution requires only a single DAG object to execute a task. Knowing this,
+we can skip the generation of unnecessary DAG objects when a task is executed, shortening the parsing time.
+This optimization is most effective when the number of generated DAGs is high.
+
+There is an experimental approach that you can take to optimize this behaviour. Note that it is not always
+possible to use (for example when generation of subsequent DAGs depends on the previous DAGs) or when
+there are some side-effects of your DAGs generation. Also the code snippet below is pretty complex and while
+we tested it and it works in most circumstances, there might be cases where detection of the currently
+parsed DAG will fail and it will revert to creating all the DAGs or fail. Use this solution with care and
+test it thoroughly.
+
+A nice example of performance improvements you can gain is shown in the
+`Airflow's Magic Loop <https://medium.com/apache-airflow/airflows-magic-loop-ec424b05b629>`_ blog post
+that describes how parsing during task execution was reduced from 120 seconds to 200 ms.
+
+The example was written before Airflow 2.4 so it uses undocumented behaviour of Airflow. In Airflow 2.4
+instead you can use py:meth:`~airflow.utils.dag_parsing_context.get_parsing_context` method
+to retrieve the current context in documented and predictable way.
+
+Upon iterating over the collection of things to generate DAGs for, you can use the context to determine
+whether you need to generate all DAG objects (when parsing in the DAG File processor), or to generate only
+a single DAG object (when executing the task).
+
+The py:meth:`~airflow.utils.dag_parsing_context.get_parsing_context` return the current parsing
+context. The context is of py:class:`~airflow.utils.dag_parsing_context.AirflowParsingContext` and
+in case only single dag/task is needed, it contains ``dag_id`` and ``task_id`` fields set.
+In case "full" parsing is needed (for example in DAG File Processor), ``dag_id`` and ``task_id``
+of the context are set to ``None``.
+
+
+.. code-block:: python
+  :emphasize-lines: 4,8,9
+
+  from airflow.models.dag import DAG
+  from airflow.utils.dag_parsing_context import get_parsing_context
+
+  current_dag_id = get_parsing_context().dag_id
+
+  for thing in list_of_things:
+      dag_id = f"generated_dag_{thing}"
+      if current_dag_id is not None and current_dag_id != dag_id:
+          continue  # skip generation of non-selected DAG
+
+      dag = DAG(dag_id=dag_id, ...)
+      globals()[dag_id] = dag

--- a/tests/dags/test_parsing_context.py
+++ b/tests/dags/test_parsing_context.py
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from pathlib import Path
+
+from airflow.models.dag import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.context import Context
+from airflow.utils.dag_parsing_context import (
+    _AIRFLOW_PARSING_CONTEXT_DAG_ID,
+    _AIRFLOW_PARSING_CONTEXT_TASK_ID,
+)
+from airflow.utils.timezone import datetime
+
+
+class DagWithParsingContext(EmptyOperator):
+    def execute(self, context: Context):
+        import os
+
+        parsing_context_file = Path("/tmp/airflow_parsing_context")
+        self.log.info("Executing")
+        # signal to the test that we've started
+        parsing_context = (
+            f"{_AIRFLOW_PARSING_CONTEXT_DAG_ID}={os.environ.get(_AIRFLOW_PARSING_CONTEXT_DAG_ID)}\n"
+            f"{_AIRFLOW_PARSING_CONTEXT_TASK_ID}={os.environ.get(_AIRFLOW_PARSING_CONTEXT_TASK_ID)}\n"
+        )
+
+        parsing_context_file.write_text(parsing_context)
+        self.log.info("Executed")
+
+
+dag1 = DAG(dag_id='test_parsing_context', start_date=datetime(2015, 1, 1))
+
+dag1_task1 = DagWithParsingContext(task_id='task1', dag=dag1, owner='airflow')


### PR DESCRIPTION
Adds proper context in the form of context managers setting
evironment variables to indicate whethere the
dag file is parsed in context of DAG processor or Task Execution
and allows to retrieve DAG_ID and TASK_ID easily.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
