### PR TITLE
Add common-sql lower bound for common-sql

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -45,7 +45,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - boto3>=1.15.0
   # watchtower 3 has been released end Jan and introduced breaking change across the board that might
   # change logging behaviour:

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -33,7 +33,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - sqlalchemy-drill>=1.1.0
 
 integrations:

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -42,7 +42,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - hmsclient>=0.1.0
   - pandas>=0.17.1
   - pyhive[hive]>=0.6.0

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -35,7 +35,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   # pinotdb v0.1.1 may still work with older versions of Apache Pinot, but we've confirmed that it
   # causes a problem with newer versions.
   - pinotdb>0.1.2

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -40,7 +40,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - requests>=2.27,<3
   - databricks-sql-connector>=2.0.0, <3.0.0
   - aiohttp>=3.6.3, <4

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -42,7 +42,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - elasticsearch>7
   - elasticsearch-dbapi
   - elasticsearch-dsl>=5.0.0

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - pyexasol>=0.5.1
   - pandas>=0.17.1
 

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -36,7 +36,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - jaydebeapi>=1.1.1
 
 integrations:

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - pymssql>=2.1.5; platform_machine != "aarch64"
 
 integrations:

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - mysql-connector-python>=8.0.11; platform_machine != "aarch64"
   - mysqlclient>=1.3.6; platform_machine != "aarch64"
 

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -35,7 +35,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - pyodbc
 
 integrations:

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - oracledb>=1.0.0
 
 integrations:

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -40,7 +40,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - psycopg2-binary>=2.7.4
 
 integrations:

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -38,7 +38,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - presto-python-client>=0.8.2
   - pandas>=0.17.1
 

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - apache-airflow-providers-http
   - slack_sdk>=3.0.0
 

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -36,7 +36,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
 
 integrations:
   - integration-name: SQLite

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - pandas>=0.17.1
   - trino>=0.301.0
 

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -36,7 +36,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.2.0
-  - apache-airflow-providers-common-sql
+  - apache-airflow-providers-common-sql>=1.1.0
   - vertica-python>=0.5.1
 
 integrations:

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -17,7 +17,7 @@
   },
   "amazon": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "boto3>=1.15.0",
       "jsonpath_ng>=1.5.3",
@@ -60,7 +60,7 @@
   },
   "apache.drill": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "sqlalchemy-drill>=1.1.0"
     ],
@@ -89,7 +89,7 @@
   },
   "apache.hive": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "hmsclient>=0.1.0",
       "pandas>=0.17.1",
@@ -131,7 +131,7 @@
   },
   "apache.pinot": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pinotdb>0.1.2"
     ],
@@ -198,7 +198,7 @@
   "databricks": {
     "deps": [
       "aiohttp>=3.6.3, <4",
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "databricks-sql-connector>=2.0.0, <3.0.0",
       "requests>=2.27,<3"
@@ -250,7 +250,7 @@
   },
   "elasticsearch": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "elasticsearch-dbapi",
       "elasticsearch-dsl>=5.0.0",
@@ -262,7 +262,7 @@
   },
   "exasol": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pandas>=0.17.1",
       "pyexasol>=0.5.1"
@@ -397,7 +397,7 @@
   },
   "jdbc": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "jaydebeapi>=1.1.1"
     ],
@@ -445,7 +445,7 @@
   },
   "microsoft.mssql": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pymssql>=2.1.5; platform_machine != \"aarch64\""
     ],
@@ -476,7 +476,7 @@
   },
   "mysql": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "mysql-connector-python>=8.0.11; platform_machine != \"aarch64\"",
       "mysqlclient>=1.3.6; platform_machine != \"aarch64\""
@@ -498,7 +498,7 @@
   },
   "odbc": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pyodbc"
     ],
@@ -521,7 +521,7 @@
   },
   "oracle": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "oracledb>=1.0.0"
     ],
@@ -553,7 +553,7 @@
   },
   "postgres": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "psycopg2-binary>=2.7.4"
     ],
@@ -564,7 +564,7 @@
   },
   "presto": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pandas>=0.17.1",
       "presto-python-client>=0.8.2"
@@ -638,7 +638,7 @@
   },
   "slack": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow-providers-http",
       "apache-airflow>=2.2.0",
       "slack_sdk>=3.0.0"
@@ -662,7 +662,7 @@
   },
   "sqlite": {
     "deps": [
-      "apache-airflow-providers-common-sql"
+      "apache-airflow-providers-common-sql>=1.1.0"
     ],
     "cross-providers-deps": [
       "common.sql"
@@ -698,7 +698,7 @@
   },
   "trino": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "pandas>=0.17.1",
       "trino>=0.301.0"
@@ -710,7 +710,7 @@
   },
   "vertica": {
     "deps": [
-      "apache-airflow-providers-common-sql",
+      "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
       "vertica-python>=0.5.1"
     ],


### PR DESCRIPTION
There are some implicit dependencies for common-sql 1.1.0 version
that slipped through our understanding of cross-dependencies
(learning for the future). We are bumping dependencies of all the
packages that depend on common-sql, to reflect that

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
