### PR TITLE
feat(KubernetesPodOperator): Add support of container_security_context

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -129,6 +129,7 @@ class KubernetesPodOperator(BaseOperator):
     :param hostnetwork: If True enable host networking on the pod.
     :param tolerations: A list of kubernetes tolerations.
     :param security_context: security options the pod should run with (PodSecurityContext).
+    :param container_security_context: security options the container should run with.
     :param dnspolicy: dnspolicy for the pod.
     :param schedulername: Specify a schedulername for the pod
     :param full_pod_spec: The complete podSpec
@@ -199,6 +200,7 @@ class KubernetesPodOperator(BaseOperator):
         hostnetwork: bool = False,
         tolerations: Optional[List[k8s.V1Toleration]] = None,
         security_context: Optional[Dict] = None,
+        container_security_context: Optional[Dict] = None,
         dnspolicy: Optional[str] = None,
         schedulername: Optional[str] = None,
         full_pod_spec: Optional[k8s.V1Pod] = None,
@@ -270,6 +272,7 @@ class KubernetesPodOperator(BaseOperator):
             [convert_toleration(toleration) for toleration in tolerations] if tolerations else []
         )
         self.security_context = security_context or {}
+        self.container_security_context = container_security_context
         self.dnspolicy = dnspolicy
         self.schedulername = schedulername
         self.full_pod_spec = full_pod_spec
@@ -556,6 +559,7 @@ class KubernetesPodOperator(BaseOperator):
                         args=self.arguments,
                         env=self.env_vars,
                         env_from=self.env_from,
+                        security_context=self.container_security_context,
                     )
                 ],
                 image_pull_secrets=self.image_pull_secrets,

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -472,11 +472,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             assert self.expected_pod == actual_pod
 
     def test_run_as_user_root(self):
-        security_context = {
-            'securityContext': {
-                'runAsUser': 0,
-            }
-        }
+        security_context = {'runAsUser': 0}
         k = KubernetesPodOperator(
             namespace='default',
             image="ubuntu:16.04",
@@ -497,11 +493,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
     def test_run_as_user_non_root(self):
         security_context = {
-            'securityContext': {
-                'runAsUser': 1000,
-            }
+            'runAsUser': 1000,
         }
-
         k = KubernetesPodOperator(
             namespace='default',
             image="ubuntu:16.04",
@@ -520,11 +513,30 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['securityContext'] = security_context
         assert self.expected_pod == actual_pod
 
+    def test_disable_privilege_escalation(self):
+        container_security_context = {'allowPrivilegeEscalation': False}
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="test-" + str(random.randint(0, 1000000)),
+            task_id="task" + self.get_current_task_name(),
+            in_cluster=False,
+            do_xcom_push=False,
+            container_security_context=container_security_context,
+        )
+        context = create_context(k)
+        k.execute(context)
+        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        self.expected_pod['spec']['containers'][0]['securityContext'] = container_security_context
+        assert self.expected_pod == actual_pod
+
     def test_fs_group(self):
         security_context = {
-            'securityContext': {
-                'fsGroup': 1000,
-            }
+            'fsGroup': 1000,
         }
 
         k = KubernetesPodOperator(

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -151,6 +151,42 @@ class TestKubernetesPodOperator:
         assert k.env_vars[0].value == "footemplated"
         assert k.env_vars[0].name == "bartemplated"
 
+    def test_security_context(self):
+        security_context = {
+            'runAsUser': 1245,
+        }
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            security_context=security_context,
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+        )
+        pod = self.run_pod(k)
+        assert pod.spec.security_context == security_context
+
+    def test_container_security_context(self):
+        container_security_context = {'allowPrivilegeEscalation': False}
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            container_security_context=container_security_context,
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+        )
+        pod = self.run_pod(k)
+        assert pod.spec.containers[0].security_context == container_security_context
+
     def test_envs_from_configmaps(
         self,
     ):


### PR DESCRIPTION
Allow to define a container security context on KubernetesPodOperator.

Why: 
On clusters restricted with strong security policy, pods cannot be executed without disable privilege escalation.

About test :
I successfully run locally there tests : _tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py_
But I was not able to run tests _kubernetes_tests/test_kubernetes_pod_operator.py_ :-(
