### PR TITLE
Avoid unnecessary error output when checking for emulated environment

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -106,9 +106,13 @@ def check_for_python_emulation():
 
 
 def check_for_rosetta_environment():
+    if sys.platform != 'darwin':
+        return
     try:
         runs_in_rosetta = subprocess.check_output(
-            ["sysctl", "-n", "sysctl.proc_translated"], text=True
+            ["sysctl", "-n", "sysctl.proc_translated"],
+            text=True,
+            stderr=subprocess.DEVNULL,
         ).strip()
         if runs_in_rosetta == '1':
             from airflow_breeze.utils.console import get_console


### PR DESCRIPTION
The #25229 introduced check for emulated environment, but
it introduced a warning being printed on Linux environment.

This avoids printing the warning and also it stops running the check
outside of MacOS (Darwin)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
