### PR TITLE
WIP: Serialized object property

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -54,6 +54,7 @@ from airflow.settings import json
 from airflow.timetables.base import Timetable
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.docs import get_docs_url
+from airflow.utils.helpers import resolve_property_value
 from airflow.utils.module_loading import as_importable_string, import_string
 from airflow.utils.operator_resources import Resources
 from airflow.utils.task_group import TaskGroup
@@ -349,6 +350,8 @@ class BaseSerialization:
         (3) Operator has a special field CLASS to record the original class
             name for displaying in UI.
         """
+        var = resolve_property_value(cls, var)
+
         if cls._is_primitive(var):
             # enum.IntEnum is an int instance, it causes json dumps error so we use its value.
             if isinstance(var, enum.Enum):
@@ -690,7 +693,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         if op.operator_extra_links:
             serialize_op['_operator_extra_links'] = cls._serialize_operator_extra_links(
-                op.operator_extra_links
+                resolve_property_value(op, op.operator_extra_links)
             )
 
         if include_deps:

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -376,3 +376,16 @@ def prune_dict(val: Any, mode='strict'):
         return new_list
     else:
         return val
+
+
+def resolve_property_value(obj, prop):
+    """Return class property value.
+
+    :param obj: Reference to class.
+    :param prop: Reference to class property.
+    :returns: If ``prop`` property than return property value,
+        otherwise it returns class attribute value.
+    """
+    if isinstance(prop, property):
+        return prop.fget(obj)
+    return prop

--- a/tests/test_utils/mock_operators.py
+++ b/tests/test_utils/mock_operators.py
@@ -67,6 +67,20 @@ class Dummy3TestOperator(BaseOperator):
     operator_extra_links = ()
 
 
+class Dummy4TestOperator(BaseOperator):
+    """
+    Example of an Operator that has an extra operator link as property
+    """
+
+    @property
+    def operator_extra_links(self):
+        return (AirflowLink(),)
+
+    def __init__(self, arg1=42, **kwargs):
+        super().__init__(**kwargs)
+        self.arg1 = arg1
+
+
 @attr.s(auto_attribs=True)
 class CustomBaseIndexOpLink(BaseOperatorLink):
     index: int = attr.ib()

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -28,6 +28,7 @@ from airflow.utils.helpers import (
     exactly_one,
     merge_dicts,
     prune_dict,
+    resolve_property_value,
     validate_group_key,
     validate_key,
 )
@@ -321,3 +322,28 @@ class TestHelpers:
         d1 = {'a': None, 'b': '', 'c': 'hi', 'd': l1}
         d2 = {'a': None, 'b': '', 'c': d1, 'd': l1, 'e': [None, '', 0, d1, l1, ['']]}
         assert prune_dict(d2, mode=mode) == expected
+
+    def test_resolve_property_value_property(self):
+        class MockClass:
+            @property
+            def mock_property(self):
+                return "mock-property-value"
+
+        assert isinstance(MockClass.mock_property, property)
+        assert MockClass.mock_property != "mock-property-value"
+        assert resolve_property_value(MockClass, MockClass.mock_property) == "mock-property-value"
+        mock_class_instance = MockClass()
+        assert (
+            resolve_property_value(mock_class_instance, mock_class_instance.mock_property)
+            == "mock-property-value"
+        )
+
+    def test_resolve_property_value_attr(self):
+        class MockClass:
+            mock_attr = "mock-attr-value"
+
+        assert not isinstance(MockClass.mock_attr, property)
+        assert MockClass.mock_attr == "mock-attr-value"
+        assert resolve_property_value(MockClass, MockClass.mock_attr) == "mock-attr-value"
+        mock_class_instance = MockClass()
+        assert resolve_property_value(mock_class_instance, mock_class_instance.mock_attr) == "mock-attr-value"


### PR DESCRIPTION
At that moment Airflow can't serialize DAG with dynamic tasks if `operator_extra_links` set as property 
related: #25243, #25215, #24676

I've tried to add get actual values of property.

---
It works in simple cases: #25215, #24676

```python
from pendulum import datetime

from airflow.decorators import dag
from airflow.sensors.external_task import ExternalTaskSensor


@dag(start_date=datetime(2022, 1, 1), schedule_interval=None)
def external_task_sensor():
    ExternalTaskSensor.partial(
        task_id='wait',
    ).expand(external_dag_id=["dag_1", "dag_2", "dag_3"])

_ = external_task_sensor()


```
![image](https://user-images.githubusercontent.com/3998685/180580272-b9011b08-4156-4518-9929-8fbc7133340e.png)

However there is no reason use property `operator_extra_links` in this cases

---

It still not completely help in case when property uses for dynamic links selections such as: #25243

```python
from pendulum import datetime

from airflow.decorators import dag
from airflow.providers.amazon.aws.operators.batch import BatchOperator


@dag(start_date=datetime(2022, 1, 1), schedule_interval=None)
def batchop_dtm():
    BatchOperator.partial(
        task_id='submit_batch_job',
        job_queue="batch_job_queue_name",
        job_definition="batch_job_definition_name",
        overrides={},
        # Set this flag to False, so we can test the sensor below
        wait_for_completion=False,
    ).expand(job_name=["job_1", "job_2", "job_3"])


_ = batchop_dtm()
```

With this PoC error changed, `airflow.models.mappedoperator.MappedOperator` doesn't have access to attributes of Task

```
Broken DAG: [/files/dags/batch_mapping.py] Traceback (most recent call last):
  File "/opt/airflow/airflow/utils/helpers.py", line 390, in resolve_property_value
    return prop.fget(obj)
  File "/opt/airflow/airflow/providers/amazon/aws/operators/batch.py", line 117, in operator_extra_links
    if self.wait_for_completion:
AttributeError: type object 'SerializedBaseOperator' has no attribute 'wait_for_completion'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/airflow/airflow/serialization/serialized_objects.py", line 1178, in to_dict
    json_dict = {"__version": cls.SERIALIZER_VERSION, "dag": cls.serialize_dag(var)}
  File "/opt/airflow/airflow/serialization/serialized_objects.py", line 1086, in serialize_dag
    raise SerializationError(f'Failed to serialize DAG {dag.dag_id!r}: {e}')
airflow.exceptions.SerializationError: Failed to serialize DAG 'batchop_dtm': type object 'SerializedBaseOperator' has no attribute 'wait_for_completion'
```

cc: @josh-fell 

