### PR TITLE
Add test_connection to Azure Batch hook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -362,3 +362,16 @@ class AzureBatchHook(BaseHook):
                 self.log.info("Waiting for %s to complete, currently on %s state", task.id, task.state)
             time.sleep(15)
         raise TimeoutError("Timed out waiting for tasks to complete")
+
+    def test_connection(self):
+        """Test a configured Azure Batch connection."""
+        try:
+            # Attempt to list existing  jobs under the configured Batch account and retrieve
+            # the first in the returned iterator. The Azure Batch API does allow for creation of a
+            # BatchServiceClient with incorrect values but then will fail properly once items are
+            # retrieved using the client. We need to _actually_ try to retrieve an object to properly
+            # test the connection.
+            next(self.get_conn().job.list(), None)
+        except Exception as e:
+            return False, str(e)
+        return True, "Successfully connected to Azure Batch."

--- a/tests/providers/microsoft/azure/hooks/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_batch.py
@@ -19,6 +19,7 @@
 import json
 import unittest
 from unittest import mock
+from unittest.mock import PropertyMock
 
 from azure.batch import BatchServiceClient, models as batch_models
 
@@ -165,3 +166,20 @@ class TestAzureBatchHook(unittest.TestCase):
     def test_wait_for_all_task_to_complete(self, mock_batch):
         # TODO: Add test
         pass
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.batch.BatchServiceClient')
+    def test_connection_success(self, mock_batch):
+        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
+        hook.get_conn().job.return_value = {}
+        status, msg = hook.test_connection()
+        print(status, msg)
+        assert status is True
+        assert msg == "Successfully connected to Azure Batch."
+
+    @mock.patch('airflow.providers.microsoft.azure.hooks.batch.BatchServiceClient')
+    def test_connection_failure(self, mock_batch):
+        hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
+        hook.get_conn().job.list = PropertyMock(side_effect=Exception("Authentication failed."))
+        status, msg = hook.test_connection()
+        assert status is False
+        assert msg == "Authentication failed."

--- a/tests/providers/microsoft/azure/hooks/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_batch.py
@@ -172,7 +172,6 @@ class TestAzureBatchHook(unittest.TestCase):
         hook = AzureBatchHook(azure_batch_conn_id=self.test_cloud_conn_id)
         hook.get_conn().job.return_value = {}
         status, msg = hook.test_connection()
-        print(status, msg)
         assert status is True
         assert msg == "Successfully connected to Azure Batch."
 


### PR DESCRIPTION
This PR enables the `Test connection` functionality for the Azure Batch Service connection type.

cc @kaxil 

<img width="1334" alt="Screenshot 2022-07-21 at 3 34 08 PM" src="https://user-images.githubusercontent.com/94376113/180458063-5daf6eb1-b6fd-4105-ba33-c1f04276de8e.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
