### PR TITLE
Graph view: Update labels after expanding groups

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -176,6 +176,7 @@ function draw() {
       // A group node
       if (d3.event.defaultPrevented) return;
       expandGroup(nodeId, node);
+      updateNodeLabels(nodes, taskInstances);
       draw();
       focusGroup(nodeId);
     } else if (nodeId in taskInstances) {


### PR DESCRIPTION
`updateNodeLabels` was only being called on the initial render and therefore the names of dynamic tasks inside of a closed group were not updating if a user clicked to expand the group.

Closes: https://github.com/apache/airflow/issues/25165

Before:
![before](https://user-images.githubusercontent.com/4600967/180202845-64ab517e-e87e-421e-acfe-0175bb5ccf4f.gif)

After:
![after](https://user-images.githubusercontent.com/4600967/180202865-7b29f621-6052-448f-ae64-73b80bc1276f.gif)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
