### PR TITLE
Fix unhashable issue with secrets.backend_kwargs and caching

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1545,19 +1545,18 @@ def get_custom_secret_backend() -> Optional[BaseSecretsBackend]:
     """Get Secret Backend if defined in airflow.cfg"""
     secrets_backend_cls = conf.getimport(section='secrets', key='backend')
     if secrets_backend_cls:
-        try:
-            backends: Any = conf.get(section='secrets', key='backend_kwargs', fallback='{}')
-            alternative_secrets_config_dict = json.loads(backends)
-        except JSONDecodeError:
-            alternative_secrets_config_dict = {}
-
-        return _custom_secrets_backend(secrets_backend_cls, **alternative_secrets_config_dict)
+        backends: Any = conf.get(section='secrets', key='backend_kwargs', fallback='{}')
+        return _custom_secrets_backend(secrets_backend_cls, backends)
     return None
 
 
 @functools.lru_cache(maxsize=2)
-def _custom_secrets_backend(secrets_backend_cls, **alternative_secrets_config_dict):
+def _custom_secrets_backend(secrets_backend_cls, backend_kwargs):
     """Separate function to create secrets backend instance to allow caching"""
+    try:
+        alternative_secrets_config_dict = json.loads(backend_kwargs)
+    except JSONDecodeError:
+        alternative_secrets_config_dict = {}
     return secrets_backend_cls(**alternative_secrets_config_dict)
 
 


### PR DESCRIPTION
This alters the caching for secrets backend so it can handle dictionary or list arguments. It does so by caching on the backend_kwargs as a json string before trying to parse the json.

closes: #25968

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
