### PR TITLE
Remove postgres extra from Helm tests venv

### DIFF
--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -96,7 +96,7 @@ function create_virtualenv() {
 
     pip install pytest freezegun "${constraints[@]}"
 
-    pip install -e ".[cncf.kubernetes,postgres]" "${constraints[@]}"
+    pip install -e ".[cncf.kubernetes]" "${constraints[@]}"
 }
 
 function run_tests() {


### PR DESCRIPTION
We do not need postgres extra when running Helm tests. The tests
started to fail because we switch to a binary postgres dependency
for postgres provider ad it started to fail because of lack of
pgconfig, but we actually do not need the extra to run the tests
so we can remove it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
