### PR TITLE
Making sure serialization tests run on all example dags

### DIFF
--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -252,8 +252,10 @@ def collect_dags(dag_folder=None):
     else:
         patterns = [
             "airflow/example_dags",
-            "airflow/providers/*/example_dags",
-            "airflow/providers/*/*/example_dags",
+            "airflow/providers/*/example_dags",  # TODO: Remove once AIP-47 is completed
+            "airflow/providers/*/*/example_dags",  # TODO: Remove once AIP-47 is completed
+            "tests/system/providers/*/",
+            "tests/system/providers/*/*/",
         ]
     for pattern in patterns:
         for directory in glob(f"{ROOT_FOLDER}/{pattern}"):


### PR DESCRIPTION
while checking the failure of `TestStringifiedDAGs::test_serialization` in https://github.com/apache/airflow/runs/7608813338?check_suite_focus=true  (PR https://github.com/apache/airflow/pull/25280 )

I noticed that we have:
https://github.com/apache/airflow/blob/7d95bd9f416c9319f6b5c00058b0a1e3bd5bf805/tests/serialization/test_dag_serialization.py#L255-L256

This test suppose to collect all example dags including providers but now in AIP-47 we move the example dags away from this path so the more we move the less coverage this test has.
To solve this I added also the new paths

Before:
```
[2022-08-01 14:31:26,772] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/example_dags
[2022-08-01 14:31:27,300] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/airbyte/example_dags
[2022-08-01 14:31:27,712] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/arangodb/example_dags
[2022-08-01 14:31:28,146] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/amazon/aws/example_dags
[2022-08-01 14:31:30,242] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/cloud/example_dags
[2022-08-01 14:31:35,071] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/marketing_platform/example_dags
[2022-08-01 14:31:35,435] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/suite/example_dags
PASSED
```

After:

```
[2022-08-01 14:32:49,956] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/example_dags
[2022-08-01 14:32:50,582] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/airbyte/example_dags
[2022-08-01 14:32:50,993] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/arangodb/example_dags
[2022-08-01 14:32:51,447] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/amazon/aws/example_dags
[2022-08-01 14:32:53,703] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/cloud/example_dags
[2022-08-01 14:32:59,081] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/marketing_platform/example_dags
[2022-08-01 14:32:59,431] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/airflow/providers/google/suite/example_dags
[2022-08-01 14:32:59,802] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/alibaba/
[2022-08-01 14:33:00,357] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/amazon/
[2022-08-01 14:33:05,983] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/apache/
[2022-08-01 14:33:06,909] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/asana/
[2022-08-01 14:33:07,237] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/cncf/
[2022-08-01 14:33:07,574] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/common/
[2022-08-01 14:33:07,889] {dagbag.py:508} INFO - Filling up the DagBag from /opt/airflow/tests/system/providers/databricks/
...
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
