### PR TITLE
Add triggered dag runs to dataset events

### DIFF
--- a/airflow/api_connexion/endpoints/dataset_endpoint.py
+++ b/airflow/api_connexion/endpoints/dataset_endpoint.py
@@ -113,6 +113,8 @@ def get_dataset_events(
     if source_map_index:
         query = query.filter(DatasetEvent.source_map_index == source_map_index)
 
+    query = query.options(subqueryload(DatasetEvent.created_dagruns))
+
     total_entries = query.count()
     query = apply_sorting(query, order_by, {}, allowed_attrs)
     events = query.offset(offset).limit(limit).all()

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3622,6 +3622,10 @@ components:
           type: integer
           description: The task map index that updated the dataset.
           nullable: true
+        created_dagruns:
+            type: array
+            items:
+              $ref: '#/components/schemas/DAGRun'
         timestamp:
           type: string
           description: The dataset event creation time

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3625,11 +3625,77 @@ components:
         created_dagruns:
             type: array
             items:
-              $ref: '#/components/schemas/DAGRun'
+              $ref: '#/components/schemas/BasicDAGRun'
         timestamp:
           type: string
           description: The dataset event creation time
           nullable: false
+
+    BasicDAGRun:
+      type: object
+      properties:
+        run_id:
+          type: string
+          nullable: true
+          description: |
+            Run ID.
+        dag_id:
+          type: string
+          readOnly: true
+        logical_date:
+          type: string
+          nullable: true
+          description: |
+            The logical date (previously called execution date). This is the time or interval covered by
+            this DAG run, according to the DAG definition.
+
+            The value of this field can be set only when creating the object. If you try to modify the
+            field of an existing object, the request fails with an BAD_REQUEST error.
+
+            This together with DAG_ID are a unique key.
+
+            *New in version 2.2.0*
+          format: date-time
+        execution_date:
+          type: string
+          nullable: true
+          description: |
+            The execution date. This is the same as logical_date, kept for backwards compatibility.
+            If both this field and logical_date are provided but with different values, the request
+            will fail with an BAD_REQUEST error.
+
+            *Changed in version 2.2.0*&#58; Field becomes nullable.
+
+            *Deprecated since version 2.2.0*&#58; Use 'logical_date' instead.
+          format: date-time
+          deprecated: true
+        start_date:
+          type: string
+          format: date-time
+          description: |
+            The start time. The time when DAG run was actually created.
+
+            *Changed in version 2.1.3*&#58; Field becomes nullable.
+          readOnly: true
+          nullable: true
+        end_date:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        data_interval_start:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        data_interval_end:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        state:
+          $ref: '#/components/schemas/DagState'
+          readOnly: true
 
     DatasetEventCollection:
       description: |

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3636,7 +3636,6 @@ components:
       properties:
         run_id:
           type: string
-          nullable: true
           description: |
             Run ID.
         dag_id:
@@ -3644,7 +3643,6 @@ components:
           readOnly: true
         logical_date:
           type: string
-          nullable: true
           description: |
             The logical date (previously called execution date). This is the time or interval covered by
             this DAG run, according to the DAG definition.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3656,19 +3656,6 @@ components:
 
             *New in version 2.2.0*
           format: date-time
-        execution_date:
-          type: string
-          nullable: true
-          description: |
-            The execution date. This is the same as logical_date, kept for backwards compatibility.
-            If both this field and logical_date are provided but with different values, the request
-            will fail with an BAD_REQUEST error.
-
-            *Changed in version 2.2.0*&#58; Field becomes nullable.
-
-            *Deprecated since version 2.2.0*&#58; Use 'logical_date' instead.
-          format: date-time
-          deprecated: true
         start_date:
           type: string
           format: date-time

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -27,6 +27,7 @@ from airflow.models.dataset import (
     DatasetModel,
     TaskOutletDatasetReference,
 )
+from airflow.api_connexion.schemas.dag_run_schema import DAGRunSchema
 
 
 class TaskOutletDatasetReferenceSchema(SQLAlchemySchema):
@@ -107,6 +108,7 @@ class DatasetEventSchema(SQLAlchemySchema):
     source_dag_id = auto_field()
     source_run_id = auto_field()
     source_map_index = auto_field()
+    created_dagruns = fields.List(fields.Nested(DAGRunSchema))
     timestamp = auto_field()
 
 

--- a/airflow/api_connexion/schemas/dataset_schema.py
+++ b/airflow/api_connexion/schemas/dataset_schema.py
@@ -21,13 +21,13 @@ from marshmallow import Schema, fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.schemas.common_schema import JsonObjectField
+from airflow.models.dagrun import DagRun
 from airflow.models.dataset import (
     DagScheduleDatasetReference,
     DatasetEvent,
     DatasetModel,
     TaskOutletDatasetReference,
 )
-from airflow.api_connexion.schemas.dag_run_schema import DAGRunSchema
 
 
 class TaskOutletDatasetReferenceSchema(SQLAlchemySchema):
@@ -92,6 +92,25 @@ dataset_schema = DatasetSchema()
 dataset_collection_schema = DatasetCollectionSchema()
 
 
+class BasicDAGRunSchema(SQLAlchemySchema):
+    """Basic Schema for DAGRun"""
+
+    class Meta:
+        """Meta"""
+
+        model = DagRun
+        dateformat = "iso"
+
+    run_id = auto_field(data_key='dag_run_id')
+    dag_id = auto_field(dump_only=True)
+    execution_date = auto_field(data_key="logical_date", dump_only=True)
+    start_date = auto_field(dump_only=True)
+    end_date = auto_field(dump_only=True)
+    state = auto_field(dump_only=True)
+    data_interval_start = auto_field(dump_only=True)
+    data_interval_end = auto_field(dump_only=True)
+
+
 class DatasetEventSchema(SQLAlchemySchema):
     """Dataset Event DB schema"""
 
@@ -108,7 +127,7 @@ class DatasetEventSchema(SQLAlchemySchema):
     source_dag_id = auto_field()
     source_run_id = auto_field()
     source_map_index = auto_field()
-    created_dagruns = fields.List(fields.Nested(DAGRunSchema))
+    created_dagruns = fields.List(fields.Nested(BasicDAGRunSchema))
     timestamp = auto_field()
 
 

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -17,13 +17,27 @@
  * under the License.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
-  Code, Link, Box, Text,
+  Flex,
+  Code,
+  Link,
+  Box,
+  Text,
+  useDisclosure,
+  ModalCloseButton,
+  Modal,
+  ModalContent,
+  ModalOverlay,
+  ModalBody,
+  ModalHeader,
 } from '@chakra-ui/react';
 
+import { Table } from 'src/components/Table';
 import Time from 'src/components/Time';
 import { getMetaValue } from 'src/utils';
+import { useContainerRef } from 'src/context/containerRef';
+import { SimpleStatus } from 'src/dag/StatusBox';
 
 interface CellProps {
   cell: {
@@ -45,6 +59,79 @@ export const DatasetLink = ({ cell: { value } }: CellProps) => {
     >
       {value}
     </Link>
+  );
+};
+
+export const DagRunLink = ({ cell: { value, row } }: CellProps) => {
+  const dagId = getMetaValue('dag_id');
+  const gridUrl = getMetaValue('grid_url');
+  const stringToReplace = dagId || '__DAG_ID__';
+  const url = `${gridUrl?.replace(stringToReplace, value)}?dag_run_id=${encodeURIComponent(row.original.dagRunId)}`;
+  return (
+    <Flex alignItems="center">
+      <SimpleStatus state={row.original.state} mr={2} />
+      <Link
+        color="blue.600"
+        href={url}
+      >
+        {value}
+      </Link>
+    </Flex>
+  );
+};
+
+export const TriggeredRuns = ({ cell: { value, row } }: CellProps) => {
+  const { isOpen, onToggle, onClose } = useDisclosure();
+  const containerRef = useContainerRef();
+
+  const columns = useMemo(
+    () => [
+      {
+        Header: 'DAG Id',
+        accessor: 'dagId',
+        Cell: DagRunLink,
+      },
+      {
+        Header: 'Execution Date',
+        accessor: 'executionDate',
+        Cell: TimeCell,
+      },
+    ],
+    [],
+  );
+
+  const data = useMemo(
+    () => value,
+    [value],
+  );
+
+  if (!value || !value.length) return null;
+
+  return (
+    <Box>
+      <Text color="blue.600" cursor="pointer" onClick={onToggle}>{value.length}</Text>
+      <Modal size="3xl" isOpen={isOpen} onClose={onClose} portalProps={{ containerRef }}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>
+            <Text as="span" color="gray.400">Dag Runs triggered by</Text>
+            <br />
+            {row.original.datasetUri}
+            <br />
+            <Text as="span" color="gray.400">at</Text>
+            <br />
+            <Time dateTime={row.original.timestamp} />
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Table
+              data={data}
+              columns={columns}
+            />
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </Box>
   );
 };
 

--- a/airflow/www/static/js/components/Table/Cells.tsx
+++ b/airflow/www/static/js/components/Table/Cells.tsx
@@ -92,8 +92,8 @@ export const TriggeredRuns = ({ cell: { value, row } }: CellProps) => {
         Cell: DagRunLink,
       },
       {
-        Header: 'Execution Date',
-        accessor: 'executionDate',
+        Header: 'Logical Date',
+        accessor: 'logicalDate',
         Cell: TimeCell,
       },
     ],

--- a/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/DatasetUpdateEvents.tsx
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 
 import {
-  DatasetLink, Table, TimeCell,
+  DatasetLink, Table, TimeCell, TriggeredRuns,
 } from 'src/components/Table';
 import { useDatasetEvents } from 'src/api';
 import type { DagRun as DagRunType } from 'src/types';
@@ -55,6 +55,11 @@ const DatasetUpdateEvents = ({ runId, taskId }: Props) => {
         Header: 'When',
         accessor: 'timestamp',
         Cell: TimeCell,
+      },
+      {
+        Header: 'Triggered Runs',
+        accessor: 'createdDagruns',
+        Cell: TriggeredRuns,
       },
     ],
     [],

--- a/airflow/www/static/js/datasets/DatasetEvents.tsx
+++ b/airflow/www/static/js/datasets/DatasetEvents.tsx
@@ -23,7 +23,7 @@ import type { SortingRule } from 'react-table';
 
 import { useDatasetEvents } from 'src/api';
 import {
-  Table, TimeCell, TaskInstanceLink,
+  Table, TimeCell, TaskInstanceLink, TriggeredRuns,
 } from 'src/components/Table';
 
 const Events = ({
@@ -54,6 +54,11 @@ const Events = ({
         Header: 'When',
         accessor: 'timestamp',
         Cell: TimeCell,
+      },
+      {
+        Header: 'Triggered Runs',
+        accessor: 'createdDagruns',
+        Cell: TriggeredRuns,
       },
     ],
     [],

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1559,18 +1559,6 @@ export interface components {
       logical_date?: string | null;
       /**
        * Format: date-time
-       * @deprecated
-       * @description The execution date. This is the same as logical_date, kept for backwards compatibility.
-       * If both this field and logical_date are provided but with different values, the request
-       * will fail with an BAD_REQUEST error.
-       *
-       * *Changed in version 2.2.0*&#58; Field becomes nullable.
-       *
-       * *Deprecated since version 2.2.0*&#58; Use 'logical_date' instead.
-       */
-      execution_date?: string | null;
-      /**
-       * Format: date-time
        * @description The start time. The time when DAG run was actually created.
        *
        * *Changed in version 2.1.3*&#58; Field becomes nullable.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1542,7 +1542,7 @@ export interface components {
     };
     BasicDAGRun: {
       /** @description Run ID. */
-      run_id?: string | null;
+      run_id?: string;
       dag_id?: string;
       /**
        * Format: date-time
@@ -1556,7 +1556,7 @@ export interface components {
        *
        * *New in version 2.2.0*
        */
-      logical_date?: string | null;
+      logical_date?: string;
       /**
        * Format: date-time
        * @description The start time. The time when DAG run was actually created.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1536,6 +1536,7 @@ export interface components {
       source_run_id?: string | null;
       /** @description The task map index that updated the dataset. */
       source_map_index?: number | null;
+      created_dagruns?: components["schemas"]["DAGRun"][];
       /** @description The dataset event creation time */
       timestamp?: string;
     };

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1536,9 +1536,53 @@ export interface components {
       source_run_id?: string | null;
       /** @description The task map index that updated the dataset. */
       source_map_index?: number | null;
-      created_dagruns?: components["schemas"]["DAGRun"][];
+      created_dagruns?: components["schemas"]["BasicDAGRun"][];
       /** @description The dataset event creation time */
       timestamp?: string;
+    };
+    BasicDAGRun: {
+      /** @description Run ID. */
+      run_id?: string | null;
+      dag_id?: string;
+      /**
+       * Format: date-time
+       * @description The logical date (previously called execution date). This is the time or interval covered by
+       * this DAG run, according to the DAG definition.
+       *
+       * The value of this field can be set only when creating the object. If you try to modify the
+       * field of an existing object, the request fails with an BAD_REQUEST error.
+       *
+       * This together with DAG_ID are a unique key.
+       *
+       * *New in version 2.2.0*
+       */
+      logical_date?: string | null;
+      /**
+       * Format: date-time
+       * @deprecated
+       * @description The execution date. This is the same as logical_date, kept for backwards compatibility.
+       * If both this field and logical_date are provided but with different values, the request
+       * will fail with an BAD_REQUEST error.
+       *
+       * *Changed in version 2.2.0*&#58; Field becomes nullable.
+       *
+       * *Deprecated since version 2.2.0*&#58; Use 'logical_date' instead.
+       */
+      execution_date?: string | null;
+      /**
+       * Format: date-time
+       * @description The start time. The time when DAG run was actually created.
+       *
+       * *Changed in version 2.1.3*&#58; Field becomes nullable.
+       */
+      start_date?: string | null;
+      /** Format: date-time */
+      end_date?: string | null;
+      /** Format: date-time */
+      data_interval_start?: string | null;
+      /** Format: date-time */
+      data_interval_end?: string | null;
+      state?: components["schemas"]["DagState"];
     };
     /**
      * @description A collection of dataset events.
@@ -4117,6 +4161,7 @@ export type TaskOutletDatasetReference = CamelCasedPropertiesDeep<components['sc
 export type DagScheduleDatasetReference = CamelCasedPropertiesDeep<components['schemas']['DagScheduleDatasetReference']>;
 export type DatasetCollection = CamelCasedPropertiesDeep<components['schemas']['DatasetCollection']>;
 export type DatasetEvent = CamelCasedPropertiesDeep<components['schemas']['DatasetEvent']>;
+export type BasicDAGRun = CamelCasedPropertiesDeep<components['schemas']['BasicDAGRun']>;
 export type DatasetEventCollection = CamelCasedPropertiesDeep<components['schemas']['DatasetEventCollection']>;
 export type ConfigOption = CamelCasedPropertiesDeep<components['schemas']['ConfigOption']>;
 export type ConfigSection = CamelCasedPropertiesDeep<components['schemas']['ConfigSection']>;

--- a/airflow/www/templates/airflow/datasets.html
+++ b/airflow/www/templates/airflow/datasets.html
@@ -38,5 +38,8 @@
 
 {% block tail_js %}
   {{ super()}}
+  <script>
+    const stateColors = {{ state_color_mapping|tojson }};
+  </script>
   <script src="{{ url_for_asset('datasets.js') }}"></script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1008,8 +1008,11 @@ class Airflow(AirflowBaseView):
     @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DATASET)])
     def datasets(self):
         """Datasets view."""
+        state_color_mapping = State.state_color.copy()
+        state_color_mapping["null"] = state_color_mapping.pop(None)
         return self.render_template(
             "airflow/datasets.html",
+            state_color_mapping=state_color_mapping,
         )
 
     @expose('/dag_stats', methods=['POST'])

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -1533,6 +1533,18 @@ class TestGetDagRunDatasetTriggerEvents(TestDagRunEndpoint):
                     'source_map_index': ti.map_index,
                     'source_run_id': ti.run_id,
                     'source_task_id': ti.task_id,
+                    'created_dagruns': [
+                        {
+                            'dag_id': 'TEST_DAG_ID',
+                            'dag_run_id': 'TEST_DAG_RUN_ID',
+                            'data_interval_end': dr.data_interval_end.isoformat(),
+                            'data_interval_start': dr.data_interval_start.isoformat(),
+                            'end_date': None,
+                            'logical_date': dr.logical_date.isoformat(),
+                            'start_date': dr.start_date.isoformat(),
+                            'state': 'running',
+                        }
+                    ],
                 }
             ],
             'total_entries': 1,

--- a/tests/api_connexion/schemas/test_dataset_schema.py
+++ b/tests/api_connexion/schemas/test_dataset_schema.py
@@ -155,6 +155,7 @@ class TestDatasetEventSchema(TestDatasetSchemaBase):
             "source_run_id": "custom",
             "source_map_index": -1,
             "timestamp": self.timestamp,
+            "created_dagruns": [],
         }
 
 
@@ -167,6 +168,7 @@ class TestDatasetEventCollectionSchema(TestDatasetSchemaBase):
             "source_task_id": "bar",
             "source_run_id": "custom",
             "source_map_index": -1,
+            "created_dagruns": [],
         }
 
         events = [DatasetEvent(id=i, **common) for i in [1, 2]]


### PR DESCRIPTION
With `created_dagruns` as part of the `DatasetEventModel`, we should include that information in the API & UI.

This adds this to the REST API response. And then displays it on a dataset details page by adding another column showing the count of dag runs created by that dataset event. Clicking on the count will show a modal with a table linking out to each dag run.

<img width="1668" alt="Screen Shot 2022-08-25 at 3 09 13 PM" src="https://user-images.githubusercontent.com/4600967/186748513-e603a221-6ac7-4cda-b879-4c5bf43dbbe5.png">

<img width="891" alt="Screen Shot 2022-08-25 at 3 09 28 PM" src="https://user-images.githubusercontent.com/4600967/186748567-49a23ba6-968a-49f4-bab2-9339118f8349.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
