### PR TITLE
Athena and EMR operator max_retries mix-up fix

### DIFF
--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -93,7 +93,7 @@ class AthenaOperator(BaseOperator):
             if max_polling_attempts and max_polling_attempts != max_tries:
                 raise Exception("max_polling_attempts must be the same value as max_tries")
             else:
-                max_polling_attempts = max_tries
+                self.max_polling_attempts = max_tries
 
     @cached_property
     def hook(self) -> AthenaHook:

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
 
 from airflow.compat.functools import cached_property
@@ -43,7 +44,9 @@ class AthenaOperator(BaseOperator):
     :param query_execution_context: Context in which query need to be run
     :param result_configuration: Dict with path to store results in and config related to encryption
     :param sleep_time: Time (in seconds) to wait between two consecutive calls to check query status on Athena
-    :param max_tries: Number of times to poll for query state before function exits
+    :param max_tries: Deprecated - use max_polling_attempts instead.
+    :param max_polling_attempts: Number of times to poll for query state before function exits
+        To limit task execution time, use execution_timeout.
     """
 
     ui_color = '#44b5e2'
@@ -64,6 +67,7 @@ class AthenaOperator(BaseOperator):
         result_configuration: Optional[Dict[str, Any]] = None,
         sleep_time: int = 30,
         max_tries: Optional[int] = None,
+        max_polling_attempts: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -76,8 +80,20 @@ class AthenaOperator(BaseOperator):
         self.query_execution_context = query_execution_context or {}
         self.result_configuration = result_configuration or {}
         self.sleep_time = sleep_time
-        self.max_tries = max_tries
+        self.max_polling_attempts = max_polling_attempts
         self.query_execution_id = None  # type: Optional[str]
+
+        if max_tries:
+            warnings.warn(
+                f"Parameter `{self.__class__.__name__}.max_tries` is deprecated and will be removed "
+                "in a future release.  Please use method `max_polling_attempts` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_polling_attempts and max_polling_attempts != max_tries:
+                raise Exception("max_polling_attempts must be the same value as max_tries")
+            else:
+                max_polling_attempts = max_tries
 
     @cached_property
     def hook(self) -> AthenaHook:
@@ -95,7 +111,7 @@ class AthenaOperator(BaseOperator):
             self.client_request_token,
             self.workgroup,
         )
-        query_status = self.hook.poll_query_status(self.query_execution_id, self.max_tries)
+        query_status = self.hook.poll_query_status(self.query_execution_id, self.max_polling_attempts)
 
         if query_status in AthenaHook.FAILURE_STATES:
             error_message = self.hook.get_state_change_reason(self.query_execution_id)

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import ast
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from uuid import uuid4
 
@@ -195,7 +196,8 @@ class EmrContainerOperator(BaseOperator):
     :param aws_conn_id: The Airflow connection used for AWS credentials.
     :param wait_for_completion: Whether or not to wait in the operator for the job to complete.
     :param poll_interval: Time (in seconds) to wait between two consecutive calls to check query status on EMR
-    :param max_tries: Maximum number of times to wait for the job run to finish.
+    :param max_tries: Deprecated - use max_polling_attempts instead.
+    :param max_polling_attempts: Maximum number of times to wait for the job run to finish.
         Defaults to None, which will poll until the job is *not* in a pending, submitted, or running state.
     :param tags: The tags assigned to job runs.
         Defaults to None
@@ -225,6 +227,7 @@ class EmrContainerOperator(BaseOperator):
         poll_interval: int = 30,
         max_tries: Optional[int] = None,
         tags: Optional[dict] = None,
+        max_polling_attempts: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -238,9 +241,21 @@ class EmrContainerOperator(BaseOperator):
         self.client_request_token = client_request_token or str(uuid4())
         self.wait_for_completion = wait_for_completion
         self.poll_interval = poll_interval
-        self.max_tries = max_tries
+        self.max_polling_attempts = max_polling_attempts
         self.tags = tags
         self.job_id: Optional[str] = None
+
+        if max_tries:
+            warnings.warn(
+                f"Parameter `{self.__class__.__name__}.max_tries` is deprecated and will be removed "
+                "in a future release.  Please use method `max_polling_attempts` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if max_polling_attempts and max_polling_attempts != max_tries:
+                raise Exception("max_polling_attempts must be the same value as max_tries")
+            else:
+                max_polling_attempts = max_tries
 
     @cached_property
     def hook(self) -> EmrContainerHook:
@@ -262,7 +277,9 @@ class EmrContainerOperator(BaseOperator):
             self.tags,
         )
         if self.wait_for_completion:
-            query_status = self.hook.poll_query_status(self.job_id, self.max_tries, self.poll_interval)
+            query_status = self.hook.poll_query_status(
+                self.job_id, self.max_polling_attempts, self.poll_interval
+            )
 
             if query_status in EmrContainerHook.FAILURE_STATES:
                 error_message = self.hook.get_job_failure_reason(self.job_id)
@@ -352,7 +369,6 @@ class EmrCreateJobFlowOperator(BaseOperator):
         self.log.info(
             'Creating JobFlow using aws-conn-id: %s, emr-conn-id: %s', self.aws_conn_id, self.emr_conn_id
         )
-
         if isinstance(self.job_flow_overrides, str):
             job_flow_overrides: Dict[str, Any] = ast.literal_eval(self.job_flow_overrides)
             self.job_flow_overrides = job_flow_overrides

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -255,7 +255,7 @@ class EmrContainerOperator(BaseOperator):
             if max_polling_attempts and max_polling_attempts != max_tries:
                 raise Exception("max_polling_attempts must be the same value as max_tries")
             else:
-                max_polling_attempts = max_tries
+                self.max_polling_attempts = max_tries
 
     @cached_property
     def hook(self) -> EmrContainerHook:


### PR DESCRIPTION
Fix for issue regarding a mix up of variable names. The solution proposed changes the variable name `max_retires` to `max_polling_attempts`. Both names are currently accepted, but if `max_tries` is used, the user is shown a deprecation warning. Internally, the operators only use `max_polling_attempts`. If both are passed, but their values are not equal, an Exception is thrown.

closes: [#22381](https://github.com/apache/airflow/issues/22381)
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
