### PR TITLE
Autorefresh dags page for queued runs

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -424,7 +424,7 @@ let refreshInterval;
 function checkActiveRuns(json) {
   // filter latest dag runs and check if there are still running dags
   const activeRuns = Object.keys(json).filter((dagId) => {
-    const dagRuns = json[dagId].filter((s) => s.state === 'running').filter((r) => r.count > 0);
+    const dagRuns = json[dagId].filter(({ state }) => state === 'running' || state === 'queued').filter((r) => r.count > 0);
     return (dagRuns.length > 0);
   });
   if (activeRuns.length === 0) {


### PR DESCRIPTION
In the dags page autorefresh, we were only checking for "running" dag runs, but we should also refresh for "queued" runs.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
