### PR TITLE
Redirect to home view when there are no valid tags in the URL

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -667,6 +667,15 @@ class Airflow(AirflowBaseView):
 
             dags_query = dags_query.filter(DagModel.dag_id.in_(filter_dag_ids))
 
+            filtered_dag_count = dags_query.count()
+            if filtered_dag_count == 0 and len(arg_tags_filter):
+                flash(
+                    "No matching DAG tags found.",
+                    "warning",
+                )
+                flask_session[FILTER_TAGS_COOKIE] = None
+                return redirect(url_for('Airflow.index'))
+
             all_dags = dags_query
             active_dags = dags_query.filter(~DagModel.is_paused)
             paused_dags = dags_query.filter(DagModel.is_paused)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -674,7 +674,7 @@ class Airflow(AirflowBaseView):
                     "warning",
                 )
                 flask_session[FILTER_TAGS_COOKIE] = None
-                return redirect(url_for('Airflow.index'))
+                return redirect(url_for("Airflow.index"))
 
             all_dags = dags_query
             active_dags = dags_query.filter(~DagModel.is_paused)

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -40,7 +40,7 @@ def test_index_redirect(admin_client):
 
 
 def test_homepage_query_count(admin_client):
-    with assert_queries_count(16):
+    with assert_queries_count(17):
         resp = admin_client.get("/home")
     check_content_in_response("DAGs", resp)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #25493

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #25493

When filtering DAGs based on tags and there are no matching DAGs, the UI will not display any DAGs as expected. The confusing part is that the tags filter box will not have any entries in there either. This is what confuses the users where they think there are no filters but there are also no DAGs.

Since the tags filter box won't allow for tags not used by DAGs, it made more sense to redirect the URL and wipe the tags when there are no valid tags in the query parameters.

When there are valid tags and invalid tags, there will be no redirects since the valid tags do still show up on the UI indicating to the user that there are filtering happening.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
