### PR TITLE
TESTING.rst: Fix typo in path

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -319,7 +319,7 @@ This enters breeze container.
 
 .. code-block:: bash
 
-    pytest tests/chart -n auto
+    pytest tests/charts -n auto
 
 This runs all chart tests using all processors you have available.
 


### PR DESCRIPTION
Critical because the path does not exist and results in error.

    ERROR: file or directory not found: tests/chart
