### PR TITLE
Possibility to document DAG with a separated markdown file

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -522,7 +522,7 @@ class DAG(LoggingMixin):
         self.has_on_success_callback = self.on_success_callback is not None
         self.has_on_failure_callback = self.on_failure_callback is not None
 
-        self.doc_md = pathlib.Path(doc_md).read_text() if Path(doc_md).is_file() else doc_md
+        self.doc_md = pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
 
         self._access_control = DAG._upgrade_outdated_dag_access_control(access_control)
         self.is_paused_upon_creation = is_paused_upon_creation

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -535,12 +535,21 @@ class DAG(LoggingMixin):
         self.validate_schedule_and_params()
 
     def get_doc_md(self, doc_md: str) -> str:
-        if doc_md is None or not doc_md.endswith('.md'):
+        if doc_md is None:
             return doc_md
 
         env = self.get_template_env(force_sandboxed=False)
+
+        if not doc_md.endswith('.md'):
+            template = jinja2.Template(doc_md)
+        else:
+            # template = env.loader.get_source(env, doc_md)[0]
+            template = env.get_template(doc_md)
+            
+        return template.render()
         
-        return env.loader.get_source(env, doc_md)[0]
+        
+        return template.render()
         #return pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
 
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -545,13 +545,11 @@ class DAG(LoggingMixin):
         else:
             # template = env.loader.get_source(env, doc_md)[0]
             template = env.get_template(doc_md)
-            
-        return template.render()
-        
-        
-        return template.render()
-        #return pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
 
+        return template.render()
+
+        return template.render()
+        # return pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
 
     def _check_schedule_interval_matches_timetable(self) -> bool:
         """Check ``schedule_interval`` and ``timetable`` match.

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -534,7 +534,7 @@ class DAG(LoggingMixin):
         self._task_group = TaskGroup.create_root(self)
         self.validate_schedule_and_params()
 
-    def get_doc_md(self, doc_md: str) -> str:
+    def get_doc_md(self, doc_md: Optional[str]) -> Optional[str]:
         if doc_md is None:
             return doc_md
 
@@ -543,8 +543,13 @@ class DAG(LoggingMixin):
         if not doc_md.endswith('.md'):
             template = jinja2.Template(doc_md)
         else:
-            # template = env.loader.get_source(env, doc_md)[0]
-            template = env.get_template(doc_md)
+            try:
+                template = env.get_template(doc_md)
+            except jinja2.exceptions.TemplateNotFound:
+                return f"""
+                # Templating Error!
+                Not able to find the template file: `{doc_md}`.
+                """
 
         return template.render()
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -522,7 +522,7 @@ class DAG(LoggingMixin):
         self.has_on_success_callback = self.on_success_callback is not None
         self.has_on_failure_callback = self.on_failure_callback is not None
 
-        self.doc_md = doc_md
+        self.doc_md = Path(doc_md).read_text() if Path(doc_md).is_file() else doc_md
 
         self._access_control = DAG._upgrade_outdated_dag_access_control(access_control)
         self.is_paused_upon_creation = is_paused_upon_creation

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -522,16 +522,27 @@ class DAG(LoggingMixin):
         self.has_on_success_callback = self.on_success_callback is not None
         self.has_on_failure_callback = self.on_failure_callback is not None
 
-        self.doc_md = pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
-
         self._access_control = DAG._upgrade_outdated_dag_access_control(access_control)
         self.is_paused_upon_creation = is_paused_upon_creation
 
         self.jinja_environment_kwargs = jinja_environment_kwargs
         self.render_template_as_native_obj = render_template_as_native_obj
+
+        self.doc_md = self.get_doc_md(doc_md)
+
         self.tags = tags or []
         self._task_group = TaskGroup.create_root(self)
         self.validate_schedule_and_params()
+
+    def get_doc_md(self, doc_md: str) -> str:
+        if doc_md is None or not doc_md.endswith('.md'):
+            return doc_md
+
+        env = self.get_template_env(force_sandboxed=False)
+        
+        return env.loader.get_source(env, doc_md)[0]
+        #return pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
+
 
     def _check_schedule_interval_matches_timetable(self) -> bool:
         """Check ``schedule_interval`` and ``timetable`` match.

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -522,7 +522,7 @@ class DAG(LoggingMixin):
         self.has_on_success_callback = self.on_success_callback is not None
         self.has_on_failure_callback = self.on_failure_callback is not None
 
-        self.doc_md = Path(doc_md).read_text() if Path(doc_md).is_file() else doc_md
+        self.doc_md = pathlib.Path(doc_md).read_text() if Path(doc_md).is_file() else doc_md
 
         self._access_control = DAG._upgrade_outdated_dag_access_control(access_control)
         self.is_paused_upon_creation = is_paused_upon_creation

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -538,7 +538,7 @@ class DAG(LoggingMixin):
         if doc_md is None:
             return doc_md
 
-        env = self.get_template_env(force_sandboxed=False)
+        env = self.get_template_env(force_sandboxed=True)
 
         if not doc_md.endswith('.md'):
             template = jinja2.Template(doc_md)
@@ -547,9 +547,6 @@ class DAG(LoggingMixin):
             template = env.get_template(doc_md)
 
         return template.render()
-
-        return template.render()
-        # return pathlib.Path(doc_md).read_text() if pathlib.Path(str(doc_md or '')).is_file() else doc_md
 
     def _check_schedule_interval_matches_timetable(self) -> bool:
         """Check ``schedule_interval`` and ``timetable`` match.

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -564,8 +564,8 @@ doc_md      markdown
 doc_rst     reStructuredText
 ==========  ================
 
-Please note that for DAGs, ``doc_md`` is the only attribute interpreted. For DAGs it can contain a string or the reference to a template file. Template references are recognized by str ending in ‘.md’.
-If a relative path is supplied it will start from the folder of the DAG file.
+Please note that for DAGs, ``doc_md`` is the only attribute interpreted. For DAGs it can contain a string or the reference to a template file. Template references are recognized by str ending in ``.md``.
+If a relative path is supplied it will start from the folder of the DAG file. Also the template file must exist or Airflow will throw a ``jinja2.exceptions.TemplateNotFound`` exception.
 
 This is especially useful if your tasks are built dynamically from configuration files, as it allows you to expose the configuration that led to the related tasks in Airflow:
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -564,7 +564,7 @@ doc_md      markdown
 doc_rst     reStructuredText
 ==========  ================
 
-Please note that for DAGs, ``doc_md`` is the only attribute interpreted.
+Please note that for DAGs, ``doc_md`` is the only attribute interpreted and it can also contain the path of a markdown file containing the DAG's documentation.
 
 This is especially useful if your tasks are built dynamically from configuration files, as it allows you to expose the configuration that led to the related tasks in Airflow:
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -564,7 +564,8 @@ doc_md      markdown
 doc_rst     reStructuredText
 ==========  ================
 
-Please note that for DAGs, ``doc_md`` is the only attribute interpreted and it can also contain the path of a markdown file containing the DAG's documentation.
+Please note that for DAGs, ``doc_md`` is the only attribute interpreted. For DAGs it can contain a string or the reference to a template file. Template references are recognized by str ending in ‘.md’.
+If a relative path is supplied it will start from the folder of the DAG file.
 
 This is especially useful if your tasks are built dynamically from configuration files, as it allows you to expose the configuration that led to the related tasks in Airflow:
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2231,25 +2231,12 @@ class TestDagDecorator:
             f.flush()
             template_file = os.path.basename(f.name)
 
-            @dag_decorator(default_args=self.DEFAULT_ARGS, doc_md=template_file)
-            def noop_pipeline():
-                """
-                {% if True %}
-                Regular DAG documentation
-                {% endif %}
-                """
+            with DAG('test-dag', start_date=DEFAULT_DATE, doc_md=template_file) as dag:
+                task = EmptyOperator(task_id='op1')
 
-                @task_decorator
-                def return_num(num):
-                    return num
-
-                return_num(4)
-
-            dag = noop_pipeline()
-
-            assert isinstance(dag, DAG)
-            assert dag.dag_id, 'test'
-            assert dag.doc_md.strip(), "External Markdown DAG documentation"
+                assert isinstance(dag, DAG)
+                assert dag.dag_id, 'test'
+                assert dag.doc_md.strip(), "External Markdown DAG documentation"
 
     def test_fails_if_arg_not_set(self):
         """Test that @dag decorated function fails if positional argument is not set"""

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2217,16 +2217,17 @@ class TestDagDecorator:
         assert dag.dag_id, 'test'
         assert dag.doc_md.strip(), "Regular DAG documentation"
 
-
     def test_resolve_documentation_template_file_rendered(self):
         """Test that @dag uses function docs as doc_md for DAG object"""
-       
+
         with NamedTemporaryFile(suffix='.md') as f:
-            f.write(b"""
+            f.write(
+                b"""
             {% if True %}
                External Markdown DAG documentation
             {% endif %}
-            """)
+            """
+            )
             f.flush()
             template_file = os.path.basename(f.name)
 
@@ -2249,7 +2250,6 @@ class TestDagDecorator:
             assert isinstance(dag, DAG)
             assert dag.dag_id, 'test'
             assert dag.doc_md.strip(), "External Markdown DAG documentation"
-
 
     def test_fails_if_arg_not_set(self):
         """Test that @dag decorated function fails if positional argument is not set"""

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2234,6 +2234,8 @@ class TestDagDecorator:
             with DAG('test-dag', start_date=DEFAULT_DATE, doc_md=template_file) as dag:
                 task = EmptyOperator(task_id='op1')
 
+                task
+
                 assert isinstance(dag, DAG)
                 assert dag.dag_id, 'test'
                 assert dag.doc_md.strip(), "External Markdown DAG documentation"

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2195,6 +2195,62 @@ class TestDagDecorator:
         assert dag.dag_id, 'test'
         assert dag.doc_md.strip(), "Regular DAG documentation"
 
+    def test_documentation_template_rendered(self):
+        """Test that @dag uses function docs as doc_md for DAG object"""
+
+        @dag_decorator(default_args=self.DEFAULT_ARGS)
+        def noop_pipeline():
+            """
+            {% if True %}
+               Regular DAG documentation
+            {% endif %}
+            """
+
+            @task_decorator
+            def return_num(num):
+                return num
+
+            return_num(4)
+
+        dag = noop_pipeline()
+        assert isinstance(dag, DAG)
+        assert dag.dag_id, 'test'
+        assert dag.doc_md.strip(), "Regular DAG documentation"
+
+
+    def test_resolve_documentation_template_file_rendered(self):
+        """Test that @dag uses function docs as doc_md for DAG object"""
+       
+        with NamedTemporaryFile(suffix='.md') as f:
+            f.write(b"""
+            {% if True %}
+               External Markdown DAG documentation
+            {% endif %}
+            """)
+            f.flush()
+            template_file = os.path.basename(f.name)
+
+            @dag_decorator(default_args=self.DEFAULT_ARGS, doc_md=template_file)
+            def noop_pipeline():
+                """
+                {% if True %}
+                Regular DAG documentation
+                {% endif %}
+                """
+
+                @task_decorator
+                def return_num(num):
+                    return num
+
+                return_num(4)
+
+            dag = noop_pipeline()
+
+            assert isinstance(dag, DAG)
+            assert dag.dag_id, 'test'
+            assert dag.doc_md.strip(), "External Markdown DAG documentation"
+
+
     def test_fails_if_arg_not_set(self):
         """Test that @dag decorated function fails if positional argument is not set"""
 


### PR DESCRIPTION
This change allows the possibility to pass the path of a markdown file to the `doc_md` argument of a DAG.

closes: https://github.com/apache/airflow/discussions/25396

