### PR TITLE
Separate "public" Dataset class from SQLA model

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -57,7 +57,7 @@ PY310 = sys.version_info >= (3, 10)
 # Things to lazy import in form 'name': 'path.to.module'
 __lazy_imports = {
     'DAG': 'airflow.models.dag',
-    'Dataset': 'airflow.models.dataset',
+    'Dataset': 'airflow.datasets',
     'XComArg': 'airflow.models.xcom_arg',
     'AirflowException': 'airflow.exceptions',
 }

--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -31,7 +31,7 @@ from airflow.api_connexion.schemas.dataset_schema import (
     dataset_schema,
 )
 from airflow.api_connexion.types import APIResponse
-from airflow.models.dataset import Dataset, DatasetEvent
+from airflow.models.dataset import DatasetEvent, DatasetModel
 from airflow.security import permissions
 from airflow.utils.session import NEW_SESSION, provide_session
 
@@ -41,8 +41,8 @@ from airflow.utils.session import NEW_SESSION, provide_session
 def get_dataset(id: int, session: Session = NEW_SESSION) -> APIResponse:
     """Get a Dataset"""
     dataset = (
-        session.query(Dataset)
-        .options(joinedload(Dataset.consuming_dags), joinedload(Dataset.producing_tasks))
+        session.query(DatasetModel)
+        .options(joinedload(DatasetModel.consuming_dags), joinedload(DatasetModel.producing_tasks))
         .get(id)
     )
     if not dataset:
@@ -67,13 +67,13 @@ def get_datasets(
     """Get datasets"""
     allowed_attrs = ['id', 'uri', 'created_at', 'updated_at']
 
-    total_entries = session.query(func.count(Dataset.id)).scalar()
-    query = session.query(Dataset)
+    total_entries = session.query(func.count(DatasetModel.id)).scalar()
+    query = session.query(DatasetModel)
     if uri_pattern:
-        query = query.filter(Dataset.uri.ilike(f"%{uri_pattern}%"))
+        query = query.filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
     query = apply_sorting(query, order_by, {}, allowed_attrs)
     datasets = (
-        query.options(subqueryload(Dataset.consuming_dags), subqueryload(Dataset.producing_tasks))
+        query.options(subqueryload(DatasetModel.consuming_dags), subqueryload(DatasetModel.producing_tasks))
         .offset(offset)
         .limit(limit)
         .all()

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -21,7 +21,7 @@ from marshmallow import Schema, fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.schemas.common_schema import JsonObjectField
-from airflow.models.dataset import Dataset, DatasetDagRef, DatasetEvent, DatasetTaskRef
+from airflow.models.dataset import DatasetDagRef, DatasetEvent, DatasetModel, DatasetTaskRef
 
 
 class DatasetTaskRefSchema(SQLAlchemySchema):
@@ -57,7 +57,7 @@ class DatasetSchema(SQLAlchemySchema):
     class Meta:
         """Meta"""
 
-        model = Dataset
+        model = DatasetModel
 
     id = auto_field()
     uri = auto_field()
@@ -71,7 +71,7 @@ class DatasetSchema(SQLAlchemySchema):
 class DatasetCollection(NamedTuple):
     """List of Datasets with meta"""
 
-    datasets: List[Dataset]
+    datasets: List[DatasetModel]
     total_entries: int
 
 

--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import attr
 
@@ -24,4 +24,4 @@ class Dataset:
     """A Dataset is used for marking data dependencies between workflows."""
 
     uri: str
-    extra: "Dict[str, Any] | None" = None
+    extra: Optional[Dict[str, Any]] = None

--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Any, Dict
+
+import attr
+
+
+@attr.define()
+class Dataset:
+    """A Dataset is used for marking data dependencies between workflows."""
+
+    uri: str
+    extra: "Dict[str, Any] | None" = None

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -38,7 +38,7 @@ datasets that never get updated.
 """
 import pendulum
 
-from airflow.models import DAG, Dataset
+from airflow import DAG, Dataset
 from airflow.operators.bash import BashOperator
 
 # [START dataset_def]

--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -27,6 +27,7 @@ from cattr import structure, unstructure
 
 from airflow.configuration import conf
 from airflow.lineage.backend import LineageBackend
+from airflow.utils.context import lazy_mapping_from_context
 from airflow.utils.module_loading import import_string
 
 ENV = jinja2.Environment()
@@ -74,7 +75,7 @@ def _render_object(obj: Any, context) -> Any:
     return structure(
         json.loads(
             ENV.from_string(json.dumps(unstructure(obj), default=lambda o: None))
-            .render(**context)
+            .render(lazy_mapping_from_context(context))
             .encode('utf-8')
         ),
         type(obj),

--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -26,7 +26,7 @@ from airflow.models.dagbag import DagBag
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
 from airflow.models.dagwarning import DagWarning
-from airflow.models.dataset import Dataset
+from airflow.models.dataset import DatasetModel
 from airflow.models.db_callback_request import DbCallbackRequest
 from airflow.models.errors import ImportError
 from airflow.models.log import Log
@@ -59,7 +59,7 @@ __all__ = [
     "DagRun",
     "DagTag",
     "DagOwnerAttributes",
-    "Dataset",
+    "DatasetModel",
     "DbCallbackRequest",
     "ImportError",
     "Log",

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -95,8 +95,8 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import NOTSET, ArgNotSet, DagRunType, EdgeInfoType
 
 if TYPE_CHECKING:
+    from airflow.datasets import Dataset
     from airflow.decorators import TaskDecoratorCollection
-    from airflow.models.dataset import Dataset
     from airflow.models.slamiss import SlaMiss
     from airflow.utils.task_group import TaskGroup
 
@@ -384,7 +384,6 @@ class DAG(LoggingMixin):
         tags: Optional[List[str]] = None,
         owner_links: Optional[Dict[str, str]] = None,
     ):
-        from airflow.models.dataset import Dataset
         from airflow.utils.task_group import TaskGroup
 
         if tags and any(len(tag) > TAG_MAX_LEN for tag in tags):
@@ -485,10 +484,12 @@ class DAG(LoggingMixin):
             )
         self.timetable: Timetable
         self.schedule_interval: ScheduleInterval
-        self.dataset_triggers: Optional[List[Dataset]] = None
+        self.dataset_triggers: Optional[List["Dataset"]] = None
 
         if schedule is not NOTSET:
             if isinstance(schedule, List):
+                from airflow.datasets import Dataset
+
                 # if List, only support List[Dataset]
                 if any(isinstance(x, Dataset) for x in schedule):
                     if not all(isinstance(x, Dataset) for x in schedule):
@@ -2643,7 +2644,8 @@ class DAG(LoggingMixin):
 
         DagCode.bulk_sync_to_db(filelocs, session=session)
 
-        from airflow.models.dataset import Dataset, DatasetDagRef, DatasetTaskRef
+        from airflow.datasets import Dataset
+        from airflow.models.dataset import DatasetDagRef, DatasetModel, DatasetTaskRef
 
         class OutletRef(NamedTuple):
             dag_id: str
@@ -2661,18 +2663,18 @@ class DAG(LoggingMixin):
         for dag in dags:
             for dataset in dag.dataset_triggers or []:
                 dag_references.add(InletRef(dag.dag_id, dataset.uri))
-                input_datasets.add(dataset)
+                input_datasets.add(DatasetModel.from_public(dataset))
             for task in dag.tasks:
                 for obj in getattr(task, '_outlets', []):  # type: Dataset
                     if isinstance(obj, Dataset):
                         outlet_references.add(OutletRef(task.dag_id, task.task_id, obj.uri))
-                        outlet_datasets.add(obj)
+                        outlet_datasets.add(DatasetModel.from_public(obj))
         all_datasets = outlet_datasets.union(input_datasets)
 
         # store datasets
         stored_datasets = {}
         for dataset in all_datasets:
-            stored_dataset = session.query(Dataset).filter(Dataset.uri == dataset.uri).first()
+            stored_dataset = session.query(DatasetModel).filter(DatasetModel.uri == dataset.uri).first()
             if stored_dataset:
                 stored_datasets[stored_dataset.uri] = stored_dataset
             else:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2675,8 +2675,13 @@ class DAG(LoggingMixin):
 
         # store datasets
         stored_datasets = {}
-        for dataset in all_datasets.keys():
-            stored_datasets[dataset.uri] = session.merge(dataset)
+        for dataset in all_datasets:
+            stored_dataset = session.query(DatasetModel).filter(DatasetModel.uri == dataset.uri).first()
+            if stored_dataset:
+                stored_datasets[stored_dataset.uri] = stored_dataset
+            else:
+                session.add(dataset)
+                stored_datasets[dataset.uri] = dataset
 
         session.flush()  # this is required to ensure each dataset has its PK loaded
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -643,7 +643,8 @@ class DagRun(Base, LoggingMixin):
         Looks at all outlet datasets that have been updated by this dag,
         and creates DAG runs that have all dataset deps fulfilled.
         """
-        from airflow.models.dataset import Dataset, DatasetDagRef, DatasetTaskRef
+        from airflow.datasets import Dataset
+        from airflow.models.dataset import DatasetDagRef, DatasetTaskRef
 
         has_dataset_outlets = False
         if self.dag:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1529,12 +1529,13 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
 
     def _create_dataset_dag_run_queue_records(self, *, session: Session) -> None:
-        from airflow.models import Dataset
+        from airflow.datasets import Dataset
+        from airflow.models.dataset import DatasetModel
 
-        for obj in getattr(self.task, '_outlets', []):
+        for obj in self.task.outlets or []:
             self.log.debug("outlet obj %s", obj)
             if isinstance(obj, Dataset):
-                dataset = session.query(Dataset).filter(Dataset.uri == obj.uri).one_or_none()
+                dataset = session.query(DatasetModel).filter(DatasetModel.uri == obj.uri).one_or_none()
                 if not dataset:
                     self.log.warning("Dataset %s not found", obj)
                     continue

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -33,8 +33,8 @@ from pendulum.tz.timezone import FixedTimezone, Timezone
 
 from airflow.compat.functools import cache
 from airflow.configuration import conf
+from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException, SerializationError
-from airflow.models import Dataset
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
 from airflow.models.dag import DAG, create_timetable

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -284,6 +284,11 @@ def lazy_mapping_from_context(source: Context) -> Mapping[str, Any]:
 
     :meta private:
     """
+    if not isinstance(source, Context):
+        # Sometimes we are passed a plain dict (usually in tests, or in User's
+        # custom operators) -- be lienent about what we accept so we don't
+        # break anything for users.
+        return source
 
     def _deprecated_proxy_factory(k: str, v: Any) -> Any:
         replacements = source._deprecation_replacements[k]

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -100,6 +100,7 @@ from airflow.api.common.mark_tasks import (
 )
 from airflow.compat.functools import cached_property
 from airflow.configuration import AIRFLOW_CONFIG, conf
+from airflow.datasets import Dataset
 from airflow.exceptions import AirflowException, ParamValidationError
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
@@ -120,7 +121,7 @@ from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.dag import DAG, get_dataset_triggered_next_run_info
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
-from airflow.models.dataset import Dataset, DatasetDagRef, DatasetDagRunQueue
+from airflow.models.dataset import DatasetDagRef, DatasetDagRunQueue, DatasetModel
 from airflow.models.operator import Operator
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
@@ -3647,11 +3648,11 @@ class Airflow(AirflowBaseView):
             data = [
                 dict(info)
                 for info in session.query(
-                    Dataset.id,
-                    Dataset.uri,
+                    DatasetModel.id,
+                    DatasetModel.uri,
                     DatasetDagRunQueue.created_at,
                 )
-                .join(DatasetDagRef, Dataset.id == DatasetDagRef.dataset_id)
+                .join(DatasetDagRef, DatasetModel.id == DatasetDagRef.dataset_id)
                 .join(
                     DatasetDagRunQueue,
                     and_(
@@ -3661,7 +3662,7 @@ class Airflow(AirflowBaseView):
                     isouter=True,
                 )
                 .filter(DatasetDagRef.dag_id == dag_id)
-                .order_by(Dataset.id)
+                .order_by(DatasetModel.id)
                 .all()
             ]
         return (

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -25,7 +25,8 @@ from parameterized import parameterized
 
 from airflow import settings
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
-from airflow.models import DAG, DagModel, DagRun, Dataset
+from airflow.datasets import Dataset
+from airflow.models import DAG, DagModel, DagRun, DatasetModel
 from airflow.models.dataset import DatasetEvent
 from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
@@ -1611,7 +1612,7 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
         created_at = pendulum.now('UTC')
         # make sure whatever is returned by this func is what comes out in response.
         d = DatasetEvent(dataset_id=1, timestamp=created_at)
-        d.dataset = Dataset(id=1, uri='hello', created_at=created_at, updated_at=created_at)
+        d.dataset = DatasetModel(id=1, uri='hello', created_at=created_at, updated_at=created_at)
         mock_get_events.return_value = [d]
         response = self.client.get(
             "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/upstreamDatasetEvents",

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -16,14 +16,12 @@
 # under the License.
 from datetime import timedelta
 from unittest import mock
-from uuid import uuid4
 
 import pendulum
 import pytest
 from freezegun import freeze_time
 from parameterized import parameterized
 
-from airflow import settings
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.datasets import Dataset
 from airflow.models import DAG, DagModel, DagRun, DatasetModel
@@ -1491,39 +1489,38 @@ class TestClearDagRun(TestDagRunEndpoint):
         assert response.status_code == 404
 
 
-def test__get_upstream_dataset_events_no_prior(configured_app):
+@pytest.mark.need_serialized_dag
+def test__get_upstream_dataset_events_no_prior(configured_app, dag_maker):
     """If no prior dag runs, return all events"""
     from airflow.api_connexion.endpoints.dag_run_endpoint import _get_upstream_dataset_events
 
+    dataset1a = Dataset(uri="ds1a")
+    dataset1b = Dataset(uri="ds1b")
     # setup dags and datasets
-    unique_id = str(uuid4())
-    session = settings.Session()
-    dataset1a = Dataset(uri=f"s3://{unique_id}-1a")
-    dataset1b = Dataset(uri=f"s3://{unique_id}-1b")
-    dag2 = DAG(dag_id=f"datasets-{unique_id}-2", schedule=[dataset1a, dataset1b])
-    DAG.bulk_write_to_db(dags=[dag2], session=session)
-    session.add_all([dataset1a, dataset1b])
-    session.commit()
+    with dag_maker(dag_id="datasets-2", schedule=[dataset1a, dataset1b]):
+        pass
 
     # add 5 events
-    session.add_all([DatasetEvent(dataset_id=dataset1a.id), DatasetEvent(dataset_id=dataset1b.id)])
-    session.add_all([DatasetEvent(dataset_id=dataset1a.id), DatasetEvent(dataset_id=dataset1b.id)])
-    session.add_all([DatasetEvent(dataset_id=dataset1a.id)])
-    session.commit()
+    session = dag_maker.session
+    ds1a_id = session.query(DatasetModel.id).filter_by(uri=dataset1a.uri).scalar()
+    ds1b_id = session.query(DatasetModel.id).filter_by(uri=dataset1b.uri).scalar()
+    session.add_all([DatasetEvent(dataset_id=ds1a_id), DatasetEvent(dataset_id=ds1b_id)])
+    session.add_all([DatasetEvent(dataset_id=ds1a_id), DatasetEvent(dataset_id=ds1b_id)])
+    session.add_all([DatasetEvent(dataset_id=ds1a_id)])
+    session.flush()
 
     # create a single dag run, no prior dag runs
-    dr = DagRun(dag2.dag_id, run_id=unique_id, run_type=DagRunType.DATASET_TRIGGERED)
-    dr.dag = dag2
-    session.add(dr)
-    session.commit()
-    session.expunge_all()
+    dr = dag_maker.create_dagrun(
+        run_id="run", run_type=DagRunType.DATASET_TRIGGERED, execution_date=timezone.utcnow()
+    )
 
     # check result
     events = _get_upstream_dataset_events(dag_run=dr, session=session)
     assert len(events) == 5
 
 
-def test__get_upstream_dataset_events_with_prior(configured_app):
+@pytest.mark.need_serialized_dag
+def test__get_upstream_dataset_events_with_prior(configured_app, dag_maker):
     """
     Events returned should be those that occurred after last DATASET_TRIGGERED
     dag run and up to the exec date of current dag run.
@@ -1531,57 +1528,48 @@ def test__get_upstream_dataset_events_with_prior(configured_app):
     from airflow.api_connexion.endpoints.dag_run_endpoint import _get_upstream_dataset_events
 
     # setup dags and datasets
-    unique_id = str(uuid4())
-    session = settings.Session()
-    dataset1a = Dataset(uri=f"s3://{unique_id}-1a")
-    dataset1b = Dataset(uri=f"s3://{unique_id}-1b")
-    dag2 = DAG(dag_id=f"datasets-{unique_id}-2", schedule=[dataset1a, dataset1b])
-    DAG.bulk_write_to_db(dags=[dag2], session=session)
-    session.add_all([dataset1a, dataset1b])
-    session.commit()
+    dataset1a = Dataset(uri="ds1a")
+    dataset1b = Dataset(uri="ds1b")
+    # setup dags and datasets
+    with dag_maker(dag_id="datasets-2", schedule=[dataset1a, dataset1b]):
+        pass
+
+    session = dag_maker.session
+    ds1a_id = session.query(DatasetModel.id).filter_by(uri=dataset1a.uri).scalar()
+    ds1b_id = session.query(DatasetModel.id).filter_by(uri=dataset1b.uri).scalar()
 
     # add 2 events, then a dag run, then 3 events, then another dag run then another event
     first_timestamp = pendulum.datetime(2022, 1, 1, tz='UTC')
     session.add_all(
         [
-            DatasetEvent(dataset_id=dataset1a.id, timestamp=first_timestamp),
-            DatasetEvent(dataset_id=dataset1b.id, timestamp=first_timestamp),
+            DatasetEvent(dataset_id=ds1a_id, timestamp=first_timestamp),
+            DatasetEvent(dataset_id=ds1b_id, timestamp=first_timestamp),
         ]
     )
-    dr1 = DagRun(
-        dag2.dag_id,
-        run_id=unique_id + '-1',
+    dag_maker.create_dagrun(
+        run_id='run-1',
         run_type=DagRunType.DATASET_TRIGGERED,
         execution_date=first_timestamp.add(microseconds=1000),
     )
-    dr1.dag = dag2
-    session.add(dr1)
     session.add_all(
         [
-            DatasetEvent(dataset_id=dataset1a.id, timestamp=first_timestamp.add(microseconds=2000)),
-            DatasetEvent(dataset_id=dataset1b.id, timestamp=first_timestamp.add(microseconds=3000)),
-            DatasetEvent(dataset_id=dataset1b.id, timestamp=first_timestamp.add(microseconds=4000)),
+            DatasetEvent(dataset_id=ds1a_id, timestamp=first_timestamp.add(microseconds=2000)),
+            DatasetEvent(dataset_id=ds1b_id, timestamp=first_timestamp.add(microseconds=3000)),
+            DatasetEvent(dataset_id=ds1b_id, timestamp=first_timestamp.add(microseconds=4000)),
         ]
     )
-    dr2 = DagRun(  # this dag run should be ignored
-        dag2.dag_id,
-        run_id=unique_id + '-3',
+    dag_maker.create_dagrun(
+        run_id='run-2',
         run_type=DagRunType.MANUAL,
         execution_date=first_timestamp.add(microseconds=3000),
     )
-    dr2.dag = dag2
-    session.add(dr2)
-    dr3 = DagRun(
-        dag2.dag_id,
-        run_id=unique_id + '-2',
+    dr3 = dag_maker.create_dagrun(
+        run_id='run-3',
         run_type=DagRunType.DATASET_TRIGGERED,
         execution_date=first_timestamp.add(microseconds=4000),  # exact same time as 3rd event in window
     )
-    dr3.dag = dag2
-    session.add(dr3)
-    session.add_all([DatasetEvent(dataset_id=dataset1a.id, timestamp=first_timestamp.add(microseconds=5000))])
-    session.commit()
-    session.expunge_all()
+    session.add_all([DatasetEvent(dataset_id=ds1a_id, timestamp=first_timestamp.add(microseconds=5000))])
+    session.flush()
 
     events = _get_upstream_dataset_events(dag_run=dr3, session=session)
 

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -19,7 +19,7 @@ import pytest
 from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
-from airflow.models.dataset import Dataset, DatasetEvent
+from airflow.models.dataset import DatasetEvent, DatasetModel
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
@@ -62,7 +62,7 @@ class TestDatasetEndpoint:
         clear_db_datasets()
 
     def _create_dataset(self, session):
-        dataset_model = Dataset(
+        dataset_model = DatasetModel(
             id=1,
             uri="s3://bucket/key",
             extra={"foo": "bar"},
@@ -77,7 +77,7 @@ class TestDatasetEndpoint:
 class TestGetDatasetEndpoint(TestDatasetEndpoint):
     def test_should_respond_200(self, session):
         self._create_dataset(session)
-        assert session.query(Dataset).count() == 1
+        assert session.query(DatasetModel).count() == 1
 
         with assert_queries_count(5):
             response = self.client.get("/api/v1/datasets/1", environ_overrides={'REMOTE_USER': "test"})
@@ -112,7 +112,7 @@ class TestGetDatasetEndpoint(TestDatasetEndpoint):
 class TestGetDatasets(TestDatasetEndpoint):
     def test_should_respond_200(self, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 id=i,
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
@@ -123,7 +123,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         ]
         session.add_all(datasets)
         session.commit()
-        assert session.query(Dataset).count() == 2
+        assert session.query(DatasetModel).count() == 2
 
         with assert_queries_count(8):
             response = self.client.get("/api/v1/datasets", environ_overrides={'REMOTE_USER': "test"})
@@ -156,7 +156,7 @@ class TestGetDatasets(TestDatasetEndpoint):
 
     def test_order_by_raises_400_for_invalid_attr(self, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
                 created_at=timezone.parse(self.default_time),
@@ -166,7 +166,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         ]
         session.add_all(datasets)
         session.commit()
-        assert session.query(Dataset).count() == 2
+        assert session.query(DatasetModel).count() == 2
 
         response = self.client.get(
             "/api/v1/datasets?order_by=fake", environ_overrides={'REMOTE_USER': "test"}
@@ -178,7 +178,7 @@ class TestGetDatasets(TestDatasetEndpoint):
 
     def test_should_raises_401_unauthenticated(self, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
                 created_at=timezone.parse(self.default_time),
@@ -188,7 +188,7 @@ class TestGetDatasets(TestDatasetEndpoint):
         ]
         session.add_all(datasets)
         session.commit()
-        assert session.query(Dataset).count() == 2
+        assert session.query(DatasetModel).count() == 2
 
         response = self.client.get("/api/v1/datasets")
 
@@ -215,10 +215,10 @@ class TestGetDatasets(TestDatasetEndpoint):
     )
     @provide_session
     def test_filter_datasets_by_uri_pattern_works(self, url, expected_datasets, session):
-        dataset1 = Dataset("s3://folder/key")
-        dataset2 = Dataset("gcp://bucket/key")
-        dataset3 = Dataset("somescheme://dataset/key")
-        dataset4 = Dataset("wasb://some_dataset_bucket_/key")
+        dataset1 = DatasetModel("s3://folder/key")
+        dataset2 = DatasetModel("gcp://bucket/key")
+        dataset3 = DatasetModel("somescheme://dataset/key")
+        dataset4 = DatasetModel("wasb://some_dataset_bucket_/key")
         session.add_all([dataset1, dataset2, dataset3, dataset4])
         session.commit()
         response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
@@ -243,7 +243,7 @@ class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
     @provide_session
     def test_limit_and_offset(self, url, expected_dataset_uris, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
                 created_at=timezone.parse(self.default_time),
@@ -262,7 +262,7 @@ class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
 
     def test_should_respect_page_size_limit_default(self, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
                 created_at=timezone.parse(self.default_time),
@@ -281,7 +281,7 @@ class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},
                 created_at=timezone.parse(self.default_time),
@@ -350,7 +350,7 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
     @provide_session
     def test_filtering(self, attr, value, session):
         datasets = [
-            Dataset(
+            DatasetModel(
                 id=i,
                 uri=f"s3://bucket/key/{i}",
                 extra={"foo": "bar"},

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -25,6 +25,7 @@ from airflow.api_connexion.schemas.dataset_schema import (
     dataset_event_schema,
     dataset_schema,
 )
+from airflow.datasets import Dataset
 from airflow.models.dataset import DatasetEvent, DatasetModel
 from airflow.operators.empty import EmptyOperator
 from tests.test_utils.db import clear_db_dags, clear_db_datasets
@@ -46,20 +47,20 @@ class TestDatasetSchemaBase:
 
 class TestDatasetSchema(TestDatasetSchemaBase):
     def test_serialize(self, dag_maker, session):
-        dataset = DatasetModel(
+        dataset = Dataset(
             uri="s3://bucket/key",
             extra={"foo": "bar"},
         )
-        session.add(dataset)
-        session.flush()
         with dag_maker(dag_id="test_dataset_upstream_schema", serialized=True, session=session):
             EmptyOperator(task_id="task1", outlets=[dataset])
         with dag_maker(
             dag_id="test_dataset_downstream_schema", schedule=[dataset], serialized=True, session=session
         ):
             EmptyOperator(task_id="task2")
-        session.flush()
-        serialized_data = dataset_schema.dump(dataset)
+
+        dataset_model = session.query(DatasetModel).filter_by(uri=dataset.uri).one()
+
+        serialized_data = dataset_schema.dump(dataset_model)
         serialized_data['id'] = 1
         assert serialized_data == {
             "id": 1,

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -25,7 +25,7 @@ from airflow.api_connexion.schemas.dataset_schema import (
     dataset_event_schema,
     dataset_schema,
 )
-from airflow.models.dataset import Dataset, DatasetEvent
+from airflow.models.dataset import DatasetEvent, DatasetModel
 from airflow.operators.empty import EmptyOperator
 from tests.test_utils.db import clear_db_dags, clear_db_datasets
 
@@ -46,7 +46,7 @@ class TestDatasetSchemaBase:
 
 class TestDatasetSchema(TestDatasetSchemaBase):
     def test_serialize(self, dag_maker, session):
-        dataset = Dataset(
+        dataset = DatasetModel(
             uri="s3://bucket/key",
             extra={"foo": "bar"},
         )
@@ -89,7 +89,7 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
     def test_serialize(self, session):
 
         datasets = [
-            Dataset(
+            DatasetModel(
                 uri=f"s3://bucket/key/{i+1}",
                 extra={"foo": "bar"},
             )
@@ -129,7 +129,7 @@ class TestDatasetCollectionSchema(TestDatasetSchemaBase):
 
 class TestDatasetEventSchema(TestDatasetSchemaBase):
     def test_serialize(self, session):
-        d = Dataset('s3://abc')
+        d = DatasetModel('s3://abc')
         session.add(d)
         session.commit()
         event = DatasetEvent(

--- a/tests/dags/test_datasets.py
+++ b/tests/dags/test_datasets.py
@@ -18,8 +18,8 @@
 
 from datetime import datetime
 
+from airflow import DAG, Dataset
 from airflow.exceptions import AirflowFailException, AirflowSkipException
-from airflow.models import DAG, Dataset
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -58,7 +58,7 @@ from airflow.models import (
     Variable,
     XCom,
 )
-from airflow.models.dataset import Dataset, DatasetDagRunQueue, DatasetEvent, DatasetTaskRef
+from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel, DatasetTaskRef
 from airflow.models.expandinput import EXPAND_INPUT_EMPTY
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
@@ -1724,13 +1724,13 @@ class TestTaskInstance:
         ]
 
         # check that one event record created for dataset1 and this TI
-        assert session.query(Dataset.uri).join(DatasetEvent.dataset).filter(
+        assert session.query(DatasetModel.uri).join(DatasetEvent.dataset).filter(
             DatasetEvent.source_task_instance == ti
         ).one() == ('s3://dag1/output_1.txt',)
 
         # check that no other dataset events recorded
         assert (
-            session.query(Dataset.uri)
+            session.query(DatasetModel.uri)
             .join(DatasetEvent.dataset)
             .filter(DatasetEvent.source_task_instance == ti)
             .count()

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -35,10 +35,11 @@ import pytest
 from dateutil.relativedelta import FR, relativedelta
 from kubernetes.client import models as k8s
 
+from airflow.datasets import Dataset
 from airflow.exceptions import SerializationError
 from airflow.hooks.base import BaseHook
 from airflow.kubernetes.pod_generator import PodGenerator
-from airflow.models import DAG, Connection, DagBag, Dataset, Operator
+from airflow.models import DAG, Connection, DagBag, Operator
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.mappedoperator import MappedOperator
 from airflow.models.param import Param, ParamsDict

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -38,7 +38,13 @@ from airflow.models import (
     errors,
 )
 from airflow.models.dagcode import DagCode
-from airflow.models.dataset import Dataset, DatasetDagRef, DatasetDagRunQueue, DatasetEvent, DatasetTaskRef
+from airflow.models.dataset import (
+    DatasetDagRef,
+    DatasetDagRunQueue,
+    DatasetEvent,
+    DatasetModel,
+    DatasetTaskRef,
+)
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.security.permissions import RESOURCE_DAG_PREFIX
 from airflow.utils.db import add_default_pool_if_not_exists, create_default_connections, reflect_tables
@@ -57,7 +63,7 @@ def clear_db_runs():
 def clear_db_datasets():
     with create_session() as session:
         session.query(DatasetEvent).delete()
-        session.query(Dataset).delete()
+        session.query(DatasetModel).delete()
         session.query(DatasetDagRunQueue).delete()
         session.query(DatasetDagRef).delete()
         session.query(DatasetTaskRef).delete()

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -22,10 +22,11 @@ import pendulum
 import pytest
 from dateutil.tz import UTC
 
+from airflow.datasets import Dataset
 from airflow.lineage.entities import File
 from airflow.models import DagBag
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import Dataset, DatasetDagRunQueue
+from airflow.models.dataset import DatasetDagRunQueue
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.task_group import TaskGroup

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -26,7 +26,7 @@ from airflow.datasets import Dataset
 from airflow.lineage.entities import File
 from airflow.models import DagBag
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import DatasetDagRunQueue
+from airflow.models.dataset import DatasetDagRunQueue, DatasetModel
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.task_group import TaskGroup
@@ -326,19 +326,20 @@ def test_has_outlet_dataset_flag(admin_client, dag_maker, session, app, monkeypa
     }
 
 
+@pytest.mark.need_serialized_dag
 def test_next_run_datasets(admin_client, dag_maker, session, app, monkeypatch):
     with monkeypatch.context() as m:
-        datasets = [Dataset(id=i, uri=f's3://bucket/key/{i}') for i in [1, 2]]
-        session.add_all(datasets)
-        session.commit()
+        datasets = [Dataset(uri=f's3://bucket/key/{i}') for i in [1, 2]]
 
         with dag_maker(dag_id=DAG_ID, schedule=datasets, serialized=True, session=session):
             EmptyOperator(task_id='task1')
 
         m.setattr(app, 'dag_bag', dag_maker.dagbag)
 
+        ds1_id = session.query(DatasetModel.id).filter_by(uri=datasets[0].uri).scalar()
+        ds2_id = session.query(DatasetModel.id).filter_by(uri=datasets[1].uri).scalar()
         ddrq = DatasetDagRunQueue(
-            target_dag_id=DAG_ID, dataset_id=1, created_at=pendulum.DateTime(2022, 8, 1, tzinfo=UTC)
+            target_dag_id=DAG_ID, dataset_id=ds1_id, created_at=pendulum.DateTime(2022, 8, 1, tzinfo=UTC)
         )
         session.add(ddrq)
         session.commit()
@@ -347,8 +348,8 @@ def test_next_run_datasets(admin_client, dag_maker, session, app, monkeypatch):
 
     assert resp.status_code == 200, resp.json
     assert resp.json == [
-        {'id': 1, 'uri': 's3://bucket/key/1', 'created_at': "2022-08-01T00:00:00+00:00"},
-        {'id': 2, 'uri': 's3://bucket/key/2', 'created_at': None},
+        {'id': ds1_id, 'uri': 's3://bucket/key/1', 'created_at': "2022-08-01T00:00:00+00:00"},
+        {'id': ds2_id, 'uri': 's3://bucket/key/2', 'created_at': None},
     ]
 
 


### PR DESCRIPTION
Importing all of SQLA can be very heavy weight (slowing import times),
and it can also make it harder if libraries want to build on top of the
Dataset concept.

Not to mention that the interal-API/db-isolation AIP should mean we
don't want to import any SQLA models directly in user code.