### PR TITLE
Remove WARN as an available logging level

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -40,7 +40,7 @@ killed_task_cleanup_time = 5
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db
 
 [logging]
-celery_logging_level = WARN
+celery_logging_level = WARNING
 
 [api]
 auth_backends = airflow.api.auth.backend.default

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -263,7 +263,7 @@ class AirflowConfigParser(ConfigParser):
         },
     }
 
-    _available_logging_levels = ['CRITICAL', 'FATAL', 'ERROR', 'WARN', 'WARNING', 'INFO', 'DEBUG']
+    _available_logging_levels = ['CRITICAL', 'FATAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG']
     enums_options = {
         ("core", "default_task_weight_rule"): sorted(WeightRule.all_weight_rules()),
         ("core", "dag_ignore_file_syntax"): ["regexp", "glob"],

--- a/newsfragments/25428.bugfix.rst
+++ b/newsfragments/25428.bugfix.rst
@@ -1,0 +1,1 @@
+Remove unsupported WARN log level

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -664,7 +664,7 @@ notacommand = OK
         exception = str(ctx.value)
         message = (
             "`[logging] logging_level` should not be 'XXX'. Possible values: "
-            "CRITICAL, FATAL, ERROR, WARN, WARNING, INFO, DEBUG."
+            "CRITICAL, FATAL, ERROR, WARNING, INFO, DEBUG."
         )
         assert message == exception
 


### PR DESCRIPTION
WARN is not an implemented logging level.
ex.gr. when an airflow component such as the scheduler or worker
is ran with `WARN` set for the `celery_logging_level`, the following exception is
raised in the underlying implementation in click library:

```
click.exceptions.BadParameter: 'WARN' is not one of 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL', 'FATAL'.
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
