### PR TITLE
Don't use Pandas for SQLTableCheckOperator

### DIFF
--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -20,7 +20,6 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
-import pandas as pd
 import pytest
 
 from airflow import DAG
@@ -47,7 +46,7 @@ class MockHook:
     def get_first(self):
         return
 
-    def get_pandas_df(self):
+    def get_records(self):
         return
 
 
@@ -120,32 +119,22 @@ class TestTableCheckOperator:
     }
 
     def _construct_operator(self, monkeypatch, checks, return_df):
-        def get_pandas_df_return(*arg):
+        def get_records(*arg):
             return return_df
 
         operator = SQLTableCheckOperator(task_id="test_task", table="test_table", checks=checks)
         monkeypatch.setattr(operator, "get_db_hook", _get_mock_db_hook)
-        monkeypatch.setattr(MockHook, "get_pandas_df", get_pandas_df_return)
+        monkeypatch.setattr(MockHook, "get_records", get_records)
         return operator
 
     def test_pass_all_checks_check(self, monkeypatch):
-        df = pd.DataFrame(
-            data={
-                "check_name": ["row_count_check", "column_sum_check"],
-                "check_result": [
-                    "1",
-                    "y",
-                ],
-            }
-        )
-        operator = self._construct_operator(monkeypatch, self.checks, df)
+        records = [('row_count_check', 1), ('column_sum_check', 'y')]
+        operator = self._construct_operator(monkeypatch, self.checks, records)
         operator.execute(context=MagicMock())
 
     def test_fail_all_checks_check(self, monkeypatch):
-        df = pd.DataFrame(
-            data={"check_name": ["row_count_check", "column_sum_check"], "check_result": ["0", "n"]}
-        )
-        operator = self._construct_operator(monkeypatch, self.checks, df)
+        records = [('row_count_check', 0), ('column_sum_check', 'n')]
+        operator = self._construct_operator(monkeypatch, self.checks, records)
         with pytest.raises(AirflowException):
             operator.execute(context=MagicMock())
 


### PR DESCRIPTION
Pandas is an optional extra for common-sql provider, so _forcing_ it for
a query that is going to return a couple of rows is not a good idea.

(We didn't notice this in CI as our tests have everyting installed)
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).