### PR TITLE
SSHHook: Saving new host keys as described in docs

### DIFF
--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -102,6 +102,12 @@ class TestSSHHook(unittest.TestCase):
     )
     CONN_SSH_WITH_EXTRA_DISABLED_ALGORITHMS = 'ssh_with_extra_disabled_algorithms'
     CONN_SSH_WITH_EXTRA_CIPHERS = 'ssh_with_extra_ciphers'
+    CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_TRUE = (
+        'ssh_with_no_host_key_check_true_and_allow_host_key_changes_true'
+    )
+    CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE = (
+        'ssh_with_no_host_key_check_true_and_allow_host_key_changes_false'
+    )
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -123,6 +129,8 @@ class TestSSHHook(unittest.TestCase):
                 cls.CONN_SSH_WITH_NO_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE,
                 cls.CONN_SSH_WITH_EXTRA_DISABLED_ALGORITHMS,
                 cls.CONN_SSH_WITH_EXTRA_CIPHERS,
+                cls.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_TRUE,
+                cls.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE,
             ]
             connections = session.query(Connection).filter(Connection.conn_id.in_(conns_to_reset))
             connections.delete(synchronize_session=False)
@@ -285,6 +293,22 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps({"ciphers": TEST_CIPHERS}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_TRUE,
+                host='remote_host',
+                conn_type='ssh',
+                extra=json.dumps({"no_host_key_check": True, "allow_host_key_change": True}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE,
+                host='remote_host',
+                conn_type='ssh',
+                extra=json.dumps({"no_host_key_check": True, "allow_host_key_change": False}),
             )
         )
 
@@ -881,3 +905,34 @@ class TestSSHHook(unittest.TestCase):
                 30,
             )
             assert ret == (0, b'airflow\n', b'')
+
+    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
+    def test_ssh_connection_with_no_host_key_check_true_and_allow_host_key_changes_true(self, ssh_mock):
+        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_TRUE)
+        with hook.get_conn():
+            assert ssh_mock.return_value.set_missing_host_key_policy.called is True
+            assert isinstance(
+                ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+            )
+            assert ssh_mock.return_value.load_host_keys.called is False
+
+    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
+    def test_ssh_connection_with_no_host_key_check_true_and_allow_host_key_changes_false(self, ssh_mock):
+        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_NO_HOST_KEY_CHECK_TRUE_AND_ALLOW_HOST_KEY_CHANGES_FALSE)
+
+        with mock.patch('os.path.isfile', return_value=True):
+            with hook.get_conn():
+                assert ssh_mock.return_value.set_missing_host_key_policy.called is True
+                assert isinstance(
+                    ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+                )
+                assert ssh_mock.return_value.load_host_keys.called is True
+
+        ssh_mock.reset_mock()
+        with mock.patch('os.path.isfile', return_value=False):
+            with hook.get_conn():
+                assert ssh_mock.return_value.set_missing_host_key_policy.called is True
+                assert isinstance(
+                    ssh_mock.return_value.set_missing_host_key_policy.call_args[0][0], paramiko.AutoAddPolicy
+                )
+                assert ssh_mock.return_value.load_host_keys.called is False


### PR DESCRIPTION
When `no_host_key_check` is true, new host keys are not added.

```
from airflow import DAG
from airflow.operators.python import PythonOperator
from airflow.providers.ssh.hooks.ssh import SSHHook
from airflow.utils.dates import days_ago

with DAG(dag_id="example_python", schedule_interval=None, start_date=days_ago(2)) as dag:
    def f():
        hook = SSHHook(ssh_conn_id="ssh_default")
        hook.exec_ssh_client_command(hook.get_conn(), "grep localhost ~/.ssh/known_hosts", False, None, None)
        # [2022-08-26, 09:52:15 UTC] {ssh.py:467} INFO - Running command: grep localhost ~/.ssh/known_hosts
        # [2022-08-26, 09:52:15 UTC] {python.py:171} INFO - Done. Returned value was: None

    t = PythonOperator(task_id="example", python_callable=f)
```

I hope that it works as the docs described bellow.
https://airflow.apache.org/docs/apache-airflow-providers-ssh/stable/connections/ssh.html
> no_host_key_check ... Default is true, ssh will automatically add new host keys to the user known hosts files.