### PR TITLE
Further limit list of versions in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -21,15 +21,13 @@ body:
     attributes:
       label: Apache Airflow version
       description: >
-        What Apache Airflow version are you using? If you do not see your version, ideally upgrade to latest
-        bugfix version on the list here and see if the issue is fixed, before reporting it.
+        What Apache Airflow version are you using? If you do not see your version, please (ideally) test on
+        the latest release or main to see if the issue is fixed before reporting it.
       multiple: false
       options:
-        - "2.3.3 (latest released)"
-        - "2.2.5"
-        - "2.1.4"
-        - "2.0.2"
+        - "2.3.3"
         - "main (development)"
+        - "Other Airflow 2 version"
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This proposes doing a step further than #25480 did and only list latest/main/other, with stronger wording about testing before reporting, while giving users an "other" escape hatch.