### PR TITLE
Fix broken auto-refresh in Airflow 2.3.4

### DIFF
--- a/airflow/www/static/js/api/useGridData.test.js
+++ b/airflow/www/static/js/api/useGridData.test.js
@@ -60,6 +60,24 @@ describe('Test areActiveRuns()', () => {
     expect(result).toBe(false);
   });
 
+  [
+    { runType: 'manual', state: 'queued', result: true },
+    { runType: 'manual', state: 'running', result: true },
+    { runType: 'scheduled', state: 'queued', result: true },
+    { runType: 'scheduled', state: 'running', result: true },
+    { runType: 'backfill', state: 'queued', result: false },
+    { runType: 'backfill', state: 'running', result: false },
+  ].forEach((conf) => {
+    test(`Returns ${conf.result} when filtering runs with runtype ["${conf.runType}"] and state ["${conf.state}"]`, () => {
+      const runConf = { ...conf };
+      delete runConf.result;
+      const runs = [runConf];
+
+      const result = areActiveRuns(runs);
+      expect(result).toBe(conf.result);
+    });
+  });
+
   test('Returns false when there are no runs', () => {
     const result = areActiveRuns();
     expect(result).toBe(false);

--- a/airflow/www/static/js/api/useGridData.ts
+++ b/airflow/www/static/js/api/useGridData.ts
@@ -57,7 +57,7 @@ const formatOrdering = (data: GridData) => ({
   ordering: data.ordering.map((o: string) => camelCase(o)) as RunOrdering,
 });
 
-export const areActiveRuns = (runs: DagRun[] = []) => runs.filter((run) => ['manual', 'manual'].includes(run.runType)).filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
+export const areActiveRuns = (runs: DagRun[] = []) => runs.filter((run) => ['manual', 'scheduled'].includes(run.runType)).filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
 
 const useGridData = () => {
   const { isRefreshOn, stopRefresh } = useAutoRefresh();


### PR DESCRIPTION
In PR #25042 the merged change included a bug that prevents the page from auto-refreshing if there aren't any manual runs on the page. We also want to auto-refresh for scheduled runs.

I've also added more complete unit tests for the expected behaviour.

This PR closes #25949 
