### PR TITLE
Add and document description fields

### DIFF
--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -42,13 +42,13 @@ def delete_variable(*, variable_key: str) -> Response:
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_VARIABLE)])
-def get_variable(*, variable_key: str) -> Response:
-    """Get a variables by key"""
-    try:
-        var = Variable.get(variable_key)
-    except KeyError:
+@provide_session
+def get_variable(*, variable_key: str, session: Session = NEW_SESSION) -> Response:
+    """Get a variable by key"""
+    var = session.query(Variable).filter(Variable.key == variable_key)
+    if not var.count():
         raise NotFound("Variable not found")
-    return variable_schema.dump({"key": variable_key, "val": var})
+    return variable_schema.dump(var.first())
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_VARIABLE)])

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3034,6 +3034,13 @@ components:
       properties:
         key:
           type: string
+        description:
+          type: string
+          description: |
+            The description of the variable.
+
+            *New in version 2.4.0*
+          nullable: true
 
     VariableCollection:
       type: object

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2245,6 +2245,10 @@ components:
         conn_type:
           type: string
           description: The connection type.
+        description:
+          type: string
+          description: The description of the connection.
+          nullable: true
         host:
           type: string
           nullable: true

--- a/airflow/api_connexion/schemas/variable_schema.py
+++ b/airflow/api_connexion/schemas/variable_schema.py
@@ -23,6 +23,7 @@ class VariableSchema(Schema):
 
     key = fields.String(required=True)
     value = fields.String(attribute="val", required=True)
+    description = fields.String(attribute="description", required=False)
 
 
 class VariableCollectionSchema(Schema):

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -730,6 +730,8 @@ export interface components {
       connection_id?: string;
       /** @description The connection type. */
       conn_type?: string;
+      /** @description The description of the connection. */
+      description?: string;
       /** @description Host of the connection. */
       host?: string | null;
       /** @description Login of the connection. */
@@ -1209,6 +1211,8 @@ export interface components {
      */
     VariableCollectionItem: {
       key?: string;
+      /** @description The description of the variable. */
+      description?: string;
     };
     /**
      * @description Collection of variables.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -731,7 +731,7 @@ export interface components {
       /** @description The connection type. */
       conn_type?: string;
       /** @description The description of the connection. */
-      description?: string;
+      description?: string | null;
       /** @description Host of the connection. */
       host?: string | null;
       /** @description Login of the connection. */
@@ -1211,8 +1211,12 @@ export interface components {
      */
     VariableCollectionItem: {
       key?: string;
-      /** @description The description of the variable. */
-      description?: string;
+      /**
+       * @description The description of the variable.
+       *
+       * *New in version 2.4.0*
+       */
+      description?: string | null;
     };
     /**
      * @description Collection of variables.

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -109,7 +109,7 @@ class TestGetVariable(TestVariableEndpoint):
             "/api/v1/variables/TEST_VARIABLE_KEY", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
-        assert response.json == {"key": "TEST_VARIABLE_KEY", "value": expected_value}
+        assert response.json == {"key": "TEST_VARIABLE_KEY", "value": expected_value, "description": None}
 
     def test_should_respond_404_if_not_found(self):
         response = self.client.get(
@@ -132,8 +132,8 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=2&offset=0",
                 {
                     "variables": [
-                        {"key": "var1", "value": "1"},
-                        {"key": "var2", "value": "foo"},
+                        {"key": "var1", "value": "1", "description": "I am a variable"},
+                        {"key": "var2", "value": "foo", "description": "Another variable"},
                     ],
                     "total_entries": 3,
                 },
@@ -142,8 +142,8 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=2&offset=1",
                 {
                     "variables": [
-                        {"key": "var2", "value": "foo"},
-                        {"key": "var3", "value": "[100, 101]"},
+                        {"key": "var2", "value": "foo", "description": "Another variable"},
+                        {"key": "var3", "value": "[100, 101]", "description": None},
                     ],
                     "total_entries": 3,
                 },
@@ -152,7 +152,7 @@ class TestGetVariables(TestVariableEndpoint):
                 "/api/v1/variables?limit=1&offset=2",
                 {
                     "variables": [
-                        {"key": "var3", "value": "[100, 101]"},
+                        {"key": "var3", "value": "[100, 101]", "description": None},
                     ],
                     "total_entries": 3,
                 },
@@ -160,8 +160,8 @@ class TestGetVariables(TestVariableEndpoint):
         ]
     )
     def test_should_get_list_variables(self, query, expected):
-        Variable.set("var1", 1)
-        Variable.set("var2", "foo")
+        Variable.set("var1", 1, "I am a variable")
+        Variable.set("var2", "foo", "Another variable")
         Variable.set("var3", "[100, 101]")
         response = self.client.get(query, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
@@ -279,6 +279,7 @@ class TestPostVariables(TestVariableEndpoint):
         assert response.json == {
             "key": "var_create",
             "value": "{}",
+            "description": None,
         }
 
     def test_should_reject_invalid_request(self):


### PR DESCRIPTION
Adds the description field to variables API calls, and documents that the connections API was already including it.

Closes #22007.