### PR TITLE
Optimize log when using VerticaOperator

### DIFF
--- a/airflow/providers/vertica/operators/vertica.py
+++ b/airflow/providers/vertica/operators/vertica.py
@@ -48,5 +48,5 @@ class VerticaOperator(BaseOperator):
 
     def execute(self, context: 'Context') -> None:
         self.log.info('Executing: %s', self.sql)
-        hook = VerticaHook(vertica_conn_id=self.vertica_conn_id)
+        hook = VerticaHook(vertica_conn_id=self.vertica_conn_id, log_sql=False)
         hook.run(sql=self.sql)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #25456

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


This PR is about passing `False` to `log_sql` argument when initializing VerticaHook to execute VerticaOperator. Related to issue #25456, SQL queries are duplicated in task log. I'm trying to disable one of them.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
