### PR TITLE
Fix Flask deprecation warning

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -108,7 +108,7 @@ def create_app(config=None, testing=False):
         flask_app.config['SQLALCHEMY_ENGINE_OPTIONS'] = settings.prepare_engine_args()
 
     # Configure the JSON encoder used by `|tojson` filter from Flask
-    flask_app.json_encoder = AirflowJsonEncoder
+    flask_app.json_provider_class = AirflowJsonEncoder
 
     csrf.init_app(flask_app)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ install_requires =
     # Flask 2.3 is scheduled to introduce a number of deprecation removals - some of them might be breaking
     # for our dependencies - notably `_app_ctx_stack` and `_request_ctx_stack` removals.
     # We should remove the limitation after 2.3 is released and our dependencies are updated to handle it
-    flask>=2.0,<2.3
+    flask>=2.2,<2.3
     # We are tightly coupled with FAB version because we vendored in part of FAB code related to security manager
     # This is done as part of preparation to removing FAB as dependency, but we are not ready for it yet
     # Every time we update FAB version here, please make sure that you review the classes and models in

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -387,10 +387,10 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
 
 
 class TestGetTaskInstances(TestTaskInstanceEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "task_instances, update_extras, url, expected_ti",
         [
-            (
-                "test execution date filter",
+            pytest.param(
                 [
                     {"execution_date": DEFAULT_DATETIME_1},
                     {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -402,9 +402,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     f"taskInstances?execution_date_lte={DEFAULT_DATETIME_STR_1}"
                 ),
                 1,
+                id="test execution date filter",
             ),
-            (
-                "test start date filter",
+            pytest.param(
                 [
                     {"start_date": DEFAULT_DATETIME_1},
                     {"start_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -416,9 +416,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     f"?start_date_gte={DEFAULT_DATETIME_STR_1}&start_date_lte={DEFAULT_DATETIME_STR_2}"
                 ),
                 2,
+                id="test start date filter",
             ),
-            (
-                "test end date filter",
+            pytest.param(
                 [
                     {"end_date": DEFAULT_DATETIME_1},
                     {"end_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -430,9 +430,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     f"end_date_gte={DEFAULT_DATETIME_STR_1}&end_date_lte={DEFAULT_DATETIME_STR_2}"
                 ),
                 2,
+                id="test end date filter",
             ),
-            (
-                "test duration filter",
+            pytest.param(
                 [
                     {"duration": 100},
                     {"duration": 150},
@@ -444,9 +444,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     "taskInstances?duration_gte=100&duration_lte=200"
                 ),
                 3,
+                id="test duration filter",
             ),
-            (
-                "test duration filter ~",
+            pytest.param(
                 [
                     {"duration": 100},
                     {"duration": 150},
@@ -455,9 +455,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 "/api/v1/dags/~/dagRuns/~/taskInstances?duration_gte=100&duration_lte=200",
                 3,
+                id="test duration filter ~",
             ),
-            (
-                "test state filter",
+            pytest.param(
                 [
                     {"state": State.RUNNING},
                     {"state": State.QUEUED},
@@ -470,9 +470,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     "TEST_DAG_RUN_ID/taskInstances?state=running,queued,none"
                 ),
                 3,
+                id="test state filter",
             ),
-            (
-                "test null states with no filter",
+            pytest.param(
                 [
                     {"state": State.NONE},
                     {"state": State.NONE},
@@ -482,9 +482,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 False,
                 ("/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances"),
                 4,
+                id="test null states with no filter",
             ),
-            (
-                "test pool filter",
+            pytest.param(
                 [
                     {"pool": "test_pool_1"},
                     {"pool": "test_pool_2"},
@@ -496,9 +496,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     "TEST_DAG_RUN_ID/taskInstances?pool=test_pool_1,test_pool_2"
                 ),
                 2,
+                id="test pool filter",
             ),
-            (
-                "test pool filter ~",
+            pytest.param(
                 [
                     {"pool": "test_pool_1"},
                     {"pool": "test_pool_2"},
@@ -507,9 +507,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 "/api/v1/dags/~/dagRuns/~/taskInstances?pool=test_pool_1,test_pool_2",
                 2,
+                id="test pool filter ~",
             ),
-            (
-                "test queue filter",
+            pytest.param(
                 [
                     {"queue": "test_queue_1"},
                     {"queue": "test_queue_2"},
@@ -521,9 +521,9 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                     "/taskInstances?queue=test_queue_1,test_queue_2"
                 ),
                 2,
+                id="test queue filter",
             ),
-            (
-                "test queue filter ~",
+            pytest.param(
                 [
                     {"queue": "test_queue_1"},
                     {"queue": "test_queue_2"},
@@ -532,11 +532,11 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 "/api/v1/dags/~/dagRuns/~/taskInstances?queue=test_queue_1,test_queue_2",
                 2,
+                id="test queue filter ~",
             ),
-        ]
+        ],
     )
-    @provide_session
-    def test_should_respond_200(self, _, task_instances, update_extras, url, expected_ti, session):
+    def test_should_respond_200(self, task_instances, update_extras, url, expected_ti, session):
 
         self.create_task_instances(
             session,
@@ -576,10 +576,10 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
 
 
 class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "task_instances, update_extras, payload, expected_ti_count, username",
         [
-            (
-                "test queue filter",
+            pytest.param(
                 [
                     {"queue": "test_queue_1"},
                     {"queue": "test_queue_2"},
@@ -589,9 +589,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 {"queue": ["test_queue_1", "test_queue_2"]},
                 2,
                 "test",
+                id="test queue filter",
             ),
-            (
-                "test pool filter",
+            pytest.param(
                 [
                     {"pool": "test_pool_1"},
                     {"pool": "test_pool_2"},
@@ -601,9 +601,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 {"pool": ["test_pool_1", "test_pool_2"]},
                 2,
                 "test_dag_read_only",
+                id="test pool filter",
             ),
-            (
-                "test state filter",
+            pytest.param(
                 [
                     {"state": State.RUNNING},
                     {"state": State.QUEUED},
@@ -614,9 +614,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 {"state": ["running", "queued", "none"]},
                 3,
                 "test_task_read_only",
+                id="test state filter",
             ),
-            (
-                "test dag with null states",
+            pytest.param(
                 [
                     {"state": State.NONE},
                     {"state": State.NONE},
@@ -627,9 +627,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 {},
                 4,
                 "test_task_read_only",
+                id="test dag with null states",
             ),
-            (
-                "test duration filter",
+            pytest.param(
                 [
                     {"duration": 100},
                     {"duration": 150},
@@ -639,9 +639,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 {"duration_gte": 100, "duration_lte": 200},
                 3,
                 "test",
+                id="test duration filter",
             ),
-            (
-                "test end date filter",
+            pytest.param(
                 [
                     {"end_date": DEFAULT_DATETIME_1},
                     {"end_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -654,9 +654,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 },
                 2,
                 "test_task_read_only",
+                id="test end date filter",
             ),
-            (
-                "test start date filter",
+            pytest.param(
                 [
                     {"start_date": DEFAULT_DATETIME_1},
                     {"start_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -669,9 +669,9 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 },
                 2,
                 "test_dag_read_only",
+                id="test start date filter",
             ),
-            (
-                "with execution date filter",
+            pytest.param(
                 [
                     {"execution_date": DEFAULT_DATETIME_1},
                     {"execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1)},
@@ -682,17 +682,17 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
                 ],
                 False,
                 {
-                    "execution_date_gte": DEFAULT_DATETIME_1,
-                    "execution_date_lte": (DEFAULT_DATETIME_1 + dt.timedelta(days=2)),
+                    "execution_date_gte": DEFAULT_DATETIME_1.isoformat(),
+                    "execution_date_lte": (DEFAULT_DATETIME_1 + dt.timedelta(days=2)).isoformat(),
                 },
                 3,
                 "test",
+                id="with execution date filter",
             ),
-        ]
+        ],
     )
-    @provide_session
     def test_should_respond_200(
-        self, _, task_instances, update_extras, payload, expected_ti_count, username, session
+        self, task_instances, update_extras, payload, expected_ti_count, username, session
     ):
         self.create_task_instances(
             session,
@@ -1205,7 +1205,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "print_the_context",
-                "execution_date": DEFAULT_DATETIME_1,
+                "execution_date": DEFAULT_DATETIME_1.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,
@@ -1365,7 +1365,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "print_the_context",
-                "execution_date": DEFAULT_DATETIME_1,
+                "execution_date": DEFAULT_DATETIME_1.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,
@@ -1383,7 +1383,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "print_the_context",
-                "execution_date": DEFAULT_DATETIME_1,
+                "execution_date": DEFAULT_DATETIME_1.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,
@@ -1400,7 +1400,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "print_the_context",
-                "execution_date": DEFAULT_DATETIME_1,
+                "execution_date": DEFAULT_DATETIME_1.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,
@@ -1420,7 +1420,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "print_the_context",
-                "execution_date": date,
+                "execution_date": date.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,
@@ -1441,7 +1441,7 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             json={
                 "dry_run": True,
                 "task_id": "INVALID_TASK",
-                "execution_date": DEFAULT_DATETIME_1,
+                "execution_date": DEFAULT_DATETIME_1.isoformat(),
                 "include_upstream": True,
                 "include_downstream": True,
                 "include_future": True,


### PR DESCRIPTION
`app.json_encoder` has been deprecated in favor of
`app.json_provider_class`, and the former is being removed in Flask 2.3.
