### PR TITLE
Fix CHANGELOG for common.sql provider  and add amazon commit 

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -48,6 +48,7 @@ Features
 * ``SQSPublishOperator should allow sending messages to a FIFO Queue (#25171)``
 * ``Glue Job Driver logging (#25142)``
 * ``Bump typing-extensions and mypy for ParamSpec (#25088)``
+* ``Enable multiple query execution in RedshiftDataOperator (#25619)``
 
 Bug Fixes
 ~~~~~~~~~
@@ -72,6 +73,7 @@ Bug Fixes
    * ``Sagemaker System Tests - Part 2 of 3 - example_sagemaker.py (#25079)``
    * ``Migrate lambda sample dag to system test (AIP-47) (#24355)``
    * ``SageMaker system tests - Part 1 of 3 - Prep Work (AIP-47) (#25078)``
+   * ``Prepare docs for new providers release (August 2022) (#25618)``
 
 4.1.0
 .....

--- a/airflow/providers/common/sql/CHANGELOG.rst
+++ b/airflow/providers/common/sql/CHANGELOG.rst
@@ -27,7 +27,21 @@ Changelog
 1.1.0
 .....
 
+Features
+~~~~~~~~
 
+* ``Improve taskflow type hints with ParamSpec (#25173)``
+* ``Move all "old" SQL operators to common.sql providers (#25350)``
+* ``Deprecate hql parameters and synchronize DBApiHook method APIs (#25299)``
+* ``Unify DbApiHook.run() method with the methods which override it (#23971)``
+* ``Common SQLCheckOperators Various Functionality Update (#25164)``
+
+Bug Fixes
+~~~~~~~~~
+
+* ``Allow Legacy SqlSensor to use the common.sql providers (#25293)``
+* ``Fix fetch_all_handler & db-api tests for it (#25430)``
+* ``Align Common SQL provider logo location (#25538)``
 
 1.0.0
 .....

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -23,6 +23,7 @@ description: |
 
 versions:
   - 1.1.0
+  - 1.0.0
 
 dependencies:
   - sqlparse>=0.4.2

--- a/docs/apache-airflow-providers-amazon/commits.rst
+++ b/docs/apache-airflow-providers-amazon/commits.rst
@@ -36,6 +36,8 @@ Latest change: 2022-08-10
 =================================================================================================  ===========  ==========================================================================================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ==========================================================================================================================================================
+`358593c6b6 <https://github.com/apache/airflow/commit/358593c6b65620807103ae16946825e0bfad974f>`_  2022-08-10   ``Enable multiple query execution in RedshiftDataOperator (#25619)``
+`e5ac6c7cfb <https://github.com/apache/airflow/commit/e5ac6c7cfb189c33e3b247f7d5aec59fe5e89a00>`_  2022-08-10   ``Prepare docs for new providers release (August 2022) (#25618)``
 `8a1b7d43e0 <https://github.com/apache/airflow/commit/8a1b7d43e05e38576a728f2c49e75a63093f9103>`_  2022-08-10   ``Refactor monolithic ECS Operator into Operators, Sensors, and a Hook (#25413)``
 `85137f3763 <https://github.com/apache/airflow/commit/85137f376373876267675f606cffdb788caa4818>`_  2022-08-09   ``Remove deprecated modules from Amazon provider package (#25609)``
 `a0212a3593 <https://github.com/apache/airflow/commit/a0212a35930f44d88e12f19e83ec5c9caa0af82a>`_  2022-08-08   ``refactor: Deprecate parameter 'host' as an extra attribute for the connection. Depreciation is happening in favor of 'endpoint_url' in extra. (#25494)``

--- a/docs/apache-airflow-providers-common-sql/commits.rst
+++ b/docs/apache-airflow-providers-common-sql/commits.rst
@@ -43,5 +43,15 @@ Commit                                                                          
 `5d4abbd58c <https://github.com/apache/airflow/commit/5d4abbd58c33e7dfa8505e307d43420459d3df55>`_  2022-07-27   ``Deprecate hql parameters and synchronize DBApiHook method APIs (#25299)``
 `df00436569 <https://github.com/apache/airflow/commit/df00436569bb6fb79ce8c0b7ca71dddf02b854ef>`_  2022-07-22   ``Unify DbApiHook.run() method with the methods which override it (#23971)``
 `be7cb1e837 <https://github.com/apache/airflow/commit/be7cb1e837b875f44fcf7903329755245dd02dc3>`_  2022-07-22   ``Common SQLCheckOperators Various Functionality Update (#25164)``
-`46bbfdade0 <https://github.com/apache/airflow/commit/46bbfdade0638cb8a5d187e47034b84e68ddf762>`_  2022-07-07   ``Move all SQL classes to common-sql provider (#24836)``
 =================================================================================================  ===========  ============================================================================
+
+1.0.0
+.....
+
+Latest change: 2022-07-07
+
+=================================================================================================  ===========  ========================================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  ========================================================
+`46bbfdade0 <https://github.com/apache/airflow/commit/46bbfdade0638cb8a5d187e47034b84e68ddf762>`_  2022-07-07   ``Move all SQL classes to common-sql provider (#24836)``
+=================================================================================================  ===========  ========================================================


### PR DESCRIPTION
By mistake (overridden version in provider.yaml) the common.sql
provider had missing release notes.

This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
