### PR TITLE
Implement `EmrEksCreateClusterOperator`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -197,6 +197,29 @@ class EmrContainerHook(AwsBaseHook):
         super().__init__(client_type="emr-containers", *args, **kwargs)  # type: ignore
         self.virtual_cluster_id = virtual_cluster_id
 
+    def create_emr_on_eks_cluster(
+        self, virtual_cluster_name: str, eks_cluster_name: str, eks_namespace: str
+    ) -> str:
+        response = self.conn.create_virtual_cluster(
+            name=virtual_cluster_name,
+            containerProvider={
+                "id": eks_cluster_name,
+                "type": "EKS",
+                "info": {"eksInfo": {"namespace": eks_namespace}},
+            },
+        )
+
+        print(response)
+
+        if response['ResponseMetadata']['HTTPStatusCode'] != 200:
+            raise AirflowException(f'Create EMR EKS Cluster failed: {response}')
+        else:
+            self.log.info(
+                "Create EMR EKS Cluster success - virtual cluster id %s",
+                response['id'],
+            )
+            return response['id']
+
     def submit_job(
         self,
         name: str,

--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -214,8 +214,6 @@ class EmrContainerHook(AwsBaseHook):
             tags=tags or {},
         )
 
-        print(response)
-
         if response['ResponseMetadata']['HTTPStatusCode'] != 200:
             raise AirflowException(f'Create EMR EKS Cluster failed: {response}')
         else:

--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -198,7 +198,11 @@ class EmrContainerHook(AwsBaseHook):
         self.virtual_cluster_id = virtual_cluster_id
 
     def create_emr_on_eks_cluster(
-        self, virtual_cluster_name: str, eks_cluster_name: str, eks_namespace: str
+        self,
+        virtual_cluster_name: str,
+        eks_cluster_name: str,
+        eks_namespace: str,
+        tags: Optional[dict] = None,
     ) -> str:
         response = self.conn.create_virtual_cluster(
             name=virtual_cluster_name,
@@ -207,6 +211,7 @@ class EmrContainerHook(AwsBaseHook):
                 "type": "EKS",
                 "info": {"eksInfo": {"namespace": eks_namespace}},
             },
+            tags=tags or {},
         )
 
         print(response)

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -126,33 +126,21 @@ class EmrEksCreateClusterOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:EmrEksCreateClusterOperator`
 
-    :param name: The name of the job run.
-    :param virtual_cluster_id: The EMR on EKS virtual cluster ID
-    :param execution_role_arn: The IAM role ARN associated with the job run.
-    :param release_label: The Amazon EMR release version to use for the job run.
-    :param job_driver: Job configuration details, e.g. the Spark job parameters.
-    :param configuration_overrides: The configuration overrides for the job run,
-        specifically either application configuration or monitoring configuration.
-    :param client_request_token: The client idempotency token of the job run request.
-        Use this if you want to specify a unique ID to prevent two jobs from getting started.
-        If no token is provided, a UUIDv4 token will be generated for you.
+    :param virtual_cluster_name: The name of the EMR EKS virtual cluster to create.
+    :param eks_cluster_name: The EKS cluster used by the EMR virtual cluster.
+    :param eks_namespace: namespace used by the EKS cluster.
+    :param virtual_cluster_id: The EMR on EKS virtual cluster id.
     :param aws_conn_id: The Airflow connection used for AWS credentials.
-    :param wait_for_completion: Whether or not to wait in the operator for the job to complete.
-    :param poll_interval: Time (in seconds) to wait between two consecutive calls to check query status on EMR
-    :param max_tries: Maximum number of times to wait for the job run to finish.
-        Defaults to None, which will poll until the job is *not* in a pending, submitted, or running state.
-    :param tags: The tags assigned to job runs.
+    :param tags: The tags assigned to created cluster.
         Defaults to None
     """
 
-    # template_fields: Sequence[str] = (
-    #     "name",
-    #     "virtual_cluster_id",
-    #     "execution_role_arn",
-    #     "release_label",
-    #     "job_driver",
-    # )
-    # ui_color = "#f9c915"
+    template_fields: Sequence[str] = (
+        "virtual_cluster_name",
+        "eks_cluster_name",
+        "eks_namespace",
+    )
+    ui_color = "#f9c915"
 
     def __init__(
         self,
@@ -160,17 +148,8 @@ class EmrEksCreateClusterOperator(BaseOperator):
         virtual_cluster_name: str,
         eks_cluster_name: str,
         eks_namespace: str,
-        # name: str,
         virtual_cluster_id: str = '',
-        # execution_role_arn: str,
-        # release_label: str,
-        # job_driver: dict,
-        # configuration_overrides: Optional[dict] = None,
-        # client_request_token: Optional[str] = None,
         aws_conn_id: str = "aws_default",
-        # wait_for_completion: bool = True,
-        # poll_interval: int = 30,
-        # max_tries: Optional[int] = None,
         tags: Optional[dict] = None,
         **kwargs: Any,
     ) -> None:
@@ -178,19 +157,9 @@ class EmrEksCreateClusterOperator(BaseOperator):
         self.virtual_cluster_name = virtual_cluster_name
         self.eks_cluster_name = eks_cluster_name
         self.eks_namespace = eks_namespace
-        # self.name = name
         self.virtual_cluster_id = virtual_cluster_id
-        # self.execution_role_arn = execution_role_arn
-        # self.release_label = release_label
-        # self.job_driver = job_driver
-        # self.configuration_overrides = configuration_overrides or {}
         self.aws_conn_id = aws_conn_id
-        # self.client_request_token = client_request_token or str(uuid4())
-        # self.wait_for_completion = wait_for_completion
-        # self.poll_interval = poll_interval
-        # self.max_tries = max_tries
         self.tags = tags
-        # self.job_id: Optional[str] = None
 
     @cached_property
     def hook(self) -> EmrContainerHook:
@@ -198,12 +167,10 @@ class EmrEksCreateClusterOperator(BaseOperator):
         return EmrContainerHook(self.aws_conn_id)
 
     def execute(self, context: 'Context') -> Optional[str]:
-        """Create EMR EKS Cluster"""
+        """Create EMR on EKS virtual Cluster"""
         self.virtual_cluster_id = self.hook.create_emr_on_eks_cluster(
             self.virtual_cluster_name, self.eks_cluster_name, self.eks_namespace, self.tags
         )
-        print("Hi Phani, the cluster created is...", self.virtual_cluster_id)
-
         return self.virtual_cluster_id
 
 

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -171,7 +171,7 @@ class EmrEksCreateClusterOperator(BaseOperator):
         # wait_for_completion: bool = True,
         # poll_interval: int = 30,
         # max_tries: Optional[int] = None,
-        # tags: Optional[dict] = None,
+        tags: Optional[dict] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -189,7 +189,7 @@ class EmrEksCreateClusterOperator(BaseOperator):
         # self.wait_for_completion = wait_for_completion
         # self.poll_interval = poll_interval
         # self.max_tries = max_tries
-        # self.tags = tags
+        self.tags = tags
         # self.job_id: Optional[str] = None
 
     @cached_property
@@ -200,25 +200,8 @@ class EmrEksCreateClusterOperator(BaseOperator):
     def execute(self, context: 'Context') -> Optional[str]:
         """Create EMR EKS Cluster"""
         self.virtual_cluster_id = self.hook.create_emr_on_eks_cluster(
-            self.virtual_cluster_name,
-            self.eks_cluster_name,
-            self.eks_namespace,
+            self.virtual_cluster_name, self.eks_cluster_name, self.eks_namespace, self.tags
         )
-        # if self.wait_for_completion:
-        #     query_status = self.hook.poll_query_status(self.job_id, self.max_tries, self.poll_interval)
-        #
-        #     if query_status in EmrContainerHook.FAILURE_STATES:
-        #         error_message = self.hook.get_job_failure_reason(self.job_id)
-        #         raise AirflowException(
-        #             f"EMR Containers job failed. Final state is {query_status}. "
-        #             f"query_execution_id is {self.job_id}. Error: {error_message}"
-        #         )
-        #     elif not query_status or query_status in EmrContainerHook.INTERMEDIATE_STATES:
-        #         raise AirflowException(
-        #             f"Final state of EMR Containers job is {query_status}. "
-        #             f"Max tries of poll status exceeded, query_execution_id is {self.job_id}."
-        #         )
-
         print("Hi Phani, the cluster created is...", self.virtual_cluster_id)
 
         return self.virtual_cluster_id

--- a/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
@@ -31,7 +31,32 @@ Prerequisite Tasks
 Operators
 ---------
 
+
+.. _howto/operator:EmrEksCreateClusterOperator:
+
+
+Create an Amazon EMR EKS virtual cluster
+========================================
+
+
+The ``EmrEksCreateClusterOperator`` will create an Amazon EMR on EKS virtual cluster
+The example DAG below shows how to create an EMR on EKS virtual cluster.
+
+To create an Amazon EMR cluster on Amazon EKS, you need to specify a virtual cluster name,
+the eks cluster that you would like to use , and an eks namespace.
+
+Refer to the `EMR on EKS Development guide <https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/virtual-cluster.html>`__
+for more details.
+
+.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr_eks.py
+    :language: python
+    :start-after: [START howto_operator_emr_eks_create_cluster]
+    :end-before: [END howto_operator_emr_eks_create_cluster]
+
+
+
 .. _howto/operator:EmrContainerOperator:
+
 
 Submit a job to an Amazon EMR virtual cluster
 =============================================
@@ -71,6 +96,7 @@ that gets passed to the operator with the ``aws_conn_id`` parameter. The operato
     :dedent: 4
     :start-after: [START howto_operator_emr_container]
     :end-before: [END howto_operator_emr_container]
+
 
 Sensors
 -------

--- a/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
@@ -39,7 +39,7 @@ Create an Amazon EMR EKS virtual cluster
 ========================================
 
 
-The ``EmrEksCreateClusterOperator`` will create an Amazon EMR on EKS virtual cluster
+The ``EmrEksCreateClusterOperator`` will create an Amazon EMR on EKS virtual cluster.
 The example DAG below shows how to create an EMR on EKS virtual cluster.
 
 To create an Amazon EMR cluster on Amazon EKS, you need to specify a virtual cluster name,

--- a/tests/providers/amazon/aws/hooks/test_emr_containers.py
+++ b/tests/providers/amazon/aws/hooks/test_emr_containers.py
@@ -28,6 +28,8 @@ SUBMIT_JOB_SUCCESS_RETURN = {
     'virtualClusterId': 'vc1234',
 }
 
+CREATE_EMR_ON_EKS_CLUSTER_RETURN = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'id': 'vc1234'}
+
 JOB1_RUN_DESCRIPTION = {
     'jobRun': {
         'id': 'job123456',
@@ -52,6 +54,21 @@ class TestEmrContainerHook(unittest.TestCase):
     def test_init(self):
         assert self.emr_containers.aws_conn_id == 'aws_default'
         assert self.emr_containers.virtual_cluster_id == 'vc1234'
+
+    @mock.patch("boto3.session.Session")
+    def test_create_emr_on_eks_cluster(self, mock_session):
+        emr_client_mock = mock.MagicMock()
+        emr_client_mock.create_virtual_cluster.return_value = CREATE_EMR_ON_EKS_CLUSTER_RETURN
+        emr_session_mock = mock.MagicMock()
+        emr_session_mock.client.return_value = emr_client_mock
+        mock_session.return_value = emr_session_mock
+
+        emr_on_eks_create_cluster_response = self.emr_containers.create_emr_on_eks_cluster(
+            virtual_cluster_name="test_virtual_cluster",
+            eks_cluster_name="test_eks_cluster",
+            eks_namespace="test_eks_namespace",
+        )
+        assert emr_on_eks_create_cluster_response == "vc1234"
 
     @mock.patch("boto3.session.Session")
     def test_submit_job(self, mock_session):

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -24,13 +24,15 @@ import pytest
 from airflow import configuration
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
-from airflow.providers.amazon.aws.operators.emr import EmrContainerOperator
+from airflow.providers.amazon.aws.operators.emr import EmrContainerOperator, EmrEksCreateClusterOperator
 
 SUBMIT_JOB_SUCCESS_RETURN = {
     'ResponseMetadata': {'HTTPStatusCode': 200},
     'id': 'job123456',
     'virtualClusterId': 'vc1234',
 }
+
+CREATE_EMR_ON_EKS_CLUSTER_RETURN = {'ResponseMetadata': {'HTTPStatusCode': 200}, 'id': 'vc1234'}
 
 GENERATED_UUID = '800647a9-adda-4237-94e6-f542c85fa55b'
 
@@ -137,3 +139,42 @@ class TestEmrContainerOperator(unittest.TestCase):
             assert mock_check_query_status.call_count == 3
             assert 'Final state of EMR Containers job is SUBMITTED' in str(ctx.value)
             assert 'Max tries of poll status exceeded' in str(ctx.value)
+
+
+class TestEmrEksCreateClusterOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.amazon.aws.hooks.emr.EmrContainerHook')
+    def setUp(self, emr_hook_mock):
+        configuration.load_test_config()
+
+        self.emr_hook_mock = emr_hook_mock
+        self.emr_container = EmrEksCreateClusterOperator(
+            task_id='start_cluster',
+            virtual_cluster_name="test_virtual_cluster",
+            eks_cluster_name="test_eks_cluster",
+            eks_namespace="test_eks_namespace",
+            tags={},
+        )
+
+    @mock.patch.object(EmrContainerHook, 'create_emr_on_eks_cluster')
+    def test_emr_on_eks_execute_without_failure(self, mock_create_emr_on_eks_cluster):
+        mock_create_emr_on_eks_cluster.return_value = "vc1234"
+
+        self.emr_container.execute(None)
+
+        mock_create_emr_on_eks_cluster.assert_called_once_with(
+            'test_virtual_cluster', 'test_eks_cluster', 'test_eks_namespace', {}
+        )
+        assert self.emr_container.virtual_cluster_name == 'test_virtual_cluster'
+
+    @mock.patch.object(EmrContainerHook, 'create_emr_on_eks_cluster')
+    def test_emr_on_eks_execute_with_failure(self, mock_create_emr_on_eks_cluster):
+        expected_exception_msg = (
+            "An error occurred (ValidationException) when calling the "
+            "CreateVirtualCluster "
+            "operation:"
+            "A virtual cluster already exists in the given namespace"
+        )
+        mock_create_emr_on_eks_cluster.side_effect = AirflowException(expected_exception_msg)
+        with pytest.raises(AirflowException) as ctx:
+            self.emr_container.execute(None)
+        assert expected_exception_msg in str(ctx.value)


### PR DESCRIPTION
This PR adds the implementation for a new operator called `EmrEksCreateClusterOperator` , which allows the users the ability to create an Amazon EMR on EKS virtual cluster from Airflow. Currently we only have the ability to submit jobs on EMR EKS virtual clusters.

cc @kaxil @ashb 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
