### PR TITLE
removed recommendation for using 'token' as login in databricks connection when using auth via PAT

### DIFF
--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -55,7 +55,7 @@ Host (required)
 Login (optional)
     * If authentication with *Databricks login credentials* is used then specify the ``username`` used to login to Databricks.
     * If *authentication with Azure Service Principal* is used then specify the ID of the Azure Service Principal
-    * If authentication with *PAT* is used then leave this field empty
+    * If authentication with *PAT* is used then either leave this field empty or use 'token' as login (both work, the only difference is that if login is empty then token will be sent in request header as Bearer token, if login is 'token' then it will be sent using Basic Auth which is allowed by Databricks API, this may be useful if you plan to reuse this connection with e.g. SimpleHttpOperator)
 
 Password (optional)
     * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -55,11 +55,12 @@ Host (required)
 Login (optional)
     * If authentication with *Databricks login credentials* is used then specify the ``username`` used to login to Databricks.
     * If *authentication with Azure Service Principal* is used then specify the ID of the Azure Service Principal
+    * If authentication with *PAT* is used then leave this field empty
 
 Password (optional)
     * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.
     * If authentication with *Azure Service Principal* is used then specify the secret of the Azure Service Principal
-    * if authentication with *PAT* is used, then specify PAT and use ``token`` as the login (recommended)
+    * If authentication with *PAT* is used, then specify PAT (recommended)
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.


### PR DESCRIPTION
This brings docs in line with what the code does.

If I'm looking at the correct thing in the code the condition that decides whether to use PAT token is checking whether login is empty not whether it is 'token' https://github.com/apache/airflow/blob/main/airflow/providers/databricks/hooks/databricks_base.py#L421
