### PR TITLE
Adding a parameter for exclusion of trashed files in GoogleDriveHook

### DIFF
--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -136,8 +136,9 @@ class GoogleDriveHook(GoogleBaseHook):
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
-        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
+        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
+
         :return: True if the file exists, False otherwise
         :rtype: bool
         """
@@ -155,8 +156,9 @@ class GoogleDriveHook(GoogleBaseHook):
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
-        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
+        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
+
         :return: Google Drive file id if the file exists, otherwise None
         :rtype: str if file exists else None
         """

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -128,24 +128,34 @@ class GoogleDriveHook(GoogleBaseHook):
         request = service.files().get_media(fileId=file_id)
         return request
 
-    def exists(self, folder_id: str, file_name: str, drive_id: Optional[str] = None):
+    def exists(
+        self, folder_id: str, file_name: str, include_trashed: bool = True, drive_id: Optional[str] = None
+    ):
         """
         Checks to see if a file exists within a Google Drive folder
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
+        :param include_trashed: Whether to include 'trahsed' objects or not, default True as Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
         :return: True if the file exists, False otherwise
         :rtype: bool
         """
-        return bool(self.get_file_id(folder_id=folder_id, file_name=file_name, drive_id=drive_id))
+        return bool(
+            self.get_file_id(
+                folder_id=folder_id, file_name=file_name, include_trashed=include_trashed, drive_id=drive_id
+            )
+        )
 
-    def get_file_id(self, folder_id: str, file_name: str, drive_id: Optional[str] = None):
+    def get_file_id(
+        self, folder_id: str, file_name: str, include_trashed: bool = True, drive_id: Optional[str] = None
+    ):
         """
         Returns the file id of a Google Drive file
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
+        :param include_trashed: Whether to include 'trashed' objects or not, default True as in Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
         :return: Google Drive file id if the file exists, otherwise None
         :rtype: str if file exists else None
@@ -153,6 +163,10 @@ class GoogleDriveHook(GoogleBaseHook):
         query = f"name = '{file_name}'"
         if folder_id:
             query += f" and parents in '{folder_id}'"
+
+        if not include_trashed:
+            query += " and trashed=false"
+
         service = self.get_conn()
         if drive_id:
             files = (

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -129,7 +129,7 @@ class GoogleDriveHook(GoogleBaseHook):
         return request
 
     def exists(
-        self, folder_id: str, file_name: str, include_trashed: bool = True, drive_id: Optional[str] = None
+        self, folder_id: str, file_name: str, drive_id: Optional[str] = None, *, include_trashed: bool = True
     ):
         """
         Checks to see if a file exists within a Google Drive folder
@@ -148,7 +148,7 @@ class GoogleDriveHook(GoogleBaseHook):
         )
 
     def get_file_id(
-        self, folder_id: str, file_name: str, include_trashed: bool = True, drive_id: Optional[str] = None
+        self, folder_id: str, file_name: str, drive_id: Optional[str] = None, *, include_trashed: bool = True
     ):
         """
         Returns the file id of a Google Drive file

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -155,7 +155,7 @@ class GoogleDriveHook(GoogleBaseHook):
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
-        :param include_trashed: Whether to include 'trashed' objects or not, default True as in Google API.
+        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
         :return: Google Drive file id if the file exists, otherwise None
         :rtype: str if file exists else None

--- a/airflow/providers/google/suite/hooks/drive.py
+++ b/airflow/providers/google/suite/hooks/drive.py
@@ -136,7 +136,7 @@ class GoogleDriveHook(GoogleBaseHook):
 
         :param folder_id: The id of the Google Drive folder in which the file resides
         :param file_name: The name of a file in Google Drive
-        :param include_trashed: Whether to include 'trahsed' objects or not, default True as Google API.
+        :param include_trashed: Whether to include objects in trash or not, default True as in Google API.
         :param drive_id: Optional. The id of the shared Google Drive in which the file resides.
         :return: True if the file exists, False otherwise
         :rtype: bool

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -167,7 +167,9 @@ class TestGoogleDriveHook(unittest.TestCase):
         file_name = "abc123.csv"
 
         result_value = self.gdrive_hook.exists(folder_id=folder_id, file_name=file_name, drive_id=drive_id)
-        mock_method.assert_called_once_with(folder_id=folder_id, file_name=file_name, drive_id=drive_id)
+        mock_method.assert_called_once_with(
+            folder_id=folder_id, file_name=file_name, drive_id=drive_id, include_trashed=True
+        )
         self.assertEqual(True, result_value)
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_file_id")
@@ -178,7 +180,24 @@ class TestGoogleDriveHook(unittest.TestCase):
         file_name = "abc123.csv"
 
         self.gdrive_hook.exists(folder_id=folder_id, file_name=file_name, drive_id=drive_id)
-        mock_method.assert_called_once_with(folder_id=folder_id, file_name=file_name, drive_id=drive_id)
+        mock_method.assert_called_once_with(
+            folder_id=folder_id, file_name=file_name, drive_id=drive_id, include_trashed=True
+        )
+
+    @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_file_id")
+    @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
+    def test_exists_when_trashed_is_false(self, mock_get_conn, mock_method):
+        folder_id = "abxy1z"
+        drive_id = "abc123"
+        file_name = "abc123.csv"
+        include_trashed = False
+
+        self.gdrive_hook.exists(
+            folder_id=folder_id, file_name=file_name, drive_id=drive_id, include_trashed=include_trashed
+        )
+        mock_method.assert_called_once_with(
+            folder_id=folder_id, file_name=file_name, drive_id=drive_id, include_trashed=False
+        )
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
     def test_get_media_request(self, mock_get_conn):


### PR DESCRIPTION
GoogleDriveHook is currently returning all the files with the specified naming, regardless if they are in the "trash folder" or not.
Taking inspiration from the following PR: #24446, I saw that the [Google Drive API ](https://developers.google.com/drive/api/v3/reference/files/list?apix_params=%7B%22q%22%3A%22name%20%3D%20%27abcd_test%27%20and%20trashed%3Dfalse%22%7D) has a parameter that we can add to the query (`trashed=false/true`) that specifies whether we want the API to return trashed files or not (default is `True` -> show trashed files).

This PR is adding this query param to the `GoogleDriveHook`.


related: #24446