### PR TITLE
Remove implementation of `__eq__` method from DatasetEvent

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -309,10 +309,7 @@ class DatasetEvent(Base):
         return self.dataset.uri
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, self.__class__):
-            return self.dataset_id == other.dataset_id and self.timestamp == other.timestamp
-        else:
-            return NotImplemented
+        raise ValueError('this is a test')
 
     def __repr__(self) -> str:
         args = []

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -308,9 +308,6 @@ class DatasetEvent(Base):
     def uri(self):
         return self.dataset.uri
 
-    def __eq__(self, other) -> bool:
-        raise ValueError('this is a test')
-
     def __repr__(self) -> str:
         args = []
         for attr in [


### PR DESCRIPTION
Given that in the future we might allow registering  of dataset events from other systems, dataset_id + timestamp might not be quite enough grain.  So rather than have to make a "breaking" change to `__eq__` in the future, it would be better to avoid defining it now.  It's only used in a test.