### PR TITLE
Add missing import in best-practices code example

### DIFF
--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -483,6 +483,7 @@ This is an example test want to verify the structure of a code-generated DAG aga
 
     import pytest
 
+    from airflow import DAG
     from airflow.utils.state import DagRunState, TaskInstanceState
     from airflow.utils.types import DagRunType
 

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -273,6 +273,7 @@ It's easier to grab the concept with an example. Let's say that we have the foll
 .. code-block:: python
 
     from datetime import datetime
+
     from airflow import DAG
     from airflow.decorators import task
     from airflow.exceptions import AirflowException
@@ -479,8 +480,8 @@ This is an example test want to verify the structure of a code-generated DAG aga
 .. code-block:: python
 
     import datetime
-    import pendulum
 
+    import pendulum
     import pytest
 
     from airflow import DAG


### PR DESCRIPTION
This PR adds a missing import to the "unit test for a custom operator" code example. While this code example won't run on its own any way since `MyCustomOperator` isn't defined (and probably shouldn't be for simplicity), I noticed when applying this code to my own custom operator that an import for `DAG` was missing. This PR adds that back in, so the only missing import is for the user-added custom operator.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
