### PR TITLE
Fix Serialization error in TaskCallbackRequest

### DIFF
--- a/airflow/callbacks/callback_requests.py
+++ b/airflow/callbacks/callback_requests.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import copy
 import json
 from typing import TYPE_CHECKING, Optional
 
@@ -74,8 +75,8 @@ class TaskCallbackRequest(CallbackRequest):
         self.is_failure_callback = is_failure_callback
 
     def to_json(self) -> str:
-        dict_obj = self.__dict__.copy()
-        dict_obj["simple_task_instance"] = dict_obj["simple_task_instance"].__dict__
+        dict_obj = copy.deepcopy(self.__dict__)
+        dict_obj["simple_task_instance"] = dict_obj["simple_task_instance"].as_dict()
         return json.dumps(dict_obj)
 
     @classmethod

--- a/airflow/callbacks/callback_requests.py
+++ b/airflow/callbacks/callback_requests.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import copy
 import json
 from typing import TYPE_CHECKING, Optional
 
@@ -75,8 +74,8 @@ class TaskCallbackRequest(CallbackRequest):
         self.is_failure_callback = is_failure_callback
 
     def to_json(self) -> str:
-        dict_obj = copy.deepcopy(self.__dict__)
-        dict_obj["simple_task_instance"] = dict_obj["simple_task_instance"].as_dict()
+        dict_obj = self.__dict__.copy()
+        dict_obj["simple_task_instance"] = self.simple_task_instance.as_dict()
         return json.dumps(dict_obj)
 
     @classmethod

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2631,6 +2631,15 @@ class SimpleTaskInstance:
             return self.__dict__ == other.__dict__
         return NotImplemented
 
+    def as_dict(self):
+        for key in self.__dict__:
+            if key in ['start_date', 'end_date']:
+                val = getattr(self, key)
+                if not val or isinstance(val, str):
+                    continue
+                self.__dict__.update({key: val.isoformat()})
+        return self.__dict__
+
     @classmethod
     def from_ti(cls, ti: TaskInstance) -> "SimpleTaskInstance":
         return cls(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2632,13 +2632,14 @@ class SimpleTaskInstance:
         return NotImplemented
 
     def as_dict(self):
-        for key in self.__dict__:
+        new_dict = dict(self.__dict__)
+        for key in new_dict:
             if key in ['start_date', 'end_date']:
-                val = getattr(self, key)
+                val = new_dict[key]
                 if not val or isinstance(val, str):
                     continue
-                self.__dict__.update({key: val.isoformat()})
-        return self.__dict__
+                new_dict.update({key: val.isoformat()})
+        return new_dict
 
     @classmethod
     def from_ti(cls, ti: TaskInstance) -> "SimpleTaskInstance":


### PR DESCRIPTION
How we serialize `SimpleTaskInstance `in `TaskCallbackRequest` class leads to JSON serialization error when there's start_date or end_date in the task instance. Since there's always a start_date on tis, this would always fail.
This PR aims to fix this through a new method on the SimpleTaskInstance that looks for start_date/end_date and converts them to isoformat for serialization.

Closes: https://github.com/apache/airflow/issues/25343