### PR TITLE
Allow per-timetable ordering override in grid view

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3157,11 +3157,11 @@ class DagModel(Base):
                 continue
 
     @classmethod
-    def dags_needing_dagruns(cls, session: Session) -> Tuple[Query, Dict]:
+    def dags_needing_dagruns(cls, session: Session) -> Tuple[Query, Dict[str, Tuple[datetime, datetime]]]:
         """
         Return (and lock) a list of Dag objects that are due to create a new DagRun.
 
-        This will return a resultset of rows  that is row-level-locked with a "SELECT ... FOR UPDATE" query,
+        This will return a resultset of rows that is row-level-locked with a "SELECT ... FOR UPDATE" query,
         you should ensure that any scheduling decisions are made in a single transaction -- as soon as the
         transaction is committed it will be unlocked.
         """

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, NamedTuple, Optional
+from typing import Any, Dict, NamedTuple, Optional, Sequence
 
 from pendulum import DateTime
 
@@ -123,6 +123,12 @@ class Timetable(Protocol):
 
     This defaults to and should generally be *True*, but ``NullTimetable`` sets
     this to *False*.
+    """
+
+    run_ordering: Sequence[str] = ("data_interval_end", "execution_date")
+    """How runs triggered from this timetable should be ordered in UI.
+
+    This should be a list of field names on the DAG run object.
     """
 
     @classmethod

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -27,6 +27,7 @@ class _TrivialTimetable(Timetable):
 
     periodic = False
     can_run = False
+    run_ordering = ("execution_date",)
 
     @classmethod
     def deserialize(cls, data: Dict[str, Any]) -> "Timetable":

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3624,8 +3624,10 @@ class Airflow(AirflowBaseView):
             if run_state:
                 query = query.filter(DagRun.state == run_state)
 
-            dag_runs = query.order_by(DagRun.execution_date.desc()).limit(num_runs).all()
+            ordering = (DagRun.__table__.columns[name].desc() for name in dag.timetable.run_ordering)
+            dag_runs = query.order_by(*ordering, DagRun.id.desc()).limit(num_runs).all()
             dag_runs.reverse()
+
             encoded_runs = [wwwutils.encode_dag_run(dr) for dr in dag_runs]
             data = {
                 'groups': dag_to_grid(dag, dag_runs, session),

--- a/newsfragments/25090.significant.rst
+++ b/newsfragments/25090.significant.rst
@@ -1,0 +1,5 @@
+DAG runs sorting logic changed in grid view
+
+The ordering of DAG runs in the grid view has been changed to be more "natural".
+The new logic generally orders by data interval, but a custom ordering can be
+applied by setting the DAG to use a custom timetable.


### PR DESCRIPTION
Close #25090.

I wonder if there are any other views that would benefit from this custom ordering logic.