### PR TITLE
Add pre-release limits when constructing devel-all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -376,7 +376,7 @@ repos:
         name: Update cross-dependencies for providers packages
         entry: ./scripts/ci/pre_commit/pre_commit_build_providers_dependencies.py
         language: python
-        files: ^airflow/providers/.*\.py$|^tests/providers/.*\.py$|^tests/system/providers/.*\.py$|$airflow/providers/.*/provider.yaml$
+        files: ^airflow/providers/.*\.py$|^tests/providers/.*\.py$|^tests/system/providers/.*\.py$|^airflow/providers/.*/provider.yaml$
         pass_filenames: false
         additional_dependencies: ['setuptools', 'rich>=12.4.4', 'pyyaml']
       - id: update-extras

--- a/setup.py
+++ b/setup.py
@@ -622,8 +622,18 @@ def is_package_excluded(package: str, exclusion_list: List[str]) -> bool:
     return any(package.startswith(excluded_package) for excluded_package in exclusion_list)
 
 
+def strip_provider_limits(package: str) -> str:
+    """
+    Strips limit for providers in devel_all to account for packages that were not released yet.
+
+    :param package: package name (beginning of it)
+    :return: true if package should be excluded
+    """
+    return package.split(">=")[0] if package.startswith("apache-airflow-providers") else package
+
+
 devel_all = [
-    package
+    strip_provider_limits(package)
     for package in devel_all
     if not is_package_excluded(package=package, exclusion_list=PACKAGES_EXCLUDED_FOR_ALL)
 ]


### PR DESCRIPTION
When we are constructing devel-all, we should strip the limits
to account for some shared packages that are not yet released.

Example is a common-sql package that might be limited to >1.1.0
for example as part of the change, but it might not yet be released.

It does not impact our CI, because we are anyhow removing the packages
after installing (we only care about dependencies of their) and we
are using source version of providers - but having a limit coming
from another provider will make `pip` resolver fail if we do not
strip the limits.

We also need to add .a0 as suffix whenever in our providers we refer
to other providers with >= install clause because of a bug in
`pip` that does not take into account pre-release version when
performing >= comparision, thus disallowing to release a package
that depends on new version of another package together.

We need to add >= X.Y.Za0 in case we release pre-release version to
fix the problem. Also a bug was found that would prevent to generate
the dependencies in case provider.yaml file only changed (bad
specification of .pre-commit include)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
