### PR TITLE
SQL to GCS operators update docs for parquet format

### DIFF
--- a/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/mssql_to_gcs.py
@@ -26,7 +26,7 @@ from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
 
 class MSSQLToGCSOperator(BaseSQLToGCSOperator):
     """Copy data from Microsoft SQL Server to Google Cloud Storage
-    in JSON or CSV format.
+    in JSON, CSV or Parquet format.
 
     :param mssql_conn_id: Reference to a specific MSSQL hook.
 

--- a/airflow/providers/google/cloud/transfers/mysql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/mysql_to_gcs.py
@@ -29,7 +29,7 @@ from airflow.providers.mysql.hooks.mysql import MySqlHook
 
 
 class MySQLToGCSOperator(BaseSQLToGCSOperator):
-    """Copy data from MySQL to Google Cloud Storage in JSON or CSV format.
+    """Copy data from MySQL to Google Cloud Storage in JSON, CSV or Parquet format.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/airflow/providers/google/cloud/transfers/oracle_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/oracle_to_gcs.py
@@ -29,7 +29,7 @@ from airflow.providers.oracle.hooks.oracle import OracleHook
 
 
 class OracleToGCSOperator(BaseSQLToGCSOperator):
-    """Copy data from Oracle to Google Cloud Storage in JSON or CSV format.
+    """Copy data from Oracle to Google Cloud Storage in JSON, CSV or Parquet format.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/postgres_to_gcs.py
@@ -67,7 +67,7 @@ class _PostgresServerSideCursorDecorator:
 
 class PostgresToGCSOperator(BaseSQLToGCSOperator):
     """
-    Copy data from Postgres to Google Cloud Storage in JSON or CSV format.
+    Copy data from Postgres to Google Cloud Storage in JSON, CSV or Parquet format.
 
     :param postgres_conn_id: Reference to a specific Postgres hook.
     :param use_server_side_cursor: If server-side cursor should be used for querying postgres.

--- a/airflow/providers/google/cloud/transfers/presto_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/presto_to_gcs.py
@@ -141,7 +141,7 @@ class _PrestoToGCSPrestoCursorAdapter:
 
 
 class PrestoToGCSOperator(BaseSQLToGCSOperator):
-    """Copy data from PrestoDB to Google Cloud Storage in JSON or CSV format.
+    """Copy data from PrestoDB to Google Cloud Storage in JSON, CSV or Parquet format.
 
     :param presto_conn_id: Reference to a specific Presto hook.
     """

--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 class BaseSQLToGCSOperator(BaseOperator):
     """
-    Copy data from SQL to Google Cloud Storage in JSON or CSV format.
+    Copy data from SQL to Google Cloud Storage in JSON, CSV, or Parquet format.
 
     :param sql: The SQL to execute.
     :param bucket: The bucket to upload to.
@@ -50,7 +50,7 @@ class BaseSQLToGCSOperator(BaseOperator):
         filename param docs above). This param allows developers to specify the
         file size of the splits. Check https://cloud.google.com/storage/quotas
         to see the maximum allowed file size for a single object.
-    :param export_format: Desired format of files to be exported.
+    :param export_format: Desired format of files to be exported. (json, csv or parquet)
     :param field_delimiter: The delimiter to be used for CSV files.
     :param null_marker: The null marker to be used for CSV files.
     :param gzip: Option to compress file for upload (does not apply to schemas).

--- a/airflow/providers/google/cloud/transfers/trino_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/trino_to_gcs.py
@@ -141,7 +141,7 @@ class _TrinoToGCSTrinoCursorAdapter:
 
 
 class TrinoToGCSOperator(BaseSQLToGCSOperator):
-    """Copy data from TrinoDB to Google Cloud Storage in JSON or CSV format.
+    """Copy data from TrinoDB to Google Cloud Storage in JSON, CSV or Parquet format.
 
     :param trino_conn_id: Reference to a specific Trino hook.
     """


### PR DESCRIPTION
The parquet format is not mentioned in the operators documentation (`*SQLToGCSOperator`).

Beside looking at the code, I feel like this is hard to know that the parquet format is actually supported.

This is just a small update to explicit that.