### PR TITLE
Remove useless statement in task_group_to_grid

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -321,13 +321,11 @@ def dag_to_grid(dag, dag_runs, session):
                             record['state'] = state
                             break
                     if None in record['mapped_states']:
-                        # When turnong the dict into JSON we can't have None as a key, so use the string that
-                        # the UI does
+                        # When turning the dict into JSON we can't have None as a key,
+                        # so use the string that the UI does.
                         record['mapped_states']['no_status'] = record['mapped_states'].pop(None)
 
                 for ti_summary in ti_summaries:
-                    if ti_summary.state is None:
-                        ti_summary.state == 'no_status'
                     if run_id != ti_summary.run_id:
                         run_id = ti_summary.run_id
                         if record:


### PR DESCRIPTION
This PR just removes a statement that had no effect.

We keep sending possibly 'None'  state in the grid data except for the 'mapped_states' count. (None keys in json are an issue)

I have another version of this PR [here](https://github.com/apache/airflow/compare/main...pierrejeambrun:airflow:fix-task-group-to-grid-no-status), where instead, None status are changed to 'no_status' in the entire returned payload. I don't think this is a good idea because either way the front will still have to handle None state. (Other endpoints returning `TaskInstance` will not do this transformation).

I plan to work on `grid_data` endpoint to make it return object following the api_connexion.TaskInstance schema. (run_id vs dag_run_id and other differences), to be able to unify those types in the front. (They are not playing nice with each other atm)