### PR TITLE
Fix: null bytes in new files after logrotate

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -67,7 +67,10 @@ def flower(args):
             stderr=args.stderr,
             log=args.log_file,
         )
-        with open(stdout, "w+") as stdout, open(stderr, "w+") as stderr:
+        with open(stdout, 'a') as stdout, open(stderr, 'a') as stderr:
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout)
+            truncate_file(stderr)
             ctx = daemon.DaemonContext(
                 pidfile=TimeoutPIDLockFile(pidfile, -1),
                 stdout=stdout,
@@ -177,7 +180,11 @@ def worker(args):
         # Run Celery worker as daemon
         handle = setup_logging(log_file)
 
-        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+        with (open(stdout, 'a') as stdout_handle,
+              open(stderr, 'a') as stderr_handle):
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout_handle)
+            truncate_file(stderr_handle)
             if args.umask:
                 umask = args.umask
 

--- a/airflow/cli/commands/dag_processor_command.py
+++ b/airflow/cli/commands/dag_processor_command.py
@@ -60,7 +60,11 @@ def dag_processor(args):
             "dag-processor", args.pid, args.stdout, args.stderr, args.log_file
         )
         handle = setup_logging(log_file)
-        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+        with (open(stdout, 'a') as stdout_handle,
+              open(stderr, 'a') as stderr_handle):
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout_handle)
+            truncate_file(stderr_handle)
             ctx = daemon.DaemonContext(
                 pidfile=TimeoutPIDLockFile(pid, -1),
                 files_preserve=[handle],

--- a/airflow/cli/commands/kerberos_command.py
+++ b/airflow/cli/commands/kerberos_command.py
@@ -34,7 +34,11 @@ def kerberos(args):
         pid, stdout, stderr, _ = setup_locations(
             "kerberos", args.pid, args.stdout, args.stderr, args.log_file
         )
-        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+        with (open(stdout, 'a') as stdout_handle,
+              open(stderr, 'a') as stderr_handle):
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout_handle)
+            truncate_file(stderr_handle)
             ctx = daemon.DaemonContext(
                 pidfile=TimeoutPIDLockFile(pid, -1),
                 stdout=stdout_handle,

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -65,7 +65,13 @@ def scheduler(args):
             "scheduler", args.pid, args.stdout, args.stderr, args.log_file
         )
         handle = setup_logging(log_file)
-        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+
+        with (open(stdout, 'a') as stdout_handle,
+              open(stderr, 'a') as stderr_handle):
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout_handle)
+            truncate_file(stderr_handle)
+
             ctx = daemon.DaemonContext(
                 pidfile=TimeoutPIDLockFile(pid, -1),
                 files_preserve=[handle],

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -39,7 +39,11 @@ def triggerer(args):
             "triggerer", args.pid, args.stdout, args.stderr, args.log_file
         )
         handle = setup_logging(log_file)
-        with open(stdout, 'w+') as stdout_handle, open(stderr, 'w+') as stderr_handle:
+        with (open(stdout, 'a') as stdout_handle,
+              open(stderr, 'a') as stderr_handle):
+            from airflow.cli.util import truncate_file
+            truncate_file(stdout_handle)
+            truncate_file(stderr_handle)
             ctx = daemon.DaemonContext(
                 pidfile=TimeoutPIDLockFile(pid, -1),
                 files_preserve=[handle],

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -449,7 +449,10 @@ def webserver(args):
             handle = setup_logging(log_file)
 
             base, ext = os.path.splitext(pid_file)
-            with open(stdout, 'w+') as stdout, open(stderr, 'w+') as stderr:
+            with open(stdout, 'a') as stdout, open(stderr, 'a') as stderr:
+                from airflow.cli.util import truncate_file
+                truncate_file(stdout)
+                truncate_file(stderr)
                 ctx = daemon.DaemonContext(
                     pidfile=TimeoutPIDLockFile(f"{base}-monitor{ext}", -1),
                     files_preserve=[handle],

--- a/airflow/cli/util.py
+++ b/airflow/cli/util.py
@@ -1,0 +1,7 @@
+from io import SEEK_SET
+from typing import IO
+
+
+def truncate_file(fil: IO) -> None:
+    fil.seek(0, SEEK_SET)
+    fil.truncate(0)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

See also: https://github.com/apache/airflow/discussions/25182

Currently, when logrotate rotates a file opened as `--stdout` or `--stderr` on some commands, writing the log files resume from the old position, resulting in sparse files with an ever increasing amount of null bytes at the beginning.

Switching the mode argument of open from `w+` to `a` resolves that.
Additionally, to retain old behaviour and avoid surprises in existing deployments without log rotation, these files are currently truncated after opening.


