### PR TITLE
Use cfg default_wrap value for grid logs

### DIFF
--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -54,5 +54,6 @@ global.stateColors = {
 };
 
 global.defaultDagRunDisplayNumber = 245;
+global.defaultWrap = true;
 
 global.moment = moment;

--- a/airflow/www/jest-setup.js
+++ b/airflow/www/jest-setup.js
@@ -54,6 +54,5 @@ global.stateColors = {
 };
 
 global.defaultDagRunDisplayNumber = 245;
-global.defaultWrap = true;
 
 global.moment = moment;

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
@@ -23,17 +23,10 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import type { UseQueryResult } from 'react-query';
 
+import * as utils from 'src/utils';
 import * as useTaskLogModule from 'src/api/useTaskLog';
 
 import Logs from './index';
-
-declare global {
-  namespace NodeJS {
-    interface Global {
-      defaultWrap: boolean;
-    }
-  }
-}
 
 const mockTaskLog = `
 5d28cfda3219
@@ -97,11 +90,16 @@ describe('Test Logs Component.', () => {
   });
 
   test.each([
-    { defaultWrap: true },
-    { defaultWrap: false },
-  ])('Test wrap checkbox initial value $defaultWrap', ({ defaultWrap }) => {
-    const originalDefaultWrapValue = global.defaultWrap;
-    global.defaultWrap = defaultWrap;
+    { defaultWrap: 'True', shouldBeChecked: true },
+    { defaultWrap: 'False', shouldBeChecked: false },
+    { defaultWrap: '', shouldBeChecked: false },
+  ])('Test wrap checkbox initial value $defaultWrap', ({ defaultWrap, shouldBeChecked }) => {
+    jest.spyOn(utils, 'getMetaValue').mockImplementation(
+      (meta) => {
+        if (meta === 'default_wrap') return defaultWrap;
+        return '';
+      },
+    );
 
     const tryNumber = 2;
     const { getByTestId } = render(
@@ -116,12 +114,11 @@ describe('Test Logs Component.', () => {
     );
 
     const wrapCheckbox = getByTestId('wrap-checkbox');
-    if (defaultWrap) {
+    if (shouldBeChecked) {
       expect(wrapCheckbox).toHaveAttribute('data-checked');
     } else {
       expect(wrapCheckbox.getAttribute('data-checked')).toBeNull();
     }
-    global.defaultWrap = originalDefaultWrapValue;
   });
 
   test('Test Logs Content Mapped Task', () => {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
@@ -27,6 +27,14 @@ import * as useTaskLogModule from 'src/api/useTaskLog';
 
 import Logs from './index';
 
+declare global {
+  namespace NodeJS {
+    interface Global {
+      defaultWrap: boolean;
+    }
+  }
+}
+
 const mockTaskLog = `
 5d28cfda3219
 *** Reading local file: /root/airflow/logs/dag_id=test_ui_grid/run_id=scheduled__2022-06-03T00:00:00+00:00/task_id=section_1.get_entry_group/attempt=1.log
@@ -86,6 +94,34 @@ describe('Test Logs Component.', () => {
       taskId: 'dummyTaskId',
       taskTryNumber: 1,
     });
+  });
+
+  test.each([
+    { defaultWrap: true },
+    { defaultWrap: false },
+  ])('Test wrap checkbox initial value $defaultWrap', ({ defaultWrap }) => {
+    const originalDefaultWrapValue = global.defaultWrap;
+    global.defaultWrap = defaultWrap;
+
+    const tryNumber = 2;
+    const { getByTestId } = render(
+      <Logs
+        dagId="dummyDagId"
+        dagRunId="dummyDagRunId"
+        taskId="dummyTaskId"
+        executionDate="2020:01:01T01:00+00:00"
+        mapIndex={1}
+        tryNumber={tryNumber}
+      />,
+    );
+
+    const wrapCheckbox = getByTestId('wrap-checkbox');
+    if (defaultWrap) {
+      expect(wrapCheckbox).toHaveAttribute('data-checked');
+    } else {
+      expect(wrapCheckbox.getAttribute('data-checked')).toBeNull();
+    }
+    global.defaultWrap = originalDefaultWrapValue;
   });
 
   test('Test Logs Content Mapped Task', () => {

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -40,6 +40,8 @@ import MultiSelect from 'src/components/MultiSelect';
 import LogLink from './LogLink';
 import { LogLevel, logLevelColorMapping, parseLogs } from './utils';
 
+declare const defaultWrap: boolean;
+
 interface LogLevelOption {
   label: LogLevel;
   value: LogLevel;
@@ -100,7 +102,7 @@ const Logs = ({
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedAttempt, setSelectedAttempt] = useState(1);
   const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
-  const [wrap, setWrap] = useState(false);
+  const [wrap, setWrap] = useState(defaultWrap);
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
   const { timezone } = useTimezone();
@@ -216,8 +218,10 @@ const Logs = ({
             </Flex>
             <Flex alignItems="center">
               <Checkbox
+                isChecked={wrap}
                 onChange={() => setWrap((previousState) => !previousState)}
                 px={4}
+                data-testid="wrap-checkbox"
               >
                 <Text as="strong">Wrap</Text>
               </Checkbox>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -40,8 +40,6 @@ import MultiSelect from 'src/components/MultiSelect';
 import LogLink from './LogLink';
 import { LogLevel, logLevelColorMapping, parseLogs } from './utils';
 
-declare const defaultWrap: boolean;
-
 interface LogLevelOption {
   label: LogLevel;
   value: LogLevel;
@@ -102,7 +100,7 @@ const Logs = ({
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedAttempt, setSelectedAttempt] = useState(1);
   const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
-  const [wrap, setWrap] = useState(defaultWrap);
+  const [wrap, setWrap] = useState(getMetaValue('default_wrap') === 'True');
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
   const { timezone } = useTimezone();

--- a/airflow/www/templates/airflow/grid.html
+++ b/airflow/www/templates/airflow/grid.html
@@ -42,6 +42,7 @@
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
     const defaultDagRunDisplayNumber = {{ default_dag_run_display_number }};
+    const defaultWrap = {{ default_wrap|tojson }};
     const filtersOptions = {{ filters_drop_down_values }};
   </script>
   <script src="{{ url_for_asset('grid.js') }}"></script>

--- a/airflow/www/templates/airflow/grid.html
+++ b/airflow/www/templates/airflow/grid.html
@@ -26,6 +26,7 @@
   <meta name="num_runs" content="{{ num_runs }}">
   <meta name="root" content="{{ root if root else '' }}">
   <meta name="base_date" content="{{ request.args.get('base_date') if request.args.get('base_date') else '' }}">
+  <meta name="default_wrap" content="{{ default_wrap }}">
 {% endblock %}
 
 {% block content %}
@@ -42,7 +43,6 @@
     const stateColors = {{ state_color_mapping|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
     const defaultDagRunDisplayNumber = {{ default_dag_run_display_number }};
-    const defaultWrap = {{ default_wrap|tojson }};
     const filtersOptions = {{ filters_drop_down_values }};
   </script>
   <script src="{{ url_for_asset('grid.js') }}"></script>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2745,6 +2745,7 @@ class Airflow(AirflowBaseView):
             dag_model=dag_model,
             auto_refresh_interval=conf.getint('webserver', 'auto_refresh_interval'),
             default_dag_run_display_number=default_dag_run_display_number,
+            default_wrap=conf.getboolean('webserver', 'default_wrap'),
             filters_drop_down_values=htmlsafe_json_dumps(
                 {
                     "taskStates": [state.value for state in TaskInstanceState],


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/24721

Thanks @bbovenzi for the ping. Here is a quick PR that also uses the `default_wrap` param value for the grid logs.