### PR TITLE
Remove Werkzeug limitation after flask-login was fixed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,7 @@ install_requires =
     # for example any new methods, are accounted for.
     flask-appbuilder==4.1.3
     flask-caching>=1.5.0
-    flask-login>=0.5
+    flask-login>=0.6.2
     flask-session>=0.4.0
     flask-wtf>=0.15
     graphviz>=0.12
@@ -149,9 +149,7 @@ install_requires =
     termcolor>=1.1.0
     typing-extensions>=4.0.0
     unicodecsv>=0.14.1
-    # werkzeoug 2.2.0 breaks flask-login. see https://github.com/maxcountryman/flask-login/issues/686 for details.
-    # we need werkzeug<2.2 limitation until flask_login are handle it
-    werkzeug>=2.0,<2.2
+    werkzeug>=2.0
 
 [options.packages.find]
 include =

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import re
 from typing import Callable
 from unittest import mock
 
@@ -375,7 +376,7 @@ def test_get_task_stats_from_query():
     assert data == expected_data
 
 
-INVALID_DATETIME_RESPONSE = "Invalid datetime: &#x27;invalid&#x27;"
+INVALID_DATETIME_RESPONSE = re.compile(r"Invalid datetime: &#x?\d+;invalid&#x?\d+;")
 
 
 @pytest.mark.parametrize(
@@ -432,4 +433,4 @@ def test_invalid_dates(app, admin_client, url, content):
     resp = admin_client.get(url, follow_redirects=True)
 
     assert resp.status_code == 400
-    assert content in resp.get_data().decode()
+    assert re.search(content, resp.get_data().decode())


### PR DESCRIPTION
The Werkzeug limitation removed in #25270 can be removed now, when
Flask-login is fixed and 0.6.2 version is released that supports it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
