### PR TITLE
Find cross-group tasks in iter_mapped_dependants

### DIFF
--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -833,3 +833,24 @@ def test_render_template_fields_logging(
         assert expected_log in caplog.text
     if not_expected_log:
         assert not_expected_log not in caplog.text
+
+
+def test_find_mapped_dependants_in_another_group(dag_maker):
+    from airflow.utils.task_group import TaskGroup
+
+    @task_decorator
+    def gen(x):
+        return list(range(x))
+
+    @task_decorator
+    def add(x, y):
+        return x + y
+
+    with dag_maker():
+        with TaskGroup(group_id="g1"):
+            gen_result = gen(3)
+        with TaskGroup(group_id="g2"):
+            add_result = add.partial(y=1).expand(x=gen_result)
+
+    dependants = list(gen_result.operator.iter_mapped_dependants())
+    assert dependants == [add_result.operator]


### PR DESCRIPTION
Fix #25775

As explained in the issue, this is caused by our dependant detection code not correctly look up tasks across groups. Since looking across group requires the task to know about its root group, the lookup logic has been moved from TaskMixin to AbstractOperator. We only use the logic with tasks right now, so it’s OK.