### PR TITLE
Update code examples from "classic" operators to taskflow

### DIFF
--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -22,8 +22,11 @@
 PythonOperator
 ==============
 
-Use the :class:`~airflow.operators.python.PythonOperator` to execute
-Python callables.
+Use the ``@task`` decorator to execute Python callables.
+
+.. warning::
+    Previous versions of Airflow required using :class:`~airflow.operators.python.PythonOperator`
+    to execute Python callables. The ``@task`` decorater is now the recommended method.
 
 .. exampleinclude:: /../../airflow/example_dags/example_python_operator.py
     :language: python
@@ -34,8 +37,8 @@ Python callables.
 Passing in arguments
 ^^^^^^^^^^^^^^^^^^^^
 
-Use the ``op_args`` and ``op_kwargs`` arguments to pass additional arguments
-to the Python callable.
+Pass extra arguments to the ``@task`` decorated function as you would with
+a normal Python function.
 
 .. exampleinclude:: /../../airflow/example_dags/example_python_operator.py
     :language: python
@@ -60,7 +63,12 @@ is evaluated as a :ref:`Jinja template <concepts:jinja-templating>`.
 PythonVirtualenvOperator
 ========================
 
-Use the :class:`~airflow.operators.python.PythonVirtualenvOperator` to execute Python callables inside a new Python virtual environment. The ``virtualenv`` package needs to be installed in the environment that runs Airflow (as optional dependency ``pip install airflow[virtualenv] --constraint ...``).
+Use the ``@task.virtualenv`` decorator to execute Python callables inside a new Python virtual environment.
+The ``virtualenv`` package needs to be installed in the environment that runs Airflow (as optional dependency ``pip install airflow[virtualenv] --constraint ...``).
+
+.. warning::
+    Previous versions of Airflow required using the :class:`~airflow.operators.python.PythonVirtualenvOperator`.
+    The ``@task.virtualenv`` decorater is now the recommended method.
 
 .. exampleinclude:: /../../airflow/example_dags/example_python_operator.py
     :language: python
@@ -71,8 +79,8 @@ Use the :class:`~airflow.operators.python.PythonVirtualenvOperator` to execute P
 Passing in arguments
 ^^^^^^^^^^^^^^^^^^^^
 
-You can use the ``op_args`` and ``op_kwargs`` arguments the same way you use it in the PythonOperator.
-Unfortunately we currently do not support to serialize ``var`` and ``ti`` / ``task_instance`` due to incompatibilities
+Pass extra arguments to the ``@task.virtualenv`` decorated function as you would with a normal Python function.
+Unfortunately, Airflow does not support serializing ``var``, ``ti`` and ``task_instance`` due to incompatibilities
 with the underlying library. For Airflow context variables make sure that you either have access to Airflow through
 setting ``system_site_packages`` to ``True`` or add ``apache-airflow`` to the ``requirements`` argument.
 Otherwise you won't have access to the most context variables of Airflow in ``op_kwargs``.

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -25,8 +25,8 @@ PythonOperator
 Use the ``@task`` decorator to execute Python callables.
 
 .. warning::
-    Previous versions of Airflow required using :class:`~airflow.operators.python.PythonOperator`
-    to execute Python callables. The ``@task`` decorater is now the recommended method.
+    The ``@task`` decorator is recommended over the classic :class:`~airflow.operators.python.PythonOperator`
+    to execute Python callables.
 
 .. exampleinclude:: /../../airflow/example_dags/example_python_operator.py
     :language: python
@@ -67,8 +67,8 @@ Use the ``@task.virtualenv`` decorator to execute Python callables inside a new 
 The ``virtualenv`` package needs to be installed in the environment that runs Airflow (as optional dependency ``pip install airflow[virtualenv] --constraint ...``).
 
 .. warning::
-    Previous versions of Airflow required using the :class:`~airflow.operators.python.PythonVirtualenvOperator`.
-    The ``@task.virtualenv`` decorater is now the recommended method.
+    The ``@task.virtualenv`` decorator is recommended over the classic :class:`~airflow.operators.python.PythonVirtualenvOperator`
+    to execute Python callables inside new Python virtual environments.
 
 .. exampleinclude:: /../../airflow/example_dags/example_python_operator.py
     :language: python

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -36,7 +36,7 @@ Python 3.9 support was added from Airflow 2.1.2.
 
 Airflow 2.3.0 dropped support for Python 3.6. It's tested with Python 3.7, 3.8, 3.9 and 3.10.
 
-If you have a specific task that still requires Python 2 then you can use the ``@task.virtualenv`` decorator, ``@task.docker`` decorator or the ``KubernetesPodOperator`` for this.
+If you have a specific task that still requires Python 2 then you can use the ``@task.virtualenv``, ``@task.docker`` or ``@task.kubernetes`` decorators for this.
 
 For a list of breaking changes between Python 2 and Python 3, please refer to this
 `handy blog <https://blog.couchbase.com/tips-and-tricks-for-upgrading-from-python-2-to-python-3/>`_
@@ -943,6 +943,7 @@ Classic Operator              TaskFlow Decorator
 ``PythonVirtualenvOperator``  ``@task.virtualenv``
 ``BranchPythonOperator``      ``@task.branch``
 ``DockerOperator``            ``@task.docker``
+``KubernetesPodOperator``     ``@task.kubernetes``
 ============================= ============================================
 
 

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -36,7 +36,7 @@ Python 3.9 support was added from Airflow 2.1.2.
 
 Airflow 2.3.0 dropped support for Python 3.6. It's tested with Python 3.7, 3.8, 3.9 and 3.10.
 
-If you have a specific task that still requires Python 2 then you can use the :class:`~airflow.operators.python.PythonVirtualenvOperator` or the ``KubernetesPodOperator`` for this.
+If you have a specific task that still requires Python 2 then you can use the ``@task.virtualenv`` decorator, ``@task.docker`` decorator or the ``KubernetesPodOperator`` for this.
 
 For a list of breaking changes between Python 2 and Python 3, please refer to this
 `handy blog <https://blog.couchbase.com/tips-and-tricks-for-upgrading-from-python-2-to-python-3/>`_
@@ -476,9 +476,8 @@ In the new model a user can accomplish the same thing using the following code u
 
     from kubernetes.client import models as k8s
 
-    second_task = PythonOperator(
+    @task(
         task_id="four_task",
-        python_callable=test_volume_mount,
         executor_config={
             "pod_override": k8s.V1Pod(
                 spec=k8s.V1PodSpec(
@@ -501,8 +500,12 @@ In the new model a user can accomplish the same thing using the following code u
                     ],
                 )
             )
-        },
+        }
     )
+    def test_volume_mount():
+        pass
+
+    second_task = test_volume_mount()
 
 For Airflow 2.0, the traditional ``executor_config`` will continue operation with a deprecation warning,
 but will be removed in a future version.
@@ -922,6 +925,23 @@ Exception from DAG callbacks used to crash the Airflow Scheduler. As part
 of our efforts to make the Scheduler more performant and reliable, we have changed this behavior to log the exception
 instead. On top of that, a new dag.callback_exceptions counter metric has
 been added to help better monitor callback exceptions.
+
+
+Migrating to TaskFlow API
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Airflow 2.0 introduced the TaskFlow API to simplify the declaration of Python callable tasks.
+Users are encouraged to replace classic operators with their TaskFlow decorator alternatives.
+For details, see :doc:`/tutorial_taskflow_api`.
+
+============================= ============================================
+Classic Operator              TaskFlow Decorator
+============================= ============================================
+``PythonOperator``            ``@task`` (short for ``@task.python``)
+``PythonVirtualenvOperator``  ``@task.virtualenv``
+``BranchPythonOperator``      ``@task.branch``
+``DockerOperator``            ``@task.docker``
+============================= ============================================
 
 
 Airflow CLI changes in 2.0

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -476,6 +476,7 @@ In the new model a user can accomplish the same thing using the following code u
 
     from kubernetes.client import models as k8s
 
+
     @task(
         task_id="four_task",
         executor_config={
@@ -500,10 +501,11 @@ In the new model a user can accomplish the same thing using the following code u
                     ],
                 )
             )
-        }
+        },
     )
     def test_volume_mount():
         pass
+
 
     second_task = test_volume_mount()
 


### PR DESCRIPTION
Related: #25319

### Summary

This PR updates the following documentation about classic operators (`PythonOperator`, `PythonVirtualenvOperator`, etc..) to their TaskFlow decorator alternatives.

* How-to Guides / Using Operators / PythonOperator
* Upgrading from 1.10 to 2

### How to check the updates

1. Build the docs
```
breeze build-docs --docs-only --package-filter apache-airflow
```
2. Open `docs/_build/docs/apache-airflow/latest/index.html` in your browser