### PR TITLE
Fix outlet datasets not being detected on Mapped operators

### DIFF
--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -146,16 +146,14 @@ def prepare_lineage(func: T) -> T:
 
         self.log.debug("Preparing lineage inlets and outlets")
 
-        if isinstance(self._inlets, (str, AbstractOperator)) or attr.has(self._inlets):
-            self._inlets = [
-                self._inlets,
-            ]
+        if isinstance(self.inlets, (str, AbstractOperator)):
+            self.inlets = [self.inlets]
 
-        if self._inlets and isinstance(self._inlets, list):
+        if self.inlets and isinstance(self.inlets, list):
             # get task_ids that are specified as parameter and make sure they are upstream
             task_ids = (
-                {o for o in self._inlets if isinstance(o, str)}
-                .union(op.task_id for op in self._inlets if isinstance(op, AbstractOperator))
+                {o for o in self.inlets if isinstance(o, str)}
+                .union(op.task_id for op in self.inlets if isinstance(op, AbstractOperator))
                 .intersection(self.get_flat_relative_ids(upstream=True))
             )
 
@@ -171,17 +169,12 @@ def prepare_lineage(func: T) -> T:
             ]
 
             self.inlets.extend(_inlets)
-            self.inlets.extend(self._inlets)
 
-        elif self._inlets:
+        elif self.inlets:
             raise AttributeError("inlets is not a list, operator, string or attr annotated object")
 
-        if not isinstance(self._outlets, list):
-            self._outlets = [
-                self._outlets,
-            ]
-
-        self.outlets.extend(self._outlets)
+        if not isinstance(self.outlets, list):
+            self.outlets = [self.outlets]
 
         # render inlets and outlets
         self.inlets = [_render_object(i, context) for i in self.inlets if attr.has(i)]

--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -158,7 +158,7 @@ def prepare_lineage(func: T) -> T:
             )
 
             # pick up unique direct upstream task_ids if AUTO is specified
-            if AUTO.upper() in self._inlets or AUTO.lower() in self._inlets:
+            if AUTO.upper() in self.inlets or AUTO.lower() in self.inlets:
                 task_ids = task_ids.union(task_ids.symmetric_difference(self.upstream_task_ids))
 
             _inlets = self.xcom_pull(context, task_ids=task_ids, dag_id=self.dag_id, key=PIPELINE_OUTLETS)

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -105,6 +105,9 @@ class AbstractOperator(LoggingMixin, DAGNode):
     owner: str
     task_id: str
 
+    outlets: list
+    inlets: list
+
     HIDE_ATTRS_FROM_UI: ClassVar[FrozenSet[str]] = frozenset(
         (
             'log',

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -899,11 +899,8 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self.inlets: List = []
         self.outlets: List = []
 
-        self._inlets: List = []
-        self._outlets: List = []
-
         if inlets:
-            self._inlets = (
+            self.inlets = (
                 inlets
                 if isinstance(inlets, list)
                 else [
@@ -912,7 +909,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             )
 
         if outlets:
-            self._outlets = (
+            self.outlets = (
                 outlets
                 if isinstance(outlets, list)
                 else [
@@ -959,7 +956,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         be set as a downstream task of this operator.
         """
         if isinstance(other, BaseOperator):
-            if not self._outlets and not self.supports_lineage:
+            if not self.outlets and not self.supports_lineage:
                 raise ValueError("No outlets defined for this operator")
             other.add_inlets([self.task_id])
             self.set_downstream(other)
@@ -1015,19 +1012,19 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
 
     def add_inlets(self, inlets: Iterable[Any]):
         """Sets inlets to this operator"""
-        self._inlets.extend(inlets)
+        self.inlets.extend(inlets)
 
     def add_outlets(self, outlets: Iterable[Any]):
         """Defines the outlets of this operator"""
-        self._outlets.extend(outlets)
+        self.outlets.extend(outlets)
 
     def get_inlet_defs(self):
-        """:return: list of inlets defined for this operator"""
-        return self._inlets
+        """:meta private:"""
+        return self.inlets
 
     def get_outlet_defs(self):
-        """:return: list of outlets defined for this operator"""
-        return self._outlets
+        """:meta private:"""
+        return self.outlets
 
     def get_dag(self) -> "Optional[DAG]":
         return self._dag
@@ -1451,8 +1448,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
             cls.__serialized_fields = frozenset(
                 vars(BaseOperator(task_id='test')).keys()
                 - {
-                    'inlets',
-                    'outlets',
                     'upstream_task_ids',
                     'default_args',
                     'dag',

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2666,7 +2666,7 @@ class DAG(LoggingMixin):
                 dag_references.add(InletRef(dag.dag_id, dataset.uri))
                 input_datasets[DatasetModel.from_public(dataset)] = None
             for task in dag.tasks:
-                for obj in getattr(task, '_outlets', []):  # type: Dataset
+                for obj in task.outlets or []:
                     if isinstance(obj, Dataset):
                         outlet_references.add(OutletRef(task.dag_id, task.task_id, obj.uri))
                         outlet_datasets[DatasetModel.from_public(obj)] = None

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -505,13 +505,21 @@ class MappedOperator(AbstractOperator):
     def executor_config(self) -> dict:
         return self.partial_kwargs.get("executor_config", {})
 
-    @property
-    def inlets(self) -> Optional[Any]:
+    @property  # type: ignore[override]
+    def inlets(self) -> Optional[Any]:  # type: ignore[override]
         return self.partial_kwargs.get("inlets", None)
 
-    @property
-    def outlets(self) -> Optional[Any]:
+    @inlets.setter
+    def inlets(self, value):  # type: ignore[override]
+        self.partial_kwargs["inlets"] = value
+
+    @property  # type: ignore[override]
+    def outlets(self) -> Optional[Any]:  # type: ignore[override]
         return self.partial_kwargs.get("outlets", None)
+
+    @outlets.setter
+    def outlets(self, value):  # type: ignore[override]
+        self.partial_kwargs["outlets"] = value
 
     @property
     def doc(self) -> Optional[str]:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -574,7 +574,7 @@ class DependencyDetector:
                     dependency_id=task.task_id,
                 )
             )
-        for obj in getattr(task, '_outlets', []):
+        for obj in task.outlets or []:
             if isinstance(obj, Dataset):
                 deps.append(
                     DagDependency(
@@ -773,6 +773,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             # Todo: TODO: Remove in Airflow 3.0 when dummy operator is removed
             if k == "_is_dummy":
                 k = "_is_empty"
+
+            if k in ("_outlets", "_inlets"):
+                # `_outlets` -> `outlets`
+                k = k[1:]
             if k == "_downstream_task_ids":
                 # Upgrade from old format/name
                 k = "downstream_task_ids"
@@ -813,7 +817,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 v = _ExpandInputRef(v["type"], cls._deserialize(v["value"]))
             elif k in cls._decorated_fields or k not in op.get_serialized_fields():
                 v = cls._deserialize(v)
-            elif k in ("_outlets", "_inlets"):
+            elif k in ("outlets", "inlets"):
                 v = cls._deserialize(v)
 
             # else use v as it is

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -363,7 +363,7 @@ def dag_to_grid(dag, dag_runs, session):
                 'label': item.label,
                 'extra_links': item.extra_links,
                 'is_mapped': item.is_mapped,
-                'has_outlet_datasets': any(isinstance(i, Dataset) for i in getattr(item, "_outlets", [])),
+                'has_outlet_datasets': any(isinstance(i, Dataset) for i in (item.outlets or [])),
                 'operator': item.operator_name,
             }
 

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -44,7 +44,6 @@ class TestPapermillOperator(unittest.TestCase):
             dag=None,
         )
 
-        op.pre_execute(context={})  # Make sure to have the inlets
         op.execute(context={})
 
         mock_papermill.execute_notebook.assert_called_once_with(

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -143,9 +143,7 @@ serialized_simple_dag_ground_truth = {
                 "max_retry_delay": 600.0,
                 "sla": 100.0,
                 "downstream_task_ids": [],
-                "_inlets": [],
                 "_is_empty": False,
-                "_outlets": [],
                 "ui_color": "#f0ede4",
                 "ui_fgcolor": "#000",
                 "template_ext": ['.sh', '.bash'],
@@ -174,9 +172,7 @@ serialized_simple_dag_ground_truth = {
                 "max_retry_delay": 600.0,
                 "sla": 100.0,
                 "downstream_task_ids": [],
-                "_inlets": [],
                 "_is_empty": False,
-                "_outlets": [],
                 "_operator_extra_links": [{"tests.test_utils.mock_operators.CustomOpLink": {}}],
                 "ui_color": "#fff",
                 "ui_fgcolor": "#000",
@@ -1118,31 +1114,31 @@ class TestStringifiedDAGs:
         base_operator = BaseOperator(task_id="10")
         fields = {k: v for (k, v) in vars(base_operator).items() if k in BaseOperator.get_serialized_fields()}
         assert fields == {
-            '_inlets': [],
             '_log': base_operator.log,
-            '_outlets': [],
-            '_pre_execute_hook': None,
             '_post_execute_hook': None,
+            '_pre_execute_hook': None,
             'depends_on_past': False,
-            'ignore_first_depends_on_past': True,
-            'downstream_task_ids': set(),
             'do_xcom_push': True,
             'doc': None,
             'doc_json': None,
             'doc_md': None,
             'doc_rst': None,
             'doc_yaml': None,
+            'downstream_task_ids': set(),
             'email': None,
             'email_on_failure': True,
             'email_on_retry': True,
             'execution_timeout': None,
             'executor_config': {},
+            'ignore_first_depends_on_past': True,
+            'inlets': [],
             'max_active_tis_per_dag': None,
             'max_retry_delay': None,
             'on_execute_callback': None,
             'on_failure_callback': None,
             'on_retry_callback': None,
             'on_success_callback': None,
+            'outlets': [],
             'owner': 'airflow',
             'params': {},
             'pool': 'default_pool',
@@ -1437,7 +1433,12 @@ class TestStringifiedDAGs:
                 mode="reschedule",
             )
             BashOperator(task_id='dataset_writer', bash_command="echo hello", outlets=[d2, d3])
-            BashOperator(task_id='other_dataset_writer', bash_command="echo hello", outlets=[d4])
+
+            @dag.task(outlets=[d4])
+            def other_dataset_writer(x):
+                pass
+
+            other_dataset_writer.expand(x=[1, 2])
 
         dag = SerializedDAG.to_dict(dag)
         actual = sorted(dag['dag']['dag_dependencies'], key=lambda x: tuple(x.values()))
@@ -2236,8 +2237,6 @@ def test_dummy_operator_serde(is_inherit):
         '_task_module': 'tests.serialization.test_dag_serialization',
         '_task_type': 'MyDummyOperator',
         '_operator_name': 'MyDummyOperator',
-        '_outlets': [],
-        '_inlets': [],
         'downstream_task_ids': [],
         "pool": "default_pool",
         'task_id': 'my_task',


### PR DESCRIPTION
The "driving" factor of this was confusion/inconsistency over where
outlets are stored. For BaseOperator it was stored on `self._outlets`, (but
at execution time the `@prepare_lineage` decorator would munge it and
move things in to `self.outlets`.

But for MappedOperators a) this munging never took place, and b) it
stored it on `self.outlets`.

This PR removes the ambiguity and always stores inlets/outlets in the
"public" attribute.

As a "bonus" change, this doesn't store empty lists in the serialized
DAG for these two attributes

(There's still some other problem going on with datasets + mapped tasks when it comes to actually running the tasks though)