### PR TITLE
Add support for mapped task on logs API

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -48,6 +48,7 @@ def get_log(
     task_id: str,
     task_try_number: int,
     full_content: bool = False,
+    map_index: int = -1,
     token: Optional[str] = None,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
@@ -72,13 +73,13 @@ def get_log(
     task_log_reader = TaskLogReader()
     if not task_log_reader.supports_read:
         raise BadRequest("Task log handler does not support read logs.")
-
     ti = (
         session.query(TaskInstance)
         .filter(
             TaskInstance.task_id == task_id,
             TaskInstance.dag_id == dag_id,
             TaskInstance.run_id == dag_run_id,
+            TaskInstance.map_index == map_index,
         )
         .join(TaskInstance.dag_run)
         .one_or_none()

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1461,6 +1461,7 @@ paths:
       - $ref: '#/components/parameters/TaskID'
       - $ref: '#/components/parameters/TaskTryNumber'
       - $ref: '#/components/parameters/FullContent'
+      - $ref: '#/components/parameters/FilterMapIndex'
       - $ref: '#/components/parameters/ContinuationToken'
 
     get:
@@ -4364,7 +4365,8 @@ components:
         type: string
       required: true
       description: The XCom key.
-    # Filter
+
+    # Filters
     FilterExecutionDateGTE:
       in: query
       name: execution_date_gte
@@ -4528,6 +4530,13 @@ components:
         type: integer
       description: The map index that updated the dataset.
 
+    FilterMapIndex:
+      in: query
+      name: map_index
+      schema:
+        type: integer
+      description: Filter on map index for mapped task.
+
     OrderBy:
       in: query
       name: order_by
@@ -4553,7 +4562,6 @@ components:
         *New in version 2.1.1*
 
     # Other parameters
-
     FileToken:
       in: path
       name: file_token

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -422,6 +422,8 @@ export interface paths {
          * By default, only the first fragment will be returned.
          */
         full_content?: components["parameters"]["FullContent"];
+        /** Filter on map index for mapped task. */
+        map_index?: components["parameters"]["FilterMapIndex"];
         /**
          * A token that allows you to continue fetching logs.
          * If passed, it will specify the location from which the download should be continued.
@@ -2113,6 +2115,8 @@ export interface components {
     FilterSourceRunID: string;
     /** @description The map index that updated the dataset. */
     FilterSourceMapIndex: number;
+    /** @description Filter on map index for mapped task. */
+    FilterMapIndex: number;
     /**
      * @description The name of the field to order the results by.
      * Prefix a field name with `-` to reverse the sort order.
@@ -3432,6 +3436,8 @@ export interface operations {
          * By default, only the first fragment will be returned.
          */
         full_content?: components["parameters"]["FullContent"];
+        /** Filter on map index for mapped task. */
+        map_index?: components["parameters"]["FilterMapIndex"];
         /**
          * A token that allows you to continue fetching logs.
          * If passed, it will specify the location from which the download should be continued.


### PR DESCRIPTION
This PR adds support for retrieving task logs for mapped task.

You can now provide an additional query_param `map_index` that default to -1 (for unmapped task).

Added a few tests as well.

(Before this, the endpoint would just throw an internal error because of multiple rows matching the `one_or_none` [query](https://github.com/apache/airflow/blob/main/airflow/api_connexion/endpoints/log_endpoint.py#L76))

This is the first step to be able to bring logs tab to the mapped task in the Grid UI. (Follow up PR is coming for the front-end part)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
