### PR TITLE
Add outlet_datasets to tasks endpoints

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3229,7 +3229,9 @@ components:
           type: string
           readOnly: true
         outlet_datasets:
-          $ref: '#/components/schemas/OutletDataset'
+          type: array
+          items:
+            $ref: '#/components/schemas/OutletDataset'
           readOnly: true
         start_date:
           type: string

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3228,7 +3228,7 @@ components:
         owner:
           type: string
           readOnly: true
-        outlets_datasets:
+        outlet_datasets:
           $ref: '#/components/schemas/OutletDataset'
           readOnly: true
         start_date:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3228,6 +3228,9 @@ components:
         owner:
           type: string
           readOnly: true
+        outlets_datasets:
+          $ref: '#/components/schemas/OutletDataset'
+          readOnly: true
         start_date:
           type: string
           format: 'date-time'
@@ -3307,6 +3310,22 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Task'
+
+    OutletDatasetCollection:
+      type: array
+      description: Collection of datasets stored in task outlets attribute.
+      items:
+        $ref: '#/components/schemas/OutletDataset'
+    OutletDataset:
+      type: object
+      description: Dataset stored in task outlets attribute.
+      properties:
+        uri:
+          type: string
+          description: Dataset identifier
+        extra:
+          type: object
+          description: Extra dataset information
 
     # Plugin
     PluginCollectionItem:

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1327,6 +1327,7 @@ export interface components {
       class_ref?: components["schemas"]["ClassReference"];
       task_id?: string;
       owner?: string;
+      outlets_datasets?: components["schemas"]["OutletDataset"];
       /** Format: date-time */
       start_date?: string;
       /** Format: date-time */
@@ -1356,6 +1357,15 @@ export interface components {
     /** @description Collection of tasks. */
     TaskCollection: {
       tasks?: components["schemas"]["Task"][];
+    };
+    /** @description Collection of datasets stored in task outlets attribute. */
+    OutletDatasetCollection: components["schemas"]["OutletDataset"][];
+    /** @description Dataset stored in task outlets attribute. */
+    OutletDataset: {
+      /** @description Dataset identifier */
+      uri?: string;
+      /** @description Extra dataset information */
+      extra?: { [key: string]: unknown };
     };
     /**
      * @description A plugin Item.
@@ -4034,6 +4044,8 @@ export type ExtraLink = SnakeToCamelCaseNested<components['schemas']['ExtraLink'
 export type ExtraLinkCollection = SnakeToCamelCaseNested<components['schemas']['ExtraLinkCollection']>;
 export type Task = SnakeToCamelCaseNested<components['schemas']['Task']>;
 export type TaskCollection = SnakeToCamelCaseNested<components['schemas']['TaskCollection']>;
+export type OutletDatasetCollection = SnakeToCamelCaseNested<components['schemas']['OutletDatasetCollection']>;
+export type OutletDataset = SnakeToCamelCaseNested<components['schemas']['OutletDataset']>;
 export type PluginCollectionItem = SnakeToCamelCaseNested<components['schemas']['PluginCollectionItem']>;
 export type PluginCollection = SnakeToCamelCaseNested<components['schemas']['PluginCollection']>;
 export type Role = SnakeToCamelCaseNested<components['schemas']['Role']>;

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1327,7 +1327,7 @@ export interface components {
       class_ref?: components["schemas"]["ClassReference"];
       task_id?: string;
       owner?: string;
-      outlet_datasets?: components["schemas"]["OutletDataset"];
+      outlet_datasets?: components["schemas"]["OutletDataset"][];
       /** Format: date-time */
       start_date?: string;
       /** Format: date-time */

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1327,7 +1327,7 @@ export interface components {
       class_ref?: components["schemas"]["ClassReference"];
       task_id?: string;
       owner?: string;
-      outlets_datasets?: components["schemas"]["OutletDataset"];
+      outlet_datasets?: components["schemas"]["OutletDataset"];
       /** Format: date-time */
       start_date?: string;
       /** Format: date-time */

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -106,6 +106,7 @@ class TestGetTask(TestTaskEndpoint):
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
+            "outlet_datasets": [],
             "owner": "airflow",
             'params': {
                 'foo': {
@@ -191,6 +192,7 @@ class TestGetTask(TestTaskEndpoint):
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
+            "outlet_datasets": [],
             "owner": "airflow",
             'params': {
                 'foo': {
@@ -257,6 +259,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "end_date": None,
                     "execution_timeout": None,
                     "extra_links": [],
+                    "outlet_datasets": [],
                     "owner": "airflow",
                     'params': {
                         'foo': {
@@ -293,6 +296,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "end_date": None,
                     "execution_timeout": None,
                     "extra_links": [],
+                    "outlet_datasets": [],
                     "owner": "airflow",
                     "params": {},
                     "pool": "default_pool",
@@ -332,6 +336,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "execution_timeout": None,
                     "extra_links": [],
                     "is_mapped": True,
+                    # todo: should be "outlet_datasets": [], but does not work for mapped
                     "owner": "airflow",
                     "params": {},
                     "pool": "default_pool",
@@ -360,6 +365,7 @@ class TestGetTasks(TestTaskEndpoint):
                     "end_date": None,
                     "execution_timeout": None,
                     "extra_links": [],
+                    "outlet_datasets": [],
                     "owner": "airflow",
                     "params": {},
                     "pool": "default_pool",

--- a/tests/api_connexion/schemas/test_task_schema.py
+++ b/tests/api_connexion/schemas/test_task_schema.py
@@ -39,6 +39,7 @@ class TestTaskSchema:
             "end_date": "2020-06-26T00:00:00+00:00",
             "execution_timeout": None,
             "extra_links": [],
+            "outlet_datasets": [],
             "owner": "airflow",
             "params": {},
             "pool": "default_pool",
@@ -78,6 +79,7 @@ class TestTaskCollectionSchema:
                     "end_date": None,
                     "execution_timeout": None,
                     "extra_links": [],
+                    "outlet_datasets": [],
                     "owner": "airflow",
                     'params': {
                         'foo': {


### PR DESCRIPTION
The outlets field could be used for more things than datasets.  So we can't know how to reliably serialize all the objects that might end up there.  So we just serialize the datasets (which is all we care about for the moment) and expose them under an attribute `outlet_datasets`.

@bbovenzi note that we don't have the dataset ID here.  It's not stored in the serialized dag data for simplicity reasons.  We'd have to query the DB at serialization time to retrieve the ID, so we could do it, just don't need it yet.  And, since you are just using this to check if a task has dataset outlets, this should do fine for you.  You should be able to simply check that `outlet_datasets` is nonempty.