### PR TITLE
List upstream dataset events

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -36,6 +36,7 @@ import useMappedInstances from './useMappedInstances';
 import useDatasets from './useDatasets';
 import useDataset from './useDataset';
 import useDatasetEvents from './useDatasetEvents';
+import useUpstreamDatasetEvents from './useUpstreamDatasetEvents';
 
 axios.interceptors.response.use(
   (res: AxiosResponse) => (res.data ? camelcaseKeys(res.data, { deep: true }) : res),
@@ -60,4 +61,5 @@ export {
   useDatasets,
   useDataset,
   useDatasetEvents,
+  useUpstreamDatasetEvents,
 };

--- a/airflow/www/static/js/api/useUpstreamDatasetEvents.ts
+++ b/airflow/www/static/js/api/useUpstreamDatasetEvents.ts
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios, { AxiosResponse } from 'axios';
+import { useQuery } from 'react-query';
+
+import { getMetaValue } from 'src/utils';
+import type { API } from 'src/types';
+
+interface Props {
+  runId: string;
+}
+
+interface UpstreamEventsData {
+  datasetEvents: API.DatasetEvent[];
+  totalEntries: number;
+}
+
+export default function useUpstreamDatasetEvents({ runId }: Props) {
+  const query = useQuery(
+    ['upstreamDatasetEvents', runId],
+    () => {
+      const dagId = getMetaValue('dag_id');
+      const upstreamEventsUrl = (
+        getMetaValue('upstream_dataset_events_api')
+          || `api/v1/dags/${dagId}/dagRuns/_DAG_RUN_ID_/upstreamDatasetEvents`
+      ).replace('_DAG_RUN_ID_', runId);
+      return axios.get<AxiosResponse, UpstreamEventsData>(upstreamEventsUrl);
+    },
+  );
+  return {
+    ...query,
+    data: query.data || { datasetEvents: [], totalEntries: 0 },
+  };
+}

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -35,4 +35,6 @@ export const TaskInstanceLink = ({ cell: { value, row } }: any) => {
   return (<Link color="blue.600" href={url}>{`${sourceDagId}.${value}${mapIndex}`}</Link>);
 };
 
-export const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;
+export const CodeCell = ({ cell: { value } }: any) => (
+  value ? <Code>{JSON.stringify(value)}</Code> : null
+);

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -26,20 +26,13 @@ import Time from 'src/components/Time';
 
 export const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
 
-export const GridLink = ({ cell: { value } }: any) => <Link color="blue.600" href={`/dags/${value}/grid`}>{value}</Link>;
-
 export const DatasetLink = ({ cell: { value } }: any) => <Link color="blue.600" href={`/datasets?dataset_id=${value}`}>{value}</Link>;
 
-export const RunLink = ({ cell: { value, row } }: any) => {
-  const { sourceDagId } = row.original;
-  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(value)}`;
-  return (<Link color="blue.600" href={url}>{value}</Link>);
-};
-
 export const TaskInstanceLink = ({ cell: { value, row } }: any) => {
-  const { sourceRunId, sourceDagId } = row.original;
+  const { sourceRunId, sourceDagId, sourceMapIndex } = row.original;
   const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(sourceRunId)}&task_id=${encodeURIComponent(value)}`;
-  return (<Link color="blue.600" href={url}>{value}</Link>);
+  const mapIndex = sourceMapIndex > -1 ? `[${sourceMapIndex}]` : '';
+  return (<Link color="blue.600" href={url}>{`${sourceDagId}.${value}${mapIndex}`}</Link>);
 };
 
 export const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -1,0 +1,45 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import {
+  Code, Link,
+} from '@chakra-ui/react';
+
+import Time from 'src/components/Time';
+
+export const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
+
+export const GridLink = ({ cell: { value } }: any) => <Link color="blue.600" href={`/dags/${value}/grid`}>{value}</Link>;
+
+export const DatasetLink = ({ cell: { value } }: any) => <Link color="blue.600" href={`/datasets?dataset_id=${value}`}>{value}</Link>;
+
+export const RunLink = ({ cell: { value, row } }: any) => {
+  const { sourceDagId } = row.original;
+  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(value)}`;
+  return (<Link color="blue.600" href={url}>{value}</Link>);
+};
+
+export const TaskInstanceLink = ({ cell: { value, row } }: any) => {
+  const { sourceRunId, sourceDagId } = row.original;
+  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(sourceRunId)}&task_id=${encodeURIComponent(value)}`;
+  return (<Link color="blue.600" href={url}>{value}</Link>);
+};
+
+export const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -19,22 +19,43 @@
 
 import React from 'react';
 import {
-  Code, Link,
+  Code, Link, Box, Text,
 } from '@chakra-ui/react';
 
 import Time from 'src/components/Time';
 
-export const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
+interface CellProps {
+  cell: {
+    value: any;
+    row: {
+      original: Record<string, any>;
+    }
+  }
+}
 
-export const DatasetLink = ({ cell: { value } }: any) => <Link color="blue.600" href={`/datasets?dataset_id=${value}`}>{value}</Link>;
+export const TimeCell = ({ cell: { value } }: CellProps) => <Time dateTime={value} />;
 
-export const TaskInstanceLink = ({ cell: { value, row } }: any) => {
+export const DatasetLink = ({ cell: { value, row } }: CellProps) => (
+  <Link
+    color="blue.600"
+    href={`/datasets?dataset_id=${row.original.datasetId}`}
+  >
+    {value}
+  </Link>
+);
+
+export const TaskInstanceLink = ({ cell: { value, row } }: CellProps) => {
   const { sourceRunId, sourceDagId, sourceMapIndex } = row.original;
   const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(sourceRunId)}&task_id=${encodeURIComponent(value)}`;
   const mapIndex = sourceMapIndex > -1 ? `[${sourceMapIndex}]` : '';
-  return (<Link color="blue.600" href={url}>{`${sourceDagId}.${value}${mapIndex}`}</Link>);
+  return (
+    <Box>
+      <Link color="blue.600" href={url}>{`${sourceDagId}.${value}${mapIndex}`}</Link>
+      <Text>{sourceRunId}</Text>
+    </Box>
+  );
 };
 
-export const CodeCell = ({ cell: { value } }: any) => (
+export const CodeCell = ({ cell: { value } }: CellProps) => (
   value ? <Code>{JSON.stringify(value)}</Code> : null
 );

--- a/airflow/www/static/js/components/Table/Table.test.tsx
+++ b/airflow/www/static/js/components/Table/Table.test.tsx
@@ -25,8 +25,8 @@ import { render, fireEvent, within } from '@testing-library/react';
 import { sortBy } from 'lodash';
 import type { SortingRule } from 'react-table';
 
+import { ChakraWrapper } from 'src/utils/testUtils';
 import { Table } from '.';
-import { ChakraWrapper } from '../../utils/testUtils';
 
 const data: Record<string, any>[] = [
   { firstName: 'Lamont', lastName: 'Grimes', country: 'United States' },

--- a/airflow/www/static/js/components/Table/Table.test.tsx
+++ b/airflow/www/static/js/components/Table/Table.test.tsx
@@ -25,8 +25,8 @@ import { render, fireEvent, within } from '@testing-library/react';
 import { sortBy } from 'lodash';
 import type { SortingRule } from 'react-table';
 
-import Table from './Table';
-import { ChakraWrapper } from '../utils/testUtils';
+import { Table } from '.';
+import { ChakraWrapper } from '../../utils/testUtils';
 
 const data: Record<string, any>[] = [
   { firstName: 'Lamont', lastName: 'Grimes', country: 'United States' },

--- a/airflow/www/static/js/components/Table/index.tsx
+++ b/airflow/www/static/js/components/Table/index.tsx
@@ -95,7 +95,7 @@ interface TableProps {
   onRowClicked?: (row: Row<object>, e: any) => void;
 }
 
-const Table = ({
+export const Table = ({
   data,
   columns,
   manualPagination,
@@ -272,4 +272,4 @@ const Table = ({
   );
 };
 
-export default Table;
+export * from './Cells';

--- a/airflow/www/static/js/dag/details/Dag.tsx
+++ b/airflow/www/static/js/dag/details/Dag.tsx
@@ -46,7 +46,7 @@ const Dag = () => {
   const { data: { dagRuns } } = useGridData();
 
   // Build a key/value object of operator counts, the name is hidden inside of t.classRef.className
-  const operators: Record<string, any> = {};
+  const operators: Record<string, number> = {};
   tasks.forEach((t) => {
     if (t?.classRef?.className) {
       if (!operators[t.classRef.className]) {

--- a/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
@@ -1,0 +1,97 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useMemo } from 'react';
+import {
+  Box, Heading, Text,
+} from '@chakra-ui/react';
+
+import {
+  CodeCell, DatasetLink, GridLink, RunLink, Table, TaskInstanceLink, TimeCell,
+} from 'src/components/Table';
+import { useUpstreamDatasetEvents } from 'src/api';
+import type { DagRun as DagRunType } from 'src/types';
+
+interface Props {
+  runId: DagRunType['runId'];
+}
+
+const UpstreamEvents = ({ runId }: Props) => {
+  const { data: { datasetEvents }, isLoading } = useUpstreamDatasetEvents({ runId });
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: 'Dataset ID',
+        accessor: 'datasetId',
+        Cell: DatasetLink,
+      },
+      {
+        Header: 'Created At',
+        accessor: 'createdAt',
+        Cell: TimeCell,
+      },
+      {
+        Header: 'Source DAG',
+        accessor: 'sourceDagId',
+        Cell: GridLink,
+      },
+      {
+        Header: 'Source DAG Run',
+        accessor: 'sourceRunId',
+        Cell: RunLink,
+      },
+      {
+        Header: 'Source Task',
+        accessor: 'sourceTaskId',
+        Cell: TaskInstanceLink,
+      },
+      {
+        Header: 'Source Map Index',
+        accessor: 'sourceMapIndex',
+        Cell: ({ cell: { value } }) => (value > -1 ? value : null),
+      },
+      {
+        Header: 'Extra',
+        accessor: 'extra',
+        disableSortBy: true,
+        Cell: CodeCell,
+      },
+    ],
+    [],
+  );
+
+  const data = useMemo(
+    () => datasetEvents,
+    [datasetEvents],
+  );
+
+  return (
+    <Box mt={3}>
+      <Heading size="md">Upstream Dataset Events</Heading>
+      <Text>Updates to the upstream datasets since the last dataset-triggered DAG run</Text>
+      <Table
+        data={data}
+        columns={columns}
+        isLoading={isLoading}
+      />
+    </Box>
+  );
+};
+
+export default UpstreamEvents;

--- a/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 
 import {
-  CodeCell, DatasetLink, GridLink, RunLink, Table, TaskInstanceLink, TimeCell,
+  CodeCell, DatasetLink, Table, TaskInstanceLink, TimeCell,
 } from 'src/components/Table';
 import { useUpstreamDatasetEvents } from 'src/api';
 import type { DagRun as DagRunType } from 'src/types';
@@ -47,24 +47,9 @@ const UpstreamEvents = ({ runId }: Props) => {
         Cell: TimeCell,
       },
       {
-        Header: 'Source DAG',
-        accessor: 'sourceDagId',
-        Cell: GridLink,
-      },
-      {
-        Header: 'Source DAG Run',
-        accessor: 'sourceRunId',
-        Cell: RunLink,
-      },
-      {
-        Header: 'Source Task',
+        Header: 'Source Task Instance',
         accessor: 'sourceTaskId',
         Cell: TaskInstanceLink,
-      },
-      {
-        Header: 'Source Map Index',
-        accessor: 'sourceMapIndex',
-        Cell: ({ cell: { value } }) => (value > -1 ? value : null),
       },
       {
         Header: 'Extra',

--- a/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
@@ -42,8 +42,8 @@ const UpstreamEvents = ({ runId }: Props) => {
         Cell: DatasetLink,
       },
       {
-        Header: 'Created At',
-        accessor: 'createdAt',
+        Header: 'Timestamp',
+        accessor: 'timestamp',
         Cell: TimeCell,
       },
       {

--- a/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/UpstreamEvents.tsx
@@ -37,14 +37,9 @@ const UpstreamEvents = ({ runId }: Props) => {
   const columns = useMemo(
     () => [
       {
-        Header: 'Dataset ID',
-        accessor: 'datasetId',
+        Header: 'Dataset URI',
+        accessor: 'datasetUri',
         Cell: DatasetLink,
-      },
-      {
-        Header: 'Timestamp',
-        accessor: 'timestamp',
-        Cell: TimeCell,
       },
       {
         Header: 'Source Task Instance',
@@ -56,6 +51,11 @@ const UpstreamEvents = ({ runId }: Props) => {
         accessor: 'extra',
         disableSortBy: true,
         Cell: CodeCell,
+      },
+      {
+        Header: 'When',
+        accessor: 'timestamp',
+        Cell: TimeCell,
       },
     ],
     [],

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -45,6 +45,7 @@ import MarkFailedRun from './MarkFailedRun';
 import MarkSuccessRun from './MarkSuccessRun';
 import QueueRun from './QueueRun';
 import ClearRun from './ClearRun';
+import UpstreamEvents from './UpstreamEvents';
 
 const dagId = getMetaValue('dag_id');
 const graphUrl = getMetaValue('graph_url');
@@ -169,6 +170,9 @@ const DagRun = ({ runId }: Props) => {
           )}
         </Tbody>
       </Table>
+      {runType === 'dataset_triggered' && (
+        <UpstreamEvents runId={runId} />
+      )}
     </>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -36,7 +36,7 @@ import { getMetaValue } from 'src/utils';
 import { formatDuration, getDuration } from 'src/datetime_utils';
 import { useMappedInstances } from 'src/api';
 import { SimpleStatus } from 'src/dag/StatusBox';
-import Table from 'src/components/Table';
+import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
 
 const canEdit = getMetaValue('can_edit') === 'True';

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -39,7 +39,7 @@ interface Props {
 const DatasetDetails = ({ datasetId, onBack }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
-  const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'createdAt', desc: true }]);
+  const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'timestamp', desc: true }]);
 
   const sort = sortBy[0];
   const order = sort ? `${sort.desc ? '-' : ''}${snakeCase(sort.id)}` : '';
@@ -82,35 +82,33 @@ const DatasetDetails = ({ datasetId, onBack }: Props) => {
   const memoSort = useMemo(() => sortBy, [sortBy]);
 
   return (
-    <Box maxWidth="1500px">
-      <Flex mt={3} justifyContent="space-between">
-        {isLoading && <Spinner display="block" />}
-        {!!dataset && (
-          <Box>
-            <Heading mb={2} fontWeight="normal">
-              Dataset:
-              {' '}
-              {dataset.uri}
-              <ClipboardButton value={dataset.uri} iconOnly ml={2} />
-            </Heading>
-            {!!dataset.extra && (
-              <Flex>
-                <Text mr={1}>Extra:</Text>
-                <Code>{JSON.stringify(dataset.extra)}</Code>
-              </Flex>
-            )}
-            <Flex my={2}>
-              <Text mr={1}>Updated At:</Text>
-              <Time dateTime={dataset.updatedAt} />
+    <Box mt={[6, 3]} maxWidth="1500px">
+      <Button onClick={onBack}>See all datasets</Button>
+      {isLoading && <Spinner display="block" />}
+      {!!dataset && (
+        <Box>
+          <Heading my={2} fontWeight="normal">
+            Dataset:
+            {' '}
+            {dataset.uri}
+            <ClipboardButton value={dataset.uri} iconOnly ml={2} />
+          </Heading>
+          {!!dataset.extra && (
+            <Flex>
+              <Text mr={1}>Extra:</Text>
+              <Code>{JSON.stringify(dataset.extra)}</Code>
             </Flex>
-            <Flex my={2}>
-              <Text mr={1}>Created At:</Text>
-              <Time dateTime={dataset.createdAt} />
-            </Flex>
-          </Box>
-        )}
-        <Button onClick={onBack}>See all datasets</Button>
-      </Flex>
+          )}
+          <Flex my={2}>
+            <Text mr={1}>Updated At:</Text>
+            <Time dateTime={dataset.updatedAt} />
+          </Flex>
+          <Flex my={2}>
+            <Text mr={1}>Created At:</Text>
+            <Time dateTime={dataset.createdAt} />
+          </Flex>
+        </Box>
+      )}
       <Heading size="lg" mt={3} mb={2} fontWeight="normal">Upstream Events</Heading>
       <Text>Whenever a DAG has updated this dataset.</Text>
       <Table

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -19,34 +19,22 @@
 
 import React, { useMemo, useState } from 'react';
 import {
-  Box, Heading, Text, Code, Flex, Spinner, Button, Link,
+  Box, Heading, Text, Code, Flex, Spinner, Button,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
 import type { SortingRule } from 'react-table';
 
 import Time from 'src/components/Time';
 import { useDatasetEvents, useDataset } from 'src/api';
-import Table from 'src/components/Table';
+import {
+  Table, TimeCell, CodeCell, TaskInstanceLink, RunLink, GridLink,
+} from 'src/components/Table';
 import { ClipboardButton } from 'src/components/Clipboard';
 
 interface Props {
   datasetId: string;
   onBack: () => void;
 }
-
-const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
-const GridLink = ({ cell: { value } }: any) => <Link color="blue.500" href={`/dags/${value}/grid`}>{value}</Link>;
-const RunLink = ({ cell: { value, row } }: any) => {
-  const { sourceDagId } = row.original;
-  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(value)}`;
-  return (<Link color="blue.500" href={url}>{value}</Link>);
-};
-const TaskInstanceLink = ({ cell: { value, row } }: any) => {
-  const { sourceRunId, sourceDagId } = row.original;
-  const url = `/dags/${sourceDagId}/grid?dag_run_id=${encodeURIComponent(sourceRunId)}&task_id=${encodeURIComponent(value)}`;
-  return (<Link color="blue.500" href={url}>{value}</Link>);
-};
-const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;
 
 const DatasetDetails = ({ datasetId, onBack }: Props) => {
   const limit = 25;

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -27,7 +27,7 @@ import type { SortingRule } from 'react-table';
 import Time from 'src/components/Time';
 import { useDatasetEvents, useDataset } from 'src/api';
 import {
-  Table, TimeCell, CodeCell, TaskInstanceLink, RunLink, GridLink,
+  Table, TimeCell, CodeCell, TaskInstanceLink,
 } from 'src/components/Table';
 import { ClipboardButton } from 'src/components/Clipboard';
 
@@ -60,24 +60,9 @@ const DatasetDetails = ({ datasetId, onBack }: Props) => {
         Cell: TimeCell,
       },
       {
-        Header: 'Source DAG Id',
-        accessor: 'sourceDagId',
-        Cell: GridLink,
-      },
-      {
-        Header: 'Source DAG Run Id',
-        accessor: 'sourceRunId',
-        Cell: RunLink,
-      },
-      {
-        Header: 'Source Task Id',
+        Header: 'Source Task Instance',
         accessor: 'sourceTaskId',
         Cell: TaskInstanceLink,
-      },
-      {
-        Header: 'Source Map Index',
-        accessor: 'sourceMapIndex',
-        Cell: ({ cell: { value } }) => (value > -1 ? value : null),
       },
       {
         Header: 'Extra',

--- a/airflow/www/static/js/datasets/Details.tsx
+++ b/airflow/www/static/js/datasets/Details.tsx
@@ -55,11 +55,6 @@ const DatasetDetails = ({ datasetId, onBack }: Props) => {
   const columns = useMemo(
     () => [
       {
-        Header: 'Timestamp',
-        accessor: 'timestamp',
-        Cell: TimeCell,
-      },
-      {
         Header: 'Source Task Instance',
         accessor: 'sourceTaskId',
         Cell: TaskInstanceLink,
@@ -69,6 +64,11 @@ const DatasetDetails = ({ datasetId, onBack }: Props) => {
         accessor: 'extra',
         disableSortBy: true,
         Cell: CodeCell,
+      },
+      {
+        Header: 'When',
+        accessor: 'timestamp',
+        Cell: TimeCell,
       },
     ],
     [],

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -20,23 +20,18 @@
 import React, { useMemo, useState } from 'react';
 import {
   Box,
-  Code,
   Heading,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
 import type { Row, SortingRule } from 'react-table';
 
 import { useDatasets } from 'src/api';
-import Table from 'src/components/Table';
-import Time from 'src/components/Time';
+import { Table, TimeCell, CodeCell } from 'src/components/Table';
 import type { API } from 'src/types';
 
 interface Props {
   onSelect: (datasetId: string) => void;
 }
-
-const TimeCell = ({ cell: { value } }: any) => <Time dateTime={value} />;
-const CodeCell = ({ cell: { value } }: any) => <Code>{value}</Code>;
 
 const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -69,6 +69,7 @@
   <meta name="tasks_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_endpoint_get_tasks', dag_id=dag.dag_id) }}">
   <meta name="mapped_instances_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_mapped_task_instances', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_') }}">
   <meta name="task_log_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_log_endpoint_get_log', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_', task_try_number='-1') }}">
+  <meta name="upstream_dataset_events_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_run_endpoint_get_upstream_dataset_events', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_') }}">
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">
   <meta name="csrf_token" content="{{ csrf_token() }}">


### PR DESCRIPTION
For dataset-triggered dag runs, add a list of the upstream dataset events since the last dataset-triggered run.

Also:
- Fix initial sort of the dataset events table from created_at to timestamp
- Reuse table cell components
- Change Dag/run/task links into a single link to the source task instance with the dag id

<img width="909" alt="Screen Shot 2022-07-27 at 11 08 42 AM" src="https://user-images.githubusercontent.com/4600967/181221978-c7c776d9-57c7-458b-91dc-100f03c274ae.png">
<img width="610" alt="Screen Shot 2022-07-27 at 11 08 23 AM" src="https://user-images.githubusercontent.com/4600967/181221992-456831fe-c284-4335-8dc9-0f90bc752a24.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
