### PR TITLE
Fix DAG audit_log route

### DIFF
--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -248,8 +248,7 @@ def test_dashboard_flash_messages_type(user_client):
 
 
 def test_audit_log_view(user_client, working_dags):
-    url = 'audit_log?dag_id=filter_test_1'
-    resp = user_client.get(url, follow_redirects=True)
+    resp = user_client.get('/dags/filter_test_1/audit_log')
     check_content_in_response('Dag Audit Log', resp)
 
 


### PR DESCRIPTION
This moves the audit_log route under /dags, like it's peers.