### PR TITLE
modify FacebookAdsReportingHook to pass Facebook access token in the …

### DIFF
--- a/airflow/providers/facebook/ads/hooks/ads.py
+++ b/airflow/providers/facebook/ads/hooks/ads.py
@@ -92,7 +92,7 @@ class FacebookAdsReportingHook(BaseHook):
         """
         self.log.info("Fetching fb connection: %s", self.facebook_conn_id)
         conn = self.get_connection(self.facebook_conn_id)
-        config = {**conn.extra_dejson, **{"access_token":conn.password}}
+        config = {**conn.extra_dejson, "access_token": conn.password}
         missing_keys = self.client_required_fields - config.keys()
         if missing_keys:
             message = f"{missing_keys} fields are missing"

--- a/airflow/providers/facebook/ads/hooks/ads.py
+++ b/airflow/providers/facebook/ads/hooks/ads.py
@@ -92,7 +92,7 @@ class FacebookAdsReportingHook(BaseHook):
         """
         self.log.info("Fetching fb connection: %s", self.facebook_conn_id)
         conn = self.get_connection(self.facebook_conn_id)
-        config = conn.extra_dejson
+        config = {**conn.extra_dejson, **{"access_token":conn.password}}
         missing_keys = self.client_required_fields - config.keys()
         if missing_keys:
             message = f"{missing_keys} fields are missing"


### PR DESCRIPTION
…password parameter so it's not exposed in the Astronomer UI

This change allows the user to create a connection by passing "app_id", "app_secret", and "account_id" into the extra parameter and the "access_token" into the password parameter. This allows the access_token to be masked, as is default behavior in Astronomer, rather than exposed in the UI.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
