### PR TITLE
Remove mapped operator validation code

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -692,11 +692,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
     start_date: Optional[pendulum.DateTime] = None
     end_date: Optional[pendulum.DateTime] = None
 
-    # How operator-mapping arguments should be validated. If True, a default validation implementation that
-    # calls the operator's constructor is used. If False, the operator should implement its own validation
-    # logic (default implementation is 'pass' i.e. no validation whatsoever).
-    mapped_arguments_validated_by_init: ClassVar[bool] = False
-
     # Set to True for an operator instantiated by a mapped operator.
     __from_mapped = False
 
@@ -1505,12 +1500,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         which is caught in the main _execute_task wrapper.
         """
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
-
-    @classmethod
-    def validate_mapped_arguments(cls, **kwargs: Any) -> None:
-        """Validate arguments when this operator is being mapped."""
-        if cls.mapped_arguments_validated_by_init:
-            cls(**kwargs, _airflow_from_mapped=True, _airflow_mapped_validation_only=True)
 
     def unmap(self, resolve: Union[None, Dict[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """:meta private:"""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -326,7 +326,6 @@ class MappedOperator(AbstractOperator):
     def __attrs_post_init__(self):
         from airflow.models.xcom_arg import XComArg
 
-        self._validate_argument_count()
         if self.task_group:
             self.task_group.add(self)
         if self.dag:
@@ -365,20 +364,6 @@ class MappedOperator(AbstractOperator):
                 f"not a {type(operator_deps).__name__}"
             )
         return operator_deps | {MappedTaskIsExpanded()}
-
-    def _validate_argument_count(self) -> None:
-        """Validate mapping arguments by unmapping with mocked values.
-
-        This ensures the user passed enough arguments in the DAG definition for
-        the operator to work in the task runner. This does not guarantee the
-        arguments are *valid* (that depends on the actual mapping values), but
-        makes sure there are *enough* of them.
-        """
-        if not isinstance(self.operator_class, type):
-            return  # No need to validate deserialized operator.
-        kwargs = self._expand_mapped_kwargs(None)
-        kwargs = self._get_unmap_kwargs(kwargs, strict=self._disallow_kwargs_override)
-        self.operator_class.validate_mapped_arguments(**kwargs)
 
     @property
     def task_type(self) -> str:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -133,8 +133,6 @@ class PythonOperator(BaseOperator):
         'op_kwargs',
     )
 
-    mapped_arguments_validated_by_init = True
-
     def __init__(
         self,
         *,

--- a/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
+++ b/scripts/ci/pre_commit/pre_commit_base_operator_partial_arguments.py
@@ -45,7 +45,6 @@ IGNORED = {
     "HIDE_ATTRS_FROM_UI",
     # Only on BaseOperator.
     "_dag",
-    "mapped_arguments_validated_by_init",
     "output",
     "partial",
     "shallow_copy_attrs",


### PR DESCRIPTION
`expand_kwargs()` is making this difficult. We can probably add some validation code back at some point, but the current mechanism does not work very well for zipped inputs. Fortunately this isn't really used anywhere yet, so we can take it out for now and redo it later.