### PR TITLE
Fix incorrect env_variables keyword

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -668,7 +668,7 @@ def get_env_variables_for_docker_commands(params: Union[ShellParams, BuildCiPara
     # Set constant defaults if not defined
     for variable in DOCKER_VARIABLE_CONSTANTS:
         constant_param_value = DOCKER_VARIABLE_CONSTANTS[variable]
-        if not env_variables.get(constant_param_value):
+        if not env_variables.get(variable):
             env_variables[variable] = str(constant_param_value)
     update_expected_environment_variables(env_variables)
     return env_variables


### PR DESCRIPTION
A little bug which cause breeze unable to overwrite any variables defined in `DOCKER_VARIABLE_CONSTANTS`. @potiuk 
