### PR TITLE
Workaround setuptools editable packages path issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,11 @@
 line-length = 110
 target-version = ['py37', 'py38', 'py39', 'py310']
 skip-string-normalization = true
+# The build system section is needed in order to workaround the side-effect introduced by recent
+# setup tools version. The recent setuptools version update (64.0.0) broke paths of editable installations
+# and we have to pin it to 63.4.3 version
+# The problem is tracked (and this limitation might be removed if it is solved) in:
+# https://github.com/pypa/setuptools/issues/3548
+[build-system]
+requires = ['setuptools==63.4.3']
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Setuptools 64.0.0 introduced change that broke paths of editable
cli packages. This change makes CLIs installed via editable
packages to miss paths required to import code from the editable
packages themselves.

Related to: https://github.com/pypa/setuptools/issues/3548

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
