### PR TITLE
Adding mysql index hint to use index on task_instance.state in critical section query

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -302,6 +302,7 @@ class SchedulerJob(BaseJob):
             # and the dag is not paused
             query = (
                 session.query(TI)
+                .with_hint(TI, 'USE INDEX (ti_state)', dialect_name='mysql')
                 .join(TI.dag_run)
                 .filter(DR.run_type != DagRunType.BACKFILL_JOB, DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)


### PR DESCRIPTION
Fixes #25627

---
To resolve [this issue](https://github.com/apache/airflow/issues/25627), I added a MySQL index hint on the Scheduler critical section query to ensure the `ti_state` index is used to filter scheduled tasks.
