### PR TITLE
Enable "upgrade_to_newer_dependencies" when only provider.yaml change

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -130,6 +130,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^setup.cfg",
             r"^setup.py",
             r"^generated/provider_dependencies.json$",
+            r"^airflow/providers/.*/provider.yaml$",
         ],
         FileGroupForCi.DOC_FILES: [
             r"^docs",

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -612,3 +612,54 @@ def test_no_commit_provided_trigger_full_build_for_any_event_type(github_event):
         },
         str(sc),
     )
+
+
+@pytest.mark.parametrize(
+    "files, expected_outputs,",
+    [
+        pytest.param(
+            ("airflow/models/dag.py",),
+            {
+                "upgrade-to-newer-dependencies": "false",
+            },
+            id="Regular source changed",
+        ),
+        pytest.param(
+            ("setup.py",),
+            {
+                "upgrade-to-newer-dependencies": "true",
+            },
+            id="Setup.py changed",
+        ),
+        pytest.param(
+            ("setup.cfg",),
+            {
+                "upgrade-to-newer-dependencies": "true",
+            },
+            id="Setup.cfg changed",
+        ),
+        pytest.param(
+            ('airflow/providers/microsoft/azure/provider.yaml',),
+            {
+                "upgrade-to-newer-dependencies": "true",
+            },
+            id="Provider.yaml changed",
+        ),
+        pytest.param(
+            ('generated/provider_dependencies.json',),
+            {
+                "upgrade-to-newer-dependencies": "true",
+            },
+            id="Generated provider_dependencies changed",
+        ),
+    ],
+)
+def test_upgrade_to_newer_dependencies(files: Tuple[str, ...], expected_outputs: Dict[str, str]):
+    sc = SelectiveChecks(
+        files=files,
+        commit_ref="HEAD",
+        github_event=GithubEvents.PULL_REQUEST,
+        pr_labels=(),
+        default_branch="main",
+    )
+    assert_outputs_are_printed(expected_outputs, str(sc))


### PR DESCRIPTION
When provider.yaml change and pre-commig has not be run to regenerate
generated/dependencies.json, it might happen that building CI image
will fail due to conflicting dependencies so developer has no
chance to find out that pre-commit needs to be also run dependencies
regenerated.

This PR changes selective checks to also trigger the dependencies
upgrade when only provider.yaml changed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
