### PR TITLE
Deprecate usage of `extra[host]` in AWS's connection

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -630,7 +630,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
                         "assume_role_method": "assume_role",
                         "assume_role_kwargs": {"RoleSessionName": "airflow"},
                         "aws_session_token": "AQoDYXdzEJr...EXAMPLETOKEN",
-                        "host": "http://localhost:4566",
+                        "endpoint_url": "http://localhost:4566",
                     },
                     indent=2,
                 ),

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -152,7 +152,24 @@ class AwsConnectionWrapper(LoggingMixin):
             self.log.info("Retrieving botocore config=%s from %s extra.", config_kwargs, self.conn_repr)
             self.botocore_config = Config(**config_kwargs)
 
+        if conn.host:
+            warnings.warn(
+                f"Host {conn.host} specified in the connection is not used."
+                " Please, set it on extra['endpoint_url'] instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.endpoint_url = extra.get("host")
+        if self.endpoint_url:
+            warnings.warn(
+                "extra['host'] is deprecated and will be removed in a future release."
+                " Please set extra['endpoint_url'] instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
+            self.endpoint_url = extra.get("endpoint_url")
 
         # Retrieve Assume Role Configuration
         assume_role_configs = self._get_assume_role_configs(**extra)

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -83,7 +83,7 @@ Extra (optional)
       `assume_role_with_web_identity <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html>`__
       if not specified then **assume_role** is used.
     * ``assume_role_kwargs``: Additional **kwargs** passed to ``assume_role_method``.
-    * ``host``: Endpoint URL for the connection.
+    * ``endpoint_url``: Endpoint URL for the connection.
 
 .. warning:: Extra parameters below are deprecated and will be removed in a future version of this provider.
 
@@ -98,6 +98,7 @@ Extra (optional)
       `s3cmd <https://s3tools.org/kb/item14.htm>`_ if not specified then **boto** is used.
     * ``profile``: If you are getting your credentials from the ``s3_config_file``
       you can specify the profile with this parameter.
+    * ``host``: Used as connection's URL. Use ``endpoint_url`` instead.
 
 If you are configuring the connection via a URI, ensure that all components of the URI are URL-encoded.
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Deprecate extra's `host` argument to favor connection's host.
closes: #17833
---



Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
