### PR TITLE
Limit Flask to <2.3 in the wake of 2.2 breaking our tests

### DIFF
--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -187,6 +187,13 @@ KNOWN_DEPRECATED_MESSAGES: Set[Tuple[str, str]] = {
         "scrapbook",
     ),
     ("SelectableGroups dict interface is deprecated. Use select.", "markdown"),
+    ("'_app_ctx_stack' is deprecated and will be removed in Flask 2.3.", "flask_sqlalchemy"),
+    ("'_app_ctx_stack' is deprecated and will be removed in Flask 2.3.", "flask_appbuilder"),
+    # Currently (2.2) Flask app builder has the `remoevd` typo in the messages,
+    # and they might want to fix it, so adding both
+    ("'_request_ctx_stack' is deprecated and will be remoevd in Flask 2.3.", 'flask_appbuilder'),
+    ("'_request_ctx_stack' is deprecated and will be removed in Flask 2.3.", 'flask_appbuilder'),
+    ("'_request_ctx_stack' is deprecated and will be removed in Flask 2.3.", 'flask_jwt_extended'),
 }
 
 KNOWN_COMMON_DEPRECATED_MESSAGES: Set[str] = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,10 @@ install_requires =
     cryptography>=0.9.3
     deprecated>=1.2.13
     dill>=0.2.2
-    flask>=2.0
+    # Flask 2.3 is scheduled to introduce a number of deprecation removals - some of them might be breaking
+    # for our dependencies - notably `_app_ctx_stack` and `_request_ctx_stack` removals.
+    # We should remove the limitation after 2.3 is released and our dependencies are updated to handle it
+    flask>=2.0,<2.3
     # We are tightly coupled with FAB version because we vendored in part of FAB code related to security manager
     # This is done as part of preparation to removing FAB as dependency, but we are not ready for it yet
     # Every time we update FAB version here, please make sure that you review the classes and models in


### PR DESCRIPTION
Flask 2.2 added a few deprecations and made a few changes that
made our tests stop working. Those were really test problems not
real application problems (there were no breaking changes in 2.2):

* new deprecation warnings produced
* Flask app cannot be reused in multiple tests
* The way how session lifetime is calculated makes test fail
  if freezegun is frozen using Pendulum datetime rather than the
  stdlib ones

This is an early warning for the future as the deprecation
warnings make us aware that Flask 2.3 is breaking. So this PR
fixes the 2.2 compatibility but at the same time limits Flask to
< 2.3 with appropriate information when the limit can be removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
