### PR TITLE
Support Airflow connections in Datasets

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -132,6 +132,11 @@ class DatasetModel(Base):
         if len(split_scheme) == 2:
             scheme = split_scheme[1]
 
+        # Strip userinfo from the uri
+        netloc = conn.netloc
+        if "@" in netloc:
+            netloc = netloc.split("@")[1]
+
         # Combine the paths (connection followed by dataset)
         path = conn.path
         if parsed.path:
@@ -144,7 +149,7 @@ class DatasetModel(Base):
         if parsed.query:
             query.update(parse_qs(parsed.query))
 
-        merged_conn = (scheme, conn.netloc, path, "", urlencode(query, doseq=True), conn.fragment)
+        merged_conn = (scheme, netloc, path, "", urlencode(query, doseq=True), conn.fragment)
         return urlunparse(merged_conn)
 
 

--- a/tests/models/test_dataset.py
+++ b/tests/models/test_dataset.py
@@ -60,6 +60,12 @@ class TestDatasetModel:
                 "airflow://testconn/?foo=bar",
                 "postgres://somehost/?biz=baz&foo=bar",
             ),
+            (
+                "postgres://somehost?foo=baz",
+                "airflow://testconn/?foo=bar",
+                "postgres://somehost/?foo=bar",
+            ),
+            ("postgres://user:pass@somehost", "airflow://testconn", "postgres://somehost"),
         ],
     )
     def test_canonical_uri(self, conn_uri, dataset_uri, expected_canonical_uri):

--- a/tests/models/test_dataset.py
+++ b/tests/models/test_dataset.py
@@ -46,26 +46,27 @@ class TestDatasetModel:
     @pytest.mark.parametrize(
         "conn_uri, dataset_uri, expected_canonical_uri",
         [
-            ("postgres://somehost/", "airflow://testconn/", "postgres://somehost/"),
-            ("postgres://somehost:111/base", "airflow://testconn", "postgres://somehost:111/base"),
-            ("postgres://somehost:111/base", "airflow+foo://testconn", "foo://somehost:111/base"),
+            ("postgres://somehost/", "airflow://testconn@/", "postgres://somehost/"),
+            ("postgres://somehost:111/base", "airflow://testconn@", "postgres://somehost:111/base"),
+            ("postgres://somehost:111/base", "airflow+foo://testconn@", "foo://somehost:111/base"),
+            ("postgres://somehost:111", "airflow://testconn@foo:222", "postgres://foo:222"),
             (
                 "postgres://somehost:111/base",
-                "airflow://testconn/extra",
+                "airflow://testconn@/extra",
                 "postgres://somehost:111/base/extra",
             ),
-            ("postgres://somehost:111", "airflow://testconn/?foo=bar", "postgres://somehost:111/?foo=bar"),
+            ("postgres://somehost:111", "airflow://testconn@/?foo=bar", "postgres://somehost:111/?foo=bar"),
             (
                 "postgres://somehost?biz=baz",
-                "airflow://testconn/?foo=bar",
+                "airflow://testconn@/?foo=bar",
                 "postgres://somehost/?biz=baz&foo=bar",
             ),
             (
                 "postgres://somehost?foo=baz",
-                "airflow://testconn/?foo=bar",
+                "airflow://testconn@/?foo=bar",
                 "postgres://somehost/?foo=bar",
             ),
-            ("postgres://user:pass@somehost", "airflow://testconn", "postgres://somehost"),
+            ("postgres://user:pass@somehost", "airflow://testconn@", "postgres://somehost"),
         ],
     )
     def test_canonical_uri(self, conn_uri, dataset_uri, expected_canonical_uri):


### PR DESCRIPTION
This allows use of Airflow connections in dataset uris, with a new
method to produce a canonicalized uri, which sanely combines the
connection details with the dataset uri.

While we originally were going to stick it in userinfo, since we can infer any meaning with our scheme, I figured the cleaner host section was okay to use instead.