### PR TITLE
Clarify filename_template deprecation message

### DIFF
--- a/airflow/utils/context.pyi
+++ b/airflow/utils/context.pyi
@@ -51,7 +51,7 @@ class ConnectionAccessor:
     def get(self, key: str, default_conn: Any = None) -> Any: ...
 
 # NOTE: Please keep this in sync with KNOWN_CONTEXT_KEYS in airflow/utils/context.py.
-class Context(TypedDict):
+class Context(TypedDict, total=False):
     conf: AirflowConfigParser
     conn: Any
     dag: DAG

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -50,8 +50,11 @@ class FileTaskHandler(logging.Handler):
         self.local_base = base_log_folder
         if filename_template is not None:
             warnings.warn(
-                "Passing filename_template to FileTaskHandler is deprecated and has no effect",
+                "Passing filename_template to a log handler is deprecated and has no effect",
                 DeprecationWarning,
+                # We want to reference the stack that actually instantiates the
+                # handler, not the one that calls super()__init__.
+                stacklevel=(2 if type(self) == FileTaskHandler else 3),
             )
 
     def set_context(self, ti: "TaskInstance"):


### PR DESCRIPTION
This argument is deprecated in ALL Airflow log handlers, not just FileTaskHandler.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
