### PR TITLE
Fix EMR serverless system test

### DIFF
--- a/airflow/providers/amazon/aws/sensors/emr.py
+++ b/airflow/providers/amazon/aws/sensors/emr.py
@@ -214,8 +214,6 @@ class EmrServerlessApplicationSensor(BaseSensorOperator):
         super().__init__(**kwargs)
 
     def poke(self, context: 'Context') -> bool:
-        state = None
-
         response = self.hook.conn.get_application(applicationId=self.application_id)
 
         state = response['application']['state']

--- a/tests/system/providers/amazon/aws/example_emr_serverless.py
+++ b/tests/system/providers/amazon/aws/example_emr_serverless.py
@@ -40,6 +40,7 @@ sys_test_context_task = SystemTestContextBuilder().add_variable(ROLE_ARN_KEY).bu
 
 with DAG(
     dag_id=DAG_ID,
+    schedule='@once',
     start_date=datetime(2021, 1, 1),
     tags=['example'],
     catchup=False,
@@ -70,6 +71,7 @@ with DAG(
         release_label='emr-6.6.0',
         job_type="SPARK",
         config={'name': 'new_application'},
+        wait_for_completion=False,
     )
     # [END howto_operator_emr_serverless_create_application]
 


### PR DESCRIPTION
The missing `schedule` make the DAG run 1000x times.