### PR TITLE
Grid Logs, add visual indicator of selected attempt

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -159,7 +159,7 @@ const Logs = ({
               {internalIndexes.map((index) => (
                 <Button
                   key={index}
-                  variant="ghost"
+                  variant={selectedAttempt === index ? 'solid' : 'ghost'}
                   colorScheme="blue"
                   onClick={() => setSelectedAttempt(index)}
                   data-testid={`log-attempt-select-button-${index}`}


### PR DESCRIPTION
Hello,

I find it hard to identify what is the selected attempt in the task logs.

This is just a one line PR to add a visual indicator of what is the currently selected attempt

**Before**:
![image](https://user-images.githubusercontent.com/14861206/183476800-3825a048-fbf2-4352-8b58-b14f2d51f24a.png)

**After**:
![image](https://user-images.githubusercontent.com/14861206/183476679-00576661-adac-4164-8a67-0c7ce8af9eeb.png)


