### PR TITLE
Use ParamSpec to replace ... in Callable

### DIFF
--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -20,6 +20,7 @@ from inspect import signature
 from typing import Callable, Generator, TypeVar, cast
 
 from airflow import settings
+from airflow.typing_compat import ParamSpec
 
 
 @contextlib.contextmanager
@@ -38,10 +39,11 @@ def create_session() -> Generator[settings.SASession, None, None]:
         session.close()
 
 
+PS = ParamSpec("PS")
 RT = TypeVar("RT")
 
 
-def find_session_idx(func: Callable[..., RT]) -> int:
+def find_session_idx(func: Callable[PS, RT]) -> int:
     """Find session index in function call parameter."""
     func_params = signature(func).parameters
     try:
@@ -53,7 +55,7 @@ def find_session_idx(func: Callable[..., RT]) -> int:
     return session_args_idx
 
 
-def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
+def provide_session(func: Callable[PS, RT]) -> Callable[PS, RT]:
     """
     Function decorator that provides a session if it isn't provided.
     If you want to reuse a session or run the function as part of a


### PR DESCRIPTION
For whatever reason, this makes PyLance able to infer the wrapped function's signature, which is a nice improvement.

Before:
<img width="441" alt="Screenshot 2022-08-11 at 15 56 09" src="https://user-images.githubusercontent.com/605277/184089837-1daa0891-f570-4897-8cfd-9ca10a4d4891.png">

After:
<img width="443" alt="Screenshot 2022-08-11 at 15 56 30" src="https://user-images.githubusercontent.com/605277/184089858-664580b0-b81e-423b-838c-92ba635a84df.png">

