### PR TITLE
Use tables in grid details panes

### DIFF
--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -75,16 +75,14 @@ const DagRun = ({ runId }: Props) => {
 
   return (
     <>
-      <Box>
-        <Flex justifyContent="space-between" alignItems="center">
-          <Button as={Link} variant="ghost" colorScheme="blue" href={detailsLink}>DAG Run Details</Button>
-          <Button as={Link} variant="ghost" colorScheme="blue" href={graphLink} leftIcon={<MdOutlineAccountTree />}>
-            Graph
-          </Button>
-          <MarkFailedRun dagId={dagId} runId={runId} />
-          <MarkSuccessRun dagId={dagId} runId={runId} />
-        </Flex>
-      </Box>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Button as={Link} variant="ghost" colorScheme="blue" href={detailsLink}>DAG Run Details</Button>
+        <Button as={Link} variant="ghost" colorScheme="blue" href={graphLink} leftIcon={<MdOutlineAccountTree />}>
+          Graph
+        </Button>
+        <MarkFailedRun dagId={dagId} runId={runId} />
+        <MarkSuccessRun dagId={dagId} runId={runId} />
+      </Flex>
       <Box py="4px">
         <Divider my={3} />
         <Flex justifyContent="flex-end" alignItems="center">

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -23,7 +23,11 @@ import {
   Box,
   Button,
   Link,
-  Divider, Table, Tbody, Tr, Td, Heading,
+  Divider,
+  Table,
+  Tbody,
+  Tr,
+  Td,
 } from '@chakra-ui/react';
 
 import { MdPlayArrow, MdOutlineSchedule, MdOutlineAccountTree } from 'react-icons/md';
@@ -91,17 +95,17 @@ const DagRun = ({ runId }: Props) => {
           <QueueRun dagId={dagId} runId={runId} />
         </Flex>
         <Divider my={3} />
-        <Flex alignItems="center">
-          <Text as="strong">Status:</Text>
-          <SimpleStatus state={state} mx={2} />
-          {state || 'no status'}
-        </Flex>
       </Box>
       <Table variant="striped">
         <Tbody>
-          <Tr borderBottomWidth={2} borderBottomColor="gray.300">
-            <Td><Heading size="sm">DAG Run Summary</Heading></Td>
-            <Td />
+          <Tr>
+            <Td>Status</Td>
+            <Td>
+              <Flex>
+                <SimpleStatus state={state} mx={2} />
+                {state || 'no status'}
+              </Flex>
+            </Td>
           </Tr>
           <Tr>
             <Td>Run ID</Td>

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -23,7 +23,7 @@ import {
   Box,
   Button,
   Link,
-  Divider,
+  Divider, Table, Tbody, Tr, Td, Heading,
 } from '@chakra-ui/react';
 
 import { MdPlayArrow, MdOutlineSchedule, MdOutlineAccountTree } from 'react-icons/md';
@@ -74,85 +74,100 @@ const DagRun = ({ runId }: Props) => {
   const detailsLink = appendSearchParams(dagRunDetailsUrl, detailsParams);
 
   return (
-    <Box py="4px">
-      <Flex justifyContent="space-between" alignItems="center">
-        <Button as={Link} variant="ghost" colorScheme="blue" href={detailsLink}>DAG Run Details</Button>
-        <Button as={Link} variant="ghost" colorScheme="blue" href={graphLink} leftIcon={<MdOutlineAccountTree />}>
-          Graph
-        </Button>
-        <MarkFailedRun dagId={dagId} runId={runId} />
-        <MarkSuccessRun dagId={dagId} runId={runId} />
-      </Flex>
-      <Divider my={3} />
-      <Flex justifyContent="flex-end" alignItems="center">
-        <Text fontWeight="bold" mr={2}>Re-run:</Text>
-        <ClearRun dagId={dagId} runId={runId} />
-        <QueueRun dagId={dagId} runId={runId} />
-      </Flex>
-      <Divider my={3} />
-      <Flex alignItems="center">
-        <Text as="strong">Status:</Text>
-        <SimpleStatus state={state} mx={2} />
-        {state || 'no status'}
-      </Flex>
-      <br />
-      <Text whiteSpace="nowrap">
-        Run Id:
-        {' '}
-        <ClipboardText value={runId} />
-      </Text>
-      <Text>
-        Run Type:
-        {' '}
-        {runType === 'manual' && <MdPlayArrow style={{ display: 'inline' }} />}
-        {runType === 'backfill' && <RiArrowGoBackFill style={{ display: 'inline' }} />}
-        {runType === 'scheduled' && <MdOutlineSchedule style={{ display: 'inline' }} />}
-        {runType}
-      </Text>
-      <Text>
-        Duration:
-        {' '}
-        {formatDuration(getDuration(startDate, endDate))}
-      </Text>
-      {lastSchedulingDecision && (
-      <Text>
-        Last Scheduling Decision:
-        {' '}
-        <Time dateTime={lastSchedulingDecision} />
-      </Text>
-      )}
-      <br />
-      {startDate && (
-      <Text>
-        Started:
-        {' '}
-        <Time dateTime={startDate} />
-      </Text>
-      )}
-      {endDate && (
-      <Text>
-        Ended:
-        {' '}
-        <Time dateTime={endDate} />
-      </Text>
-      )}
-      {dataIntervalStart && dataIntervalEnd && (
-        <>
-          <br />
-          <Text as="strong">Data Interval:</Text>
-          <Text>
-            Start:
-            {' '}
-            <Time dateTime={dataIntervalStart} />
-          </Text>
-          <Text>
-            End:
-            {' '}
-            <Time dateTime={dataIntervalEnd} />
-          </Text>
-        </>
-      )}
-    </Box>
+    <>
+      <Box>
+        <Flex justifyContent="space-between" alignItems="center">
+          <Button as={Link} variant="ghost" colorScheme="blue" href={detailsLink}>DAG Run Details</Button>
+          <Button as={Link} variant="ghost" colorScheme="blue" href={graphLink} leftIcon={<MdOutlineAccountTree />}>
+            Graph
+          </Button>
+          <MarkFailedRun dagId={dagId} runId={runId} />
+          <MarkSuccessRun dagId={dagId} runId={runId} />
+        </Flex>
+      </Box>
+      <Box py="4px">
+        <Divider my={3} />
+        <Flex justifyContent="flex-end" alignItems="center">
+          <Text fontWeight="bold" mr={2}>Re-run:</Text>
+          <ClearRun dagId={dagId} runId={runId} />
+          <QueueRun dagId={dagId} runId={runId} />
+        </Flex>
+        <Divider my={3} />
+        <Flex alignItems="center">
+          <Text as="strong">Status:</Text>
+          <SimpleStatus state={state} mx={2} />
+          {state || 'no status'}
+        </Flex>
+      </Box>
+      <Table variant="striped">
+        <Tbody>
+          <Tr borderBottomWidth={2} borderBottomColor="gray.300">
+            <Td><Heading size="sm">DAG Run Summary</Heading></Td>
+            <Td />
+          </Tr>
+          <Tr>
+            <Td>Run ID</Td>
+            <Td><ClipboardText value={runId} /></Td>
+          </Tr>
+          <Tr>
+            <Td>Run type</Td>
+            <Td>
+              {runType === 'manual' && <MdPlayArrow style={{ display: 'inline' }} />}
+              {runType === 'backfill' && <RiArrowGoBackFill style={{ display: 'inline' }} />}
+              {runType === 'scheduled' && <MdOutlineSchedule style={{ display: 'inline' }} />}
+              {runType}
+
+            </Td>
+          </Tr>
+          <Tr>
+            <Td>Run duration</Td>
+            <Td>
+              {formatDuration(getDuration(startDate, endDate))}
+            </Td>
+          </Tr>
+          {lastSchedulingDecision && (
+            <Tr>
+              <Td>Last scheduling decision</Td>
+              <Td>
+                <Time dateTime={lastSchedulingDecision} />
+              </Td>
+            </Tr>
+          )}
+          {startDate && (
+            <Tr>
+              <Td>Started</Td>
+              <Td>
+                <Time dateTime={startDate} />
+              </Td>
+            </Tr>
+          )}
+          {endDate && (
+            <Tr>
+              <Td>Ended</Td>
+              <Td>
+                <Time dateTime={endDate} />
+              </Td>
+            </Tr>
+          )}
+          {dataIntervalStart && dataIntervalEnd && (
+            <>
+              <Tr>
+                <Td>Data interval start</Td>
+                <Td>
+                  <Time dateTime={dataIntervalStart} />
+                </Td>
+              </Tr>
+              <Tr>
+                <Td>Data interval end</Td>
+                <Td>
+                  <Time dateTime={dataIntervalEnd} />
+                </Td>
+              </Tr>
+            </>
+          )}
+        </Tbody>
+      </Table>
+    </>
   );
 };
 

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import {
   Text,
   Box,
-  Flex,
+  Flex, Table, Tbody, Tr, Td, Heading,
 } from '@chakra-ui/react';
 
 import { finalStatesMap } from 'src/utils';
@@ -87,7 +87,7 @@ const Details = ({ instance, group, operator }: Props) => {
     }
   });
 
-  const taskIdTitle = isGroup ? 'Task Group Id: ' : 'Task Id: ';
+  const taskIdTitle = isGroup ? 'Task Group ID: ' : 'Task ID: ';
   const isStateFinal = state && ['success', 'failed', 'upstream_failed', 'skipped'].includes(state);
   const isOverall = (isMapped || isGroup) && 'Overall ';
 
@@ -95,10 +95,10 @@ const Details = ({ instance, group, operator }: Props) => {
     <Flex flexWrap="wrap" justifyContent="space-between">
       <Box>
         {tooltip && (
-          <>
-            <Text>{tooltip}</Text>
-            <br />
-          </>
+        <>
+          <Text>{tooltip}</Text>
+          <br />
+        </>
         )}
         {mappedStates && numMapped > 0 && (
         <Text>
@@ -119,45 +119,50 @@ const Details = ({ instance, group, operator }: Props) => {
         {summary.length > 0 && (
           summary
         )}
-        <br />
-        <Text>
-          {taskIdTitle}
-          <ClipboardText value={taskId} />
-        </Text>
-        <Text whiteSpace="nowrap">
-          Run Id:
-          {' '}
-          <ClipboardText value={runId} />
-        </Text>
-        {operator && (
-          <Text>
-            Operator:
-            {' '}
-            {operator}
-          </Text>
-        )}
-        <br />
-        <Text>
-          {isOverall}
-          Duration:
-          {' '}
-          {formatDuration(getDuration(startDate, endDate))}
-        </Text>
-        {startDate && (
-        <Text>
-          Started:
-          {' '}
-          <Time dateTime={startDate} />
-        </Text>
-        )}
-        {endDate && isStateFinal && (
-        <Text>
-          Ended:
-          {' '}
-          <Time dateTime={endDate} />
-        </Text>
-        )}
       </Box>
+      <br />
+      <br />
+      <Table variant="striped">
+        <Tbody>
+          <Tr borderBottomWidth={2} borderBottomColor="gray.300">
+            <Td><Heading size="sm">Task Instance Details</Heading></Td>
+            <Td />
+          </Tr>
+          <Tr>
+            <Td>{taskIdTitle}</Td>
+            <Td><ClipboardText value={taskId} /></Td>
+          </Tr>
+          <Tr>
+            <Td>Run ID</Td>
+            <Td><Text whiteSpace="nowrap"><ClipboardText value={runId} /></Text></Td>
+          </Tr>
+          {operator && (
+          <Tr>
+            <Td>Operator</Td>
+            <Td>{operator}</Td>
+          </Tr>
+          )}
+          <Tr>
+            <Td>
+              {isOverall}
+              Duration
+            </Td>
+            <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
+          </Tr>
+          {startDate && (
+          <Tr>
+            <Td>Started</Td>
+            <Td><Time dateTime={startDate} /></Td>
+          </Tr>
+          )}
+          {endDate && isStateFinal && (
+          <Tr>
+            <Td>Ended</Td>
+            <Td><Time dateTime={endDate} /></Td>
+          </Tr>
+          )}
+        </Tbody>
+      </Table>
     </Flex>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -21,7 +21,12 @@ import React from 'react';
 import {
   Text,
   Box,
-  Flex, Table, Tbody, Tr, Td, Heading,
+  Flex,
+  Table,
+  Tbody,
+  Tr,
+  Td,
+  Heading,
 } from '@chakra-ui/react';
 
 import { finalStatesMap } from 'src/utils';

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -26,7 +26,6 @@ import {
   Tbody,
   Tr,
   Td,
-  Heading,
 } from '@chakra-ui/react';
 
 import { finalStatesMap } from 'src/utils';
@@ -92,7 +91,7 @@ const Details = ({ instance, group, operator }: Props) => {
     }
   });
 
-  const taskIdTitle = isGroup ? 'Task Group ID: ' : 'Task ID: ';
+  const taskIdTitle = isGroup ? 'Task Group ID' : 'Task ID';
   const isStateFinal = state && ['success', 'failed', 'upstream_failed', 'skipped'].includes(state);
   const isOverall = (isMapped || isGroup) && 'Overall ';
 
@@ -100,27 +99,19 @@ const Details = ({ instance, group, operator }: Props) => {
     <Flex flexWrap="wrap" justifyContent="space-between">
       <Box>
         {tooltip && (
-        <>
-          <Text>{tooltip}</Text>
-          <br />
-        </>
+          <>
+            <Text>{tooltip}</Text>
+            <br />
+          </>
         )}
         {mappedStates && numMapped > 0 && (
-        <Text>
-          {numMapped}
-          {' '}
-          {numMapped === 1 ? 'Task ' : 'Tasks '}
-          Mapped
-        </Text>
-        )}
-        <Flex alignItems="center">
-          <Text as="strong">
-            {isOverall}
-            Status:
+          <Text>
+            {numMapped}
+            {' '}
+            {numMapped === 1 ? 'Task ' : 'Tasks '}
+            Mapped
           </Text>
-          <SimpleStatus state={state} mx={2} />
-          {state || 'no status'}
-        </Flex>
+        )}
         {summary.length > 0 && (
           summary
         )}
@@ -129,9 +120,17 @@ const Details = ({ instance, group, operator }: Props) => {
       <br />
       <Table variant="striped">
         <Tbody>
-          <Tr borderBottomWidth={2} borderBottomColor="gray.300">
-            <Td><Heading size="sm">Task Instance Details</Heading></Td>
-            <Td />
+          <Tr>
+            <Td>
+              {isOverall}
+              Status
+            </Td>
+            <Td>
+              <Flex>
+                <SimpleStatus state={state} mx={2} />
+                {state || 'no status'}
+              </Flex>
+            </Td>
           </Tr>
           <Tr>
             <Td>{taskIdTitle}</Td>
@@ -142,10 +141,10 @@ const Details = ({ instance, group, operator }: Props) => {
             <Td><Text whiteSpace="nowrap"><ClipboardText value={runId} /></Text></Td>
           </Tr>
           {operator && (
-          <Tr>
-            <Td>Operator</Td>
-            <Td>{operator}</Td>
-          </Tr>
+            <Tr>
+              <Td>Operator</Td>
+              <Td>{operator}</Td>
+            </Tr>
           )}
           <Tr>
             <Td>
@@ -155,16 +154,16 @@ const Details = ({ instance, group, operator }: Props) => {
             <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
           </Tr>
           {startDate && (
-          <Tr>
-            <Td>Started</Td>
-            <Td><Time dateTime={startDate} /></Td>
-          </Tr>
+            <Tr>
+              <Td>Started</Td>
+              <Td><Time dateTime={startDate} /></Td>
+            </Tr>
           )}
           {endDate && isStateFinal && (
-          <Tr>
-            <Td>Ended</Td>
-            <Td><Time dateTime={endDate} /></Td>
-          </Tr>
+            <Tr>
+              <Td>Ended</Td>
+              <Td><Time dateTime={endDate} /></Td>
+            </Tr>
           )}
         </Tbody>
       </Table>

--- a/scripts/ci/pre_commit/pre_commit_www_lint.py
+++ b/scripts/ci/pre_commit/pre_commit_www_lint.py
@@ -28,4 +28,4 @@ if __name__ == '__main__':
     dir = Path("airflow") / "www"
     subprocess.check_call(['yarn', '--frozen-lockfile', '--non-interactive'], cwd=dir)
     subprocess.check_call(['yarn', 'run', 'generate-api-types'], cwd=dir)
-    subprocess.check_call(['yarn', 'run', 'lint'], cwd=dir)
+    subprocess.check_call(['yarn', 'run', 'lint:fix'], cwd=dir)


### PR DESCRIPTION
Uses HTML tables in grid details panes for DagRun details and Task Instance details

Improves readability


# DagRun details

## before
<img width="769" alt="image" src="https://user-images.githubusercontent.com/15932138/180626192-a4b4bd7c-91d0-4312-bb37-2f0b076cb4f8.png">

## after
<img width="771" alt="image" src="https://user-images.githubusercontent.com/15932138/180788187-aaee4a22-de8d-4907-aebe-77d29f8be51c.png">

# TaskInstance details

## before
<img width="755" alt="image" src="https://user-images.githubusercontent.com/15932138/180632966-a4b4c384-105b-439e-a29c-eff0608ff716.png">

## after
<img width="764" alt="image" src="https://user-images.githubusercontent.com/15932138/180788604-d0356123-6fb6-41b7-86cd-0df51eb12e1e.png">

