### PR TITLE
Fix `airflow db reset` when dangling tables exist

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1609,7 +1609,8 @@ def drop_airflow_moved_tables(session):
     tables = set(inspect(session.get_bind()).get_table_names())
     to_delete = [Table(x, Base.metadata) for x in tables if x.startswith(AIRFLOW_MOVED_TABLE_PREFIX)]
     for tbl in to_delete:
-        tbl.drop(settings.engine, checkfirst=True)
+        tbl.drop(settings.engine, checkfirst=False)
+        Base.metadata.remove(tbl)
 
 
 def drop_flask_models(connection):


### PR DESCRIPTION
If one of the "dangling" tables already existed in the DB, performing an `airflow db reset` would delete the tables, but it would then try and _re-create_ the table later. This was because the Table object was still associated with the Metadata object.

The fix is to remove the it from Metadata once we have dropped it.