### PR TITLE
Include missing mention of `external_executor_id` in docstring

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -405,7 +405,8 @@
       default: "utf-8"
     - name: sql_engine_collation_for_ids
       description: |
-        Collation for ``dag_id``, ``task_id``, ``key`` columns in case they have different encoding.
+        Collation for ``dag_id``, ``task_id``, ``key``, ``external_executor_id`` columns
+        in case they have different encoding.
         By default this collation is the same as the database collation, however for ``mysql`` and ``mariadb``
         the default is ``utf8mb3_bin`` so that the index sizes of our index keys will not exceed
         the maximum size of allowed index when collation is set to ``utf8mb4`` variant

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -226,7 +226,8 @@ sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/airflow.db
 # The encoding for the databases
 sql_engine_encoding = utf-8
 
-# Collation for ``dag_id``, ``task_id``, ``key`` columns in case they have different encoding.
+# Collation for ``dag_id``, ``task_id``, ``key``, ``external_executor_id`` columns
+# in case they have different encoding.
 # By default this collation is the same as the database collation, however for ``mysql`` and ``mariadb``
 # the default is ``utf8mb3_bin`` so that the index sizes of our index keys will not exceed
 # the maximum size of allowed index when collation is set to ``utf8mb4`` variant


### PR DESCRIPTION
As suggested by @potiuk in https://github.com/apache/airflow/issues/24526#issuecomment-1190658878 this fixes missing information in the docstring for the `sql_engine_collation_for_ids` setting.