### PR TITLE
Speed-up Python Helm Unit tests by ~30%

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -775,9 +775,11 @@ EXTRA_PYTEST_ARGS=(
 )
 
 if [[ "${TEST_TYPE}" == "Helm" ]]; then
+    _cpus="$(grep -c 'cpu[0-9]' /proc/stat)"
+    echo "Running tests with ${_cpus} CPUs in parallel"
     # Enable parallelism
     EXTRA_PYTEST_ARGS+=(
-        "-n" "auto"
+        "-n" "${_cpus}"
     )
 else
     EXTRA_PYTEST_ARGS+=(

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -36,7 +36,7 @@ def verify_an_image(
             f"[error]Error when inspecting {image_type} image: {command_result.returncode}[/]"
         )
         return command_result.returncode, f"Testing {image_type} python {image_name}"
-    pytest_args = ("-n", "auto", "--color=yes")
+    pytest_args = ("-n", str(os.cpu_count()), "--color=yes")
     if image_type == 'PROD':
         test_path = AIRFLOW_SOURCES_ROOT / "docker_tests" / "test_prod_image.py"
     else:
@@ -64,7 +64,7 @@ def run_docker_compose_tests(
     if command_result.returncode != 0:
         get_console().print(f"[error]Error when inspecting PROD image: {command_result.returncode}[/]")
         return command_result.returncode, f"Testing docker-compose python with {image_name}"
-    pytest_args = ("-n", "auto", "--color=yes")
+    pytest_args = ("-n", str(os.cpu_count()), "--color=yes")
     test_path = AIRFLOW_SOURCES_ROOT / "docker_tests" / "test_docker_compose_quick_start.py"
     env = os.environ.copy()
     env['DOCKER_IMAGE'] = image_name

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -272,9 +272,11 @@ EXTRA_PYTEST_ARGS=(
 )
 
 if [[ "${TEST_TYPE}" == "Helm" ]]; then
+    _cpus="$(grep -c 'cpu[0-9]' /proc/stat)"
+    echo "Running tests with ${_cpus} CPUs in parallel"
     # Enable parallelism
     EXTRA_PYTEST_ARGS+=(
-        "-n" "auto"
+        "-n" "${_cpus}"
     )
 else
     EXTRA_PYTEST_ARGS+=(


### PR DESCRIPTION
The `pytest -n auto` switch does not give the accurate maximum number
of parallel tests we can run. It uses the number of CPUs not the number
of cores.

The Helm tests utilise ~70% of available CPUs when the CPUS have dual cores,
so we shoudl be able to gain 5 minutes (from 22 to 17) when Helm
tests are run on self-hosted runners, and even more ~12 minutes
(32 m instead of 45m) when run on Public Runner.

The gains on docker-compose tests have not been measured yet but they are
likely similar.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
