### PR TITLE
Fix migration code for the dag_owner_attributes table

### DIFF
--- a/airflow/migrations/versions/0116_2_4_0_add_dag_owner_attributes_table.py
+++ b/airflow/migrations/versions/0116_2_4_0_add_dag_owner_attributes_table.py
@@ -27,6 +27,8 @@ Create Date: 2022-08-04 16:59:45.406589
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.migrations.db_types import StringID
+
 # revision identifiers, used by Alembic.
 revision = '1486deb605b4'
 down_revision = 'f4ff391becb5'
@@ -39,7 +41,7 @@ def upgrade():
     """Apply Add ``DagOwnerAttributes`` table"""
     op.create_table(
         'dag_owner_attributes',
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
         sa.Column('owner', sa.String(length=500), nullable=False),
         sa.Column('link', sa.String(length=500), nullable=False),
         sa.ForeignKeyConstraint(['dag_id'], ['dag.dag_id'], ondelete='CASCADE'),


### PR DESCRIPTION
When running migrations on MySQL, the migration code for `dag_owner_attributes` fails with error:

```
1215 (HY000): Cannot add foreign key constraint
```

This is caused by the type incompatibility between table definition of the `dag_id` column
that was declared as `sa.Column('dag_id', sa.String(length=250), nullable=False)`, but the
`dag_id` in `dag` table is declared as `StringID()` that is mapped into UTF-8
string (`dag_id VARCHAR(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL`).
MySQL is sensitive in difference of the charset declarations and fails because of it.

related: #25280 
