### PR TITLE
Remove Amazon S3 Connection Type

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -24,6 +24,14 @@
 Changelog
 ---------
 
+.. warning::
+  In this version of provider Amazon S3 Connection (``conn_type="s3"``) removed due to the fact that it was always
+  an alias to :ref:`Amazon Web Services Connection <howto/connection:aws>` (``conn_type="aws"``).
+  This might only have effect to testing connection in the UI/API.
+  In order to restore ability to test connection you need to change connection type from **Amazon S3**
+  to **Amazon Web Services** manually.
+
+
 5.1.0
 .....
 

--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -27,9 +27,9 @@ Changelog
 .. warning::
   In this version of provider Amazon S3 Connection (``conn_type="s3"``) removed due to the fact that it was always
   an alias to :ref:`Amazon Web Services Connection <howto/connection:aws>` (``conn_type="aws"``).
-  This might only have effect to testing connection in the UI/API.
-  In order to restore ability to test connection you need to change connection type from **Amazon S3**
-  to **Amazon Web Services** manually.
+  In practice the only impact is you won't be able to ``test`` the connection in the web UI / API.
+  In order to restore ability to test connection you need to change connection type from **Amazon S3** (``conn_type="s3"``)
+  to **Amazon Web Services** (``conn_type="aws"``) manually.
 
 
 5.1.0

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -20,7 +20,7 @@ This module contains Base AWS Hook.
 
 .. seealso::
     For more information on how to use this hook, take a look at the guide:
-    :ref:`howto/connection:AWSHook`
+    :ref:`howto/connection:aws`
 """
 from __future__ import annotations
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -114,9 +114,6 @@ class S3Hook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
-    conn_type = 's3'
-    hook_name = 'Amazon S3'
-
     def __init__(
         self,
         aws_conn_id: str | None = AwsBaseHook.default_conn_name,

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -128,9 +128,19 @@ class AwsConnectionWrapper(LoggingMixin):
         self.password = conn.password
         self.extra_config = deepcopy(conn.extra_dejson)
 
-        if self.conn_type != "aws":
+        if self.conn_type.lower() == "s3":
             warnings.warn(
-                f"{self.conn_repr} expected connection type 'aws', got {self.conn_type!r}.",
+                f"{self.conn_repr} has connection type 's3', "
+                "which has been replaced by connection type 'aws'. "
+                "Please update your connection to have `conn_type='aws'`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        elif self.conn_type != "aws":
+            warnings.warn(
+                f"{self.conn_repr} expected connection type 'aws', got {self.conn_type!r}. "
+                "This connection might not work correctly. "
+                "Please use Amazon Web Services Connection type.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -548,8 +548,6 @@ extra-links:
   - airflow.providers.amazon.aws.links.logs.CloudWatchEventsLink
 
 connection-types:
-  - hook-class-name: airflow.providers.amazon.aws.hooks.s3.S3Hook
-    connection-type: s3
   - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook
     connection-type: aws
   - hook-class-name: airflow.providers.amazon.aws.hooks.emr.EmrHook

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -15,7 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/connection:AWSHook:
+.. _howto/connection:aws:
 
 Amazon Web Services Connection
 ==============================

--- a/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
+++ b/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
@@ -37,11 +37,11 @@ To enable this feature, ``airflow.cfg`` must be configured as follows:
     # id that provides access to the storage location.
     remote_logging = True
     remote_base_log_folder = s3://my-bucket/path/to/logs
-    remote_log_conn_id = MyS3Conn
+    remote_log_conn_id = my_s3_conn
     # Use server-side encryption for logs stored in S3
     encrypt_s3_logs = False
 
-In the above example, Airflow will try to use ``S3Hook('MyS3Conn')``.
+In the above example, Airflow will try to use ``S3Hook(aws_conn_id='my_s3_conn')``.
 
 You can also use `LocalStack <https://localstack.cloud/>`_ to emulate Amazon S3 locally.
 To configure it, you must additionally set the endpoint url to point to your local stack.

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -77,10 +77,20 @@ class TestAwsConnectionWrapper:
         wrap_conn = AwsConnectionWrapper(conn=mock_connection_factory(conn_type=conn_type))
         assert wrap_conn.conn_type == "aws"
 
-    @pytest.mark.parametrize("conn_type", ["AWS", "boto3", "s3", "emr", "google", "google-cloud-platform"])
+    @pytest.mark.parametrize("conn_type", ["AWS", "boto3", "emr", "google", "google-cloud-platform"])
     def test_unexpected_aws_connection_type(self, conn_type):
         warning_message = f"expected connection type 'aws', got '{conn_type}'"
         with pytest.warns(UserWarning, match=warning_message):
+            wrap_conn = AwsConnectionWrapper(conn=mock_connection_factory(conn_type=conn_type))
+            assert wrap_conn.conn_type == conn_type
+
+    @pytest.mark.parametrize("conn_type", ["s3", "S3"])
+    def test_deprecated_s3_connection_type(self, conn_type):
+        warning_message = (
+            r".* has connection type 's3', which has been replaced by connection type 'aws'\. "
+            r"Please update your connection to have `conn_type='aws'`."
+        )
+        with pytest.warns(DeprecationWarning, match=warning_message):
             wrap_conn = AwsConnectionWrapper(conn=mock_connection_factory(conn_type=conn_type))
             assert wrap_conn.conn_type == conn_type
 


### PR DESCRIPTION
AWS S3 Connection it is just kind of alias for Amazon Web Services Connection and most possible exists for historical reason.

All community provided packages expected Amazon Web Services Connection.
Due to the fact that AWS S3 Connection do not give any advantages IMHO better mark it ~deprecated~ remove and inform users switch to Amazon Web Services Connection.