### PR TITLE
Deprecate hql parameters and synchronize DBApiHook method APIs

### DIFF
--- a/airflow/providers/apache/hive/CHANGELOG.rst
+++ b/airflow/providers/apache/hive/CHANGELOG.rst
@@ -24,6 +24,17 @@
 Changelog
 ---------
 
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+* The ``hql`` parameter in ``get_records`` of ``HiveServer2Hook`` has been renamed to sql to match the
+  ``get_records`` DbApiHook signature. If you used it as a positional parameter, this is no change for you,
+  but if you used it as keyword one, you need to rename it.
+* ``hive_conf`` parameter has been renamed to ``parameters`` and it is now second parameter, to match ``get_records``
+  signature from the DbApiHook. You need to rename it if you used it.
+* ``schema`` parameter in ``get_records`` is an optional kwargs extra parameter that you can add, to match
+  the schema of ``get_records`` from DbApiHook.
+
 3.1.0
 .....
 

--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -138,7 +138,7 @@ class HiveStatsCollectionOperator(BaseOperator):
 
         presto = PrestoHook(presto_conn_id=self.presto_conn_id)
         self.log.info('Executing SQL check: %s', sql)
-        row = presto.get_first(hql=sql)
+        row = presto.get_first(sql)
         self.log.info("Record: %s", row)
         if not row:
             raise AirflowException("The query returned None")

--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -111,7 +111,7 @@ class HiveToMySqlOperator(BaseOperator):
                 mysql = self._call_preoperator()
                 mysql.bulk_load(table=self.mysql_table, tmp_file=tmp_file.name)
         else:
-            hive_results = hive.get_records(self.sql, hive_conf=hive_conf)
+            hive_results = hive.get_records(self.sql, parameters=hive_conf)
             mysql = self._call_preoperator()
             mysql.insert_rows(table=self.mysql_table, rows=hive_results)
 

--- a/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -68,7 +68,7 @@ class HiveToSambaOperator(BaseOperator):
         with NamedTemporaryFile() as tmp_file:
             self.log.info("Fetching file from Hive")
             hive = HiveServer2Hook(hiveserver2_conn_id=self.hiveserver2_conn_id)
-            hive.to_csv(hql=self.hql, csv_filepath=tmp_file.name, hive_conf=context_to_airflow_vars(context))
+            hive.to_csv(self.hql, csv_filepath=tmp_file.name, hive_conf=context_to_airflow_vars(context))
             self.log.info("Pushing to samba")
             samba = SambaHook(samba_conn_id=self.samba_conn_id)
             samba.push_from_local(self.destination_filepath, tmp_file.name)

--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -275,7 +275,9 @@ class PinotDbApiHook(DbApiHook):
         endpoint = conn.extra_dejson.get('endpoint', 'query/sql')
         return f'{conn_type}://{host}/{endpoint}'
 
-    def get_records(self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
+    def get_records(
+        self, sql: Union[str, List[str]], parameters: Optional[Union[Iterable, Mapping]] = None, **kwargs
+    ) -> Any:
         """
         Executes the sql and returns a set of records.
 
@@ -287,7 +289,9 @@ class PinotDbApiHook(DbApiHook):
             cur.execute(sql)
             return cur.fetchall()
 
-    def get_first(self, sql: str, parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
+    def get_first(
+        self, sql: Union[str, List[str]], parameters: Optional[Union[Iterable, Mapping]] = None
+    ) -> Any:
         """
         Executes the sql and returns the first resulting row.
 

--- a/airflow/providers/common/sql/CHANGELOG.rst
+++ b/airflow/providers/common/sql/CHANGELOG.rst
@@ -15,6 +15,11 @@
     specific language governing permissions and limitations
     under the License.
 
+.. NOTE TO CONTRIBUTORS:
+    Please, only add notes to the Changelog just below the "Changelog" header when there are some breaking changes
+    and you want to add an explanation to the users on how they are supposed to deal with them.
+    The changelog is updated and maintained semi-automatically by release manager.
+
 
 Changelog
 ---------

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -181,7 +181,12 @@ class DbApiHook(BaseHook):
         with closing(self.get_conn()) as conn:
             yield from psql.read_sql(sql, con=conn, params=parameters, chunksize=chunksize, **kwargs)
 
-    def get_records(self, sql, parameters=None):
+    def get_records(
+        self,
+        sql: Union[str, List[str]],
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        **kwargs: dict,
+    ):
         """
         Executes the sql and returns a set of records.
 
@@ -197,7 +202,7 @@ class DbApiHook(BaseHook):
                     cur.execute(sql)
                 return cur.fetchall()
 
-    def get_first(self, sql, parameters=None):
+    def get_first(self, sql: Union[str, List[str]], parameters=None):
         """
         Executes the sql and returns the first resulting row.
 

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -77,7 +77,12 @@ class ExasolHook(DbApiHook):
             df = conn.export_to_pandas(sql, query_params=parameters, **kwargs)
             return df
 
-    def get_records(self, sql: str, parameters: Optional[dict] = None) -> List[Union[dict, Tuple[Any, ...]]]:
+    def get_records(
+        self,
+        sql: Union[str, List[str]],
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        **kwargs: dict,
+    ) -> List[Union[dict, Tuple[Any, ...]]]:
         """
         Executes the sql and returns a set of records.
 
@@ -89,7 +94,7 @@ class ExasolHook(DbApiHook):
             with closing(conn.execute(sql, parameters)) as cur:
                 return cur.fetchall()
 
-    def get_first(self, sql: str, parameters: Optional[dict] = None) -> Optional[Any]:
+    def get_first(self, sql: Union[str, List[str]], parameters: Optional[dict] = None) -> Optional[Any]:
         """
         Executes the sql and returns the first resulting row.
 

--- a/airflow/providers/presto/CHANGELOG.rst
+++ b/airflow/providers/presto/CHANGELOG.rst
@@ -24,6 +24,12 @@
 Changelog
 ---------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Deprecated ``hql`` parameter has been removed in ``get_records``, ``get_first``, ``get_pandas_df`` and ``run``
+methods of the ``TrinoHook``.
+
 3.1.0
 .....
 

--- a/airflow/providers/presto/CHANGELOG.rst
+++ b/airflow/providers/presto/CHANGELOG.rst
@@ -28,7 +28,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 Deprecated ``hql`` parameter has been removed in ``get_records``, ``get_first``, ``get_pandas_df`` and ``run``
-methods of the ``TrinoHook``.
+methods of the ``PrestoHook``.
 
 3.1.0
 .....

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -17,8 +17,7 @@
 # under the License.
 import json
 import os
-import warnings
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Union, overload
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 import prestodb
 from prestodb.exceptions import DatabaseError
@@ -142,82 +141,28 @@ class PrestoHook(DbApiHook):
         isolation_level = db.extra_dejson.get('isolation_level', 'AUTOCOMMIT').upper()
         return getattr(IsolationLevel, isolation_level, IsolationLevel.AUTOCOMMIT)
 
-    @overload
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None):
-        """Get a set of records from Presto
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None, hql: str = ""):
-        """:sphinx-autoapi-skip:"""
-
-    def get_records(self, sql: str = "", parameters: Optional[dict] = None, hql: str = ""):
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
+    def get_records(
+        self,
+        sql: Union[str, List[str]] = "",
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        **kwargs: dict,
+    ):
+        if not isinstance(sql, str):
+            raise ValueError(f"The sql in Presto Hook must be a string and is {sql}!")
         try:
             return super().get_records(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise PrestoException(e)
 
-    @overload
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None) -> Any:
-        """Returns only the first row, regardless of how many rows the query returns.
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None, hql: str = "") -> Any:
-        """:sphinx-autoapi-skip:"""
-
-    def get_first(self, sql: str = "", parameters: Optional[dict] = None, hql: str = "") -> Any:
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
+    def get_first(self, sql: Union[str, List[str]] = "", parameters: Optional[dict] = None) -> Any:
+        if not isinstance(sql, str):
+            raise ValueError(f"The sql in Presto Hook must be a string and is {sql}!")
         try:
             return super().get_first(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise PrestoException(e)
 
-    @overload
     def get_pandas_df(self, sql: str = "", parameters=None, **kwargs):
-        """Get a pandas dataframe from a sql query.
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
-    def get_pandas_df(self, sql: str = "", parameters=None, hql: str = "", **kwargs):
-        """:sphinx-autoapi-skip:"""
-
-    def get_pandas_df(self, sql: str = "", parameters=None, hql: str = "", **kwargs):
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
         import pandas
 
         cursor = self.get_cursor()
@@ -234,7 +179,6 @@ class PrestoHook(DbApiHook):
             df = pandas.DataFrame(**kwargs)
         return df
 
-    @overload
     def run(
         self,
         sql: Union[str, Iterable[str]],
@@ -244,40 +188,6 @@ class PrestoHook(DbApiHook):
         split_statements: bool = False,
         return_last: bool = True,
     ) -> Optional[Union[Any, List[Any]]]:
-        """Execute the statement against Presto. Can be used to create views."""
-
-    @overload
-    def run(
-        self,
-        sql: Union[str, Iterable[str]],
-        autocommit: bool = False,
-        parameters: Optional[Union[Iterable, Mapping]] = None,
-        handler: Optional[Callable] = None,
-        split_statements: bool = False,
-        return_last: bool = True,
-        hql: str = "",
-    ) -> Optional[Union[Any, List[Any]]]:
-        """:sphinx-autoapi-skip:"""
-
-    def run(
-        self,
-        sql: Union[str, Iterable[str]],
-        autocommit: bool = False,
-        parameters: Optional[Union[Iterable, Mapping]] = None,
-        handler: Optional[Callable] = None,
-        split_statements: bool = False,
-        return_last: bool = True,
-        hql: str = "",
-    ) -> Optional[Union[Any, List[Any]]]:
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
         return super().run(
             sql=sql,
             autocommit=autocommit,

--- a/airflow/providers/trino/CHANGELOG.rst
+++ b/airflow/providers/trino/CHANGELOG.rst
@@ -24,6 +24,12 @@
 Changelog
 ---------
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Deprecated ``hql`` parameter has been removed in ``get_records``, ``get_first``, ``get_pandas_df`` and ``run``
+methods of the ``TrinoHook``.
+
 3.1.0
 .....
 

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -17,9 +17,8 @@
 # under the License.
 import json
 import os
-import warnings
 from contextlib import closing
-from typing import Any, Callable, Iterable, List, Mapping, Optional, Union, overload
+from typing import Any, Callable, Iterable, List, Mapping, Optional, Union
 
 import trino
 from trino.exceptions import DatabaseError
@@ -148,96 +147,32 @@ class TrinoHook(DbApiHook):
         isolation_level = db.extra_dejson.get('isolation_level', 'AUTOCOMMIT').upper()
         return getattr(IsolationLevel, isolation_level, IsolationLevel.AUTOCOMMIT)
 
-    @overload
-    def get_records(self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None):
-        """Get a set of records from Trino
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
     def get_records(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+        self,
+        sql: Union[str, List[str]] = "",
+        parameters: Optional[Union[Iterable, Mapping]] = None,
+        **kwargs: dict,
     ):
-        """:sphinx-autoapi-skip:"""
-
-    def get_records(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
-    ):
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
+        if not isinstance(sql, str):
+            raise ValueError(f"The sql in Trino Hook must be a string and is {sql}!")
         try:
             return super().get_records(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise TrinoException(e)
 
-    @overload
-    def get_first(self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None) -> Any:
-        """Returns only the first row, regardless of how many rows the query returns.
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
     def get_first(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
+        self, sql: Union[str, List[str]] = "", parameters: Optional[Union[Iterable, Mapping]] = None
     ) -> Any:
-        """:sphinx-autoapi-skip:"""
-
-    def get_first(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = ""
-    ) -> Any:
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
+        if not isinstance(sql, str):
+            raise ValueError(f"The sql in Trino Hook must be a string and is {sql}!")
         try:
             return super().get_first(self.strip_sql_string(sql), parameters)
         except DatabaseError as e:
             raise TrinoException(e)
 
-    @overload
     def get_pandas_df(
         self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, **kwargs
     ):  # type: ignore[override]
-        """Get a pandas dataframe from a sql query.
-
-        :param sql: SQL statement to be executed.
-        :param parameters: The parameters to render the SQL query with.
-        """
-
-    @overload
-    def get_pandas_df(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = "", **kwargs
-    ):  # type: ignore[override]
-        """:sphinx-autoapi-skip:"""
-
-    def get_pandas_df(
-        self, sql: str = "", parameters: Optional[Union[Iterable, Mapping]] = None, hql: str = "", **kwargs
-    ):  # type: ignore[override]
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
         import pandas
 
         cursor = self.get_cursor()
@@ -254,7 +189,6 @@ class TrinoHook(DbApiHook):
             df = pandas.DataFrame(**kwargs)
         return df
 
-    @overload
     def run(
         self,
         sql: Union[str, Iterable[str]],
@@ -264,40 +198,6 @@ class TrinoHook(DbApiHook):
         split_statements: bool = False,
         return_last: bool = True,
     ) -> Optional[Union[Any, List[Any]]]:
-        """Execute the statement against Trino. Can be used to create views."""
-
-    @overload
-    def run(
-        self,
-        sql: Union[str, Iterable[str]],
-        autocommit: bool = False,
-        parameters: Optional[Union[Iterable, Mapping]] = None,
-        handler: Optional[Callable] = None,
-        split_statements: bool = False,
-        return_last: bool = True,
-        hql: str = "",
-    ) -> Optional[Union[Any, List[Any]]]:
-        """:sphinx-autoapi-skip:"""
-
-    def run(
-        self,
-        sql: Union[str, Iterable[str]],
-        autocommit: bool = False,
-        parameters: Optional[Union[Iterable, Mapping]] = None,
-        handler: Optional[Callable] = None,
-        split_statements: bool = False,
-        return_last: bool = True,
-        hql: str = "",
-    ) -> Optional[Union[Any, List[Any]]]:
-        """:sphinx-autoapi-skip:"""
-        if hql:
-            warnings.warn(
-                "The hql parameter has been deprecated. You should pass the sql parameter.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            sql = hql
-
         return super().run(
             sql=sql,
             autocommit=autocommit,

--- a/scripts/ci/libraries/_testing.sh
+++ b/scripts/ci/libraries/_testing.sh
@@ -143,7 +143,7 @@ function testing::setup_docker_compose_backend() {
             # so we need to mount an external volume for its db location
             # the external db must allow for parallel testing so TEST_TYPE
             # is added to the volume name
-            export MSSQL_DATA_VOLUME="${HOME}/tmp-mssql-volume-${TEST_TYPE}-${MSSQL_VERSION}"
+            export MSSQL_DATA_VOLUME="${HOME}/tmp-mssql-volume-${TEST_TYPE/\[*\]/}-${MSSQL_VERSION}"
             mkdir -p "${MSSQL_DATA_VOLUME}"
             # MSSQL 2019 runs with non-root user by default so we have to make the volumes world-writeable
             # This is a bit scary and we could get by making it group-writeable but the group would have

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -826,7 +826,7 @@ class TestHiveServer2Hook(unittest.TestCase):
             )
 
             output = '\n'.join(
-                res_tuple[0] for res_tuple in hook.get_results(hql=hql, hive_conf={'key': 'value'})['data']
+                res_tuple[0] for res_tuple in hook.get_results(hql, hive_conf={'key': 'value'})['data']
             )
         assert 'value' in output
         assert 'test_dag_id' in output

--- a/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
@@ -45,7 +45,7 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
         HiveToMySqlOperator(**self.kwargs).execute(context={})
 
         mock_hive_hook.assert_called_once_with(hiveserver2_conn_id=self.kwargs['hiveserver2_conn_id'])
-        mock_hive_hook.return_value.get_records.assert_called_once_with('sql', hive_conf={})
+        mock_hive_hook.return_value.get_records.assert_called_once_with('sql', parameters={})
         mock_mysql_hook.assert_called_once_with(mysql_conn_id=self.kwargs['mysql_conn_id'])
         mock_mysql_hook.return_value.insert_rows.assert_called_once_with(
             table=self.kwargs['mysql_table'], rows=mock_hive_hook.return_value.get_records.return_value
@@ -112,7 +112,7 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
             hive_conf = context_to_airflow_vars(context)
             hive_conf.update(self.kwargs['hive_conf'])
 
-        mock_hive_hook.get_records.assert_called_once_with(self.kwargs['sql'], hive_conf=hive_conf)
+        mock_hive_hook.get_records.assert_called_once_with(self.kwargs['sql'], parameters=hive_conf)
 
     @unittest.skipIf(
         'AIRFLOW_RUNALL_TESTS' not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"

--- a/tests/providers/apache/hive/transfers/test_hive_to_samba.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_samba.py
@@ -64,7 +64,7 @@ class TestHive2SambaOperator(TestHiveEnvironment):
 
         mock_hive_hook.assert_called_once_with(hiveserver2_conn_id=self.kwargs['hiveserver2_conn_id'])
         mock_hive_hook.return_value.to_csv.assert_called_once_with(
-            hql=self.kwargs['hql'],
+            self.kwargs['hql'],
             csv_filepath=mock_tmp_file.name,
             hive_conf=context_to_airflow_vars(context),
         )


### PR DESCRIPTION
Various providers deriving from DbApi had some variations in some
methods that were derived from the common DbApi Hook. Mostly they
were about extra parameters added and hql parameter used instead of
sql. This prevents from really "common" approach in DbApiHook as
some common sql operators rely on signatures being the same.

This introduced breaking changes in a few providers - but those
breaking changes are easy to fix and most have already been
deprecated.

I also had to make sure all types are correct (hence cloud_sql typing fixes).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
