### PR TITLE
Return None if an XComArg fails to resolve

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -91,6 +91,19 @@ class AirflowOptionalProviderFeatureException(AirflowException):
     """Raise by providers when imports are missing for optional provider features."""
 
 
+class XComNotFound(AirflowException):
+    """Raise when an XCom reference is being resolved against a non-existent XCom."""
+
+    def __init__(self, dag_id: str, task_id: str, key: str) -> None:
+        super().__init__()
+        self.dag_id = dag_id
+        self.task_id = task_id
+        self.key = key
+
+    def __str__(self) -> str:
+        return f'XComArg result from {self.task_id} at {self.dag_id} with key="{self.key}" is not found!'
+
+
 class UnmappableOperator(AirflowException):
     """Raise when an operator is not implemented to be mappable."""
 

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -35,7 +35,6 @@ from typing import (
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from airflow.exceptions import AirflowException
 from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
@@ -324,15 +323,8 @@ class PlainXComArg(XComArg):
         Pull XCom value for the existing arg. This method is run during ``op.execute()``
         in respectable context.
         """
-        result = context["ti"].xcom_pull(
-            task_ids=self.operator.task_id, key=str(self.key), default=NOTSET, session=session
-        )
-        if result is NOTSET:
-            raise AirflowException(
-                f'XComArg result from {self.operator.task_id} at {context["ti"].dag_id} '
-                f'with key="{self.key}" is not found!'
-            )
-        return result
+        source_id = self.operator.task_id
+        return context["ti"].xcom_pull(task_ids=source_id, key=str(self.key), default=None, session=session)
 
 
 class _MapResult(Sequence):


### PR DESCRIPTION
Reinstatiating #24401 with more explaination and a test case. Fix #24338.

When we reach the part to resolve XCom inputs, the scheduler already made sure the current task's upstreams "allow" this task to run (by logic in TriggerRuleDep). So if an upstream does not push a referenced XCom, it should be expected by the user, and therefore not be failed by
Airflow.

This change makes the XCom resolution return None instead of raising an exception. This is a reasonable choice since the XCom does not allow pushing None by design, and receiving None can therefore only mean that corresponding XCom push did not happen.