### PR TITLE
Add `custom_operator_name` attr to _BranchPythonDecoratedOperator

### DIFF
--- a/airflow/decorators/branch_python.py
+++ b/airflow/decorators/branch_python.py
@@ -45,6 +45,8 @@ class _BranchPythonDecoratedOperator(DecoratedOperator, BranchPythonOperator):
     # there are some cases we can't deepcopy the objects (e.g protobuf).
     shallow_copy_attrs: Sequence[str] = ('python_callable',)
 
+    custom_operator_name: str = "@task.branch"
+
     def __init__(
         self,
         **kwargs,


### PR DESCRIPTION
Related: #22834

The `@task.branch` decorator snuck in while #22834 was being worked on. Adding a custom operator name for tasks using this decorator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
