### PR TITLE
Add redshift create cluster snapshot operator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -145,6 +145,7 @@ class RedshiftHook(AwsBaseHook):
         :param snapshot_identifier: unique identifier for a snapshot of a cluster
         :param cluster_identifier: unique identifier of a cluster
         :param retention_period: The number of days that a manual snapshot is retained.
+            If the value is -1, the manual snapshot is retained indefinitely.
         """
         response = self.get_conn().create_cluster_snapshot(
             SnapshotIdentifier=snapshot_identifier,

--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -136,15 +136,19 @@ class RedshiftHook(AwsBaseHook):
         )
         return response['Cluster'] if response['Cluster'] else None
 
-    def create_cluster_snapshot(self, snapshot_identifier: str, cluster_identifier: str) -> str:
+    def create_cluster_snapshot(
+        self, snapshot_identifier: str, cluster_identifier: str, retention_period: int = -1
+    ) -> str:
         """
         Creates a snapshot of a cluster
 
         :param snapshot_identifier: unique identifier for a snapshot of a cluster
         :param cluster_identifier: unique identifier of a cluster
+        :param retention_period: The number of days that a manual snapshot is retained.
         """
         response = self.get_conn().create_cluster_snapshot(
             SnapshotIdentifier=snapshot_identifier,
             ClusterIdentifier=cluster_identifier,
+            ManualSnapshotRetentionPeriod=retention_period,
         )
         return response['Snapshot'] if response['Snapshot'] else None

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -17,9 +17,9 @@
 import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
+from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
-from airflow.exceptions import AirflowException
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -247,12 +247,17 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
     """
     Creates a manual snapshot of the specified cluster. The cluster must be in the available state
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:RedshiftCreateClusterSnapshotOperator`
+
     :param snapshot_identifier: A unique identifier for the snapshot that you are requesting
     :param cluster_identifier: The cluster identifier for which you want a snapshot
     :param retention_period: The number of days that a manual snapshot is retained.
         If the value is -1, the manual snapshot is retained indefinitely.
-    :param wait_for_completion: Whether wait for cluster to be in ``available`` state
-    :param poll_interval: Time (in seconds) to wait between two consecutive calls to check cluster state
+    :param wait_for_completion: Whether wait for the cluster snapshot to be in ``available`` state
+    :param poll_interval: Time (in seconds) to wait between two consecutive calls to check state
+    :param max_attempt: The maximum number of attempts to be made to check the state
     :param aws_conn_id: The Airflow connection used for AWS credentials.
         The default connection id is ``aws_default``
     """
@@ -264,7 +269,8 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         cluster_identifier: str,
         retention_period: int = -1,
         wait_for_completion: bool = False,
-        poll_interval: float = 5.0,
+        poll_interval: int = 15,
+        max_attempt: int = 20,
         aws_conn_id: str = "aws_default",
         **kwargs,
     ):
@@ -274,6 +280,7 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         self.retention_period = retention_period
         self.wait_for_completion = wait_for_completion
         self.poll_interval = poll_interval
+        self.max_attempt = max_attempt
         self.redshift_hook = RedshiftHook(aws_conn_id=aws_conn_id)
 
     def execute(self, context: "Context") -> Any:
@@ -291,16 +298,14 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         )
 
         if self.wait_for_completion:
-            cluster_status: str = self.check_status()
-            while cluster_status != "available":
-                self.log.info(
-                    "cluster status is %s. Sleeping for %s seconds.", cluster_status, self.poll_interval
-                )
-                time.sleep(self.poll_interval)
-                cluster_status = self.check_status()
-
-    def check_status(self) -> str:
-        return self.redshift_hook.cluster_status(self.cluster_identifier)
+            self.redshift_hook.get_conn().get_waiter("snapshot_available").wait(
+                ClusterIdentifier=self.cluster_identifier,
+                SnapshotIdentifier=self.snapshot_identifier,
+                WaiterConfig={
+                    "Delay": self.poll_interval,
+                    "MaxAttempts": self.max_attempt,
+                },
+            )
 
 
 class RedshiftResumeClusterOperator(BaseOperator):

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
-from build.lib.airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -249,9 +249,12 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
 
     :param snapshot_identifier: A unique identifier for the snapshot that you are requesting
     :param cluster_identifier: The cluster identifier for which you want a snapshot
-    :param retention_period: The number of days that a manual snapshot is retained
+    :param retention_period: The number of days that a manual snapshot is retained.
+        If the value is -1, the manual snapshot is retained indefinitely.
     :param wait_for_completion: Whether wait for cluster to be in ``available`` state
     :param poll_interval: Time (in seconds) to wait between two consecutive calls to check cluster state
+    :param aws_conn_id: The Airflow connection used for AWS credentials.
+        The default connection id is ``aws_default``
     """
 
     def __init__(
@@ -273,11 +276,11 @@ class RedshiftCreateClusterSnapshotOperator(BaseOperator):
         self.poll_interval = poll_interval
         self.redshift_hook = RedshiftHook(aws_conn_id=aws_conn_id)
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: "Context") -> Any:
         cluster_state = self.redshift_hook.cluster_status(cluster_identifier=self.cluster_identifier)
         if cluster_state != "available":
             raise AirflowException(
-                f"Redshift cluster must be in available state."
+                "Redshift cluster must be in available state. "
                 f"Redshift cluster current state is {cluster_state}"
             )
 

--- a/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
@@ -80,7 +80,7 @@ Create an Amazon Redshift cluster snapshot
 ==========================================
 
 To create Amazon Redshift cluster snapshot you can use
-:class:`RedshiftDeleteClusterOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`
+:class:`RedshiftCreateClusterSnapshotOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`
 
 .. exampleinclude:: /../../tests/system/providers/amazon/aws/example_redshift_cluster.py
   :language: python

--- a/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
+++ b/docs/apache-airflow-providers-amazon/operators/redshift_cluster.rst
@@ -74,6 +74,20 @@ To pause an 'available' Amazon Redshift cluster you can use
     :start-after: [START howto_operator_redshift_pause_cluster]
     :end-before: [END howto_operator_redshift_pause_cluster]
 
+.. _howto/operator:RedshiftCreateClusterSnapshotOperator:
+
+Create an Amazon Redshift cluster snapshot
+==========================================
+
+To create Amazon Redshift cluster snapshot you can use
+:class:`RedshiftDeleteClusterOperator <airflow.providers.amazon.aws.operators.redshift_cluster>`
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_redshift_cluster.py
+  :language: python
+  :dedent: 4
+  :start-after: [START howto_operator_redshift_create_cluster_snapshot]
+  :end-before: [END howto_operator_redshift_create_cluster_snapshot]
+
 .. _howto/operator:RedshiftDeleteClusterOperator:
 
 Delete an Amazon Redshift cluster

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -17,12 +17,16 @@
 
 from unittest import mock
 
+import pytest
+
 from airflow.providers.amazon.aws.operators.redshift_cluster import (
     RedshiftCreateClusterOperator,
+    RedshiftCreateClusterSnapshotOperator,
     RedshiftDeleteClusterOperator,
     RedshiftPauseClusterOperator,
     RedshiftResumeClusterOperator,
 )
+from build.lib.airflow.exceptions import AirflowException
 
 
 class TestRedshiftCreateClusterOperator:
@@ -97,6 +101,32 @@ class TestRedshiftCreateClusterOperator:
             MasterUserPassword="Test123$",
             **params,
         )
+
+
+class TestRedshiftCreateClusterSnapshotOperator:
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")
+    def test_create_cluster_snapshot_is_called_when_cluster_is_available(
+        self, mock_get_conn, mock_cluster_status
+    ):
+        mock_cluster_status.return_value = "available"
+        create_snapshot = RedshiftCreateClusterSnapshotOperator(
+            task_id="test_snapshot", cluster_identifier="test_cluster", snapshot_identifier="test_snapshot"
+        )
+        create_snapshot.execute(None)
+        mock_get_conn.return_value.create_cluster_snapshot.assert_called_once_with(
+            ClusterIdentifier='test_cluster',
+            SnapshotIdentifier="test_snapshot",
+        )
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
+    def test_raise_exception_when_cluster_is_not_available(self, mock_cluster_status):
+        mock_cluster_status.return_value = "paused"
+        create_snapshot = RedshiftCreateClusterSnapshotOperator(
+            task_id="test_snapshot", cluster_identifier="test_cluster", snapshot_identifier="test_snapshot"
+        )
+        with pytest.raises(AirflowException):
+            create_snapshot.execute(None)
 
 
 class TestResumeClusterOperator:

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -123,6 +123,8 @@ class TestRedshiftCreateClusterSnapshotOperator:
             ManualSnapshotRetentionPeriod=1,
         )
 
+        mock_get_conn.return_value.get_waiter.return_value.wait.assert_not_called()
+
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     def test_raise_exception_when_cluster_is_not_available(self, mock_cluster_status):
         mock_cluster_status.return_value = "paused"

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -123,7 +123,7 @@ class TestRedshiftCreateClusterSnapshotOperator:
             ManualSnapshotRetentionPeriod=1,
         )
 
-        mock_get_conn.return_value.get_waiter.return_value.wait.assert_not_called()
+        mock_get_conn.return_value.get_waiter.wait.assert_not_called()
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     def test_raise_exception_when_cluster_is_not_available(self, mock_cluster_status):
@@ -136,7 +136,7 @@ class TestRedshiftCreateClusterSnapshotOperator:
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")
-    def test_create_cluster_snapshot_with_no_wait(self, mock_get_conn, mock_cluster_status):
+    def test_create_cluster_snapshot_with_wait(self, mock_get_conn, mock_cluster_status):
         mock_cluster_status.return_value = "available"
         create_snapshot = RedshiftCreateClusterSnapshotOperator(
             task_id="test_snapshot",

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -123,7 +123,7 @@ class TestRedshiftCreateClusterSnapshotOperator:
             ManualSnapshotRetentionPeriod=1,
         )
 
-        mock_get_conn.return_value.get_waiter.wait.assert_not_called()
+        mock_get_conn.return_value.get_waiter.assert_not_called()
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     def test_raise_exception_when_cluster_is_not_available(self, mock_cluster_status):

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -26,7 +26,7 @@ from airflow.providers.amazon.aws.operators.redshift_cluster import (
     RedshiftPauseClusterOperator,
     RedshiftResumeClusterOperator,
 )
-from build.lib.airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException
 
 
 class TestRedshiftCreateClusterOperator:

--- a/tests/system/providers/amazon/aws/example_redshift_cluster.py
+++ b/tests/system/providers/amazon/aws/example_redshift_cluster.py
@@ -23,6 +23,7 @@ from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.operators.redshift_cluster import (
     RedshiftCreateClusterOperator,
+    RedshiftCreateClusterSnapshotOperator,
     RedshiftDeleteClusterOperator,
     RedshiftPauseClusterOperator,
     RedshiftResumeClusterOperator,
@@ -34,6 +35,9 @@ from tests.system.providers.amazon.aws.utils import set_env_id
 ENV_ID = set_env_id()
 DAG_ID = 'example_redshift_cluster'
 REDSHIFT_CLUSTER_IDENTIFIER = getenv("REDSHIFT_CLUSTER_IDENTIFIER", "redshift-cluster-1")
+REDSHIFT_CLUSTER_SNAPSHOT_IDENTIFIER = getenv(
+    "REDSHIFT_CLUSTER_SNAPSHOT_IDENTIFIER", "redshift-cluster-snapshot-1"
+)
 
 with DAG(
     dag_id=DAG_ID,
@@ -85,6 +89,17 @@ with DAG(
     )
     # [END howto_operator_redshift_resume_cluster]
 
+    # [START howto_operator_redshift_create_cluster_snapshot]
+    task_create_cluster_snapshot = RedshiftCreateClusterSnapshotOperator(
+        task_id='create_cluster_snapshot',
+        cluster_identifier=REDSHIFT_CLUSTER_IDENTIFIER,
+        snapshot_identifier=REDSHIFT_CLUSTER_SNAPSHOT_IDENTIFIER,
+        retention_period=1,
+        poll_interval=5,
+        timeout=60 * 15,
+    )
+    # [END howto_operator_redshift_create_cluster_snapshot]
+
     # [START howto_operator_redshift_delete_cluster]
     task_delete_cluster = RedshiftDeleteClusterOperator(
         task_id="delete_cluster",
@@ -99,6 +114,7 @@ with DAG(
         task_pause_cluster,
         task_wait_cluster_paused,
         task_resume_cluster,
+        task_create_cluster_snapshot,
         task_delete_cluster,
     )
 

--- a/tests/system/providers/amazon/aws/example_redshift_cluster.py
+++ b/tests/system/providers/amazon/aws/example_redshift_cluster.py
@@ -96,7 +96,6 @@ with DAG(
         snapshot_identifier=REDSHIFT_CLUSTER_SNAPSHOT_IDENTIFIER,
         retention_period=1,
         poll_interval=5,
-        timeout=60 * 15,
     )
     # [END howto_operator_redshift_create_cluster_snapshot]
 


### PR DESCRIPTION
Add `RedshiftCreateClusterSnapshotOperator` to create snapshot for a redshift cluster. by default, it won't wait for the cluster to be available.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
