### PR TITLE
Add groups in CI output for parallell tasks

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands.py
@@ -164,9 +164,7 @@ def fix_ownership(github_repository: str, use_sudo: bool, verbose: bool, dry_run
         shell_params.airflow_image_name_with_tag,
         "/opt/airflow/scripts/in_container/run_fix_ownership.sh",
     ]
-    run_command(
-        cmd, verbose=verbose, dry_run=dry_run, text=True, env=env, check=False, enabled_output_group=True
-    )
+    run_command(cmd, verbose=verbose, dry_run=dry_run, text=True, env=env, check=False)
     # Always succeed
     sys.exit(0)
 

--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import multiprocessing as mp
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -24,6 +24,7 @@ import click
 
 from airflow_breeze.params.build_ci_params import BuildCiParams
 from airflow_breeze.params.shell_params import ShellParams
+from airflow_breeze.utils.ci_group import ci_group
 from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.common_options import (
     option_additional_dev_apt_command,
@@ -72,7 +73,7 @@ from airflow_breeze.utils.common_options import (
     option_wait_for_image,
 )
 from airflow_breeze.utils.confirm import STANDARD_TIMEOUT, Answer, user_confirm
-from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.docker_command_utils import (
     build_cache,
     make_sure_builder_configured,
@@ -84,7 +85,11 @@ from airflow_breeze.utils.docker_command_utils import (
 from airflow_breeze.utils.image import run_pull_image, run_pull_in_parallel, tag_image_as_latest
 from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_refreshed
 from airflow_breeze.utils.md5_build_check import md5sum_check_if_build_is_needed
-from airflow_breeze.utils.parallel import check_async_run_results
+from airflow_breeze.utils.parallel import (
+    check_async_run_results,
+    progress_method_docker_buildx,
+    run_with_pool,
+)
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT, BUILD_CACHE_DIR
 from airflow_breeze.utils.python_versions import get_python_version_list
 from airflow_breeze.utils.registry import login_to_github_docker_registry
@@ -105,13 +110,17 @@ def ci_image():
     pass
 
 
-def check_if_image_building_is_needed(ci_image_params: BuildCiParams, dry_run: bool, verbose: bool) -> bool:
+def check_if_image_building_is_needed(
+    ci_image_params: BuildCiParams, output: Optional[Output], dry_run: bool, verbose: bool
+) -> bool:
     """Starts building attempt. Returns false if we should not continue"""
     if not ci_image_params.force_build and not ci_image_params.upgrade_to_newer_dependencies:
         if not should_we_run_the_build(build_ci_params=ci_image_params):
             return False
     if ci_image_params.prepare_buildx_cache or ci_image_params.push:
-        login_to_github_docker_registry(image_params=ci_image_params, dry_run=dry_run, verbose=verbose)
+        login_to_github_docker_registry(
+            image_params=ci_image_params, dry_run=dry_run, output=output, verbose=verbose
+        )
     return True
 
 
@@ -123,24 +132,29 @@ def run_build_in_parallel(
     verbose: bool,
 ) -> None:
     warm_up_docker_builder(image_params_list[0], verbose=verbose, dry_run=dry_run)
-    get_console().print(
-        f"\n[info]Building with parallelism = {parallelism} for the images: {python_version_list}:"
-    )
-    pool = mp.Pool(parallelism)
-    results = [
-        pool.apply_async(
-            run_build_ci_image,
-            args=(verbose, dry_run, image_param, True),
-        )
-        for image_param in image_params_list
-    ]
-    check_async_run_results(results)
-    pool.close()
+    with ci_group(f"Building for {python_version_list}"):
+        all_params = [f"CI {image_params.python}" for image_params in image_params_list]
+        with run_with_pool(
+            parallelism=parallelism, all_params=all_params, progress_method=progress_method_docker_buildx
+        ) as (pool, outputs):
+            results = [
+                pool.apply_async(
+                    run_build_ci_image,
+                    kwds={
+                        "ci_image_params": image_params,
+                        "verbose": verbose,
+                        "dry_run": dry_run,
+                        "output": outputs[index],
+                    },
+                )
+                for index, image_params in enumerate(image_params_list)
+            ]
+    check_async_run_results(results, outputs)
 
 
 def start_building(params: BuildCiParams, dry_run: bool, verbose: bool):
-    check_if_image_building_is_needed(params, dry_run=dry_run, verbose=verbose)
-    make_sure_builder_configured(parallel=True, params=params, dry_run=dry_run, verbose=verbose)
+    check_if_image_building_is_needed(params, output=None, dry_run=dry_run, verbose=verbose)
+    make_sure_builder_configured(params=params, dry_run=dry_run, verbose=verbose)
 
 
 @ci_image.command(name='build')
@@ -196,7 +210,10 @@ def build(
 
     def run_build(ci_image_params: BuildCiParams) -> None:
         return_code, info = run_build_ci_image(
-            verbose=verbose, dry_run=dry_run, ci_image_params=ci_image_params, parallel=False
+            ci_image_params=ci_image_params,
+            output=None,
+            verbose=verbose,
+            dry_run=dry_run,
         )
         if return_code != 0:
             get_console().print(f"[error]Error when building image! {info}")
@@ -214,7 +231,7 @@ def build(
             params.python = python
             params.answer = answer
             params_list.append(params)
-        start_building(params_list[0], dry_run, verbose)
+        start_building(params=params_list[0], dry_run=dry_run, verbose=verbose)
         run_build_in_parallel(
             image_params_list=params_list,
             python_version_list=python_version_list,
@@ -224,7 +241,7 @@ def build(
         )
     else:
         params = BuildCiParams(**parameters_passed)
-        start_building(params, dry_run, verbose)
+        start_building(params=params, dry_run=dry_run, verbose=verbose)
         run_build(ci_image_params=params)
 
 
@@ -294,6 +311,7 @@ def pull(
         )
         return_code, info = run_pull_image(
             image_params=image_params,
+            output=None,
             dry_run=dry_run,
             verbose=verbose,
             wait_for_image=wait_for_image,
@@ -340,6 +358,7 @@ def verify(
     get_console().print(f"[info]Verifying CI image: {image_name}[/]")
     return_code, info = verify_an_image(
         image_name=image_name,
+        output=None,
         verbose=verbose,
         dry_run=dry_run,
         image_type='CI',
@@ -359,7 +378,6 @@ def should_we_run_the_build(build_ci_params: BuildCiParams) -> bool:
     * Builds Image/Skips/Quits depending on the answer
 
     :param build_ci_params: parameters for the build
-    :param verbose: should we get verbose information
     """
     # We import those locally so that click autocomplete works
     from inputimeout import TimeoutOccurred
@@ -412,7 +430,10 @@ def should_we_run_the_build(build_ci_params: BuildCiParams) -> bool:
 
 
 def run_build_ci_image(
-    verbose: bool, dry_run: bool, ci_image_params: BuildCiParams, parallel: bool
+    ci_image_params: BuildCiParams,
+    verbose: bool,
+    dry_run: bool,
+    output: Optional[Output],
 ) -> Tuple[int, str]:
     """
     Builds CI image:
@@ -430,32 +451,34 @@ def run_build_ci_image(
     :param verbose: print commands when running
     :param dry_run: do not execute "write" commands - just print what would happen
     :param ci_image_params: CI image parameters
-    :param parallel: whether the pull is run as part of parallel execution
+    :param output: output redirection
     """
     if (
         ci_image_params.is_multi_platform()
         and not ci_image_params.push
         and not ci_image_params.prepare_buildx_cache
     ):
-        get_console().print(
+        get_console(output=output).print(
             "\n[red]You cannot use multi-platform build without using --push flag or "
             "preparing buildx cache![/]\n"
         )
         return 1, "Error: building multi-platform image without --push."
     if verbose or dry_run:
-        get_console().print(
+        get_console(output=output).print(
             f"\n[info]Building CI image of airflow from {AIRFLOW_SOURCES_ROOT} "
             f"python version: {ci_image_params.python}[/]\n"
         )
     if ci_image_params.prepare_buildx_cache:
         build_command_result = build_cache(
-            image_params=ci_image_params, dry_run=dry_run, verbose=verbose, parallel=parallel
+            image_params=ci_image_params, output=output, dry_run=dry_run, verbose=verbose
         )
     else:
         if ci_image_params.empty_image:
             env = os.environ.copy()
             env['DOCKER_BUILDKIT'] = "1"
-            get_console().print(f"\n[info]Building empty CI Image for Python {ci_image_params.python}\n")
+            get_console(output=output).print(
+                f"\n[info]Building empty CI Image for Python {ci_image_params.python}\n"
+            )
             build_command_result = run_command(
                 prepare_docker_build_from_input(image_params=ci_image_params),
                 input="FROM scratch\n",
@@ -464,10 +487,13 @@ def run_build_ci_image(
                 cwd=AIRFLOW_SOURCES_ROOT,
                 text=True,
                 env=env,
-                enabled_output_group=not parallel,
+                stdout=output.file if output else None,
+                stderr=subprocess.STDOUT,
             )
         else:
-            get_console().print(f"\n[info]Building CI Image for Python {ci_image_params.python}\n")
+            get_console(output=output).print(
+                f"\n[info]Building CI Image for Python {ci_image_params.python}\n"
+            )
             build_command_result = run_command(
                 prepare_docker_build_command(
                     image_params=ci_image_params,
@@ -478,14 +504,20 @@ def run_build_ci_image(
                 cwd=AIRFLOW_SOURCES_ROOT,
                 text=True,
                 check=False,
-                enabled_output_group=not parallel,
+                stdout=output.file if output else None,
+                stderr=subprocess.STDOUT,
             )
             if build_command_result.returncode == 0:
                 if ci_image_params.tag_as_latest:
-                    build_command_result = tag_image_as_latest(ci_image_params, dry_run, verbose)
+                    build_command_result = tag_image_as_latest(
+                        image_params=ci_image_params,
+                        output=output,
+                        dry_run=dry_run,
+                        verbose=verbose,
+                    )
                 if ci_image_params.preparing_latest_image():
                     if dry_run:
-                        get_console().print(
+                        get_console(output=output).print(
                             "[info]Not updating build hash because we are in `dry_run` mode.[/]"
                         )
                     else:
@@ -516,9 +548,9 @@ def rebuild_or_pull_ci_image_if_needed(
     if command_params.image_tag is not None and command_params.image_tag != "latest":
         return_code, message = run_pull_image(
             image_params=ci_image_params,
+            output=None,
             dry_run=dry_run,
             verbose=verbose,
-            parallel=False,
             wait_for_image=True,
             tag_as_latest=False,
         )
@@ -535,5 +567,7 @@ def rebuild_or_pull_ci_image_if_needed(
             'Forcing build.[/]'
         )
         ci_image_params.force_build = True
-    if check_if_image_building_is_needed(ci_image_params=ci_image_params, dry_run=dry_run, verbose=verbose):
-        run_build_ci_image(verbose, dry_run=dry_run, ci_image_params=ci_image_params, parallel=False)
+    if check_if_image_building_is_needed(
+        ci_image_params=ci_image_params, output=None, dry_run=dry_run, verbose=verbose
+    ):
+        run_build_ci_image(ci_image_params=ci_image_params, output=None, verbose=verbose, dry_run=dry_run)

--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -248,7 +248,6 @@ def cleanup(verbose: bool, dry_run: bool, github_repository: str, all: bool, ans
             verbose=verbose,
             dry_run=dry_run,
             check=False,
-            enabled_output_group=True,
         )
     elif given_answer == Answer.QUIT:
         sys.exit(0)

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import multiprocessing as mp
 import shlex
+import subprocess
 import sys
 import time
 from copy import deepcopy
@@ -34,6 +34,7 @@ from airflow_breeze.global_constants import (
     MULTI_PLATFORM,
 )
 from airflow_breeze.params.shell_params import ShellParams
+from airflow_breeze.utils.ci_group import ci_group
 from airflow_breeze.utils.click_utils import BreezeGroup
 from airflow_breeze.utils.common_options import (
     argument_packages,
@@ -56,14 +57,14 @@ from airflow_breeze.utils.common_options import (
     option_version_suffix_for_pypi,
 )
 from airflow_breeze.utils.confirm import Answer, user_confirm
-from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.docker_command_utils import (
     get_env_variables_for_docker_commands,
     get_extra_docker_flags,
     perform_environment_checks,
 )
-from airflow_breeze.utils.parallel import check_async_run_results
+from airflow_breeze.utils.parallel import check_async_run_results, run_with_pool
 from airflow_breeze.utils.python_versions import get_python_version_list
 from airflow_breeze.utils.run_utils import RunCommandResult, run_command, run_compile_www_assets
 
@@ -82,7 +83,7 @@ def run_with_debug(
     dry_run: bool,
     debug: bool,
     enable_input: bool = False,
-    enabled_output_group: bool = False,
+    **kwargs,
 ) -> RunCommandResult:
     env_variables = get_env_variables_for_docker_commands(params)
     extra_docker_flags = get_extra_docker_flags(mount_sources=params.mount_sources)
@@ -118,17 +119,17 @@ echo -e '\\e[34mRun this command to debug:
             verbose=verbose,
             dry_run=dry_run,
             env=env_variables,
-            enabled_output_group=enabled_output_group,
+            **kwargs,
         )
     else:
         base_command.extend(command)
         return run_command(
             base_command,
-            enabled_output_group=enabled_output_group,
             verbose=verbose,
             dry_run=dry_run,
             env=env_variables,
             check=False,
+            **kwargs,
         )
 
 
@@ -178,7 +179,6 @@ def prepare_airflow_packages(
         verbose=verbose,
         dry_run=dry_run,
         debug=debug,
-        enabled_output_group=True,
     )
     sys.exit(result_command.returncode)
 
@@ -275,7 +275,11 @@ def prepare_provider_packages(
 
 
 def run_generate_constraints(
-    shell_params: ShellParams, dry_run: bool, verbose: bool, debug: bool, parallel: bool = False
+    shell_params: ShellParams,
+    dry_run: bool,
+    verbose: bool,
+    debug: bool,
+    output: Optional[Output],
 ) -> Tuple[int, str]:
     cmd_to_run = [
         "/opt/airflow/scripts/in_container/run_generate_constraints.sh",
@@ -286,11 +290,12 @@ def run_generate_constraints(
         verbose=verbose,
         dry_run=dry_run,
         debug=debug,
-        enabled_output_group=not parallel,
+        stdout=output.file if output else None,
+        stderr=subprocess.STDOUT,
     )
     return (
         generate_constraints_result.returncode,
-        f"Generate constraints Python {shell_params.python}:{shell_params.airflow_constraints_mode}",
+        f"Constraints {shell_params.airflow_constraints_mode}:{shell_params.python}",
     )
 
 
@@ -302,20 +307,26 @@ def run_generate_constraints_in_parallel(
     verbose: bool,
 ):
     """Run generate constraints in parallel"""
-    get_console().print(
-        f"\n[info]Generating constraints with parallelism = {parallelism} "
-        f"for the constraints: {python_version_list}[/]"
-    )
-    pool = mp.Pool(parallelism)
-    results = [
-        pool.apply_async(
-            run_generate_constraints,
-            args=(shell_param, dry_run, verbose, False, True),
-        )
-        for shell_param in shell_params_list
-    ]
-    check_async_run_results(results)
-    pool.close()
+    with ci_group(f"Constraints for {python_version_list}"):
+        all_params = [
+            f"Constraints {shell_params.airflow_constraints_mode}:{shell_params.python}"
+            for shell_params in shell_params_list
+        ]
+        with run_with_pool(parallelism=parallelism, all_params=all_params) as (pool, outputs):
+            results = [
+                pool.apply_async(
+                    run_generate_constraints,
+                    kwds={
+                        "shell_params": shell_params,
+                        "dry_run": dry_run,
+                        "verbose": verbose,
+                        "debug": False,
+                        "output": outputs[index],
+                    },
+                )
+                for index, shell_params in enumerate(shell_params_list)
+            ]
+    check_async_run_results(results, outputs)
 
 
 @release_management.command(
@@ -405,10 +416,10 @@ def generate_constraints(
         )
         return_code, info = run_generate_constraints(
             shell_params=shell_params,
+            output=None,
             dry_run=dry_run,
             verbose=verbose,
             debug=debug,
-            parallel=False,
         )
         if return_code != 0:
             get_console().print(f"[error]There was an error when generating constraints: {info}[/]")
@@ -470,7 +481,6 @@ def verify_provider_packages(
         verbose=verbose,
         dry_run=dry_run,
         debug=debug,
-        enabled_output_group=True,
     )
     sys.exit(result_command.returncode)
 

--- a/dev/breeze/src/airflow_breeze/utils/ci_group.py
+++ b/dev/breeze/src/airflow_breeze/utils/ci_group.py
@@ -19,10 +19,14 @@ import os
 from contextlib import contextmanager
 
 from airflow_breeze.utils.console import MessageType, get_console
+from airflow_breeze.utils.path_utils import skip_group_putput
+
+# only allow top-level group
+_in_ci_group = False
 
 
 @contextmanager
-def ci_group(title: str, enabled: bool = True, message_type: MessageType = MessageType.INFO):
+def ci_group(title: str, message_type: MessageType = MessageType.INFO):
     """
     If used in GitHub Action, creates an expandable group in the GitHub Action log.
     Otherwise, display simple text groups.
@@ -30,13 +34,12 @@ def ci_group(title: str, enabled: bool = True, message_type: MessageType = Messa
     For more information, see:
     https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#grouping-log-lines
     """
-    if not enabled:
+    global _in_ci_group
+    if _in_ci_group or skip_group_putput() or os.environ.get('GITHUB_ACTIONS', 'false') != "true":
         yield
         return
-    if os.environ.get('GITHUB_ACTIONS', 'false') != "true":
-        get_console().print(f"[{message_type.value}]{title}[/]")
-        yield
-        return
-    get_console().print(f"::group::<CLICK_TO_EXPAND>: [{message_type.value}]{title}[/]")
+    _in_ci_group = True
+    get_console().print(f"::group::[{message_type.value}]{title}[/]")
     yield
     get_console().print("::endgroup::")
+    _in_ci_group = False

--- a/dev/breeze/src/airflow_breeze/utils/console.py
+++ b/dev/breeze/src/airflow_breeze/utils/console.py
@@ -21,6 +21,7 @@ to be only run in CI or real development terminal - in both cases we want to hav
 import os
 from enum import Enum
 from functools import lru_cache
+from typing import NamedTuple, Optional, TextIO
 
 from rich.console import Console
 from rich.theme import Theme
@@ -70,23 +71,34 @@ def message_type_from_return_code(return_code: int) -> MessageType:
     return MessageType.ERROR
 
 
+class Output(NamedTuple):
+    title: str
+    file_name: str
+
+    @property
+    def file(self) -> TextIO:
+        return open(self.file_name, "a+t")
+
+
 @lru_cache(maxsize=None)
-def get_console() -> Console:
+def get_console(output: Optional[Output] = None) -> Console:
     return Console(
         force_terminal=True,
         color_system="standard",
         width=180 if not recording_width else int(recording_width),
+        file=output.file if output else None,
         theme=get_theme(),
         record=True if recording_file else False,
     )
 
 
 @lru_cache(maxsize=None)
-def get_stderr_console() -> Console:
+def get_stderr_console(output: Optional[Output] = None) -> Console:
     return Console(
         force_terminal=True,
         color_system="standard",
         stderr=True,
+        file=output.file if output else None,
         width=180 if not recording_width else int(recording_width),
         theme=get_theme(),
         record=True if recording_file else False,

--- a/dev/breeze/src/airflow_breeze/utils/image.py
+++ b/dev/breeze/src/airflow_breeze/utils/image.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import multiprocessing as mp
 import subprocess
 import time
-from typing import List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 from airflow_breeze.global_constants import (
     ALLOWED_PYTHON_MAJOR_MINOR_VERSIONS,
@@ -29,9 +28,10 @@ from airflow_breeze.params.build_ci_params import BuildCiParams
 from airflow_breeze.params.build_prod_params import BuildProdParams
 from airflow_breeze.params.common_build_params import CommonBuildParams
 from airflow_breeze.params.shell_params import ShellParams
-from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.ci_group import ci_group
+from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.mark_image_as_refreshed import mark_image_as_refreshed
-from airflow_breeze.utils.parallel import check_async_run_results
+from airflow_breeze.utils.parallel import check_async_run_results, progress_method_docker_pull, run_with_pool
 from airflow_breeze.utils.registry import login_to_github_docker_registry
 from airflow_breeze.utils.run_tests import verify_an_image
 from airflow_breeze.utils.run_utils import RunCommandResult, run_command
@@ -49,73 +49,76 @@ def run_pull_in_parallel(
     extra_pytest_args: Tuple,
 ):
     """Run image pull in parallel"""
-    get_console().print(
-        f"\n[info]Pulling with parallelism = {parallelism} for the images: {python_version_list}:"
-    )
-    pool = mp.Pool(parallelism)
-    poll_time = 10.0
-    if not verify:
-        results = [
-            pool.apply_async(
-                run_pull_image,
-                args=(image_param, dry_run, verbose, wait_for_image, tag_as_latest, poll_time, True),
-            )
-            for image_param in image_params_list
-        ]
-    else:
-        results = [
-            pool.apply_async(
-                run_pull_and_verify_image,
-                args=(
-                    image_param,
-                    dry_run,
-                    verbose,
-                    wait_for_image,
-                    tag_as_latest,
-                    poll_time,
-                    extra_pytest_args,
-                ),
-            )
-            for image_param in image_params_list
-        ]
-    check_async_run_results(results)
-    pool.close()
+    all_params = [f"Image {image_params.python}" for image_params in image_params_list]
+    with ci_group(f"Pull{'/verify' if verify else ''} for {python_version_list}"):
+        with run_with_pool(
+            parallelism=parallelism, all_params=all_params, progress_method=progress_method_docker_pull
+        ) as (pool, outputs):
+
+            def get_right_method() -> Callable[..., Tuple[int, str]]:
+                if verify:
+                    return run_pull_and_verify_image
+                else:
+                    return run_pull_image
+
+            def get_kwds(index: int, image_param: Union[BuildCiParams, BuildProdParams]):
+                d = {
+                    "image_params": image_param,
+                    "wait_for_image": wait_for_image,
+                    "tag_as_latest": tag_as_latest,
+                    "poll_time": 10.0,
+                    "output": outputs[index],
+                    "dry_run": dry_run,
+                    "verbose": verbose,
+                }
+                if verify:
+                    d['extra_pytest_args'] = extra_pytest_args
+                return d
+
+            results = [
+                pool.apply_async(get_right_method(), kwds=get_kwds(index, image_param))
+                for index, image_param in enumerate(image_params_list)
+            ]
+    check_async_run_results(results, outputs)
 
 
 def run_pull_image(
     image_params: CommonBuildParams,
-    dry_run: bool,
-    verbose: bool,
     wait_for_image: bool,
     tag_as_latest: bool,
+    dry_run: bool,
+    verbose: bool,
+    output: Optional[Output],
     poll_time: float = 10.0,
-    parallel: bool = False,
 ) -> Tuple[int, str]:
     """
     Pull image specified.
     :param image_params: Image parameters.
     :param dry_run: whether it's dry run
     :param verbose: whether it's verbose
+    :param output: output to write to
     :param wait_for_image: whether we should wait for the image to be available
     :param tag_as_latest: tag the image as latest
     :param poll_time: what's the polling time between checks if images are there (default 10 s)
-    :param parallel: whether the pull is run as part of parallel execution
     :return: Tuple of return code and description of the image pulled
     """
-    get_console().print(
+    get_console(output=output).print(
         f"\n[info]Pulling {image_params.image_type} image of airflow python version: "
         f"{image_params.python} image: {image_params.airflow_image_name_with_tag} "
         f"with wait for image: {wait_for_image}[/]\n"
     )
     while True:
-        login_to_github_docker_registry(image_params=image_params, dry_run=dry_run, verbose=verbose)
+        login_to_github_docker_registry(
+            image_params=image_params, output=output, dry_run=dry_run, verbose=verbose
+        )
         command_to_run = ["docker", "pull", image_params.airflow_image_name_with_tag]
         command_result = run_command(
             command_to_run,
             verbose=verbose,
             dry_run=dry_run,
             check=False,
-            enabled_output_group=not parallel,
+            stdout=output.file if output else None,
+            stderr=subprocess.STDOUT,
         )
         if command_result.returncode == 0:
             command_result = run_command(
@@ -130,10 +133,12 @@ def run_pull_image(
                 if command_result.returncode == 0:
                     image_size = int(command_result.stdout.strip())
                     if image_size == 0:
-                        get_console().print("\n[error]The image size was 0 - image creation failed.[/]\n")
+                        get_console(output=output).print(
+                            "\n[error]The image size was 0 - image creation failed.[/]\n"
+                        )
                         return 1, f"Image Python {image_params.python}"
                 else:
-                    get_console().print(
+                    get_console(output=output).print(
                         "\n[error]There was an error pulling the size of the image. Failing.[/]\n"
                     )
                     return (
@@ -141,28 +146,35 @@ def run_pull_image(
                         f"Image Python {image_params.python}",
                     )
             if tag_as_latest:
-                command_result = tag_image_as_latest(image_params, dry_run, verbose)
+                command_result = tag_image_as_latest(
+                    image_params=image_params,
+                    output=output,
+                    dry_run=dry_run,
+                    verbose=verbose,
+                )
                 if command_result.returncode == 0 and isinstance(image_params, BuildCiParams):
                     mark_image_as_refreshed(image_params)
             return command_result.returncode, f"Image Python {image_params.python}"
         if wait_for_image:
             if verbose or dry_run:
-                get_console().print(
+                get_console(output=output).print(
                     f"\n[info]Waiting for {poll_time} seconds for "
                     f"{image_params.airflow_image_name_with_tag}.[/]\n"
                 )
             time.sleep(poll_time)
             continue
         else:
-            get_console().print(
+            get_console(output=output).print(
                 f"\n[error]There was an error pulling the image {image_params.python}. Failing.[/]\n"
             )
             return command_result.returncode, f"Image Python {image_params.python}"
 
 
-def tag_image_as_latest(image_params: CommonBuildParams, dry_run: bool, verbose: bool) -> RunCommandResult:
+def tag_image_as_latest(
+    image_params: CommonBuildParams, output: Optional[Output], dry_run: bool, verbose: bool
+) -> RunCommandResult:
     if image_params.airflow_image_name_with_tag == image_params.airflow_image_name:
-        get_console().print(
+        get_console(output=output).print(
             f"[info]Skip tagging {image_params.airflow_image_name} as latest as it is already 'latest'[/]"
         )
         return subprocess.CompletedProcess(returncode=0, args=[])
@@ -182,23 +194,31 @@ def tag_image_as_latest(image_params: CommonBuildParams, dry_run: bool, verbose:
 
 def run_pull_and_verify_image(
     image_params: CommonBuildParams,
-    dry_run: bool,
-    verbose: bool,
     wait_for_image: bool,
     tag_as_latest: bool,
+    dry_run: bool,
+    verbose: bool,
     poll_time: float,
     extra_pytest_args: Tuple,
+    output: Optional[Output],
 ) -> Tuple[int, str]:
     return_code, info = run_pull_image(
-        image_params, dry_run, verbose, wait_for_image, tag_as_latest, poll_time
+        image_params=image_params,
+        wait_for_image=wait_for_image,
+        tag_as_latest=tag_as_latest,
+        output=output,
+        dry_run=dry_run,
+        verbose=verbose,
+        poll_time=poll_time,
     )
     if return_code != 0:
-        get_console().print(
+        get_console(output=output).print(
             f"\n[error]Not running verification for {image_params.python} as pulling failed.[/]\n"
         )
     return verify_an_image(
         image_name=image_params.airflow_image_name_with_tag,
         image_type=image_params.image_type,
+        output=output,
         dry_run=dry_run,
         verbose=verbose,
         slim_image=False,

--- a/dev/breeze/src/airflow_breeze/utils/parallel.py
+++ b/dev/breeze/src/airflow_breeze/utils/parallel.py
@@ -14,13 +14,164 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import datetime
+import os
+import re
+import signal
 import sys
 import time
-from multiprocessing.pool import ApplyResult
-from typing import List
+from contextlib import contextmanager
+from multiprocessing.pool import ApplyResult, Pool
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from threading import Event, Thread
+from typing import Callable, Dict, Generator, List, Optional, Tuple
 
-from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.ci_group import ci_group
+from airflow_breeze.utils.console import MessageType, Output, get_console
+
+
+def init_worker():
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+
+def create_pool(parallelism: int) -> Pool:
+    # we need to ignore SIGINT handling in workers in order to handle Ctrl-C nicely (with Pool's terminate)
+    return Pool(parallelism, initializer=init_worker())
+
+
+def get_temp_file_name() -> str:
+    file = NamedTemporaryFile(mode="w+t", delete=False)
+    name = file.name
+    file.close()
+    return name
+
+
+def get_output_files(titles: List[str]) -> List[Output]:
+    outputs = [Output(title=titles[i], file_name=get_temp_file_name()) for i in range(len(titles))]
+    for out in outputs:
+        get_console().print(f"[info]Capturing output of {out.title}:[/] {out.file_name}")
+    return outputs
+
+
+def nice_timedelta(delta: datetime.timedelta):
+    d = {'d': delta.days}
+    d['h'], rem = divmod(delta.seconds, 3600)
+    d['m'], d['s'] = divmod(rem, 60)
+    return "{d} days {h:02}:{m:02}:{s:02}".format(**d) if d['d'] else "{h:02}:{m:02}:{s:02}".format(**d)
+
+
+ANSI_COLOUR_MATCHER = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+
+
+def remove_ansi_colours(line):
+    return ANSI_COLOUR_MATCHER.sub('', line)
+
+
+def get_last_lines_of_file(file_name: str, num_lines: int = 2) -> Tuple[List[str], List[str]]:
+    """
+    Get last lines of a file efficiently, without reading the whole file (with some limitations).
+    Assumptions ara that line length not bigger than ~180 chars.
+
+    :param file_name: name of the file
+    :param num_lines: number of lines to return (max)
+    :return: Tuple - last lines of the file in two variants: original and with removed ansi colours
+    """
+    # account for EOL
+    max_read = (180 + 2) * num_lines
+    seek_size = min(os.stat(file_name).st_size, max_read)
+    with open(file_name, 'rb') as temp_f:
+        temp_f.seek(-seek_size, os.SEEK_END)
+        tail = temp_f.read().decode(errors="ignore")
+    last_lines = tail.splitlines()[-num_lines:]
+    last_lines_no_colors = [remove_ansi_colours(line) for line in last_lines]
+    return last_lines, last_lines_no_colors
+
+
+DOCKER_BUILDX_PROGRESS_MATCHER = re.compile(r'\s*#(\d*) ')
+last_docker_build_lines: Dict[Output, str] = {}
+
+
+def progress_method_docker_buildx(output: Output) -> Optional[str]:
+    last_lines, last_lines_no_colors = get_last_lines_of_file(output.file_name, num_lines=5)
+    best_progress: int = 0
+    best_line: Optional[str] = None
+    for index, line in enumerate(last_lines_no_colors):
+        match = DOCKER_BUILDX_PROGRESS_MATCHER.match(line)
+        if match:
+            docker_progress = int(match.group(1))
+            if docker_progress > best_progress:
+                best_progress = docker_progress
+                best_line = last_lines[index]
+    if best_line is None:
+        best_line = last_docker_build_lines.get(output)
+    else:
+        last_docker_build_lines[output] = best_line
+    return f"Progress: {output.title:<20} {best_line}"
+
+
+DOCKER_PULL_PROGRESS_MATCHER = re.compile(r'^[0-9a-f]+: .*|.*\[[ 0-9]+%].*')
+last_docker_pull_lines: Dict[Output, str] = {}
+
+
+def progress_method_docker_pull(output: Output) -> Optional[str]:
+    last_lines, last_lines_no_colors = get_last_lines_of_file(output.file_name, num_lines=15)
+    best_line: Optional[str] = None
+    for index, line in enumerate(last_lines_no_colors):
+        match = DOCKER_PULL_PROGRESS_MATCHER.match(line)
+        if match:
+            best_line = last_lines[index]
+    if best_line is None:
+        best_line = last_docker_pull_lines.get(output)
+    else:
+        last_docker_pull_lines[output] = best_line
+    return f"Progress: {output.title:<20} {best_line}"
+
+
+class ParallelMonitor(Thread):
+    def __init__(
+        self,
+        outputs: List[Output],
+        time_in_seconds: int = 10,
+        progress_method: Optional[Callable[[Output], Optional[str]]] = None,
+    ):
+        super().__init__()
+        self.outputs = outputs
+        self.time_in_seconds = time_in_seconds
+        self.exit_event = Event()
+        self.progress_method = progress_method
+        self.start_time = datetime.datetime.utcnow()
+        self.last_custom_progress: Optional[str] = None
+
+    def print_single_progress(self, output: Output):
+        if self.progress_method:
+            progress = self.progress_method(output)
+            if not progress and self.last_custom_progress:
+                progress = self.last_custom_progress
+            if progress:
+                print(self.progress_method(output))
+                return
+        size = os.path.getsize(output.file_name) if Path(output.file_name).exists() else 0
+        print(f"Progress: {output.title:<70} {size:>93} bytes")
+
+    def print_summary(self):
+        time_passed = datetime.datetime.utcnow() - self.start_time
+        get_console().rule()
+        for output in self.outputs:
+            self.print_single_progress(output)
+        get_console().rule(title=f"Time passed: {nice_timedelta(time_passed)}")
+
+    def cancel(self):
+        get_console().print("[info]Finishing progress monitoring.")
+        self.exit_event.set()
+
+    def run(self):
+        try:
+            while not self.exit_event.is_set():
+                self.print_summary()
+                self.exit_event.wait(self.time_in_seconds)
+        except Exception:
+            get_console().print_exception(show_locals=True)
 
 
 def print_async_summary(completed_list: List[ApplyResult]) -> None:
@@ -44,10 +195,11 @@ def get_completed_result_list(results: List[ApplyResult]) -> List[ApplyResult]:
     return list(filter(lambda result: result.ready(), results))
 
 
-def check_async_run_results(results: List[ApplyResult], poll_time: float = 0.2):
+def check_async_run_results(results: List[ApplyResult], outputs: List[Output], poll_time: float = 0.2):
     """
     Check if all async results were success. Exits with error if not.
     :param results: results of parallel runs (expected in the form of Tuple: (return_code, info)
+    :param outputs: outputs where results are written to
     :param poll_time: what's the poll time between checks
     """
     completed_number = 0
@@ -71,11 +223,35 @@ def check_async_run_results(results: List[ApplyResult], poll_time: float = 0.2):
     )
     print_async_summary(completed_list)
     errors = False
-    for result in results:
+    for i, result in enumerate(results):
         if result.get()[0] != 0:
             errors = True
+            message_type = MessageType.ERROR
+        else:
+            message_type = MessageType.SUCCESS
+        with ci_group(title=f"{outputs[i].title}", message_type=message_type):
+            os.write(1, Path(outputs[i].file_name).read_bytes())
+
     if errors:
         get_console().print("\n[error]There were errors when running some tasks. Quitting.[/]\n")
         sys.exit(1)
     else:
         get_console().print("\n[success]All images are OK.[/]\n")
+
+
+@contextmanager
+def run_with_pool(
+    parallelism: int,
+    all_params: List[str],
+    time_in_seconds: int = 10,
+    progress_method: Optional[Callable[[Output], Optional[str]]] = None,
+) -> Generator[Tuple[Pool, List[Output]], None, None]:
+    get_console().print(f"Parallelism: {parallelism}")
+    pool = create_pool(parallelism)
+    outputs = get_output_files(all_params)
+    m = ParallelMonitor(outputs=outputs, time_in_seconds=time_in_seconds, progress_method=progress_method)
+    m.start()
+    yield pool, outputs
+    pool.close()
+    pool.join()
+    m.cancel()

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -61,6 +61,10 @@ def skip_upgrade_check():
     return in_self_upgrade() or in_autocomplete() or in_help() or hasattr(sys, '_called_from_test')
 
 
+def skip_group_putput():
+    return in_autocomplete() or in_help()
+
+
 def get_package_setup_metadata_hash() -> str:
     """
     Retrieves hash of setup files from the source of installation of Breeze.
@@ -290,4 +294,3 @@ def create_directories_and_files() -> None:
     (AIRFLOW_SOURCES_ROOT / ".bash_aliases").touch()
     (AIRFLOW_SOURCES_ROOT / ".bash_history").touch()
     (AIRFLOW_SOURCES_ROOT / ".inputrc").touch()
-    create_static_check_volumes()

--- a/dev/breeze/src/airflow_breeze/utils/run_tests.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_tests.py
@@ -14,25 +14,36 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import os
+import subprocess
 import sys
 from subprocess import DEVNULL
-from typing import Tuple
+from typing import Optional, Tuple
 
-from airflow_breeze.utils.console import get_console
+from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
 from airflow_breeze.utils.run_utils import run_command
 
 
 def verify_an_image(
-    image_name: str, image_type: str, dry_run: bool, verbose: bool, slim_image: bool, extra_pytest_args: Tuple
+    image_name: str,
+    image_type: str,
+    output: Optional[Output],
+    dry_run: bool,
+    verbose: bool,
+    slim_image: bool,
+    extra_pytest_args: Tuple,
 ) -> Tuple[int, str]:
     command_result = run_command(
-        ["docker", "inspect", image_name], dry_run=dry_run, verbose=verbose, check=False, stdout=DEVNULL
+        ["docker", "inspect", image_name],
+        dry_run=dry_run,
+        verbose=verbose,
+        check=False,
+        stdout=DEVNULL,
+        stderr=output.file if output else None,
     )
     if command_result.returncode != 0:
-        get_console().print(
+        get_console(output=output).print(
             f"[error]Error when inspecting {image_type} image: {command_result.returncode}[/]"
         )
         return command_result.returncode, f"Testing {image_type} python {image_name}"
@@ -50,6 +61,8 @@ def verify_an_image(
         dry_run=dry_run,
         verbose=verbose,
         env=env,
+        stdout=output.file if output else None,
+        stderr=subprocess.STDOUT,
         check=False,
     )
     return command_result.returncode, f"Testing {image_type} python {image_name}"


### PR DESCRIPTION
Some of our tasks run in parallel in CI. Their output is now grouped
one group per parallel task and printed at the end only.

Progress is displayed while the tasks are executed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
