### PR TITLE
Add dags_tags_filter_condition config to allow using AND

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1420,6 +1420,13 @@
       type: string
       example: "dagrun_cleared,failed"
       default: ~
+    - name: dags_tags_filter_condition
+      description: |
+        When filtering based on tags, the type of logical condition to use.
+        There are only two expected values: "AND" and "OR".
+      type: string
+      example: "AND"
+      default: "OR"
 
 - name: email
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -716,6 +716,9 @@ audit_view_excluded_events = gantt,landing_times,tries,duration,calendar,graph,g
 # Example: audit_view_included_events = dagrun_cleared,failed
 # audit_view_included_events =
 
+# Logical condition for tags filtering (AND or OR).
+dags_tags_filter_condition = AND
+
 [email]
 
 # Configuration email backend and whether to


### PR DESCRIPTION
Allowing filtering of multiple tags using "AND" instead of "OR."
Currently, it's only a config flag, which means it's static per server and not per user. In the future, we should add a UI select box.
closes: #10724