### PR TITLE
Hide unused fields for Amazon Web Services connection

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -584,13 +584,29 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:
-        """Returns custom field behaviour."""
+        """Returns custom UI field behaviour for AWS Connection."""
         return {
             "hidden_fields": ['host', 'schema', 'port'],
-            "relabeling": {},
-            "placeholders": {
+            "relabeling": {
                 'login': 'AWS Access Key ID',
                 'password': 'AWS Secret Access Key',
+            },
+            "placeholders": {
+                'login': 'AKIAIOSFODNN7EXAMPLE',
+                'password': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+                'extra': json.dumps(
+                    {
+                        "region_name": "us-east-1",
+                        "session_kwargs": {"profile_name": "default"},
+                        "config_kwargs": {"retries": {"mode": "standard", "max_attempts": 10}},
+                        "role_arn": "arn:aws:iam::123456789098:role/role-name",
+                        "assume_role_method": "assume_role",
+                        "assume_role_kwargs": {"RoleSessionName": "airflow"},
+                        "aws_session_token": "AQoDYXdzEJr...EXAMPLETOKEN",
+                        "host": "http://localhost:4566",
+                    },
+                    indent=2,
+                ),
             },
         }
 

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -586,15 +586,15 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     def get_ui_field_behaviour() -> Dict[str, Any]:
         """Returns custom UI field behaviour for AWS Connection."""
         return {
-            "hidden_fields": ['host', 'schema', 'port'],
+            "hidden_fields": ["host", "schema", "port"],
             "relabeling": {
-                'login': 'AWS Access Key ID',
-                'password': 'AWS Secret Access Key',
+                "login": "AWS Access Key ID",
+                "password": "AWS Secret Access Key",
             },
             "placeholders": {
-                'login': 'AKIAIOSFODNN7EXAMPLE',
-                'password': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-                'extra': json.dumps(
+                "login": "AKIAIOSFODNN7EXAMPLE",
+                "password": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "extra": json.dumps(
                     {
                         "region_name": "us-east-1",
                         "session_kwargs": {"profile_name": "default"},

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -582,6 +582,18 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
         return retry_decorator
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict[str, Any]:
+        """Returns custom field behaviour."""
+        return {
+            "hidden_fields": ['host', 'schema', 'port'],
+            "relabeling": {},
+            "placeholders": {
+                'login': 'AWS Access Key ID',
+                'password': 'AWS Secret Access Key',
+            },
+        }
+
     def test_connection(self):
         """
         Tests the AWS connection by call AWS STS (Security Token Service) GetCallerIdentity API.

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -589,7 +589,7 @@ extra-links:
 connection-types:
   - hook-class-name: airflow.providers.amazon.aws.hooks.s3.S3Hook
     connection-type: s3
-  - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
+  - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook
     connection-type: aws
   - hook-class-name: airflow.providers.amazon.aws.hooks.emr.EmrHook
     connection-type: emr

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -123,7 +123,8 @@ Examples
     )
 
     # Generate Environment Variable Name and Connection URI
-    env_key, conn_uri = f"AIRFLOW_CONN_{conn.conn_id.upper()}", conn.get_uri()
+    env_key = f"AIRFLOW_CONN_{conn.conn_id.upper()}"
+    conn_uri = conn.get_uri()
     print(f"{env_key}={conn_uri}")
     # AIRFLOW_CONN_SAMPLE_AWS_CONNECTION=aws://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY@/?region_name=eu-central-1
 

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -28,8 +28,8 @@ Authenticating to AWS
 
 Authentication may be performed using any of the `boto3 options <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuring-credentials>`_. Alternatively, one can pass credentials in as a Connection initialisation parameter.
 
-To use IAM instance profile, create an "empty" connection (i.e. one with no Login or Password specified, or
-``aws://``).
+To use IAM instance profile, create an "empty" connection (i.e. one with no AWS Access Key ID or AWS Secret Access Key
+specified, or ``aws://``).
 
 
 Default Connection IDs
@@ -49,13 +49,13 @@ Configuring the Connection
 --------------------------
 
 
-Login (optional)
+AWS Access Key ID (optional)
     Specify the AWS access key ID used for the initial connection.
     If you do an `assume role <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`__
     by specifying a ``role_arn`` in the **Extra** field,
     then temporary credentials will be used for subsequent calls to AWS.
 
-Password (optional)
+AWS Secret Access Key (optional)
     Specify the AWS secret access key used for the initial connection.
     If you do an `assume role <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`__
     by specifying a ``role_arn`` in the **Extra** field,
@@ -104,6 +104,33 @@ If you are configuring the connection via a URI, ensure that all components of t
 Examples
 --------
 
+**Snippet for create Connection as URI**:
+  .. code-block:: python
+
+    import os
+    from airflow.models.connection import Connection
+
+
+    conn = Connection(
+        conn_id="sample_aws_connection",
+        conn_type="aws",
+        login="AKIAIOSFODNN7EXAMPLE",  # Reference to AWS Access Key ID
+        password="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",  # Reference to AWS Secret Access Key
+        extra={
+            # Specify extra parameters here
+            "region_name": "eu-central-1",
+        },
+    )
+
+    # Generate Environment Variable Name and Connection URI
+    env_key, conn_uri = f"AIRFLOW_CONN_{conn.conn_id.upper()}", conn.get_uri()
+    print(f"{env_key}={conn_uri}")
+    # AIRFLOW_CONN_SAMPLE_AWS_CONNECTION=aws://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI%2FK7MDENG%2FbPxRfiCYEXAMPLEKEY@/?region_name=eu-central-1
+
+    # Test connection
+    os.environ[env_key] = conn_uri
+    print(conn.test_connection())
+
 **Using instance profile**:
   .. code-block:: bash
 
@@ -125,7 +152,7 @@ Examples for the **Extra** field
 
 1. Using *~/.aws/credentials* and *~/.aws/config* file, with a profile.
 
-This assumes all other Connection fields eg **Login** are empty.
+This assumes all other Connection fields eg **AWS Access Key ID** or **AWS Secret Access Key**  are empty.
 
 .. code-block:: json
 


### PR DESCRIPTION
Follow up #25256

Seems like `host`, `port`, `schema` never used in AWS Connection, disable it in UI.

![image](https://user-images.githubusercontent.com/3998685/181860026-6376987f-d58d-44f2-a7dd-990f0b7cf8ba.png)


