### PR TITLE
Let timetables control generated run_ids.

### DIFF
--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -20,8 +20,6 @@ import json
 from datetime import datetime
 from typing import List, Optional, Union
 
-import pendulum
-
 from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.utils import timezone
@@ -67,9 +65,11 @@ def _trigger_dag(
                 f"The execution_date [{execution_date.isoformat()}] should be >= start_date "
                 f"[{min_dag_start_date.isoformat()}] from DAG's default_args"
             )
+    logical_date = timezone.coerce_datetime(execution_date)
 
+    data_interval = dag.timetable.infer_manual_data_interval(run_after=logical_date)
     run_id = run_id or dag.timetable.generate_run_id(
-        run_type=DagRunType.MANUAL, logical_date=execution_date, data_interval=None
+        run_type=DagRunType.MANUAL, logical_date=logical_date, data_interval=data_interval
     )
     dag_run = DagRun.find_duplicate(dag_id=dag_id, execution_date=execution_date, run_id=run_id)
 
@@ -92,9 +92,7 @@ def _trigger_dag(
             conf=run_conf,
             external_trigger=True,
             dag_hash=dag_bag.dags_hash.get(dag_id),
-            data_interval=_dag.timetable.infer_manual_data_interval(
-                run_after=pendulum.instance(execution_date)
-            ),
+            data_interval=data_interval,
         )
         dag_runs.append(dag_run)
 

--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -68,7 +68,9 @@ def _trigger_dag(
                 f"[{min_dag_start_date.isoformat()}] from DAG's default_args"
             )
 
-    run_id = run_id or DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
+    run_id = run_id or dag.timetable.generate_run_id(
+        run_type=DagRunType.MANUAL, logical_date=execution_date, data_interval=None
+    )
     dag_run = DagRun.find_duplicate(dag_id=dag_id, execution_date=execution_date, run_id=run_id)
 
     if dag_run:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -409,7 +409,8 @@ class DagRun(Base, LoggingMixin):
     @staticmethod
     def generate_run_id(run_type: DagRunType, execution_date: datetime) -> str:
         """Generate Run ID based on Run Type and Execution Date"""
-        return f"{run_type}__{execution_date.isoformat()}"
+        # _Ensure_ run_type is a DagRunType, not just a string from user code
+        return DagRunType(run_type).generate_run_id(execution_date)
 
     @provide_session
     def get_task_instances(

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -212,6 +212,4 @@ class Timetable(Protocol):
         data_interval: Optional[DataInterval],
         **extra,
     ) -> str:
-        from airflow.models.dagrun import DagRun
-
-        return DagRun.generate_run_id(run_type, logical_date)
+        return run_type.generate_run_id(logical_date)

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -15,11 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Optional, Sequence
 
 from pendulum import DateTime
 
 from airflow.typing_compat import Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from airflow.utils.types import DagRunType
 
 
 class DataInterval(NamedTuple):
@@ -200,3 +203,15 @@ class Timetable(Protocol):
             a DagRunInfo object when asked at another time.
         """
         raise NotImplementedError()
+
+    def generate_run_id(
+        self,
+        *,
+        run_type: "DagRunType",
+        logical_date: DateTime,
+        data_interval: Optional[DataInterval],
+        **extra,
+    ) -> str:
+        from airflow.models.dagrun import DagRun
+
+        return DagRun.generate_run_id(run_type, logical_date)

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -15,9 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 import enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from airflow.typing_compat import TypedDict
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class ArgNotSet:
@@ -49,6 +52,9 @@ class DagRunType(str, enum.Enum):
 
     def __str__(self) -> str:
         return self.value
+
+    def generate_run_id(self, logical_date: "datetime") -> str:
+        return f"{self}__{logical_date.isoformat()}"
 
     @staticmethod
     def from_run_id(run_id: str) -> "DagRunType":

--- a/docs/apache-airflow/howto/timetable.rst
+++ b/docs/apache-airflow/howto/timetable.rst
@@ -323,3 +323,31 @@ The *i* icon  would show,  ``Schedule: after each workday, at 08:00:00``.
 .. seealso::
     Module :mod:`airflow.timetables.interval`
         check ``CronDataIntervalTimetable`` description implementation which provides comprehensive cron description in UI.
+
+Changing generated ``run_id``
+-----------------------------
+
+.. versionadded:: 2.4
+
+Since Airflow 2.4, Timetables are also responsible for generating the ``run_id`` for DagRuns.
+
+For example to have the Run ID show a "human friendly" date of when the run started (that is, the end of the data interval, rather then the start which is the date currently used) you could add a method like this to a custom timetable:
+
+.. code-block:: python
+
+    def generate_run_id(
+        self,
+        *,
+        run_type: DagRunType,
+        logical_date: DateTime,
+        data_interval: DataInterval | None,
+        **extra,
+    ) -> str:
+        if run_type == DagRunType.SCHEDULED and data_interval:
+            return data_interval.end.format("YYYY-MM-DD dddd")
+        return super().generate_run_id(
+            run_type=run_type, logical_date=logical_date, data_interval=data_interval, **extra
+        )
+
+
+Remember that the RunID is limited to 250 characters, and must be unique within a DAG.

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2728,3 +2728,20 @@ def test_get_dataset_triggered_next_run_info(dag_maker):
     info = get_dataset_triggered_next_run_info([dag2.dag_id, dag3.dag_id], session=session)
     assert "1 of 2 datasets updated" == info[dag2.dag_id]
     assert "1 of 3 datasets updated" == info[dag3.dag_id]
+
+
+def test_dag_uses_timetable_for_run_id(session):
+    class CustomRunIdTimetable(Timetable):
+        def generate_run_id(self, *, run_type, logical_date, data_interval, **extra) -> str:
+            return 'abc'
+
+    dag = DAG(dag_id='test', start_date=DEFAULT_DATE, schedule=CustomRunIdTimetable())
+
+    dag_run = dag.create_dagrun(
+        run_type=DagRunType.MANUAL,
+        state=DagRunState.QUEUED,
+        execution_date=DEFAULT_DATE,
+        data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+    )
+
+    assert dag_run.run_id == 'abc'


### PR DESCRIPTION
Rather than a cluster policy level setting I have decided to add this to the Timetable as that felt like a more natural fit to me (Timetables are responsible for saying when a DagRun should be created, extending that to also make it say _what_ the run should be called felt like a natural etension to me.)

This isn't _quite_ as easy to control as the OP asked for (where you could just subclass `DAG` and add a method; timetables have to be "registered" via a plugin, but that can be in-tree).

Closes #21923
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).