### PR TITLE
Grid, fix toast for axios errors

### DIFF
--- a/airflow/www/static/js/utils/useErrorToast.test.tsx
+++ b/airflow/www/static/js/utils/useErrorToast.test.tsx
@@ -19,19 +19,35 @@
 
 /* global describe, test, expect */
 
+import type { AxiosError } from 'axios';
 import { getErrorDescription } from './useErrorToast';
 
 describe('Test getErrorDescription()', () => {
   test('Returns expected results', () => {
     let description;
 
-    // is response.data is defined
-    description = getErrorDescription({ response: { data: 'uh oh' } });
-    expect(description).toBe('uh oh');
+    // @ts-ignore
+    const axiosError: AxiosError = new Error('Error message');
 
-    // if it is not, use default message
-    description = getErrorDescription({ response: { data: '' } });
-    expect(description).toBe('Something went wrong.');
+    axiosError.toJSON = () => ({});
+    axiosError.response = {
+      data: 'Not available for this Executor',
+      status: 400,
+      statusText: 'BadRequest',
+      headers: {},
+      config: {},
+    };
+    axiosError.isAxiosError = true;
+
+    // if response.data is defined
+    description = getErrorDescription(axiosError);
+    expect(description).toBe('Not available for this Executor');
+
+    axiosError.response.data = '';
+
+    // if it is not, use the error message
+    description = getErrorDescription(axiosError);
+    expect(description).toBe('Error message');
 
     // if error object, return the message
     description = getErrorDescription(new Error('no no'));

--- a/airflow/www/static/js/utils/useErrorToast.ts
+++ b/airflow/www/static/js/utils/useErrorToast.ts
@@ -19,20 +19,18 @@
 
 import { useToast } from '@chakra-ui/react';
 import type { ReactNode } from 'react';
+import axios from 'axios';
 
-interface ErrorObj {
-  response: {
-    data: string,
-  }
-}
-
-type ErrorType = Error | string | ErrorObj | null;
+type ErrorType = Error | string | null;
 
 export const getErrorDescription = (error?: ErrorType, fallbackMessage?: string) => {
   if (typeof error === 'string') return error;
-  if (error instanceof Error) return error.message;
-  if (error?.response?.data) {
-    return error.response.data;
+  if (error instanceof Error) {
+    let { message } = error;
+    if (axios.isAxiosError(error)) {
+      message = error.response?.data || error.message;
+    }
+    return message;
   }
   return fallbackMessage || 'Something went wrong.';
 };


### PR DESCRIPTION
Error raised by axios (`AxiosError`) are not properly  displayed in the toast. (Cf picture bellow).

`AxiosError` is a subclass of `Error` and therefore handled as standard `Error`, never reading from `error.response.data` but from `error.message`.

Added a check for Error deciding whether to read from `error.message` or `error.response.data`. (and removed the part that was never called after the Error check).

Updated the tests accordingly. Axios does not expose a way to construct `AxiosError` manually. (enhanceError, createError, AxiosError are not exposed because they are part of axios core). I constructed a custom object with the correct properties to be considered as an AxiosError from axios type guard (`axios.isAxiosError`). It is similar to what `axios.enhanceError` does. (If you have a better way to construct an `AxiosError`, I'd be glad to take it).

**Before**:
![image](https://user-images.githubusercontent.com/14861206/184495418-d41f0a0f-57be-4914-8fad-294ba184445c.png)

**After**:
![image](https://user-images.githubusercontent.com/14861206/184495012-df0e7262-8bbd-4a09-852d-52cb5b07fcb9.png)
