### PR TITLE
Update areActiveRuns and fix tests

### DIFF
--- a/airflow/www/static/js/api/useGridData.test.js
+++ b/airflow/www/static/js/api/useGridData.test.js
@@ -34,17 +34,17 @@ describe('Test areActiveRuns()', () => {
     const runs = [
       { runType: 'scheduled', state: 'success' },
       { runType: 'manual', state: 'failed' },
-      { runType: 'manual', state: 'not_queued' },
+      { runType: 'manual', state: 'failed' },
     ];
     const result = areActiveRuns(runs);
     expect(result).toBe(false);
   });
 
-  test('Returns false when filtering runs runtype ["backfill"] and state ["not_queued"]', () => {
+  test('Returns false when filtering runs runtype ["backfill"] and state ["failed"]', () => {
     const runs = [
       { runType: 'scheduled', state: 'success' },
       { runType: 'manual', state: 'failed' },
-      { runType: 'backfill', state: 'not_queued' },
+      { runType: 'backfill', state: 'failed' },
     ];
     const result = areActiveRuns(runs);
     expect(result).toBe(false);
@@ -61,20 +61,35 @@ describe('Test areActiveRuns()', () => {
   });
 
   [
-    { runType: 'manual', state: 'queued', result: true },
-    { runType: 'manual', state: 'running', result: true },
-    { runType: 'scheduled', state: 'queued', result: true },
-    { runType: 'scheduled', state: 'running', result: true },
-    { runType: 'backfill', state: 'queued', result: false },
-    { runType: 'backfill', state: 'running', result: false },
-  ].forEach((conf) => {
-    test(`Returns ${conf.result} when filtering runs with runtype ["${conf.runType}"] and state ["${conf.state}"]`, () => {
-      const runConf = { ...conf };
-      delete runConf.result;
-      const runs = [runConf];
-
+    {
+      runType: 'manual', state: 'queued', expectedResult: true,
+    },
+    {
+      runType: 'manual', state: 'running', expectedResult: true,
+    },
+    {
+      runType: 'scheduled', state: 'queued', expectedResult: true,
+    },
+    {
+      runType: 'scheduled', state: 'running', expectedResult: true,
+    },
+    {
+      runType: 'dataset_triggered', state: 'queued', expectedResult: true,
+    },
+    {
+      runType: 'dataset_triggered', state: 'running', expectedResult: true,
+    },
+    {
+      runType: 'backfill', state: 'queued', expectedResult: false,
+    },
+    {
+      runType: 'backfill', state: 'running', expectedResult: false,
+    },
+  ].forEach(({ state, runType, expectedResult }) => {
+    test(`Returns ${expectedResult} when filtering runs with runtype ["${runType}"] and state ["${state}"]`, () => {
+      const runs = [{ runType, state }];
       const result = areActiveRuns(runs);
-      expect(result).toBe(conf.result);
+      expect(result).toBe(expectedResult);
     });
   });
 

--- a/airflow/www/static/js/api/useGridData.ts
+++ b/airflow/www/static/js/api/useGridData.ts
@@ -57,7 +57,7 @@ const formatOrdering = (data: GridData) => ({
   ordering: data.ordering.map((o: string) => camelCase(o)) as RunOrdering,
 });
 
-export const areActiveRuns = (runs: DagRun[] = []) => runs.filter((run) => ['manual', 'scheduled'].includes(run.runType)).filter((run) => ['queued', 'running', 'scheduled'].includes(run.state)).length > 0;
+export const areActiveRuns = (runs: DagRun[] = []) => runs.filter((run) => ['manual', 'scheduled', 'dataset_triggered'].includes(run.runType)).filter((run) => ['queued', 'running'].includes(run.state)).length > 0;
 
 const useGridData = () => {
   const { isRefreshOn, stopRefresh } = useAutoRefresh();


### PR DESCRIPTION
DagRun.state can only take  the following values: `'success' | 'running' | 'queued' | 'failed'`

A few tests are run with `DagRun.state` that are not valid (eg `not_queued`). This is also an issue for moving the file to a typescript version.

In the same manner the `areActiveRuns` second filter checks for state that cannot appear for a `DagRun.state` (`scheduled`).

As discussed with @bbovenzi, we feel like the auto-refresh should work for `dataset_triggered` dag run.