### PR TITLE
Fix `airflow-github needs-categorization` tool handling of renamed files

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -173,6 +173,11 @@ def is_core_commit(files: List[str]) -> bool:
         for ignore in non_core_files:
             if file.startswith(ignore):
                 break
+            # Handle renaming. Form: {old_name => new_name}somename.py
+            elif file.startswith("{"):
+                new_files = file[1:].split(" => ")
+                if any(n.strip().startswith(ignore) for n in new_files):
+                    break
         else:
             return True
     return False


### PR DESCRIPTION
Renamed files are listed by github to start with `{old-filename} -> {new-filename}`.
Currently, these are treated as core files. Here we search the renamed files if it starts with what should be ignored

This bug made us have all of AIP-47 PRs appear as core