### PR TITLE
Fix Grid task row scrollbar overlapping on Firefox

### DIFF
--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -126,6 +126,7 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
         ref={scrollRef}
         maxHeight="900px"
         position="relative"
+        pr={4}
       >
         <Table pr="10px">
           <Thead>


### PR DESCRIPTION
Fixes: https://github.com/apache/airflow/issues/25512

As suggested by @bbovenzi, we just add a small right padding to not have overlapping between the scrollbar and the content.

**On Chrome**
![image](https://user-images.githubusercontent.com/14861206/183116373-181d8ffb-10af-4103-bed4-4f05798d5cc8.png)


**On FireFox**
![image](https://user-images.githubusercontent.com/14861206/183116296-31e17e46-8c68-4e12-b051-c7636e241152.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
