### PR TITLE
Fix migration issues and tighten the CI upgrade/downgrade test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1088,8 +1088,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
       - name: "Test downgrade"
         run: ./scripts/ci/testing/run_downgrade_test.sh
-      - name: "Test Offline SQL generation"
-        run: ./scripts/ci/testing/run_offline_sql_test.sh
       - name: "Tests: ${{needs.build-info.outputs.test-types}}"
         run: ./scripts/ci/testing/ci_run_airflow_testing.sh
         env:

--- a/airflow/migrations/versions/0105_2_3_0_add_map_index_to_taskfail.py
+++ b/airflow/migrations/versions/0105_2_3_0_add_map_index_to_taskfail.py
@@ -144,7 +144,7 @@ def downgrade():
         join_columns=['dag_id', 'run_id'],
     )
     op.execute(update_query)
-    with op.batch_alter_table('task_fail', copy_from=task_fail) as batch_op:
+    with op.batch_alter_table('task_fail') as batch_op:
         batch_op.alter_column('execution_date', existing_type=TIMESTAMP, nullable=False)
         if dialect_name != 'sqlite':
             batch_op.drop_constraint('task_fail_ti_fkey', type_='foreignkey')

--- a/airflow/migrations/versions/0113_2_4_0_compare_types_between_orm_and_db.py
+++ b/airflow/migrations/versions/0113_2_4_0_compare_types_between_orm_and_db.py
@@ -163,6 +163,15 @@ def downgrade():
         batch_op.alter_column(
             'created_at', existing_type=TIMESTAMP(), type_=sa.DateTime(), existing_nullable=False
         )
+    with op.batch_alter_table('serialized_dag', schema=None) as batch_op:
+        # drop server_default
+        batch_op.alter_column(
+            'dag_hash',
+            existing_type=sa.String(32),
+            server_default='Hash not calculated yet',
+            type_=sa.String(32),
+            existing_nullable=False,
+        )
     with op.batch_alter_table('trigger', schema=None) as batch_op:
         batch_op.alter_column(
             'created_date', existing_type=TIMESTAMP(), type_=sa.DateTime(), existing_nullable=False

--- a/airflow/migrations/versions/0113_2_4_0_compare_types_between_orm_and_db.py
+++ b/airflow/migrations/versions/0113_2_4_0_compare_types_between_orm_and_db.py
@@ -164,7 +164,7 @@ def downgrade():
             'created_at', existing_type=TIMESTAMP(), type_=sa.DateTime(), existing_nullable=False
         )
     with op.batch_alter_table('serialized_dag', schema=None) as batch_op:
-        # drop server_default
+        # add server_default
         batch_op.alter_column(
             'dag_hash',
             existing_type=sa.String(32),

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -153,7 +153,7 @@ def _create_dataset_event_dag_run_table():
         ),
         sa.PrimaryKeyConstraint('dag_run_id', 'event_id', name=op.f('dagrun_dataset_events_pkey')),
     )
-    with op.batch_alter_table('dagrun_dataset_events') as batch_op:
+    with op.batch_alter_table('dagrun_dataset_event') as batch_op:
         batch_op.create_index('idx_dagrun_dataset_events_dag_run_id', ['dag_run_id'], unique=False)
         batch_op.create_index('idx_dagrun_dataset_events_event_id', ['event_id'], unique=False)
 

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -98,7 +98,6 @@ config_list: List[_TableConfig] = [
     _TableConfig(table_name='import_error', recency_column_name='timestamp'),
     _TableConfig(table_name='log', recency_column_name='dttm'),
     _TableConfig(table_name='rendered_task_instance_fields', recency_column_name='execution_date'),
-    _TableConfig(table_name='sensor_instance', recency_column_name='updated_at'),
     _TableConfig(table_name='sla_miss', recency_column_name='timestamp'),
     _TableConfig(table_name='task_fail', recency_column_name='start_date'),
     _TableConfig(table_name='task_instance', recency_column_name='start_date'),

--- a/scripts/ci/testing/run_downgrade_test.sh
+++ b/scripts/ci/testing/run_downgrade_test.sh
@@ -20,4 +20,11 @@
 
 testing::get_docker_compose_local
 testing::setup_docker_compose_backend "downgrade"
-testing::run_command_in_docker "downgrade" "airflow db downgrade -r e959f08ac86c -y"
+# This runs downgrades for DBs created from the migration file
+testing::run_command_in_docker "downgrade" "airflow db reset --skip-init -y \
+    && airflow db upgrade --to-revision heads && airflow db downgrade -r e959f08ac86c -y \
+    && airflow db upgrade"
+# This tests upgrade/downgrade for DBs created from the ORM
+testing::run_command_in_docker "downgrade" "airflow db reset -y \
+    && airflow db upgrade && airflow db downgrade -r e959f08ac86c -y \
+    && airflow db upgrade"


### PR DESCRIPTION
There was a typo that was not detected in the migration file which prevented upgrades.
On fixing the typo, some other migration issues were detected.
Apart from postgres, other dbs couldn't upgrade -> downgrade -> upgrade. This was partly
because we now create new DB from the ORM which also uses a naming convention to create constraints.

I have applied a fix, the side effect is that it breaks offline generation of sql for mysql. This is because it uses the new naming convention to create constraints when we run upgrade through the migration file. In
migration file 0093, we dropped unique keys with names dag_id & dag_id_2 while with the naming
convention in place, these two now have a unique name across all db that's different from the names
we use to drop the keys. Because of that, I have chosen to use sqlalchemy inspector to get the name
and drop them.