### PR TITLE
Fix aws cli installation script

### DIFF
--- a/scripts/in_container/bin/install_aws.sh
+++ b/scripts/in_container/bin/install_aws.sh
@@ -35,7 +35,11 @@ if command -v aws; then
     exit 1
 fi
 
-DOWNLOAD_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+    DOWNLOAD_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+else
+    DOWNLOAD_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+fi
 
 if [[ -e ${INSTALL_DIR} ]]; then
     echo "The install directory (${INSTALL_DIR}) already exists. This may mean AWS CLI is already installed."

--- a/scripts/in_container/bin/install_aws.sh
+++ b/scripts/in_container/bin/install_aws.sh
@@ -35,7 +35,8 @@ if command -v aws; then
     exit 1
 fi
 
-if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+HOST=$(uname -m)
+if [[ ${HOST} == "arm64" || ${HOST} == "aarch64" ]]; then
     DOWNLOAD_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
 else
     DOWNLOAD_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"


### PR DESCRIPTION
When I try to install aws cli on local breeze container using `install_aws.sh` , it is downloading wrong version of aws cli, and hence my DAG gives below error.

`2022-08-12, 17:50:27 UTC] {subprocess.py:74} INFO - Running command: ['/bin/bash', '-c', 'aws configure set aws_access_key_id xxxxxxx; aws configure set aws_secret_access_key xxxxxxxx; aws configure set default.region us-east-2; ']
[2022-08-12, 17:50:27 UTC] {subprocess.py:85} INFO - Output:
[2022-08-12, 17:50:27 UTC] {subprocess.py:92} INFO - qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory`

`root@026277d36c70:/opt/airflow# uname -m --> aarch64 `

The reason is because the `install_aws.sh` script takes wrong download URL for `aarch64` OS version.
This PR corrects the download URL based on underlying OS version on the container.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
