### PR TITLE
Fix asset compilation via setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,9 @@ class CompileAssets(Command):
 
     def run(self) -> None:
         """Run a command to compile and build assets."""
-        subprocess.check_call('./airflow/www/compile_assets.sh')
+        www_dir = AIRFLOW_SOURCES_ROOT / "airflow" / "www"
+        subprocess.check_call(['yarn', 'install', '--frozen-lockfile'], cwd=str(www_dir))
+        subprocess.check_call(['yarn', 'run', 'build'], cwd=str(www_dir))
 
 
 class ListExtras(Command):


### PR DESCRIPTION
Asset compilation via setup.py has been broken in #25169.

This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
