### PR TITLE
Adding ClickHouse Provider

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -42,6 +42,7 @@ body:
         - asana
         - atlassian-jira
         - celery
+        - clickhouse
         - cloudant
         - cncf-kubernetes
         - common-sql

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -613,7 +613,7 @@ This is the full list of those extras:
 airbyte, alibaba, all, all_dbs, amazon, apache.atlas, apache.beam, apache.cassandra, apache.drill,
 apache.druid, apache.hdfs, apache.hive, apache.kylin, apache.livy, apache.pig, apache.pinot,
 apache.spark, apache.sqoop, apache.webhdfs, arangodb, asana, async, atlas, atlassian.jira, aws,
-azure, cassandra, celery, cgroups, cloudant, cncf.kubernetes, common.sql, crypto, dask, databricks,
+azure, cassandra, celery, cgroups, clickhouse, cloudant, cncf.kubernetes, common.sql, crypto, dask, databricks,
 datadog, dbt.cloud, deprecated_api, devel, devel_all, devel_ci, devel_hadoop, dingding, discord,
 doc, docker, druid, elasticsearch, exasol, facebook, ftp, gcp, gcp_api, github, github_enterprise,
 google, google_auth, grpc, hashicorp, hdfs, hive, http, imap, influxdb, jdbc, jenkins, jira,

--- a/INSTALL
+++ b/INSTALL
@@ -97,7 +97,7 @@ The list of available extras:
 airbyte, alibaba, all, all_dbs, amazon, apache.atlas, apache.beam, apache.cassandra, apache.drill,
 apache.druid, apache.hdfs, apache.hive, apache.kylin, apache.livy, apache.pig, apache.pinot,
 apache.spark, apache.sqoop, apache.webhdfs, arangodb, asana, async, atlas, atlassian.jira, aws,
-azure, cassandra, celery, cgroups, cloudant, cncf.kubernetes, common.sql, crypto, dask, databricks,
+azure, cassandra, celery, cgroups, clickhouse, cloudant, cncf.kubernetes, common.sql, crypto, dask, databricks,
 datadog, dbt.cloud, deprecated_api, devel, devel_all, devel_ci, devel_hadoop, dingding, discord,
 doc, docker, druid, elasticsearch, exasol, facebook, ftp, gcp, gcp_api, github, github_enterprise,
 google, google_auth, grpc, hashicorp, hdfs, hive, http, imap, influxdb, jdbc, jenkins, jira,

--- a/airflow/providers/clickhouse/CHANGELOG.rst
+++ b/airflow/providers/clickhouse/CHANGELOG.rst
@@ -1,0 +1,25 @@
+
+
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Changelog
+---------
+1.0.0
+.....
+
+Initial version of the provider.

--- a/airflow/providers/clickhouse/__init__.py
+++ b/airflow/providers/clickhouse/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/clickhouse/example_dags/__init__.py
+++ b/airflow/providers/clickhouse/example_dags/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/clickhouse/example_dags/example_clickhouse.py
+++ b/airflow/providers/clickhouse/example_dags/example_clickhouse.py
@@ -17,59 +17,73 @@
 from datetime import datetime
 
 from airflow.models.dag import DAG
-from airflow.providers.arangodb.operators.arangodb import AQLOperator
-from airflow.providers.arangodb.sensors.arangodb import AQLSensor
+from airflow.providers.clickhouse.operators.clickhouse import ClickHouseOperator
+from airflow.providers.clickhouse.sensors.clickhouse import ClickHouseSensor
 
 dag = DAG(
-    'example_arangodb_operator',
+    'example_clickhouse_operator',
     start_date=datetime(2021, 1, 1),
     tags=['example'],
     catchup=False,
 )
 
-# [START howto_aql_sensor_arangodb]
+# [START howto_sensor_clickhouse]
 
-sensor = AQLSensor(
-    task_id="aql_sensor",
-    query="FOR doc IN students FILTER doc.name == 'judy' RETURN doc",
+sensor = ClickHouseSensor(
+    task_id="clickhouse_sensor",
+    sql="SELECT * FROM gettingstarted.clickstream where customer_id='customer1'",
     timeout=60,
     poke_interval=10,
     dag=dag,
 )
 
-# [END howto_aql_sensor_arangodb]
+# [END howto_sensor_clickhouse]
 
-# [START howto_aql_sensor_template_file_arangodb]
+# [START howto_sensor_template_file_clickhouse]
 
-sensor = AQLSensor(
-    task_id="aql_sensor_template_file",
-    query="search_one.sql",
+sensor_tf = ClickHouseSensor(
+    task_id="clickhouse_sensor_template",
+    sql="search_one.sql",
     timeout=60,
     poke_interval=10,
     dag=dag,
 )
 
-# [END howto_aql_sensor_template_file_arangodb]
+
+# [END howto_sensor_template_file_clickhouse]
 
 
-# [START howto_aql_operator_arangodb]
+# [START howto_operator_clickhouse]
 
-operator = AQLOperator(
-    task_id='aql_operator',
-    query="FOR doc IN students RETURN doc",
+operator = ClickHouseOperator(
+    task_id='clickhouse_operator',
+    sql="SELECT * FROM gettingstarted.clickstream",
     dag=dag,
-    result_processor=lambda cursor: print([document["name"] for document in cursor]),
+    result_processor=lambda cursor: print(cursor)
 )
 
-# [END howto_aql_operator_arangodb]
+# [END howto_operator_clickhouse]
 
-# [START howto_aql_operator_template_file_arangodb]
+# [START howto_operator_clickhouse_with_database]
 
-operator = AQLOperator(
-    task_id='aql_operator_template_file',
+operator_with_database = ClickHouseOperator(
+    task_id='clickhouse_operator_with_db',
+    sql="SELECT * FROM clickstream",
+    database='gettingstarted',
     dag=dag,
-    result_processor=lambda cursor: print([document["name"] for document in cursor]),
-    query="search_all.sql",
+    result_processor=lambda cursor: print(cursor)
 )
 
-# [END howto_aql_operator_template_file_arangodb]
+# [END howto_operator_clickhouse_with_database]
+
+# [START howto_operator_template_file_clickhouse]
+
+operator_tf = ClickHouseOperator(
+    task_id='clickhouse_operator_tf',
+    sql="search_all.sql",
+    dag=dag,
+    result_processor=lambda cursor: print(cursor)
+)
+
+# [END howto_operator_template_file_clickhouse]
+

--- a/airflow/providers/clickhouse/example_dags/example_clickhouse.py
+++ b/airflow/providers/clickhouse/example_dags/example_clickhouse.py
@@ -68,8 +68,7 @@ operator = ClickHouseOperator(
 
 operator_with_database = ClickHouseOperator(
     task_id='clickhouse_operator_with_db',
-    sql="SELECT * FROM clickstream",
-    database='gettingstarted',
+    sql="SELECT * FROM clickstream",    database='gettingstarted',
     dag=dag,
     result_processor=lambda cursor: print(cursor)
 )

--- a/airflow/providers/clickhouse/example_dags/example_clickhouse.py
+++ b/airflow/providers/clickhouse/example_dags/example_clickhouse.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from datetime import datetime
+
+from airflow.models.dag import DAG
+from airflow.providers.arangodb.operators.arangodb import AQLOperator
+from airflow.providers.arangodb.sensors.arangodb import AQLSensor
+
+dag = DAG(
+    'example_arangodb_operator',
+    start_date=datetime(2021, 1, 1),
+    tags=['example'],
+    catchup=False,
+)
+
+# [START howto_aql_sensor_arangodb]
+
+sensor = AQLSensor(
+    task_id="aql_sensor",
+    query="FOR doc IN students FILTER doc.name == 'judy' RETURN doc",
+    timeout=60,
+    poke_interval=10,
+    dag=dag,
+)
+
+# [END howto_aql_sensor_arangodb]
+
+# [START howto_aql_sensor_template_file_arangodb]
+
+sensor = AQLSensor(
+    task_id="aql_sensor_template_file",
+    query="search_one.sql",
+    timeout=60,
+    poke_interval=10,
+    dag=dag,
+)
+
+# [END howto_aql_sensor_template_file_arangodb]
+
+
+# [START howto_aql_operator_arangodb]
+
+operator = AQLOperator(
+    task_id='aql_operator',
+    query="FOR doc IN students RETURN doc",
+    dag=dag,
+    result_processor=lambda cursor: print([document["name"] for document in cursor]),
+)
+
+# [END howto_aql_operator_arangodb]
+
+# [START howto_aql_operator_template_file_arangodb]
+
+operator = AQLOperator(
+    task_id='aql_operator_template_file',
+    dag=dag,
+    result_processor=lambda cursor: print([document["name"] for document in cursor]),
+    query="search_all.sql",
+)
+
+# [END howto_aql_operator_template_file_arangodb]

--- a/airflow/providers/clickhouse/example_dags/example_clickhouse.py
+++ b/airflow/providers/clickhouse/example_dags/example_clickhouse.py
@@ -68,7 +68,7 @@ operator = ClickHouseOperator(
 
 operator_with_database = ClickHouseOperator(
     task_id='clickhouse_operator_with_db',
-    sql="SELECT * FROM clickstream",    database='gettingstarted',
+    sql="SELECT * FROM clickstream",
     dag=dag,
     result_processor=lambda cursor: print(cursor)
 )

--- a/airflow/providers/clickhouse/example_dags/example_clickhouse.py
+++ b/airflow/providers/clickhouse/example_dags/example_clickhouse.py
@@ -59,7 +59,7 @@ operator = ClickHouseOperator(
     task_id='clickhouse_operator',
     sql="SELECT * FROM gettingstarted.clickstream",
     dag=dag,
-    result_processor=lambda cursor: print(cursor)
+    result_processor=lambda cursor: print(cursor),
 )
 
 # [END howto_operator_clickhouse]
@@ -70,7 +70,7 @@ operator_with_database = ClickHouseOperator(
     task_id='clickhouse_operator_with_db',
     sql="SELECT * FROM clickstream",
     dag=dag,
-    result_processor=lambda cursor: print(cursor)
+    result_processor=lambda cursor: print(cursor),
 )
 
 # [END howto_operator_clickhouse_with_database]
@@ -81,8 +81,7 @@ operator_tf = ClickHouseOperator(
     task_id='clickhouse_operator_tf',
     sql="search_all.sql",
     dag=dag,
-    result_processor=lambda cursor: print(cursor)
+    result_processor=lambda cursor: print(cursor),
 )
 
 # [END howto_operator_template_file_clickhouse]
-

--- a/airflow/providers/clickhouse/hooks/__init__.py
+++ b/airflow/providers/clickhouse/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -1,0 +1,129 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module allows connecting to a ClickHouse."""
+from typing import Any, Dict, Optional
+
+from clickhouse_driver import Client as ClickHouseClient
+
+from airflow import AirflowException
+from airflow.hooks.base import BaseHook
+
+
+class ClickHouseHook(BaseHook):
+    """
+    Interact with ClickHouse.
+
+    Performs a connection to ClickHouse and retrieves client.
+
+    :param clickhouse_conn_id: Reference to :ref:`ClickHouse connection id <howto/connection:clickhouse>`.
+    :param database:Optional[str], database for the hook, if not provided schema from Connection will be
+    used`.
+    """
+
+    conn_name_attr = 'clickhouse_conn_id'
+    default_conn_name = 'clickhouse_default'
+    conn_type = 'clickhouse'
+    hook_name = 'ClickHouse'
+
+    def __init__(self, clickhouse_conn_id: str = default_conn_name, database: Optional[str] = None, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.clickhouse_conn_id = clickhouse_conn_id
+        self.database = database
+
+        self.client: Optional[ClickHouseClient] = None
+        self.get_conn()
+
+    def get_conn(self) -> ClickHouseClient:
+        """Function that initiates a new ClickHouse connection"""
+        if self.client is not None:
+            return self.client
+
+        conn = self.get_connection(self.clickhouse_conn_id)
+        connection_kwargs = conn.extra_dejson.copy()
+
+        if conn.port:
+            connection_kwargs.update(port=int(conn.port))
+        if conn.login:
+            connection_kwargs.update(user=conn.login)
+        if conn.password:
+            connection_kwargs.update(password=conn.password)
+
+        #  if custom database is provided use it or use from schema
+        if self.database:
+            connection_kwargs.update(database=self.database)
+        elif conn.schema:
+            connection_kwargs.update(database=conn.schema)
+
+        self.client = ClickHouseClient(conn.host or 'localhost', **connection_kwargs)
+        return self.client
+
+    def query(self, query, **kwargs) -> Any:
+        """
+        Function to create a clickhouse session
+        and execute the AQL query in the session.
+
+        :param query: AQL query
+        :return: Result
+        """
+        try:
+            if self.db_conn:
+                result = self.db_conn.aql.execute(query, **kwargs)
+                return result
+            else:
+                raise AirflowException(
+                    f"Failed to execute AQLQuery, error connecting to database: {self.database}"
+                )
+        except Exception as error:
+            raise AirflowException(f"Failed to execute AQLQuery, error: {str(error)}")
+
+    def create_database(self, name):
+        if not self.db_conn.has_database(name):
+            self.db_conn.create_database(name)
+            return True
+        else:
+            self.log.info('Database already exists: %s', name)
+            return False
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict[str, Any]:
+        import json
+        return {
+            "relabeling": {
+                'host': 'ClickHouse Host',
+                'port': 'ClickHouse Port',
+                'schema': 'ClickHouse Database',
+                'login': 'ClickHouse Username',
+                'password': 'ClickHouse Password',
+                'extra': 'extra configs (https://clickhouse-driver.readthedocs.io/en/latest/api.html'
+                         '#connection) '
+            },
+            "placeholders": {
+                'host': 'http://127.0.0.1',
+                'port': '8123',
+                'schema': 'default',
+                'login': 'root',
+                'password': 'password',
+                'extra': json.dumps(
+                    {
+                        "key for config": "value for config",
+                    },
+                    indent=1,
+                ),
+            },
+        }

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -28,12 +28,11 @@ from airflow.hooks.base import BaseHook
 class ClickHouseHook(BaseHook):
     """
     Interact with ClickHouse.
-
     Performs a connection to ClickHouse and retrieves client.
 
-    :param clickhouse_conn_id: Reference to :ref:`ClickHouse connection id <howto/connection:clickhouse>`.
-    :param database:Optional[str], database for the hook, if not provided schema from Connection will be
-    used`.
+    :param clickhouse_conn_id: Reference to
+        :ref:`ClickHouse connection id<howto/connection:clickhouse>`.
+    :param database: database for the hook, if not provided schema from Connection will be used (optional).
     """
 
     conn_name_attr = 'clickhouse_conn_id'
@@ -83,9 +82,8 @@ class ClickHouseHook(BaseHook):
         :param params: substitution parameters for SELECT queries and data for INSERT queries.
         :param kwargs: additional optional parameters from API
 
-        :return: output of method Client(*args).execute(params)
-
-        for more, refer - https://clickhouse-driver.readthedocs.io/en/latest/api.html
+        :return: output of method `Client(*args).execute(params)`
+            for more, refer - https://clickhouse-driver.readthedocs.io/en/latest/api.html
         """
         try:
             self.log.info('Running: %s (with parameters %s)', sql, params)
@@ -100,7 +98,6 @@ class ClickHouseHook(BaseHook):
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:
         import json
-        #  TODO: check why this is not working.
         return {
             "relabeling": {
                 'host': 'ClickHouse Host',

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -92,7 +92,7 @@ class ClickHouseHook(BaseHook):
         if conn.password:
             connection_kwargs.update(password=conn.password)
 
-        #  if custom database is provided use it or use from schema
+        #  if  database is provided use it or use from schema
         if self.database:
             connection_kwargs.update(database=self.database)
         elif conn.schema:

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -40,8 +40,9 @@ class ClickHouseHook(BaseHook):
     conn_type = 'clickhouse'
     hook_name = 'ClickHouse'
 
-    def __init__(self, clickhouse_conn_id: str = default_conn_name, database: Optional[str] = None, *args,
-                 **kwargs) -> None:
+    def __init__(
+        self, clickhouse_conn_id: str = default_conn_name, database: Optional[str] = None, *args, **kwargs
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.clickhouse_conn_id = clickhouse_conn_id
         self.database = database
@@ -98,6 +99,7 @@ class ClickHouseHook(BaseHook):
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:
         import json
+
         return {
             "relabeling": {
                 'host': 'ClickHouse Host',
@@ -106,7 +108,7 @@ class ClickHouseHook(BaseHook):
                 'login': 'ClickHouse Username',
                 'password': 'ClickHouse Password',
                 'extra': 'extra configs from'
-                         '(https://clickhouse-driver.readthedocs.io/en/latest/api.html#connection)'
+                '(https://clickhouse-driver.readthedocs.io/en/latest/api.html#connection)',
             },
             "placeholders": {
                 'host': 'http://127.0.0.1',

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -74,12 +74,12 @@ class ClickHouseHook(BaseHook):
         self.client = ClickHouseClient(conn.host or 'localhost', **connection_kwargs)
         return self.client
 
-    def query(self, query: str, params: Optional[dict] = None, **kwargs) -> Any:
+    def query(self, sql: str, params: Optional[dict] = None, **kwargs) -> Any:
         """
         Function to create a clickhouse session
         and execute the sql query in the session.
 
-        :param query: sql query
+        :param sql: sql query
         :param params: substitution parameters for SELECT queries and data for INSERT queries.
         :param kwargs: additional optional parameters from API
 
@@ -88,14 +88,14 @@ class ClickHouseHook(BaseHook):
         for more, refer - https://clickhouse-driver.readthedocs.io/en/latest/api.html
         """
         try:
-            self.log.info('Running: %s (with parameters %s)', query, params)
-            result = self.client.execute(query, params=params, **kwargs)
+            self.log.info('Running: %s (with parameters %s)', sql, params)
+            result = self.client.execute(sql, params=params, **kwargs)
             return result
         except Exception as error:
             raise AirflowException(f"Failed to execute SQL Query, error: {str(error)}")
 
     def get_records(self, sql: str, parameters: Optional[dict] = None) -> Optional[Tuple]:
-        return self.query(query=sql, params=parameters)
+        return self.query(sql=sql, params=parameters)
 
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -100,6 +100,7 @@ class ClickHouseHook(BaseHook):
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:
         import json
+        #  TODO: check why this is not working.
         return {
             "relabeling": {
                 'host': 'ClickHouse Host',
@@ -124,3 +125,15 @@ class ClickHouseHook(BaseHook):
                 ),
             },
         }
+
+    def test_connection(self):
+        """Tests the Clickhouse connection"""
+        status, message = False, ''
+        try:
+            if self.query("select 1"):
+                status = True
+                message = 'Clickhouse connection successfully tested!'
+        except Exception as e:
+            status = False
+            message = str(e)
+        return status, message

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -17,7 +17,8 @@
 # under the License.
 
 """This module allows connecting to a ClickHouse."""
-from typing import Any, Dict, Optional
+from itertools import islice
+from typing import Any, Dict, Optional, Union, Generator
 
 from clickhouse_driver import Client as ClickHouseClient
 
@@ -41,13 +42,40 @@ class ClickHouseHook(BaseHook):
     conn_type = 'clickhouse'
     hook_name = 'ClickHouse'
 
-    def __init__(self, clickhouse_conn_id: str = default_conn_name, database: Optional[str] = None, *args, **kwargs) -> None:
+    def __init__(self, clickhouse_conn_id: str = default_conn_name, database: Optional[str] = None, *args,
+                 **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.clickhouse_conn_id = clickhouse_conn_id
         self.database = database
 
         self.client: Optional[ClickHouseClient] = None
         self.get_conn()
+
+    @staticmethod
+    def _log_params(
+        parameters: Union[dict, list, tuple, Generator],
+        limit: int = 10,
+    ) -> str:
+        if isinstance(parameters, Generator) or len(parameters) <= limit:
+            return str(parameters)
+        if isinstance(parameters, dict):
+            head = dict(islice(parameters.items(), limit))
+        else:
+            head = parameters[:limit]
+        head_str = str(head)
+        closing_paren = head_str[-1]
+        return f'{head_str[:-1]} … and {len(parameters) - limit} ' \
+               f'more parameters{closing_paren}'
+
+    def _log_query(
+        self,
+        sql: str,
+        parameters: Union[None, dict, list, tuple, Generator],
+    ) -> None:
+        self.log.info(
+            '%s%s', sql,
+            f' with {self._log_params(parameters)}' if parameters else '',
+        )
 
     def get_conn(self) -> ClickHouseClient:
         """Function that initiates a new ClickHouse connection"""
@@ -73,32 +101,25 @@ class ClickHouseHook(BaseHook):
         self.client = ClickHouseClient(conn.host or 'localhost', **connection_kwargs)
         return self.client
 
-    def query(self, query, **kwargs) -> Any:
+    def query(self, query: str, params: Optional[dict] = None, **kwargs) -> Any:
         """
         Function to create a clickhouse session
-        and execute the AQL query in the session.
+        and execute the sql query in the session.
 
-        :param query: AQL query
-        :return: Result
+        :param query: sql query
+        :param params: substitution parameters for SELECT queries and data for INSERT queries.
+        :param kwargs: additional optional parameters from API
+
+        :return: output of method Client(params).execute(params)
+
+        for more, refer - https://clickhouse-driver.readthedocs.io/en/latest/api.html
         """
         try:
-            if self.db_conn:
-                result = self.db_conn.aql.execute(query, **kwargs)
-                return result
-            else:
-                raise AirflowException(
-                    f"Failed to execute AQLQuery, error connecting to database: {self.database}"
-                )
+            self._log_query(query, params)
+            result = self.client.execute(query, params=params, **kwargs)
+            return result
         except Exception as error:
-            raise AirflowException(f"Failed to execute AQLQuery, error: {str(error)}")
-
-    def create_database(self, name):
-        if not self.db_conn.has_database(name):
-            self.db_conn.create_database(name)
-            return True
-        else:
-            self.log.info('Database already exists: %s', name)
-            return False
+            raise AirflowException(f"Failed to execute SQL Query, error: {str(error)}")
 
     @staticmethod
     def get_ui_field_behaviour() -> Dict[str, Any]:
@@ -110,8 +131,8 @@ class ClickHouseHook(BaseHook):
                 'schema': 'ClickHouse Database',
                 'login': 'ClickHouse Username',
                 'password': 'ClickHouse Password',
-                'extra': 'extra configs (https://clickhouse-driver.readthedocs.io/en/latest/api.html'
-                         '#connection) '
+                'extra': 'extra configs from'
+                         '(https://clickhouse-driver.readthedocs.io/en/latest/api.html#connection)'
             },
             "placeholders": {
                 'host': 'http://127.0.0.1',

--- a/airflow/providers/clickhouse/hooks/clickhouse.py
+++ b/airflow/providers/clickhouse/hooks/clickhouse.py
@@ -101,6 +101,7 @@ class ClickHouseHook(BaseHook):
         import json
 
         return {
+            "hidden_fields": [],
             "relabeling": {
                 'host': 'ClickHouse Host',
                 'port': 'ClickHouse Port',

--- a/airflow/providers/clickhouse/operators/__init__.py
+++ b/airflow/providers/clickhouse/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Callable, Optional, Sequence, Any, Dict
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence
 
 from airflow.models import BaseOperator
 from airflow.providers.clickhouse.hooks.clickhouse import ClickHouseHook

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -32,7 +32,7 @@ class ClickHouseOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:ClickHouseOperator`
 
-    :param query: the SQL query to be executed. Can receive a str representing a
+    :param sql: the SQL query to be executed. Can receive a str representing a
         SQL statement, or you can provide .sql file having the query
     :param params: substitution parameters for SELECT queries and data for INSERT queries.
     :param database:Optional[str], database to query, if not provided schema from Connection will be used
@@ -41,16 +41,16 @@ class ClickHouseOperator(BaseOperator):
     :param clickhouse_conn_id: Reference to :ref:`ClickHouse connection id <howto/connection:clickhouse>`.
     """
 
-    template_fields: Sequence[str] = ('query',)
+    template_fields: Sequence[str] = ('sql',)
 
     template_ext: Sequence[str] = (".sql",)
-    template_fields_renderers = {"query": "sql"}
+    template_fields_renderers = {"sql": "sql"}
     ui_color = '#bfb050'
 
     def __init__(
         self,
         *,
-        query: str,
+        sql: str,
         clickhouse_conn_id: str = 'clickhouse_default',
         params: Optional[Dict[str, Any]] = None,
         database: Optional[str] = None,
@@ -59,7 +59,7 @@ class ClickHouseOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.clickhouse_conn_id = clickhouse_conn_id
-        self.query = query
+        self.sql = sql
         self.params = params
         self.database = database
         self.result_processor = result_processor
@@ -67,6 +67,6 @@ class ClickHouseOperator(BaseOperator):
     def execute(self, context: 'Context'):
         hook = ClickHouseHook(clickhouse_conn_id=self.clickhouse_conn_id, database=self.database)
 
-        result = hook.query(query=self.query, params=self.params)
+        result = hook.query(sql=self.sql, params=self.params)
         if self.result_processor:
             self.result_processor(result)

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -35,10 +35,10 @@ class ClickHouseOperator(BaseOperator):
     :param sql: the SQL query to be executed. Can receive a str representing a
         SQL statement, or you can provide .sql file having the query
     :param params: substitution parameters for SELECT queries and data for INSERT queries.
-    :param database:Optional[str], database to query, if not provided schema from Connection will be used
-
+    :param database: database to query, if not provided schema from Connection will be used (optional)
     :param result_processor: function to further process the Result from ClickHouse
-    :param clickhouse_conn_id: Reference to :ref:`ClickHouse connection id <howto/connection:clickhouse>`.
+    :param clickhouse_conn_id: Reference to
+        :ref:`ClickHouse connection id<howto/connection:clickhouse>`.
     """
 
     template_fields: Sequence[str] = ('sql',)

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import TYPE_CHECKING, Callable, Optional, Sequence, Any, Dict
+
+from airflow.models import BaseOperator
+from airflow.providers.clickhouse.hooks.clickhouse import ClickHouseHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class ClickHouseOperator(BaseOperator):
+    """
+    Executes SQL query in a ClickHouse database
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:ClickHouseOperator`
+
+    :param query: the SQL query to be executed. Can receive a str representing a
+        SQL statement, or you can provide .sql file having the query
+    :param params: substitution parameters for SELECT queries and data for INSERT queries.
+    :param database:Optional[str], database to query, if not provided schema from Connection will be used
+
+    :param result_processor: function to further process the Result from ClickHouse
+    :param clickhouse_conn_id: Reference to :ref:`ClickHouse connection id <howto/connection:clickhouse>`.
+    """
+
+    template_fields: Sequence[str] = ('query',)
+
+    template_ext: Sequence[str] = (".sql",)
+    template_fields_renderers = {"query": "sql"}
+
+    def __init__(
+        self,
+        *,
+        query: str,
+        clickhouse_conn_id: str = 'clickhouse_default',
+        params: Optional[Dict[str, Any]] = None,
+        database: Optional[str] = None,
+        result_processor: Optional[Callable] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.clickhouse_conn_id = clickhouse_conn_id
+        self.query = query
+        self.params = params
+        self.database = database
+        self.result_processor = result_processor
+
+    def execute(self, context: 'Context'):
+        hook = ClickHouseHook(clickhouse_conn_id=self.clickhouse_conn_id, database=self.database)
+
+        result = hook.query(query=self.query, params=self.params)
+        if self.result_processor:
+            self.result_processor(result)

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -45,6 +45,7 @@ class ClickHouseOperator(BaseOperator):
 
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"query": "sql"}
+    ui_color = '#bfb050'
 
     def __init__(
         self,

--- a/airflow/providers/clickhouse/operators/clickhouse.py
+++ b/airflow/providers/clickhouse/operators/clickhouse.py
@@ -45,7 +45,7 @@ class ClickHouseOperator(BaseOperator):
 
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "sql"}
-    ui_color = '#bfb050'
+    ui_color = '#ebcc34'
 
     def __init__(
         self,

--- a/airflow/providers/clickhouse/provider.yaml
+++ b/airflow/providers/clickhouse/provider.yaml
@@ -20,8 +20,13 @@ package-name: apache-airflow-providers-clickhouse
 name: ClickHouse
 description: |
     `ClickHouse <https://www.clickhouse.com/>`__
+
 versions:
   - 1.0.0
+
+dependencies:
+  - apache-airflow>=2.2.0
+  - clickhouse-driver>=0.2.3
 
 integrations:
   - integration-name: ClickHouse

--- a/airflow/providers/clickhouse/provider.yaml
+++ b/airflow/providers/clickhouse/provider.yaml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+package-name: apache-airflow-providers-clickhouse
+name: ClickHouse
+description: |
+    `ClickHouse <https://www.clickhouse.com/>`__
+versions:
+  - 1.0.0
+
+integrations:
+  - integration-name: ClickHouse
+    external-doc-url: https://www.clickhouse.com/
+    tags: [software]
+
+hooks:
+  - integration-name: ClickHouse
+    python-modules:
+      - airflow.providers.clickhouse.hooks.clickhouse
+
+operators:
+  - integration-name: ClickHouse
+    python-modules:
+      - airflow.providers.clickhouse.operators.clickhouse
+
+sensors:
+  - integration-name: ClickHouse
+    python-modules:
+      - airflow.providers.clickhouse.sensors.clickhouse
+
+connection-types:
+  - hook-class-name: airflow.providers.clickhouse.hooks.clickhouse.ClickHouseHook
+    connection-type: clickhouse

--- a/airflow/providers/clickhouse/sensors/__init__.py
+++ b/airflow/providers/clickhouse/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/clickhouse/sensors/clickhouse.py
+++ b/airflow/providers/clickhouse/sensors/clickhouse.py
@@ -26,7 +26,7 @@ class ClickHouseSensor(SqlSensor):
     Checks for the existence of a document which
     matches the given query in ClickHouse. Example:
 
-    :param query: The query to poke, or you can provide .sql file having the query
+    :param sql: The query to poke, or you can provide .sql file having the query
     :param parameters: The parameters to render the SQL query with (optional).
     :param database:Optional[str], database to query, if not provided schema from Connection will be used
     :param success: Success criteria for the sensor is a Callable that takes first_cell
@@ -42,7 +42,7 @@ class ClickHouseSensor(SqlSensor):
     ui_color = '#a3985f'
 
     def __init__(self,
-                 query: str,
+                 sql: str,
                  parameters: Optional[Dict[str, Any]] = None,
                  database: Optional[str] = None,
                  success: Optional[Callable[[Any], bool]] = None,
@@ -53,7 +53,7 @@ class ClickHouseSensor(SqlSensor):
                  **kwargs) -> None:
         super().__init__(
             conn_id=clickhouse_conn_id,
-            sql=query,
+            sql=sql,
             parameters=parameters,
             success=success,
             failure=failure,

--- a/airflow/providers/clickhouse/sensors/clickhouse.py
+++ b/airflow/providers/clickhouse/sensors/clickhouse.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, Dict, Any, Callable
+from typing import Any, Callable, Dict, Optional
 
 from airflow.providers.clickhouse.hooks.clickhouse import ClickHouseHook
 from airflow.sensors.sql import SqlSensor
@@ -40,16 +40,18 @@ class ClickHouseSensor(SqlSensor):
 
     ui_color = '#a3985f'
 
-    def __init__(self,
-                 sql: str,
-                 parameters: Optional[Dict[str, Any]] = None,
-                 database: Optional[str] = None,
-                 success: Optional[Callable[[Any], bool]] = None,
-                 failure: Optional[Callable[[Any], bool]] = None,
-                 fail_on_empty: bool = False,
-                 clickhouse_conn_id: str = "clickhouse_default",
-                 *args,
-                 **kwargs) -> None:
+    def __init__(
+        self,
+        sql: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        database: Optional[str] = None,
+        success: Optional[Callable[[Any], bool]] = None,
+        failure: Optional[Callable[[Any], bool]] = None,
+        fail_on_empty: bool = False,
+        clickhouse_conn_id: str = "clickhouse_default",
+        *args,
+        **kwargs,
+    ) -> None:
         super().__init__(
             conn_id=clickhouse_conn_id,
             sql=sql,

--- a/airflow/providers/clickhouse/sensors/clickhouse.py
+++ b/airflow/providers/clickhouse/sensors/clickhouse.py
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional, Dict, Any, Callable
+
+from airflow.providers.clickhouse.hooks.clickhouse import ClickHouseHook
+from airflow.sensors.sql import SqlSensor
+
+
+class ClickHouseSensor(SqlSensor):
+    """
+    Checks for the existence of a document which
+    matches the given query in ClickHouse. Example:
+
+    :param query: The query to poke, or you can provide .sql file having the query
+    :param parameters: The parameters to render the SQL query with (optional).
+    :param database:Optional[str], database to query, if not provided schema from Connection will be used
+    :param success: Success criteria for the sensor is a Callable that takes first_cell
+        as the only argument, and returns a boolean (optional).
+    :param failure: Failure criteria for the sensor is a Callable that takes first_cell
+        as the only argument and return a boolean (optional).
+    :param fail_on_empty: Explicitly fail on no rows returned.
+
+    :param clickhouse_conn_id: The :ref:`ClickHouse connection id <howto/connection:clickhouse>` to use
+        when connecting to ClickHouse.
+    """
+
+    ui_color = '#a3985f'
+
+    def __init__(self,
+                 query: str,
+                 parameters: Optional[Dict[str, Any]] = None,
+                 database: Optional[str] = None,
+                 success: Optional[Callable[[Any], bool]] = None,
+                 failure: Optional[Callable[[Any], bool]] = None,
+                 fail_on_empty: bool = False,
+                 clickhouse_conn_id: str = "clickhouse_default",
+                 *args,
+                 **kwargs) -> None:
+        super().__init__(
+            conn_id=clickhouse_conn_id,
+            sql=query,
+            parameters=parameters,
+            success=success,
+            failure=failure,
+            fail_on_empty=fail_on_empty,
+            *args,
+            **kwargs,
+        )
+        self.database = database
+
+    def _get_hook(self) -> ClickHouseHook:
+        return ClickHouseHook(
+            clickhouse_conn_id=self.conn_id,
+            database=self.database,
+        )

--- a/airflow/providers/clickhouse/sensors/clickhouse.py
+++ b/airflow/providers/clickhouse/sensors/clickhouse.py
@@ -28,14 +28,13 @@ class ClickHouseSensor(SqlSensor):
 
     :param sql: The query to poke, or you can provide .sql file having the query
     :param parameters: The parameters to render the SQL query with (optional).
-    :param database:Optional[str], database to query, if not provided schema from Connection will be used
+    :param database: Database to query, if not provided schema from Connection will be used (optional).
     :param success: Success criteria for the sensor is a Callable that takes first_cell
         as the only argument, and returns a boolean (optional).
     :param failure: Failure criteria for the sensor is a Callable that takes first_cell
         as the only argument and return a boolean (optional).
     :param fail_on_empty: Explicitly fail on no rows returned.
-
-    :param clickhouse_conn_id: The :ref:`ClickHouse connection id <howto/connection:clickhouse>` to use
+    :param clickhouse_conn_id: The :ref:`ClickHouse connection id<howto/connection:clickhouse>` to use
         when connecting to ClickHouse.
     """
 

--- a/docs/apache-airflow-providers-clickhouse/commits.rst
+++ b/docs/apache-airflow-providers-clickhouse/commits.rst
@@ -1,0 +1,31 @@
+
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Package apache-airflow-providers-clickhouse
+------------------------------------------------------
+
+`Clickhouse <https://www.clickhouse.com/>`__
+
+
+This is detailed commit list of changes for versions provider package: ``clickhouse``.
+For high-level changelog, see :doc:`package information including changelog <index>`.
+
+
+1.0.0
+.....

--- a/docs/apache-airflow-providers-clickhouse/connections/clickhouse.rst
+++ b/docs/apache-airflow-providers-clickhouse/connections/clickhouse.rst
@@ -15,10 +15,10 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:arangodb:
+.. _howto/connection:clickhouse:
 
 ClickHouse Connection
-====================
+=====================
 The ClickHouse connection provides credentials for accessing the ClickHouse.
 
 Configuring the Connection

--- a/docs/apache-airflow-providers-clickhouse/connections/clickhouse.rst
+++ b/docs/apache-airflow-providers-clickhouse/connections/clickhouse.rst
@@ -1,0 +1,35 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/connection:arangodb:
+
+ClickHouse Connection
+====================
+The ClickHouse connection provides credentials for accessing the ClickHouse.
+
+Configuring the Connection
+--------------------------
+ClickHouse Host (required)
+    Specify ClickHouse Host URL `eg. "http://127.0.0.1"`
+ClickHouse Database/Schema (required)
+    Specify `Database/Schema` for the ClickHouse. eg. `default`
+ClickHouse Login (required)
+    Specify `username` for the ClickHouse, eg. `root`
+ClickHouse Password (required)
+    Specify `password` for the ClickHouse
+ClickHouse Port (required)
+    Specify `port` for the ClickHouse

--- a/docs/apache-airflow-providers-clickhouse/index.rst
+++ b/docs/apache-airflow-providers-clickhouse/index.rst
@@ -1,0 +1,92 @@
+
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+``apache-airflow-providers-clickhouse``
+=====================================
+
+Content
+-------
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Guides
+
+    Connection types <connections/clickhouse>
+    Operators <operators/index>
+
+.. toctree::
+    :maxdepth: 1
+    :caption: References
+
+    Python API <_api/airflow/providers/clickhouse/index>
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Resources
+
+    Example DAGs <https://github.com/apache/airflow/tree/main/airflow/providers/clickhouse/example_dags>
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Resources
+
+    PyPI Repository <https://pypi.org/project/apache-airflow-providers-clickhouse/>
+    Installing from sources <installing-providers-from-sources>
+
+.. THE REMAINDER OF THE FILE IS AUTOMATICALLY GENERATED. IT WILL BE OVERWRITTEN AT RELEASE TIME!
+
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Commits
+
+    Detailed list of commits <commits>
+
+
+Package apache-airflow-providers-clickhouse
+------------------------------------------------------
+
+`Clickhouse <https://www.clickhouse.com/>`__
+
+
+Release: 1.0.0
+
+Provider package
+----------------
+
+This is a provider package for ``clickhouse`` provider. All classes for this provider package
+are in ``airflow.providers.clickhouse`` python package.
+
+Installation
+------------
+
+You can install this package on top of an existing Airflow 2 installation (see ``Requirements`` below)
+for the minimum Airflow version supported) via
+``pip install apache-airflow-providers-clickhouse``
+
+Requirements
+------------
+
+======================   ==================
+PIP package               Version required
+======================   ==================
+``apache-airflow``          ``>=2.2.0``
+``clickhouse-driver``       ``>=0.2.3``
+======================   ==================
+
+.. include:: ../../airflow/providers/clickhouse/CHANGELOG.rst

--- a/docs/apache-airflow-providers-clickhouse/index.rst
+++ b/docs/apache-airflow-providers-clickhouse/index.rst
@@ -17,7 +17,7 @@
     under the License.
 
 ``apache-airflow-providers-clickhouse``
-=====================================
+=======================================
 
 Content
 -------

--- a/docs/apache-airflow-providers-clickhouse/installing-providers-from-sources.rst
+++ b/docs/apache-airflow-providers-clickhouse/installing-providers-from-sources.rst
@@ -1,0 +1,18 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. include:: ../installing-providers-from-sources.rst

--- a/docs/apache-airflow-providers-clickhouse/operators/index.rst
+++ b/docs/apache-airflow-providers-clickhouse/operators/index.rst
@@ -20,7 +20,7 @@
 .. _howto/operator:ClickHouseOperator:
 
 Operators
-=======================
+==========
 You can build your own Operator hook in :class:`~airflow.providers.clickhouse.hooks.ClickHouseHook`,
 
 

--- a/docs/apache-airflow-providers-clickhouse/operators/index.rst
+++ b/docs/apache-airflow-providers-clickhouse/operators/index.rst
@@ -1,0 +1,73 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/operator:ClickHouseOperator:
+
+Operators
+=======================
+You can build your own Operator hook in :class:`~airflow.providers.clickhouse.hooks.ClickHouseHook`,
+
+
+Use the :class:`~airflow.providers.clickhouse.operators.ClickHouseOperator` to execute
+SQL query in `ClickHouse <https://www.clickhouse.com/>`__.
+
+You can further process your result using :class:`~airflow.providers.clickhouse.operators.ClickHouseOperator` and
+further process the result using **result_processor** Callable as you like.
+
+An example of Listing all rows in **gettingstarted.clickstream** table can be implemented as following:
+
+.. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py
+    :language: python
+    :start-after: [START howto_operator_clickhouse]
+    :end-before: [END howto_operator_clickhouse]
+
+You can also provide file template (.sql) to load query, remember path is relative to **dags/** folder, if you want to provide any other path
+please provide **template_searchpath** while creating **DAG** object,
+
+.. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py
+    :language: python
+    :start-after: [START howto_operator_template_file_clickhouse]
+    :end-before: [END howto_operator_template_file_clickhouse]
+
+Furthermore, you can also query into default database ( provided in ClickHouse Connection ) without using it inside the query as follows,
+
+.. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py
+    :language: python
+    :start-after: [START howto_operator_clickhouse_with_database]
+    :end-before: [END howto_operator_clickhouse_with_database]
+
+Sensors
+=======
+
+Use the :class:`~airflow.providers.clickhouse.sensors.ClickHouseSensor` to wait for a condition using
+SQL query in `ClickHouse <https://www.clickhouse.com/>`__.
+
+An example for waiting a record **gettingstarted.clickstream** table with **customer_id** as **customer_1** as follows
+
+.. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py
+    :language: python
+    :start-after: [START howto_sensor_clickhouse]
+    :end-before: [END howto_sensor_clickhouse]
+
+Similar to **ClickHouseOperator**, You can also provide file template to load query -
+
+.. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py
+    :language: python
+    :start-after: [START howto_sensor_template_file_clickhouse]
+    :end-before: [END howto_sensor_template_file_clickhouse]

--- a/docs/apache-airflow-providers-clickhouse/operators/index.rst
+++ b/docs/apache-airflow-providers-clickhouse/operators/index.rst
@@ -21,9 +21,7 @@
 
 Operators
 ==========
-You can build your own Operator hook in :class:`~airflow.providers.clickhouse.hooks.ClickHouseHook`,
-
-
+You can build your own Operator using hook in :class:`~airflow.providers.clickhouse.hooks.ClickHouseHook`,
 Use the :class:`~airflow.providers.clickhouse.operators.ClickHouseOperator` to execute
 SQL query in `ClickHouse <https://www.clickhouse.com/>`__.
 
@@ -57,7 +55,6 @@ Sensors
 
 Use the :class:`~airflow.providers.clickhouse.sensors.ClickHouseSensor` to wait for a condition using
 SQL query in `ClickHouse <https://www.clickhouse.com/>`__.
-
 An example for waiting a record **gettingstarted.clickstream** table with **customer_id** as **customer_1** as follows
 
 .. exampleinclude:: /../../airflow/providers/clickhouse/example_dags/example_clickhouse.py

--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -222,6 +222,8 @@ These are extras that add dependencies needed for integration with other softwar
 +=====================+=====================================================+===========================================+
 | arangodb            | ``pip install 'apache-airflow[arangodb]'``          | ArangoDB operators, sensors and hook      |
 +---------------------+-----------------------------------------------------+-------------------------------------------+
+| clickhouse          | ``pip install 'apache-airflow[clickhouse]'``        | ClickHouse operators, sensors and hook    |
++---------------------+-----------------------------------------------------+-------------------------------------------+
 | docker              | ``pip install 'apache-airflow[docker]'``            | Docker hooks and operators                |
 +---------------------+-----------------------------------------------------+-------------------------------------------+
 | elasticsearch       | ``pip install 'apache-airflow[elasticsearch]'``     | Elasticsearch hooks and Log Handler       |

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -225,6 +225,8 @@ classpath
 classpaths
 cleartext
 cli
+Clickhouse
+clickhouse
 clientId
 Cloudant
 cloudant

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -181,6 +181,15 @@
     ],
     "cross-providers-deps": []
   },
+  "clickhouse": {
+    "deps": [
+      "apache-airflow>=2.2.0",
+      "clickhouse-driver>=0.2.3"
+    ],
+    "cross-providers-deps": [
+      "arangodb"
+    ]
+  },
   "cloudant": {
     "deps": [
       "apache-airflow>=2.2.0",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -186,9 +186,7 @@
       "apache-airflow>=2.2.0",
       "clickhouse-driver>=0.2.3"
     ],
-    "cross-providers-deps": [
-      "arangodb"
-    ]
+    "cross-providers-deps": []
   },
   "cloudant": {
     "deps": [

--- a/setup.py
+++ b/setup.py
@@ -240,12 +240,6 @@ cgroups = [
     # Cgroupspy 0.2.2 added Python 3.10 compatibility
     'cgroupspy>=0.2.2',
 ]
-clickhouse = [
-    'clickhouse-driver>=0.2.3',
-]
-cloudant = [
-    'cloudant>=2.0',
-]
 dask = [
     # Dask support is limited, we need Dask team to upgrade support for dask if we were to continue
     # Supporting it in the future

--- a/setup.py
+++ b/setup.py
@@ -240,6 +240,12 @@ cgroups = [
     # Cgroupspy 0.2.2 added Python 3.10 compatibility
     'cgroupspy>=0.2.2',
 ]
+clickhouse = [
+    'clickhouse-driver>=0.2.3',
+]
+cloudant = [
+    'cloudant>=2.0',
+]
 dask = [
     # Dask support is limited, we need Dask team to upgrade support for dask if we were to continue
     # Supporting it in the future
@@ -575,6 +581,7 @@ ALL_DB_PROVIDERS = [
     'apache.hive',
     'apache.pinot',
     'arangodb',
+    'clickhouse',
     'cloudant',
     'databricks',
     'exasol',

--- a/tests/providers/clickhouse/__init__.py
+++ b/tests/providers/clickhouse/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/clickhouse/hooks/__init__.py
+++ b/tests/providers/clickhouse/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/clickhouse/hooks/test_clickhouse.py
+++ b/tests/providers/clickhouse/hooks/test_clickhouse.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, patch
+
+from airflow.models import Connection
+from airflow.providers.clickhouse.hooks.clickhouse import ClickHouseHook
+from airflow.utils import db
+
+clickhouse_client_mock = Mock(name="clickhouse_client_for_test")
+
+
+class TestClickHouseHook(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        db.merge_conn(
+            Connection(
+                conn_id='clickhouse_default',
+                conn_type='clickhouse',
+                host='http://127.0.0.1',
+                port=9000,
+                login='default',
+                password='password',
+                schema='default',
+            )
+        )
+
+    @patch(
+        "airflow.providers.clickhouse.hooks.clickhouse.ClickHouseClient",
+        autospec=True,
+        return_value=clickhouse_client_mock,
+    )
+    def test_get_conn(self, clickhouse_mock):
+        clickhouse_hook = ClickHouseHook(database='default')
+
+        assert clickhouse_hook.database == 'default'
+        assert clickhouse_hook.client is not None
+        assert clickhouse_mock.called
+        assert isinstance(clickhouse_hook.client, Mock)
+
+    @patch(
+        "airflow.providers.clickhouse.hooks.clickhouse.ClickHouseClient",
+        autospec=True,
+        return_value=clickhouse_client_mock,
+    )
+    def test_query(self, clickhouse_mock):
+        clickhouse_hook = ClickHouseHook()
+
+        clickhouse_query = "SELECT * FROM gettingstarted.clickstream where customer_id='customer1'"
+        clickhouse_hook.query(clickhouse_query)
+
+        assert clickhouse_mock.called
+        assert isinstance(clickhouse_hook.client, Mock)
+        assert clickhouse_mock.return_value.execute.called
+

--- a/tests/providers/clickhouse/hooks/test_clickhouse.py
+++ b/tests/providers/clickhouse/hooks/test_clickhouse.py
@@ -67,4 +67,3 @@ class TestClickHouseHook(unittest.TestCase):
         assert clickhouse_mock.called
         assert isinstance(clickhouse_hook.client, Mock)
         assert clickhouse_mock.return_value.execute.called
-

--- a/tests/providers/clickhouse/operators/__init__.py
+++ b/tests/providers/clickhouse/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/clickhouse/operators/test_clickhouse.py
+++ b/tests/providers/clickhouse/operators/test_clickhouse.py
@@ -14,3 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+import unittest
+from unittest import mock
+
+from airflow.providers.clickhouse.operators.clickhouse import ClickHouseOperator
+
+
+class TestClickHouseOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.clickhouse.operators.clickhouse.ClickHouseHook')
+    def test_clickhouse_operator_test(self, mock_hook):
+        clickhouse_query = "SELECT * FROM gettingstarted.clickstream where customer_id='customer1'"
+        op = ClickHouseOperator(task_id='basic_clickhouse_operator', sql=clickhouse_query)
+        op.execute(mock.MagicMock())
+        mock_hook.assert_called_once_with(clickhouse_conn_id='clickhouse_default', database=None)
+        mock_hook.return_value.query.assert_called_once_with(sql=clickhouse_query, params=None)

--- a/tests/providers/clickhouse/sensors/__init__.py
+++ b/tests/providers/clickhouse/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.


### PR DESCRIPTION
closes: #10893 

---
## Description

Adding ClickHouse provider based on its Python SDK https://clickhouse-driver.readthedocs.io/en/latest/

Users can create their own custom operators leveraging the **ClickHouseHook**  directly 
or building their operator on **ClickHouseOperator** by providing **result_processor**  method,

```
operator = ClickHouseOperator(
    task_id='clickhouse_operator',
    sql="SELECT * FROM gettingstarted.clickstream",
    dag=dag,
    result_processor=lambda cursor: print(cursor)
)
```

The sensor can be implemented by SQL

```
sensor = ClickHouseSensor(
    task_id="clickhouse_sensor",
    sql="SELECT * FROM gettingstarted.clickstream where customer_id='customer1'",
    timeout=60,
    poke_interval=10,
    dag=dag,
)
```