### PR TITLE
Add downstream dataset events to task instance details

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -34,6 +34,7 @@ import { SimpleStatus } from 'src/dag/StatusBox';
 import Time from 'src/components/Time';
 import { ClipboardText } from 'src/components/Clipboard';
 import type { Task, TaskInstance, TaskState } from 'src/types';
+import DownstreamEvents from './DownstreamEvents';
 
 interface Props {
   instance: TaskInstance;
@@ -57,6 +58,7 @@ const Details = ({ instance, group }: Props) => {
     isMapped,
     tooltip,
     operator,
+    hasOutletDatasets,
   } = group;
 
   const numMap = finalStatesMap();
@@ -167,6 +169,9 @@ const Details = ({ instance, group }: Props) => {
           )}
         </Tbody>
       </Table>
+      {hasOutletDatasets && (
+        <DownstreamEvents taskId={taskId} runId={runId} />
+      )}
     </Flex>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/DownstreamEvents.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/DownstreamEvents.tsx
@@ -22,17 +22,21 @@ import {
 } from '@chakra-ui/react';
 
 import {
-  CodeCell, DatasetLink, Table, TaskInstanceLink, TimeCell,
+  CodeCell, DatasetLink, Table, TimeCell,
 } from 'src/components/Table';
-import { useUpstreamDatasetEvents } from 'src/api';
+import { useDatasetEvents } from 'src/api';
 import type { DagRun as DagRunType } from 'src/types';
+import { getMetaValue } from 'src/utils';
 
 interface Props {
   runId: DagRunType['runId'];
+  taskId: string;
 }
 
-const UpstreamEvents = ({ runId }: Props) => {
-  const { data: { datasetEvents }, isLoading } = useUpstreamDatasetEvents({ runId });
+const dagId = getMetaValue('dag_id') || undefined;
+
+const DownstreamEvents = ({ runId, taskId }: Props) => {
+  const { data: { datasetEvents }, isLoading } = useDatasetEvents({ runId, taskId, dagId });
 
   const columns = useMemo(
     () => [
@@ -40,11 +44,6 @@ const UpstreamEvents = ({ runId }: Props) => {
         Header: 'Dataset URI',
         accessor: 'datasetUri',
         Cell: DatasetLink,
-      },
-      {
-        Header: 'Source Task Instance',
-        accessor: 'sourceTaskId',
-        Cell: TaskInstanceLink,
       },
       {
         Header: 'Extra',
@@ -68,8 +67,8 @@ const UpstreamEvents = ({ runId }: Props) => {
 
   return (
     <Box mt={3} flexGrow={1}>
-      <Heading size="md">Upstream Dataset Events</Heading>
-      <Text>Updates to the upstream datasets since the last dataset-triggered DAG run</Text>
+      <Heading size="md">Downstream Dataset Events</Heading>
+      <Text>Dataset updates created by this task instance</Text>
       <Table
         data={data}
         columns={columns}
@@ -79,4 +78,4 @@ const UpstreamEvents = ({ runId }: Props) => {
   );
 };
 
-export default UpstreamEvents;
+export default DownstreamEvents;


### PR DESCRIPTION
Add downstream events of datasets that were updated by a task instance in the Grid view's task instance details section.

<img width="871" alt="Screen Shot 2022-07-28 at 4 12 16 PM" src="https://user-images.githubusercontent.com/4600967/181573513-2aef1cf9-35db-489d-a3c0-6fbf2d570357.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
