### PR TITLE
Improve docker documentation

### DIFF
--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -124,7 +124,8 @@ Using custom images
 
 When you want to run Airflow locally, you might want to use an extended image, containing some additional dependencies - for
 example you might add new python packages, or upgrade airflow providers to a later version. This can be done very easily
-by placing a custom Dockerfile alongside your ``docker-compose.yaml``. Then you can use ``docker-compose build`` command
+by specifying ``build: .`` in your ``docker-compose.yaml`` and placing a custom Dockerfile alongside your
+``docker-compose.yaml``. Then you can use ``docker-compose build`` command
 to build your image (you need to do it only once). You can also add the ``--build`` flag to your ``docker-compose`` commands
 to rebuild the images on-the-fly when you run other ``docker-compose`` commands.
 

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -88,7 +88,7 @@ Usage
 =====
 
 The :envvar:`AIRFLOW_HOME` is set by default to ``/opt/airflow/`` - this means that DAGs
-are in default in the ``/opt/airflow/dags`` folder and logs are in the ``/opt/airflow/logs``
+are by default in the ``/opt/airflow/dags`` folder and logs are in the ``/opt/airflow/logs``
 
 The working directory is ``/opt/airflow`` by default.
 


### PR DESCRIPTION
I followed the [Quick Start - Running Airflow in Docker - Using custom images](https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#using-custom-images) step by step and noticed something that could probably be improved.