### PR TITLE
Fix RDS system test

### DIFF
--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -278,7 +278,7 @@ class RdsCopyDbSnapshotOperator(RdsBaseOperator):
             self._await_status(
                 item_type,
                 self.target_db_snapshot_identifier,
-                wait_statuses=['copying'],
+                wait_statuses=['creating', 'copying'],
                 ok_statuses=['available'],
             )
         return copy_response


### PR DESCRIPTION
The status of the snapshot can be `creating` and `copying`. I ran into that issue while running the system test.

[See doc](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.create_db_cluster_snapshot)