### PR TITLE
Fix SQL split string to include `;-less` statements

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -244,7 +244,9 @@ class DbApiHook(BaseForDbApiHook):
         :return: list of individual expressions
         """
         splits = sqlparse.split(sqlparse.format(sql, strip_comments=True))
-        statements = [s.rstrip(';') for s in splits if s.endswith(';')]
+        statements: List[str] = list(
+            filter(None, [s.rstrip(';').strip() if s.endswith(';') else s.strip() for s in splits])
+        )
         return statements
 
     def run(

--- a/tests/providers/common/sql/hooks/test_sqlparse.py
+++ b/tests/providers/common/sql/hooks/test_sqlparse.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+
+@pytest.mark.parametrize(
+    "line,parsed_statements",
+    [
+        ('SELECT * FROM table', ['SELECT * FROM table']),
+        ('SELECT * FROM table;', ['SELECT * FROM table']),
+        ('SELECT * FROM table; # comment', ['SELECT * FROM table']),
+        ('SELECT * FROM table; # comment;', ['SELECT * FROM table']),
+        (' SELECT * FROM table ; # comment;', ['SELECT * FROM table']),
+        ('SELECT * FROM table;;;;;', ['SELECT * FROM table']),
+        ('SELECT * FROM table;;# comment;;;', ['SELECT * FROM table']),
+        ('SELECT * FROM table;;# comment;; ;', ['SELECT * FROM table']),
+        (
+            'SELECT * FROM table; SELECT * FROM table2 # comment',
+            ['SELECT * FROM table', 'SELECT * FROM table2'],
+        ),
+    ],
+)
+def test_sqlparse(line, parsed_statements):
+    assert DbApiHook.split_sql_string(line) == parsed_statements


### PR DESCRIPTION
There was a bug in an incoming change to common-sql provider
introduced in #23971 where `;-less` statements were removed
when "split_statements" flag was used. Since this flag is used
by default in Databricks statement, it introduced backwards
incompatible change.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
