### PR TITLE
Add missing option when pushing latest images to cache :(

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1765,7 +1765,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: needs.build-info.outputs.default-branch == 'main'
       - name: "Push PROD latest image ${{ matrix.platform }}"
         run: >
-          breeze build-prod-image --tag-as-latest
+          breeze build-prod-image --tag-as-latest --install-packages-from-context
           --push-image --run-in-parallel --platform ${{ matrix.platform }}
         if: matrix.platform == 'linux/amd64'
       - name: "Stop ARM instance"


### PR DESCRIPTION
The #25380 re-introduced pushing image as latest on main success
and (as unfortunately happens) since this is only testable after
merge, a small bug crippled in making main build fail.

This flag should fix the problem.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
