### PR TITLE
BashOperator - resolve bash by absolute path

### DIFF
--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import shutil
 from typing import Dict, Optional, Sequence
 
 from airflow.compat.functools import cached_property
@@ -174,6 +175,7 @@ class BashOperator(BaseOperator):
         return env
 
     def execute(self, context: Context):
+        bash_path = shutil.which("bash") or "bash"
         if self.cwd is not None:
             if not os.path.exists(self.cwd):
                 raise AirflowException(f"Can not find the cwd: {self.cwd}")
@@ -181,7 +183,7 @@ class BashOperator(BaseOperator):
                 raise AirflowException(f"The cwd {self.cwd} must be a directory")
         env = self.get_env(context)
         result = self.subprocess_hook.run_command(
-            command=['bash', '-c', self.bash_command],
+            command=[bash_path, '-c', self.bash_command],
             env=env,
             output_encoding=self.output_encoding,
             cwd=self.cwd,


### PR DESCRIPTION
Fixes https://github.com/apache/airflow/issues/25330

Necessary because maybe the user sets `env` but doesn't set `PATH`.  Now `PATH` is empty and the subprocess can't find bash.  I'm a little confused why this is not a more common failure mode, does `subprocess` have a list of default locations to look or something?

Existing tests of BashOperator should be sufficient.