### PR TITLE
Add datasets to dag dependencies view

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2120,12 +2120,6 @@
       type: string
       example: ~
       default: "False"
-    - name: dependency_detector
-      description: DAG dependency detector class to use
-      version_added: 2.1.0
-      type: string
-      example: ~
-      default: "airflow.serialization.serialized_objects.DependencyDetector"
     - name: trigger_timeout_check_interval
       description: |
         How often to check for expired trigger requests that have not run yet.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1073,9 +1073,6 @@ use_job_schedule = True
 # Only has effect if schedule_interval is set to None in DAG
 allow_trigger_in_future = False
 
-# DAG dependency detector class to use
-dependency_detector = airflow.serialization.serialized_objects.DependencyDetector
-
 # How often to check for expired trigger requests that have not run yet.
 trigger_timeout_check_interval = 15
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -623,12 +623,11 @@ class DagBag(LoggingMixin):
                 )
                 self.log.debug("Calling the DAG.bulk_sync_to_db method")
                 try:
-                    DAG.bulk_write_to_db(self.dags.values(), session=session)
-
                     # Write Serialized DAGs to DB, capturing errors
                     for dag in self.dags.values():
-                        error_info = _serialize_dag_capturing_errors(dag, session)
-                        serialize_errors.extend(error_info)
+                        serialize_errors.extend(_serialize_dag_capturing_errors(dag, session))
+
+                    DAG.bulk_write_to_db(self.dags.values(), session=session)
                 except OperationalError:
                     session.rollback()
                     raise

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -623,11 +623,12 @@ class DagBag(LoggingMixin):
                 )
                 self.log.debug("Calling the DAG.bulk_sync_to_db method")
                 try:
+                    DAG.bulk_write_to_db(self.dags.values(), session=session)
+
                     # Write Serialized DAGs to DB, capturing errors
                     for dag in self.dags.values():
-                        serialize_errors.extend(_serialize_dag_capturing_errors(dag, session))
-
-                    DAG.bulk_write_to_db(self.dags.values(), session=session)
+                        error_info = _serialize_dag_capturing_errors(dag, session)
+                        serialize_errors.extend(error_info)
                 except OperationalError:
                     session.rollback()
                     raise

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -596,9 +596,9 @@ class DependencyDetector:
         return deps
 
     @staticmethod
-    def detect_dag_dependencies(dag: DAG) -> List["DagDependency"]:
+    def detect_dag_dependencies(dag: Optional[DAG]) -> List["DagDependency"]:
         """Detects dependencies set directly on the DAG object."""
-        if dag.schedule_on:
+        if dag and dag.schedule_on:
             return [
                 DagDependency(
                     source="dataset",
@@ -870,7 +870,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         return op
 
     @classmethod
-    def detect_dependencies(cls, op: Operator) -> Optional['DagDependency']:
+    def detect_dependencies(cls, op: Operator) -> Set['DagDependency']:
         """Detects between DAG dependencies for the operator."""
         dependency_detector = DependencyDetector()
         custom_dependency_detector = conf.getimport('scheduler', 'dependency_detector', fallback=None)

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -623,7 +623,7 @@ class DependencyDetector:
 
 
 class SerializedBaseOperator(BaseOperator, BaseSerialization):
-    """A JSON serializable  representation of operator.
+    """A JSON serializable representation of operator.
 
     All operators are casted to SerializedBaseOperator after deserialization.
     Class specific attributes used by UI are move to object attributes.

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -873,7 +873,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     def detect_dependencies(cls, op: Operator) -> Optional['DagDependency']:
         """Detects between DAG dependencies for the operator."""
         dependency_detector = DependencyDetector()
-        custom_dependency_detector = conf.getimport('scheduler', 'dependency_detector')
+        custom_dependency_detector = conf.getimport('scheduler', 'dependency_detector', fallback=None)
         deps = set()
         if not (custom_dependency_detector is None or type(dependency_detector) is DependencyDetector):
             warnings.warn(

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -1023,7 +1023,6 @@ class SerializedDAG(DAG, BaseSerialization):
     """
 
     _decorated_fields = {'schedule_interval', 'default_args', '_access_control'}
-    dependency_detector = conf.getimport('scheduler', 'dependency_detector')
 
     @staticmethod
     def __get_constructor_defaults():

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -882,7 +882,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 DeprecationWarning,
             )
             dep = custom_dependency_detector.detect_task_dependencies(op)
-            if dep:
+            if type(dep) is DagDependency:
                 deps.add(dep)
         deps.update(dependency_detector.detect_task_dependencies(op))
         deps.update(dependency_detector.detect_dag_dependencies(op.dag))

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -564,9 +564,6 @@ class DependencyDetector:
     @staticmethod
     def detect_task_dependencies(task: Operator) -> List['DagDependency']:
         """Detects dependencies caused by tasks"""
-        from airflow.settings import Session
-
-        session = Session()
         deps = []
         if isinstance(task, TriggerDagRunOperator):
             deps.append(
@@ -588,13 +585,12 @@ class DependencyDetector:
             )
         for obj in getattr(task, '_outlets', []):
             if isinstance(obj, Dataset):
-                dataset_id = session.query(Dataset.id).filter(Dataset.uri == obj.uri).scalar()
                 deps.append(
                     DagDependency(
                         source=task.dag_id,
                         target='dataset',
                         dependency_type='dataset',
-                        dependency_id=f"Dataset {dataset_id}",
+                        dependency_id=obj.uri,
                     )
                 )
         return deps
@@ -603,20 +599,14 @@ class DependencyDetector:
     def detect_dag_dependencies(dag: DAG) -> List["DagDependency"]:
         """Detects dependencies set directly on the DAG object."""
         if dag.schedule_on:
-            from airflow.settings import Session
-
-            session = Session()
-            dataset_ids = [
-                session.query(Dataset.id).filter(Dataset.uri == x.uri).scalar() for x in dag.schedule_on
-            ]
             return [
                 DagDependency(
                     source="dataset",
                     target=dag.dag_id,
                     dependency_type="dataset",
-                    dependency_id=f"Dataset {x}",
+                    dependency_id=x.uri,
                 )
-                for x in dataset_ids
+                for x in dag.schedule_on
             ]
         else:
             return []

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -555,7 +555,11 @@ class BaseSerialization:
 
 
 class DependencyDetector:
-    """Detects dependencies between DAGs."""
+    """
+    Detects dependencies between DAGs.
+
+    :meta private:
+    """
 
     @staticmethod
     def detect_task_dependencies(task: Operator) -> List['DagDependency']:

--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -161,6 +161,11 @@ g.node text {
   background-color: #e6f1f2;
 }
 
+.legend-item.dataset {
+  float: left;
+  background-color: #fcecd4;
+}
+
 g.node.dag rect {
   fill: #e8f7e4;
 }
@@ -171,4 +176,8 @@ g.node.trigger rect {
 
 g.node.sensor rect {
   fill: #e6f1f2;
+}
+
+g.node.dataset rect {
+  fill: #fcecd4;
 }

--- a/airflow/www/templates/airflow/dag_dependencies.html
+++ b/airflow/www/templates/airflow/dag_dependencies.html
@@ -43,6 +43,7 @@ under the License.
     <span class="legend-item dag">dag</span>
     <span class="legend-item trigger">trigger</span>
     <span class="legend-item sensor">sensor</span>
+    <span class="legend-item dataset">dataset</span>
   </div>
   <div style="float:right">Last refresh: <time datetime="{{ last_refresh }}">{{ last_refresh }}</time></div>
 </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5330,6 +5330,14 @@ class DagDependenciesView(AirflowBaseView):
 
     @staticmethod
     def _node_dict(node_id, label, node_class):
+        def trunc_uri(val):
+            if len(val) > 25:
+                return val[0:23] + '...'
+            else:
+                return val
+
+        if node_class == 'dataset':
+            label = trunc_uri(label)
         return {
             "id": node_id,
             "value": {"label": label, "rx": 5, "ry": 5, "class": node_class},

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5330,14 +5330,6 @@ class DagDependenciesView(AirflowBaseView):
 
     @staticmethod
     def _node_dict(node_id, label, node_class):
-        def trunc_uri(val):
-            if len(val) > 25:
-                return val[0:23] + '...'
-            else:
-                return val
-
-        if node_class == 'dataset':
-            label = trunc_uri(label)
         return {
             "id": node_id,
             "value": {"label": label, "rx": 5, "ry": 5, "class": node_class},

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -5309,24 +5309,24 @@ class DagDependenciesView(AirflowBaseView):
 
     def _calculate_graph(self):
 
-        nodes: List[Dict[str, Any]] = []
-        edges: List[Dict[str, str]] = []
+        nodes_dict: Dict[str, Any] = {}
+        edge_tuples: Set[Dict[str, str]] = set()
 
         for dag, dependencies in SerializedDagModel.get_dag_dependencies().items():
             dag_node_id = f"dag:{dag}"
-            nodes.append(self._node_dict(dag_node_id, dag, "dag"))
+            if dag_node_id not in nodes_dict:
+                nodes_dict[dag_node_id] = self._node_dict(dag_node_id, dag, "dag")
 
             for dep in dependencies:
-                nodes.append(self._node_dict(dep.node_id, dep.dependency_id, dep.dependency_type))
-                edges.extend(
-                    [
-                        {"u": f"dag:{dep.source}", "v": dep.node_id},
-                        {"u": dep.node_id, "v": f"dag:{dep.target}"},
-                    ]
-                )
+                if dep.node_id not in nodes_dict:
+                    nodes_dict[dep.node_id] = self._node_dict(
+                        dep.node_id, dep.dependency_id, dep.dependency_type
+                    )
+                edge_tuples.add((f"dag:{dep.source}", dep.node_id))
+                edge_tuples.add((dep.node_id, f"dag:{dep.target}"))
 
-        self.nodes = nodes
-        self.edges = edges
+        self.nodes = list(nodes_dict.values())
+        self.edges = [{"u": u, "v": v} for u, v in edge_tuples]
 
     @staticmethod
     def _node_dict(node_id, label, node_class):


### PR DESCRIPTION
Adds datasets to the dag dependencies view.

May want to reduce round trips to DB to look up dataset ID somehow.  (i may work on this tomorrow)

In future, if we can add optional `name` to dataset, better to use that for node labels.

As part of this I also remove the "dependency detector" as a configurable thing.  I'll call a vote by lazy consensus for this.

I really don't think something so small as determining the graph behavior in one view warrants pluggability in this way, and it just makes it harder to make changes. If the goal is just to allow for custom operators to register their dag deps, there are ways we can do this without needing to make this class pluggable.

cc @blag 

<img width="625" alt="image" src="https://user-images.githubusercontent.com/15932138/179912298-23d12445-6ec4-48b6-a949-360edd204fd6.png">
