### PR TITLE
Fix Databricks provider for Airflow 2.2.x

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_base.py
+++ b/airflow/providers/databricks/hooks/databricks_base.py
@@ -141,9 +141,6 @@ class BaseDatabricksHook(BaseHook):
         package_name = manager.hooks[BaseDatabricksHook.conn_type].package_name  # type: ignore[union-attr]
         provider = manager.providers[package_name]
         version = provider.version
-        if provider.is_source:
-            version += "-source"
-
         python_version = platform.python_version()
         system = platform.system().lower()
         ua_string = (


### PR DESCRIPTION
The problem was caused by using `ProviderInfo.is_source` field that was introduced only in Airflow 2.3.0.