### PR TITLE
Discard semicolon stripping in SQL hook

### DIFF
--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -232,6 +232,10 @@ class DbApiHook(BaseForDbApiHook):
                 return cur.fetchone()
 
     @staticmethod
+    def strip_sql_string(sql: str) -> str:
+        return sql.strip().rstrip(';')
+
+    @staticmethod
     def split_sql_string(sql: str) -> List[str]:
         """
         Splits string into multiple SQL expressions

--- a/airflow/providers/common/sql/hooks/sql.py
+++ b/airflow/providers/common/sql/hooks/sql.py
@@ -232,10 +232,6 @@ class DbApiHook(BaseForDbApiHook):
                 return cur.fetchone()
 
     @staticmethod
-    def strip_sql_string(sql: str) -> str:
-        return sql.strip().rstrip(';')
-
-    @staticmethod
     def split_sql_string(sql: str) -> List[str]:
         """
         Splits string into multiple SQL expressions
@@ -244,9 +240,7 @@ class DbApiHook(BaseForDbApiHook):
         :return: list of individual expressions
         """
         splits = sqlparse.split(sqlparse.format(sql, strip_comments=True))
-        statements: List[str] = list(
-            filter(None, [s.rstrip(';').strip() if s.endswith(';') else s.strip() for s in splits])
-        )
+        statements: List[str] = list(filter(None, splits))
         return statements
 
     def run(
@@ -278,7 +272,7 @@ class DbApiHook(BaseForDbApiHook):
             if split_statements:
                 sql = self.split_sql_string(sql)
             else:
-                sql = [self.strip_sql_string(sql)]
+                sql = [sql]
 
         if sql:
             self.log.debug("Executing following statements against DB: %s", list(sql))

--- a/tests/providers/common/sql/hooks/test_sqlparse.py
+++ b/tests/providers/common/sql/hooks/test_sqlparse.py
@@ -24,16 +24,13 @@ from airflow.providers.common.sql.hooks.sql import DbApiHook
     "line,parsed_statements",
     [
         ('SELECT * FROM table', ['SELECT * FROM table']),
-        ('SELECT * FROM table;', ['SELECT * FROM table']),
-        ('SELECT * FROM table; # comment', ['SELECT * FROM table']),
-        ('SELECT * FROM table; # comment;', ['SELECT * FROM table']),
-        (' SELECT * FROM table ; # comment;', ['SELECT * FROM table']),
-        ('SELECT * FROM table;;;;;', ['SELECT * FROM table']),
-        ('SELECT * FROM table;;# comment;;;', ['SELECT * FROM table']),
-        ('SELECT * FROM table;;# comment;; ;', ['SELECT * FROM table']),
+        ('SELECT * FROM table;', ['SELECT * FROM table;']),
+        ('SELECT * FROM table; # comment', ['SELECT * FROM table;']),
+        ('SELECT * FROM table; # comment;', ['SELECT * FROM table;']),
+        (' SELECT * FROM table ; # comment;', ['SELECT * FROM table ;']),
         (
             'SELECT * FROM table; SELECT * FROM table2 # comment',
-            ['SELECT * FROM table', 'SELECT * FROM table2'],
+            ['SELECT * FROM table;', 'SELECT * FROM table2'],
         ),
     ],
 )

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -83,7 +83,7 @@ class TestDatabricksSqlHookQueryByName(unittest.TestCase):
         assert schema == test_schema
         assert results == []
 
-        cur.execute.assert_has_calls([mock.call(q) for q in [query.rstrip(';')]])
+        cur.execute.assert_has_calls([mock.call(q) for q in [query]])
         cur.close.assert_called()
 
     def test_no_query(self):

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -268,7 +268,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = None
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END')]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(); END;')]
         assert result == parameters
 
     def test_callproc_dict(self):
@@ -280,7 +280,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = {k: bindvar(v) for k, v in parameters.items()}
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END', parameters)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:a,:b,:c); END;', parameters)]
         assert result == parameters
 
     def test_callproc_list(self):
@@ -292,7 +292,7 @@ class TestOracleHook(unittest.TestCase):
 
         self.cur.bindvars = list(map(bindvar, parameters))
         result = self.db_hook.callproc('proc', True, parameters)
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END', parameters)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3); END;', parameters)]
         assert result == parameters
 
     def test_callproc_out_param(self):
@@ -306,7 +306,7 @@ class TestOracleHook(unittest.TestCase):
         self.cur.bindvars = [bindvar(p() if type(p) is type else p) for p in parameters]
         result = self.db_hook.callproc('proc', True, parameters)
         expected = [1, 0, 0.0, False, '']
-        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END', expected)]
+        assert self.cur.execute.mock_calls == [mock.call('BEGIN proc(:1,:2,:3,:4,:5); END;', expected)]
         assert result == expected
 
     def test_test_connection_use_dual_table(self):


### PR DESCRIPTION
Motivation:
Some databases (at least Oracle) need mandatory `;` at the end of the SQL query.
Also, possibly semicolon stripping might affect T-SQL statements.

How to fix it?
1.  Add optional `strip_semicolon` and set it to `False` by default in Oracle
2. Remove stripping for all cases.

I think the second solution is better because basically it returns previous behavior for the hook and does not add additional complexity.


closes: #25851
