### PR TITLE
postgres provider: use non-binary psycopg2

### DIFF
--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `PostgreSQL <https://www.postgresql.org/>`__
 
 versions:
+  - 6.0.0
   - 5.2.0
   - 5.1.0
   - 5.0.0
@@ -41,7 +42,7 @@ versions:
 dependencies:
   - apache-airflow>=2.2.0
   - apache-airflow-providers-common-sql>=1.1.0
-  - psycopg2-binary>=2.7.4
+  - psycopg2>=2.8.0
 
 integrations:
   - integration-name: PostgreSQL

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -22,7 +22,6 @@ description: |
   `PostgreSQL <https://www.postgresql.org/>`__
 
 versions:
-  - 6.0.0
   - 5.2.0
   - 5.1.0
   - 5.0.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -555,7 +555,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
-      "psycopg2-binary>=2.7.4"
+      "psycopg2>=2.8.0"
     ],
     "cross-providers-deps": [
       "amazon",


### PR DESCRIPTION
The non-binary version of psycopg2 is now used, and the version requirement changed to psycopg2>=2.8.0.
The non-binary version is used because the binary version of psycopg2 is not recommended for production
use. The minimum version of psycopg2 was changed because psycopg2 < 2.8.0 includes a binary distribution
which will be installed by default.
If not already present, you will need to add the postgresql development libraries. On debian-based systems,
this is provided by the package libpq-dev.

Closes: https://github.com/apache/airflow/issues/25712
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
