### PR TITLE
Allow AWS Secrets Backends use AWS Connection capabilities

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -377,7 +377,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     def __init__(
         self,
         aws_conn_id: Optional[str] = default_conn_name,
-        verify: Union[bool, str, None] = None,
+        verify: Optional[Union[bool, str]] = None,
         region_name: Optional[str] = None,
         client_type: Optional[str] = None,
         resource_type: Optional[str] = None,
@@ -424,9 +424,9 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         return self.conn_config.botocore_config
 
     @property
-    def verify(self) -> Optional[str]:
+    def verify(self) -> Optional[Union[bool, str]]:
         """Verify or not SSL certificates boto3 client/resource read-only property."""
-        return self.conn_config.region_name
+        return self.conn_config.verify
 
     def get_session(self, region_name: Optional[str] = None) -> boto3.session.Session:
         """Get the underlying boto3.session.Session(region_name=region_name)."""

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -124,13 +124,7 @@ class BaseSessionFactory(LoggingMixin):
         return self._create_session_with_assume_role(session_kwargs=self.conn.session_kwargs)
 
     def _create_basic_session(self, session_kwargs: Dict[str, Any]) -> boto3.session.Session:
-        return boto3.session.Session(
-            aws_access_key_id=self.conn.aws_access_key_id,
-            aws_secret_access_key=self.conn.aws_secret_access_key,
-            aws_session_token=self.conn.aws_session_token,
-            region_name=self.region_name,
-            **session_kwargs,
-        )
+        return boto3.session.Session(**session_kwargs)
 
     def _create_session_with_assume_role(self, session_kwargs: Dict[str, Any]) -> boto3.session.Session:
         if self.conn.assume_role_method == 'assume_role_with_web_identity':
@@ -391,11 +385,12 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     ) -> None:
         super().__init__()
         self.aws_conn_id = aws_conn_id
-        self.verify = verify
         self.client_type = client_type
         self.resource_type = resource_type
+
         self._region_name = region_name
         self._config = config
+        self._verify = verify
 
     @cached_property
     def conn_config(self) -> AwsConnectionWrapper:
@@ -415,9 +410,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
                 )
 
         return AwsConnectionWrapper(
-            conn=connection or Connection(conn_id=None, conn_type="aws"),
-            region_name=self._region_name,
-            botocore_config=self._config,
+            conn=connection, region_name=self._region_name, botocore_config=self._config, verify=self._verify
         )
 
     @property
@@ -429,6 +422,11 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
     def config(self) -> Optional[Config]:
         """Configuration for botocore client read-only property."""
         return self.conn_config.botocore_config
+
+    @property
+    def verify(self) -> Optional[str]:
+        """Verify or not SSL certificates boto3 client/resource read-only property."""
+        return self.conn_config.region_name
 
     def get_session(self, region_name: Optional[str] = None) -> boto3.session.Session:
         """Get the underlying boto3.session.Session(region_name=region_name)."""

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -51,7 +51,7 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     key ``sql_alchemy_conn``.
 
     You can also pass additional keyword arguments listed in AWS Connection Extra config
-    to this class, and they would be used for establish connection and passed on to Boto3 client.
+    to this class, and they would be used for establishing a connection and passed on to Boto3 client.
 
     .. code-block:: ini
 
@@ -91,7 +91,6 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     :param config_prefix: Specifies the prefix of the secret to read to get Configurations.
         If set to None (null value in the configuration), requests for configurations will not be sent to
         AWS Secrets Manager. If you don't want a config_prefix, set it as an empty string
-    :param profile_name: The name of a profile to use. If not given, then the default profile is used.
     :param sep: separator used to concatenate secret_prefix and secret_id. Default: "/"
     :param full_url_mode: if True, the secrets must be stored as one conn URI in just one field per secret.
         If False (set it as false in backend_kwargs), you can store the secret using different

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -19,23 +19,15 @@
 
 import ast
 import json
-import re
 import warnings
 from typing import Any, Dict, List, Optional
 from urllib.parse import unquote, urlencode
 
-import boto3
-
 from airflow.compat.functools import cached_property
 from airflow.models.connection import Connection
-from airflow.providers.amazon.aws.utils import get_airflow_version
+from airflow.providers.amazon.aws.utils import get_airflow_version, trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
-
-
-def _parse_version(val):
-    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(int(x) for x in val.split('.'))
 
 
 class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
@@ -58,8 +50,17 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     if you provide ``{"config_prefix": "airflow/config"}`` and request config
     key ``sql_alchemy_conn``.
 
-    You can also pass additional keyword arguments like ``aws_secret_access_key``, ``aws_access_key_id``
-    or ``region_name`` to this class and they would be passed on to Boto3 client.
+    You can also pass additional keyword arguments listed in AWS Connection Extra config
+    to this class, and they would be used for establish connection and passed on to Boto3 client.
+
+    .. code-block:: ini
+
+        [secrets]
+        backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
+        backend_kwargs = {"connections_prefix": "airflow/connections", "region_name": "eu-west-1"}
+
+    .. seealso::
+        :ref:`howto/connection:aws:configuring-the-connection`
 
     There are two ways of storing secrets in Secret Manager for using them with this operator:
     storing them as a conn URI in one field, or taking advantage of native approach of Secrets Manager
@@ -110,7 +111,6 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
         connections_prefix: str = 'airflow/connections',
         variables_prefix: str = 'airflow/variables',
         config_prefix: str = 'airflow/config',
-        profile_name: Optional[str] = None,
         sep: str = "/",
         full_url_mode: bool = True,
         are_secret_values_urlencoded: Optional[bool] = None,
@@ -130,7 +130,6 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
             self.config_prefix = config_prefix.rstrip(sep)
         else:
             self.config_prefix = config_prefix
-        self.profile_name = profile_name
         self.sep = sep
         self.full_url_mode = full_url_mode
 
@@ -154,14 +153,34 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
                 )
             self.are_secret_values_urlencoded = are_secret_values_urlencoded
         self.extra_conn_words = extra_conn_words or {}
+
+        self.profile_name = kwargs.get("profile_name", None)
+        # Remove client specific arguments from kwargs
+        self.api_version = kwargs.pop("api_version", None)
+        self.use_ssl = kwargs.pop("use_ssl", None)
+
         self.kwargs = kwargs
 
     @cached_property
     def client(self):
         """Create a Secrets Manager client"""
-        session = boto3.session.Session(profile_name=self.profile_name)
+        from airflow.providers.amazon.aws.hooks.base_aws import SessionFactory
+        from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 
-        return session.client(service_name="secretsmanager", **self.kwargs)
+        conn_id = f"{self.__class__.__name__}__connection"
+        conn_config = AwsConnectionWrapper.from_connection_metadata(conn_id=conn_id, extra=self.kwargs)
+        client_kwargs = trim_none_values(
+            {
+                "region_name": conn_config.region_name,
+                "verify": conn_config.verify,
+                "endpoint_url": conn_config.endpoint_url,
+                "api_version": self.api_version,
+                "use_ssl": self.use_ssl,
+            }
+        )
+
+        session = SessionFactory(conn=conn_config).create_session()
+        return session.client(service_name="secretsmanager", **client_kwargs)
 
     @staticmethod
     def _format_uri_with_extra(secret, conn_string: str) -> str:

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -16,21 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 """Objects relating to sourcing connections from AWS SSM Parameter Store"""
-import re
+
 import warnings
 from typing import Optional
 
-import boto3
-
 from airflow.compat.functools import cached_property
-from airflow.providers.amazon.aws.utils import get_airflow_version
+from airflow.providers.amazon.aws.utils import get_airflow_version, trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
-
-
-def _parse_version(val):
-    val = re.sub(r'(\d+\.\d+\.\d+).*', lambda x: x.group(1), val)
-    return tuple(int(x) for x in val.split('.'))
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
@@ -56,7 +49,19 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         If set to None (null), requests for variables will not be sent to AWS SSM Parameter Store.
     :param config_prefix: Specifies the prefix of the secret to read to get Variables.
         If set to None (null), requests for configurations will not be sent to AWS SSM Parameter Store.
-    :param profile_name: The name of a profile to use. If not given, then the default profile is used.
+
+    You can also pass additional keyword arguments listed in AWS Connection Extra config
+    to this class, and they would be used for establish connection and passed on to Boto3 client.
+
+    .. code-block:: ini
+
+        [secrets]
+        backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
+        backend_kwargs = {"connections_prefix": "airflow/connections", "region_name": "eu-west-1"}
+
+    .. seealso::
+        :ref:`howto/connection:aws:configuring-the-connection`
+
     """
 
     def __init__(
@@ -64,7 +69,6 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         connections_prefix: str = '/airflow/connections',
         variables_prefix: str = '/airflow/variables',
         config_prefix: str = '/airflow/config',
-        profile_name: Optional[str] = None,
         **kwargs,
     ):
         super().__init__()
@@ -80,14 +84,34 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
             self.config_prefix = config_prefix.rstrip('/')
         else:
             self.config_prefix = config_prefix
-        self.profile_name = profile_name
+
+        self.profile_name = kwargs.get("profile_name", None)
+        # Remove client specific arguments from kwargs
+        self.api_version = kwargs.pop("api_version", None)
+        self.use_ssl = kwargs.pop("use_ssl", None)
+
         self.kwargs = kwargs
 
     @cached_property
     def client(self):
         """Create a SSM client"""
-        session = boto3.Session(profile_name=self.profile_name)
-        return session.client("ssm", **self.kwargs)
+        from airflow.providers.amazon.aws.hooks.base_aws import SessionFactory
+        from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
+
+        conn_id = f"{self.__class__.__name__}__connection"
+        conn_config = AwsConnectionWrapper.from_connection_metadata(conn_id=conn_id, extra=self.kwargs)
+        client_kwargs = trim_none_values(
+            {
+                "region_name": conn_config.region_name,
+                "verify": conn_config.verify,
+                "endpoint_url": conn_config.endpoint_url,
+                "api_version": self.api_version,
+                "use_ssl": self.use_ssl,
+            }
+        )
+
+        session = SessionFactory(conn=conn_config).create_session()
+        return session.client(service_name="ssm", **client_kwargs)
 
     def get_conn_value(self, conn_id: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -24,7 +24,9 @@ from botocore.config import Config
 
 from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection
@@ -51,11 +53,13 @@ class AwsConnectionWrapper(LoggingMixin):
 
     conn: InitVar[Optional[Union["Connection", "AwsConnectionWrapper"]]]
     region_name: Optional[str] = field(default=None)
+    # boto3 client/resource configs
     botocore_config: Optional[Config] = field(default=None)
+    verify: Optional[Union[bool, str]] = field(default=None)
 
     # Reference to Airflow Connection attributes
     # ``extra_config`` contains original Airflow Connection Extra.
-    conn_id: Optional[str] = field(init=False, default=None)
+    conn_id: Optional[Union[str, ArgNotSet]] = field(init=False, default=NOTSET)
     conn_type: Optional[str] = field(init=False, default=None)
     login: Optional[str] = field(init=False, repr=False, default=None)
     password: Optional[str] = field(init=False, repr=False, default=None)
@@ -66,8 +70,8 @@ class AwsConnectionWrapper(LoggingMixin):
     aws_secret_access_key: Optional[str] = field(init=False, default=None)
     aws_session_token: Optional[str] = field(init=False, default=None)
 
-    # Additional boto3.session.Session keyword arguments.
-    session_kwargs: Dict[str, Any] = field(init=False, default_factory=dict)
+    # AWS Shared Credential profile_name
+    profile_name: Optional[str] = field(init=False, default=None)
     # Custom endpoint_url for boto3.client and boto3.resource
     endpoint_url: Optional[str] = field(init=False, default=None)
 
@@ -108,6 +112,14 @@ class AwsConnectionWrapper(LoggingMixin):
             return
 
         extra = deepcopy(conn.extra_dejson)
+        session_kwargs = extra.get("session_kwargs", {})
+        if session_kwargs:
+            warnings.warn(
+                "'session_kwargs' in extra config is deprecated and will be removed in a future releases. "
+                f"Please specify arguments passed to boto3 Session directly in {self.conn_repr} extra.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Assign attributes from AWS Connection
         self.conn_id = conn.conn_id
@@ -127,13 +139,33 @@ class AwsConnectionWrapper(LoggingMixin):
         init_credentials = self._get_credentials(**extra)
         self.aws_access_key_id, self.aws_secret_access_key, self.aws_session_token = init_credentials
 
-        if not self.region_name and "region_name" in extra:
-            self.region_name = extra["region_name"]
-            self.log.info("Retrieving region_name=%s from %s extra.", self.region_name, self.conn_repr)
+        if not self.region_name:
+            if "region_name" in extra:
+                self.region_name = extra["region_name"]
+                self.log.info("Retrieving region_name=%s from %s extra.", self.region_name, self.conn_repr)
+            elif "region_name" in session_kwargs:
+                self.region_name = session_kwargs["region_name"]
+                self.log.info(
+                    "Retrieving region_name=%s from %s extra['session_kwargs'].",
+                    self.region_name,
+                    self.conn_repr,
+                )
 
-        if "session_kwargs" in extra:
-            self.session_kwargs = extra["session_kwargs"]
-            self.log.info("Retrieving session_kwargs=%s from %s extra.", self.session_kwargs, self.conn_repr)
+        if not self.verify and "verify" in extra:
+            self.verify = extra["verify"]
+            self.log.debug("Retrieving verify=%s from %s extra.", self.verify, self.conn_repr)
+
+        self.profile_name = extra.get("session_kwargs", {}).get("profile_name")
+        if "profile_name" in extra:
+            self.profile_name = extra["profile_name"]
+            self.log.info("Retrieving profile_name=%s from %s extra.", self.profile_name, self.conn_repr)
+        elif "profile_name" in session_kwargs:
+            self.profile_name = session_kwargs["profile_name"]
+            self.log.info(
+                "Retrieving profile_name=%s from %s extra['session_kwargs'].",
+                self.profile_name,
+                self.conn_repr,
+            )
 
         # Warn the user that an invalid parameter is being used which actually not related to 'profile_name'.
         if "profile" in extra and "s3_config_file" not in extra:
@@ -175,13 +207,48 @@ class AwsConnectionWrapper(LoggingMixin):
         assume_role_configs = self._get_assume_role_configs(**extra)
         self.role_arn, self.assume_role_method, self.assume_role_kwargs = assume_role_configs
 
+    @classmethod
+    def from_connection_metadata(
+        cls,
+        conn_id: Optional[str] = None,
+        login: Optional[str] = None,
+        password: Optional[str] = None,
+        extra: Dict[str, Any] = None,
+    ):
+        """
+        Create config from connection metadata.
+
+        :param conn_id: Custom connection ID.
+        :param login: AWS Access Key ID.
+        :param password: AWS Secret Access Key.
+        :param extra: Connection Extra metadata.
+        """
+        from airflow.models.connection import Connection
+
+        return cls(
+            conn=Connection(conn_id=conn_id, conn_type="aws", login=login, password=password, extra=extra)
+        )
+
     @property
     def extra_dejson(self):
         """Compatibility with `airflow.models.Connection.extra_dejson` property."""
         return self.extra_config
 
+    @property
+    def session_kwargs(self) -> Dict[str, Any]:
+        """Additional kwargs passed to boto3.session.Session."""
+        return trim_none_values(
+            {
+                "aws_access_key_id": self.aws_access_key_id,
+                "aws_secret_access_key": self.aws_secret_access_key,
+                "aws_session_token": self.aws_session_token,
+                "region_name": self.region_name,
+                "profile_name": self.profile_name,
+            }
+        )
+
     def __bool__(self):
-        return self.conn_id is not None
+        return self.conn_id is not NOTSET
 
     def _get_credentials(
         self,
@@ -193,6 +260,7 @@ class AwsConnectionWrapper(LoggingMixin):
         s3_config_file: Optional[str] = None,
         s3_config_format: Optional[str] = None,
         profile: Optional[str] = None,
+        session_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         """
@@ -201,16 +269,26 @@ class AwsConnectionWrapper(LoggingMixin):
         ``aws_access_key_id`` and ``aws_secret_access_key`` order
         1. From Connection login and password
         2. From Connection extra['aws_access_key_id'] and extra['aws_access_key_id']
-        3. (deprecated) From local credentials file
+        3. (deprecated) Form Connection extra['session_kwargs']
+        4. (deprecated) From local credentials file
 
         Get ``aws_session_token`` from extra['aws_access_key_id']
 
         """
+        session_kwargs = session_kwargs or {}
+        session_aws_access_key_id = session_kwargs.get("aws_access_key_id")
+        session_aws_secret_access_key = session_kwargs.get("aws_secret_access_key")
+        session_aws_session_token = session_kwargs.get("aws_session_token")
+
         if self.login and self.password:
             self.log.info("%s credentials retrieved from login and password.", self.conn_repr)
             aws_access_key_id, aws_secret_access_key = self.login, self.password
         elif aws_access_key_id and aws_secret_access_key:
             self.log.info("%s credentials retrieved from extra.", self.conn_repr)
+        elif session_aws_access_key_id and session_aws_secret_access_key:
+            aws_access_key_id = session_aws_access_key_id
+            aws_secret_access_key = session_aws_secret_access_key
+            self.log.info("%s credentials retrieved from extra['session_kwargs'].", self.conn_repr)
         elif s3_config_file:
             aws_access_key_id, aws_secret_access_key = _parse_s3_config(
                 s3_config_file,
@@ -222,6 +300,13 @@ class AwsConnectionWrapper(LoggingMixin):
         if aws_session_token:
             self.log.info(
                 "%s session token retrieved from extra, please note you are responsible for renewing these.",
+                self.conn_repr,
+            )
+        elif session_aws_session_token:
+            aws_session_token = session_aws_session_token
+            self.log.info(
+                "%s session token retrieved from extra['session_kwargs'], "
+                "please note you are responsible for renewing these.",
                 self.conn_repr,
             )
 

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -26,7 +26,15 @@ from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.types import NOTSET, ArgNotSet
+
+try:
+    from airflow.utils.types import NOTSET, ArgNotSet
+except ImportError:  # TODO: Remove when the provider has an Airflow 2.3+ requirement.
+
+    class ArgNotSet:  # type: ignore[no-redef]
+        """Sentinel type for annotations, useful when None is not viable."""
+
+    NOTSET = ArgNotSet()
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -142,26 +142,25 @@ class AwsConnectionWrapper(LoggingMixin):
         if not self.region_name:
             if "region_name" in extra:
                 self.region_name = extra["region_name"]
-                self.log.info("Retrieving region_name=%s from %s extra.", self.region_name, self.conn_repr)
+                self.log.debug("Retrieving region_name=%s from %s extra.", self.region_name, self.conn_repr)
             elif "region_name" in session_kwargs:
                 self.region_name = session_kwargs["region_name"]
-                self.log.info(
+                self.log.debug(
                     "Retrieving region_name=%s from %s extra['session_kwargs'].",
                     self.region_name,
                     self.conn_repr,
                 )
 
-        if not self.verify and "verify" in extra:
+        if self.verify is None and "verify" in extra:
             self.verify = extra["verify"]
             self.log.debug("Retrieving verify=%s from %s extra.", self.verify, self.conn_repr)
 
-        self.profile_name = extra.get("session_kwargs", {}).get("profile_name")
         if "profile_name" in extra:
             self.profile_name = extra["profile_name"]
-            self.log.info("Retrieving profile_name=%s from %s extra.", self.profile_name, self.conn_repr)
+            self.log.debug("Retrieving profile_name=%s from %s extra.", self.profile_name, self.conn_repr)
         elif "profile_name" in session_kwargs:
             self.profile_name = session_kwargs["profile_name"]
-            self.log.info(
+            self.log.debug(
                 "Retrieving profile_name=%s from %s extra['session_kwargs'].",
                 self.profile_name,
                 self.conn_repr,
@@ -181,7 +180,7 @@ class AwsConnectionWrapper(LoggingMixin):
         config_kwargs = extra.get("config_kwargs")
         if not self.botocore_config and config_kwargs:
             # https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
-            self.log.info("Retrieving botocore config=%s from %s extra.", config_kwargs, self.conn_repr)
+            self.log.debug("Retrieving botocore config=%s from %s extra.", config_kwargs, self.conn_repr)
             self.botocore_config = Config(**config_kwargs)
 
         if conn.host:
@@ -213,7 +212,7 @@ class AwsConnectionWrapper(LoggingMixin):
         conn_id: Optional[str] = None,
         login: Optional[str] = None,
         password: Optional[str] = None,
-        extra: Dict[str, Any] = None,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Create config from connection metadata.
@@ -326,7 +325,7 @@ class AwsConnectionWrapper(LoggingMixin):
     ) -> Tuple[Optional[str], Optional[str], Dict[Any, str]]:
         """Get assume role configs from Connection extra."""
         if role_arn:
-            self.log.info("Retrieving role_arn=%r from %s extra.", role_arn, self.conn_repr)
+            self.log.debug("Retrieving role_arn=%r from %s extra.", role_arn, self.conn_repr)
         elif aws_account_id and aws_iam_role:
             warnings.warn(
                 "Constructing 'role_arn' from extra['aws_account_id'] and extra['aws_iam_role'] is deprecated"
@@ -336,7 +335,7 @@ class AwsConnectionWrapper(LoggingMixin):
                 stacklevel=3,
             )
             role_arn = f"arn:aws:iam::{aws_account_id}:role/{aws_iam_role}"
-            self.log.info(
+            self.log.debug(
                 "Constructions role_arn=%r from %s extra['aws_account_id'] and extra['aws_iam_role'].",
                 role_arn,
                 self.conn_repr,
@@ -353,7 +352,7 @@ class AwsConnectionWrapper(LoggingMixin):
                 f' Currently {supported_methods} are supported.'
                 ' (Exclude this setting will default to "assume_role").'
             )
-        self.log.info("Retrieve assume_role_method=%r from %s.", assume_role_method, self.conn_repr)
+        self.log.debug("Retrieve assume_role_method=%r from %s.", assume_role_method, self.conn_repr)
 
         assume_role_kwargs = assume_role_kwargs or {}
         if "ExternalId" not in assume_role_kwargs and external_id:

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -44,6 +44,7 @@ automatically the credentials from there.
     This is no longer the case and the region needs to be set manually, either in the connection screens in Airflow,
     or via the ``AWS_DEFAULT_REGION`` environment variable.
 
+.. _howto/connection:aws:configuring-the-connection:
 
 Configuring the Connection
 --------------------------
@@ -63,19 +64,21 @@ AWS Secret Access Key (optional)
 
 Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in AWS
-    connection. The following parameters are all optional:
+    connection. All parameters are optional.
+
+    The following extra parameters used for create initial
+    `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__:
 
     * ``aws_access_key_id``: AWS access key ID used for the initial connection.
     * ``aws_secret_access_key``: AWS secret access key used for the initial connection
     * ``aws_session_token``: AWS session token used for the initial connection if you use external credentials.
       You are responsible for renewing these.
     * ``region_name``: AWS Region for the connection.
-    * ``session_kwargs``: Additional **kwargs** passed to
-      `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__.
-    * ``config_kwargs``: Additional **kwargs** used to construct a
-      `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__
-      passed to `boto3.client <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client>`__
-      and `boto3.resource <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.resource>`__.
+    * ``profile_name``: The name of a profile to use listed in
+      `configuration and credential file settings <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings>`__.
+
+    The following extra parameters used for `assume role <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`__:
+
     * ``role_arn``: If specified, then assume this role, obtaining a set of temporary security credentials using the ``assume_role_method``.
     * ``assume_role_method``: AWS STS client method, one of
       `assume_role <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`__,
@@ -83,7 +86,15 @@ Extra (optional)
       `assume_role_with_web_identity <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html>`__
       if not specified then **assume_role** is used.
     * ``assume_role_kwargs``: Additional **kwargs** passed to ``assume_role_method``.
+
+    The following extra parameters used for passed to
+    `boto3.client <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client>`__
+    and `boto3.resource <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.resource>`__:
+
+    * ``config_kwargs``: Additional **kwargs** used to construct a
+      `botocore.config.Config <https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html>`__.
     * ``endpoint_url``: Endpoint URL for the connection.
+    * ``verify``: Whether or not to verify SSL certificates.
 
 .. warning:: Extra parameters below are deprecated and will be removed in a future version of this provider.
 
@@ -99,6 +110,8 @@ Extra (optional)
     * ``profile``: If you are getting your credentials from the ``s3_config_file``
       you can specify the profile with this parameter.
     * ``host``: Used as connection's URL. Use ``endpoint_url`` instead.
+    * ``session_kwargs``: Additional **kwargs** passed to
+      `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__.
 
 If you are configuring the connection via a URI, ensure that all components of the URI are URL-encoded.
 
@@ -159,9 +172,7 @@ This assumes all other Connection fields eg **AWS Access Key ID** or **AWS Secre
 .. code-block:: json
 
     {
-      "session_kwargs": {
-        "profile_name": "my_profile"
-      }
+      "profile_name": "my_profile"
     }
 
 
@@ -285,7 +296,7 @@ Set in AWS Config File
 **~/.aws/config**:
   .. code-block:: ini
 
-    [awesome_aws_profile]
+    [profile awesome_aws_profile]
     retry_mode = standard
     max_attempts = 10
 
@@ -293,9 +304,7 @@ Set in AWS Config File
   .. code-block:: json
 
     {
-      "session_kwargs": {
-        "profile_name": "awesome_aws_profile"
-      }
+      "profile_name": "awesome_aws_profile"
     }
 
 Set by Environment Variables

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -66,7 +66,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in AWS
     connection. All parameters are optional.
 
-    The following extra parameters used for create initial
+    The following extra parameters used to create an initial
     `boto3.session.Session <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html>`__:
 
     * ``aws_access_key_id``: AWS access key ID used for the initial connection.
@@ -87,7 +87,7 @@ Extra (optional)
       if not specified then **assume_role** is used.
     * ``assume_role_kwargs``: Additional **kwargs** passed to ``assume_role_method``.
 
-    The following extra parameters used for passed to
+    The following extra parameters used for
     `boto3.client <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.client>`__
     and `boto3.resource <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html#boto3.session.Session.resource>`__:
 

--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-secrets-manager.rst
@@ -30,8 +30,15 @@ Here is a sample configuration:
     backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
     backend_kwargs = {"connections_prefix": "airflow/connections", "variables_prefix": "airflow/variables", "profile_name": "default", "full_url_mode": false}
 
-To authenticate you can either supply a profile name to reference aws profile, e.g. defined in ``~/.aws/config`` or set
-environment variables like ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, ``AWS_DEFAULT_REGION``.
+To authenticate you can either supply arguments listed in
+:ref:`Amazon Webservices Connection Extra config <howto/connection:aws:configuring-the-connection>` or set
+`environment variables <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables>`__.
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
+    backend_kwargs = {"connections_prefix": "airflow/connections", "variables_prefix": "airflow/variables", "role_arn": "arn:aws:iam::123456789098:role/role-name"}
 
 
 Storing and Retrieving Connections

--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
@@ -31,6 +31,17 @@ Here is a sample configuration:
     backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
     backend_kwargs = {"connections_prefix": "/airflow/connections", "variables_prefix": "/airflow/variables", "profile_name": "default"}
 
+To authenticate you can either supply arguments listed in
+:ref:`Amazon Webservices Connection Extra config <howto/connection:aws:configuring-the-connection>` or set
+`environment variables <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables>`__.
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
+    backend_kwargs = {"connections_prefix": "airflow/connections", "variables_prefix": "airflow/variables", "role_arn": "arn:aws:iam::123456789098:role/role-name"}
+
+
 Optional lookup
 """""""""""""""
 

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -733,6 +733,20 @@ class TestAwsBaseHook:
         assert session == MOCK_BOTO3_SESSION
         assert endpoint == hook.conn_config.endpoint_url
 
+    @pytest.mark.parametrize("verify", [None, "path/to/cert/hook-bundle.pem", False])
+    @pytest.mark.parametrize("conn_verify", [None, "path/to/cert/conn-bundle.pem", False])
+    def test_resolve_verify(self, verify, conn_verify):
+        mock_conn = Connection(
+            conn_id="test_conn",
+            conn_type="aws",
+            extra={"verify": conn_verify} if conn_verify is not None else {},
+        )
+
+        with unittest.mock.patch.dict('os.environ', AIRFLOW_CONN_TEST_CONN=mock_conn.get_uri()):
+            hook = AwsBaseHook(aws_conn_id="test_conn", verify=verify)
+            expected = verify if verify is not None else conn_verify
+            assert hook.verify == expected
+
 
 class ThrowErrorUntilCount:
     """Holds counter state for invoking a method several times in a row."""

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -205,17 +205,20 @@ class TestSessionFactory:
         assert any(logging_message in log_text for log_text in caplog.messages)
 
     @pytest.mark.parametrize("region_name", ["eu-central-1", None])
+    @pytest.mark.parametrize("profile_name", ["default", None])
     @mock.patch("boto3.session.Session", new_callable=mock.PropertyMock, return_value=MOCK_BOTO3_SESSION)
-    def test_create_session_from_credentials(self, mock_boto3_session, region_name):
-        mock_conn = AwsConnectionWrapper(conn=Connection(conn_type=MOCK_CONN_TYPE, conn_id=MOCK_AWS_CONN_ID))
-        sf = BaseSessionFactory(conn=mock_conn, region_name=region_name, config=None)
-        session = sf.create_session()
-        mock_boto3_session.assert_called_once_with(
-            aws_access_key_id=mock_conn.aws_access_key_id,
-            aws_secret_access_key=mock_conn.aws_secret_access_key,
-            aws_session_token=mock_conn.aws_session_token,
-            region_name=region_name,
+    def test_create_session_from_credentials(self, mock_boto3_session, region_name, profile_name):
+        mock_conn = Connection(
+            conn_type=MOCK_CONN_TYPE, conn_id=MOCK_AWS_CONN_ID, extra={"profile_name": profile_name}
         )
+        mock_conn_config = AwsConnectionWrapper(conn=mock_conn)
+        sf = BaseSessionFactory(conn=mock_conn_config, region_name=region_name, config=None)
+        session = sf.create_session()
+
+        expected_arguments = mock_conn_config.session_kwargs
+        if region_name:
+            expected_arguments["region_name"] = region_name
+        mock_boto3_session.assert_called_once_with(**expected_arguments)
         assert session == MOCK_BOTO3_SESSION
 
 
@@ -385,12 +388,7 @@ class TestAwsBaseHook:
 
         mock_boto3.assert_has_calls(
             [
-                mock.call.session.Session(
-                    aws_access_key_id=None,
-                    aws_secret_access_key=None,
-                    aws_session_token=None,
-                    region_name=None,
-                ),
+                mock.call.session.Session(),
                 mock.call.session.Session()._session.__bool__(),
                 mock.call.session.Session(botocore_session=mock_session.get_session.return_value),
                 mock.call.session.Session().get_credentials(),

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -268,3 +268,30 @@ class TestSecretsManagerBackend(TestCase):
 
         assert secrets_manager_backend.get_config("config") is None
         mock_get_secret.assert_not_called()
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.SessionFactory")
+    def test_passing_client_kwargs(self, mock_session_factory):
+        secrets_manager_backend = SecretsManagerBackend(
+            use_ssl=False, role_arn="arn:aws:iam::222222222222:role/awesome-role", region_name="eu-central-1"
+        )
+
+        # Mock SessionFactory, session and client
+        mock_session_factory_instance = mock_session_factory.return_value
+        mock_ssm_client = mock.MagicMock(return_value="mock-secretsmanager-client")
+        mock_session = mock.MagicMock()
+        mock_session.client = mock_ssm_client
+        mock_create_session = mock.MagicMock(return_value=mock_session)
+        mock_session_factory_instance.create_session = mock_create_session
+
+        secrets_manager_backend.client
+        assert mock_session_factory.call_count == 1
+        assert "conn" in mock_session_factory.call_args.kwargs
+
+        conn_wrapper = mock_session_factory.call_args.kwargs["conn"]
+        assert conn_wrapper.conn_id == "SecretsManagerBackend__connection"
+        assert conn_wrapper.role_arn == "arn:aws:iam::222222222222:role/awesome-role"
+        assert conn_wrapper.region_name == "eu-central-1"
+
+        mock_ssm_client.assert_called_once_with(
+            service_name='secretsmanager', region_name="eu-central-1", use_ssl=False
+        )

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -285,9 +285,10 @@ class TestSecretsManagerBackend(TestCase):
 
         secrets_manager_backend.client
         assert mock_session_factory.call_count == 1
-        assert "conn" in mock_session_factory.call_args.kwargs
+        mock_session_factory_call_kwargs = mock_session_factory.call_args[1]
+        assert "conn" in mock_session_factory_call_kwargs
+        conn_wrapper = mock_session_factory_call_kwargs["conn"]
 
-        conn_wrapper = mock_session_factory.call_args.kwargs["conn"]
         assert conn_wrapper.conn_id == "SecretsManagerBackend__connection"
         assert conn_wrapper.role_arn == "arn:aws:iam::222222222222:role/awesome-role"
         assert conn_wrapper.region_name == "eu-central-1"

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -141,9 +141,10 @@ class TestSsmSecrets(TestCase):
 
         systems_manager.client
         assert mock_session_factory.call_count == 1
-        assert "conn" in mock_session_factory.call_args.kwargs
+        mock_session_factory_call_kwargs = mock_session_factory.call_args[1]
+        assert "conn" in mock_session_factory_call_kwargs
+        conn_wrapper = mock_session_factory_call_kwargs["conn"]
 
-        conn_wrapper = mock_session_factory.call_args.kwargs["conn"]
         assert conn_wrapper.conn_id == "SystemsManagerParameterStoreBackend__connection"
         assert conn_wrapper.role_arn == "arn:aws:iam::222222222222:role/awesome-role"
 

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -116,11 +116,14 @@ class TestSsmSecrets(TestCase):
         {
             ('secrets', 'backend'): 'airflow.providers.amazon.aws.secrets.systems_manager.'
             'SystemsManagerParameterStoreBackend',
-            ('secrets', 'backend_kwargs'): '{"use_ssl": false}',
+            (
+                'secrets',
+                'backend_kwargs',
+            ): '{"use_ssl": false, "role_arn": "arn:aws:iam::222222222222:role/awesome-role"}',
         }
     )
-    @mock.patch("airflow.providers.amazon.aws.secrets.systems_manager.boto3.Session.client")
-    def test_passing_client_kwargs(self, mock_ssm_client):
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.SessionFactory")
+    def test_passing_client_kwargs(self, mock_session_factory):
         backends = initialize_secrets_backends()
         systems_manager = [
             backend
@@ -128,8 +131,23 @@ class TestSsmSecrets(TestCase):
             if backend.__class__.__name__ == 'SystemsManagerParameterStoreBackend'
         ][0]
 
+        # Mock SessionFactory, session and client
+        mock_session_factory_instance = mock_session_factory.return_value
+        mock_ssm_client = mock.MagicMock(return_value="mock-ssm-client")
+        mock_session = mock.MagicMock()
+        mock_session.client = mock_ssm_client
+        mock_create_session = mock.MagicMock(return_value=mock_session)
+        mock_session_factory_instance.create_session = mock_create_session
+
         systems_manager.client
-        mock_ssm_client.assert_called_once_with('ssm', use_ssl=False)
+        assert mock_session_factory.call_count == 1
+        assert "conn" in mock_session_factory.call_args.kwargs
+
+        conn_wrapper = mock_session_factory.call_args.kwargs["conn"]
+        assert conn_wrapper.conn_id == "SystemsManagerParameterStoreBackend__connection"
+        assert conn_wrapper.role_arn == "arn:aws:iam::222222222222:role/awesome-role"
+
+        mock_ssm_client.assert_called_once_with(service_name='ssm', use_ssl=False)
 
     @mock.patch(
         "airflow.providers.amazon.aws.secrets.systems_manager."


### PR DESCRIPTION
In additional added new Extra Connection parameters
* `profile_name` - this only one parameter which could be assigned to `session_kwargs` without any side effects in current provider, so I thought there is no reason use `session_kwargs`.
* `verify` - this parameter could specified at that moment only in hook (right now), but not in connection.

Update documentation and split Extra Connection Config by sections.

closes: #25326 _(updated, initially mention wrong issue)_