### PR TITLE
Add auto refresh to grid logs

### DIFF
--- a/airflow/www/static/js/api/useTaskLog.tsx
+++ b/airflow/www/static/js/api/useTaskLog.tsx
@@ -19,6 +19,7 @@
 
 import axios, { AxiosResponse } from 'axios';
 import { useQuery } from 'react-query';
+import { useAutoRefresh } from 'src/context/autorefresh';
 
 import { getMetaValue } from 'src/utils';
 
@@ -38,11 +39,14 @@ const useTaskLog = ({
     url = taskLogApi.replace('_DAG_RUN_ID_', dagRunId).replace('_TASK_ID_', taskId).replace(/-1$/, taskTryNumber.toString());
   }
 
+  const { isRefreshOn } = useAutoRefresh();
+
   return useQuery(
     ['taskLogs', dagId, dagRunId, taskId, taskTryNumber, fullContent],
     () => axios.get<AxiosResponse, string>(url, { headers: { Accept: 'text/plain' }, params: { full_content: fullContent } }),
     {
       placeholderData: '',
+      refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
     },
   );
 };


### PR DESCRIPTION
Related discussions: https://github.com/apache/airflow/discussions/25537

We already wanted to do this on the log page, now that logs are in the grid (react), auto refresh is simple to implement.

_As usual you can configure the refetch interval via the **auto_refresh_interval** param. (3s by default)_
