### PR TITLE
Restore pushing CI image as latest to GHCR.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1702,7 +1702,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         platform: ["linux/amd64", "linux/arm64"]
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
-      PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1744,7 +1743,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
         if: matrix.platform == 'linux/arm64'
-      - name: "Push CI cache ${{ matrix.python-version }} ${{ matrix.platform }}"
+      - name: "Push CI cache ${{ matrix.platform }}"
         run: >
           breeze build-image
           --builder airflow_cache
@@ -1752,8 +1751,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           --run-in-parallel
           --force-build
           --platform ${{ matrix.platform }}
-        env:
-          PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
+      - name: "Push CI latest image ${{ matrix.platform }}"
+        run: >
+          breeze build-image --tag-as-latest --push-image --run-in-parallel --platform ${{ matrix.platform }}
+        if: matrix.platform == 'linux/amd64'
       - name: "Move dist packages to docker-context files"
         run: mv -v ./dist/*.whl ./docker-context-files
         if: needs.build-info.outputs.default-branch == 'main'
@@ -1764,9 +1765,12 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           --install-packages-from-context
           --prepare-buildx-cache
           --platform ${{ matrix.platform }}
-        env:
-          PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
         if: needs.build-info.outputs.default-branch == 'main'
+      - name: "Push PROD latest image ${{ matrix.platform }}"
+        run: >
+          breeze build-prod-image --tag-as-latest
+          --push-image --run-in-parallel --platform ${{ matrix.platform }}
+        if: matrix.platform == 'linux/amd64'
       - name: "Stop ARM instance"
         run: ./scripts/ci/images/ci_stop_arm_instance.sh
         if: always() && matrix.platform == 'linux/arm64'


### PR DESCRIPTION
We stopped pushing latest CI/PROD images to ghcr.io when we started to
run multiplatform builds and switched to --cache-from option of
buildx. Hoever there are still some workflows that might require
the latest image (for example Codespaces) and generally speaking
someone could just pull the image if they are curious.

This PR adds back pushing the image (only "linux/amd"
during image cache preparation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
