### PR TITLE
Dataset details view

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -34,6 +34,7 @@ import useConfirmMarkTask from './useConfirmMarkTask';
 import useGridData from './useGridData';
 import useMappedInstances from './useMappedInstances';
 import useDatasets from './useDatasets';
+import useDatasetEvents from './useDatasetEvents';
 
 axios.interceptors.response.use(
   (res: AxiosResponse) => (res.data ? camelcaseKeys(res.data, { deep: true }) : res),
@@ -56,4 +57,5 @@ export {
   useGridData,
   useMappedInstances,
   useDatasets,
+  useDatasetEvents,
 };

--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -34,6 +34,7 @@ import useConfirmMarkTask from './useConfirmMarkTask';
 import useGridData from './useGridData';
 import useMappedInstances from './useMappedInstances';
 import useDatasets from './useDatasets';
+import useDataset from './useDataset';
 import useDatasetEvents from './useDatasetEvents';
 
 axios.interceptors.response.use(
@@ -57,5 +58,6 @@ export {
   useGridData,
   useMappedInstances,
   useDatasets,
+  useDataset,
   useDatasetEvents,
 };

--- a/airflow/www/static/js/api/useDataset.ts
+++ b/airflow/www/static/js/api/useDataset.ts
@@ -23,33 +23,16 @@ import { useQuery } from 'react-query';
 import { getMetaValue } from 'src/utils';
 import type { API } from 'src/types';
 
-interface DatasetsData {
-  datasets: API.Dataset[];
-  totalEntries: number;
-}
-
 interface Props {
-  limit?: number;
-  offset?: number;
-  order?: string;
+  datasetId: string;
 }
 
-export default function useDatasets({ limit, offset, order }: Props) {
-  const query = useQuery(
-    ['datasets', limit, offset, order],
+export default function useDataset({ datasetId }: Props) {
+  return useQuery(
+    ['dataset', datasetId],
     () => {
-      const datasetsUrl = getMetaValue('datasets_api') || '/api/v1/datasets';
-      const orderParam = order ? { order_by: order } : {};
-      return axios.get<AxiosResponse, DatasetsData>(datasetsUrl, {
-        params: { offset, limit, ...orderParam },
-      });
-    },
-    {
-      keepPreviousData: true,
+      const datasetUrl = `${getMetaValue('datasets_api') || '/api/v1/datasets'}/${datasetId}`;
+      return axios.get<AxiosResponse, API.Dataset>(datasetUrl);
     },
   );
-  return {
-    ...query,
-    data: query.data ?? { datasets: [], totalEntries: 0 },
-  };
 }

--- a/airflow/www/static/js/api/useDatasetEvents.ts
+++ b/airflow/www/static/js/api/useDatasetEvents.ts
@@ -23,25 +23,43 @@ import { useQuery } from 'react-query';
 import { getMetaValue } from 'src/utils';
 import type { API } from 'src/types';
 
-interface DatasetsData {
-  datasets: API.Dataset[];
+interface DatasetEventsData {
+  datasetEvents: API.DatasetEvent[];
   totalEntries: number;
 }
 
 interface Props {
+  datasetId?: string;
+  dagId?: string;
+  taskId?: string;
+  runId?: string;
+  mapIndex?: number;
   limit?: number;
   offset?: number;
   order?: string;
 }
 
-export default function useDatasets({ limit, offset, order }: Props) {
+export default function useDatasetEvents({
+  datasetId, dagId, runId, taskId, mapIndex, limit, offset, order,
+}: Props) {
   const query = useQuery(
-    ['datasets', limit, offset, order],
+    ['datasets-events', datasetId, dagId, runId, taskId, mapIndex, limit, offset, order],
     () => {
-      const datasetsUrl = getMetaValue('datasets_api') || '/api/v1/datasets';
-      const orderParam = order ? { order_by: order } : {};
-      return axios.get<AxiosResponse, DatasetsData>(datasetsUrl, {
-        params: { offset, limit, ...orderParam },
+      const datasetsUrl = getMetaValue('dataset_events_api') || '/api/v1/datasets/events';
+
+      const params = new URLSearchParams();
+
+      if (limit) params.set('limit', limit.toString());
+      if (offset) params.set('offset', offset.toString());
+      if (order) params.set('order_by', order);
+      if (datasetId) params.set('dataset_id', datasetId);
+      if (dagId) params.set('source_dag_id', dagId);
+      if (runId) params.set('source_run_id', runId);
+      if (taskId) params.set('source_task_id', taskId);
+      if (mapIndex) params.set('source_map_index', mapIndex.toString());
+
+      return axios.get<AxiosResponse, DatasetEventsData>(datasetsUrl, {
+        params,
       });
     },
     {
@@ -50,6 +68,6 @@ export default function useDatasets({ limit, offset, order }: Props) {
   );
   return {
     ...query,
-    data: query.data ?? { datasets: [], totalEntries: 0 },
+    data: query.data ?? { datasetEvents: [], totalEntries: 0 },
   };
 }

--- a/airflow/www/static/js/components/Table.tsx
+++ b/airflow/www/static/js/components/Table.tsx
@@ -46,6 +46,7 @@ import {
   Column,
   Hooks,
   SortingRule,
+  Row,
 } from 'react-table';
 import {
   MdKeyboardArrowLeft, MdKeyboardArrowRight,
@@ -83,18 +84,23 @@ interface TableProps {
     offset: number;
     setOffset: (offset: number) => void;
   },
+  manualSort?: {
+    sortBy: SortingRule<number>[];
+    setSortBy: (sortBy: SortingRule<number>[]) => void;
+    initialSortBy?: SortingRule<number>[];
+  },
   pageSize?: number;
-  setSortBy?: (sortBy: SortingRule<number>[]) => void;
   isLoading?: boolean;
   selectRows?: (selectedRows: number[]) => void;
-  onRowClicked?: (row: any, e: any) => void;
+  onRowClicked?: (row: Row<object>, e: any) => void;
 }
+
 const Table = ({
   data,
   columns,
   manualPagination,
+  manualSort,
   pageSize = 25,
-  setSortBy,
   isLoading = false,
   selectRows,
   onRowClicked,
@@ -145,10 +151,12 @@ const Table = ({
       data,
       pageCount,
       manualPagination: !!manualPagination,
-      manualSortBy: !!setSortBy,
+      manualSortBy: !!manualSort,
+      disableMultiSort: !!manualSort, // API currently supports ordering by a single column
       initialState: {
         pageIndex: offset ? offset / pageSize : 0,
         pageSize,
+        sortBy: manualSort?.initialSortBy || [],
       },
     },
     useSortBy,
@@ -167,8 +175,10 @@ const Table = ({
   };
 
   useEffect(() => {
-    if (setSortBy) setSortBy(sortBy);
-  }, [sortBy, setSortBy]);
+    if (manualSort) {
+      manualSort.setSortBy(sortBy);
+    }
+  }, [sortBy, manualSort]);
 
   useEffect(() => {
     if (selectRows) {

--- a/airflow/www/static/js/components/Table.tsx
+++ b/airflow/www/static/js/components/Table.tsx
@@ -152,7 +152,7 @@ const Table = ({
       pageCount,
       manualPagination: !!manualPagination,
       manualSortBy: !!manualSort,
-      disableMultiSort: !!manualSort, // API currently supports ordering by a single column
+      disableMultiSort: !!manualSort, // API only supporting ordering by a single column
       initialState: {
         pageIndex: offset ? offset / pageSize : 0,
         pageSize,
@@ -227,7 +227,6 @@ const Table = ({
                 _odd={{ backgroundColor: oddColor }}
                 _hover={onRowClicked && { backgroundColor: hoverColor, cursor: 'pointer' }}
                 onClick={onRowClicked ? (e: any) => onRowClicked(row, e) : undefined}
-                data-group
               >
                 {row.cells.map((cell) => (
                   <Td

--- a/airflow/www/static/js/components/Table.tsx
+++ b/airflow/www/static/js/components/Table.tsx
@@ -85,9 +85,9 @@ interface TableProps {
     setOffset: (offset: number) => void;
   },
   manualSort?: {
-    sortBy: SortingRule<number>[];
-    setSortBy: (sortBy: SortingRule<number>[]) => void;
-    initialSortBy?: SortingRule<number>[];
+    sortBy: SortingRule<object>[];
+    setSortBy: (sortBy: SortingRule<object>[]) => void;
+    initialSortBy?: SortingRule<object>[];
   },
   pageSize?: number;
   isLoading?: boolean;
@@ -174,6 +174,7 @@ const Table = ({
     if (setOffset) setOffset((pageIndex - 1 || 0) * pageSize);
   };
 
+  // When the sortBy state changes we need to manually call setSortBy
   useEffect(() => {
     if (manualSort) {
       manualSort.setSortBy(sortBy);

--- a/airflow/www/static/js/components/Table.tsx
+++ b/airflow/www/static/js/components/Table.tsx
@@ -87,6 +87,7 @@ interface TableProps {
   setSortBy?: (sortBy: SortingRule<number>[]) => void;
   isLoading?: boolean;
   selectRows?: (selectedRows: number[]) => void;
+  onRowClicked?: (row: any, e: any) => void;
 }
 const Table = ({
   data,
@@ -96,6 +97,7 @@ const Table = ({
   setSortBy,
   isLoading = false,
   selectRows,
+  onRowClicked,
 }: TableProps) => {
   const { totalEntries, offset, setOffset } = manualPagination || {};
   const oddColor = useColorModeValue('gray.50', 'gray.900');
@@ -212,7 +214,9 @@ const Table = ({
               <Tr
                 {...row.getRowProps()}
                 _odd={{ backgroundColor: oddColor }}
-                _hover={{ backgroundColor: hoverColor }}
+                _hover={onRowClicked && { backgroundColor: hoverColor, cursor: 'pointer' }}
+                onClick={onRowClicked ? (e: any) => onRowClicked(row, e) : undefined}
+                data-group
               >
                 {row.cells.map((cell) => (
                   <Td

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -160,7 +160,10 @@ const MappedInstances = ({
           totalEntries,
         }}
         pageSize={limit}
-        setSortBy={setSortBy}
+        manualSort={{
+          setSortBy,
+          sortBy,
+        }}
         isLoading={isLoading}
         selectRows={canEdit ? selectRows : undefined}
       />

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -1,0 +1,154 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useMemo, useState } from 'react';
+import {
+  Box, Heading, Text, Code, Flex, Spinner, Button, Link,
+} from '@chakra-ui/react';
+import { snakeCase } from 'lodash';
+import type { SortingRule } from 'react-table';
+
+import Time from 'src/components/Time';
+import { useDatasetEvents } from 'src/api';
+import useDataset from 'src/api/useDataset';
+import Table from 'src/components/Table';
+
+interface Props {
+  datasetId: string;
+  onBack: () => void;
+}
+
+const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
+const GridLink = ({ cell: { value } }: any) => <Link color="blue.500" href={`/dags/${value}/grid`}>{value}</Link>;
+const RunLink = ({ cell: { value, row } }: any) => {
+  const { sourceDagId } = row.original;
+  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(value)}`;
+  return (<Link color="blue.500" href={url}>{value}</Link>);
+};
+const TaskInstanceLink = ({ cell: { value, row } }: any) => {
+  const { sourceRunId, sourceDagId } = row.original;
+  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(sourceRunId)}&task_id=${encodeURIComponent(value)}`;
+  return (<Link color="blue.500" href={url}>{value}</Link>);
+};
+
+const DatasetDetails = ({ datasetId, onBack }: Props) => {
+  const limit = 25;
+  const [offset, setOffset] = useState(0);
+  const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'createdAt', desc: true }]);
+
+  const sort = sortBy[0];
+  const order = sort ? `${sort.desc ? '-' : ''}${snakeCase(sort.id)}` : '';
+
+  const { data: dataset, isLoading } = useDataset({ datasetId });
+  const {
+    data: { datasetEvents, totalEntries },
+    isLoading: isEventsLoading,
+  } = useDatasetEvents({
+    datasetId, limit, offset, order,
+  });
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: 'Created At',
+        accessor: 'createdAt',
+        Cell: TimeCell,
+      },
+      {
+        Header: 'Source DAG Id',
+        accessor: 'sourceDagId',
+        Cell: GridLink,
+      },
+      {
+        Header: 'Source DAG Run Id',
+        accessor: 'sourceRunId',
+        Cell: RunLink,
+      },
+      {
+        Header: 'Source Task Id',
+        accessor: 'sourceTaskId',
+        Cell: TaskInstanceLink,
+      },
+      {
+        Header: 'Source Map Index',
+        accessor: 'sourceMapIndex',
+        Cell: ({ cell: { value } }) => (value > -1 ? value : null),
+      },
+    ],
+    [],
+  );
+
+  const data = useMemo(
+    () => datasetEvents,
+    [datasetEvents],
+  );
+
+  return (
+    <Box maxWidth="1500px">
+      <Flex mt={3} justifyContent="space-between">
+        {isLoading && <Box><Spinner /></Box>}
+        {!!dataset && (
+          <Box>
+            <Heading mb={2} fontWeight="normal">
+              Dataset
+              {' '}
+              {dataset.id}
+            </Heading>
+            <Text my={2}>
+              URI:
+              {' '}
+              {dataset.uri}
+            </Text>
+            {!!dataset.extra && (
+              <Flex>
+                <Text mr={1}>Extra:</Text>
+                <Code>{dataset.extra}</Code>
+              </Flex>
+            )}
+            <Flex my={2}>
+              <Text mr={1}>Updated At:</Text>
+              <Time dateTime={dataset.updatedAt} />
+            </Flex>
+            <Flex my={2}>
+              <Text mr={1}>Created At:</Text>
+              <Time dateTime={dataset.createdAt} />
+            </Flex>
+          </Box>
+        )}
+        <Button onClick={onBack}>See all datasets</Button>
+      </Flex>
+      <Heading size="lg" mt={3} mb={2} fontWeight="normal">Dataset Events</Heading>
+      <Table
+        data={data}
+        columns={columns}
+        isLoading={isLoading}
+        manualPagination={{
+          offset,
+          setOffset,
+          totalEntries,
+        }}
+        pageSize={limit}
+        setSortBy={setSortBy}
+      />
+      {!isLoading && isEventsLoading && <Spinner />}
+    </Box>
+  );
+};
+
+export default DatasetDetails;

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -24,11 +24,12 @@ import {
   Heading,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
-import type { SortingRule } from 'react-table';
+import type { Row, SortingRule } from 'react-table';
 
 import { useDatasets } from 'src/api';
 import Table from 'src/components/Table';
 import Time from 'src/components/Time';
+import type { API } from 'src/types';
 
 interface Props {
   onSelect: (datasetId: string) => void;
@@ -49,10 +50,6 @@ const DatasetsList = ({ onSelect }: Props) => {
 
   const columns = useMemo(
     () => [
-      {
-        Header: 'ID',
-        accessor: 'id',
-      },
       {
         Header: 'URI',
         accessor: 'uri',
@@ -82,8 +79,8 @@ const DatasetsList = ({ onSelect }: Props) => {
     [datasets],
   );
 
-  const onDatasetSelect = (e: any) => {
-    onSelect(e.id);
+  const onDatasetSelect = (row: Row<API.Dataset>) => {
+    onSelect(row.id);
   };
 
   return (
@@ -102,7 +99,10 @@ const DatasetsList = ({ onSelect }: Props) => {
             totalEntries,
           }}
           pageSize={limit}
-          setSortBy={setSortBy}
+          manualSort={{
+            setSortBy,
+            sortBy,
+          }}
           onRowClicked={onDatasetSelect}
         />
       </Box>

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -18,15 +18,26 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { Box, Code, Heading } from '@chakra-ui/react';
+import {
+  Box,
+  Code,
+  Heading,
+} from '@chakra-ui/react';
+import { snakeCase } from 'lodash';
+import type { SortingRule } from 'react-table';
 
 import { useDatasets } from 'src/api';
 import Table from 'src/components/Table';
 import Time from 'src/components/Time';
-import { snakeCase } from 'lodash';
-import type { SortingRule } from 'react-table';
 
-const DatasetsList = () => {
+interface Props {
+  onSelect: (datasetId: string) => void;
+}
+
+const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
+const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;
+
+const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([]);
@@ -39,6 +50,10 @@ const DatasetsList = () => {
   const columns = useMemo(
     () => [
       {
+        Header: 'ID',
+        accessor: 'id',
+      },
+      {
         Header: 'URI',
         accessor: 'uri',
       },
@@ -46,31 +61,33 @@ const DatasetsList = () => {
         Header: 'Extra',
         accessor: 'extra',
         disableSortBy: true,
+        Cell: CodeCell,
       },
       {
         Header: 'Created At',
         accessor: 'createdAt',
+        Cell: TimeCell,
       },
       {
         Header: 'Updated At',
         accessor: 'updatedAt',
+        Cell: TimeCell,
       },
     ],
     [],
   );
 
   const data = useMemo(
-    () => datasets.map((d) => ({
-      ...d,
-      extra: <Code>{d.extra}</Code>,
-      createdAt: <Time dateTime={d.createdAt} />,
-      updatedAt: <Time dateTime={d.updatedAt} />,
-    })),
+    () => datasets,
     [datasets],
   );
 
+  const onDatasetSelect = (e: any) => {
+    onSelect(e.id);
+  };
+
   return (
-    <Box>
+    <Box maxWidth="1500px">
       <Heading mt={3} mb={2} fontWeight="normal">
         Datasets
       </Heading>
@@ -86,6 +103,7 @@ const DatasetsList = () => {
           }}
           pageSize={limit}
           setSortBy={setSortBy}
+          onRowClicked={onDatasetSelect}
         />
       </Box>
     </Box>

--- a/airflow/www/static/js/datasets/index.tsx
+++ b/airflow/www/static/js/datasets/index.tsx
@@ -22,10 +22,13 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import createCache from '@emotion/cache';
+import { useSearchParams } from 'react-router-dom';
+import { Center } from '@chakra-ui/react';
 
 import App from 'src/App';
 
 import DatasetsList from './List';
+import DatasetDetails from './Details';
 
 // create shadowRoot
 const root = document.querySelector('#root');
@@ -36,13 +39,36 @@ const cache = createCache({
 });
 const mainElement = document.getElementById('react-container');
 
+const DATASET_ID = 'dataset_id';
+
+const Datasets = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const onBack = () => {
+    searchParams.delete(DATASET_ID);
+    setSearchParams(searchParams);
+  };
+
+  const onSelect = (datasetId: string) => {
+    searchParams.set(DATASET_ID, datasetId);
+    setSearchParams(searchParams);
+  };
+
+  const datasetId = searchParams.get(DATASET_ID);
+  return (datasetId
+    ? <DatasetDetails datasetId={datasetId} onBack={onBack} />
+    : <DatasetsList onSelect={onSelect} />
+  );
+};
+
 if (mainElement) {
   shadowRoot?.appendChild(mainElement);
-
   const reactRoot = createRoot(mainElement);
   reactRoot.render(
     <App cache={cache}>
-      <DatasetsList />
+      <Center>
+        <Datasets />
+      </Center>
     </App>,
   );
 }

--- a/airflow/www/templates/airflow/datasets.html
+++ b/airflow/www/templates/airflow/datasets.html
@@ -23,6 +23,7 @@
 {% block head_meta %}
   {{ super() }}
   <meta name="datasets_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_datasets') }}">
+  <meta name="dataset_events_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dataset_endpoint_get_dataset_events') }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Create a dataset details view that contains a list of dataset events with links over to the source dag/run/task

<img width="1041" alt="Screen Shot 2022-07-21 at 11 46 47 AM" src="https://user-images.githubusercontent.com/4600967/180196145-08efc1bc-b336-4d35-bea7-bf5bd6999918.png">

I also fixed some issues with the Table component and updated the tests to make sure the manual pagination and sorting work.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
