### PR TITLE
Reduce operator_name dupe in serialised JSON

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -857,7 +857,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
             op_data = {k: v for k, v in encoded_op.items() if k in BaseOperator.get_serialized_fields()}
             try:
                 operator_name = encoded_op["_operator_name"]
-            except:
+            except KeyError:
                 operator_name = encoded_op["_task_type"]
             op = MappedOperator(
                 operator_class=op_data,

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -325,7 +325,13 @@ class BaseSerialization:
             if cls._is_excluded(value, key, object_to_serialize):
                 continue
 
-            if key in decorated_fields:
+            if key == '_operator_name':
+                # when operator_name matches task_type, we can remove
+                # it to reduce the JSON payload
+                task_type = getattr(object_to_serialize, '_task_type', None)
+                if value != task_type:
+                    serialized_object[key] = cls._serialize(value)
+            elif key in decorated_fields:
                 serialized_object[key] = cls._serialize(value)
             elif key == "timetable" and value is not None:
                 serialized_object[key] = _encode_timetable(value)
@@ -684,7 +690,8 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         serialize_op = cls.serialize_to_json(op, cls._decorated_fields)
         serialize_op['_task_type'] = getattr(op, "_task_type", type(op).__name__)
         serialize_op['_task_module'] = getattr(op, "_task_module", type(op).__module__)
-        serialize_op['_operator_name'] = op.operator_name
+        if op.operator_name != serialize_op['_task_type']:
+            serialize_op['_operator_name'] = op.operator_name
 
         # Used to determine if an Operator is inherited from EmptyOperator
         serialize_op['_is_empty'] = op.inherits_from_empty_operator
@@ -744,6 +751,9 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
         # Extra Operator Links defined in Plugins
         op_extra_links_from_plugin = {}
+
+        if "_operator_name" not in encoded_op:
+            encoded_op["_operator_name"] = encoded_op["_task_type"]
 
         # We don't want to load Extra Operator links in Scheduler
         if cls._load_operator_extra_links:
@@ -845,6 +855,10 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         if encoded_op.get("_is_mapped", False):
             # Most of these will be loaded later, these are just some stand-ins.
             op_data = {k: v for k, v in encoded_op.items() if k in BaseOperator.get_serialized_fields()}
+            try:
+                operator_name = encoded_op["_operator_name"]
+            except:
+                operator_name = encoded_op["_task_type"]
             op = MappedOperator(
                 operator_class=op_data,
                 expand_input=EXPAND_INPUT_EMPTY,
@@ -861,7 +875,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 is_empty=False,
                 task_module=encoded_op["_task_module"],
                 task_type=encoded_op["_task_type"],
-                operator_name=encoded_op["_operator_name"],
+                operator_name=operator_name,
                 dag=None,
                 task_group=None,
                 start_date=None,

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -151,7 +151,6 @@ serialized_simple_dag_ground_truth = {
                 "template_fields_renderers": {'bash_command': 'bash', 'env': 'json'},
                 "bash_command": "echo {{ task.task_id }}",
                 "_task_type": "BashOperator",
-                "_operator_name": "BashOperator",
                 "_task_module": "airflow.operators.bash",
                 "pool": "default_pool",
                 "executor_config": {
@@ -1854,7 +1853,6 @@ def test_operator_expand_serde():
         '_is_mapped': True,
         '_task_module': 'airflow.operators.bash',
         '_task_type': 'BashOperator',
-        '_operator_name': 'BashOperator',
         'downstream_task_ids': [],
         'expand_input': {
             "type": "dict-of-lists",
@@ -1886,7 +1884,6 @@ def test_operator_expand_serde():
 
     assert op.operator_class == {
         '_task_type': 'BashOperator',
-        '_operator_name': 'BashOperator',
         'downstream_task_ids': [],
         'task_id': 'a',
         'template_ext': ['.sh', '.bash'],
@@ -1913,7 +1910,6 @@ def test_operator_expand_xcomarg_serde():
         '_is_mapped': True,
         '_task_module': 'tests.test_utils.mock_operators',
         '_task_type': 'MockOperator',
-        '_operator_name': 'MockOperator',
         'downstream_task_ids': [],
         'expand_input': {
             "type": "dict-of-lists",
@@ -1963,7 +1959,6 @@ def test_operator_expand_kwargs_serde(strict):
         '_is_mapped': True,
         '_task_module': 'tests.test_utils.mock_operators',
         '_task_type': 'MockOperator',
-        '_operator_name': 'MockOperator',
         'downstream_task_ids': [],
         'expand_input': {
             "type": "list-of-dicts",
@@ -2236,7 +2231,6 @@ def test_dummy_operator_serde(is_inherit):
         '_is_empty': is_inherit,
         '_task_module': 'tests.serialization.test_dag_serialization',
         '_task_type': 'MyDummyOperator',
-        '_operator_name': 'MyDummyOperator',
         'downstream_task_ids': [],
         "pool": "default_pool",
         'task_id': 'my_task',


### PR DESCRIPTION
Often the operator_name will match the task_type, so this can be
removed from the JSON serialisation to save some bytes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
