### PR TITLE
Grid: Display group/mapped summaries with the rest of the detail info

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -20,7 +20,6 @@
 import React from 'react';
 import {
   Text,
-  Box,
   Flex,
   Table,
   Tbody,
@@ -84,12 +83,17 @@ const Details = ({ instance, group }: Props) => {
     if (key > 0) {
       summary.push(
         // eslint-disable-next-line react/no-array-index-key
-        <Flex key={val} ml="10px" alignItems="center">
-          <SimpleStatus state={val as TaskState} mx={2} />
-          {val}
-          {': '}
-          {key}
-        </Flex>,
+        <Tr key={val}>
+          <Td />
+          <Td>
+            <Flex alignItems="center">
+              <SimpleStatus state={val as TaskState} mx={2} />
+              {val}
+              {': '}
+              {key}
+            </Flex>
+          </Td>
+        </Tr>,
       );
     }
   });
@@ -100,29 +104,13 @@ const Details = ({ instance, group }: Props) => {
 
   return (
     <Flex flexWrap="wrap" justifyContent="space-between">
-      <Box>
-        {tooltip && (
-          <>
-            <Text>{tooltip}</Text>
-            <br />
-          </>
-        )}
-        {mappedStates && numMapped > 0 && (
-          <Text>
-            {numMapped}
-            {' '}
-            {numMapped === 1 ? 'Task ' : 'Tasks '}
-            Mapped
-          </Text>
-        )}
-        {summary.length > 0 && (
-          summary
-        )}
-      </Box>
-      <br />
-      <br />
       <Table variant="striped">
         <Tbody>
+          {tooltip && (
+            <Tr>
+              <Td colSpan={2}>{tooltip}</Td>
+            </Tr>
+          )}
           <Tr>
             <Td>
               {isOverall}
@@ -135,6 +123,19 @@ const Details = ({ instance, group }: Props) => {
               </Flex>
             </Td>
           </Tr>
+          {mappedStates && numMapped > 0 && (
+            <Tr>
+              <Td colSpan={2}>
+                {numMapped}
+                {' '}
+                {numMapped === 1 ? 'Task ' : 'Tasks '}
+                Mapped
+              </Td>
+            </Tr>
+          )}
+          {summary.length > 0 && (
+            summary
+          )}
           <Tr>
             <Td>{taskIdTitle}</Td>
             <Td><ClipboardText value={taskId} /></Td>


### PR DESCRIPTION
We switched to a table component to display details in the grid view. But we missed the task group and mapped task summaries.


Before:
<img width="466" alt="Screen Shot 2022-08-15 at 9 38 05 AM" src="https://user-images.githubusercontent.com/4600967/184650401-a20c867a-cd21-4ca0-b111-bfc798abdcbe.png">

After:
<img width="601" alt="Screen Shot 2022-08-15 at 9 44 46 AM" src="https://user-images.githubusercontent.com/4600967/184650402-67be80ab-80df-4647-ac4e-28a12014faa4.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
