### PR TITLE
Improve taskflow type hints with ParamSpec

### DIFF
--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -20,9 +20,9 @@
 # necessarily exist at run time. See "Creating Custom @task Decorators"
 # documentation for more details.
 
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Union, overload
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union, overload
 
-from airflow.decorators.base import Function, Task, TaskDecorator
+from airflow.decorators.base import FParams, FReturn, Task, TaskDecorator
 from airflow.decorators.branch_python import branch_task
 from airflow.decorators.python import python_task
 from airflow.decorators.python_virtualenv import virtualenv_task
@@ -68,7 +68,7 @@ class TaskDecoratorCollection:
         """
     # [START mixin_for_typing]
     @overload
-    def python(self, python_callable: Function) -> Task[Function]: ...
+    def python(self, python_callable: Callable[FParams, FReturn]) -> Task[FParams, FReturn]: ...
     # [END mixin_for_typing]
     @overload
     def __call__(
@@ -81,7 +81,7 @@ class TaskDecoratorCollection:
     ) -> TaskDecorator:
         """Aliasing ``python``; signature should match exactly."""
     @overload
-    def __call__(self, python_callable: Function) -> Task[Function]:
+    def __call__(self, python_callable: Callable[FParams, FReturn]) -> Task[FParams, FReturn]:
         """Aliasing ``python``; signature should match exactly."""
     @overload
     def virtualenv(
@@ -122,7 +122,7 @@ class TaskDecoratorCollection:
             such as transmission a large amount of XCom to TaskAPI.
         """
     @overload
-    def virtualenv(self, python_callable: Function) -> Task[Function]: ...
+    def virtualenv(self, python_callable: Callable[FParams, FReturn]) -> Task[FParams, FReturn]: ...
     @overload
     def branch(self, *, multiple_outputs: Optional[bool] = None, **kwargs) -> TaskDecorator:
         """Create a decorator to wrap the decorated callable into a BranchPythonOperator.
@@ -134,7 +134,7 @@ class TaskDecoratorCollection:
             Dict will unroll to XCom values with keys as XCom keys. Defaults to False.
         """
     @overload
-    def branch(self, python_callable: Function) -> Task[Function]: ...
+    def branch(self, python_callable: Callable[FParams, FReturn]) -> Task[FParams, FReturn]: ...
     # [START decorator_signature]
     def docker(
         self,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -328,7 +328,7 @@ class KubernetesPodOperator(BaseOperator):
         if include_try_number:
             labels.update(try_number=ti.try_number)
         # In the case of sub dags this is just useful
-        if context['dag'].is_subdag:
+        if context['dag'].parent_dag:
             labels['parent_dag_id'] = context['dag'].parent_dag.dag_id
         # Ensure that label is valid for Kube,
         # and if not truncate/remove invalid chars and replace with short hash.

--- a/airflow/providers/dbt/cloud/hooks/dbt.py
+++ b/airflow/providers/dbt/cloud/hooks/dbt.py
@@ -87,7 +87,7 @@ class TokenAuth(AuthBase):
 class JobRunInfo(TypedDict):
     """Type class for the ``job_run_info`` dictionary."""
 
-    account_id: int
+    account_id: Optional[int]
     run_id: int
 
 

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -46,6 +46,7 @@ from airflow.hooks.base import BaseHook
 from airflow.utils.state import State
 
 if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
     from airflow.utils.context import Context
 
 
@@ -139,7 +140,7 @@ class QuboleHook(BaseHook):
         self.kwargs = kwargs
         self.cls = COMMAND_CLASSES[self.kwargs['command_type']]
         self.cmd: Optional[Command] = None
-        self.task_instance = None
+        self.task_instance: Optional["TaskInstance"] = None
 
     @staticmethod
     def handle_failure_retry(context) -> None:

--- a/airflow/providers/salesforce/operators/bulk.py
+++ b/airflow/providers/salesforce/operators/bulk.py
@@ -47,7 +47,7 @@ class SalesforceBulkOperator(BaseOperator):
     def __init__(
         self,
         *,
-        operation: Literal[available_operations],
+        operation: Literal['insert', 'update', 'upsert', 'delete', 'hard_delete'],
         object_name: str,
         payload: list,
         external_id_field: str = 'Id',

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -21,10 +21,28 @@ This module provides helper code to make type annotation within Airflow
 codebase easier.
 """
 
-try:
-    # Literal, Protocol and TypedDict are only added to typing module starting from
-    # python 3.8 we can safely remove this shim import after Airflow drops
-    # support for <3.8
-    from typing import Literal, Protocol, TypedDict, runtime_checkable  # type: ignore
-except ImportError:
-    from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable  # type: ignore # noqa
+__all__ = [
+    "Literal",
+    "ParamSpec",
+    "Protocol",
+    "TypedDict",
+    "runtime_checkable",
+]
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol, TypedDict, runtime_checkable
+else:
+    from typing_extensions import Protocol, TypedDict, runtime_checkable
+
+# Literal in 3.8 is limited to one single argument, not e.g. "Literal[1, 2]".
+if sys.version_info >= (3, 9):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec


### PR DESCRIPTION
~~This needs #25085 to be merged first. Only the last commit is relevant.~~

~~Submitted for CI now.~~

This should be ready. I needed to fix a few more (valid although unrelated) typing issues since Mypy started to flag them.

The main thing here is to replace the `Function` type var with `Callable[FParams, FReturn]` so we can do polymorphism against `FParams` without being tied to `FReturn`.