### PR TITLE
Remove faulthandler_timeout

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,6 @@ norecursedirs =
     tests/test_utils
     tests/dags_corrupted
     tests/dags
-faulthandler_timeout = 480
 log_level = INFO
 filterwarnings =
     error::pytest.PytestCollectionWarning


### PR DESCRIPTION
More narrow and specific timeouts are already defined [here](https://github.com/apache/airflow/blob/main/scripts/docker/entrypoint_ci.sh#L260-L262). As such, `faulthandler_timeout` does not add any particular value and make test lasting more than 8 minutes fail.