### PR TITLE
Check expand_kwargs() input type before unmapping

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -455,7 +455,7 @@ class DecoratedMappedOperator(MappedOperator):
         assert self.expand_input is EXPAND_INPUT_EMPTY
         return {"op_kwargs": super()._expand_mapped_kwargs(resolve)}
 
-    def _get_unmap_kwargs(self, mapped_kwargs: Dict[str, Any], *, strict: bool) -> Dict[str, Any]:
+    def _get_unmap_kwargs(self, mapped_kwargs: Mapping[str, Any], *, strict: bool) -> Dict[str, Any]:
         if strict:
             prevent_duplicates(
                 self.partial_kwargs["op_kwargs"],

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -257,7 +257,10 @@ class ListOfDictsExpandInput(NamedTuple):
             raise ValueError(f"expand_kwargs() expects a list[dict], not list[{type(mapping).__name__}]")
         for key in mapping:
             if not isinstance(key, str):
-                raise ValueError(f"expand_kwargs() input dict keys must be str, not {type(key).__name__}")
+                raise ValueError(
+                    f"expand_kwargs() input dict keys must all be str, "
+                    f"but {key!r} is of type {type(key).__name__}"
+                )
         return mapping
 
 

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -199,6 +199,12 @@ class DictOfListsExpandInput(NamedTuple):
         return {k: self._expand_mapped_field(k, v, context, session=session) for k, v in self.value.items()}
 
 
+def _describe_type(value: Any) -> str:
+    if value is None:
+        return "None"
+    return type(value).__name__
+
+
 class ListOfDictsExpandInput(NamedTuple):
     """Storage type of a mapped operator's mapped kwargs.
 
@@ -251,15 +257,15 @@ class ListOfDictsExpandInput(NamedTuple):
             raise RuntimeError("can't resolve task-mapping argument without expanding")
         mappings = self.value.resolve(context, session)
         if not isinstance(mappings, collections.abc.Sequence):
-            raise ValueError(f"expand_kwargs() expects a list[dict], not {type(mappings).__name__}")
+            raise ValueError(f"expand_kwargs() expects a list[dict], not {_describe_type(mappings)}")
         mapping = mappings[map_index]
         if not isinstance(mapping, collections.abc.Mapping):
-            raise ValueError(f"expand_kwargs() expects a list[dict], not list[{type(mapping).__name__}]")
+            raise ValueError(f"expand_kwargs() expects a list[dict], not list[{_describe_type(mapping)}]")
         for key in mapping:
             if not isinstance(key, str):
                 raise ValueError(
                     f"expand_kwargs() input dict keys must all be str, "
-                    f"but {key!r} is of type {type(key).__name__}"
+                    f"but {key!r} is of type {_describe_type(key)}"
                 )
         return mapping
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -30,6 +30,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Mapping,
     Optional,
     Sequence,
     Set,
@@ -123,7 +124,7 @@ def validate_mapping_kwargs(op: Type["BaseOperator"], func: ValidationSource, va
     raise TypeError(f"{op.__name__}.{func}() got {error}")
 
 
-def prevent_duplicates(kwargs1: Dict[str, Any], kwargs2: Dict[str, Any], *, fail_reason: str) -> None:
+def prevent_duplicates(kwargs1: Dict[str, Any], kwargs2: Mapping[str, Any], *, fail_reason: str) -> None:
     duplicated_keys = set(kwargs1).intersection(kwargs2)
     if not duplicated_keys:
         return
@@ -528,7 +529,7 @@ class MappedOperator(AbstractOperator):
         """Implementing DAGNode."""
         return DagAttributeTypes.OP, self.task_id
 
-    def _expand_mapped_kwargs(self, resolve: Optional[Tuple[Context, Session]]) -> Dict[str, Any]:
+    def _expand_mapped_kwargs(self, resolve: Optional[Tuple[Context, Session]]) -> Mapping[str, Any]:
         """Get the kwargs to create the unmapped operator.
 
         If *resolve* is not *None*, it must be a two-tuple to provide context to
@@ -546,7 +547,7 @@ class MappedOperator(AbstractOperator):
             return expand_input.resolve(*resolve)
         return expand_input.get_unresolved_kwargs()
 
-    def _get_unmap_kwargs(self, mapped_kwargs: Dict[str, Any], *, strict: bool) -> Dict[str, Any]:
+    def _get_unmap_kwargs(self, mapped_kwargs: Mapping[str, Any], *, strict: bool) -> Dict[str, Any]:
         """Get init kwargs to unmap the underlying operator class.
 
         :param mapped_kwargs: The dict returned by ``_expand_mapped_kwargs``.
@@ -569,7 +570,7 @@ class MappedOperator(AbstractOperator):
             **mapped_kwargs,
         }
 
-    def unmap(self, resolve: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
+    def unmap(self, resolve: Union[None, Mapping[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """Get the "normal" Operator after applying the current mapping.
 
         If ``operator_class`` is not a class (i.e. this DAG has been

--- a/tests/models/test_xcom_arg_map.py
+++ b/tests/models/test_xcom_arg_map.py
@@ -128,9 +128,9 @@ def test_xcom_convert_to_kwargs_fails_task(dag_maker, session):
     tis[("pull", 1)].run()
 
     # But the third one fails because the map() result cannot be used as kwargs.
-    with pytest.raises(TypeError) as ctx:
+    with pytest.raises(ValueError) as ctx:
         tis[("pull", 2)].run()
-    assert str(ctx.value) == "'NoneType' object is not iterable"
+    assert str(ctx.value) == "expand_kwargs() expects a list[dict], not list[None]"
 
     assert [tis[("pull", i)].state for i in range(3)] == [
         TaskInstanceState.SUCCESS,


### PR DESCRIPTION
This was originally done when the value is pushed in upstream, but that was removed when we implemented `map()`, and now should be done when the value is pulled. The task would have failed without these explicit checks, but with very cryptic error messages.

Close #25352