### PR TITLE
React tests should also run when only `www` change

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -148,6 +148,9 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^airflow/ui/.*\.[tj]sx?$",
             r"^airflow/ui/[^/]+\.json$",
             r"^airflow/ui/.*\.lock$",
+            r"^airflow/www/.*\.[tj]sx?$",
+            r"^airflow/www/[^/]+\.json$",
+            r"^airflow/www/.*\.lock$",
         ],
         FileGroupForCi.WWW_FILES: [
             r"^airflow/www/.*\.js[x]?$",


### PR DESCRIPTION
We only run React tests when airflow/ui changed but we have
actually started to do more and more react in airflow/www.

This caused a green build in #25880 for example even though it
started to fail in `main`.

We add www also to the react tests trigger

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
