### PR TITLE
Fix BranchDateTimeOperator to be timezone-awreness-insensitive

### DIFF
--- a/airflow/example_dags/example_branch_datetime_operator.py
+++ b/airflow/example_dags/example_branch_datetime_operator.py
@@ -76,3 +76,28 @@ cond2 = BranchDateTimeOperator(
 # Run empty_task_1 if cond2 executes between 15:00:00, and 00:00:00 of the following day
 cond2 >> [empty_task_12, empty_task_22]
 # [END howto_branch_datetime_operator_next_day]
+
+dag3 = DAG(
+    dag_id="example_branch_datetime_operator_3",
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    catchup=False,
+    tags=["example"],
+    schedule="@daily",
+)
+# [START howto_branch_datetime_operator_logical_date]
+empty_task_13 = EmptyOperator(task_id='date_in_range', dag=dag3)
+empty_task_23 = EmptyOperator(task_id='date_outside_range', dag=dag3)
+
+cond3 = BranchDateTimeOperator(
+    task_id='datetime_branch',
+    use_task_logical_date=True,
+    follow_task_ids_if_true=['date_in_range'],
+    follow_task_ids_if_false=['date_outside_range'],
+    target_upper=pendulum.datetime(2020, 10, 10, 15, 0, 0),
+    target_lower=pendulum.datetime(2020, 10, 10, 14, 0, 0),
+    dag=dag3,
+)
+
+# Run empty_task_3 if cond1 executes between 2020-10-10 14:00:00 and 2020-10-10 15:00:00
+cond3 >> [empty_task_13, empty_task_23]
+# [END howto_branch_datetime_operator_logical_date]

--- a/airflow/operators/datetime.py
+++ b/airflow/operators/datetime.py
@@ -77,11 +77,13 @@ class BranchDateTimeOperator(BaseBranchOperator):
 
     def choose_branch(self, context: Context) -> Union[str, Iterable[str]]:
         if self.use_task_logical_date:
-            now = timezone.make_naive(context["logical_date"], self.dag.timezone)
+            now = context["logical_date"]
         else:
-            now = timezone.make_naive(timezone.utcnow(), self.dag.timezone)
-
+            now = timezone.coerce_datetime(timezone.utcnow())
         lower, upper = target_times_as_dates(now, self.target_lower, self.target_upper)
+        lower = timezone.coerce_datetime(lower, self.dag.timezone)
+        upper = timezone.coerce_datetime(upper, self.dag.timezone)
+
         if upper is not None and upper < now:
             return self.follow_task_ids_if_false
 

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -206,26 +206,26 @@ def parse(string: str, timezone=None) -> DateTime:
 
 
 @overload
-def coerce_datetime(v: None) -> None:
+def coerce_datetime(v: None, tz: Optional[dt.tzinfo] = None) -> None:
     ...
 
 
 @overload
-def coerce_datetime(v: DateTime) -> DateTime:
+def coerce_datetime(v: DateTime, tz: Optional[dt.tzinfo] = None) -> DateTime:
     ...
 
 
 @overload
-def coerce_datetime(v: dt.datetime) -> DateTime:
+def coerce_datetime(v: dt.datetime, tz: Optional[dt.tzinfo] = None) -> DateTime:
     ...
 
 
-def coerce_datetime(v: Optional[dt.datetime]) -> Optional[DateTime]:
-    """Convert whatever is passed in to an timezone-aware ``pendulum.DateTime``."""
+def coerce_datetime(v: Optional[dt.datetime], tz: Optional[dt.tzinfo] = None) -> Optional[DateTime]:
+    """Convert whatever is passed in to a timezone-aware ``pendulum.DateTime``."""
     if v is None:
         return None
     if isinstance(v, DateTime):
-        return v if v.tzinfo else make_aware(v)
+        return v if v.tzinfo else make_aware(v, tz)
     # Only dt.datetime is left here
     return pendulum.instance(v if v.tzinfo else make_aware(v))
 

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -221,13 +221,20 @@ def coerce_datetime(v: dt.datetime, tz: Optional[dt.tzinfo] = None) -> DateTime:
 
 
 def coerce_datetime(v: Optional[dt.datetime], tz: Optional[dt.tzinfo] = None) -> Optional[DateTime]:
-    """Convert whatever is passed in to a timezone-aware ``pendulum.DateTime``."""
+    """Convert ``v`` into a timezone-aware ``pendulum.DateTime``.
+
+    * If ``v`` is *None*, *None* is returned.
+    * If ``v`` is a naive datetime, it is converted to an aware Pendulum DateTime.
+    * If ``v`` is an aware datetime, it is converted to a Pendulum DateTime.
+      Note that ``tz`` is **not** taken into account in this case; the datetime
+      will maintain its original tzinfo!
+    """
     if v is None:
         return None
     if isinstance(v, DateTime):
         return v if v.tzinfo else make_aware(v, tz)
-    # Only dt.datetime is left here
-    return pendulum.instance(v if v.tzinfo else make_aware(v))
+    # Only dt.datetime is left here.
+    return pendulum.instance(v if v.tzinfo else make_aware(v, tz))
 
 
 def td_format(td_object: Union[None, dt.timedelta, float, int]) -> Optional[str]:

--- a/docs/apache-airflow/howto/operator/datetime.rst
+++ b/docs/apache-airflow/howto/operator/datetime.rst
@@ -22,18 +22,53 @@
 BranchDateTimeOperator
 ======================
 
-Use the :class:`~airflow.operators.datetime.BranchDateTimeOperator` to branch into one of two execution paths depending on whether the date and/or time of execution falls into the range given by two target arguments.
+Use the :class:`~airflow.operators.datetime.BranchDateTimeOperator` to branch into one of two execution paths
+depending on whether the time falls into the range given by two target arguments,
+
+This operator has two modes. First mode is to use current time (machine clock time at the
+moment the DAG is executed), and the second mode is to use the ``logical_date`` of the DAG run it is run
+with.
+
+
+Usage with current time
+-----------------------
+
+The usages above might be useful in certain situations - for example when DAG is used to perform cleanups
+and maintenance and is not really supposed to be used for any DAGs that are supposed to be back-filled,
+because the "current time" make back-filling non-idempotent, it's result depend on the time when the DAG
+actually was run. It's also slightly non-deterministic potentially even if it is run on schedule. It can
+take some time between when the DAGRun was scheduled and executed and it might mean that even if
+the DAGRun was scheduled properly, the actual time used for branching decision will be different than the
+schedule time and the branching decision might be different depending on those delays.
 
 .. exampleinclude:: /../../airflow/example_dags/example_branch_datetime_operator.py
     :language: python
     :start-after: [START howto_branch_datetime_operator]
     :end-before: [END howto_branch_datetime_operator]
 
-The target parameters, ``target_upper`` and ``target_lower``, can receive a ``datetime.datetime``, a ``datetime.time``, or ``None``. When a ``datetime.time`` object is used, it will be combined with the current date in order to allow comparisons with it. In the event that ``target_upper`` is set to a ``datetime.time`` that occurs before the given ``target_lower``, a day will be added to ``target_upper``. This is done to allow for time periods that span over two dates.
+The target parameters, ``target_upper`` and ``target_lower``, can receive a ``datetime.datetime``,
+a ``datetime.time``, or ``None``. When a ``datetime.time`` object is used, it will be combined with
+the current date in order to allow comparisons with it. In the event that ``target_upper`` is set
+to a ``datetime.time`` that occurs before the given ``target_lower``, a day will be added to ``target_upper``.
+This is done to allow for time periods that span over two dates.
 
 .. exampleinclude:: /../../airflow/example_dags/example_branch_datetime_operator.py
     :language: python
     :start-after: [START howto_branch_datetime_operator_next_day]
     :end-before: [END howto_branch_datetime_operator_next_day]
 
-If a target parameter is set to ``None``, the operator will perform a unilateral comparison using only the non-``None`` target. Setting both ``target_upper`` and ``target_lower`` to ``None`` will raise an exception.
+If a target parameter is set to ``None``, the operator will perform a unilateral comparison using only
+the non-``None`` target. Setting both ``target_upper`` and ``target_lower`` to ``None``
+will raise an exception.
+
+Usage with logical date
+-----------------------
+
+The usage is much more "data range" friendly. The ``logical_date`` does not change when the DAG is re-run and
+it is not affected by execution delays, so this approach is suitable for idempotent DAG runs that might be
+back-filled.
+
+.. exampleinclude:: /../../airflow/example_dags/example_branch_datetime_operator.py
+    :language: python
+    :start-after: [START howto_branch_datetime_operator_logical_date]
+    :end-before: [END howto_branch_datetime_operator_logical_date]

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -956,6 +956,7 @@ infile
 influxdb
 infoType
 infoTypes
+ing
 ingestions
 ini
 init


### PR DESCRIPTION
The BranchDateTimeOperator was sensitive to whether timezone
aware or timezone noive parameters were passed to it. Actually
it worked a bit unpredictably - if use_task_logical_date was
used, the lower/upper ranges were supposed to be timezone aware,
but when "now()" was used, the ranges were supposed to be timezone
naive. One of our examples has been broken because it was
comparing naive and aware datetime.

This PR coerces all values to timezone aware Pendulum datetime using
the timezone of the Dag, which makes it insensitive to whether the
aware or naive ranges have been used.

Also, we missed example in the howto showing logical date usage
(and it was rather strange as logical date is the only reasonable
usage of the operator - using utcnow() make the DAG essentially
non-idempotent - it's result depends on when the task is run which
might make sense in some cases but most of the time is something
that should be discouraged.

The documentation has been updated to explain that.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
