### PR TITLE
fix(hooks/exasol): handle non resultSet query result types

### DIFF
--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -164,6 +164,10 @@ class ExasolHook(DbApiHook):
                 with closing(conn.execute(query, parameters)) as cur:
                     results = []
 
+                    if cur.result_type != "resultSet":
+                        # can't be iterated over
+                        break
+
                     if handler is not None:
                         cur = handler(cur)
 

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -139,7 +139,7 @@ class TestExasolHook(unittest.TestCase):
 
     def test_no_result_set(self):
         """Queries like DROP and SELECT are of type rowCount (not resultSet),
-         which raises an error in pyexasol if trying to iterate over them"""
+        which raises an error in pyexasol if trying to iterate over them"""
         self.cur.result_type = mock.Mock()
         self.cur.result_type.return_value = 'rowCount'
 

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -137,6 +137,15 @@ class TestExasolHook(unittest.TestCase):
             self.db_hook.run(sql=[])
         assert err.value.args[0] == "List of SQL statements is empty"
 
+    def test_no_result_set(self):
+        """Queries like DROP and SELECT are of type rowCount (not resultSet),
+         which raises an error in pyexasol if trying to iterate over them"""
+        self.cur.result_type = mock.Mock()
+        self.cur.result_type.return_value = 'rowCount'
+
+        sql = 'SQL'
+        self.db_hook.run(sql)
+
     def test_bulk_load(self):
         with pytest.raises(NotImplementedError):
             self.db_hook.bulk_load('table', '/tmp/file')


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/apache/airflow/commit/b7c3c9657a6737a06afcb907e55f95a98d51a56c (authored by @kazanzhy) which added iterating over ExaStatement when using `ExasolHook.run()`.
Iteration can only be done for statements with a `result_type=resultSet`, for other result types, pyexasol raises `ExaRuntimeError(self.connection, 'Attempt to fetch from statement without result set')`. This happens for all `create` and `drop` statements (their result type is `rowCount`).
Therefore, an extra check is needed before the iteration.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
