### PR TITLE
Grid logs for mapped instances

### DIFF
--- a/airflow/www/static/js/api/index.ts
+++ b/airflow/www/static/js/api/index.ts
@@ -36,6 +36,7 @@ import useDatasets from './useDatasets';
 import useDataset from './useDataset';
 import useDatasetEvents from './useDatasetEvents';
 import useUpstreamDatasetEvents from './useUpstreamDatasetEvents';
+import useTaskInstance from './useTaskInstance';
 
 axios.interceptors.response.use(
   (res: AxiosResponse) => (res.data ? camelcaseKeys(res.data, { deep: true }) : res),
@@ -45,19 +46,20 @@ axios.defaults.headers.common.Accept = 'application/json';
 
 export {
   useClearRun,
-  useQueueRun,
-  useMarkFailedRun,
-  useMarkSuccessRun,
-  useRunTask,
   useClearTask,
-  useMarkFailedTask,
-  useMarkSuccessTask,
-  useExtraLinks,
   useConfirmMarkTask,
-  useGridData,
-  useMappedInstances,
-  useDatasets,
   useDataset,
   useDatasetEvents,
+  useDatasets,
+  useExtraLinks,
+  useGridData,
+  useMappedInstances,
+  useMarkFailedRun,
+  useMarkFailedTask,
+  useMarkSuccessRun,
+  useMarkSuccessTask,
+  useQueueRun,
+  useRunTask,
+  useTaskInstance,
   useUpstreamDatasetEvents,
 };

--- a/airflow/www/static/js/api/useTaskInstance.tsx
+++ b/airflow/www/static/js/api/useTaskInstance.tsx
@@ -1,0 +1,70 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios, { AxiosResponse } from 'axios';
+import type { API, TaskInstance } from 'src/types';
+import { useQuery } from 'react-query';
+import { useAutoRefresh } from 'src/context/autorefresh';
+
+import { getMetaValue } from 'src/utils';
+
+/* GridData.TaskInstance and API.TaskInstance are not compatible at the moment.
+ * Remove this function when changing the api response for grid_data_url to comply
+ * with API.TaskInstance.
+ */
+const convertTaskInstance = (
+  ti:
+  API.TaskInstance,
+) => ({ ...ti, runId: ti.dagRunId }) as TaskInstance;
+
+const taskInstanceApi = getMetaValue('task_instance_api');
+
+const useTaskInstance = ({
+  dagId, dagRunId, taskId, mapIndex, enabled,
+}: {
+  dagId: string,
+  dagRunId: string,
+  taskId: string | null,
+  mapIndex?: number,
+  enabled: boolean
+}) => {
+  let url: string = '';
+  if (taskInstanceApi) {
+    url = taskInstanceApi.replace('_DAG_RUN_ID_', dagRunId).replace('_TASK_ID_', taskId || '');
+  }
+
+  if (mapIndex !== undefined && mapIndex >= 0) {
+    url += `/${mapIndex.toString()}`;
+  }
+
+  const { isRefreshOn } = useAutoRefresh();
+
+  return useQuery(
+    ['taskIntance', dagId, dagRunId, taskId, mapIndex],
+    () => axios.get<AxiosResponse, API.TaskInstance>(url, { headers: { Accept: 'text/plain' } }),
+    {
+      placeholderData: {},
+      refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
+      enabled,
+      select: convertTaskInstance,
+    },
+  );
+};
+
+export default useTaskInstance;

--- a/airflow/www/static/js/api/useTaskLog.tsx
+++ b/airflow/www/static/js/api/useTaskLog.tsx
@@ -26,12 +26,13 @@ import { getMetaValue } from 'src/utils';
 const taskLogApi = getMetaValue('task_log_api');
 
 const useTaskLog = ({
-  dagId, dagRunId, taskId, taskTryNumber, fullContent,
+  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent,
 }: {
   dagId: string,
   dagRunId: string,
   taskId: string,
   taskTryNumber: number,
+  mapIndex?: number,
   fullContent: boolean,
 }) => {
   let url: string = '';
@@ -42,8 +43,8 @@ const useTaskLog = ({
   const { isRefreshOn } = useAutoRefresh();
 
   return useQuery(
-    ['taskLogs', dagId, dagRunId, taskId, taskTryNumber, fullContent],
-    () => axios.get<AxiosResponse, string>(url, { headers: { Accept: 'text/plain' }, params: { full_content: fullContent } }),
+    ['taskLogs', dagId, dagRunId, taskId, mapIndex, taskTryNumber, fullContent],
+    () => axios.get<AxiosResponse, string>(url, { headers: { Accept: 'text/plain' }, params: { map_index: mapIndex, full_content: fullContent } }),
     {
       placeholderData: '',
       refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,

--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -75,8 +75,8 @@ const Header = () => {
 
   const isDagDetails = !runId && !taskId;
   const isRunDetails = !!(runId && !taskId);
-  const isTaskDetails = runId && taskId && mapIndex === undefined;
-  const isMappedTaskDetails = runId && taskId && mapIndex !== undefined;
+  const isTaskDetails = runId && taskId && mapIndex === null;
+  const isMappedTaskDetails = runId && taskId && mapIndex !== null;
 
   return (
     <Breadcrumb separator={<Text color="gray.300">/</Text>}>
@@ -99,7 +99,7 @@ const Header = () => {
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}
-      {mapIndex !== undefined && (
+      {mapIndex !== null && (
         <BreadcrumbItem isCurrentPage mt={4}>
           <BreadcrumbLink _hover={isMappedTaskDetails ? { cursor: 'default' } : undefined}>
             <BreadcrumbText label="Map Index" value={mapIndex} />

--- a/airflow/www/static/js/dag/details/Header.tsx
+++ b/airflow/www/static/js/dag/details/Header.tsx
@@ -38,7 +38,7 @@ const dagId = getMetaValue('dag_id');
 const Header = () => {
   const { data: { dagRuns, groups } } = useGridData();
 
-  const { selected: { taskId, runId }, onSelect, clearSelection } = useSelection();
+  const { selected: { taskId, runId, mapIndex }, onSelect, clearSelection } = useSelection();
   const dagRun = dagRuns.find((r) => r.runId === runId);
 
   // clearSelection if the current selected dagRun is
@@ -75,7 +75,8 @@ const Header = () => {
 
   const isDagDetails = !runId && !taskId;
   const isRunDetails = !!(runId && !taskId);
-  const isTaskDetails = runId && taskId;
+  const isTaskDetails = runId && taskId && mapIndex === undefined;
+  const isMappedTaskDetails = runId && taskId && mapIndex !== undefined;
 
   return (
     <Breadcrumb separator={<Text color="gray.300">/</Text>}>
@@ -93,8 +94,15 @@ const Header = () => {
       )}
       {taskId && (
         <BreadcrumbItem isCurrentPage mt={4}>
-          <BreadcrumbLink _hover={isTaskDetails ? { cursor: 'default' } : undefined}>
+          <BreadcrumbLink onClick={() => onSelect({ runId, taskId })} _hover={isTaskDetails ? { cursor: 'default' } : undefined}>
             <BreadcrumbText label="Task" value={`${taskName}${group?.isMapped ? ' []' : ''}`} />
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+      )}
+      {mapIndex !== undefined && (
+        <BreadcrumbItem isCurrentPage mt={4}>
+          <BreadcrumbLink _hover={isMappedTaskDetails ? { cursor: 'default' } : undefined}>
+            <BreadcrumbText label="Map Index" value={mapIndex} />
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -32,7 +32,7 @@ import DagRunContent from './dagRun';
 import DagContent from './Dag';
 
 const Details = () => {
-  const { selected: { runId, taskId } } = useSelection();
+  const { selected: { runId, taskId, mapIndex }, onSelect } = useSelection();
   return (
     <Flex flexDirection="column" pl={3} mr={3} flexGrow={1} maxWidth="750px">
       <Header />
@@ -46,6 +46,8 @@ const Details = () => {
         <TaskInstanceContent
           runId={runId}
           taskId={taskId}
+          mapIndex={mapIndex}
+          onSelect={onSelect}
         />
         )}
       </Box>

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -46,7 +46,7 @@ const Details = () => {
         <TaskInstanceContent
           runId={runId}
           taskId={taskId}
-          mapIndex={mapIndex}
+          mapIndex={mapIndex === null ? undefined : mapIndex}
           onSelect={onSelect}
         />
         )}

--- a/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
@@ -29,18 +29,16 @@ const BackToTaskSummary = ({ isMapIndexDefined, onClick }: Props) => {
   if (!isMapIndexDefined) return null;
 
   return (
-    <div>
-      <Flex justifyContent="right">
-        <Button
-          variant="ghost"
-          colorScheme="blue"
-          onClick={onClick}
-          size="lg"
-        >
-          Back to Dynamic Task Summary
-        </Button>
-      </Flex>
-    </div>
+    <Flex justifyContent="right">
+      <Button
+        variant="ghost"
+        colorScheme="blue"
+        onClick={onClick}
+        size="lg"
+      >
+        Back to Dynamic Task Summary
+      </Button>
+    </Flex>
   );
 };
 

--- a/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
@@ -1,0 +1,50 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { Button, Flex } from '@chakra-ui/react';
+
+interface Props {
+  isMapIndexDefined: boolean;
+  onClick: () => void;
+}
+
+const BackToTaskSummary = ({ isMapIndexDefined, onClick }: Props) => {
+  if (!isMapIndexDefined) return null;
+
+  return (
+    <div>
+      {isMapIndexDefined && (
+        <Flex justifyContent="right">
+          <Button
+            variant="ghost"
+            colorScheme="blue"
+            onClick={onClick}
+            size="lg"
+          >
+            Back to Dynamic Task Summary
+          </Button>
+        </Flex>
+
+      )}
+    </div>
+  );
+};
+
+export default BackToTaskSummary;

--- a/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/BackToTaskSummary.tsx
@@ -30,19 +30,16 @@ const BackToTaskSummary = ({ isMapIndexDefined, onClick }: Props) => {
 
   return (
     <div>
-      {isMapIndexDefined && (
-        <Flex justifyContent="right">
-          <Button
-            variant="ghost"
-            colorScheme="blue"
-            onClick={onClick}
-            size="lg"
-          >
-            Back to Dynamic Task Summary
-          </Button>
-        </Flex>
-
-      )}
+      <Flex justifyContent="right">
+        <Button
+          variant="ghost"
+          colorScheme="blue"
+          onClick={onClick}
+          size="lg"
+        >
+          Back to Dynamic Task Summary
+        </Button>
+      </Flex>
     </div>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -52,6 +52,7 @@ const Details = ({ instance, group }: Props) => {
     endDate,
     state,
     mappedStates,
+    mapIndex,
   } = instance;
 
   const {
@@ -142,6 +143,12 @@ const Details = ({ instance, group }: Props) => {
             <Td>Run ID</Td>
             <Td><Text whiteSpace="nowrap"><ClipboardText value={runId} /></Text></Td>
           </Tr>
+          {mapIndex !== undefined && (
+            <Tr>
+              <Td>Map Index</Td>
+              <Td>{mapIndex}</Td>
+            </Tr>
+          )}
           {operator && (
             <Tr>
               <Td>Operator</Td>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.test.tsx
@@ -41,7 +41,7 @@ describe('Test LogLink Component.', () => {
     expect(linkElement).toBeDefined();
     expect(linkElement).not.toHaveAttribute('target');
     expect(linkElement?.href.includes(
-      `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&format=file&try_number=${tryNumber}`,
+      `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&map_index=-1&format=file&try_number=${tryNumber}`,
     )).toBeTruthy();
   });
 
@@ -61,7 +61,7 @@ describe('Test LogLink Component.', () => {
     expect(linkElement).toBeDefined();
     expect(linkElement).toHaveAttribute('target', '_blank');
     expect(linkElement?.href.includes(
-      `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&try_number=${tryNumber}`,
+      `?dag_id=dummyDagId&task_id=dummyTaskId&execution_date=2020%3A01%3A01T01%3A00%2B00%3A00&map_index=-1&try_number=${tryNumber}`,
     )).toBeTruthy();
   });
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/LogLink.tsx
@@ -32,15 +32,17 @@ interface Props {
   executionDate: DagRun['executionDate'];
   isInternal?: boolean;
   tryNumber: TaskInstance['tryNumber'];
+  mapIndex?: TaskInstance['mapIndex'];
 }
 
 const LogLink = ({
-  dagId, taskId, executionDate, isInternal, tryNumber,
+  dagId, taskId, executionDate, isInternal, tryNumber, mapIndex,
 }: Props) => {
   let fullMetadataUrl = `${isInternal ? logsWithMetadataUrl : externalLogUrl
   }?dag_id=${encodeURIComponent(dagId)
   }&task_id=${encodeURIComponent(taskId)
   }&execution_date=${encodeURIComponent(executionDate)
+  }&map_index=${encodeURIComponent(mapIndex?.toString() ?? '-1')
   }`;
 
   if (isInternal && tryNumber) {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
@@ -78,6 +78,43 @@ describe('Test Logs Component.', () => {
       { exact: false },
     )).toBeDefined();
     expect(getByText('AIRFLOW_CTX_DAG_ID=test_ui_grid', { exact: false })).toBeDefined();
+
+    expect(useTaskLogMock).toHaveBeenLastCalledWith({
+      dagId: 'dummyDagId',
+      dagRunId: 'dummyDagRunId',
+      fullContent: false,
+      taskId: 'dummyTaskId',
+      taskTryNumber: 1,
+    });
+  });
+
+  test('Test Logs Content Mapped Task', () => {
+    const tryNumber = 2;
+    const { getByText } = render(
+      <Logs
+        dagId="dummyDagId"
+        dagRunId="dummyDagRunId"
+        taskId="dummyTaskId"
+        executionDate="2020:01:01T01:00+00:00"
+        mapIndex={1}
+        tryNumber={tryNumber}
+      />,
+    );
+    expect(getByText('[2022-06-04, 00:00:01 UTC] {taskinstance.py:1329} INFO -', { exact: false })).toBeDefined();
+    expect(getByText(
+      '[2022-06-04, 00:00:01 UTC] {standard_task_runner.py:81} INFO - Job 1626: Subtask section_1.get_entry_group',
+      { exact: false },
+    )).toBeDefined();
+    expect(getByText('AIRFLOW_CTX_DAG_ID=test_ui_grid', { exact: false })).toBeDefined();
+
+    expect(useTaskLogMock).toHaveBeenLastCalledWith({
+      dagId: 'dummyDagId',
+      dagRunId: 'dummyDagRunId',
+      fullContent: false,
+      mapIndex: 1,
+      taskId: 'dummyTaskId',
+      taskTryNumber: 1,
+    });
   });
 
   test('Test Logs Attempt Select Button', () => {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -158,7 +158,7 @@ const Logs = ({
 
   return (
     <>
-      {tryNumber! > 0 && (
+      {tryNumber !== undefined && tryNumber > 0 && (
         <>
           <Text as="span"> (by attempts)</Text>
           <Flex my={1} justifyContent="space-between">

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -84,6 +84,7 @@ interface Props {
   dagId: Dag['id'];
   dagRunId: DagRun['runId'];
   taskId: TaskInstance['taskId'];
+  mapIndex?: TaskInstance['mapIndex'];
   executionDate: DagRun['executionDate'];
   tryNumber: TaskInstance['tryNumber'];
 }
@@ -92,6 +93,7 @@ const Logs = ({
   dagId,
   dagRunId,
   taskId,
+  mapIndex,
   executionDate,
   tryNumber,
 }: Props) => {
@@ -106,6 +108,7 @@ const Logs = ({
     dagId,
     dagRunId,
     taskId,
+    mapIndex,
     taskTryNumber: selectedAttempt,
     fullContent: shouldRequestFullContent,
   });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -158,7 +158,7 @@ const Logs = ({
 
   return (
     <>
-      {tryNumber !== undefined && tryNumber > 0 && (
+      {tryNumber !== undefined && (
         <>
           <Text as="span"> (by attempts)</Text>
           <Flex my={1} justifyContent="space-between">

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -116,7 +116,11 @@ const Logs = ({
   const params = new URLSearchParams({
     task_id: taskId,
     execution_date: executionDate,
-  }).toString();
+  });
+
+  if (mapIndex !== undefined) {
+    params.append('map_index', mapIndex.toString());
+  }
 
   const { parsedLogs, fileSources = [] } = useMemo(
     () => parseLogs(
@@ -230,9 +234,10 @@ const Logs = ({
                 executionDate={executionDate}
                 isInternal
                 tryNumber={tryNumber}
+                mapIndex={mapIndex}
               />
               <LinkButton
-                href={`${logUrl}&${params}`}
+                href={`${logUrl}&${params.toString()}`}
               >
                 See More
               </LinkButton>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -143,7 +143,7 @@ const Logs = ({
   useEffect(() => {
     // Reset fileSourceFilters and selected attempt when changing to
     // a task that do not have those filters anymore.
-    if (!internalIndexes.includes(selectedAttempt)) {
+    if (!internalIndexes.includes(selectedAttempt) && internalIndexes.length) {
       setSelectedAttempt(internalIndexes[0]);
     }
 

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -33,18 +33,16 @@ import { useMappedInstances } from 'src/api';
 import { SimpleStatus } from 'src/dag/StatusBox';
 import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
-import type { TaskInstance } from 'src/types';
 
 interface Props {
   dagId: string;
   runId: string;
   taskId: string;
   onRowClicked: (row: Row) => void;
-  mapIndex?: TaskInstance['mapIndex'];
 }
 
 const MappedInstances = ({
-  dagId, runId, taskId, onRowClicked, mapIndex,
+  dagId, runId, taskId, onRowClicked,
 }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
@@ -102,8 +100,6 @@ const MappedInstances = ({
     ],
     [],
   );
-
-  if (mapIndex !== undefined) { return null; }
 
   return (
     <Box>

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, {
-  useState, useMemo, useEffect,
+  useState, useMemo,
 } from 'react';
 import {
   Flex,
@@ -26,34 +26,25 @@ import {
   Box,
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
-import type { SortingRule } from 'react-table';
+import type { Row, SortingRule } from 'react-table';
 
 import { formatDuration, getDuration } from 'src/datetime_utils';
 import { useMappedInstances } from 'src/api';
 import { SimpleStatus } from 'src/dag/StatusBox';
 import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
-import type { API, TaskInstance } from 'src/types';
+import type { TaskInstance } from 'src/types';
 
 interface Props {
   dagId: string;
   runId: string;
   taskId: string;
-  onRowClicked: (rowMapIndex: number, taskInstances: TaskInstance[]) => void;
+  onRowClicked: (row: Row) => void;
   mapIndex?: TaskInstance['mapIndex'];
-  onMappedInstancesFetch: (mappedTaskInstances: TaskInstance[]) => void;
 }
 
-/* GridData.TaskInstance and API.TaskInstance are not compatible at the moment.
- * Remove this function when changing the api response for grid_data_url to comply
- * with API.TaskInstance.
- */
-const convertTaskInstances = (taskInstances: API.TaskInstance[]) => taskInstances.map(
-  (ti) => ({ ...ti, runId: ti.dagRunId }) as TaskInstance,
-);
-
 const MappedInstances = ({
-  dagId, runId, taskId, onRowClicked, onMappedInstancesFetch, mapIndex,
+  dagId, runId, taskId, onRowClicked, mapIndex,
 }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
@@ -69,15 +60,6 @@ const MappedInstances = ({
   } = useMappedInstances({
     dagId, runId, taskId, limit, offset, order,
   });
-
-  const convertedTaskInstances = useMemo(
-    () => convertTaskInstances(taskInstances),
-    [taskInstances],
-  );
-
-  useEffect(() => {
-    onMappedInstancesFetch(convertedTaskInstances);
-  }, [mapIndex, onMappedInstancesFetch, convertedTaskInstances]);
 
   const data = useMemo(() => taskInstances.map((mi) => ({
     ...mi,
@@ -141,9 +123,7 @@ const MappedInstances = ({
           sortBy,
         }}
         isLoading={isLoading}
-        onRowClicked={
-          (row) => onRowClicked(row.values.mapIndex, convertedTaskInstances)
-        }
+        onRowClicked={onRowClicked}
       />
     </Box>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -17,7 +17,9 @@
  * under the License.
  */
 
-import React, { useState, useMemo, useEffect } from 'react';
+import React, {
+  useState, useMemo, useEffect, SyntheticEvent,
+} from 'react';
 import {
   Flex,
   Text,
@@ -59,11 +61,13 @@ interface Props {
   taskId: string;
   onRowClicked: (rowMapIndex: number, taskInstances: TaskInstance[]) => void;
   mapIndex?: TaskInstance['mapIndex'];
-  onMappedInstanceFetch: (mappedTaskInstances: TaskInstance[]) => void;
+  onMappedInstancesFetch: (mappedTaskInstances: TaskInstance[]) => void;
 }
 
+const stopPropagation = (e: SyntheticEvent) => e.stopPropagation();
+
 const MappedInstances = ({
-  dagId, runId, taskId, onRowClicked, onMappedInstanceFetch, mapIndex,
+  dagId, runId, taskId, onRowClicked, onMappedInstancesFetch, mapIndex,
 }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
@@ -81,8 +85,8 @@ const MappedInstances = ({
   });
 
   useEffect(() => {
-    onMappedInstanceFetch(taskInstances as TaskInstance[]);
-  }, [mapIndex, onMappedInstanceFetch, taskInstances]);
+    onMappedInstancesFetch(taskInstances as TaskInstance[]);
+  }, [mapIndex, onMappedInstancesFetch, taskInstances]);
 
   const data = useMemo(
     () => taskInstances.map((mi) => {
@@ -109,10 +113,10 @@ const MappedInstances = ({
         endDate: <Time dateTime={mi.endDate} />,
         links: (
           <Flex alignItems="center">
-            <IconLink mr={1} title="Details" aria-label="Details" icon={<MdDetails />} href={detailsLink} />
-            <IconLink mr={1} title="Rendered Templates" aria-label="Rendered Templates" icon={<MdCode />} href={renderedLink} />
-            <IconLink mr={1} title="Log" aria-label="Log" icon={<MdReorder />} href={logLink} />
-            <IconLink title="XCom" fontWeight="bold" aria-label="XCom" icon={<MdSyncAlt />} href={xcomLink} />
+            <IconLink mr={1} onClick={stopPropagation} title="Details" aria-label="Details" icon={<MdDetails />} href={detailsLink} />
+            <IconLink mr={1} onClick={stopPropagation} title="Rendered Templates" aria-label="Rendered Templates" icon={<MdCode />} href={renderedLink} />
+            <IconLink mr={1} onClick={stopPropagation} title="Log" aria-label="Log" icon={<MdReorder />} href={logLink} />
+            <IconLink onClick={stopPropagation} title="XCom" fontWeight="bold" aria-label="XCom" icon={<MdSyncAlt />} href={xcomLink} />
           </Flex>
         ),
       };

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import {
   Flex,
   Text,
@@ -30,7 +30,7 @@ import { snakeCase } from 'lodash';
 import {
   MdDetails, MdCode, MdSyncAlt, MdReorder,
 } from 'react-icons/md';
-import type { Row, SortingRule } from 'react-table';
+import type { SortingRule } from 'react-table';
 
 import { getMetaValue } from 'src/utils';
 import { formatDuration, getDuration } from 'src/datetime_utils';
@@ -57,11 +57,13 @@ interface Props {
   dagId: string;
   runId: string;
   taskId: string;
-  onRowClicked: (selectedRow: Row, taskInstances: TaskInstance[]) => void;
+  onRowClicked: (rowMapIndex: number, taskInstances: TaskInstance[]) => void;
+  mapIndex?: TaskInstance['mapIndex'];
+  onMappedInstanceFetch: (mappedTaskInstances: TaskInstance[]) => void;
 }
 
 const MappedInstances = ({
-  dagId, runId, taskId, onRowClicked,
+  dagId, runId, taskId, onRowClicked, onMappedInstanceFetch, mapIndex,
 }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
@@ -77,6 +79,10 @@ const MappedInstances = ({
   } = useMappedInstances({
     dagId, runId, taskId, limit, offset, order,
   });
+
+  useEffect(() => {
+    onMappedInstanceFetch(taskInstances as TaskInstance[]);
+  }, [mapIndex, onMappedInstanceFetch, taskInstances]);
 
   const data = useMemo(
     () => taskInstances.map((mi) => {
@@ -147,6 +153,8 @@ const MappedInstances = ({
     [],
   );
 
+  if (mapIndex !== undefined) { return null; }
+
   return (
     <Box>
       <br />
@@ -165,7 +173,7 @@ const MappedInstances = ({
           sortBy,
         }}
         isLoading={isLoading}
-        onRowClicked={(row) => onRowClicked(row, taskInstances as TaskInstance[])}
+        onRowClicked={(row) => onRowClicked(row.values.mapIndex, taskInstances as TaskInstance[])}
       />
     </Box>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/MappedInstances.tsx
@@ -30,7 +30,7 @@ import { snakeCase } from 'lodash';
 import {
   MdDetails, MdCode, MdSyncAlt, MdReorder,
 } from 'react-icons/md';
-import type { SortingRule } from 'react-table';
+import type { Row, SortingRule } from 'react-table';
 
 import { getMetaValue } from 'src/utils';
 import { formatDuration, getDuration } from 'src/datetime_utils';
@@ -38,8 +38,8 @@ import { useMappedInstances } from 'src/api';
 import { SimpleStatus } from 'src/dag/StatusBox';
 import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
+import type { TaskInstance } from 'src/types';
 
-const canEdit = getMetaValue('can_edit') === 'True';
 const renderedTemplatesUrl = getMetaValue('rendered_templates_url');
 const logUrl = getMetaValue('log_url');
 const taskUrl = getMetaValue('task_url');
@@ -57,11 +57,11 @@ interface Props {
   dagId: string;
   runId: string;
   taskId: string;
-  selectRows: (selectedRows: number[]) => void;
+  onRowClicked: (selectedRow: Row, taskInstances: TaskInstance[]) => void;
 }
 
 const MappedInstances = ({
-  dagId, runId, taskId, selectRows,
+  dagId, runId, taskId, onRowClicked,
 }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
@@ -165,7 +165,7 @@ const MappedInstances = ({
           sortBy,
         }}
         isLoading={isLoading}
-        selectRows={canEdit ? selectRows : undefined}
+        onRowClicked={(row) => onRowClicked(row, taskInstances as TaskInstance[])}
       />
     </Box>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/Nav.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Nav.tsx
@@ -46,16 +46,18 @@ interface Props {
   executionDate: string;
   operator?: string;
   isMapped?: boolean;
+  mapIndex?: number;
 }
 
 const Nav = ({
-  runId, taskId, executionDate, operator, isMapped = false,
+  runId, taskId, executionDate, operator, isMapped = false, mapIndex,
 }: Props) => {
   if (!taskId) return null;
   const params = new URLSearchParams({
     task_id: taskId,
     execution_date: executionDate,
-  }).toString();
+    map_index: mapIndex?.toString() ?? '-1',
+  });
   const detailsLink = `${taskUrl}&${params}`;
   const renderedLink = `${renderedTemplatesUrl}&${params}`;
   const logLink = `${logUrl}&${params}`;
@@ -90,7 +92,7 @@ const Nav = ({
   return (
     <>
       <Flex flexWrap="wrap">
-        {!isMapped && (
+        {(!isMapped || mapIndex !== undefined) && (
         <>
           <LinkButton href={detailsLink}>Task Instance Details</LinkButton>
           <LinkButton href={renderedLink}>Rendered Template</LinkButton>

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -96,8 +96,9 @@ const TaskInstance = ({
     setPreferedTabIndex(index);
   };
 
+  const isMappedTaskSummary = !!isMapped && !isMapIndexDefined;
   const isGroup = !!children;
-  const showLogs = !isGroup && ((!isMapped) || (isMapped && isMapIndexDefined)) && !!instance;
+  const showLogs = !(isGroup || isMappedTaskSummary);
 
   let isPreferedTabDisplayed = false;
 
@@ -106,7 +107,7 @@ const TaskInstance = ({
       isPreferedTabDisplayed = true;
       break;
     case 1:
-      isPreferedTabDisplayed = showLogs;
+      isPreferedTabDisplayed = showLogs || isMappedTaskSummary;
       break;
     default:
       isPreferedTabDisplayed = false;
@@ -143,6 +144,11 @@ const TaskInstance = ({
           <Tab>
             <Text as="strong">Details</Text>
           </Tab>
+          { isMappedTaskSummary && (
+            <Tab>
+              <Text as="strong">Mapped Tasks</Text>
+            </Tab>
+          )}
           { showLogs && (
             <Tab>
               <Text as="strong">Logs</Text>
@@ -179,6 +185,12 @@ const TaskInstance = ({
                   extraLinks={group?.extraLinks || []}
                 />
               )}
+            </Box>
+          </TabPanel>
+
+          {/* Mapped Task Instances Tab */}
+          { isMappedTaskSummary && (
+          <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
               {isMapped && taskId && (
                 <MappedInstances
                   dagId={dagId}
@@ -191,8 +203,8 @@ const TaskInstance = ({
                   }
                 />
               )}
-            </Box>
           </TabPanel>
+          )}
 
           {/* Logs Tab */}
           { showLogs && (
@@ -203,7 +215,7 @@ const TaskInstance = ({
               taskId={taskId!}
               mapIndex={mapIndex}
               executionDate={executionDate}
-              tryNumber={instance.tryNumber}
+              tryNumber={instance?.tryNumber}
             />
           </TabPanel>
           )}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -132,6 +132,7 @@ const TaskInstance = ({
           taskId={taskId}
           runId={runId}
           isMapped={isMapped}
+          mapIndex={mapIndex}
           executionDate={executionDate}
           operator={operator}
         />

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -114,9 +114,10 @@ const TaskInstance = ({
   }
 
   const onRowClicked = (row: Row, mappedTaskInstances: TaskInstanceType[]) => {
-    const taskInstance = mappedTaskInstances.find((ti) => ti.mapIndex === row.index);
+    const rowMapIndex = row.values.mapIndex;
+    const taskInstance = mappedTaskInstances.find((ti) => ti.mapIndex === rowMapIndex);
     setInstance(taskInstance);
-    onSelect({ runId, taskId, mapIndex: parseInt(row.id, 10) });
+    onSelect({ runId, taskId, mapIndex: rowMapIndex });
   };
 
   return (

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -60,7 +60,7 @@ const TaskInstance = ({
   taskId, runId, mapIndex, onSelect,
 }: Props) => {
   const isMapIndexDefined = !(mapIndex === undefined);
-  const selectedRows: number[] = isMapIndexDefined ? [mapIndex] : [];
+  const actionsMapIndexes = isMapIndexDefined ? [mapIndex] : [];
   const { data: { dagRuns, groups } } = useGridData();
 
   const storageTabIndex = parseInt(localStorage.getItem(detailsPanelActiveTabIndex) || '0', 10);
@@ -119,7 +119,7 @@ const TaskInstance = ({
 
   let taskActionsTitle = 'Task Actions';
   if (isMapped) {
-    taskActionsTitle += ` for ${selectedRows.length || 'all'} mapped task${selectedRows.length !== 1 ? 's' : ''}`;
+    taskActionsTitle += ` for ${actionsMapIndexes.length || 'all'} mapped task${actionsMapIndexes.length !== 1 ? 's' : ''}`;
   }
 
   const onRowClicked = (rowMapIndex: number, mappedTaskInstances: TaskInstanceType[]) => {
@@ -173,7 +173,7 @@ const TaskInstance = ({
                 taskId={taskId}
                 dagId={dagId}
                 executionDate={executionDate}
-                mapIndexes={selectedRows}
+                mapIndexes={actionsMapIndexes}
               />
               )}
               {instance && <Details instance={instance} group={group} />}
@@ -188,24 +188,6 @@ const TaskInstance = ({
             </Box>
           </TabPanel>
 
-          {/* Mapped Task Instances Tab */}
-          { isMappedTaskSummary && (
-          <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
-              {isMapped && taskId && (
-                <MappedInstances
-                  dagId={dagId}
-                  runId={runId}
-                  taskId={taskId}
-                  onRowClicked={onRowClicked}
-                  mapIndex={mapIndex}
-                  onMappedInstancesFetch={
-                    (taskInstances) => setInstanceForMappedIndex(mapIndex, taskInstances)
-                  }
-                />
-              )}
-          </TabPanel>
-          )}
-
           {/* Logs Tab */}
           { showLogs && (
           <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
@@ -219,6 +201,22 @@ const TaskInstance = ({
             />
           </TabPanel>
           )}
+
+          {/* Mapped Task Instances Tab */}
+          <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
+            {isMapped && taskId && (
+            <MappedInstances
+              dagId={dagId}
+              runId={runId}
+              taskId={taskId}
+              onRowClicked={onRowClicked}
+              mapIndex={mapIndex}
+              onMappedInstancesFetch={
+                    (taskInstances) => setInstanceForMappedIndex(mapIndex, taskInstances)
+                  }
+            />
+            )}
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </Box>

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -170,14 +170,14 @@ const TaskInstance = ({
                   extraLinks={group?.extraLinks || []}
                 />
               )}
-              {(isMapped && taskId) && (
+              {isMapped && taskId && (
                 <MappedInstances
                   dagId={dagId}
                   runId={runId}
                   taskId={taskId}
                   onRowClicked={onRowClicked}
                   mapIndex={mapIndex}
-                  onMappedInstanceFetch={
+                  onMappedInstancesFetch={
                     (taskInstances) => setInstanceForMappedIndex(mapIndex, taskInstances)
                   }
                 />

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -43,6 +43,7 @@ import TaskNav from './Nav';
 import Details from './Details';
 import MappedInstances from './MappedInstances';
 import TaskActions from './taskActions';
+import BackToTaskSummary from './BackToTaskSummary';
 
 const detailsPanelActiveTabIndex = 'detailsPanelActiveTabIndex';
 
@@ -148,9 +149,16 @@ const TaskInstance = ({
             </Tab>
           )}
         </TabList>
+
+        <BackToTaskSummary
+          isMapIndexDefined={isMapIndexDefined}
+          onClick={() => onSelect({ runId, taskId })}
+        />
+
         <TabPanels>
+
           {/* Details Tab */}
-          <TabPanel>
+          <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
             <Box py="4px">
               {!isGroup && (
               <TaskActions
@@ -185,9 +193,10 @@ const TaskInstance = ({
               )}
             </Box>
           </TabPanel>
+
           {/* Logs Tab */}
           { showLogs && (
-          <TabPanel>
+          <TabPanel pt={isMapIndexDefined ? '0px' : undefined}>
             <Logs
               dagId={dagId}
               dagRunId={runId}

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionButton.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/ActionButton.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { Button } from '@chakra-ui/react';
+import { Button, ButtonProps } from '@chakra-ui/react';
 
 const titleMap = {
   past: 'Also include past task instances when clearing this one',
@@ -29,8 +29,11 @@ const titleMap = {
   failed: 'Only consider failed task instances when clearing this one',
 };
 
-const ActionButton = ({ name, ...rest }) => (
-  <Button title={titleMap[name.toLowerCase()]} {...rest}>{name}</Button>
+type KeysOfTitleMap = keyof (typeof titleMap);
+
+type Props = ButtonProps & { name: Capitalize<KeysOfTitleMap> } ;
+const ActionButton = ({ name, ...rest }: Props) => (
+  <Button title={titleMap[name.toLowerCase() as KeysOfTitleMap]} {...rest}>{name}</Button>
 );
 
 export default ActionButton;

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/index.tsx
@@ -1,0 +1,76 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import {
+  Box,
+  VStack,
+  Divider,
+  StackDivider,
+  Text,
+} from '@chakra-ui/react';
+
+import type { CommonActionProps } from './types';
+import RunAction from './Run';
+import ClearAction from './Clear';
+import MarkFailedAction from './MarkFailed';
+import MarkSuccessAction from './MarkSuccess';
+
+type Props = {
+  title: string;
+} & CommonActionProps;
+
+const TaskActions = ({
+  title, runId, taskId, dagId, executionDate, mapIndexes,
+}: Props) => (
+  <Box my={3}>
+    <Text as="strong">{title}</Text>
+    <Divider my={2} />
+    <VStack justifyContent="center" divider={<StackDivider my={3} />}>
+      <RunAction
+        runId={runId}
+        taskId={taskId}
+        dagId={dagId}
+        mapIndexes={mapIndexes}
+      />
+      <ClearAction
+        runId={runId}
+        taskId={taskId}
+        dagId={dagId}
+        executionDate={executionDate}
+        mapIndexes={mapIndexes}
+      />
+      <MarkFailedAction
+        runId={runId}
+        taskId={taskId}
+        dagId={dagId}
+        mapIndexes={mapIndexes}
+      />
+      <MarkSuccessAction
+        runId={runId}
+        taskId={taskId}
+        dagId={dagId}
+        mapIndexes={mapIndexes}
+      />
+    </VStack>
+    <Divider my={2} />
+  </Box>
+);
+
+export default TaskActions;

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/types.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/types.tsx
@@ -17,31 +17,12 @@
  * under the License.
  */
 
-import React from 'react';
-import {
-  Box,
-  Heading,
-} from '@chakra-ui/react';
+import type { Dag, DagRun, TaskInstance } from 'src/types';
 
-interface Props {
-  label: string;
-  value: React.ReactNode;
+export interface CommonActionProps {
+  runId: DagRun['runId'],
+  taskId: TaskInstance['taskId'] | null,
+  dagId: Dag['id'],
+  executionDate: DagRun['executionDate'],
+  mapIndexes: number[]
 }
-
-const BreadcrumbText = ({ label, value }: Props) => (
-  <Box position="relative">
-    <Heading
-      as="h5"
-      size="sm"
-      color="gray.300"
-      position="absolute"
-      top="-12px"
-      whiteSpace="nowrap"
-    >
-      {label}
-    </Heading>
-    <Heading as="h3" size="md">{value}</Heading>
-  </Box>
-);
-
-export default BreadcrumbText;

--- a/airflow/www/static/js/dag/useSelection.test.tsx
+++ b/airflow/www/static/js/dag/useSelection.test.tsx
@@ -49,8 +49,10 @@ describe('Test useSelection hook', () => {
 
   test.each([
     { taskId: 'task_1', runId: 'run_1', mapIndex: 2 },
-    { runId: 'run_1', taskId: null, mapIndex: null },
-    { taskId: 'task_1', runId: null, mapIndex: 1 },
+    { taskId: null, runId: 'run_1', mapIndex: null },
+    { taskId: 'task_2', runId: null, mapIndex: 1 },
+    { taskId: 'task_3', runId: null, mapIndex: -1 },
+    { taskId: 'task_4', runId: null, mapIndex: 0 },
   ])('Test onSelect() and clearSelection()', async (selected) => {
     const { result } = renderHook(() => useSelection(), { wrapper: Wrapper });
 

--- a/airflow/www/static/js/dag/useSelection.test.tsx
+++ b/airflow/www/static/js/dag/useSelection.test.tsx
@@ -38,17 +38,19 @@ describe('Test useSelection hook', () => {
       selected: {
         runId,
         taskId,
+        mapIndex,
       },
     } = result.current;
 
     expect(runId).toBeNull();
     expect(taskId).toBeNull();
+    expect(mapIndex).toBeNull();
   });
 
   test.each([
-    { taskId: 'task_1', runId: 'run_1' },
-    { runId: 'run_1', taskId: null },
-    { taskId: 'task_1', runId: null },
+    { taskId: 'task_1', runId: 'run_1', mapIndex: 2 },
+    { runId: 'run_1', taskId: null, mapIndex: null },
+    { taskId: 'task_1', runId: null, mapIndex: 1 },
   ])('Test onSelect() and clearSelection()', async (selected) => {
     const { result } = renderHook(() => useSelection(), { wrapper: Wrapper });
 
@@ -58,6 +60,7 @@ describe('Test useSelection hook', () => {
 
     expect(result.current.selected.taskId).toBe(selected.taskId);
     expect(result.current.selected.runId).toBe(selected.runId);
+    expect(result.current.selected.mapIndex).toBe(selected.mapIndex);
 
     // clearSelection
     await act(async () => {
@@ -66,5 +69,6 @@ describe('Test useSelection hook', () => {
 
     expect(result.current.selected.taskId).toBeNull();
     expect(result.current.selected.runId).toBeNull();
+    expect(result.current.selected.mapIndex).toBeNull();
   });
 });

--- a/airflow/www/static/js/dag/useSelection.ts
+++ b/airflow/www/static/js/dag/useSelection.ts
@@ -36,6 +36,7 @@ const useSelection = () => {
   const clearSelection = () => {
     searchParams.delete(RUN_ID);
     searchParams.delete(TASK_ID);
+    searchParams.delete(MAP_INDEX);
     setSearchParams(searchParams);
   };
 
@@ -57,7 +58,7 @@ const useSelection = () => {
   const runId = searchParams.get(RUN_ID);
   const taskId = searchParams.get(TASK_ID);
   const mapIndexParam = searchParams.get(MAP_INDEX);
-  const mapIndex = mapIndexParam !== null ? parseInt(mapIndexParam, 10) : undefined;
+  const mapIndex = mapIndexParam !== null ? parseInt(mapIndexParam, 10) : null;
 
   return {
     selected: {

--- a/airflow/www/static/js/dag/useSelection.ts
+++ b/airflow/www/static/js/dag/useSelection.ts
@@ -21,10 +21,12 @@ import { useSearchParams } from 'react-router-dom';
 
 const RUN_ID = 'dag_run_id';
 const TASK_ID = 'task_id';
+const MAP_INDEX = 'map_index';
 
 export interface SelectionProps {
   runId?: string | null ;
   taskId?: string | null;
+  mapIndex?: number | null;
 }
 
 const useSelection = () => {
@@ -37,7 +39,7 @@ const useSelection = () => {
     setSearchParams(searchParams);
   };
 
-  const onSelect = ({ runId, taskId }: SelectionProps) => {
+  const onSelect = ({ runId, taskId, mapIndex }: SelectionProps) => {
     const params = new URLSearchParams(searchParams);
 
     if (runId) params.set(RUN_ID, runId);
@@ -46,16 +48,22 @@ const useSelection = () => {
     if (taskId) params.set(TASK_ID, taskId);
     else params.delete(TASK_ID);
 
+    if (mapIndex || mapIndex === 0) params.set(MAP_INDEX, mapIndex.toString());
+    else params.delete(MAP_INDEX);
+
     setSearchParams(params);
   };
 
   const runId = searchParams.get(RUN_ID);
   const taskId = searchParams.get(TASK_ID);
+  const mapIndexParam = searchParams.get(MAP_INDEX);
+  const mapIndex = mapIndexParam !== null ? parseInt(mapIndexParam, 10) : undefined;
 
   return {
     selected: {
       runId,
       taskId,
+      mapIndex,
     },
     clearSelection,
     onSelect,

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -63,6 +63,7 @@ interface TaskInstance {
   mappedStates?: {
     [key: string]: number;
   },
+  mapIndex?: number;
   tryNumber?: number;
 }
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -72,6 +72,7 @@
   <meta name="mapped_instances_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_mapped_task_instances', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_') }}">
   <meta name="task_log_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_log_endpoint_get_log', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_', task_try_number='-1') }}">
   <meta name="upstream_dataset_events_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_dag_run_endpoint_get_upstream_dataset_events', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_') }}">
+  <meta name="task_instance_api" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_task_instance_endpoint_get_task_instance', dag_id=dag.dag_id, dag_run_id='_DAG_RUN_ID_', task_id='_TASK_ID_') }}">
   <!-- End Urls -->
   <meta name="is_paused" content="{{ dag_is_paused }}">
   <meta name="csrf_token" content="{{ csrf_token() }}">


### PR DESCRIPTION
https://github.com/apache/airflow/pull/25568 added support for retrieving mapped instance task logs.

This PR adds support for displaying these logs in the Grid details side panel.
- Mapped Instances rows in the table are not selectable anymore. (Actions are done on all of them)
- Mapped Instances rows are clickable and bring a new details page for mapped instances. (We can see the Map Index on top of other detailed information).
- For the new details, logs tab is available and show the logs for this particular map index.
- Breadcrumbs get extended with the map index and the `taskInstance` breadcrumbs becomes clickable in this particular case.
- Extracting tasks actions into its own component.
- Add a button to go back to the dynamic task summary (thanks @bbovenzi)
- Add navigation link the same way we have for normal taks (xcom, details, templates, ...) and remove those links from MappedInstance Table (thanks @bbovenzi)
- Move the MappedInstance Table to its own tab (again thanks @bbovenzi)
- Added a few unit tests.

Tested on:
- Mapped Tasks (obviously) :heavy_check_mark: 
- Groups with mapped task :heavy_check_mark: 
- Logs display, `See More` and `Download` links, and logs filters :heavy_check_mark: 
- When there is multiple pages in the `MappedInstances` Table :heavy_check_mark:
- Breadcrumbs navigation :heavy_check_mark:
- Task actions for all mapped task are working :heavy_check_mark:
- Task actions from the details of a mapped task instance does not work with the `SequentialExecutor` but the calls seems fine. (I didn't modify that part)

Also fixes: https://github.com/apache/airflow/issues/25616


![image](https://user-images.githubusercontent.com/14861206/183724859-8288d983-981f-448a-ada9-6330bef9809a.png)
![image](https://user-images.githubusercontent.com/14861206/183745340-5ef82450-7cd8-4648-b97e-1fcec3301ee1.png)

