### PR TITLE
Correctly render `results_parser_callable` parameter in Qubole operator docs

### DIFF
--- a/airflow/providers/qubole/operators/qubole_check.py
+++ b/airflow/providers/qubole/operators/qubole_check.py
@@ -86,18 +86,14 @@ class QuboleCheckOperator(_QuboleCheckOperatorMixin, SQLCheckOperator, QuboleOpe
         :ref:`howto/operator:QuboleCheckOperator`
 
     :param qubole_conn_id: Connection id which consists of qds auth_token
+    :param results_parser_callable: This is an optional parameter to extend the flexibility of parsing the
+        results of Qubole command to the users. This is a Python callable which can hold the logic to parse
+        list of rows returned by Qubole command. By default, only the values on first row are used for
+        performing checks. This callable should return a list of records on which the checks have to be
+        performed.
 
     kwargs:
-
         Arguments specific to Qubole command can be referred from QuboleOperator docs.
-
-        :results_parser_callable: This is an optional parameter to
-            extend the flexibility of parsing the results of Qubole
-            command to the users. This is a python callable which
-            can hold the logic to parse list of rows returned by Qubole command.
-            By default, only the values on first row are used for performing checks.
-            This callable should return a list of records on
-            which the checks have to be performed.
 
     .. note:: All fields in common with template fields of
         QuboleOperator and SQLCheckOperator are template-supported.
@@ -138,27 +134,18 @@ class QuboleValueCheckOperator(_QuboleCheckOperatorMixin, SQLValueCheckOperator,
     is not within the permissible limit of expected value.
 
     :param qubole_conn_id: Connection id which consists of qds auth_token
-
     :param pass_value: Expected value of the query results.
-
-    :param tolerance: Defines the permissible pass_value range, for example if
-        tolerance is 2, the Qubole command output can be anything between
-        -2*pass_value and 2*pass_value, without the operator erring out.
-
-
+    :param tolerance: Defines the permissible pass_value range, for example if tolerance is 2, the Qubole
+        command output can be anything between -2*pass_value and 2*pass_value, without the operator erring
+        out.
+    :param results_parser_callable: This is an optional parameter to extend the flexibility of parsing the
+        results of Qubole command to the users. This is a Python callable which can hold the logic to parse
+        list of rows returned by Qubole command. By default, only the values on first row are used for
+        performing checks. This callable should return a list of records on which the checks have to be
+        performed.
 
     kwargs:
-
         Arguments specific to Qubole command can be referred from QuboleOperator docs.
-
-        :results_parser_callable: This is an optional parameter to
-            extend the flexibility of parsing the results of Qubole
-            command to the users. This is a python callable which
-            can hold the logic to parse list of rows returned by Qubole command.
-            By default, only the values on first row are used for performing checks.
-            This callable should return a list of records on
-            which the checks have to be performed.
-
 
     .. note:: All fields in common with template fields of
             QuboleOperator and SQLValueCheckOperator are template-supported.


### PR DESCRIPTION
Within the Python API docs for both `QuboleCheckOperator` and `QuboleValueCheckOperator`, the `results_parser_callable` parameter is improperly listed under a "kwargs" section. This could be confusing to users reading the docs as this is an explicit input to these operators rather part of catch-all keyword args.


`QuboleCheckOperator`
**Before**
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/48934154/182657633-0034aea2-35d8-4419-ad70-655c136c8a47.png">
**After**
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/48934154/182657719-4de93499-fe75-4dab-9c55-d4af2b11a967.png">

`QuboleValueCheckOperator`
**Before**
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/48934154/182657799-1eeedeb9-f828-4085-88be-0c5549dd337b.png">

**After**
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/48934154/182657872-4307f6b3-7d1b-440b-99d5-c0302ae92306.png">



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
