### PR TITLE
Databricks: update user-agent string

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_base.py
+++ b/airflow/providers/databricks/hooks/databricks_base.py
@@ -23,6 +23,7 @@ operators talk to the ``api/2.0/jobs/runs/submit``
 `endpoint <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_.
 """
 import copy
+import platform
 import time
 from typing import Any, Dict, Optional, Tuple
 from urllib.parse import urlparse
@@ -143,7 +144,13 @@ class BaseDatabricksHook(BaseHook):
         if provider.is_source:
             version += "-source"
 
-        return f'Airflow/{__version__} Databricks/{version} ({self.caller})'
+        python_version = platform.python_version()
+        system = platform.system().lower()
+        ua_string = (
+            f"databricks-aiflow/{version} _/0.0.0 python/{python_version} os/{system} "
+            f"airflow/{__version__} operator/{self.caller}"
+        )
+        return ua_string
 
     @cached_property
     def host(self) -> str:

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -244,6 +244,12 @@ class TestDatabricksHook(unittest.TestCase):
 
         self.hook = DatabricksHook(retry_delay=0)
 
+    def test_user_agent_string(self):
+        op = "DatabricksSql"
+        hook = DatabricksHook(retry_delay=0, caller=op)
+        ua_string = hook.user_agent_value
+        assert ua_string.endswith(f" operator/{op}")
+
     def test_parse_host_with_proper_host(self):
         host = self.hook._parse_host(HOST)
         assert host == HOST


### PR DESCRIPTION
Just after the previous PR was merged, Databricks dev ecosystem team came with formal
guidance on the format of User Agent string for integrations.  This PR updates the User
Agent string to match it, and added a unit test for it

