### PR TITLE
Add origin request args when triggering a run

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -204,7 +204,12 @@
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                   <input type="hidden" name="unpause" value="True">
-                  <input type="hidden" name="origin" value="{{ url_for(request.endpoint, dag_id=dag.dag_id) }}">
+                  <!-- for task instance detail pages, dag_id is still a query param -->
+                  {% if request.args.get('dag_id') is not none %}
+                    <input type="hidden" name="origin" value="{{ url_for(request.endpoint, **request.args) }}">
+                  {% else %}
+                    <input type="hidden" name="origin" value="{{ url_for(request.endpoint, dag_id=dag.dag_id, **request.args) }}">
+                  {% endif %}
                   <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                 </form>
               </li>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -205,7 +205,7 @@
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
                   <input type="hidden" name="unpause" value="True">
                   <!-- for task instance detail pages, dag_id is still a query param -->
-                  {% if request.args.get('dag_id') is not none %}
+                  {% if 'dag_id' in request.args %}
                     <input type="hidden" name="origin" value="{{ url_for(request.endpoint, **request.args) }}">
                   {% else %}
                     <input type="hidden" name="origin" value="{{ url_for(request.endpoint, dag_id=dag.dag_id, **request.args) }}">


### PR DESCRIPTION
Include the query parameters in the origin when manually triggering a dag run from the dag page. Prevents request errors when triggering a run from a task instance detail page and losing your place elsewhere the dag page.

Fixes: https://github.com/apache/airflow/issues/24725

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
