### PR TITLE
Fix AIRFLOW_EXTRAS in CI for 2.2 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,7 +841,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           --use-packages-from-dist --package-format wheel --airflow-constraints-reference constraints-2.2.0
         env:
           # The extras below are all extras that should be installed with Airflow 2.2.0
-          AIRFLOW_EXTRAS: "airbyte,alibaba,amazon,apache.atlas.apache.beam,apache.cassandra,apache.drill,\
+          AIRFLOW_EXTRAS: "airbyte,alibaba,amazon,apache.atlas,apache.beam,apache.cassandra,apache.drill,\
             apache.druid,apache.hdfs,apache.hive,apache.kylin,apache.livy,apache.pig,apache.pinot,\
             apache.spark,apache.sqoop,apache.webhdfs,asana,async,\
             celery,cgroups,cloudant,cncf.kubernetes,dask,databricks,datadog,\


### PR DESCRIPTION
When running the "Build and test provider packages wheel" test in CI, the following warning appears:
`WARNING: apache-airflow 2.2.0 does not provide the extra 'apache.atlas.apache.beam'`

Fixing the `AIRFLOW_EXTRAS` list by replacing a period with a comma.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
