### PR TITLE
[docs] Update DAG run to clarify when a DAG actually runs

### DIFF
--- a/docs/apache-airflow/dag-run.rst
+++ b/docs/apache-airflow/dag-run.rst
@@ -51,26 +51,25 @@ a ``str``, a ``datetime.timedelta`` object, or one of the following cron "preset
 .. tip::
     You can use an online editor for CRON expressions such as `Crontab guru <https://crontab.guru/>`_
 
-+----------------+----------------------------------------------------------------+-----------------+
-| preset         | meaning                                                        | cron            |
-+================+================================================================+=================+
-| ``None``       | Don't schedule, use for exclusively "externally triggered"     |                 |
-|                | DAGs                                                           |                 |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@once``      | Schedule once and only once                                    |                 |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@hourly``    | Run once an hour at the beginning of the hour                  | ``0 * * * *``   |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@daily``     | Run once a day at midnight                                     | ``0 0 * * *``   |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@weekly``    | Run once a week at midnight on Sunday morning                  | ``0 0 * * 0``   |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@monthly``   | Run once a month at midnight of the first day of the month     | ``0 0 1 * *``   |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@quarterly`` | Run once a quarter at midnight on the first day                | ``0 0 1 */3 *`` |
-+----------------+----------------------------------------------------------------+-----------------+
-| ``@yearly``    | Run once a year at midnight of January 1                       | ``0 0 1 1 *``   |
-+----------------+----------------------------------------------------------------+-----------------+
++----------------+--------------------------------------------------------------------+-----------------+
+| preset         | meaning                                                            | cron            |
++================+====================================================================+=================+
+| ``None``       | Don't schedule, use for exclusively "externally triggered" DAGs    |                 |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@once``      | Schedule once and only once                                        |                 |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@hourly``    | Run once an hour at the end of the hour                            | ``0 * * * *``   |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@daily``     | Run once a day at midnight (24:00)                                 | ``0 0 * * *``   |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@weekly``    | Run once a week at midnight (24:00) on Sunday                      | ``0 0 * * 0``   |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@monthly``   | Run once a month at midnight (24:00) of the first day of the month | ``0 0 1 * *``   |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@quarterly`` | Run once a quarter at midnight (24:00) on the first day            | ``0 0 1 */3 *`` |
++----------------+--------------------------------------------------------------------+-----------------+
+| ``@yearly``    | Run once a year at midnight (24:00) of January 1                   | ``0 0 1 1 *``   |
++----------------+--------------------------------------------------------------------+-----------------+
 
 Your DAG will be instantiated for each schedule along with a corresponding
 DAG Run entry in the database backend.
@@ -83,8 +82,8 @@ Data Interval
 
 Each DAG run in Airflow has an assigned "data interval" that represents the time
 range it operates in. For a DAG scheduled with ``@daily``, for example, each of
-its data interval would start at midnight of each day and end at midnight of the
-next day.
+its data interval would start each day at midnight (00:00) and end at midnight 
+(24:00).
 
 A DAG run is usually scheduled *after* its associated data interval has ended,
 to ensure the run is able to collect all the data within the time period. In

--- a/docs/apache-airflow/dag-run.rst
+++ b/docs/apache-airflow/dag-run.rst
@@ -82,7 +82,7 @@ Data Interval
 
 Each DAG run in Airflow has an assigned "data interval" that represents the time
 range it operates in. For a DAG scheduled with ``@daily``, for example, each of
-its data interval would start each day at midnight (00:00) and end at midnight 
+its data interval would start each day at midnight (00:00) and end at midnight
 (24:00).
 
 A DAG run is usually scheduled *after* its associated data interval has ended,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I was trying to decipher when exactly a DAG run associated with a given `ds` would run, i.e., at midnight (00:00) or midnight (24:00). Per the docs, 

> A DAG run is usually scheduled after its associated data interval has ended, to ensure the run is able to collect all the data within the time period. In other words, a run covering the data period of 2020-01-01 generally does not start to run until 2020-01-01 has ended, i.e. after 2020-01-02 00:00:00.

and observing DAG runs it seems like these DAG runs occur at the end of said day rather than the beginning. 

This PR updates the documentation—hopefully I got this correct—to:

1. Remove confusion. As reported in [this](https://en.wikipedia.org/wiki/12-hour_clock#Confusion_at_noon_and_midnight) Wikipedia article there's some ambiguity around what day midnight is associated with and thus I felt being explicit—via the use of a 24 hour clock—would help clarify.
2. Address inaccuracies/inconsistencies, i.e., some DAG presets state "midnight" whereas others reference the morning— "midnight on Sunday morning". Additionally I think "... at the _beginning_ of the hour" should be "... at the _end_ of the hour" assuming these windows operate in a consistent manner.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
