### PR TITLE
User must supply the % in uri pattern

### DIFF
--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -70,7 +70,7 @@ def get_datasets(
     total_entries = session.query(func.count(Dataset.id)).scalar()
     query = session.query(Dataset)
     if uri_pattern:
-        query = query.filter(Dataset.uri.ilike(f"%{uri_pattern}%"))
+        query = query.filter(Dataset.uri.ilike(uri_pattern))
     query = apply_sorting(query, order_by, {}, allowed_attrs)
     datasets = (
         query.options(

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1654,7 +1654,8 @@ paths:
             type: string
           required: false
           description: |
-            If set, only return datasets with uris matching this pattern.
+            If set, only return datasets with URIs matching this pattern using a string pattern
+            to be evaluated as a SQL-compliant case-insensive LIKE expression.
       responses:
         '200':
           description: Success.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3604,7 +3604,10 @@ export interface operations {
          * *New in version 2.1.0*
          */
         order_by?: components["parameters"]["OrderBy"];
-        /** If set, only return datasets with uris matching this pattern. */
+        /**
+         * If set, only return datasets with URIs matching this pattern using a string pattern
+         * to be evaluated as a SQL-compliant case-insensive LIKE expression.
+         */
         uri_pattern?: string;
       };
     };

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -194,16 +194,20 @@ class TestGetDatasets(TestDatasetEndpoint):
 
         assert_401(response)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        'url, expected_datasets',
         [
-            ("api/v1/datasets?uri_pattern=s3", {"s3://folder/key"}),
-            ("api/v1/datasets?uri_pattern=bucket", {"gcp://bucket/key", 'wasb://some_dataset_bucket_/key'}),
+            ("api/v1/datasets?uri_pattern=s3%25", {"s3://folder/key"}),
             (
-                "api/v1/datasets?uri_pattern=dataset",
+                "api/v1/datasets?uri_pattern=%25bucket%25",
+                {"gcp://bucket/key", 'wasb://some_dataset_bucket_/key'},
+            ),
+            (
+                "api/v1/datasets?uri_pattern=%25dataset%25",
                 {"somescheme://dataset/key", "wasb://some_dataset_bucket_/key"},
             ),
             (
-                "api/v1/datasets?uri_pattern=",
+                "api/v1/datasets?uri_pattern=%25",
                 {
                     'gcp://bucket/key',
                     's3://folder/key',
@@ -211,7 +215,16 @@ class TestGetDatasets(TestDatasetEndpoint):
                     "wasb://some_dataset_bucket_/key",
                 },
             ),
-        ]
+            (
+                "api/v1/datasets?uri_pattern=%25",
+                {
+                    'gcp://bucket/key',
+                    's3://folder/key',
+                    'somescheme://dataset/key',
+                    "wasb://some_dataset_bucket_/key",
+                },
+            ),
+        ],
     )
     @provide_session
     def test_filter_datasets_by_uri_pattern_works(self, url, expected_datasets, session):


### PR DESCRIPTION
This way you can do one-sided `ilike`, or exact match.

Note this differs from how it's done with dag_id, but this is a different endpoint so I don't think it matters.  The other behavior is not good because it unnecessarily limits the functionality for users.

cc @blag 