### PR TITLE
Add URI to dataset event response

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3555,7 +3555,10 @@ components:
           type: string
           description: The dataset event creation time
           nullable: false
-
+        dataset:
+          $ref: '#/components/schemas/Dataset'
+          description: The dataset for which the event occurred.
+          nullable: false
 
     DatasetEventCollection:
       description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3494,7 +3494,7 @@ components:
           description: The dataset uri
           nullable: false
         extra:
-          type: string
+          type: object
           description: The dataset extra
           nullable: true
         created_at:
@@ -3532,8 +3532,8 @@ components:
           type: integer
           description: The dataset id
         extra:
-          type: string
-          description: The dataset extra
+          type: object
+          description: The dataset event extra
           nullable: true
         source_dag_id:
           type: string

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3531,6 +3531,10 @@ components:
         dataset_id:
           type: integer
           description: The dataset id
+        dataset_uri:
+          type: string
+          description: The URI of the dataset
+          nullable: false
         extra:
           type: object
           description: The dataset event extra
@@ -3554,10 +3558,6 @@ components:
         created_at:
           type: string
           description: The dataset event creation time
-          nullable: false
-        uri:
-          type: string
-          description: The URI of the dataset
           nullable: false
 
     DatasetEventCollection:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3555,9 +3555,9 @@ components:
           type: string
           description: The dataset event creation time
           nullable: false
-        dataset:
-          $ref: '#/components/schemas/Dataset'
-          description: The dataset for which the event occurred.
+        uri:
+          type: string
+          description: The URI of the dataset
           nullable: false
 
     DatasetEventCollection:

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -72,7 +72,7 @@ class DatasetEventSchema(SQLAlchemySchema):
     source_run_id = auto_field()
     source_map_index = auto_field()
     created_at = auto_field()
-    dataset = fields.Nested(DatasetSchema)
+    uri = fields.String(attribute='dataset.uri', dump_only=True)
 
 
 class DatasetEventCollection(NamedTuple):

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -66,13 +66,13 @@ class DatasetEventSchema(SQLAlchemySchema):
 
     id = auto_field()
     dataset_id = auto_field()
+    dataset_uri = fields.String(attribute='dataset.uri', dump_only=True)
     extra = fields.Dict()
     source_task_id = auto_field()
     source_dag_id = auto_field()
     source_run_id = auto_field()
     source_map_index = auto_field()
     created_at = auto_field()
-    uri = fields.String(attribute='dataset.uri', dump_only=True)
 
 
 class DatasetEventCollection(NamedTuple):

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -72,6 +72,7 @@ class DatasetEventSchema(SQLAlchemySchema):
     source_run_id = auto_field()
     source_map_index = auto_field()
     created_at = auto_field()
+    dataset = fields.Nested(DatasetSchema)
 
 
 class DatasetEventCollection(NamedTuple):

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -33,7 +33,7 @@ class DatasetSchema(SQLAlchemySchema):
 
     id = auto_field()
     uri = auto_field()
-    extra = auto_field()
+    extra = fields.Dict()
     created_at = auto_field()
     updated_at = auto_field()
 
@@ -66,7 +66,7 @@ class DatasetEventSchema(SQLAlchemySchema):
 
     id = auto_field()
     dataset_id = auto_field()
-    extra = auto_field()
+    extra = fields.Dict()
     source_task_id = auto_field()
     source_dag_id = auto_field()
     source_run_id = auto_field()

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -261,6 +261,10 @@ class DatasetEvent(Base):
         uselist=False,
     )
 
+    @property
+    def uri(self):
+        return self.dataset.uri
+
     def __eq__(self, other) -> bool:
         if isinstance(other, self.__class__):
             return self.dataset_id == other.dataset_id and self.created_at == other.created_at

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -123,7 +123,7 @@ const DatasetDetails = ({ datasetId, onBack }: Props) => {
             {!!dataset.extra && (
               <Flex>
                 <Text mr={1}>Extra:</Text>
-                <Code>{dataset.extra}</Code>
+                <Code>{JSON.stringify(dataset.extra)}</Code>
               </Flex>
             )}
             <Flex my={2}>

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1486,6 +1486,8 @@ export interface components {
     DatasetEvent: {
       /** @description The dataset id */
       dataset_id?: number;
+      /** @description The URI of the dataset */
+      dataset_uri?: string;
       /** @description The dataset event extra */
       extra?: { [key: string]: unknown } | null;
       /** @description The DAG ID that updated the dataset. */
@@ -1498,8 +1500,6 @@ export interface components {
       source_map_index?: number | null;
       /** @description The dataset event creation time */
       created_at?: string;
-      /** @description The URI of the dataset */
-      uri?: string;
     };
     /**
      * @description A collection of dataset events.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1464,7 +1464,7 @@ export interface components {
       /** @description The dataset uri */
       uri?: string;
       /** @description The dataset extra */
-      extra?: string | null;
+      extra?: { [key: string]: unknown } | null;
       /** @description The dataset creation time */
       created_at?: string;
       /** @description The dataset update time */
@@ -1486,8 +1486,8 @@ export interface components {
     DatasetEvent: {
       /** @description The dataset id */
       dataset_id?: number;
-      /** @description The dataset extra */
-      extra?: string | null;
+      /** @description The dataset event extra */
+      extra?: { [key: string]: unknown } | null;
       /** @description The DAG ID that updated the dataset. */
       source_dag_id?: string | null;
       /** @description The task ID that updated the dataset. */

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1498,8 +1498,8 @@ export interface components {
       source_map_index?: number | null;
       /** @description The dataset event creation time */
       created_at?: string;
-      /** @description The dataset for which the event occurred. */
-      dataset?: components["schemas"]["Dataset"];
+      /** @description The URI of the dataset */
+      uri?: string;
     };
     /**
      * @description A collection of dataset events.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1498,6 +1498,8 @@ export interface components {
       source_map_index?: number | null;
       /** @description The dataset event creation time */
       created_at?: string;
+      /** @description The dataset for which the event occurred. */
+      dataset?: components["schemas"]["Dataset"];
     };
     /**
      * @description A collection of dataset events.

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1594,16 +1594,6 @@ def test__get_upstream_dataset_events_with_prior(configured_app):
     ]
 
 
-def dataset_to_dict(d):
-    return dict(
-        id=d.id,
-        uri=d.uri,
-        extra=d.extra,
-        created_at=str(d.created_at),
-        updated_at=str(d.updated_at),
-    )
-
-
 class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
     @mock.patch('airflow.api_connexion.endpoints.dag_run_endpoint._get_upstream_dataset_events')
     def test_should_respond_200(self, mock_get_events, session):
@@ -1635,7 +1625,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
                 {
                     'created_at': str(created_at),
                     'dataset_id': 1,
-                    'dataset': dataset_to_dict(d.dataset),
+                    'uri': d.dataset.uri,
                     'extra': None,
                     'id': None,
                     'source_dag_id': None,

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1625,7 +1625,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
                 {
                     'created_at': str(created_at),
                     'dataset_id': 1,
-                    'uri': d.dataset.uri,
+                    'dataset_uri': d.dataset.uri,
                     'extra': None,
                     'id': None,
                     'source_dag_id': None,

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1594,6 +1594,16 @@ def test__get_upstream_dataset_events_with_prior(configured_app):
     ]
 
 
+def dataset_to_dict(d):
+    return dict(
+        id=d.id,
+        uri=d.uri,
+        extra=d.extra,
+        created_at=str(d.created_at),
+        updated_at=str(d.updated_at),
+    )
+
+
 class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
     @mock.patch('airflow.api_connexion.endpoints.dag_run_endpoint._get_upstream_dataset_events')
     def test_should_respond_200(self, mock_get_events, session):
@@ -1612,7 +1622,9 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         assert len(result) == 1
         created_at = pendulum.now('UTC')
         # make sure whatever is returned by this func is what comes out in response.
-        mock_get_events.return_value = [DatasetEvent(dataset_id=1, created_at=created_at)]
+        d = DatasetEvent(dataset_id=1, created_at=created_at)
+        d.dataset = Dataset(id=1, uri='hello', created_at=created_at, updated_at=created_at)
+        mock_get_events.return_value = [d]
         response = self.client.get(
             "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamDatasetEvents",
             environ_overrides={'REMOTE_USER': "test"},
@@ -1623,6 +1635,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
                 {
                     'created_at': str(created_at),
                     'dataset_id': 1,
+                    'dataset': dataset_to_dict(d.dataset),
                     'extra': None,
                     'id': None,
                     'source_dag_id': None,

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -284,26 +284,27 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
                     "id": 1,
                     "created_at": self.default_time,
                     **common,
-                    "uri": d.uri,
+                    "dataset_uri": d.uri,
                 },
                 {
                     "id": 2,
                     "created_at": self.default_time,
                     **common,
-                    "uri": d.uri,
+                    "dataset_uri": d.uri,
                 },
             ],
             "total_entries": 2,
         }
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        'attr, value',
         [
             ('dataset_id', '2'),
             ('source_dag_id', 'dag2'),
             ('source_task_id', 'task2'),
             ('source_run_id', 'run2'),
             ('source_map_index', '2'),
-        ]
+        ],
     )
     @provide_session
     def test_filtering(self, attr, value, session):
@@ -346,7 +347,7 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
                 {
                     "id": 2,
                     "dataset_id": 2,
-                    "uri": datasets[1].uri,
+                    "dataset_uri": datasets[1].uri,
                     "extra": None,
                     "source_dag_id": "dag2",
                     "source_task_id": "task2",

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -47,16 +47,6 @@ def configured_app(minimal_app_for_api):
     delete_user(app, username="test_no_permissions")  # type: ignore
 
 
-def dataset_to_dict(d):
-    return dict(
-        id=d.id,
-        uri=d.uri,
-        extra=d.extra,
-        created_at=str(d.created_at),
-        updated_at=str(d.updated_at),
-    )
-
-
 class TestDatasetEndpoint:
 
     default_time = "2020-06-11T18:00:00+00:00"
@@ -294,13 +284,13 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
                     "id": 1,
                     "created_at": self.default_time,
                     **common,
-                    "dataset": dataset_to_dict(d),
+                    "uri": d.uri,
                 },
                 {
                     "id": 2,
                     "created_at": self.default_time,
                     **common,
-                    "dataset": dataset_to_dict(d),
+                    "uri": d.uri,
                 },
             ],
             "total_entries": 2,
@@ -356,7 +346,7 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
                 {
                     "id": 2,
                     "dataset_id": 2,
-                    "dataset": dataset_to_dict(datasets[1]),
+                    "uri": datasets[1].uri,
                     "extra": None,
                     "source_dag_id": "dag2",
                     "source_task_id": "task2",

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -52,7 +52,7 @@ class TestDatasetSchema(TestDatasetSchemaBase):
         assert serialized_data == {
             "id": 1,
             "uri": "s3://bucket/key",
-            "extra": "{'foo': 'bar'}",
+            "extra": {'foo': 'bar'},
             "created_at": self.timestamp,
             "updated_at": self.timestamp,
         }
@@ -82,14 +82,14 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
                 {
                     "id": 1,
                     "uri": "s3://bucket/key/1",
-                    "extra": "{'foo': 'bar'}",
+                    "extra": {'foo': 'bar'},
                     "created_at": self.timestamp,
                     "updated_at": self.timestamp,
                 },
                 {
                     "id": 2,
                     "uri": "s3://bucket/key/2",
-                    "extra": "{'foo': 'bar'}",
+                    "extra": {'foo': 'bar'},
                     "created_at": self.timestamp,
                     "updated_at": self.timestamp,
                 },
@@ -116,7 +116,7 @@ class TestDatasetEventSchema(TestDatasetSchemaBase):
         assert serialized_data == {
             "id": 1,
             "dataset_id": 10,
-            "extra": "{'foo': 'bar'}",
+            "extra": {'foo': 'bar'},
             "source_dag_id": "foo",
             "source_task_id": "bar",
             "source_run_id": "custom",
@@ -129,7 +129,7 @@ class TestDatasetEventCollectionSchema(TestDatasetSchemaBase):
     def test_serialize(self, session):
         common = {
             "dataset_id": 10,
-            "extra": "{'foo': 'bar'}",
+            "extra": {'foo': 'bar'},
             "source_dag_id": "foo",
             "source_task_id": "bar",
             "source_run_id": "custom",

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -100,9 +100,12 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
 
 class TestDatasetEventSchema(TestDatasetSchemaBase):
     def test_serialize(self, session):
+        d = Dataset('s3://abc')
+        session.add(d)
+        session.commit()
         event = DatasetEvent(
             id=1,
-            dataset_id=10,
+            dataset_id=d.id,
             extra={"foo": "bar"},
             source_dag_id="foo",
             source_task_id="bar",
@@ -115,7 +118,8 @@ class TestDatasetEventSchema(TestDatasetSchemaBase):
         serialized_data = dataset_event_schema.dump(event)
         assert serialized_data == {
             "id": 1,
-            "dataset_id": 10,
+            "dataset_id": d.id,
+            "dataset_uri": "s3://abc",
             "extra": {'foo': 'bar'},
             "source_dag_id": "foo",
             "source_task_id": "bar",


### PR DESCRIPTION
Added `dataset` node on dataset event object in API response.

Response now looks like this:

```
{
  "dataset_events": [
      "dataset_id": 25,
      "extra": null,
      "id": 17,
      "source_dag_id": "dag3",
      "source_map_index": -1,
      "source_run_id": "dataset_triggered__2022-07-11T02:16:08.050068+00:00",
      "source_task_id": "downstream_1",
      "uri": "s3://downstream_1_task/dataset_other.txt"
    },
...
```

Note: also fixed serialization of the `event` field, which initially felt like small fix but there were a number of tests to update.  I can split into sep pr if nec.