### PR TITLE
Fix "This Session's transaction has been rolled back"

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1138,6 +1138,10 @@ class DagRun(Base, LoggingMixin):
         :param session: the session to use
 
         """
+        # Fetch the information we need before handling the exception to avoid
+        # PendingRollbackError due to the session being invalidated on exception
+        # see https://github.com/apache/superset/pull/530
+        run_id = self.run_id
         try:
             if hook_is_noop:
                 session.bulk_insert_mappings(TI, tasks)
@@ -1151,7 +1155,7 @@ class DagRun(Base, LoggingMixin):
             self.log.info(
                 'Hit IntegrityError while creating the TIs for %s- %s',
                 dag_id,
-                self.run_id,
+                run_id,
                 exc_info=True,
             )
             self.log.info('Doing session rollback.')


### PR DESCRIPTION
Accessing the run_id on exception leads to error because sessions are invalidated on exception. Here we extract the information we need to log the exception before handling the exception

Here's how to reproduce the scheduler crash:
Run this dag in main:
```python
from datetime import datetime

from airflow import DAG
from airflow.decorators import task

with DAG(dag_id='mvp_map_task_bug', start_date=datetime(2022, 1, 1), schedule_interval='@daily', catchup=False) as dag:
    @task
    def get_files():
        return [1,2,3,4,5,6]

    @task
    def download_files(file: str):
        print(f"{file}")

    files = download_files.expand(file=get_files())
```
Stop the scheduler
Reduce the list in the `get_files` to something like [1,2,3]
Change this `difference` to `symmetric_difference`: https://github.com/apache/airflow/blob/171aaf017aee068d8e1b76121c8c75310c854d9e/airflow/models/dagrun.py#L1189

Start the scheduler and clear the above task so it can run again. 
Now, it'll try to create new TIs and the Scheduler will crash. Switch to this PR and try the same again. You will notice that the scheduler survived the crash and rollback was successful.