### PR TITLE
Add option to mask sensitive data in UI configuration page

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -926,6 +926,18 @@ class AirflowConfigParser(ConfigParser):
         else:
             self._filter_by_source(config_sources, display_source, self._get_secret_option)
 
+        if not display_sensitive:
+            # This ensures the ones from config file is hidden too
+            # if they are not provided through env, cmd and secret
+            hidden = '< hidden >'
+            for (section, key) in self.sensitive_config_values:
+                if config_sources[section].get(key, None):
+                    if display_source:
+                        source = config_sources[section][key][1]
+                        config_sources[section][key] = (hidden, source)
+                    else:
+                        config_sources[section][key] = hidden
+
         return config_sources
 
     def _include_secrets(
@@ -992,7 +1004,7 @@ class AirflowConfigParser(ConfigParser):
                 continue
             if not display_sensitive and env_var != self._env_var_name('core', 'unit_test_mode'):
                 # Don't hide cmd/secret values here
-                if not env_var.lower().endswith('cmd') and not env_var.lower().endswith("cmd"):
+                if not env_var.lower().endswith('cmd') and not env_var.lower().endswith("secret"):
                     opt = '< hidden >'
             elif raw:
                 opt = opt.replace('%', '%%')

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -906,7 +906,6 @@ class AirflowConfigParser(ConfigParser):
             include_cmds=include_cmds,
             include_env=include_env,
             include_secret=include_secret,
-            display_sensitive=display_sensitive,
         )
 
         # add env vars and overwrite because they have priority
@@ -992,7 +991,9 @@ class AirflowConfigParser(ConfigParser):
                 log.warning("Ignoring unknown env var '%s'", env_var)
                 continue
             if not display_sensitive and env_var != self._env_var_name('core', 'unit_test_mode'):
-                opt = '< hidden >'
+                # Don't hide cmd/secret values here
+                if not env_var.lower().endswith('cmd') and not env_var.lower().endswith("cmd"):
+                    opt = '< hidden >'
             elif raw:
                 opt = opt.replace('%', '%%')
             if display_source:
@@ -1065,7 +1066,6 @@ class AirflowConfigParser(ConfigParser):
         include_env: bool,
         include_cmds: bool,
         include_secret: bool,
-        display_sensitive: bool,
     ):
         for (source_name, config) in configs:
             for section in config.sections():
@@ -1081,7 +1081,6 @@ class AirflowConfigParser(ConfigParser):
                     include_env=include_env,
                     include_cmds=include_cmds,
                     include_secret=include_secret,
-                    display_sensitive=display_sensitive,
                 )
 
     @staticmethod
@@ -1152,7 +1151,6 @@ class AirflowConfigParser(ConfigParser):
         include_env: bool,
         include_cmds: bool,
         include_secret: bool,
-        display_sensitive: bool,
     ):
         sect = config_sources.setdefault(section, OrderedDict())
         for (k, val) in config.items(section=section, raw=raw):
@@ -1188,9 +1186,6 @@ class AirflowConfigParser(ConfigParser):
                         )
                     ):
                         continue
-            if not display_sensitive:
-                if (section, k) in AirflowConfigParser.sensitive_config_values:
-                    val = '< hidden >'
             if display_source:
                 sect[k] = (val, source_name)
             else:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -142,6 +142,20 @@ def default_config_yaml() -> List[Dict[str, Any]]:
         return yaml.safe_load(config_file)
 
 
+SENSITIVE_CONFIG_VALUES = {
+    ('database', 'sql_alchemy_conn'),
+    ('core', 'fernet_key'),
+    ('celery', 'broker_url'),
+    ('celery', 'flower_basic_auth'),
+    ('celery', 'result_backend'),
+    ('atlas', 'password'),
+    ('smtp', 'smtp_password'),
+    ('webserver', 'secret_key'),
+    # The following options are deprecated
+    ('core', 'sql_alchemy_conn'),
+}
+
+
 class AirflowConfigParser(ConfigParser):
     """Custom Airflow Configparser supporting defaults and deprecated options"""
 
@@ -150,18 +164,8 @@ class AirflowConfigParser(ConfigParser):
     # is to not store password on boxes in text files.
     # These configs can also be fetched from Secrets backend
     # following the "{section}__{name}__secret" pattern
-    sensitive_config_values: Set[Tuple[str, str]] = {
-        ('database', 'sql_alchemy_conn'),
-        ('core', 'fernet_key'),
-        ('celery', 'broker_url'),
-        ('celery', 'flower_basic_auth'),
-        ('celery', 'result_backend'),
-        ('atlas', 'password'),
-        ('smtp', 'smtp_password'),
-        ('webserver', 'secret_key'),
-        # The following options are deprecated
-        ('core', 'sql_alchemy_conn'),
-    }
+
+    sensitive_config_values: Set[Tuple[str, str]] = SENSITIVE_CONFIG_VALUES
 
     # A mapping of (new section, new option) -> (old section, old option, since_version).
     # When reading new option, the old option will be checked to see if it exists. If it does a

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -906,6 +906,7 @@ class AirflowConfigParser(ConfigParser):
             include_cmds=include_cmds,
             include_env=include_env,
             include_secret=include_secret,
+            display_sensitive=display_sensitive,
         )
 
         # add env vars and overwrite because they have priority
@@ -1064,6 +1065,7 @@ class AirflowConfigParser(ConfigParser):
         include_env: bool,
         include_cmds: bool,
         include_secret: bool,
+        display_sensitive: bool,
     ):
         for (source_name, config) in configs:
             for section in config.sections():
@@ -1079,6 +1081,7 @@ class AirflowConfigParser(ConfigParser):
                     include_env=include_env,
                     include_cmds=include_cmds,
                     include_secret=include_secret,
+                    display_sensitive=display_sensitive,
                 )
 
     @staticmethod
@@ -1149,6 +1152,7 @@ class AirflowConfigParser(ConfigParser):
         include_env: bool,
         include_cmds: bool,
         include_secret: bool,
+        display_sensitive: bool,
     ):
         sect = config_sources.setdefault(section, OrderedDict())
         for (k, val) in config.items(section=section, raw=raw):
@@ -1184,6 +1188,9 @@ class AirflowConfigParser(ConfigParser):
                         )
                     ):
                         continue
+            if not display_sensitive:
+                if (section, k) in AirflowConfigParser.sensitive_config_values:
+                    val = '< hidden >'
             if display_source:
                 sect[k] = (val, source_name)
             else:

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -931,6 +931,8 @@ class AirflowConfigParser(ConfigParser):
             # if they are not provided through env, cmd and secret
             hidden = '< hidden >'
             for (section, key) in self.sensitive_config_values:
+                if not config_sources.get(section):
+                    continue
                 if config_sources[section].get(key, None):
                     if display_source:
                         source = config_sources[section][key][1]

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -891,6 +891,15 @@ class AirflowConfigParser(ConfigParser):
         :return: Dictionary, where the key is the name of the section and the content is
             the dictionary with the name of the parameter and its value.
         """
+        if not display_sensitive:
+            # We want to hide the sensitive values at the appropriate methods
+            # since envs from cmds, secrets can be read at _include_envs method
+            if not all([include_env, include_cmds, include_secret]):
+                raise ValueError(
+                    "If display_sensitive is false, then include_env, "
+                    "include_cmds, include_secret must all be set as True"
+                )
+
         config_sources: ConfigSourcesType = {}
         configs = [
             ('default', self.airflow_defaults),
@@ -1008,6 +1017,7 @@ class AirflowConfigParser(ConfigParser):
                 # Don't hide cmd/secret values here
                 if not env_var.lower().endswith('cmd') and not env_var.lower().endswith("secret"):
                     opt = '< hidden >'
+
             elif raw:
                 opt = opt.replace('%', '%%')
             if display_source:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3775,6 +3775,7 @@ class ConfigurationView(AirflowBaseView):
                 for key, (value, source) in parameters.items()
             ]
         elif expose_config.lower() in ['true', 't', '1']:
+
             with open(AIRFLOW_CONFIG) as file:
                 config = file.read()
             table = [

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3765,7 +3765,7 @@ class ConfigurationView(AirflowBaseView):
                 config = ''.join(config)
 
             table = [
-                (section, key, value, source)
+                (section, key, str(value), source)
                 for section, parameters in conf.as_dict(True, False).items()
                 for key, (value, source) in parameters.items()
             ]
@@ -3774,7 +3774,7 @@ class ConfigurationView(AirflowBaseView):
             with open(AIRFLOW_CONFIG) as file:
                 config = file.read()
             table = [
-                (section, key, value, source)
+                (section, key, str(value), source)
                 for section, parameters in conf.as_dict(True, True).items()
                 for key, (value, source) in parameters.items()
             ]

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3759,21 +3759,14 @@ class ConfigurationView(AirflowBaseView):
                         # this masks the keys wherever it's found not
                         # minding the section
                         if key in line and not line.startswith('#'):
-                            config[config.index(line)] = key + ' = ***\n'
+                            config[config.index(line)] = key + ' = < hidden >\n'
                             break
 
                 config = ''.join(config)
 
-            running_conf = conf.as_dict(True, True)
-            for section, key in SENSITIVE_CONFIG_VALUES:
-                running_conf_value = running_conf[section].get(key, None)
-                if running_conf_value:
-                    new = ('***', running_conf_value[1])
-                    running_conf[section][key] = new
-
             table = [
                 (section, key, value, source)
-                for section, parameters in running_conf.items()
+                for section, parameters in conf.as_dict(True, False).items()
                 for key, (value, source) in parameters.items()
             ]
         elif expose_config.lower() in ['true', 't', '1']:
@@ -3791,6 +3784,7 @@ class ConfigurationView(AirflowBaseView):
                 "configuration, most likely for security reasons."
             )
             table = None
+
         if raw:
             return Response(response=config, status=200, mimetype="application/text")
         else:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3756,6 +3756,8 @@ class ConfigurationView(AirflowBaseView):
                 config = file.readlines()
                 for line in config:
                     for _, key in SENSITIVE_CONFIG_VALUES:
+                        # this masks the keys wherever it's found not
+                        # minding the section
                         if key in line and not line.startswith('#'):
                             config[config.index(line)] = key + ' = ***\n'
                             break

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ install_requires =
     # Colorlog 6.x merges TTYColoredFormatter into ColoredFormatter, breaking backwards compatibility with 4.x
     # Update CustomTTYColoredFormatter to remove
     colorlog>=4.0.2, <5.0
+    configupdater>=3.1.1
     connexion[swagger-ui,flask]>=2.10.0
     cron-descriptor>=1.2.24
     croniter>=0.3.17

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -559,6 +559,15 @@ notacommand = OK
             # the environment variable's echo command
             assert test_cmdenv_conf.get('testcmdenv', 'notacommand') == 'OK'
 
+    @pytest.mark.parametrize('display_sensitive, result', [(True, 'OK'), (False, '< hidden >')])
+    def test_as_dict_display_sensitivewith_command_from_env(self, display_sensitive, result):
+
+        test_cmdenv_conf = AirflowConfigParser()
+        test_cmdenv_conf.sensitive_config_values.add(('testcmdenv', 'itsacommand'))
+        with unittest.mock.patch.dict('os.environ'):
+            asdict = test_cmdenv_conf.as_dict(True, display_sensitive)
+            assert asdict['testcmdenv']['itsacommand'] == (result, 'cmd')
+
     def test_parameterized_config_gen(self):
         config = textwrap.dedent(
             """

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -260,6 +260,9 @@ sql_alchemy_conn = airflow
         }
 
         assert 'sqlite:////Users/airflow/airflow/airflow.db' == test_conf.get('test', 'sql_alchemy_conn')
+        # Hide sensitive fields
+        asdict = test_conf.as_dict(display_sensitive=False)
+        assert '< hidden >' == asdict['test']['sql_alchemy_conn']
 
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     @conf_vars(

--- a/tests/www/views/test_views_configuration.py
+++ b/tests/www/views/test_views_configuration.py
@@ -55,6 +55,16 @@ def test_configuration_redacted(admin_client):
 
 
 @conf_vars({("webserver", "expose_config"): 'non-sensitive-only'})
+def test_configuration_redacted_in_running_configuration(admin_client):
+    resp = admin_client.get('configuration', follow_redirects=True)
+    for section, key in SENSITIVE_CONFIG_VALUES:
+        value = conf.get(section, key, fallback='')
+        if not value or value == 'airflow':
+            continue
+        check_content_not_in_response("<td class='code'>" + html.escape(value) + '</td', resp)
+
+
+@conf_vars({("webserver", "expose_config"): 'non-sensitive-only'})
 @conf_vars({("database", "# sql_alchemy_conn"): 'testconn'})
 @conf_vars({("core", "  # secret_key"): 'core_secret'})
 @conf_vars({("core", "fernet_key"): 'secret_fernet_key'})

--- a/tests/www/views/test_views_configuration.py
+++ b/tests/www/views/test_views_configuration.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.configuration import SENSITIVE_CONFIG_VALUES, conf
+from tests.test_utils.config import conf_vars
+from tests.test_utils.www import check_content_in_response, check_content_not_in_response
+
+
+@conf_vars({("webserver", "expose_config"): 'False'})
+def test_user_cant_view_configuration(admin_client):
+    resp = admin_client.get('configuration', follow_redirects=True)
+    check_content_in_response(
+        "Your Airflow administrator chose not to expose the configuration, "
+        "most likely for security reasons.",
+        resp,
+    )
+
+
+@conf_vars({("webserver", "expose_config"): 'True'})
+def test_user_can_view_configuration(admin_client):
+    resp = admin_client.get('configuration', follow_redirects=True)
+    for section, key in SENSITIVE_CONFIG_VALUES:
+        value = conf.get(section, key, fallback='')
+        if not value:
+            continue
+        check_content_in_response(value, resp)
+
+
+@conf_vars({("webserver", "expose_config"): 'non-sensitive-only'})
+def test_configuration_redacted(admin_client):
+    resp = admin_client.get('configuration', follow_redirects=True)
+    for section, key in SENSITIVE_CONFIG_VALUES:
+        value = conf.get(section, key, fallback='')
+        if not value or value == 'airflow':
+            continue
+        if value.startswith('db+postgresql'):  # this is in configuration comment
+            continue
+        check_content_not_in_response(value, resp)

--- a/tests/www/views/test_views_configuration.py
+++ b/tests/www/views/test_views_configuration.py
@@ -35,9 +35,7 @@ def test_user_can_view_configuration(admin_client):
     resp = admin_client.get('configuration', follow_redirects=True)
     for section, key in SENSITIVE_CONFIG_VALUES:
         value = conf.get(section, key, fallback='')
-        if not value or 'mssql' in value:
-            # TODO: investigate why mssql db can't be found
-            # in response at this point
+        if not value:
             continue
         check_content_in_response(value, resp)
 

--- a/tests/www/views/test_views_configuration.py
+++ b/tests/www/views/test_views_configuration.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+
 from airflow.configuration import SENSITIVE_CONFIG_VALUES, conf
 from tests.test_utils.config import conf_vars
 from tests.test_utils.www import check_content_in_response, check_content_not_in_response

--- a/tests/www/views/test_views_configuration.py
+++ b/tests/www/views/test_views_configuration.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import html
 
 from airflow.configuration import SENSITIVE_CONFIG_VALUES, conf
 from tests.test_utils.config import conf_vars
@@ -38,7 +39,7 @@ def test_user_can_view_configuration(admin_client):
         value = conf.get(section, key, fallback='')
         if not value:
             continue
-        check_content_in_response(value, resp)
+        check_content_in_response(html.escape(value), resp)
 
 
 @conf_vars({("webserver", "expose_config"): 'non-sensitive-only'})


### PR DESCRIPTION
This PR adds an option to mask sensitive data in the UI configuration page, making it possible to view the page with redated data
