### PR TITLE
Fix PostgresToGCSOperat bool dtype

### DIFF
--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -88,7 +88,7 @@ class PostgresToGCSOperator(BaseSQLToGCSOperator):
         20: 'INTEGER',
         21: 'INTEGER',
         23: 'INTEGER',
-        16: 'BOOLEAN',
+        16: 'BOOL',
         700: 'FLOAT',
         701: 'FLOAT',
         1700: 'FLOAT',


### PR DESCRIPTION
When converting postgres boolean data type it was defaulting to the
parquet parquet.string() data type. Pyarrow would then raise an error
when attempting to convert the boolean data type into its string.

Changing the PostgresToGCSOperator class map `data_type` to convert
postgres boolean type to bigquery `BOOL` data type which then maps to
the parquet `pa.bool_()` data type when `_convert_parquet_schema` is
called.

closes: #25474

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
