### PR TITLE
Remove missing extras in Airflow 2.2 check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -848,10 +848,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           # The extras below are all extras that should be installed with Airflow 2.2.0
           AIRFLOW_EXTRAS: "airbyte,alibaba,amazon,apache.atlas.apache.beam,apache.cassandra,apache.drill,\
             apache.druid,apache.hdfs,apache.hive,apache.kylin,apache.livy,apache.pig,apache.pinot,\
-            apache.spark,apache.sqoop,apache.webhdfs,arangodb,asana,async,\
-            celery,cgroups,cloudant,cncf.kubernetes,dask,databricks,datadog,dbt.cloud,\
+            apache.spark,apache.sqoop,apache.webhdfs,asana,async,\
+            celery,cgroups,cloudant,cncf.kubernetes,dask,databricks,datadog,\
             deprecated_api,dingding,discord,docker,\
-            elasticsearch,exasol,facebook,ftp,github,github_enterprise,google,google_auth,\
+            elasticsearch,exasol,facebook,ftp,github_enterprise,google,google_auth,\
             grpc,hashicorp,http,imap,influxdb,jdbc,jenkins,jira,kerberos,ldap,\
             leveldb,microsoft.azure,microsoft.mssql,microsoft.psrp,microsoft.winrm,mongo,mysql,\
             neo4j,odbc,openfaas,opsgenie,oracle,pagerduty,pandas,papermill,password,plexus,\


### PR DESCRIPTION
The Airflow 2.2 check install airflow with predefined set of extras,
but some of those extras were missing in 2.2 because the providers
were not existing yet then. There was also a 'dot' instead of coma
in the list of extras between apache.beam and apache.atlas.

It did not have too bad effect, because those dependencies are
pulled in when the providers get installed, but it did not correctly
test the apache.atlas and apache.beam upgrade scenarios - from the
versions that were installed in 2.2 to the latest version in main.

This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
