### PR TITLE
Make tag fetching when preparing providers optional.

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -717,7 +717,7 @@ def make_sure_remote_apache_exists_and_fetch(git_update: bool, verbose: bool):
     except subprocess.CalledProcessError as e:
         console.print(
             '[yellow]Error when fetching tags from remote. Your tags might not be refreshed. '
-            f'please refresh the tags manually via {" ".join(fetch_command)}\n'
+            f'Please refresh the tags manually via {" ".join(fetch_command)}\n'
         )
         console.print(f'[yellow]The error was: {e}')
 

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -710,10 +710,16 @@ def make_sure_remote_apache_exists_and_fetch(git_update: bool, verbose: bool):
         fetch_command.append("--unshallow")
     if verbose:
         console.print(f"Running command: '{' '.join(fetch_command)}'")
-    subprocess.check_call(
-        fetch_command,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        subprocess.check_call(
+            fetch_command,
+        )
+    except subprocess.CalledProcessError as e:
+        console.print(
+            '[yellow]Error when fetching tags from remote. Your tags might not be refreshed. '
+            f'please refresh the tags manually via {" ".join(fetch_command)}\n'
+        )
+        console.print(f'[yellow]The error was: {e}')
 
 
 def get_git_log_command(


### PR DESCRIPTION
Tag fetching is only needed to make sure we do not generate
packages that have already been generated. However this is just
an optimisation for CI runs. There is no harm if the tags are
not refreshed and we generate the package again locally.

Tag fetching might faile in various cases - for example when
you are in corporate environment and require specific certificates
to be available or when you are working from a worktree.

After this change fetching tag will produce warning when there is
an error and instruction on how you can fetch tags manually.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
