### PR TITLE
Fix BatchOperator links on wait_for_completion = True

### DIFF
--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -115,7 +115,7 @@ class BatchOperator(BaseOperator):
     def operator_extra_links(self):
         op_extra_links = [BatchJobDetailsLink()]
         if self.wait_for_completion:
-            op_extra_links.extend(BatchJobDefinitionLink(), BatchJobQueueLink())
+            op_extra_links.extend([BatchJobDefinitionLink(), BatchJobQueueLink()])
         if not self.array_properties:
             # There is no CloudWatch Link to the parent Batch Job available.
             op_extra_links.append(CloudWatchEventsLink())


### PR DESCRIPTION
Fix incidentally wrong usage of `list.extend` method in `operator_extra_links` property of _BatchOperator_

```
Broken DAG: [/files/dags/example_batch.py] Traceback (most recent call last):
  File "/opt/airflow/airflow/serialization/serialized_objects.py", line 658, in _serialize_node
    if op.operator_extra_links:
  File "/opt/airflow/airflow/providers/amazon/aws/operators/batch.py", line 118, in operator_extra_links
    op_extra_links.extend(BatchJobDefinitionLink(), BatchJobQueueLink())
TypeError: extend() takes exactly one argument (2 given)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/airflow/airflow/serialization/serialized_objects.py", line 1125, in to_dict
    json_dict = {"__version": cls.SERIALIZER_VERSION, "dag": cls.serialize_dag(var)}
  File "/opt/airflow/airflow/serialization/serialized_objects.py", line 1033, in serialize_dag
    raise SerializationError(f'Failed to serialize DAG {dag.dag_id!r}: {e}')
airflow.exceptions.SerializationError: Failed to serialize DAG 'example_batch_submit_job_2': extend() takes exactly one argument (2 given)
```
