### PR TITLE
Better warning and instructions in case someone runs emulated Python

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -157,15 +157,21 @@ def check_for_rosetta_environment():
             from airflow_breeze.utils.console import get_console
 
             get_console().print(
-                '\n\n[error]You are starting breeze in `rosetta 2` emulated environment on Mac[/]'
+                '\n\n[error]You are starting breeze in `rosetta 2` emulated environment on Mac[/]\n'
             )
             get_console().print(
-                '[warning]This is very bad and your Python is 10x slower as it is emulated[/]'
+                '[warning]This is very bad and your Python is 10x slower as it is emulated[/]\n'
             )
             get_console().print(
-                '[warning]You likely have wrong architecture-based IDE (PyCharm/VSCode/Intellij) that '
-                'you run it on\n'
-                'You should download the right architecture for your Mac (Apple Silicon or Intel)[/]\n'
+                'You have emulated Python interpreter (Intel rather than ARM). You should check:\n\n'
+                '  * Your IDE (PyCharm/VSCode/Intellij): the "About" window should show `aarch64` '
+                'not `x86_64` in "Runtime version".\n'
+                '  * Your python: run  "python -c '
+                'import platform; print(platform.uname().machine)"). '
+                'It should show `arm64` not `x86_64`.\n'
+                '  * Your `brew`: run "brew config" and it should show `arm` in CPU line not `x86`.\n\n'
+                'If you have mixed Intel/ARM binaries installed you should likely nuke and '
+                'reinstall your development environment (including brew and Python) from scratch!\n\n'
             )
             from inputimeout import inputimeout
 


### PR DESCRIPTION
It seems that the problem with runnig an emulated Python with rosetta
on Macs M1/M2 might be more widespread. There are various scenarios
where people could get the emulated Python:

* Installing application with pre-bundled Intel Python (Intellj/PyCharm)
* Installing older Python via anaconda
* Transferring the configuration from Intel based Macs (yes, Apple
  will NOT warn you when you are copying brew, python and other
  binaries during the Apple-blessed "Transfer my Mac").

This means that proably quite a number of people currently runs
Intel, emulated version of Python on their shiny new M1s which
slows the Python (and thus Airflow) more than 10x.

We alredy had a warning about it, but now it is more explicit, telling
the user what exactly should be checked and how to rectify from
the situation (basically nuking the development environment including
brew and restarting from scratch is the best option you have).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
