### PR TITLE
Less hacky double-rendering prevention in mapped task

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -25,12 +25,12 @@ from typing import (
     Collection,
     Dict,
     Generic,
-    Iterable,
     Iterator,
     Mapping,
     Optional,
     Sequence,
     Set,
+    Tuple,
     Type,
     TypeVar,
     cast,
@@ -74,8 +74,6 @@ from airflow.utils.task_group import TaskGroup, TaskGroupContext
 from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
-    import jinja2  # Slow import.
-
     from airflow.models.mappedoperator import Mappable
 
 
@@ -459,59 +457,25 @@ class DecoratedMappedOperator(MappedOperator):
         super(DecoratedMappedOperator, DecoratedMappedOperator).__attrs_post_init__(self)
         XComArg.apply_upstream_relationship(self, self.op_kwargs_expand_input.value)
 
-    def _expand_mapped_kwargs(self, context: Context, session: Session) -> Mapping[str, Any]:
+    def _expand_mapped_kwargs(self, context: Context, session: Session) -> Tuple[Mapping[str, Any], Set[int]]:
         # We only use op_kwargs_expand_input so this must always be empty.
         assert self.expand_input is EXPAND_INPUT_EMPTY
-        return {"op_kwargs": super()._expand_mapped_kwargs(context, session)}
+        op_kwargs, resolved_oids = super()._expand_mapped_kwargs(context, session)
+        return {"op_kwargs": op_kwargs}, resolved_oids
 
     def _get_unmap_kwargs(self, mapped_kwargs: Mapping[str, Any], *, strict: bool) -> Dict[str, Any]:
-        if strict:
-            prevent_duplicates(
-                self.partial_kwargs["op_kwargs"],
-                mapped_kwargs["op_kwargs"],
-                fail_reason="mapping already partial",
-            )
+        partial_op_kwargs = self.partial_kwargs["op_kwargs"]
+        mapped_op_kwargs = mapped_kwargs["op_kwargs"]
 
-        static_kwargs = {k for k, _ in self.op_kwargs_expand_input.iter_parse_time_resolved_kwargs()}
-        self._combined_op_kwargs = {**self.partial_kwargs["op_kwargs"], **mapped_kwargs["op_kwargs"]}
-        self._already_resolved_op_kwargs = {k for k in mapped_kwargs["op_kwargs"] if k not in static_kwargs}
+        if strict:
+            prevent_duplicates(partial_op_kwargs, mapped_op_kwargs, fail_reason="mapping already partial")
 
         kwargs = {
             "multiple_outputs": self.multiple_outputs,
             "python_callable": self.python_callable,
-            "op_kwargs": self._combined_op_kwargs,
+            "op_kwargs": {**partial_op_kwargs, **mapped_op_kwargs},
         }
         return super()._get_unmap_kwargs(kwargs, strict=False)
-
-    def _get_template_fields_to_render(self, expanded: Iterable[str]) -> Iterable[str]:
-        # Different from a regular MappedOperator, we still want to render
-        # some fields in op_kwargs (those that are NOT passed as XComArg from
-        # upstream). Already-rendered op_kwargs keys are detected in a different
-        # way (see render_template below and _get_unmap_kwargs above).
-        assert list(expanded) == ["op_kwargs"]
-        return self.template_fields
-
-    def render_template(
-        self,
-        value: Any,
-        context: Context,
-        jinja_env: Optional["jinja2.Environment"] = None,
-        seen_oids: Optional[Set] = None,
-    ) -> Any:
-        if value is not getattr(self, "_combined_op_kwargs", object()):
-            return super().render_template(value, context, jinja_env=jinja_env, seen_oids=seen_oids)
-
-        def _render_if_not_already_resolved(key: str, value: Any):
-            if key in self._already_resolved_op_kwargs:
-                return value
-            # The magic super() doesn't work here, so we use the explicit form.
-            # Not using super(..., self) to work around pyupgrade bug.
-            return super(DecoratedMappedOperator, DecoratedMappedOperator).render_template(
-                self, value, context=context, jinja_env=jinja_env, seen_oids=seen_oids
-            )
-
-        # Avoid rendering values that came out of resolved XComArgs.
-        return {k: _render_if_not_already_resolved(k, v) for k, v in value.items()}
 
 
 class Task(Generic[FParams, FReturn]):

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -31,7 +31,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Type,
     TypeVar,
     cast,
@@ -460,10 +459,10 @@ class DecoratedMappedOperator(MappedOperator):
         super(DecoratedMappedOperator, DecoratedMappedOperator).__attrs_post_init__(self)
         XComArg.apply_upstream_relationship(self, self.op_kwargs_expand_input.value)
 
-    def _expand_mapped_kwargs(self, resolve: Optional[Tuple[Context, Session]]) -> Dict[str, Any]:
+    def _expand_mapped_kwargs(self, context: Context, session: Session) -> Mapping[str, Any]:
         # We only use op_kwargs_expand_input so this must always be empty.
         assert self.expand_input is EXPAND_INPUT_EMPTY
-        return {"op_kwargs": super()._expand_mapped_kwargs(resolve)}
+        return {"op_kwargs": super()._expand_mapped_kwargs(context, session)}
 
     def _get_unmap_kwargs(self, mapped_kwargs: Mapping[str, Any], *, strict: bool) -> Dict[str, Any]:
         if strict:

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -404,7 +404,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
         template_fields: Iterable[str],
         context: Context,
         jinja_env: "jinja2.Environment",
-        seen_oids: Set,
+        seen_oids: Set[int],
         *,
         session: "Session" = NEW_SESSION,
     ) -> None:
@@ -441,7 +441,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
         content: Any,
         context: Context,
         jinja_env: Optional["jinja2.Environment"] = None,
-        seen_oids: Optional[Set] = None,
+        seen_oids: Optional[Set[int]] = None,
     ) -> Any:
         """Render a templated string.
 
@@ -460,6 +460,14 @@ class AbstractOperator(LoggingMixin, DAGNode):
         # "content" is a bad name, but we're stuck to it being public API.
         value = content
         del content
+
+        if seen_oids is not None:
+            oids = seen_oids
+        else:
+            oids = set()
+
+        if id(value) in oids:
+            return value
 
         if not jinja_env:
             jinja_env = self.get_template_env()
@@ -482,21 +490,17 @@ class AbstractOperator(LoggingMixin, DAGNode):
 
         # Fast path for common built-in collections.
         if value.__class__ is tuple:
-            return tuple(self.render_template(element, context, jinja_env) for element in value)
+            return tuple(self.render_template(element, context, jinja_env, oids) for element in value)
         elif isinstance(value, tuple):  # Special case for named tuples.
-            return value.__class__(*(self.render_template(el, context, jinja_env) for el in value))
+            return value.__class__(*(self.render_template(el, context, jinja_env, oids) for el in value))
         elif isinstance(value, list):
-            return [self.render_template(element, context, jinja_env) for element in value]
+            return [self.render_template(element, context, jinja_env, oids) for element in value]
         elif isinstance(value, dict):
-            return {key: self.render_template(value, context, jinja_env) for key, value in value.items()}
+            return {k: self.render_template(v, context, jinja_env, oids) for k, v in value.items()}
         elif isinstance(value, set):
-            return {self.render_template(element, context, jinja_env) for element in value}
+            return {self.render_template(element, context, jinja_env, oids) for element in value}
 
         # More complex collections.
-        if seen_oids is None:
-            oids = set()
-        else:
-            oids = seen_oids
         self._render_nested_template_fields(value, context, jinja_env, oids)
         return value
 

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -568,15 +568,15 @@ class MappedOperator(AbstractOperator):
     def unmap(self, resolve: Union[None, Mapping[str, Any], Tuple[Context, Session]]) -> "BaseOperator":
         """Get the "normal" Operator after applying the current mapping.
 
-        If ``operator_class`` is not a class (i.e. this DAG has been
-        deserialized), this returns a SerializedBaseOperator that aims to
-        "look like" the actual unmapping result.
+        The *resolve* argument is only used if ``operator_class`` is a real
+        class, i.e. if this operator is not serialized. If ``operator_class`` is
+        not a class (i.e. this DAG has been deserialized), this returns a
+        SerializedBaseOperator that "looks like" the actual unmapping result.
 
-        :param resolve: Only used if ``operator_class`` is a real class. If this
-            is a two-tuple (context, session), the information is used to
-            resolve the mapped arguments into init arguments. If this is a
-            mapping, no resolving happens, the mapping directly provides those
-            init arguments resolved from mapped kwargs.
+        If *resolve* is a two-tuple (context, session), the information is used
+        to resolve the mapped arguments into init arguments. If it is a mapping,
+        no resolving happens, the mapping directly provides those init arguments
+        resolved from mapped kwargs.
 
         :meta private:
         """


### PR DESCRIPTION
Instead of inventing a separate way to track what XComArg has been rendered (due to task unmapping), we can actually track this with seen_oids. This makes the mechanism considerably less hacky.