### PR TITLE
Use temporary directories for tests remote aws loggers

### DIFF
--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -55,10 +55,10 @@ def logmock():
 class TestCloudwatchTaskHandler:
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template, tmpdir_factory):
+    def setup(self, create_log_template, tmp_path_factory):
         self.remote_log_group = 'log_group_name'
         self.region_name = 'us-west-2'
-        self.local_log_location = str(tmpdir_factory.mktemp("local-cloudwatch-log-location"))
+        self.local_log_location = str(tmp_path_factory.mktemp("local-cloudwatch-log-location"))
         create_log_template('{dag_id}/{task_id}/{execution_date}/{try_number}.log')
         self.cloudwatch_task_handler = CloudwatchTaskHandler(
             self.local_log_location,

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -55,10 +55,10 @@ def logmock():
 class TestCloudwatchTaskHandler:
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template):
+    def setup(self, create_log_template, tmpdir_factory):
         self.remote_log_group = 'log_group_name'
         self.region_name = 'us-west-2'
-        self.local_log_location = 'local/log/location'
+        self.local_log_location = str(tmpdir_factory.mktemp("local-cloudwatch-log-location"))
         create_log_template('{dag_id}/{task_id}/{execution_date}/{try_number}.log')
         self.cloudwatch_task_handler = CloudwatchTaskHandler(
             self.local_log_location,

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -51,11 +51,11 @@ def s3mock():
 class TestS3TaskHandler:
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template):
+    def setup(self, create_log_template, tmpdir_factory):
         self.remote_log_base = 's3://bucket/remote/log/location'
         self.remote_log_location = 's3://bucket/remote/log/location/1.log'
         self.remote_log_key = 'remote/log/location/1.log'
-        self.local_log_location = 'local/log/location'
+        self.local_log_location = str(tmpdir_factory.mktemp("local-s3-log-location"))
         create_log_template('{try_number}.log')
         self.s3_task_handler = S3TaskHandler(self.local_log_location, self.remote_log_base)
         # Vivfy the hook now with the config override
@@ -144,7 +144,8 @@ class TestS3TaskHandler:
             self.s3_task_handler.set_context(self.ti)
 
         assert self.s3_task_handler.upload_on_close
-        mock_open.assert_called_once_with(os.path.abspath('local/log/location/1.log'), 'w')
+        expected_log_location = os.path.abspath(os.path.join(self.local_log_location, '1.log'))
+        mock_open.assert_called_once_with(expected_log_location, 'w')
         mock_open().write.assert_not_called()
 
     def test_read(self):

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -51,11 +51,11 @@ def s3mock():
 class TestS3TaskHandler:
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     @pytest.fixture(autouse=True)
-    def setup(self, create_log_template, tmpdir_factory):
+    def setup(self, create_log_template, tmp_path_factory):
         self.remote_log_base = 's3://bucket/remote/log/location'
         self.remote_log_location = 's3://bucket/remote/log/location/1.log'
         self.remote_log_key = 'remote/log/location/1.log'
-        self.local_log_location = str(tmpdir_factory.mktemp("local-s3-log-location"))
+        self.local_log_location = str(tmp_path_factory.mktemp("local-s3-log-location"))
         create_log_template('{try_number}.log')
         self.s3_task_handler = S3TaskHandler(self.local_log_location, self.remote_log_base)
         # Vivfy the hook now with the config override
@@ -144,8 +144,7 @@ class TestS3TaskHandler:
             self.s3_task_handler.set_context(self.ti)
 
         assert self.s3_task_handler.upload_on_close
-        expected_log_location = os.path.abspath(os.path.join(self.local_log_location, '1.log'))
-        mock_open.assert_called_once_with(expected_log_location, 'w')
+        mock_open.assert_called_once_with(os.path.join(self.local_log_location, '1.log'), 'w')
         mock_open().write.assert_not_called()
 
     def test_read(self):


### PR DESCRIPTION
During execute tests in IDE I incidentally add in repo log file from tests Cloudwatch handlers. 
Right now it create files depend on current working directory.

Use native `pytest` temporary directory factory for test Remote AWS Tasks Logs Handlers for preventing this in the future

cc: @potiuk 