### PR TITLE
Refactor test DAGs to unclutter example DAGs

### DIFF
--- a/tests/dags/test_datasets.py
+++ b/tests/dags/test_datasets.py
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+
+from airflow.exceptions import AirflowFailException, AirflowSkipException
+from airflow.models import DAG, Dataset
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
+
+skip_task_dag_dataset = Dataset('s3://dag_with_skip_task/output_1.txt', extra={'hi': 'bye'})
+fail_task_dag_dataset = Dataset('s3://dag_with_fail_task/output_1.txt', extra={'hi': 'bye'})
+
+
+def raise_skip_exc():
+    raise AirflowSkipException
+
+
+dag_with_skip_task = DAG(
+    dag_id='dag_with_skip_task',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_interval='@daily',
+    tags=['upstream-skipping'],
+)
+PythonOperator(
+    task_id='skip_task',
+    outlets=[skip_task_dag_dataset],
+    python_callable=raise_skip_exc,
+    dag=dag_with_skip_task,
+)
+
+with DAG(
+    dag_id='dag_that_follows_dag_with_skip',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_on=[skip_task_dag_dataset],
+    tags=['downstream-skipped'],
+) as dag_that_follows_dag_with_skip:
+    BashOperator(
+        task_id='dag_that_follows_dag_with_skip_task',
+        bash_command="sleep 5",
+    )
+
+
+def raise_fail_exc():
+    raise AirflowFailException
+
+
+dag_with_fail_task = DAG(
+    dag_id='dag_with_fail_task',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_interval='@daily',
+    tags=['upstream-skipping'],
+)
+PythonOperator(
+    task_id='fail_task',
+    outlets=[fail_task_dag_dataset],
+    python_callable=raise_fail_exc,
+    dag=dag_with_fail_task,
+)
+
+with DAG(
+    dag_id='dag_that_follows_dag_with_fail',
+    catchup=False,
+    start_date=datetime(2020, 1, 1),
+    schedule_on=[fail_task_dag_dataset],
+    tags=['downstream-failed'],
+) as dag_that_follows_dag_with_fail:
+    BashOperator(
+        task_id='dag_that_follows_dag_with_fail_task',
+        bash_command="sleep 5",
+    )

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1573,17 +1573,17 @@ class TestTaskInstance:
         failed, a DatasetDagRunQueue is not logged, and a DatasetEvent is
         not generated
         """
-        from airflow.example_dags import example_datasets
-        from airflow.example_dags.example_datasets import dag9
+        from tests.dags import test_datasets
+        from tests.dags.test_datasets import dag_with_fail_task
 
         session = settings.Session()
-        dagbag = DagBag(dag_folder=example_datasets.__file__)
+        dagbag = DagBag(dag_folder=test_datasets.__file__)
         dagbag.collect_dags(only_if_updated=False, safe_mode=False)
         dagbag.sync_to_db(session=session)
         run_id = str(uuid4())
-        dr = DagRun(dag9.dag_id, run_id=run_id, run_type='anything')
+        dr = DagRun(dag_with_fail_task.dag_id, run_id=run_id, run_type='anything')
         session.merge(dr)
-        task = dag9.get_task('fail_task')
+        task = dag_with_fail_task.get_task('fail_task')
         ti = TaskInstance(task, run_id=run_id)
         session.merge(ti)
         session.commit()
@@ -1604,17 +1604,17 @@ class TestTaskInstance:
         is skipped, a DatasetDagRunQueue is not logged, and a DatasetEvent is
         not generated
         """
-        from airflow.example_dags import example_datasets
-        from airflow.example_dags.example_datasets import dag7
+        from tests.dags import test_datasets
+        from tests.dags.test_datasets import dag_with_skip_task
 
         session = settings.Session()
-        dagbag = DagBag(dag_folder=example_datasets.__file__)
+        dagbag = DagBag(dag_folder=test_datasets.__file__)
         dagbag.collect_dags(only_if_updated=False, safe_mode=False)
         dagbag.sync_to_db(session=session)
         run_id = str(uuid4())
-        dr = DagRun(dag7.dag_id, run_id=run_id, run_type='anything')
+        dr = DagRun(dag_with_skip_task.dag_id, run_id=run_id, run_type='anything')
         session.merge(dr)
-        task = dag7.get_task('skip_task')
+        task = dag_with_skip_task.get_task('skip_task')
         ti = TaskInstance(task, run_id=run_id)
         session.merge(ti)
         session.commit()


### PR DESCRIPTION
PR #25086 added a few more dags to the example dags that were used in tests. However, those additions cluttered up the example dags folder, so instead of adding test dags to the examples folder, this PR moves those dags out to the `tests/dags` directory.