### PR TITLE
Filter out non-editable apache-airflow from constraints.

### DIFF
--- a/scripts/in_container/run_generate_constraints.sh
+++ b/scripts/in_container/run_generate_constraints.sh
@@ -102,6 +102,7 @@ echo
 
 pip freeze | sort | \
     grep -v "apache_airflow" | \
+    grep -v "apache-airflow==" | \
     grep -v "@" | \
     grep -v "/opt/airflow" >>"${CURRENT_CONSTRAINT_FILE}"
 


### PR DESCRIPTION
The constraint files should not contain apache-airflow. So far
apache-airflow has been automatically filtered out by the fact that it
has been an editable installation and we filtered out all editable
and file installations from `pip freeze`.

However as of ~12 August 2022, likely setuptools change triggered
a slight behaviour change when `eager-upgrade` installation of
providers from PyPi was run in the CI image. Previously airflow
remained an editable install, but as of 12th of August, such an
installation causes removal of editable airlfow install and
reinstalls it in non-editable mode. While this change is somewhat
confusing, we have to protect against it and remove apache-airflow
from `pip freeze` also in non-editable mode.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
