### PR TITLE
Sync up plugin API schema and definition

### DIFF
--- a/airflow/api_connexion/endpoints/plugin_endpoint.py
+++ b/airflow/api_connexion/endpoints/plugin_endpoint.py
@@ -27,7 +27,5 @@ from airflow.security import permissions
 def get_plugins(*, limit: int, offset: int = 0) -> APIResponse:
     """Get plugins endpoint"""
     plugins_info = get_plugin_info()
-    total_entries = len(plugins_info)
-    plugins_info = plugins_info[offset:]
-    plugins_info = plugins_info[:limit]
-    return plugin_collection_schema.dump(PluginCollection(plugins=plugins_info, total_entries=total_entries))
+    collection = PluginCollection(plugins=plugins_info[offset:][:limit], total_entries=len(plugins_info))
+    return plugin_collection_schema.dump(collection)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3332,9 +3332,6 @@ components:
 
         *New in version 2.1.0*
       properties:
-        number:
-          type: string
-          description: The plugin number
         name:
           type: string
           description: The name of the plugin

--- a/airflow/api_connexion/schemas/plugin_schema.py
+++ b/airflow/api_connexion/schemas/plugin_schema.py
@@ -23,16 +23,15 @@ from marshmallow import Schema, fields
 class PluginSchema(Schema):
     """Plugin schema"""
 
-    number = fields.Int()
     name = fields.String()
     hooks = fields.List(fields.String())
     executors = fields.List(fields.String())
-    macros = fields.List(fields.String())
-    flask_blueprints = fields.List(fields.String())
-    appbuilder_views = fields.List(fields.String())
+    macros = fields.List(fields.Dict())
+    flask_blueprints = fields.List(fields.Dict())
+    appbuilder_views = fields.List(fields.Dict())
     appbuilder_menu_items = fields.List(fields.Dict())
-    global_operator_extra_links = fields.List(fields.String())
-    operator_extra_links = fields.List(fields.String())
+    global_operator_extra_links = fields.List(fields.Dict())
+    operator_extra_links = fields.List(fields.Dict())
     source = fields.String()
 
 

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1371,8 +1371,6 @@ export interface components {
      * *New in version 2.1.0*
      */
     PluginCollectionItem: {
-      /** @description The plugin number */
-      number?: string;
       /** @description The name of the plugin */
       name?: string;
       /** @description The plugin hooks */


### PR DESCRIPTION
Fix #25492. Many of the entries should have been objects (dicts), not strings. These have been defined like this ever since the API endpoint’s introduction in #14280.

I also removed `number` since, as far as I can tell, it is not set or used anywhere in the code.

We should probably add a bit more structure in those dicts, but this is the minimal change needed to make the schema make sense.