### PR TITLE
Remove implementation of `__hash__` method on DatasetEvent

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -314,9 +314,6 @@ class DatasetEvent(Base):
         else:
             return NotImplemented
 
-    def __hash__(self) -> int:
-        return hash((self.dataset_id, self.created_at))
-
     def __repr__(self) -> str:
         args = []
         for attr in [


### PR DESCRIPTION
It is not used (we know this because it's currently defined with attrs that do not exist, namely _created_at_). We could fix this, but it's somewhat questionable that dataset + timestamp is the "right" choice, so, since it's not used, better not to implement.
