### PR TITLE
Fix Flask Login user setting for Flask 2.2 and Flask-Login 0.6.2

### DIFF
--- a/airflow/providers/google/common/auth_backend/google_openid.py
+++ b/airflow/providers/google/common/auth_backend/google_openid.py
@@ -23,7 +23,7 @@ from typing import Callable, Optional, TypeVar, cast
 import google
 import google.auth.transport.requests
 import google.oauth2.id_token
-from flask import Response, _request_ctx_stack, current_app, request as flask_request  # type: ignore
+from flask import Response, current_app, request as flask_request  # type: ignore
 from google.auth import exceptions
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2 import service_account
@@ -101,8 +101,7 @@ def _lookup_user(user_email: str):
 
 
 def _set_current_user(user):
-    ctx = _request_ctx_stack.top
-    ctx.user = user
+    current_app.appbuilder.sm.lm._update_request_context_with_user(user=user)  # type: ignore[attr-defined]
 
 
 T = TypeVar("T", bound=Callable)


### PR DESCRIPTION
The Google openid auth backend of ours had hard-coded way of
seting the current user which was not compatible with Flask 2.2

With Flask-login 0.6.2 the user is stored in g module of flask, where
before, it was stored in _request_ctx_stack. Unforatunately the
google_openid rather than using _update_request_context_with_user
set the user directly in context. In Flask-login 0.6.2 this stopped
working.

This change switches to use the _update_request_context_with_user
method rather than directly storing user in context which works before
and after the Flask-Login 0.6.2 change.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
