### PR TITLE
Correct compile assets command in tmux welcome message

### DIFF
--- a/scripts/in_container/run_tmux_welcome.sh
+++ b/scripts/in_container/run_tmux_welcome.sh
@@ -25,7 +25,7 @@ echo "     NOTE! If you want to rebuild webserver assets dynamically:"
 echo
 echo "        * Restart airflow webserver with '-d' flag."
 echo "          AND (in a separate terminal in your host):"
-echo "        * Run 'breeze www-compile-assets --dev'."
+echo "        * Run 'breeze compile-www-assets --dev'."
 echo "           OR"
 echo "        * Run 'yarn dev' in the 'airflow/www' if you have yarn installed and want to watch recompiling happens."
 echo


### PR DESCRIPTION
The current message had a couple words reversed in the compile assets command.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
