### PR TITLE
Update Helm version in Breeze as well

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1054,7 +1054,7 @@ ARG RUNTIME_APT_DEPS="\
       xxd"
 
 # Install Helm
-ARG HELM_VERSION="v3.6.3"
+ARG HELM_VERSION="v3.9.2"
 
 RUN SYSTEM=$(uname -s | tr '[:upper:]' '[:lower:]') \
     && PLATFORM=$([ "$(uname -m)" = "aarch64" ] && echo "arm64" || echo "amd64" ) \

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -55,7 +55,7 @@ ALLOWED_INTEGRATIONS = [
 ALLOWED_KUBERNETES_MODES = ['image']
 ALLOWED_KUBERNETES_VERSIONS = ['v1.24.0', 'v1.23.6', 'v1.22.9', 'v1.21.12', 'v1.20.15']
 ALLOWED_KIND_VERSIONS = ['v0.14.0']
-ALLOWED_HELM_VERSIONS = ['v3.6.3']
+ALLOWED_HELM_VERSIONS = ['v3.9.2']
 ALLOWED_EXECUTORS = ['KubernetesExecutor', 'CeleryExecutor', 'LocalExecutor', 'CeleryKubernetesExecutor']
 ALLOWED_KIND_OPERATIONS = ['start', 'stop', 'restart', 'status', 'deploy', 'test', 'shell', 'k9s']
 ALLOWED_CONSTRAINTS_MODES_CI = ['constraints-source-providers', 'constraints', 'constraints-no-providers']
@@ -239,7 +239,7 @@ ENABLED_SYSTEMS = ""
 CURRENT_KUBERNETES_MODES = ['image']
 CURRENT_KUBERNETES_VERSIONS = ['v1.24.0', 'v1.23.6', 'v1.22.9', 'v1.21.12', 'v1.20.15']
 CURRENT_KIND_VERSIONS = ['v0.14.0']
-CURRENT_HELM_VERSIONS = ['v3.6.3']
+CURRENT_HELM_VERSIONS = ['v3.9.2']
 CURRENT_EXECUTORS = ['KubernetesExecutor']
 
 DEFAULT_KUBERNETES_MODE = CURRENT_KUBERNETES_MODES[0]


### PR DESCRIPTION
Follow-up after #25582 - Helm version was still not upgraded in
Breeze and Docker CI image.

This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
