### PR TITLE
Update core example DAGs to use `@task.branch` decorator

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -533,7 +533,7 @@ class Task(Generic[FParams, FReturn]):
     def expand_kwargs(self, kwargs: XComArg, *, strict: bool = True) -> XComArg:
         ...
 
-    def override(self, **kwargs: Any) -> "_TaskDecorator[Function, OperatorSubclass]":
+    def override(self, **kwargs: Any) -> "_TaskDecorator[FParams, FReturn, OperatorSubclass]":
         ...
 
 
@@ -556,7 +556,7 @@ class TaskDecorator(Protocol):
     ) -> Callable[[Callable[FParams, FReturn]], Task[FParams, FReturn]]:
         """For the decorator factory ``@task()`` case."""
 
-    def override(self, **kwargs: Any) -> "_TaskDecorator[Function, OperatorSubclass]":
+    def override(self, **kwargs: Any) -> "_TaskDecorator[FParams, FReturn, OperatorSubclass]":
         ...
 
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -533,7 +533,7 @@ class Task(Generic[FParams, FReturn]):
     def expand_kwargs(self, kwargs: XComArg, *, strict: bool = True) -> XComArg:
         ...
 
-    def override(self, **kwargs: Any) -> "_TaskDecorator[FParams, FReturn, OperatorSubclass]":
+    def override(self, **kwargs: Any) -> "Task[FParams, FReturn]":
         ...
 
 
@@ -556,7 +556,7 @@ class TaskDecorator(Protocol):
     ) -> Callable[[Callable[FParams, FReturn]], Task[FParams, FReturn]]:
         """For the decorator factory ``@task()`` case."""
 
-    def override(self, **kwargs: Any) -> "_TaskDecorator[FParams, FReturn, OperatorSubclass]":
+    def override(self, **kwargs: Any) -> "Task[FParams, FReturn]":
         ...
 
 

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -533,6 +533,9 @@ class Task(Generic[FParams, FReturn]):
     def expand_kwargs(self, kwargs: XComArg, *, strict: bool = True) -> XComArg:
         ...
 
+    def override(self, **kwargs: Any) -> "_TaskDecorator[Function, OperatorSubclass]":
+        ...
+
 
 class TaskDecorator(Protocol):
     """Type declaration for ``task_decorator_factory`` return type."""
@@ -552,6 +555,9 @@ class TaskDecorator(Protocol):
         **kwargs: Any,
     ) -> Callable[[Callable[FParams, FReturn]], Task[FParams, FReturn]]:
         """For the decorator factory ``@task()`` case."""
+
+    def override(self, **kwargs: Any) -> "_TaskDecorator[Function, OperatorSubclass]":
+        ...
 
 
 def task_decorator_factory(

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -16,15 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Example DAG demonstrating the usage of the BranchPythonOperator."""
+"""Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
 import random
 
 import pendulum
 
 from airflow import DAG
+from airflow.decorators import task
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import BranchPythonOperator
 from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -35,31 +35,24 @@ with DAG(
     schedule_interval="@daily",
     tags=['example', 'example2'],
 ) as dag:
-    run_this_first = EmptyOperator(
-        task_id='run_this_first',
-    )
+    run_this_first = EmptyOperator(task_id='run_this_first')
 
     options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
 
-    branching = BranchPythonOperator(
-        task_id='branching',
-        python_callable=lambda: random.choice(options),
-    )
-    run_this_first >> branching
+    @task.branch()
+    def branching():
+        return random.choice(options)
 
-    join = EmptyOperator(
-        task_id='join',
-        trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
-    )
+    branch = branching()
+
+    run_this_first >> branch
+
+    join = EmptyOperator(task_id='join', trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
 
     for option in options:
-        t = EmptyOperator(
-            task_id=option,
-        )
+        t = EmptyOperator(task_id=option)
 
-        empty_follow = EmptyOperator(
-            task_id='follow_' + option,
-        )
+        empty_follow = EmptyOperator(task_id='follow_' + option)
 
         # Label is optional here, but it can help identify more complex branches
-        branching >> Label(option) >> t >> empty_follow >> join
+        branch >> Label(option) >> t >> empty_follow >> join

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -16,15 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
+"""Example DAG demonstrating the usage of the BranchPythonOperator."""
 
 import random
 
 import pendulum
 
 from airflow import DAG
-from airflow.decorators import task
 from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import BranchPythonOperator
 from airflow.utils.edgemodifier import Label
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -35,24 +35,31 @@ with DAG(
     schedule_interval="@daily",
     tags=['example', 'example2'],
 ) as dag:
-    run_this_first = EmptyOperator(task_id='run_this_first')
+    run_this_first = EmptyOperator(
+        task_id='run_this_first',
+    )
 
     options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
 
-    @task.branch()
-    def branching():
-        return random.choice(options)
+    branching = BranchPythonOperator(
+        task_id='branching',
+        python_callable=lambda: random.choice(options),
+    )
+    run_this_first >> branching
 
-    branch = branching()
-
-    run_this_first >> branch
-
-    join = EmptyOperator(task_id='join', trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
+    join = EmptyOperator(
+        task_id='join',
+        trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
+    )
 
     for option in options:
-        t = EmptyOperator(task_id=option)
+        t = EmptyOperator(
+            task_id=option,
+        )
 
-        empty_follow = EmptyOperator(task_id='follow_' + option)
+        empty_follow = EmptyOperator(
+            task_id='follow_' + option,
+        )
 
         # Label is optional here, but it can help identify more complex branches
-        branch >> Label(option) >> t >> empty_follow >> join
+        branching >> Label(option) >> t >> empty_follow >> join

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -16,10 +16,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Example DAG demonstrating the usage of the BranchPythonOperator."""
+"""Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
 import random
-from datetime import datetime
+
+import pendulum
 
 from airflow import DAG
 from airflow.decorators import task
@@ -29,38 +30,29 @@ from airflow.utils.trigger_rule import TriggerRule
 
 with DAG(
     dag_id='example_branch_python_operator_decorator',
-    start_date=datetime(2021, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     catchup=False,
     schedule_interval="@daily",
     tags=['example', 'example2'],
 ) as dag:
-    run_this_first = EmptyOperator(
-        task_id='run_this_first',
-    )
+    run_this_first = EmptyOperator(task_id='run_this_first')
 
     options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
 
     @task.branch(task_id="branching")
-    def random_choice():
-        return random.choice(options)
+    def random_choice(choices):
+        return random.choice(choices)
 
-    random_choice_instance = random_choice()
+    random_choice_instance = random_choice(choices=options)
 
     run_this_first >> random_choice_instance
 
-    join = EmptyOperator(
-        task_id='join',
-        trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
-    )
+    join = EmptyOperator(task_id='join', trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
 
     for option in options:
-        t = EmptyOperator(
-            task_id=option,
-        )
+        t = EmptyOperator(task_id=option)
 
-        empty_follow = EmptyOperator(
-            task_id='follow_' + option,
-        )
+        empty_follow = EmptyOperator(task_id='follow_' + option)
 
         # Label is optional here, but it can help identify more complex branches
         random_choice_instance >> Label(option) >> t >> empty_follow >> join

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -19,7 +19,7 @@
 """Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
 import random
-from typing import List
+from __future__ import annotations
 
 import pendulum
 
@@ -41,7 +41,7 @@ with DAG(
     options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
 
     @task.branch(task_id="branching")
-    def random_choice(choices: List[str]) -> str:
+    def random_choice(choices: list[str]) -> str:
         return random.choice(choices)
 
     random_choice_instance = random_choice(choices=options)

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -18,6 +18,7 @@
 
 """Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
+from typing import List
 import random
 
 import pendulum
@@ -40,7 +41,7 @@ with DAG(
     options = ['branch_a', 'branch_b', 'branch_c', 'branch_d']
 
     @task.branch(task_id="branching")
-    def random_choice(choices):
+    def random_choice(choices: List[str]) -> str:
         return random.choice(choices)
 
     random_choice_instance = random_choice(choices=options)

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -18,8 +18,8 @@
 
 """Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
-from typing import List
 import random
+from typing import List
 
 import pendulum
 

--- a/airflow/example_dags/example_branch_operator_decorator.py
+++ b/airflow/example_dags/example_branch_operator_decorator.py
@@ -18,8 +18,9 @@
 
 """Example DAG demonstrating the usage of the ``@task.branch`` TaskFlow API decorator."""
 
-import random
 from __future__ import annotations
+
+import random
 
 import pendulum
 

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -17,16 +17,17 @@
 # under the License.
 
 """
-Example DAG demonstrating the usage of BranchPythonOperator with depends_on_past=True, where tasks may be run
-or skipped on alternating runs.
+Example DAG demonstrating the usage of ``@task.branch`` TaskFlow API decorator with depends_on_past=True,
+where tasks may be run or skipped on alternating runs.
 """
 import pendulum
 
 from airflow import DAG
+from airflow.decorators import task
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import BranchPythonOperator
 
 
+@task.branch()
 def should_run(**kwargs):
     """
     Determine which empty_task should be run based on if the execution date minute is even or odd.
@@ -52,10 +53,7 @@ with DAG(
     default_args={'depends_on_past': True},
     tags=['example'],
 ) as dag:
-    cond = BranchPythonOperator(
-        task_id='condition',
-        python_callable=should_run,
-    )
+    cond = should_run()
 
     empty_task_1 = EmptyOperator(task_id='empty_task_1')
     empty_task_2 = EmptyOperator(task_id='empty_task_2')

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -74,7 +74,7 @@ with DAG(
     schedule_on=[dag1_dataset],
     tags=['downstream'],
 ) as dag3:
-# [END dag_dep]
+    # [END dag_dep]
     BashOperator(
         outlets=[Dataset('s3://downstream_1_task/dataset_other.txt')],
         task_id='downstream_1',

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -36,7 +36,7 @@ example_dataset_dag4_req_dag1_dag2 should run.
 Dags example_dataset_dag5_req_dag1_D and example_dataset_dag6_req_DD should not run because they depend on
 datasets that never get updated.
 """
-from datetime import datetime
+import pendulum
 
 from airflow.models import DAG, Dataset
 from airflow.operators.bash import BashOperator
@@ -49,7 +49,7 @@ dag2_dataset = Dataset('s3://dag2/output_1.txt', extra={'hi': 'bye'})
 dag1 = DAG(
     dag_id='example_dataset_dag1',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_interval='@daily',
     tags=['upstream'],
 )
@@ -61,21 +61,17 @@ BashOperator(outlets=[dag1_dataset], task_id='upstream_task_1', bash_command="sl
 with DAG(
     dag_id='example_dataset_dag2',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_interval=None,
     tags=['upstream'],
 ) as dag2:
-    BashOperator(
-        outlets=[dag2_dataset],
-        task_id='upstream_task_2',
-        bash_command="sleep 5",
-    )
+    BashOperator(outlets=[dag2_dataset], task_id='upstream_task_2', bash_command="sleep 5")
 
 # [START dag_dep]
 dag3 = DAG(
     dag_id='example_dataset_dag3_req_dag1',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_on=[dag1_dataset],
     tags=['downstream'],
 )
@@ -91,7 +87,7 @@ BashOperator(
 with DAG(
     dag_id='example_dataset_dag4_req_dag1_dag2',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_on=[dag1_dataset, dag2_dataset],
     tags=['downstream'],
 ) as dag4:
@@ -104,7 +100,7 @@ with DAG(
 with DAG(
     dag_id='example_dataset_dag5_req_dag1_D',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_on=[
         dag1_dataset,
         Dataset('s3://this-dataset-doesnt-get-triggered'),
@@ -120,7 +116,7 @@ with DAG(
 with DAG(
     dag_id='example_dataset_dag6_req_DD',
     catchup=False,
-    start_date=datetime(2020, 1, 1),
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
     schedule_on=[
         Dataset('s3://unrelated/dataset3.txt'),
         Dataset('s3://unrelated/dataset_other_unknown.txt'),

--- a/airflow/example_dags/example_nested_branch_dag.py
+++ b/airflow/example_dags/example_nested_branch_dag.py
@@ -36,8 +36,8 @@ with DAG(
     tags=["example"],
 ) as dag:
 
-    @task.branch
-    def branch(task_id_to_return):
+    @task.branch()
+    def branch(task_id_to_return: str) -> str:
         return task_id_to_return
 
     branch_1 = branch.override(task_id="branch_1")(task_id_to_return="true_1")

--- a/airflow/example_dags/example_nested_branch_dag.py
+++ b/airflow/example_dags/example_nested_branch_dag.py
@@ -19,13 +19,13 @@
 """
 Example DAG demonstrating a workflow with nested branching. The join tasks are created with
 ``none_failed_min_one_success`` trigger rule such that they are skipped whenever their corresponding
-``BranchPythonOperator`` are skipped.
+branching tasks are skipped.
 """
 import pendulum
 
+from airflow.decorators import task
 from airflow.models import DAG
 from airflow.operators.empty import EmptyOperator
-from airflow.operators.python import BranchPythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 with DAG(
@@ -35,11 +35,17 @@ with DAG(
     schedule_interval="@daily",
     tags=["example"],
 ) as dag:
-    branch_1 = BranchPythonOperator(task_id="branch_1", python_callable=lambda: "true_1")
+
+    @task.branch
+    def branch(task_id_to_return):
+        return task_id_to_return
+
+    branch_1 = branch.override(task_id="branch_1")(task_id_to_return="true_1")
     join_1 = EmptyOperator(task_id="join_1", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
     true_1 = EmptyOperator(task_id="true_1")
     false_1 = EmptyOperator(task_id="false_1")
-    branch_2 = BranchPythonOperator(task_id="branch_2", python_callable=lambda: "true_2")
+
+    branch_2 = branch.override(task_id="branch_2")(task_id_to_return="true_2")
     join_2 = EmptyOperator(task_id="join_2", trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
     true_2 = EmptyOperator(task_id="true_2")
     false_2 = EmptyOperator(task_id="false_2")

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from functools import wraps
 from time import perf_counter
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -45,7 +46,6 @@ from typing import (
 import jsonschema
 from packaging import version as packaging_version
 
-from airflow.decorators.base import TaskDecorator
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.hooks.base import BaseHook
 from airflow.typing_compat import Literal
@@ -64,6 +64,9 @@ else:
 MIN_PROVIDER_VERSIONS = {
     "apache-airflow-providers-celery": "2.1.0",
 }
+
+if TYPE_CHECKING:
+    from airflow.decorators.base import TaskDecorator
 
 
 class LazyDictWithCache(MutableMapping):
@@ -895,8 +898,7 @@ class ProvidersManager(LoggingMixin):
         return self._hooks_lazy_dict
 
     @property
-    # def taskflow_decorators(self) -> Dict[str, Callable]:
-    def taskflow_decorators(self) -> Dict[str, TaskDecorator]:
+    def taskflow_decorators(self) -> Dict[str, "TaskDecorator"]:
         self.initialize_providers_taskflow_decorator()
         return self._taskflow_decorators
 

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -45,6 +45,7 @@ from typing import (
 import jsonschema
 from packaging import version as packaging_version
 
+from airflow.decorators.base import TaskDecorator
 from airflow.exceptions import AirflowOptionalProviderFeatureException
 from airflow.hooks.base import BaseHook
 from airflow.typing_compat import Literal
@@ -894,7 +895,8 @@ class ProvidersManager(LoggingMixin):
         return self._hooks_lazy_dict
 
     @property
-    def taskflow_decorators(self) -> Dict[str, Callable]:
+    # def taskflow_decorators(self) -> Dict[str, Callable]:
+    def taskflow_decorators(self) -> Dict[str, TaskDecorator]:
         self.initialize_providers_taskflow_decorator()
         return self._taskflow_decorators
 

--- a/docs/apache-airflow/concepts/datasets.rst
+++ b/docs/apache-airflow/concepts/datasets.rst
@@ -33,6 +33,7 @@ Then reference the dataset as a task outlet:
 
 .. exampleinclude:: /../../airflow/example_dags/example_datasets.py
     :language: python
+    :dedent: 4
     :start-after: [START task_outlet]
     :end-before: [END task_outlet]
 


### PR DESCRIPTION
Related: #9415

Now that the `@task.branch` TaskFlow decorator has been released, the core example DAGs which previously used the `BranchPythonOperator` should now use the decorator where applicable.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
