### PR TITLE
Fix : SFTP Sensor fails to locate file when file_pattern is provided

### DIFF
--- a/airflow/providers/sftp/sensors/sftp.py
+++ b/airflow/providers/sftp/sensors/sftp.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains SFTP sensor."""
+import os
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
@@ -67,7 +68,7 @@ class SFTPSensor(BaseSensorOperator):
         if self.file_pattern:
             file_from_pattern = self.hook.get_file_by_pattern(self.path, self.file_pattern)
             if file_from_pattern:
-                actual_file_to_check = file_from_pattern
+                actual_file_to_check = os.path.join(self.path, file_from_pattern)
             else:
                 return False
         else:

--- a/airflow/providers/sftp/sensors/sftp.py
+++ b/airflow/providers/sftp/sensors/sftp.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains SFTP sensor."""
-import os
+import posixpath
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional, Sequence
 
@@ -68,7 +68,7 @@ class SFTPSensor(BaseSensorOperator):
         if self.file_pattern:
             file_from_pattern = self.hook.get_file_by_pattern(self.path, self.file_pattern)
             if file_from_pattern:
-                actual_file_to_check = os.path.join(self.path, file_from_pattern)
+                actual_file_to_check = posixpath.join(self.path, file_from_pattern)
             else:
                 return False
         else:

--- a/tests/providers/sftp/sensors/test_sftp.py
+++ b/tests/providers/sftp/sensors/test_sftp.py
@@ -101,6 +101,7 @@ class TestSFTPSensor(unittest.TestCase):
     @patch('airflow.providers.sftp.sensors.sftp.SFTPHook')
     def test_file_with_pattern_parameter_call(self, sftp_hook_mock):
         sftp_hook_mock.return_value.get_mod_time.return_value = '19700101000000'
+        sftp_hook_mock.return_value.get_file_by_pattern.return_value = 'text_file.txt'
         sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/', file_pattern="*.txt")
         context = {'ds': '1970-01-01'}
         output = sftp_sensor.poke(context)
@@ -110,7 +111,7 @@ class TestSFTPSensor(unittest.TestCase):
     @patch('airflow.providers.sftp.sensors.sftp.SFTPHook')
     def test_file_present_with_pattern(self, sftp_hook_mock):
         sftp_hook_mock.return_value.get_mod_time.return_value = '19700101000000'
-        sftp_hook_mock.return_value.get_file_by_pattern.return_value = '/path/to/file/text_file.txt'
+        sftp_hook_mock.return_value.get_file_by_pattern.return_value = 'text_file.txt'
         sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/', file_pattern="*.txt")
         context = {'ds': '1970-01-01'}
         output = sftp_sensor.poke(context)


### PR DESCRIPTION
Background : Pull request # [24084](https://github.com/apache/airflow/pull/24084) added the ability to provide `fnamtch` file pattern to SFTP sensor. But sensor fails to locate the file when the file pattern is provided. 
 
Issue : Code fails to get modified time once file matching to the given pattern is found. [Line # 77](https://github.com/apache/airflow/blob/main/airflow/providers/sftp/sensors/sftp.py#L77) from sftp.py file fails with no such file error. 

`mod_time = self.hook.get_mod_time(actual_file_to_check)`

Root cause: Code assumes that the `get_file_by_pattern` method returns a complete path for a file matching the given `fnamtch` expression. While we are only getting file name in return. `get_file_by_pattern` internally relies on [Paramiko SFTP clients listdir()](https://docs.paramiko.org/en/stable/api/sftp.html#paramiko.sftp_client.SFTPClient.listdir) method to retrieve files contained in given path folder. `listdir()` method only returns file names and not the complete file path. 

Related code, sftp.py file [line # 68.](https://github.com/apache/airflow/blob/main/airflow/providers/sftp/sensors/sftp.py#L68)
`file_from_pattern = self.hook.get_file_by_pattern(self.path, self.file_pattern)`

Fix : Prepending the path to `actual_file_to_check `variable fixes the issue. 

`actual_file_to_check = os.path.join(self.path, file_from_pattern)`

Related : [24084](https://github.com/apache/airflow/pull/24084)

