### PR TITLE
Remove `--type all` from breeze static checks docs

### DIFF
--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -402,7 +402,7 @@ The static code checks can be launched using the Breeze environment.
 You run the static code checks via ``breeze static-check`` or commands.
 
 You can see the list of available static checks either via ``--help`` flag or by using the autocomplete
-option. Note that the ``all`` static check runs all configured static checks.
+option.
 
 Run the ``mypy`` check for the currently staged changes:
 
@@ -432,19 +432,19 @@ Run all checks for the currently staged files:
 
 .. code-block:: bash
 
-     breeze static-checks --type all
+     breeze static-checks
 
 Run all checks for all files:
 
 .. code-block:: bash
 
-    breeze static-checks --type all --all-files
+    breeze static-checks --all-files
 
 Run all checks for last commit :
 
 .. code-block:: bash
 
-     breeze static-checks --type all --last-commit
+     breeze static-checks --last-commit
 
 Debugging pre-commit check scripts requiring image
 --------------------------------------------------


### PR DESCRIPTION
The hook was removed sometime in the past(?):
```
IL-C02Y53RGJHD2:~ eladk$ breeze static-checks --type all
Checking pre-commit installed for /Users/eladk/.local/pipx/venvs/apache-airflow-breeze/bin/python

Package pre_commit is installed. Good version 2.19.0 (>= 2.0.0)

Good version of Docker: 20.10.7.
Good version of docker-compose: 1.29.2
Good Docker context used: default.
No hook with id `all` in stage `commit`
There were errors during pre-commit check. They should be fixed

```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
