### PR TITLE
Get boto3.session.Session by appropriate method

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -100,10 +100,10 @@ class GlueJobHook(AwsBaseHook):
 
     def get_iam_execution_role(self) -> Dict:
         """:return: iam role for job execution"""
-        session, endpoint_url = self._get_credentials(region_name=self.region_name)
-        iam_client = session.client('iam', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
-
         try:
+            iam_client = self.get_session(region_name=self.region_name).client(
+                'iam', endpoint_url=self.conn_config.endpoint_url, config=self.config, verify=self.verify
+            )
             glue_execution_role = iam_client.get_role(RoleName=self.role_name)
             self.log.info("Iam Role Name: %s", self.role_name)
             return glue_execution_role

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -215,12 +215,9 @@ class S3Hook(AwsBaseHook):
         :return: the bucket object to the bucket name.
         :rtype: boto3.S3.Bucket
         """
-        # Buckets have no regions, and we cannot remove the region name from _get_credentials as we would
-        # break compatibility, so we set it explicitly to None.
-        session, endpoint_url = self._get_credentials(region_name=None)
-        s3_resource = session.resource(
+        s3_resource = self.get_session().resource(
             "s3",
-            endpoint_url=endpoint_url,
+            endpoint_url=self.conn_config.endpoint_url,
             config=self.config,
             verify=self.verify,
         )
@@ -465,12 +462,9 @@ class S3Hook(AwsBaseHook):
         :return: the key object from the bucket
         :rtype: boto3.s3.Object
         """
-        # Buckets have no regions, and we cannot remove the region name from _get_credentials as we would
-        # break compatibility, so we set it explicitly to None.
-        session, endpoint_url = self._get_credentials(region_name=None)
-        s3_resource = session.resource(
+        s3_resource = self.get_session().resource(
             "s3",
-            endpoint_url=endpoint_url,
+            endpoint_url=self.conn_config.endpoint_url,
             config=self.config,
             verify=self.verify,
         )

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -16,8 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
-import unittest
 from unittest import mock
+
+import boto3
+import pytest
 
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 
@@ -27,19 +29,19 @@ except ImportError:
     mock_iam = mock_glue = None
 
 
-class TestGlueJobHook(unittest.TestCase):
-    def setUp(self):
+class TestGlueJobHook:
+    @pytest.fixture(autouse=True)
+    def setup(self):
         self.some_aws_region = "us-west-2"
 
-    @unittest.skipIf(mock_iam is None, 'mock_iam package not present')
+    @pytest.mark.skipif(mock_glue is None, reason="mock_glue package not present")
     @mock_iam
-    def test_get_iam_execution_role(self):
-        hook = GlueJobHook(
-            job_name='aws_test_glue_job', s3_bucket='some_bucket', iam_role_name='my_test_role'
-        )
-        iam_role = hook.get_client_type('iam').create_role(
-            Path="/",
-            RoleName='my_test_role',
+    @pytest.mark.parametrize("role_path", ["/", "/custom-path/"])
+    def test_get_iam_execution_role(self, role_path):
+        expected_role = "my_test_role"
+        boto3.client("iam").create_role(
+            Path=role_path,
+            RoleName=expected_role,
             AssumeRolePolicyDocument=json.dumps(
                 {
                     "Version": "2012-10-17",
@@ -51,11 +53,18 @@ class TestGlueJobHook(unittest.TestCase):
                 }
             ),
         )
+
+        hook = GlueJobHook(
+            aws_conn_id=None,
+            job_name='aws_test_glue_job',
+            s3_bucket='some_bucket',
+            iam_role_name=expected_role,
+        )
         iam_role = hook.get_iam_execution_role()
         assert iam_role is not None
         assert "Role" in iam_role
         assert "Arn" in iam_role['Role']
-        assert iam_role['Role']['Arn'] == "arn:aws:iam::123456789012:role/my_test_role"
+        assert iam_role['Role']['Arn'] == f"arn:aws:iam::123456789012:role{role_path}{expected_role}"
 
     @mock.patch.object(GlueJobHook, "get_conn")
     def test_get_or_create_glue_job_get_existing_job(self, mock_get_conn):
@@ -84,7 +93,7 @@ class TestGlueJobHook(unittest.TestCase):
         mock_get_conn.return_value.get_job.assert_called_once_with(JobName=hook.job_name)
         assert result == expected_job_name
 
-    @unittest.skipIf(mock_glue is None, "mock_glue package not present")
+    @pytest.mark.skipif(mock_glue is None, reason="mock_glue package not present")
     @mock_glue
     @mock.patch.object(GlueJobHook, "get_iam_execution_role")
     def test_get_or_create_glue_job_create_new_job(self, mock_get_iam_execution_role):
@@ -135,10 +144,7 @@ class TestGlueJobHook(unittest.TestCase):
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
-        with self.assertRaises(
-            ValueError,
-            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
-        ):
+        with pytest.raises(ValueError, match="Cannot specify num_of_dpus with custom WorkerType"):
             GlueJobHook(
                 job_name='aws_test_glue_job',
                 desc='This is test case job from Airflow',
@@ -175,7 +181,3 @@ class TestGlueJobHook(unittest.TestCase):
         glue_job_run = glue_job_hook.initialize_job(some_script_arguments, some_run_kwargs)
         glue_job_run_state = glue_job_hook.get_job_state(glue_job_run['JobName'], glue_job_run['JobRunId'])
         assert glue_job_run_state == mock_job_run_state, 'Mocks but be equal'
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Right now AWS Hooks obtain `boto3.session.Session` usual by call `_get_credentials`. This method return `Tuple[boto3.session.Session, Optional[str]]` and actually not return credentials, only session and `endpoint_url`.

Since #25336 all hook/connections configs stored in `conn_config` cached property, we do not need to call `_get_credentials` to obtain `endpoint_url` as well as other connection attributes.

Also change all aws hooks which uses this `_get_credentials`.

Right now (main branch) other providers do not use this method directly, however current version of PostgreSQL provider use this method (#25424), so we can't remove `_get_credentials`.

Some minor changes - remove information about that S3 Bucket has not region (#20463). In fact AWS S3 Buckets has region in other hand you could access to any buckets from any region if you have a permission (might be only one limitation endpoint should be in the same AWS Region Partition).

cc: @vincbeck @ferruzzi @o-nikolas @potiuk 