### PR TITLE
Add a way to import Airflow without side-effects

### DIFF
--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -46,7 +46,8 @@ __all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39', 'PY310
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
 # Perform side-effects unless someone has explicitly opted out before import
-if not os.environ.get("AIRFLOW__AS_LIBRARY", None):
+# WARNING: DO NOT USE THIS UNLESS YOU REALLY KNOW WHAT YOU'RE DOING.
+if not os.environ.get("_AIRFLOW__AS_LIBRARY", None):
     settings.initialize()
 
 login: Optional[Callable] = None

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -29,6 +29,7 @@ isort:skip_file
 
 # flake8: noqa: F401
 
+import os
 import sys
 from typing import Callable, Optional
 
@@ -44,7 +45,9 @@ __all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39', 'PY310
 # lib.)
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 
-settings.initialize()
+# Perform side-effects unless someone has explicitly opted out before import
+if not os.environ.get("AIRFLOW__AS_LIBRARY", None):
+    settings.initialize()
 
 login: Optional[Callable] = None
 


### PR DESCRIPTION
I know it's been a long-standing issue that it should be possible to import Airflow as a library without side-effects, and while I think the ultimate fix for this is to go through and steadily remove the need to call `settings.initalize()` in `__init__.py`, I am currently working on a project where I would really like to use Airflow without it doing strange things to logging, sys.path, or atexit.

As such, this PR wraps the import side-effect in a simple environment variable check that code can use to disable the side-effects for now, while we slowly try and progress towards a "cleaner" solution. Without this, I am having to dynamically modify the source code of `__init__.py` in an import hook, and nobody wants that!

I don't believe it's possible to write tests for this as Airflow is already imported when tests are running, but if you can think of a way, let me know and I'll have a go. The environment variable name is also up for consideration - I just picked something that looked a bit like a setting, but we can deliberately make it not look like that if we want.