### PR TITLE
Fix datasets list page

### DIFF
--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -21,6 +21,9 @@ import React, { useMemo, useState } from 'react';
 import {
   Box,
   Heading,
+  Flex,
+  Button,
+  Link,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
 import type { Row, SortingRule } from 'react-table';
@@ -28,6 +31,7 @@ import type { Row, SortingRule } from 'react-table';
 import { useDatasets } from 'src/api';
 import { Table, TimeCell, CodeCell } from 'src/components/Table';
 import type { API } from 'src/types';
+import { MdOutlineAccountTree } from 'react-icons/md';
 
 interface Props {
   onSelect: (datasetId: string) => void;
@@ -80,9 +84,20 @@ const DatasetsList = ({ onSelect }: Props) => {
 
   return (
     <Box maxWidth="1500px">
-      <Heading mt={3} mb={2} fontWeight="normal">
-        Datasets
-      </Heading>
+      <Flex justifyContent="space-between" alignItems="center">
+        <Heading mt={3} mb={2} fontWeight="normal" title="View Dag-Dataset Dependencies">
+          Datasets
+        </Heading>
+        <Button
+          as={Link}
+          variant="outline"
+          colorScheme="blue"
+          href="/dag-dependencies"
+          leftIcon={<MdOutlineAccountTree />}
+        >
+          Graph
+        </Button>
+      </Flex>
       <Box borderWidth={1}>
         <Table
           data={data}

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -79,7 +79,7 @@ const DatasetsList = ({ onSelect }: Props) => {
   );
 
   const onDatasetSelect = (row: Row<API.Dataset>) => {
-    onSelect(row.id);
+    if (row.original.id) onSelect(row.original.id.toString());
   };
 
   return (


### PR DESCRIPTION
- Add a link to the dag dependencies graph to see how datasets<>dags are connected.

- Access the `dataset_id` and not the row id when clicking on a dataset in the list.

<img width="1476" alt="Screen Shot 2022-07-28 at 5 42 09 PM" src="https://user-images.githubusercontent.com/4600967/181592376-70c8bfbd-d89b-42a0-b7c2-8ff44dbe78a3.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
