### PR TITLE
Chart: custom labels for extrasecrets/configmaps

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -32,6 +32,9 @@ metadata:
 {{- with $Global.Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- if $configMapContent.labels }}
+{{ toYaml $configMapContent.labels | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -32,6 +32,9 @@ metadata:
 {{- with $Global.Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- if $secretContent.labels }}
+{{ toYaml $secretContent.labels | indent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -857,6 +857,15 @@
                         "description": "Type **as string** of secret E.G. Opaque, kubernetes.io/dockerconfigjson, etc.",
                         "type": "string"
                     },
+                    "labels": {
+                        "description": "Labels for the secret",
+                        "type": "object",
+                        "additionalProperties": {
+                            "description": "Label key",
+                            "default": null,
+                            "type": "string"
+                        }
+                    },
                     "data": {
                         "description": "Content **as string** for the 'data' item of the secret (can be templated)",
                         "type": "string"
@@ -887,8 +896,17 @@
                 "minProperties": 1,
                 "additionalProperties": false,
                 "properties": {
+                    "labels": {
+                        "description": "Labels for the configmap",
+                        "type": "object",
+                        "additionalProperties": {
+                            "description": "Label key",
+                            "default": null,
+                            "type": "string"
+                        }
+                    },
                     "data": {
-                        "description": "Content **as string** for the 'data' item of the secret (can be templated)",
+                        "description": "Content **as string** for the 'data' item of the configmap (can be templated)",
                         "type": "string"
                     }
                 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -860,9 +860,8 @@
                     "labels": {
                         "description": "Labels for the secret",
                         "type": "object",
+                        "default": null,
                         "additionalProperties": {
-                            "description": "Label key",
-                            "default": null,
                             "type": "string"
                         }
                     },
@@ -899,9 +898,8 @@
                     "labels": {
                         "description": "Labels for the configmap",
                         "type": "object",
+                        "default": null,
                         "additionalProperties": {
-                            "description": "Label key",
-                            "default": null,
                             "type": "string"
                         }
                     },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -268,7 +268,7 @@ enableBuiltInSecretEnvVars:
 
 # Extra secrets that will be managed by the chart
 # (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
-# The format is "key/value" where
+# The format for secret data is "key/value" where
 #    * key (can be templated) is the name of the secret that will be created
 #    * value: an object with the standard 'data' or 'stringData' key (or both).
 #          The value associated with those keys must be a string (can be templated)
@@ -277,6 +277,8 @@ extraSecrets: {}
 # extraSecrets:
 #   '{{ .Release.Name }}-airflow-connections':
 #     type: 'Opaque'
+#     labels:
+#       my.custom.label/v1: my_custom_label_value_1
 #     data: |
 #       AIRFLOW_CONN_GCP: 'base64_encoded_gcp_conn_string'
 #       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'
@@ -288,7 +290,7 @@ extraSecrets: {}
 
 # Extra ConfigMaps that will be managed by the chart
 # (You can use them with extraEnv or extraEnvFrom or some of the extraVolumes values).
-# The format is "key/value" where
+# The format for configmap data is "key/value" where
 #    * key (can be templated) is the name of the configmap that will be created
 #    * value: an object with the standard 'data' key.
 #          The value associated with this keys must be a string (can be templated)
@@ -296,6 +298,8 @@ extraConfigMaps: {}
 # eg:
 # extraConfigMaps:
 #   '{{ .Release.Name }}-airflow-variables':
+#     labels:
+#       my.custom.label/v2: my_custom_label_value_2
 #     data: |
 #       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"

--- a/chart/values_schema.schema.json
+++ b/chart/values_schema.schema.json
@@ -5,8 +5,19 @@
     "definitions": {
         "leafs": {
             "additionalProperties": {
-                "additionalProperties": {
-                    "$ref": "#/definitions/leafs"
+                "if": {
+                    "not": {
+                        "properties": {
+                            "description": {
+                                "pattern": "^Labels for the configmap$|^Labels for the secret$"
+                            }
+                        }
+                    }
+                },
+                "then": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/leafs"
+                    }
                 }
             },
             "if": {


### PR DESCRIPTION
This PR allows users to specify custom labels for secrets/configmaps created with `extraSecrets`/`extraConfigMaps` params

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
