### PR TITLE
Add werkzeug limitation until flask-login will handle it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -149,7 +149,7 @@ install_requires =
     termcolor>=1.1.0
     typing-extensions>=4.0.0
     unicodecsv>=0.14.1
-    werkzeug>=2.0
+    werkzeug>=2.0,<2.2
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -149,6 +149,8 @@ install_requires =
     termcolor>=1.1.0
     typing-extensions>=4.0.0
     unicodecsv>=0.14.1
+    # werkzeoug 2.2.0 breaks flask-login. see https://github.com/maxcountryman/flask-login/issues/686 for details.
+    # we need werkzeug<2.2 limitation until flask_login are handle it
     werkzeug>=2.0,<2.2
 
 [options.packages.find]


### PR DESCRIPTION
related: #25269

werkzeoug 2.2.0 breaks flask-login.
This will be problem who doesn't use `pip --constraint` 

The breaks caused by https://github.com/pallets/werkzeug/pull/2433 and flask-login already knows it https://github.com/maxcountryman/flask-login/issues/686

I think we need werkzeug<2.2 limitation until flask_login are handle it

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
