### PR TITLE
Convert TimeSensorAsync target_time to utc on call time

### DIFF
--- a/airflow/sensors/time_sensor.py
+++ b/airflow/sensors/time_sensor.py
@@ -51,9 +51,11 @@ class TimeSensorAsync(BaseSensorOperator):
         super().__init__(**kwargs)
         self.target_time = target_time
 
-        self.target_datetime = timezone.coerce_datetime(
+        aware_time = timezone.coerce_datetime(
             datetime.datetime.combine(datetime.datetime.today(), self.target_time)
         )
+
+        self.target_datetime = timezone.convert_to_utc(aware_time)
 
     def execute(self, context: Context):
         self.defer(

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -68,3 +68,10 @@ class TestTimeSensorAsync:
         assert exc_info.value.trigger.moment == timezone.datetime(2020, 7, 7, 10)
         assert exc_info.value.method_name == "execute_complete"
         assert exc_info.value.kwargs is None
+
+    def test_target_time_aware(self):
+        with DAG("test_target_time_aware", start_date=timezone.datetime(2020, 1, 1, 23, 0)):
+            aware_time = time(0, 1).replace(tzinfo=pendulum.local_timezone())
+            op = TimeSensorAsync(task_id="test", target_time=aware_time)
+            assert hasattr(op.target_datetime.tzinfo, "offset")
+            assert op.target_datetime.tzinfo.offset == 0


### PR DESCRIPTION
This PR fixes the error raised on DateTimeTrigger when TimeSensorAsync target_time is timezone-aware.

closes: #24736
related: #24736

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
