### PR TITLE
Add dataset-triggered run type icon

### DIFF
--- a/airflow/www/static/js/components/RunTypeIcon.tsx
+++ b/airflow/www/static/js/components/RunTypeIcon.tsx
@@ -1,0 +1,47 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { MdPlayArrow, MdOutlineSchedule } from 'react-icons/md';
+import { RiArrowGoBackFill } from 'react-icons/ri';
+import { HiDatabase } from 'react-icons/hi';
+
+import type { IconBaseProps } from 'react-icons';
+import type { DagRun } from 'src/types';
+
+interface Props extends IconBaseProps {
+  runType: DagRun['runType'];
+}
+
+const DagRunTypeIcon = ({ runType, ...rest }: Props) => {
+  switch (runType) {
+    case 'manual':
+      return <MdPlayArrow style={{ display: 'inline' }} {...rest} />;
+    case 'backfill':
+      return <RiArrowGoBackFill style={{ display: 'inline' }} {...rest} />;
+    case 'scheduled':
+      return <MdOutlineSchedule style={{ display: 'inline' }} {...rest} />;
+    case 'dataset_triggered':
+      return <HiDatabase style={{ display: 'inline' }} {...rest} />;
+    default:
+      return null;
+  }
+};
+
+export default DagRunTypeIcon;

--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -24,13 +24,12 @@ import {
   BreadcrumbLink,
   Text,
 } from '@chakra-ui/react';
-import { MdPlayArrow, MdOutlineSchedule } from 'react-icons/md';
-import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import { getMetaValue } from 'src/utils';
 import useSelection from 'src/dag/useSelection';
 import Time from 'src/components/Time';
 import { useTasks, useGridData } from 'src/api';
+import RunTypeIcon from 'src/components/RunTypeIcon';
 
 import BreadcrumbText from './BreadcrumbText';
 
@@ -54,33 +53,21 @@ const Header = () => {
 
   let runLabel;
   if (dagRun && runId) {
-    if (runId.includes('manual__') || runId.includes('scheduled__') || runId.includes('backfill__')) {
-      runLabel = (<Time dateTime={dagRun.dataIntervalStart || dagRun.executionDate} />);
-    } else {
-      runLabel = runId;
-    }
-    if (dagRun.runType === 'manual') {
-      runLabel = (
-        <>
-          <MdPlayArrow style={{ display: 'inline' }} />
-          {runLabel}
-        </>
-      );
-    } else if (dagRun.runType === 'backfill') {
-      runLabel = (
-        <>
-          <RiArrowGoBackFill style={{ display: 'inline' }} />
-          {runLabel}
-        </>
-      );
-    } else if (dagRun.runType === 'scheduled') {
-      runLabel = (
-        <>
-          <MdOutlineSchedule style={{ display: 'inline' }} />
-          {runLabel}
-        </>
-      );
-    }
+    // If a runId includes the runtype then parse the time, otherwise use the custom run id
+    const runName = (
+      runId.includes('manual__')
+      || runId.includes('scheduled__')
+      || runId.includes('backfill__')
+      || runId.includes('dataset_triggered__')
+    )
+      ? <Time dateTime={dagRun.dataIntervalStart || dagRun.executionDate} />
+      : runId;
+    runLabel = (
+      <>
+        <RunTypeIcon runType={dagRun.runType} />
+        {runName}
+      </>
+    );
   }
 
   const isMapped = task && task.isMapped;

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -30,8 +30,7 @@ import {
   Td,
 } from '@chakra-ui/react';
 
-import { MdPlayArrow, MdOutlineSchedule, MdOutlineAccountTree } from 'react-icons/md';
-import { RiArrowGoBackFill } from 'react-icons/ri';
+import { MdOutlineAccountTree } from 'react-icons/md';
 
 import { useGridData } from 'src/api';
 import { appendSearchParams, getMetaValue } from 'src/utils';
@@ -40,6 +39,7 @@ import { SimpleStatus } from 'src/dag/StatusBox';
 import { ClipboardText } from 'src/components/Clipboard';
 import { formatDuration, getDuration } from 'src/datetime_utils';
 import Time from 'src/components/Time';
+import RunTypeIcon from 'src/components/RunTypeIcon';
 
 import MarkFailedRun from './MarkFailedRun';
 import MarkSuccessRun from './MarkSuccessRun';
@@ -114,11 +114,8 @@ const DagRun = ({ runId }: Props) => {
           <Tr>
             <Td>Run type</Td>
             <Td>
-              {runType === 'manual' && <MdPlayArrow style={{ display: 'inline' }} />}
-              {runType === 'backfill' && <RiArrowGoBackFill style={{ display: 'inline' }} />}
-              {runType === 'scheduled' && <MdOutlineSchedule style={{ display: 'inline' }} />}
+            <RunTypeIcon runType={runType} />
               {runType}
-
             </Td>
           </Tr>
           <Tr>

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -114,7 +114,7 @@ const DagRun = ({ runId }: Props) => {
           <Tr>
             <Td>Run type</Td>
             <Td>
-            <RunTypeIcon runType={runType} />
+              <RunTypeIcon runType={runType} />
               {runType}
             </Td>
           </Tr>

--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -29,13 +29,12 @@ import {
   VStack,
   useTheme,
 } from '@chakra-ui/react';
-import { MdPlayArrow } from 'react-icons/md';
-import { RiArrowGoBackFill } from 'react-icons/ri';
 
 import { useContainerRef } from 'src/context/containerRef';
 import Time from 'src/components/Time';
 import type { SelectionProps } from 'src/dag/useSelection';
 import { hoverDelay } from 'src/utils';
+import RunTypeIcon from 'src/components/RunTypeIcon';
 
 import DagRunTooltip from './Tooltip';
 import type { RunWithDuration } from '.';
@@ -54,6 +53,9 @@ interface Props {
 const DagRunBar = ({
   run, max, index, totalRuns, isSelected, onSelect,
 }: Props) => {
+  const {
+    runType, runId, duration, state, executionDate,
+  } = run;
   const containerRef = useContainerRef();
   const { colors } = useTheme();
   const hoverBlue = `${colors.blue[100]}50`;
@@ -61,12 +63,12 @@ const DagRunBar = ({
   // Fetch the corresponding column element and set its background color when hovering
   const onMouseEnter = () => {
     if (!isSelected) {
-      const els = Array.from(containerRef?.current?.getElementsByClassName(`js-${run.runId}`) as HTMLCollectionOf<HTMLElement>);
+      const els = Array.from(containerRef?.current?.getElementsByClassName(`js-${runId}`) as HTMLCollectionOf<HTMLElement>);
       els.forEach((e) => { e.style.backgroundColor = hoverBlue; });
     }
   };
   const onMouseLeave = () => {
-    const els = Array.from(containerRef?.current?.getElementsByClassName(`js-${run.runId}`) as HTMLCollectionOf<HTMLElement>);
+    const els = Array.from(containerRef?.current?.getElementsByClassName(`js-${runId}`) as HTMLCollectionOf<HTMLElement>);
     els.forEach((e) => { e.style.backgroundColor = ''; });
   };
 
@@ -77,7 +79,7 @@ const DagRunBar = ({
 
   return (
     <Box
-      className={`js-${run.runId}`}
+      className={`js-${runId}`}
       data-selected={isSelected}
       bg={isSelected ? 'blue.100' : undefined}
       transition="background-color 0.2s"
@@ -95,7 +97,7 @@ const DagRunBar = ({
         zIndex={1}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
-        onClick={() => onSelect({ runId: run.runId })}
+        onClick={() => onSelect({ runId })}
       >
         <Tooltip
           label={<DagRunTooltip dagRun={run} />}
@@ -106,9 +108,9 @@ const DagRunBar = ({
         >
           <Flex
             width="10px"
-            height={`${(run.duration / max) * BAR_HEIGHT}px`}
+            height={`${(duration / max) * BAR_HEIGHT}px`}
             minHeight="14px"
-            backgroundColor={stateColors[run.state]}
+            backgroundColor={stateColors[state]}
             borderRadius={2}
             cursor="pointer"
             pb="2px"
@@ -119,15 +121,21 @@ const DagRunBar = ({
             zIndex={1}
             data-testid="run"
           >
-            {run.runType === 'manual' && <MdPlayArrow size="8px" color="white" data-testid="manual-run" />}
-            {run.runType === 'backfill' && <RiArrowGoBackFill size="8px" color="white" data-testid="backfill-run" />}
+            {runType !== 'scheduled' && (
+              <RunTypeIcon
+                runType={runType}
+                size="8px"
+                color="white"
+                data-testid={`${runType}-run`}
+              />
+            )}
           </Flex>
         </Tooltip>
       </Flex>
       {shouldShowTick && (
       <VStack position="absolute" top="0" left="8px" spacing={0} zIndex={0} width={0}>
         <Text fontSize="sm" color="gray.400" whiteSpace="nowrap" transform="rotate(-30deg) translateX(28px)" mt="-23px !important">
-          <Time dateTime={run.executionDate} format="MMM DD, HH:mm" />
+          <Time dateTime={executionDate} format="MMM DD, HH:mm" />
         </Text>
         <Box borderLeftWidth={1} opacity={0.7} height="100px" zIndex={0} />
       </VStack>

--- a/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
+++ b/airflow/www/static/js/dag/grid/dagRuns/Bar.tsx
@@ -121,6 +121,7 @@ const DagRunBar = ({
             zIndex={1}
             data-testid="run"
           >
+            {/* Scheduled is the default, hence no icon */}
             {runType !== 'scheduled' && (
               <RunTypeIcon
                 runType={runType}


### PR DESCRIPTION
Add a new icon for `dataset-triggered` dag run types. Now that we have a few runTypes, I moved the icon logic to its own component.

<img width="856" alt="Screen Shot 2022-07-26 at 10 59 46 AM" src="https://user-images.githubusercontent.com/4600967/180979730-93516c81-8b78-4cac-9a3c-8831f0e44781.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
