### PR TITLE
Add `output` property to MappedOperator

### DIFF
--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -19,7 +19,7 @@
 """Example DAG demonstrating the usage of XComs."""
 import pendulum
 
-from airflow import DAG
+from airflow import DAG, XComArg
 from airflow.decorators import task
 from airflow.operators.bash import BashOperator
 
@@ -79,8 +79,8 @@ with DAG(
     bash_pull = BashOperator(
         task_id='bash_pull',
         bash_command='echo "bash pull demo" && '
-        f'echo "The xcom pushed manually is {bash_push.output["manually_pushed_value"]}" && '
-        f'echo "The returned_value xcom is {bash_push.output}" && '
+        f'echo "The xcom pushed manually is {XComArg(bash_push, key="manually_pushed_value")}" && '
+        f'echo "The returned_value xcom is {XComArg(bash_push)}" && '
         'echo "finished"',
         do_xcom_push=False,
     )
@@ -90,6 +90,3 @@ with DAG(
     [bash_pull, python_pull_from_bash] << bash_push
 
     puller(push_by_returning()) << push()
-
-    # Task dependencies created via `XComArgs`:
-    #   pull << push2

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -156,13 +156,6 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def node_id(self) -> str:
         return self.task_id
 
-    @property
-    def output(self):
-        """Returns reference to XCom pushed by current operator"""
-        from airflow.models.xcom_arg import XComArg
-
-        return XComArg(operator=self)
-
     def get_template_env(self) -> "jinja2.Environment":
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
         # This is imported locally since Jinja2 is heavy and we don't need it

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -156,6 +156,13 @@ class AbstractOperator(LoggingMixin, DAGNode):
     def node_id(self) -> str:
         return self.task_id
 
+    @property
+    def output(self):
+        """Returns reference to XCom pushed by current operator"""
+        from airflow.models.xcom_arg import XComArg
+
+        return XComArg(operator=self)
+
     def get_template_env(self) -> "jinja2.Environment":
         """Fetch a Jinja template environment from the DAG or instantiate empty environment if no DAG."""
         # This is imported locally since Jinja2 is heavy and we don't need it

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1364,13 +1364,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         """Required by DAGNode."""
         return [self]
 
-    @property
-    def output(self):
-        """Returns reference to XCom pushed by current operator"""
-        from airflow.models.xcom_arg import XComArg
-
-        return XComArg(operator=self)
-
     @staticmethod
     def xcom_push(
         context: Any,

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
 
     from airflow.models.dag import DAG
     from airflow.models.taskinstance import TaskInstanceKey
+    from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
@@ -1363,6 +1364,13 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     def leaves(self) -> List["BaseOperator"]:
         """Required by DAGNode."""
         return [self]
+
+    @property
+    def output(self) -> "XComArg":
+        """Returns reference to XCom pushed by current operator"""
+        from airflow.models.xcom_arg import XComArg
+
+        return XComArg(operator=self)
 
     @staticmethod
     def xcom_push(

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -530,6 +530,13 @@ class MappedOperator(AbstractOperator):
         """Implementing Operator."""
         return self.dag
 
+    @property
+    def output(self) -> "XComArg":
+        """Returns reference to XCom pushed by current operator"""
+        from airflow.models.xcom_arg import XComArg
+
+        return XComArg(operator=self)
+
     def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
         """Implementing DAGNode."""
         return DagAttributeTypes.OP, self.task_id

--- a/airflow/providers/amazon/aws/example_dags/example_dms.py
+++ b/airflow/providers/amazon/aws/example_dags/example_dms.py
@@ -23,6 +23,7 @@ https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.html#CHAP_Securit
 import json
 import os
 from datetime import datetime
+from typing import cast
 
 import boto3
 from sqlalchemy import Column, MetaData, String, Table, create_engine
@@ -256,10 +257,12 @@ with DAG(
     )
     # [END howto_operator_dms_create_task]
 
+    task_arn = cast(str, create_task.output)
+
     # [START howto_operator_dms_start_task]
     start_task = DmsStartTaskOperator(
         task_id='start_task',
-        replication_task_arn=create_task.output,
+        replication_task_arn=task_arn,
     )
     # [END howto_operator_dms_start_task]
 
@@ -280,7 +283,7 @@ with DAG(
 
     await_task_start = DmsTaskBaseSensor(
         task_id='await_task_start',
-        replication_task_arn=create_task.output,
+        replication_task_arn=task_arn,
         target_statuses=['running'],
         termination_statuses=['stopped', 'deleting', 'failed'],
     )
@@ -288,7 +291,7 @@ with DAG(
     # [START howto_operator_dms_stop_task]
     stop_task = DmsStopTaskOperator(
         task_id='stop_task',
-        replication_task_arn=create_task.output,
+        replication_task_arn=task_arn,
     )
     # [END howto_operator_dms_stop_task]
 
@@ -296,14 +299,14 @@ with DAG(
     # [START howto_sensor_dms_task_completed]
     await_task_stop = DmsTaskCompletedSensor(
         task_id='await_task_stop',
-        replication_task_arn=create_task.output,
+        replication_task_arn=task_arn,
     )
     # [END howto_sensor_dms_task_completed]
 
     # [START howto_operator_dms_delete_task]
     delete_task = DmsDeleteTaskOperator(
         task_id='delete_task',
-        replication_task_arn=create_task.output,
+        replication_task_arn=task_arn,
         trigger_rule='all_done',
     )
     # [END howto_operator_dms_delete_task]

--- a/airflow/providers/amazon/aws/example_dags/example_ecs.py
+++ b/airflow/providers/amazon/aws/example_dags/example_ecs.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from datetime import datetime
+from typing import cast
 
 from airflow import DAG
 from airflow.models.baseoperator import chain
@@ -99,10 +100,12 @@ with DAG(
     )
     # [END howto_operator_ecs_register_task_definition]
 
+    registered_task_definition = cast(str, register_task.output)
+
     # [START howto_sensor_ecs_task_definition_state]
     await_task_definition = EcsTaskDefinitionStateSensor(
         task_id='await_task_definition',
-        task_definition=register_task.output,
+        task_definition=registered_task_definition,
     )
     # [END howto_sensor_ecs_task_definition_state]
 
@@ -110,7 +113,7 @@ with DAG(
     run_task = EcsRunTaskOperator(
         task_id="run_task",
         cluster=EXISTING_CLUSTER_NAME,
-        task_definition=register_task.output,
+        task_definition=registered_task_definition,
         launch_type="EC2",
         overrides={
             "containerOverrides": [
@@ -156,7 +159,7 @@ with DAG(
     deregister_task = EcsDeregisterTaskDefinitionOperator(
         task_id='deregister_task',
         trigger_rule=TriggerRule.ALL_DONE,
-        task_definition=register_task.output,
+        task_definition=registered_task_definition,
     )
     # [END howto_operator_ecs_deregister_task_definition]
 

--- a/airflow/providers/amazon/aws/example_dags/example_emr.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr.py
@@ -17,6 +17,7 @@
 # under the License.
 import os
 from datetime import datetime
+from typing import cast
 
 from airflow import DAG
 from airflow.models.baseoperator import chain
@@ -79,23 +80,25 @@ with DAG(
     )
     # [END howto_operator_emr_create_job_flow]
 
+    job_flow_id = cast(str, job_flow_creator.output)
+
     # [START howto_sensor_emr_job_flow]
     job_sensor = EmrJobFlowSensor(
         task_id='check_job_flow',
-        job_flow_id=job_flow_creator.output,
+        job_flow_id=job_flow_id
     )
     # [END howto_sensor_emr_job_flow]
 
     # [START howto_operator_emr_modify_cluster]
     cluster_modifier = EmrModifyClusterOperator(
-        task_id='modify_cluster', cluster_id=job_flow_creator.output, step_concurrency_level=1
+        task_id='modify_cluster', cluster_id=job_flow_id, step_concurrency_level=1
     )
     # [END howto_operator_emr_modify_cluster]
 
     # [START howto_operator_emr_add_steps]
     step_adder = EmrAddStepsOperator(
         task_id='add_steps',
-        job_flow_id=job_flow_creator.output,
+        job_flow_id=job_flow_id,
         steps=SPARK_STEPS,
     )
     # [END howto_operator_emr_add_steps]
@@ -103,7 +106,7 @@ with DAG(
     # [START howto_sensor_emr_step]
     step_checker = EmrStepSensor(
         task_id='watch_step',
-        job_flow_id=job_flow_creator.output,
+        job_flow_id=job_flow_id,
         step_id="{{ task_instance.xcom_pull(task_ids='add_steps', key='return_value')[0] }}",
     )
     # [END howto_sensor_emr_step]
@@ -111,7 +114,7 @@ with DAG(
     # [START howto_operator_emr_terminate_job_flow]
     cluster_remover = EmrTerminateJobFlowOperator(
         task_id='remove_cluster',
-        job_flow_id=job_flow_creator.output,
+        job_flow_id=job_flow_id,
     )
     # [END howto_operator_emr_terminate_job_flow]
 

--- a/airflow/providers/amazon/aws/example_dags/example_emr.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr.py
@@ -83,10 +83,7 @@ with DAG(
     job_flow_id = cast(str, job_flow_creator.output)
 
     # [START howto_sensor_emr_job_flow]
-    job_sensor = EmrJobFlowSensor(
-        task_id='check_job_flow',
-        job_flow_id=job_flow_id
-    )
+    job_sensor = EmrJobFlowSensor(task_id='check_job_flow', job_flow_id=job_flow_id)
     # [END howto_sensor_emr_job_flow]
 
     # [START howto_operator_emr_modify_cluster]

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -67,7 +68,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output['dataset_id']
+    dataset_id = cast(str, XComArg(create_dataset_task, key='dataset_id'))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -80,7 +81,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output['model_id']
+    model_id = cast(str, XComArg(create_model, key='model_id'))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -68,7 +69,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output['dataset_id']
+    dataset_id = cast(str, XComArg(create_dataset_task, key='dataset_id'))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -81,7 +82,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output['model_id']
+    model_id = cast(str, XComArg(create_model, key='model_id'))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_tables.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_tables.py
@@ -22,9 +22,9 @@ Example Airflow DAG that uses Google AutoML services.
 import os
 from copy import deepcopy
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLBatchPredictOperator,
@@ -103,7 +103,7 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    dataset_id = create_dataset_task.output['dataset_id']
+    dataset_id = cast(str, XComArg(create_dataset_task, key='dataset_id'))
     # [END howto_operator_automl_create_dataset]
 
     MODEL["dataset_id"] = dataset_id
@@ -158,7 +158,7 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    model_id = create_model_task.output['model_id']
+    model_id = cast(str, XComArg(create_model_task, key='model_id'))
     # [END howto_operator_automl_create_model]
 
     # [START howto_operator_automl_delete_model]
@@ -209,7 +209,7 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    dataset_id = create_dataset_task2.output['dataset_id']
+    dataset_id = cast(str, XComArg(create_dataset_task2, key='dataset_id'))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_tables.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_tables.py
@@ -24,7 +24,8 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Dict, List, cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLBatchPredictOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_translation.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_translation.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -74,7 +75,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output["dataset_id"]
+    dataset_id = cast(str, XComArg(create_dataset_task, key="dataset_id"))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -87,7 +88,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output["model_id"]
+    model_id = cast(str, XComArg(create_model, key="model_id"))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_translation.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_translation.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -71,7 +72,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output["dataset_id"]
+    dataset_id = cast(str, XComArg(create_dataset_task, key="dataset_id"))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -84,7 +85,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output["model_id"]
+    model_id = cast(str, XComArg(create_model, key="model_id"))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -72,7 +73,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output["dataset_id"]
+    dataset_id = cast(str, XComArg(create_dataset_task, key="dataset_id"))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -85,7 +86,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output["model_id"]
+    model_id = cast(str, XComArg(create_model, key="model_id"))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -71,7 +72,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output["dataset_id"]
+    dataset_id = cast(str, XComArg(create_dataset_task, key="dataset_id"))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -84,7 +85,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output["model_id"]
+    model_id = cast(str, XComArg(create_model, key="model_id"))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/airflow/providers/google/cloud/example_dags/example_bigquery_dts.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_dts.py
@@ -24,7 +24,8 @@ import time
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.operators.bigquery_dts import (
     BigQueryCreateDataTransferOperator,
     BigQueryDataTransferServiceStartTransferRunsOperator,

--- a/airflow/providers/google/cloud/example_dags/example_bigquery_dts.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_dts.py
@@ -22,8 +22,9 @@ Example Airflow DAG that creates and deletes Bigquery data transfer configuratio
 import os
 import time
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.operators.bigquery_dts import (
     BigQueryCreateDataTransferOperator,
     BigQueryDataTransferServiceStartTransferRunsOperator,
@@ -75,7 +76,7 @@ with models.DAG(
         task_id="gcp_bigquery_create_transfer",
     )
 
-    transfer_config_id = gcp_bigquery_create_transfer.output["transfer_config_id"]
+    transfer_config_id = cast(str, XComArg(gcp_bigquery_create_transfer, key="transfer_config_id"))
     # [END howto_bigquery_create_data_transfer]
 
     # [START howto_bigquery_start_transfer]
@@ -90,7 +91,7 @@ with models.DAG(
     gcp_run_sensor = BigQueryDataTransferServiceTransferRunSensor(
         task_id="gcp_run_sensor",
         transfer_config_id=transfer_config_id,
-        run_id=gcp_bigquery_start_transfer.output["run_id"],
+        run_id=cast(str, XComArg(gcp_bigquery_start_transfer, key="run_id")),
         expected_statuses={"SUCCEEDED"},
     )
     # [END howto_bigquery_dts_sensor]

--- a/airflow/providers/google/cloud/example_dags/example_datafusion.py
+++ b/airflow/providers/google/cloud/example_dags/example_datafusion.py
@@ -20,6 +20,7 @@ Example Airflow DAG that shows how to use DataFusion.
 """
 import os
 from datetime import datetime
+from typing import cast
 
 from airflow import models
 from airflow.operators.bash import BashOperator
@@ -221,7 +222,7 @@ with models.DAG(
     start_pipeline_sensor = CloudDataFusionPipelineStateSensor(
         task_id="pipeline_state_sensor",
         pipeline_name=PIPELINE_NAME,
-        pipeline_id=start_pipeline_async.output,
+        pipeline_id=cast(str, start_pipeline_async.output),
         expected_statuses=["COMPLETED"],
         failure_statuses=["FAILED"],
         instance_name=INSTANCE_NAME,

--- a/airflow/providers/google/cloud/example_dags/example_looker.py
+++ b/airflow/providers/google/cloud/example_dags/example_looker.py
@@ -21,6 +21,7 @@ operators to submit PDT materialization job and manage it.
 """
 
 from datetime import datetime
+from typing import cast
 
 from airflow import models
 from airflow.providers.google.cloud.operators.looker import LookerStartPdtBuildOperator
@@ -43,7 +44,7 @@ with models.DAG(
     check_pdt_task_async_sensor = LookerCheckPdtBuildSensor(
         task_id='check_pdt_task_async_sensor',
         looker_conn_id='your_airflow_connection_for_looker',
-        materialization_id=start_pdt_task_async.output,
+        materialization_id=cast(str, start_pdt_task_async.output),
         poke_interval=10,
     )
     # [END cloud_looker_async_start_pdt_sensor]

--- a/airflow/providers/google/cloud/example_dags/example_vision.py
+++ b/airflow/providers/google/cloud/example_dags/example_vision.py
@@ -33,6 +33,7 @@ This DAG relies on the following OS environment variables
 
 import os
 from datetime import datetime
+from typing import cast
 
 from airflow import models
 from airflow.operators.bash import BashOperator
@@ -135,7 +136,7 @@ with models.DAG(
     )
     # [END howto_operator_vision_product_set_create]
 
-    product_set_create_output = product_set_create.output
+    product_set_create_output = cast(str, product_set_create.output)
 
     # [START howto_operator_vision_product_set_get]
     product_set_get = CloudVisionGetProductSetOperator(
@@ -172,7 +173,7 @@ with models.DAG(
     )
     # [END howto_operator_vision_product_create]
 
-    product_create_output = product_create.output
+    product_create_output = cast(str, product_create.output)
 
     # [START howto_operator_vision_product_get]
     product_get = CloudVisionGetProductOperator(

--- a/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
@@ -22,7 +22,8 @@ import os
 from datetime import datetime
 from typing import Dict, cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook
 from airflow.providers.google.marketing_platform.operators.display_video import (

--- a/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
@@ -20,9 +20,9 @@ Example Airflow DAG that shows how to use DisplayVideo.
 """
 import os
 from datetime import datetime
-from typing import Dict
+from typing import Dict, cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook
 from airflow.providers.google.marketing_platform.operators.display_video import (
@@ -91,7 +91,7 @@ with models.DAG(
 ) as dag1:
     # [START howto_google_display_video_createquery_report_operator]
     create_report = GoogleDisplayVideo360CreateReportOperator(body=REPORT, task_id="create_report")
-    report_id = create_report.output["report_id"]
+    report_id = cast(str, XComArg(create_report, key="report_id"))
     # [END howto_google_display_video_createquery_report_operator]
 
     # [START howto_google_display_video_runquery_report_operator]

--- a/tests/system/providers/airbyte/example_airbyte_trigger_job.py
+++ b/tests/system/providers/airbyte/example_airbyte_trigger_job.py
@@ -20,6 +20,7 @@
 
 import os
 from datetime import datetime, timedelta
+from typing import cast
 
 from airflow import DAG
 from airflow.providers.airbyte.operators.airbyte import AirbyteTriggerSyncOperator
@@ -54,7 +55,7 @@ with DAG(
 
     airbyte_sensor = AirbyteJobSensor(
         task_id='airbyte_sensor_source_dest_example',
-        airbyte_job_id=async_source_destination.output,
+        airbyte_job_id=cast(int, async_source_destination.output),
     )
     # [END howto_operator_airbyte_asynchronous]
 

--- a/tests/system/providers/amazon/aws/example_athena.py
+++ b/tests/system/providers/amazon/aws/example_athena.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
+from typing import cast
 
 import boto3
 
@@ -121,7 +122,7 @@ with DAG(
     # [START howto_sensor_athena]
     await_query = AthenaSensor(
         task_id='await_query',
-        query_execution_id=read_table.output,
+        query_execution_id=cast(str, read_table.output),
     )
     # [END howto_sensor_athena]
 

--- a/tests/system/providers/amazon/aws/example_batch.py
+++ b/tests/system/providers/amazon/aws/example_batch.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
+from typing import cast
 
 import boto3
 
@@ -193,7 +194,7 @@ with DAG(
     # [START howto_sensor_batch]
     wait_for_batch_job = BatchSensor(
         task_id='wait_for_batch_job',
-        job_id=submit_batch_job.output,
+        job_id=cast(str, submit_batch_job.output),
     )
     # [END howto_sensor_batch]
 

--- a/tests/system/providers/amazon/aws/example_emr_serverless.py
+++ b/tests/system/providers/amazon/aws/example_emr_serverless.py
@@ -17,6 +17,7 @@
 
 
 from datetime import datetime
+from typing import cast
 
 from airflow.models.baseoperator import chain
 from airflow.models.dag import DAG
@@ -73,17 +74,19 @@ with DAG(
     )
     # [END howto_operator_emr_serverless_create_application]
 
+    emr_serverless_app_id = cast(str, emr_serverless_app.output)
+
     # [START howto_sensor_emr_serverless_application]
     wait_for_app_creation = EmrServerlessApplicationSensor(
         task_id='wait_for_app_creation',
-        application_id=emr_serverless_app.output,
+        application_id=emr_serverless_app_id,
     )
     # [END howto_sensor_emr_serverless_application]
 
     # [START howto_operator_emr_serverless_start_job]
     start_job = EmrServerlessStartJobOperator(
         task_id='start_emr_serverless_job',
-        application_id=emr_serverless_app.output,
+        application_id=emr_serverless_app_id,
         execution_role_arn=role_arn,
         job_driver=SPARK_JOB_DRIVER,
         configuration_overrides=SPARK_CONFIGURATION_OVERRIDES,
@@ -92,14 +95,14 @@ with DAG(
 
     # [START howto_sensor_emr_serverless_job]
     wait_for_job = EmrServerlessJobSensor(
-        task_id='wait_for_job', application_id=emr_serverless_app.output, job_run_id=start_job.output
+        task_id='wait_for_job', application_id=emr_serverless_app_id, job_run_id=cast(str, start_job.output)
     )
     # [END howto_sensor_emr_serverless_job]
 
     # [START howto_operator_emr_serverless_delete_application]
     delete_app = EmrServerlessDeleteApplicationOperator(
         task_id='delete_application',
-        application_id=emr_serverless_app.output,
+        application_id=emr_serverless_app_id,
         trigger_rule=TriggerRule.ALL_DONE,
     )
     # [END howto_operator_emr_serverless_delete_application]

--- a/tests/system/providers/amazon/aws/example_glue.py
+++ b/tests/system/providers/amazon/aws/example_glue.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, cast
 
 import boto3
 from botocore.client import BaseClient
@@ -174,7 +174,7 @@ with DAG(
         task_id='wait_for_job',
         job_name=glue_job_name,
         # Job ID extracted from previous Glue Job Operator task
-        run_id=submit_glue_job.output,
+        run_id=cast(str, submit_glue_job.output),
     )
     # [END howto_sensor_glue]
 

--- a/tests/system/providers/amazon/aws/example_glue.py
+++ b/tests/system/providers/amazon/aws/example_glue.py
@@ -162,7 +162,7 @@ with DAG(
         job_name=glue_job_name,
         script_location=f's3://{bucket_name}/etl_script.py',
         s3_bucket=bucket_name,
-        iam_role_name=role_name,
+        iam_role_name=cast(str, role_name),
         create_job_kwargs={'GlueVersion': '3.0', 'NumberOfWorkers': 2, 'WorkerType': 'G.1X'},
         # Waits by default, set False to test the Sensor below
         wait_for_completion=False,
@@ -199,7 +199,7 @@ with DAG(
         # TEST TEARDOWN
         glue_cleanup(glue_crawler_name, glue_job_name, glue_db_name),
         delete_bucket,
-        delete_logs(submit_glue_job.output, glue_crawler_name),
+        delete_logs(cast(str, submit_glue_job.output), glue_crawler_name),
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/amazon/aws/example_step_functions.py
+++ b/tests/system/providers/amazon/aws/example_step_functions.py
@@ -80,7 +80,7 @@ with DAG(
 
     # [START howto_operator_step_function_start_execution]
     start_execution = StepFunctionStartExecutionOperator(
-        task_id='start_execution', state_machine_arn=state_machine_arn
+        task_id='start_execution', state_machine_arn=cast(str, state_machine_arn)
     )
     # [END howto_operator_step_function_start_execution]
 

--- a/tests/system/providers/amazon/aws/example_step_functions.py
+++ b/tests/system/providers/amazon/aws/example_step_functions.py
@@ -16,6 +16,7 @@
 # under the License.
 import json
 from datetime import datetime
+from typing import cast
 
 from airflow import DAG
 from airflow.decorators import task
@@ -83,15 +84,17 @@ with DAG(
     )
     # [END howto_operator_step_function_start_execution]
 
+    execution_arn = cast(str, start_execution.output)
+
     # [START howto_sensor_step_function_execution]
     wait_for_execution = StepFunctionExecutionSensor(
-        task_id='wait_for_execution', execution_arn=start_execution.output
+        task_id='wait_for_execution', execution_arn=execution_arn
     )
     # [END howto_sensor_step_function_execution]
 
     # [START howto_operator_step_function_get_execution_output]
     get_execution_output = StepFunctionGetExecutionOutputOperator(
-        task_id='get_execution_output', execution_arn=start_execution.output
+        task_id='get_execution_output', execution_arn=execution_arn
     )
     # [END howto_operator_step_function_get_execution_output]
 

--- a/tests/system/providers/dbt/cloud/example_dbt_cloud.py
+++ b/tests/system/providers/dbt/cloud/example_dbt_cloud.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from datetime import datetime
+from typing import cast
 
 from airflow.models import DAG
 
@@ -56,7 +57,7 @@ with DAG(
 
     # [START howto_operator_dbt_cloud_get_artifact]
     get_run_results_artifact = DbtCloudGetJobRunArtifactOperator(
-        task_id="get_run_results_artifact", run_id=trigger_job_run1.output, path="run_results.json"
+        task_id="get_run_results_artifact", run_id=cast(int, trigger_job_run1.output), path="run_results.json"
     )
     # [END howto_operator_dbt_cloud_get_artifact]
 
@@ -71,7 +72,7 @@ with DAG(
 
     # [START howto_operator_dbt_cloud_run_job_sensor]
     job_run_sensor = DbtCloudJobRunSensor(
-        task_id="job_run_sensor", run_id=trigger_job_run2.output, timeout=20
+        task_id="job_run_sensor", run_id=cast(int, trigger_job_run2.output), timeout=20
     )
     # [END howto_operator_dbt_cloud_run_job_sensor]
 

--- a/tests/system/providers/google/cloud/automl/example_automl_nl_text_extraction.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_nl_text_extraction.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/tests/system/providers/google/cloud/automl/example_automl_nl_text_extraction.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_nl_text_extraction.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -72,7 +73,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output['dataset_id']
+    dataset_id = cast(str, XComArg(create_dataset_task, key='dataset_id'))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -85,7 +86,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output['model_id']
+    model_id = cast(str, XComArg(create_model, key='model_id'))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/tests/system/providers/google/cloud/automl/example_automl_vision_classification.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_vision_classification.py
@@ -23,7 +23,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,

--- a/tests/system/providers/google/cloud/automl/example_automl_vision_classification.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_vision_classification.py
@@ -21,8 +21,9 @@ Example Airflow DAG that uses Google AutoML services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
@@ -73,7 +74,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = create_dataset_task.output["dataset_id"]
+    dataset_id = cast(str, XComArg(create_dataset_task, key="dataset_id"))
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -86,7 +87,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = create_model.output["model_id"]
+    model_id = cast(str, XComArg(create_model, key="model_id"))
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",

--- a/tests/system/providers/google/cloud/cloud_build/example_cloud_build.py
+++ b/tests/system/providers/google/cloud/cloud_build/example_cloud_build.py
@@ -31,13 +31,14 @@ This DAG relies on the following OS environment variables:
 import os
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import yaml
 from future.backports.urllib.parse import urlparse
 
 from airflow import models
 from airflow.models.baseoperator import chain
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.cloud_build import (
     CloudBuildCancelBuildOperator,
@@ -106,7 +107,7 @@ with models.DAG(
 
     # [START howto_operator_create_build_from_storage_result]
     create_build_from_storage_result = BashOperator(
-        bash_command=f"echo { create_build_from_storage.output['results'] }",
+        bash_command=f"echo {cast(str, XComArg(create_build_from_storage, key='results'))}",
         task_id="create_build_from_storage_result",
     )
     # [END howto_operator_create_build_from_storage_result]
@@ -119,7 +120,7 @@ with models.DAG(
 
     # [START howto_operator_create_build_from_repo_result]
     create_build_from_repo_result = BashOperator(
-        bash_command=f"echo { create_build_from_repo.output['results'] }",
+        bash_command=f"echo {cast(str, XComArg(create_build_from_repo, key='results'))}",
         task_id="create_build_from_repo_result",
     )
     # [END howto_operator_create_build_from_repo_result]
@@ -142,7 +143,7 @@ with models.DAG(
     # [START howto_operator_cancel_build]
     cancel_build = CloudBuildCancelBuildOperator(
         task_id="cancel_build",
-        id_=create_build_without_wait.output['id'],
+        id_=cast(str, XComArg(create_build_without_wait, key='id')),
         project_id=PROJECT_ID,
     )
     # [END howto_operator_cancel_build]
@@ -150,7 +151,7 @@ with models.DAG(
     # [START howto_operator_retry_build]
     retry_build = CloudBuildRetryBuildOperator(
         task_id="retry_build",
-        id_=cancel_build.output['id'],
+        id_=cast(str, XComArg(cancel_build, key='id')),
         project_id=PROJECT_ID,
     )
     # [END howto_operator_retry_build]
@@ -158,7 +159,7 @@ with models.DAG(
     # [START howto_operator_get_build]
     get_build = CloudBuildGetBuildOperator(
         task_id="get_build",
-        id_=retry_build.output['id'],
+        id_=cast(str, XComArg(retry_build, key='id')),
         project_id=PROJECT_ID,
     )
     # [END howto_operator_get_build]

--- a/tests/system/providers/google/cloud/cloud_build/example_cloud_build_trigger.py
+++ b/tests/system/providers/google/cloud/cloud_build/example_cloud_build_trigger.py
@@ -24,10 +24,11 @@ This DAG relies on the following OS environment variables:
 
 import os
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from airflow import models
 from airflow.models.baseoperator import chain
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.operators.cloud_build import (
     CloudBuildCreateBuildTriggerOperator,
     CloudBuildDeleteBuildTriggerOperator,
@@ -90,11 +91,13 @@ with models.DAG(
     )
     # [END howto_operator_create_build_trigger]
 
+    build_trigger_id = cast(str, XComArg(create_build_trigger, key="id"))
+
     # [START howto_operator_run_build_trigger]
     run_build_trigger = CloudBuildRunBuildTriggerOperator(
         task_id="run_build_trigger",
         project_id=PROJECT_ID,
-        trigger_id=create_build_trigger.output['id'],
+        trigger_id=build_trigger_id,
         source=create_build_from_repo_body['source']['repo_source'],
     )
     # [END howto_operator_run_build_trigger]
@@ -103,7 +106,7 @@ with models.DAG(
     update_build_trigger = CloudBuildUpdateBuildTriggerOperator(
         task_id="update_build_trigger",
         project_id=PROJECT_ID,
-        trigger_id=create_build_trigger.output['id'],
+        trigger_id=build_trigger_id,
         trigger=update_build_trigger_body,
     )
     # [END howto_operator_update_build_trigger]
@@ -112,7 +115,7 @@ with models.DAG(
     get_build_trigger = CloudBuildGetBuildTriggerOperator(
         task_id="get_build_trigger",
         project_id=PROJECT_ID,
-        trigger_id=create_build_trigger.output['id'],
+        trigger_id=build_trigger_id,
     )
     # [END howto_operator_get_build_trigger]
 
@@ -120,7 +123,7 @@ with models.DAG(
     delete_build_trigger = CloudBuildDeleteBuildTriggerOperator(
         task_id="delete_build_trigger",
         project_id=PROJECT_ID,
-        trigger_id=create_build_trigger.output['id'],
+        trigger_id=build_trigger_id,
     )
     # [END howto_operator_delete_build_trigger]
 

--- a/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
+++ b/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
@@ -31,7 +31,7 @@ import os
 from datetime import datetime
 from urllib.parse import urlsplit
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.operators.cloud_sql import (
     CloudSQLCreateInstanceDatabaseOperator,
     CloudSQLCreateInstanceOperator,
@@ -196,9 +196,11 @@ with models.DAG(
 
     # For export & import to work we need to add the Cloud SQL instance's Service Account
     # write access to the destination GCS bucket.
+    service_account_email = XComArg(sql_instance_create_task, key='service_account_email')
+
     # [START howto_operator_cloudsql_export_gcs_permissions]
     sql_gcp_add_bucket_permission_task = GCSBucketCreateAclEntryOperator(
-        entity=f"user-{sql_instance_create_task.output['service_account_email']}",
+        entity=f"user-{service_account_email}",
         role="WRITER",
         bucket=file_url_split[1],  # netloc (bucket)
         task_id='sql_gcp_add_bucket_permission_task',
@@ -215,7 +217,7 @@ with models.DAG(
     # read access to the target GCS object.
     # [START howto_operator_cloudsql_import_gcs_permissions]
     sql_gcp_add_object_permission_task = GCSObjectCreateAclEntryOperator(
-        entity=f"user-{sql_instance_create_task.output['service_account_email']}",
+        entity=f"user-{service_account_email}",
         role="READER",
         bucket=file_url_split[1],  # netloc (bucket)
         object_name=file_url_split[2][1:],  # path (strip first '/')

--- a/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
+++ b/tests/system/providers/google/cloud/cloud_sql/example_cloud_sql.py
@@ -31,7 +31,8 @@ import os
 from datetime import datetime
 from urllib.parse import urlsplit
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.operators.cloud_sql import (
     CloudSQLCreateInstanceDatabaseOperator,
     CloudSQLCreateInstanceOperator,

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
@@ -21,6 +21,7 @@ Example Airflow DAG for DataprocSubmitJobOperator with async spark job.
 
 import os
 from datetime import datetime
+from typing import cast
 
 from airflow import models
 from airflow.providers.google.cloud.operators.dataproc import (
@@ -90,7 +91,7 @@ with models.DAG(
         task_id='spark_task_async_sensor_task',
         region=REGION,
         project_id=PROJECT_ID,
-        dataproc_job_id=spark_task_async.output,
+        dataproc_job_id=cast(str, spark_task_async.output),
         poke_interval=10,
     )
     # [END cloud_dataproc_async_submit_sensor]

--- a/tests/system/providers/google/cloud/datastore/example_datastore_rollback.py
+++ b/tests/system/providers/google/cloud/datastore/example_datastore_rollback.py
@@ -22,7 +22,7 @@ Airflow System Test DAG that verifies Datastore rollback operators.
 
 import os
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 from airflow import models
 from airflow.providers.google.cloud.operators.datastore import (
@@ -54,7 +54,7 @@ with models.DAG(
     # [START how_to_rollback_transaction]
     rollback_transaction = CloudDatastoreRollbackOperator(
         task_id="rollback_transaction",
-        transaction=begin_transaction_to_rollback.output,
+        transaction=cast(str, begin_transaction_to_rollback.output),
     )
     # [END how_to_rollback_transaction]
 

--- a/tests/system/providers/google/cloud/gcs/example_sheets.py
+++ b/tests/system/providers/google/cloud/gcs/example_sheets.py
@@ -19,7 +19,8 @@
 import os
 from datetime import datetime
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.sheets_to_gcs import GoogleSheetsToGCSOperator

--- a/tests/system/providers/google/cloud/gcs/example_sheets.py
+++ b/tests/system/providers/google/cloud/gcs/example_sheets.py
@@ -19,7 +19,7 @@
 import os
 from datetime import datetime
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.cloud.transfers.sheets_to_gcs import GoogleSheetsToGCSOperator
@@ -68,7 +68,7 @@ with models.DAG(
     # [START print_spreadsheet_url]
     print_spreadsheet_url = BashOperator(
         task_id="print_spreadsheet_url",
-        bash_command=f"echo {create_spreadsheet.output['spreadsheet_url']}",
+        bash_command=f"echo {XComArg(create_spreadsheet, key='spreadsheet_url')}",
     )
     # [END print_spreadsheet_url]
 

--- a/tests/system/providers/google/cloud/pubsub/example_pubsub.py
+++ b/tests/system/providers/google/cloud/pubsub/example_pubsub.py
@@ -21,6 +21,7 @@ Example Airflow DAG that uses Google PubSub services.
 """
 import os
 from datetime import datetime
+from typing import cast
 
 from airflow import models
 from airflow.operators.bash import BashOperator
@@ -71,7 +72,7 @@ with models.DAG(
     # [END howto_operator_gcp_pubsub_create_subscription]
 
     # [START howto_operator_gcp_pubsub_pull_message_with_sensor]
-    subscription = subscribe_task.output
+    subscription = cast(str, subscribe_task.output)
 
     pull_messages = PubSubPullSensor(
         task_id="pull_messages",

--- a/tests/system/providers/google/cloud/workflows/example_workflows.py
+++ b/tests/system/providers/google/cloud/workflows/example_workflows.py
@@ -17,10 +17,11 @@
 
 import os
 from datetime import datetime
+from typing import cast
 
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from airflow import DAG
+from airflow import DAG, XComArg
 from airflow.providers.google.cloud.operators.workflows import (
     WorkflowsCancelExecutionOperator,
     WorkflowsCreateExecutionOperator,
@@ -143,7 +144,7 @@ with DAG(
     )
     # [END how_to_create_execution]
 
-    create_execution_id = create_execution.output["execution_id"]
+    create_execution_id = cast(str, XComArg(create_execution, key="execution_id"))
 
     # [START how_to_wait_for_execution]
     wait_for_execution = WorkflowExecutionSensor(
@@ -187,7 +188,7 @@ with DAG(
         workflow_id=SLEEP_WORKFLOW_ID,
     )
 
-    cancel_execution_id = create_execution_for_cancel.output["execution_id"]
+    cancel_execution_id = cast(str, XComArg(create_execution_for_cancel, key="execution_id"))
 
     # [START how_to_cancel_execution]
     cancel_execution = WorkflowsCancelExecutionOperator(

--- a/tests/system/providers/google/cloud/workflows/example_workflows.py
+++ b/tests/system/providers/google/cloud/workflows/example_workflows.py
@@ -21,7 +21,8 @@ from typing import cast
 
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from airflow import DAG, XComArg
+from airflow import DAG
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.operators.workflows import (
     WorkflowsCancelExecutionOperator,
     WorkflowsCreateExecutionOperator,

--- a/tests/system/providers/google/datacatalog/example_datacatalog_entries.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_entries.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,
@@ -69,7 +69,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_group_result]
     create_entry_group_result = BashOperator(
         task_id="create_entry_group_result",
-        bash_command=f"echo {create_entry_group.output['entry_group_id']}",
+        bash_command=f"echo {XComArg(create_entry_group, key='entry_group_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_group_result]
 
@@ -90,7 +90,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_gcs_result]
     create_entry_gcs_result = BashOperator(
         task_id="create_entry_gcs_result",
-        bash_command=f"echo {create_entry_gcs.output['entry_id']}",
+        bash_command=f"echo {XComArg(create_entry_gcs, key='entry_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_gcs_result]
 

--- a/tests/system/providers/google/datacatalog/example_datacatalog_entries.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_entries.py
@@ -21,7 +21,8 @@ from datetime import datetime
 
 from google.protobuf.field_mask_pb2 import FieldMask
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,

--- a/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
@@ -22,7 +22,8 @@ from typing import cast
 
 from google.cloud.datacatalog import TagField, TagTemplateField
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,

--- a/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_search_catalog.py
@@ -18,10 +18,11 @@
 
 import os
 from datetime import datetime
+from typing import cast
 
 from google.cloud.datacatalog import TagField, TagTemplateField
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,
@@ -73,7 +74,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_group_result]
     create_entry_group_result = BashOperator(
         task_id="create_entry_group_result",
-        bash_command=f"echo {create_entry_group.output['entry_group_id']}",
+        bash_command=f"echo {XComArg(create_entry_group, key='entry_group_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_group_result]
 
@@ -94,7 +95,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_gcs_result]
     create_entry_gcs_result = BashOperator(
         task_id="create_entry_gcs_result",
-        bash_command=f"echo {create_entry_gcs.output['entry_id']}",
+        bash_command=f"echo {XComArg(create_entry_gcs, key='entry_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_gcs_result]
 
@@ -109,10 +110,12 @@ with models.DAG(
     )
     # [END howto_operator_gcp_datacatalog_create_tag]
 
+    tag_id = cast(str, XComArg(create_tag, key='tag_id'))
+
     # [START howto_operator_gcp_datacatalog_create_tag_result]
     create_tag_result = BashOperator(
         task_id="create_tag_result",
-        bash_command=f"echo {create_tag.output['tag_id']}",
+        bash_command=f"echo {tag_id}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_result]
 
@@ -135,7 +138,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_tag_template_result]
     create_tag_template_result = BashOperator(
         task_id="create_tag_template_result",
-        bash_command=f"echo {create_tag_template.output['tag_template_id']}",
+        bash_command=f"echo {XComArg(create_tag_template, key='tag_template_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_result]
 
@@ -174,7 +177,7 @@ with models.DAG(
         location=LOCATION,
         entry_group=ENTRY_GROUP_ID,
         entry=ENTRY_ID,
-        tag=create_tag.output["tag_id"],
+        tag=tag_id,
     )
     # [END howto_operator_gcp_datacatalog_delete_tag]
     delete_tag.trigger_rule = TriggerRule.ALL_DONE

--- a/tests/system/providers/google/datacatalog/example_datacatalog_tag_templates.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_tag_templates.py
@@ -21,7 +21,8 @@ from datetime import datetime
 
 from google.cloud.datacatalog import FieldType, TagTemplateField
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateTagTemplateFieldOperator,

--- a/tests/system/providers/google/datacatalog/example_datacatalog_tag_templates.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_tag_templates.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from google.cloud.datacatalog import FieldType, TagTemplateField
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateTagTemplateFieldOperator,
@@ -73,7 +73,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_tag_template_result]
     create_tag_template_result = BashOperator(
         task_id="create_tag_template_result",
-        bash_command=f"echo {create_tag_template.output['tag_template_id']}",
+        bash_command=f"echo {XComArg(create_tag_template, key='tag_template_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_result]
 
@@ -92,7 +92,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_tag_template_field_result]
     create_tag_template_field_result = BashOperator(
         task_id="create_tag_template_field_result",
-        bash_command=f"echo {create_tag_template_field.output['tag_template_field_id']}",
+        bash_command=f"echo {XComArg(create_tag_template_field, key='tag_template_field_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_field_result]
 

--- a/tests/system/providers/google/datacatalog/example_datacatalog_tags.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_tags.py
@@ -22,7 +22,8 @@ from typing import cast
 
 from google.cloud.datacatalog import TagField, TagTemplateField
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,

--- a/tests/system/providers/google/datacatalog/example_datacatalog_tags.py
+++ b/tests/system/providers/google/datacatalog/example_datacatalog_tags.py
@@ -18,10 +18,11 @@
 
 import os
 from datetime import datetime
+from typing import cast
 
 from google.cloud.datacatalog import TagField, TagTemplateField
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.datacatalog import (
     CloudDataCatalogCreateEntryGroupOperator,
@@ -74,7 +75,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_group_result]
     create_entry_group_result = BashOperator(
         task_id="create_entry_group_result",
-        bash_command=f"echo {create_entry_group.output['entry_group_id']}",
+        bash_command=f"echo {XComArg(create_entry_group, key='entry_group_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_group_result]
 
@@ -95,7 +96,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_entry_gcs_result]
     create_entry_gcs_result = BashOperator(
         task_id="create_entry_gcs_result",
-        bash_command=f"echo {create_entry_gcs.output['entry_id']}",
+        bash_command=f"echo {XComArg(create_entry_gcs, key='entry_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_gcs_result]
 
@@ -110,10 +111,12 @@ with models.DAG(
     )
     # [END howto_operator_gcp_datacatalog_create_tag]
 
+    tag_id = cast(str, XComArg(create_tag, key='tag_id'))
+
     # [START howto_operator_gcp_datacatalog_create_tag_result]
     create_tag_result = BashOperator(
         task_id="create_tag_result",
-        bash_command=f"echo {create_tag.output['tag_id']}",
+        bash_command=f"echo {tag_id}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_result]
 
@@ -136,7 +139,7 @@ with models.DAG(
     # [START howto_operator_gcp_datacatalog_create_tag_template_result]
     create_tag_template_result = BashOperator(
         task_id="create_tag_template_result",
-        bash_command=f"echo {create_tag_template.output['tag_template_id']}",
+        bash_command=f"echo {XComArg(create_tag_template, key='tag_template_id')}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_result]
 
@@ -160,7 +163,7 @@ with models.DAG(
         location=LOCATION,
         entry_group=ENTRY_GROUP_ID,
         entry=ENTRY_ID,
-        tag_id=f"{create_tag.output['tag_id']}",
+        tag_id=tag_id,
     )
     # [END howto_operator_gcp_datacatalog_update_tag]
 
@@ -185,7 +188,7 @@ with models.DAG(
         location=LOCATION,
         entry_group=ENTRY_GROUP_ID,
         entry=ENTRY_ID,
-        tag=create_tag.output["tag_id"],
+        tag=tag_id,
     )
     # [END howto_operator_gcp_datacatalog_delete_tag]
     delete_tag.trigger_rule = TriggerRule.ALL_DONE

--- a/tests/system/providers/google/marketing_platform/example_campaign_manager.py
+++ b/tests/system/providers/google/marketing_platform/example_campaign_manager.py
@@ -21,8 +21,9 @@ Example Airflow DAG that shows how to use CampaignManager.
 import os
 import time
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.marketing_platform.operators.campaign_manager import (
     GoogleCampaignManagerBatchInsertConversionsOperator,
@@ -105,14 +106,14 @@ with models.DAG(
     create_report = GoogleCampaignManagerInsertReportOperator(
         profile_id=PROFILE_ID, report=REPORT, task_id="create_report"
     )
-    report_id = create_report.output["report_id"]
+    report_id = cast(str, XComArg(create_report, key="report_id"))
     # [END howto_campaign_manager_insert_report_operator]
 
     # [START howto_campaign_manager_run_report_operator]
     run_report = GoogleCampaignManagerRunReportOperator(
         profile_id=PROFILE_ID, report_id=report_id, task_id="run_report"
     )
-    file_id = run_report.output["file_id"]
+    file_id = cast(str, XComArg(run_report, key="file_id"))
     # [END howto_campaign_manager_run_report_operator]
 
     # [START howto_campaign_manager_wait_for_operation]

--- a/tests/system/providers/google/marketing_platform/example_campaign_manager.py
+++ b/tests/system/providers/google/marketing_platform/example_campaign_manager.py
@@ -23,7 +23,8 @@ import time
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
 from airflow.providers.google.marketing_platform.operators.campaign_manager import (
     GoogleCampaignManagerBatchInsertConversionsOperator,

--- a/tests/system/providers/google/marketing_platform/example_search_ads.py
+++ b/tests/system/providers/google/marketing_platform/example_search_ads.py
@@ -20,8 +20,9 @@ Example Airflow DAG that shows how to use SearchAds.
 """
 import os
 from datetime import datetime
+from typing import cast
 
-from airflow import models
+from airflow import XComArg, models
 from airflow.providers.google.marketing_platform.operators.search_ads import (
     GoogleSearchAdsDownloadReportOperator,
     GoogleSearchAdsInsertReportOperator,
@@ -59,7 +60,7 @@ with models.DAG(
     # [END howto_search_ads_generate_report_operator]
 
     # [START howto_search_ads_get_report_id]
-    report_id = generate_report.output["report_id"]
+    report_id = cast(str, XComArg(generate_report, key="report_id"))
     # [END howto_search_ads_get_report_id]
 
     # [START howto_search_ads_get_report_operator]

--- a/tests/system/providers/google/marketing_platform/example_search_ads.py
+++ b/tests/system/providers/google/marketing_platform/example_search_ads.py
@@ -22,7 +22,8 @@ import os
 from datetime import datetime
 from typing import cast
 
-from airflow import XComArg, models
+from airflow import models
+from airflow.models.xcom_arg import XComArg
 from airflow.providers.google.marketing_platform.operators.search_ads import (
     GoogleSearchAdsDownloadReportOperator,
     GoogleSearchAdsInsertReportOperator,

--- a/tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
+++ b/tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
@@ -16,7 +16,9 @@
 # under the License.
 import os
 from datetime import datetime, timedelta
+from typing import cast
 
+from airflow import XComArg
 from airflow.models import DAG
 
 try:
@@ -65,7 +67,7 @@ with DAG(
 
     pipeline_run_sensor = AzureDataFactoryPipelineRunStatusSensor(
         task_id="pipeline_run_sensor",
-        run_id=run_pipeline2.output["run_id"],
+        run_id=cast(str, XComArg(run_pipeline2, key="run_id")),
     )
     # [END howto_operator_adf_run_pipeline_async]
 

--- a/tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
+++ b/tests/system/providers/microsoft/azure/example_adf_run_pipeline.py
@@ -18,8 +18,8 @@ import os
 from datetime import datetime, timedelta
 from typing import cast
 
-from airflow import XComArg
 from airflow.models import DAG
+from airflow.models.xcom_arg import XComArg
 
 try:
     from airflow.operators.empty import EmptyOperator

--- a/tests/system/providers/tableau/example_tableau.py
+++ b/tests/system/providers/tableau/example_tableau.py
@@ -22,6 +22,7 @@ when the operation actually finishes. That's why we have another task that check
 """
 import os
 from datetime import datetime, timedelta
+from typing import cast
 
 from airflow import DAG
 from airflow.providers.tableau.operators.tableau import TableauOperator
@@ -60,7 +61,7 @@ with DAG(
     )
     # The following task queries the status of the workbook refresh job until it succeeds.
     task_check_job_status = TableauJobStatusSensor(
-        job_id=task_refresh_workbook_non_blocking.output,
+        job_id=cast(str, task_refresh_workbook_non_blocking.output),
         task_id='check_tableau_job_status',
     )
 

--- a/tests/system/providers/tableau/example_tableau_refresh_workbook.py
+++ b/tests/system/providers/tableau/example_tableau_refresh_workbook.py
@@ -22,6 +22,7 @@ when the operation actually finishes. That's why we have another task that check
 """
 import os
 from datetime import datetime, timedelta
+from typing import cast
 
 from airflow import DAG
 from airflow.providers.tableau.operators.tableau import TableauOperator
@@ -58,7 +59,7 @@ with DAG(
     )
     # The following task queries the status of the workbook refresh job until it succeeds.
     task_check_job_status = TableauJobStatusSensor(
-        job_id=task_refresh_workbook_non_blocking.output,
+        job_id=cast(str, task_refresh_workbook_non_blocking.output),
         task_id='check_tableau_job_status',
     )
 


### PR DESCRIPTION
Currently the `output` property of operators is only available to unmapped "classic" operators. There can be use cases in which `XComs` from a set of mapped tasks need to be consumed by a downstream task. Of course, accessing these mapped-task `XComs` can be done with the typical Jinja template, but having the convenience of using the `output` property would be a "quality of life" improvement for DAG authors (especially since task dependencies would then be automatically implemented too).

~Rather than adding the property to `MappedOperator` and have this property definition exist in two locations (along with `BaseOperator`), I opted to add this to `AbstractOperator` given all tasks have an output even if that output is empty and both `BaseOperator` and `MappedOperator` share the `AbstractOperator` implementation. If there a higher-level reason to have two instances of the property definition, I'm happy to oblige.~

This PR adds the `output` property to `MappedOperator` and includes a return type annotation for `XComArg`. Additionally, until a more appropriate API implementation of accessing a different `XCom` key from `output` other than "return_value" is decided, the example DAGs and system tests using this API have been updated to explicitly use `XComArg(operator, key=...)` instead.

~TODO:~
~Add docs demonstrating the use of this property with mapped tasks.~ May be handled in #25617

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
