### PR TITLE
Implement expand_kwargs() against a literal list

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -337,8 +337,12 @@ class _TaskDecorator(Generic[FParams, FReturn, OperatorSubclass]):
         return self._expand(DictOfListsExpandInput(map_kwargs), strict=False)
 
     def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> XComArg:
-        if not isinstance(kwargs, XComArg):
-            raise TypeError(f"expected XComArg object, not {type(kwargs).__name__}")
+        if isinstance(kwargs, Sequence):
+            for item in kwargs:
+                if not isinstance(item, (XComArg, Mapping)):
+                    raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
+        elif not isinstance(kwargs, XComArg):
+            raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
         return self._expand(ListOfDictsExpandInput(kwargs), strict=strict)
 
     def _expand(self, expand_input: ExpandInput, *, strict: bool) -> XComArg:

--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -18,7 +18,6 @@
 import inspect
 import re
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -57,6 +56,8 @@ from airflow.models.expandinput import (
     DictOfListsExpandInput,
     ExpandInput,
     ListOfDictsExpandInput,
+    OperatorExpandArgument,
+    OperatorExpandKwargsArgument,
 )
 from airflow.models.mappedoperator import (
     MappedOperator,
@@ -72,9 +73,6 @@ from airflow.utils import timezone
 from airflow.utils.context import KNOWN_CONTEXT_KEYS, Context
 from airflow.utils.task_group import TaskGroup, TaskGroupContext
 from airflow.utils.types import NOTSET
-
-if TYPE_CHECKING:
-    from airflow.models.mappedoperator import Mappable
 
 
 def validate_python_callable(python_callable: Any) -> None:
@@ -329,7 +327,7 @@ class _TaskDecorator(Generic[FParams, FReturn, OperatorSubclass]):
             names = ", ".join(repr(n) for n in kwargs_left)
             raise TypeError(f"{func}() got unexpected keyword arguments {names}")
 
-    def expand(self, **map_kwargs: "Mappable") -> XComArg:
+    def expand(self, **map_kwargs: OperatorExpandArgument) -> XComArg:
         if not map_kwargs:
             raise TypeError("no arguments to expand against")
         self._validate_arg_names("expand", map_kwargs)
@@ -338,7 +336,7 @@ class _TaskDecorator(Generic[FParams, FReturn, OperatorSubclass]):
         # to False to skip the checks on execution.
         return self._expand(DictOfListsExpandInput(map_kwargs), strict=False)
 
-    def expand_kwargs(self, kwargs: XComArg, *, strict: bool = True) -> XComArg:
+    def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> XComArg:
         if not isinstance(kwargs, XComArg):
             raise TypeError(f"expected XComArg object, not {type(kwargs).__name__}")
         return self._expand(ListOfDictsExpandInput(kwargs), strict=strict)
@@ -500,10 +498,10 @@ class Task(Generic[FParams, FReturn]):
     def partial(self, **kwargs: Any) -> "Task[FParams, FReturn]":
         ...
 
-    def expand(self, **kwargs: "Mappable") -> XComArg:
+    def expand(self, **kwargs: OperatorExpandArgument) -> XComArg:
         ...
 
-    def expand_kwargs(self, kwargs: XComArg, *, strict: bool = True) -> XComArg:
+    def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> XComArg:
         ...
 
     def override(self, **kwargs: Any) -> "Task[FParams, FReturn]":

--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -29,7 +29,7 @@ from airflow.utils.task_group import TaskGroup
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
-    from airflow.models.mappedoperator import Mappable
+    from airflow.models.mappedoperator import OperatorExpandArgument
 
 F = TypeVar("F", bound=Callable)
 R = TypeVar("R")
@@ -100,7 +100,7 @@ class Group(Generic[F]):
     function: F
 
     # Return value should match F's return type, but that's impossible to declare.
-    def expand(self, **kwargs: "Mappable") -> Any:
+    def expand(self, **kwargs: "OperatorExpandArgument") -> Any:
         ...
 
     def partial(self, **kwargs: Any) -> "Group[F]":

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -74,10 +74,6 @@ class DictOfListsExpandInput(NamedTuple):
 
     value: dict[str, OperatorExpandArgument]
 
-    def get_unresolved_kwargs(self) -> dict[str, Any]:
-        """Get the kwargs dict that can be inferred without resolving."""
-        return self.value
-
     def iter_parse_time_resolved_kwargs(self) -> Iterable[tuple[str, Sized]]:
         """Generate kwargs with values available on parse-time."""
         from airflow.models.xcom_arg import XComArg
@@ -171,14 +167,6 @@ class ListOfDictsExpandInput(NamedTuple):
     """
 
     value: XComArg
-
-    def get_unresolved_kwargs(self) -> dict[str, Any]:
-        """Get the kwargs dict that can be inferred without resolving.
-
-        Since the list-of-dicts case relies entirely on run-time XCom, there's
-        no kwargs structure available, so this just returns an empty dict.
-        """
-        return {}
 
     def iter_parse_time_resolved_kwargs(self) -> Iterable[tuple[str, Sized]]:
         return ()

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -22,7 +22,7 @@ import collections
 import collections.abc
 import functools
 import operator
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, NamedTuple, Sequence, Sized, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, NamedTuple, Sequence, Sized, Union
 
 from airflow.compat.functools import cache
 from airflow.utils.context import Context
@@ -34,9 +34,13 @@ if TYPE_CHECKING:
 
 ExpandInput = Union["DictOfListsExpandInput", "ListOfDictsExpandInput"]
 
-# BaseOperator.expand() can be called on an XComArg, sequence, or dict (not any
-# mapping since we need the value to be ordered).
-Mappable = Union["XComArg", Sequence, dict]
+# Each keyword argument to expand() can be an XComArg, sequence, or dict (not
+# any mapping since we need the value to be ordered).
+OperatorExpandArgument = Union["XComArg", Sequence, Dict[str, Any]]
+
+# The single argument of expand_kwargs() can be an XComArg, or a list with each
+# element being either an XComArg or a dict.
+OperatorExpandKwargsArgument = Union["XComArg", Sequence[Union["XComArg", Mapping[str, Any]]]]
 
 
 # For isinstance() check.
@@ -68,7 +72,7 @@ class DictOfListsExpandInput(NamedTuple):
     This is created from ``expand(**kwargs)``.
     """
 
-    value: dict[str, Mappable]
+    value: dict[str, OperatorExpandArgument]
 
     def get_unresolved_kwargs(self) -> dict[str, Any]:
         """Get the kwargs dict that can be inferred without resolving."""

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -196,8 +196,12 @@ class OperatorPartial:
     def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> "MappedOperator":
         from airflow.models.xcom_arg import XComArg
 
-        if not isinstance(kwargs, XComArg):
-            raise TypeError(f"expected XComArg object, not {type(kwargs).__name__}")
+        if isinstance(kwargs, collections.abc.Sequence):
+            for item in kwargs:
+                if not isinstance(item, (XComArg, collections.abc.Mapping)):
+                    raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
+        elif not isinstance(kwargs, XComArg):
+            raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
         return self._expand(ListOfDictsExpandInput(kwargs), strict=strict)
 
     def _expand(self, expand_input: ExpandInput, *, strict: bool) -> "MappedOperator":

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
+    from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
 ValidationSource = Union[Literal["expand"], Literal["partial"]]

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -64,8 +64,9 @@ from airflow.models.expandinput import (
     DictOfListsExpandInput,
     ExpandInput,
     ListOfDictsExpandInput,
-    Mappable,
     NotFullyPopulated,
+    OperatorExpandArgument,
+    OperatorExpandKwargsArgument,
     get_mappable_types,
 )
 from airflow.models.pool import Pool
@@ -87,7 +88,6 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
     from airflow.models.taskinstance import TaskInstance
-    from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
 ValidationSource = Union[Literal["expand"], Literal["partial"]]
@@ -184,7 +184,7 @@ class OperatorPartial:
                 task_id = f"at {hex(id(self))}"
             warnings.warn(f"Task {task_id} was never mapped!")
 
-    def expand(self, **mapped_kwargs: "Mappable") -> "MappedOperator":
+    def expand(self, **mapped_kwargs: OperatorExpandArgument) -> "MappedOperator":
         if not mapped_kwargs:
             raise TypeError("no arguments to expand against")
         validate_mapping_kwargs(self.operator_class, "expand", mapped_kwargs)
@@ -193,7 +193,7 @@ class OperatorPartial:
         # to False to skip the checks on execution.
         return self._expand(DictOfListsExpandInput(mapped_kwargs), strict=False)
 
-    def expand_kwargs(self, kwargs: "XComArg", *, strict: bool = True) -> "MappedOperator":
+    def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> "MappedOperator":
         from airflow.models.xcom_arg import XComArg
 
         if not isinstance(kwargs, XComArg):


### PR DESCRIPTION
This adds literal support to `expand_kwargs()`:

```python
task.expand_kwargs([{"arg": 1}, {"arg": 2}, ...])

# Literal list can contain either literal dict or XComArg.
task.expand_kwargs([xcom_arg, {"arg": 2}, ...])
```

This matches the `expand()` interface.

This needs #25924 to go in first and is submitted for CI now.