### PR TITLE
make MsSQL tests runnable on Python 3.8

### DIFF
--- a/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mssql_to_gcs.py
@@ -22,10 +22,7 @@ from unittest import mock
 
 from parameterized import parameterized
 
-from airflow import PY38
-
-if not PY38:
-    from airflow.providers.google.cloud.transfers.mssql_to_gcs import MSSQLToGCSOperator
+from airflow.providers.google.cloud.transfers.mssql_to_gcs import MSSQLToGCSOperator
 
 TASK_ID = 'test-mssql-to-gcs'
 MSSQL_CONN_ID = 'mssql_conn_test'
@@ -51,7 +48,6 @@ SCHEMA_JSON = [
 ]
 
 
-@unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
 class TestMsSqlToGoogleCloudStorageOperator(unittest.TestCase):
     @parameterized.expand(
         [

--- a/tests/providers/microsoft/mssql/hooks/test_mssql.py
+++ b/tests/providers/microsoft/mssql/hooks/test_mssql.py
@@ -19,17 +19,13 @@
 import unittest
 from unittest import mock
 
-from airflow import PY38
 from airflow.models import Connection
-
-if not PY38:
-    from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
+from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 
 PYMSSQL_CONN = Connection(host='ip', schema='share', login='username', password='password', port=8081)
 
 
 class TestMsSqlHook(unittest.TestCase):
-    @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
     @mock.patch('airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook.get_conn')
     @mock.patch('airflow.providers.common.sql.hooks.sql.DbApiHook.get_connection')
     def test_get_conn_should_return_connection(self, get_connection, mssql_get_conn):
@@ -42,7 +38,6 @@ class TestMsSqlHook(unittest.TestCase):
         assert mssql_get_conn.return_value == conn
         mssql_get_conn.assert_called_once()
 
-    @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
     @mock.patch('airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook.get_conn')
     @mock.patch('airflow.providers.common.sql.hooks.sql.DbApiHook.get_connection')
     def test_set_autocommit_should_invoke_autocommit(self, get_connection, mssql_get_conn):
@@ -57,7 +52,6 @@ class TestMsSqlHook(unittest.TestCase):
         mssql_get_conn.assert_called_once()
         mssql_get_conn.return_value.autocommit.assert_called_once_with(autocommit_value)
 
-    @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
     @mock.patch('airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook.get_conn')
     @mock.patch('airflow.providers.common.sql.hooks.sql.DbApiHook.get_connection')
     def test_get_autocommit_should_return_autocommit_state(self, get_connection, mssql_get_conn):

--- a/tests/providers/microsoft/mssql/operators/test_mssql.py
+++ b/tests/providers/microsoft/mssql/operators/test_mssql.py
@@ -16,18 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
-from airflow import PY38, AirflowException
-
-if not PY38:
-    from airflow.providers.microsoft.mssql.operators.mssql import MsSqlOperator
+from airflow import AirflowException
+from airflow.providers.microsoft.mssql.operators.mssql import MsSqlOperator
 
 
 class TestMsSqlOperator:
-    @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
     @mock.patch('airflow.hooks.base.BaseHook.get_connection')
     def test_get_hook_from_conn(self, get_connection):
         """
@@ -45,7 +41,6 @@ class TestMsSqlOperator:
         op = MsSqlOperator(task_id='test', sql='')
         assert op.get_hook() == mock_hook
 
-    @unittest.skipIf(PY38, "Mssql package not available when Python >= 3.8.")
     @mock.patch('airflow.hooks.base.BaseHook.get_connection')
     def test_get_hook_default(self, get_connection):
         """


### PR DESCRIPTION
mssql lib does support newer version of python https://github.com/pymssql/pymssql/pull/659

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
