### PR TITLE
Add optional data interval to CronTriggerTimetable

### DIFF
--- a/airflow/timetables/_cron.py
+++ b/airflow/timetables/_cron.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from cron_descriptor import CasingTypeEnum, ExpressionDescriptor, FormatException, MissingFieldException
+from croniter import CroniterBadCronError, CroniterBadDateError, croniter
+from pendulum import DateTime
+from pendulum.tz.timezone import Timezone
+
+from airflow.compat.functools import cached_property
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.utils.dates import cron_presets
+from airflow.utils.timezone import convert_to_utc, make_aware, make_naive
+
+
+def _is_schedule_fixed(expression: str) -> bool:
+    """Figures out if the schedule has a fixed time (e.g. 3 AM every day).
+
+    :return: True if the schedule has a fixed time, False if not.
+
+    Detection is done by "peeking" the next two cron trigger time; if the
+    two times have the same minute and hour value, the schedule is fixed,
+    and we *don't* need to perform the DST fix.
+
+    This assumes DST happens on whole minute changes (e.g. 12:59 -> 12:00).
+    """
+    cron = croniter(expression)
+    next_a = cron.get_next(datetime.datetime)
+    next_b = cron.get_next(datetime.datetime)
+    return next_b.minute == next_a.minute and next_b.hour == next_a.hour
+
+
+class CronMixin:
+    """Mixin to provide interface to work with croniter."""
+
+    def __init__(self, cron: str, timezone: str | Timezone) -> None:
+        self._expression = cron_presets.get(cron, cron)
+
+        if isinstance(timezone, str):
+            timezone = Timezone(timezone)
+        self._timezone = timezone
+
+        descriptor = ExpressionDescriptor(
+            expression=self._expression, casing_type=CasingTypeEnum.Sentence, use_24hour_time_format=True
+        )
+        try:
+            # checking for more than 5 parameters in Cron and avoiding evaluation for now,
+            # as Croniter has inconsistent evaluation with other libraries
+            if len(croniter(self._expression).expanded) > 5:
+                raise FormatException()
+            interval_description = descriptor.get_description()
+        except (CroniterBadCronError, FormatException, MissingFieldException):
+            interval_description = ""
+        self.description = interval_description
+
+    def __eq__(self, other: Any) -> bool:
+        """Both expression and timezone should match.
+
+        This is only for testing purposes and should not be relied on otherwise.
+        """
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self._expression == other._expression and self._timezone == other._timezone
+
+    @property
+    def summary(self) -> str:
+        return self._expression
+
+    def validate(self) -> None:
+        try:
+            croniter(self._expression)
+        except (CroniterBadCronError, CroniterBadDateError) as e:
+            raise AirflowTimetableInvalid(str(e))
+
+    @cached_property
+    def _should_fix_dst(self) -> bool:
+        # This is lazy so instantiating a schedule does not immediately raise
+        # an exception. Validity is checked with validate() during DAG-bagging.
+        return not _is_schedule_fixed(self._expression)
+
+    def _get_next(self, current: DateTime) -> DateTime:
+        """Get the first schedule after specified time, with DST fixed."""
+        naive = make_naive(current, self._timezone)
+        cron = croniter(self._expression, start_time=naive)
+        scheduled = cron.get_next(datetime.datetime)
+        if not self._should_fix_dst:
+            return convert_to_utc(make_aware(scheduled, self._timezone))
+        delta = scheduled - naive
+        return convert_to_utc(current.in_timezone(self._timezone) + delta)
+
+    def _get_prev(self, current: DateTime) -> DateTime:
+        """Get the first schedule before specified time, with DST fixed."""
+        naive = make_naive(current, self._timezone)
+        cron = croniter(self._expression, start_time=naive)
+        scheduled = cron.get_prev(datetime.datetime)
+        if not self._should_fix_dst:
+            return convert_to_utc(make_aware(scheduled, self._timezone))
+        delta = naive - scheduled
+        return convert_to_utc(current.in_timezone(self._timezone) - delta)
+
+    def _align(self, current: DateTime) -> DateTime:
+        """Get the next scheduled time.
+
+        This is ``current + interval``, unless ``current`` falls right on the
+        interval boundary, when ``current`` is returned.
+        """
+        next_time = self._get_next(current)
+        if self._get_prev(next_time) != current:
+            return next_time
+        return current

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -18,17 +18,13 @@
 import datetime
 from typing import Any, Dict, Optional, Union
 
-from cron_descriptor import CasingTypeEnum, ExpressionDescriptor, FormatException, MissingFieldException
-from croniter import CroniterBadCronError, CroniterBadDateError, croniter
 from dateutil.relativedelta import relativedelta
 from pendulum import DateTime
-from pendulum.tz.timezone import Timezone
 
-from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowTimetableInvalid
+from airflow.timetables._cron import CronMixin
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.utils.dates import cron_presets
-from airflow.utils.timezone import convert_to_utc, make_aware, make_naive
+from airflow.utils.timezone import convert_to_utc
 
 Delta = Union[datetime.timedelta, relativedelta]
 
@@ -97,115 +93,7 @@ class _DataIntervalTimetable(Timetable):
         return DagRunInfo.interval(start=start, end=end)
 
 
-def _is_schedule_fixed(expression: str) -> bool:
-    """Figures out if the schedule has a fixed time (e.g. 3 AM every day).
-
-    :return: True if the schedule has a fixed time, False if not.
-
-    Detection is done by "peeking" the next two cron trigger time; if the
-    two times have the same minute and hour value, the schedule is fixed,
-    and we *don't* need to perform the DST fix.
-
-    This assumes DST happens on whole minute changes (e.g. 12:59 -> 12:00).
-    """
-    cron = croniter(expression)
-    next_a = cron.get_next(datetime.datetime)
-    next_b = cron.get_next(datetime.datetime)
-    return next_b.minute == next_a.minute and next_b.hour == next_a.hour
-
-
-class _CronMixin:
-    def __init__(self, cron: str, timezone: Union[str, Timezone]) -> None:
-        self._expression = cron_presets.get(cron, cron)
-
-        if isinstance(timezone, str):
-            timezone = Timezone(timezone)
-        self._timezone = timezone
-
-        descriptor = ExpressionDescriptor(
-            expression=self._expression, casing_type=CasingTypeEnum.Sentence, use_24hour_time_format=True
-        )
-        try:
-            # checking for more than 5 parameters in Cron and avoiding evaluation for now,
-            # as Croniter has inconsistent evaluation with other libraries
-            if len(croniter(self._expression).expanded) > 5:
-                raise FormatException()
-            interval_description = descriptor.get_description()
-        except (CroniterBadCronError, FormatException, MissingFieldException):
-            interval_description = ""
-        self.description = interval_description
-
-    @classmethod
-    def deserialize(cls, data: Dict[str, Any]) -> "Timetable":
-        from airflow.serialization.serialized_objects import decode_timezone
-
-        # We ignore typing on the next line because mypy expects it to return _CronMixin type.
-        # However, this should return Timetable since it should only be called against a timetable subclass
-        return cls(data["expression"], decode_timezone(data["timezone"]))  # type: ignore
-
-    def __eq__(self, other: Any) -> bool:
-        """Both expression and timezone should match.
-
-        This is only for testing purposes and should not be relied on otherwise.
-        """
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return self._expression == other._expression and self._timezone == other._timezone
-
-    @property
-    def summary(self) -> str:
-        return self._expression
-
-    def serialize(self) -> Dict[str, Any]:
-        from airflow.serialization.serialized_objects import encode_timezone
-
-        return {"expression": self._expression, "timezone": encode_timezone(self._timezone)}
-
-    def validate(self) -> None:
-        try:
-            croniter(self._expression)
-        except (CroniterBadCronError, CroniterBadDateError) as e:
-            raise AirflowTimetableInvalid(str(e))
-
-    @cached_property
-    def _should_fix_dst(self) -> bool:
-        # This is lazy so instantiating a schedule does not immediately raise
-        # an exception. Validity is checked with validate() during DAG-bagging.
-        return not _is_schedule_fixed(self._expression)
-
-    def _get_next(self, current: DateTime) -> DateTime:
-        """Get the first schedule after specified time, with DST fixed."""
-        naive = make_naive(current, self._timezone)
-        cron = croniter(self._expression, start_time=naive)
-        scheduled = cron.get_next(datetime.datetime)
-        if not self._should_fix_dst:
-            return convert_to_utc(make_aware(scheduled, self._timezone))
-        delta = scheduled - naive
-        return convert_to_utc(current.in_timezone(self._timezone) + delta)
-
-    def _get_prev(self, current: DateTime) -> DateTime:
-        """Get the first schedule before specified time, with DST fixed."""
-        naive = make_naive(current, self._timezone)
-        cron = croniter(self._expression, start_time=naive)
-        scheduled = cron.get_prev(datetime.datetime)
-        if not self._should_fix_dst:
-            return convert_to_utc(make_aware(scheduled, self._timezone))
-        delta = naive - scheduled
-        return convert_to_utc(current.in_timezone(self._timezone) - delta)
-
-    def _align(self, current: DateTime) -> DateTime:
-        """Get the next scheduled time.
-
-        This is ``current + interval``, unless ``current`` falls right on the
-        interval boundary, when ``current`` is returned.
-        """
-        next_time = self._get_next(current)
-        if self._get_prev(next_time) != current:
-            return next_time
-        return current
-
-
-class CronDataIntervalTimetable(_CronMixin, _DataIntervalTimetable):
+class CronDataIntervalTimetable(CronMixin, _DataIntervalTimetable):
     """Timetable that schedules data intervals with a cron expression.
 
     This corresponds to ``schedule_interval=<cron>``, where ``<cron>`` is either
@@ -217,6 +105,17 @@ class CronDataIntervalTimetable(_CronMixin, _DataIntervalTimetable):
 
     Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
     """
+
+    @classmethod
+    def deserialize(cls, data: Dict[str, Any]) -> Timetable:
+        from airflow.serialization.serialized_objects import decode_timezone
+
+        return cls(data["expression"], decode_timezone(data["timezone"]))
+
+    def serialize(self) -> Dict[str, Any]:
+        from airflow.serialization.serialized_objects import encode_timezone
+
+        return {"expression": self._expression, "timezone": encode_timezone(self._timezone)}
 
     def _skip_to_latest(self, earliest: Optional[DateTime]) -> DateTime:
         """Bound the earliest time a run can be scheduled.
@@ -247,48 +146,6 @@ class CronDataIntervalTimetable(_CronMixin, _DataIntervalTimetable):
         # run at 1am 25th is between 0am 24th and 0am 25th.
         end = self._get_prev(self._align(run_after))
         return DataInterval(start=self._get_prev(end), end=end)
-
-
-class CronTriggerTimetable(_CronMixin, Timetable):
-    """A cron-compliant timetable.
-
-    The main difference from ``CronDataIntervalTimetable`` is that a first
-    DAG Run is kicked off at the start of the period like a normal cron,
-    while a first DAG Run of ``CronDataIntervalTimetable`` starts immediately
-    after the DAG is registered.
-
-    Note that this timetable does not care the idea of *data interval*. It
-    means the value of ``data_interval_start``, ``data_interval_end`` and
-    legacy ``execution_date`` are the same - the time when a DAG run is triggered.
-
-    Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
-    """
-
-    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
-        return DataInterval.exact(run_after)
-
-    def next_dagrun_info(
-        self,
-        *,
-        last_automated_data_interval: Optional[DataInterval],
-        restriction: TimeRestriction,
-    ) -> Optional[DagRunInfo]:
-        if restriction.catchup:
-            if last_automated_data_interval is None:
-                if restriction.earliest is None:
-                    return None
-                next_start_time = self._align(restriction.earliest)
-            else:
-                next_start_time = self._get_next(last_automated_data_interval.end)
-        else:
-            current_time = DateTime.utcnow()
-            if restriction.earliest is not None and current_time < restriction.earliest:
-                next_start_time = self._align(restriction.earliest)
-            else:
-                next_start_time = self._align(current_time)
-        if restriction.latest is not None and restriction.latest < next_start_time:
-            return None
-        return DagRunInfo.exact(next_start_time)
 
 
 class DeltaDataIntervalTimetable(_DataIntervalTimetable):

--- a/airflow/timetables/trigger.py
+++ b/airflow/timetables/trigger.py
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from dateutil.relativedelta import relativedelta
+from pendulum import DateTime
+from pendulum.tz.timezone import Timezone
+
+from airflow.timetables._cron import CronMixin
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+
+
+class CronTriggerTimetable(CronMixin, Timetable):
+    """Timetable that triggers DAG runs according to a cron expression.
+
+    This is different from ``CronDataIntervalTimetable``, where the cron
+    expression specifies the *data interval* of a DAG run. With this timetable,
+    the data intervals are specified independently from the cron expression.
+    Also for the same reason, this timetable kicks off a DAG run immediately at
+    the start of the period (similar to POSIX cron), instead of needing to wait
+    for one data interval to pass.
+
+    Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
+    """
+
+    def __init__(
+        self,
+        cron: str,
+        *,
+        timezone: str | Timezone,
+        interval: datetime.timedelta | relativedelta = datetime.timedelta(),
+    ) -> None:
+        super().__init__(cron, timezone)
+        self._interval = interval
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> Timetable:
+        from airflow.serialization.serialized_objects import decode_relativedelta, decode_timezone
+
+        interval: datetime.timedelta | relativedelta
+        if isinstance(data["interval"], dict):
+            interval = decode_relativedelta(data["interval"])
+        else:
+            interval = datetime.timedelta(seconds=data["interval"])
+        return cls(data["expression"], timezone=decode_timezone(data["timezone"]), interval=interval)
+
+    def serialize(self) -> dict[str, Any]:
+        from airflow.serialization.serialized_objects import encode_relativedelta, encode_timezone
+
+        interval: float | dict[str, Any]
+        if isinstance(self._interval, datetime.timedelta):
+            interval = self._interval.total_seconds()
+        else:
+            interval = encode_relativedelta(self._interval)
+        timezone = encode_timezone(self._timezone)
+        return {"expression": self._expression, "timezone": timezone, "interval": interval}
+
+    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
+        return DataInterval(run_after - self._interval, run_after)
+
+    def next_dagrun_info(
+        self,
+        *,
+        last_automated_data_interval: DataInterval | None,
+        restriction: TimeRestriction,
+    ) -> DagRunInfo | None:
+        if restriction.catchup:
+            if last_automated_data_interval is None:
+                if restriction.earliest is None:
+                    return None
+                next_start_time = self._align(restriction.earliest)
+            else:
+                next_start_time = self._get_next(last_automated_data_interval.end)
+        else:
+            current_time = DateTime.utcnow()
+            if restriction.earliest is not None and current_time < restriction.earliest:
+                next_start_time = self._align(restriction.earliest)
+            else:
+                next_start_time = self._align(current_time)
+        if restriction.latest is not None and restriction.latest < next_start_time:
+            return None
+        return DagRunInfo.interval(next_start_time - self._interval, next_start_time)

--- a/docs/apache-airflow/concepts/timetable.rst
+++ b/docs/apache-airflow/concepts/timetable.rst
@@ -60,20 +60,43 @@ may be available in plugins.
 CronTriggerTimetable
 ^^^^^^^^^^^^^^^^^^^^
 
-A timetable which accepts a cron expression.
+A timetable that accepts a cron expression, and triggers DAG runs according to it.
 
-Note `CronDataIntervalTimetable`_ also accepts a cron expression. See `Differences between the two cron timetables`_.
+.. seealso:: `Differences between the two cron timetables`_
 
 .. code-block:: python
 
-    from airflow.timetables.interval import CronTriggerTimetable
+    from airflow.timetables.trigger import CronTriggerTimetable
 
 
     @dag(
-        timetable=CronTriggerTimetable(cron='0 1 * * 3', timezone='UTC'),  # At 01:00 on Wednesday
+        timetable=CronTriggerTimetable('0 1 * * 3', timezone='UTC'),  # At 01:00 on Wednesday
     )
     def example_dag():
         pass
+
+It is also possible to provide a static data interval to the timetable. The optional ``interval`` argument
+must be a :class:`datetime.timedelta` or ``dateutil.relativedelta.relativedelta``. If given, a triggered DAG
+run's data interval would span the specified duration, and *ends* with the trigger time.
+
+.. code-block:: python
+
+    from datetime import timedelta
+
+    from airflow.timetables.trigger import CronTriggerTimetable
+
+
+    @dag(
+        # Runs every Friday at 18:00 to cover the work week (9:00 Monday to 18:00 Friday).
+        timetable=CronTriggerTimetable(
+            "0 18 * * 5",
+            timezone="UTC",
+            interval=timedelta(days=4, hours=9),
+        ),
+    )
+    def example_dag():
+        pass
+
 
 .. _DeltaDataIntervalTimetable:
 
@@ -94,11 +117,13 @@ Schedules data intervals with a time delta. Can be selected by providing a
 CronDataIntervalTimetable
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Another timetable which accepts a cron expression. Can be selected by providing a string that is a valid
-cron expression to the ``schedule_interval`` parameter of a DAG as described in the :doc:`/concepts/dags` documentation.
+A timetable that accepts a cron expression, creates data intervals according to the interval between each cron
+trigger points, and triggers a DAG run at the end of each data interval.
 
+.. seealso:: `Differences between the two cron timetables`_
 
-Note `CronTriggerTimetable`_ also accepts a cron expression. See `Differences between the two cron timetables`_.
+This can be selected by providing a string that is a valid cron expression to the ``schedule_interval``
+parameter of a DAG as described in the :doc:`/concepts/dags` documentation.
 
 .. code-block:: python
 

--- a/tests/timetables/test_interval_timetable.py
+++ b/tests/timetables/test_interval_timetable.py
@@ -26,11 +26,7 @@ import pytest
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.settings import TIMEZONE
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.timetables.interval import (
-    CronDataIntervalTimetable,
-    CronTriggerTimetable,
-    DeltaDataIntervalTimetable,
-)
+from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
 
 START_DATE = pendulum.DateTime(2021, 9, 4, tzinfo=TIMEZONE)
 
@@ -43,12 +39,10 @@ CURRENT_TIME = pendulum.DateTime(2021, 9, 7, tzinfo=TIMEZONE)
 YESTERDAY = CURRENT_TIME - datetime.timedelta(days=1)
 
 HOURLY_CRON_TIMETABLE = CronDataIntervalTimetable("@hourly", TIMEZONE)
-HOURLY_CRON_TRIGGER_TIMETABLE = CronTriggerTimetable("@hourly", TIMEZONE)
 HOURLY_TIMEDELTA_TIMETABLE = DeltaDataIntervalTimetable(datetime.timedelta(hours=1))
 HOURLY_RELATIVEDELTA_TIMETABLE = DeltaDataIntervalTimetable(dateutil.relativedelta.relativedelta(hours=1))
 
 CRON_TIMETABLE = CronDataIntervalTimetable("30 16 * * *", TIMEZONE)
-CRON_TRIGGER_TIMETABLE = CronTriggerTimetable("30 16 * * *", TIMEZONE)
 DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
 
 
@@ -67,23 +61,6 @@ def test_no_catchup_first_starts_at_current_time(
     )
     expected_start = YESTERDAY + DELTA_FROM_MIDNIGHT
     assert next_info == DagRunInfo.interval(start=expected_start, end=CURRENT_TIME + DELTA_FROM_MIDNIGHT)
-
-
-@pytest.mark.parametrize(
-    "last_automated_data_interval",
-    [pytest.param(None, id="first-run"), pytest.param(PREV_DATA_INTERVAL_EXACT, id="subsequent")],
-)
-@freezegun.freeze_time(CURRENT_TIME)
-def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
-    last_automated_data_interval: Optional[DataInterval],
-) -> None:
-    """If ``catchup=False`` and start_date is a day before"""
-    next_info = CRON_TRIGGER_TIMETABLE.next_dagrun_info(
-        last_automated_data_interval=last_automated_data_interval,
-        restriction=TimeRestriction(earliest=YESTERDAY, latest=None, catchup=False),
-    )
-    expected = CURRENT_TIME + DELTA_FROM_MIDNIGHT
-    assert next_info == DagRunInfo.exact(expected)
 
 
 @pytest.mark.parametrize(
@@ -131,87 +108,9 @@ def test_catchup_next_info_starts_at_previous_interval_end(timetable: Timetable)
 
 
 @pytest.mark.parametrize(
-    "current_time, earliest, expected",
-    [
-        pytest.param(
-            pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE),
-            START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
-            id="current_time_on_boundary",
-        ),
-        pytest.param(
-            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
-            START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
-            id="current_time_not_on_boundary",
-        ),
-        pytest.param(
-            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
-            pendulum.DateTime(2199, 12, 31, 22, 30, 0, tzinfo=TIMEZONE),
-            DagRunInfo.exact(pendulum.DateTime(2199, 12, 31, 23, 0, 0, tzinfo=TIMEZONE)),
-            id="future_start_date",
-        ),
-    ],
-)
-def test_hourly_cron_trigger_no_catchup_next_info(
-    current_time: pendulum.DateTime,
-    earliest: pendulum.DateTime,
-    expected: DagRunInfo,
-) -> None:
-    with freezegun.freeze_time(current_time):
-        next_info = HOURLY_CRON_TRIGGER_TIMETABLE.next_dagrun_info(
-            last_automated_data_interval=PREV_DATA_INTERVAL_EXACT,
-            restriction=TimeRestriction(earliest=earliest, latest=None, catchup=False),
-        )
-    assert next_info == expected
-
-
-@pytest.mark.parametrize(
-    "last_automated_data_interval, earliest, expected",
-    [
-        pytest.param(
-            DataInterval.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
-            START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
-            id="last_automated_on_boundary",
-        ),
-        pytest.param(
-            DataInterval.exact(pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE)),
-            START_DATE,
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
-            id="last_automated_not_on_boundary",
-        ),
-        pytest.param(
-            None,
-            pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE),
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
-            id="no_last_automated_with_earliest_on_boundary",
-        ),
-        pytest.param(
-            None,
-            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
-            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
-            id="no_last_automated_with_earliest_not_on_boundary",
-        ),
-    ],
-)
-def test_hourly_cron_trigger_catchup_next_info(
-    last_automated_data_interval: DataInterval,
-    earliest: pendulum.DateTime,
-    expected: DagRunInfo,
-) -> None:
-    next_info = HOURLY_CRON_TRIGGER_TIMETABLE.next_dagrun_info(
-        last_automated_data_interval=last_automated_data_interval,
-        restriction=TimeRestriction(earliest=earliest, latest=None, catchup=True),
-    )
-    assert next_info == expected
-
-
-@pytest.mark.parametrize(
     "timetable",
     [
         pytest.param(HOURLY_CRON_TIMETABLE, id="cron"),
-        pytest.param(HOURLY_CRON_TRIGGER_TIMETABLE, id="cron_trigger"),
         pytest.param(HOURLY_TIMEDELTA_TIMETABLE, id="timedelta"),
         pytest.param(HOURLY_RELATIVEDELTA_TIMETABLE, id="relativedelta"),
     ],
@@ -227,11 +126,6 @@ def test_validate_success(timetable: Timetable) -> None:
             CronDataIntervalTimetable("0 0 1 13 0", TIMEZONE),
             "[0 0 1 13 0] is not acceptable, out of range",
             id="invalid-cron",
-        ),
-        pytest.param(
-            CronTriggerTimetable("0 0 1 13 0", TIMEZONE),
-            "[0 0 1 13 0] is not acceptable, out of range",
-            id="invalid-cron-trigger",
         ),
         pytest.param(
             DeltaDataIntervalTimetable(datetime.timedelta()),

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+from __future__ import annotations
+
+import datetime
+import typing
+
+import dateutil.relativedelta
+import freezegun
+import pendulum
+import pendulum.tz
+import pytest
+
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction
+from airflow.timetables.trigger import CronTriggerTimetable
+
+TIMEZONE = pendulum.tz.timezone("UTC")
+START_DATE = pendulum.DateTime(2021, 9, 4, tzinfo=TIMEZONE)
+
+PREV_DATA_INTERVAL_END = START_DATE + datetime.timedelta(days=1)
+PREV_DATA_INTERVAL_EXACT = DataInterval.exact(PREV_DATA_INTERVAL_END)
+
+CURRENT_TIME = pendulum.DateTime(2021, 9, 7, tzinfo=TIMEZONE)
+YESTERDAY = CURRENT_TIME - datetime.timedelta(days=1)
+
+HOURLY_CRON_TRIGGER_TIMETABLE = CronTriggerTimetable("@hourly", timezone=TIMEZONE)
+
+DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
+
+
+@pytest.mark.parametrize(
+    "last_automated_data_interval",
+    [pytest.param(None, id="first-run"), pytest.param(PREV_DATA_INTERVAL_EXACT, id="subsequent")],
+)
+@freezegun.freeze_time(CURRENT_TIME)
+def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
+    last_automated_data_interval: DataInterval | None,
+) -> None:
+    """If ``catchup=False`` and start_date is a day before"""
+    timetable = CronTriggerTimetable("30 16 * * *", timezone=TIMEZONE)
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=last_automated_data_interval,
+        restriction=TimeRestriction(earliest=YESTERDAY, latest=None, catchup=False),
+    )
+    expected = CURRENT_TIME + DELTA_FROM_MIDNIGHT
+    assert next_info == DagRunInfo.exact(expected)
+
+
+@pytest.mark.parametrize(
+    "current_time, earliest, expected",
+    [
+        pytest.param(
+            pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
+            id="current_time_on_boundary",
+        ),
+        pytest.param(
+            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="current_time_not_on_boundary",
+        ),
+        pytest.param(
+            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
+            pendulum.DateTime(2199, 12, 31, 22, 30, 0, tzinfo=TIMEZONE),
+            DagRunInfo.exact(pendulum.DateTime(2199, 12, 31, 23, 0, 0, tzinfo=TIMEZONE)),
+            id="future_start_date",
+        ),
+    ],
+)
+def test_hourly_cron_trigger_no_catchup_next_info(
+    current_time: pendulum.DateTime,
+    earliest: pendulum.DateTime,
+    expected: DagRunInfo,
+) -> None:
+    with freezegun.freeze_time(current_time):
+        next_info = HOURLY_CRON_TRIGGER_TIMETABLE.next_dagrun_info(
+            last_automated_data_interval=PREV_DATA_INTERVAL_EXACT,
+            restriction=TimeRestriction(earliest=earliest, latest=None, catchup=False),
+        )
+    assert next_info == expected
+
+
+@pytest.mark.parametrize(
+    "last_automated_data_interval, earliest, expected",
+    [
+        pytest.param(
+            DataInterval.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="last_automated_on_boundary",
+        ),
+        pytest.param(
+            DataInterval.exact(pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE)),
+            START_DATE,
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="last_automated_not_on_boundary",
+        ),
+        pytest.param(
+            None,
+            pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE),
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 0, 0, 0, tzinfo=TIMEZONE)),
+            id="no_last_automated_with_earliest_on_boundary",
+        ),
+        pytest.param(
+            None,
+            pendulum.DateTime(2022, 7, 27, 0, 30, 0, tzinfo=TIMEZONE),
+            DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
+            id="no_last_automated_with_earliest_not_on_boundary",
+        ),
+    ],
+)
+def test_hourly_cron_trigger_catchup_next_info(
+    last_automated_data_interval: DataInterval,
+    earliest: pendulum.DateTime,
+    expected: DagRunInfo,
+) -> None:
+    next_info = HOURLY_CRON_TRIGGER_TIMETABLE.next_dagrun_info(
+        last_automated_data_interval=last_automated_data_interval,
+        restriction=TimeRestriction(earliest=earliest, latest=None, catchup=True),
+    )
+    assert next_info == expected
+
+
+def test_cron_trigger_next_info_with_interval():
+    # Runs every Monday on 16:30, covering the day before the run.
+    timetable = CronTriggerTimetable(
+        "30 16 * * MON",
+        timezone=TIMEZONE,
+        interval=datetime.timedelta(hours=16, minutes=30),
+    )
+
+    next_info = timetable.next_dagrun_info(
+        last_automated_data_interval=DataInterval(
+            pendulum.DateTime(2022, 8, 1, tzinfo=TIMEZONE),
+            pendulum.DateTime(2022, 8, 1, 16, 30, tzinfo=TIMEZONE),
+        ),
+        restriction=TimeRestriction(earliest=START_DATE, latest=None, catchup=True),
+    )
+    assert next_info == DagRunInfo.interval(
+        pendulum.DateTime(2022, 8, 8, tzinfo=TIMEZONE),
+        pendulum.DateTime(2022, 8, 8, 16, 30, tzinfo=TIMEZONE),
+    )
+
+
+def test_validate_success() -> None:
+    HOURLY_CRON_TRIGGER_TIMETABLE.validate()
+
+
+def test_validate_failure() -> None:
+    timetable = CronTriggerTimetable("0 0 1 13 0", timezone=TIMEZONE)
+
+    with pytest.raises(AirflowTimetableInvalid) as ctx:
+        timetable.validate()
+    assert str(ctx.value) == "[0 0 1 13 0] is not acceptable, out of range"
+
+
+@pytest.mark.parametrize(
+    "timetable, data",
+    [
+        (HOURLY_CRON_TRIGGER_TIMETABLE, {"expression": "0 * * * *", "timezone": "UTC", "interval": 0}),
+        (
+            CronTriggerTimetable("0 0 1 12 *", timezone=TIMEZONE, interval=datetime.timedelta(hours=2)),
+            {"expression": "0 0 1 12 *", "timezone": "UTC", "interval": 7200.0},
+        ),
+        (
+            CronTriggerTimetable(
+                "0 0 1 12 0",
+                timezone=pendulum.tz.timezone("Asia/Taipei"),
+                interval=dateutil.relativedelta.relativedelta(weekday=dateutil.relativedelta.MO),
+            ),
+            {"expression": "0 0 1 12 0", "timezone": "Asia/Taipei", "interval": {"weekday": [0]}},
+        ),
+    ],
+)
+def test_serialization(timetable: CronTriggerTimetable, data: dict[str, typing.Any]) -> None:
+    assert timetable.serialize() == data
+
+    tt = CronTriggerTimetable.deserialize(data)
+    assert isinstance(tt, CronTriggerTimetable)
+    assert tt._expression == timetable._expression
+    assert tt._timezone == timetable._timezone
+    assert tt._interval == timetable._interval


### PR DESCRIPTION
This allows the user to provide a (static) data interval for DAG runs to adopt. This should be useful for most cron usages and more natural to the old schedule_interval logic. If `interval` is not provided, the default behaviour is the same as implemented in #23662.

Also moved CronTriggerTimetable to its own module. The class living in `interval` is weird.

cc @mai-nakagawa