### PR TITLE
Removed interfering force of index.

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -377,7 +377,6 @@ class DagFileProcessor(LoggingMixin):
         qry = (
             session.query(TI.task_id, func.max(DR.execution_date).label('max_ti'))
             .join(TI.dag_run)
-            .with_hint(TI, 'USE INDEX (PRIMARY)', dialect_name='mysql')
             .filter(TI.dag_id == dag.dag_id)
             .filter(or_(TI.state == State.SUCCESS, TI.state == State.SKIPPED))
             .filter(TI.task_id.in_(dag.task_ids))


### PR DESCRIPTION
Forcing index in mysql dialect causing unnecessary complexity to process the query and adds a lot to the load when DAG executed frequently enough (hourly instead of daily) and having a lot of tasks in it (every additional task increment query time significantly).

Below a few explain plans collected on mysql 8.0.28.

- daily execution, 4 tasks in it, forcing index is set, but plan optimizer decides to use range, execution time: 1.5s
![image](https://user-images.githubusercontent.com/7289205/181808830-22451dfe-fc92-47bc-b7de-a8164fd4222b.png)
- daily execution, 4 tasks in it, forcing index is **NOT** set, plan optimizer decides to use range, execution time: 1.5s
![image](https://user-images.githubusercontent.com/7289205/181808711-2f4efcce-614b-478e-854b-9949e0c2e708.png)

Summary: when range fits in [range_optimizer_max_mem_size](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_range_optimizer_max_mem_size), optimizer decides to use range scan instead of the optimization provided by hint and request executed fast enough (less than one second in both cases)

- hourly execution, 96 tasks in it, forcing index is set, plan optimizer follows the hint, execution time: 15s
![image](https://user-images.githubusercontent.com/7289205/181808586-29b25c04-fdc6-4ab1-8390-99fe00f79c73.png)
- hourly execution, 96 tasks in it, forcing index is **NOT** set, plan optimizer does a better job, execution time: 8s
![image](https://user-images.githubusercontent.com/7289205/181808438-013327ea-57c7-49b5-87d5-51052a29b10d.png)

Summary: when range **DOESN'T** fit in [range_optimizer_max_mem_size](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_range_optimizer_max_mem_size), optimizer follows the hint which produces much more expensive plan than w/o this hint.