### PR TITLE
Set template_fields on RDS operators

### DIFF
--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -585,6 +585,8 @@ class RdsCreateDbInstanceOperator(RdsBaseOperator):
     :param wait_for_completion:  If True, waits for creation of the DB instance to complete. (default: True)
     """
 
+    template_fields = ("db_instance_identifier", "db_instance_class", "rds_kwargs")
+
     def __init__(
         self,
         *,
@@ -636,6 +638,8 @@ class RdsDeleteDbInstanceOperator(RdsBaseOperator):
     :param aws_conn_id: The Airflow connection used for AWS credentials.
     :param wait_for_completion:  If True, waits for deletion of the DB instance to complete. (default: True)
     """
+
+    template_fields = ("db_instance_identifier", "rds_kwargs")
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/rds.py
+++ b/airflow/providers/amazon/aws/operators/rds.py
@@ -585,7 +585,7 @@ class RdsCreateDbInstanceOperator(RdsBaseOperator):
     :param wait_for_completion:  If True, waits for creation of the DB instance to complete. (default: True)
     """
 
-    template_fields = ("db_instance_identifier", "db_instance_class", "rds_kwargs")
+    template_fields = ("db_instance_identifier", "db_instance_class", "engine", "rds_kwargs")
 
     def __init__(
         self,

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -934,7 +934,7 @@ Migrating to TaskFlow API
 
 Airflow 2.0 introduced the TaskFlow API to simplify the declaration of Python callable tasks.
 Users are encouraged to replace classic operators with their TaskFlow decorator alternatives.
-For details, see :doc:`/tutorial_taskflow_api`.
+For details on the TaskFlow API, see :doc:`the TaskFlow tutorial </tutorial/taskflow>`.
 
 ============================= ============================================
 Classic Operator              TaskFlow Decorator

--- a/tests/system/providers/amazon/aws/example_rds_event.py
+++ b/tests/system/providers/amazon/aws/example_rds_event.py
@@ -23,7 +23,6 @@ import boto3
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
-from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.operators.rds import (
     RdsCreateDbInstanceOperator,
     RdsCreateEventSubscriptionOperator,

--- a/tests/system/providers/amazon/aws/example_rds_event.py
+++ b/tests/system/providers/amazon/aws/example_rds_event.py
@@ -25,7 +25,9 @@ from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.operators.rds import (
+    RdsCreateDbInstanceOperator,
     RdsCreateEventSubscriptionOperator,
+    RdsDeleteDbInstanceOperator,
     RdsDeleteEventSubscriptionOperator,
 )
 from airflow.utils.trigger_rule import TriggerRule
@@ -39,35 +41,6 @@ sys_test_context_task = SystemTestContextBuilder().build()
 @task
 def create_sns_topic(env_id) -> str:
     return boto3.client('sns').create_topic(Name=f'{env_id}-topic')['TopicArn']
-
-
-@task
-def create_rds_instance(db_name, instance_name) -> None:
-    rds_client = RdsHook().get_conn()
-    rds_client.create_db_instance(
-        DBName=db_name,
-        DBInstanceIdentifier=instance_name,
-        AllocatedStorage=20,
-        DBInstanceClass='db.t3.micro',
-        Engine='postgres',
-        MasterUsername='username',
-        # NEVER store your production password in plaintext in a DAG like this.
-        # Use Airflow Secrets or a secret manager for this in production.
-        MasterUserPassword='rds_password',
-    )
-
-    rds_client.get_waiter('db_instance_available').wait(DBInstanceIdentifier=instance_name)
-
-
-@task(trigger_rule=TriggerRule.ALL_DONE)
-def delete_db_instance(instance_name) -> None:
-    rds_client = RdsHook().get_conn()
-    rds_client.delete_db_instance(
-        DBInstanceIdentifier=instance_name,
-        SkipFinalSnapshot=True,
-    )
-
-    rds_client.get_waiter('db_instance_deleted').wait(DBInstanceIdentifier=instance_name)
 
 
 @task(trigger_rule=TriggerRule.ALL_DONE)
@@ -90,6 +63,21 @@ with DAG(
 
     sns_topic = create_sns_topic(test_context[ENV_ID_KEY])
 
+    create_db_instance = RdsCreateDbInstanceOperator(
+        task_id="create_db_instance",
+        db_instance_identifier=rds_instance_name,
+        db_instance_class="db.t4g.micro",
+        engine="postgres",
+        rds_kwargs={
+            "MasterUsername": "rds_username",
+            # NEVER store your production password in plaintext in a DAG like this.
+            # Use Airflow Secrets or a secret manager for this in production.
+            "MasterUserPassword": "rds_password",
+            "AllocatedStorage": 20,
+            "DBName": rds_db_name,
+        },
+    )
+
     # [START howto_operator_rds_create_event_subscription]
     create_subscription = RdsCreateEventSubscriptionOperator(
         task_id='create_subscription',
@@ -108,16 +96,23 @@ with DAG(
     )
     # [END howto_operator_rds_delete_event_subscription]
 
+    delete_db_instance = RdsDeleteDbInstanceOperator(
+        task_id="delete_db_instance",
+        db_instance_identifier=rds_instance_name,
+        rds_kwargs={"SkipFinalSnapshot": True},
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
     chain(
         # TEST SETUP
         test_context,
         sns_topic,
-        create_rds_instance(rds_db_name, rds_instance_name),
+        create_db_instance,
         # TEST BODY
         create_subscription,
         delete_subscription,
         # TEST TEARDOWN
-        delete_db_instance(rds_instance_name),
+        delete_db_instance,
         delete_sns_topic(sns_topic),
     )
 

--- a/tests/system/providers/amazon/aws/example_rds_snapshot.py
+++ b/tests/system/providers/amazon/aws/example_rds_snapshot.py
@@ -23,7 +23,9 @@ from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.operators.rds import (
     RdsCopyDbSnapshotOperator,
+    RdsCreateDbInstanceOperator,
     RdsCreateDbSnapshotOperator,
+    RdsDeleteDbInstanceOperator,
     RdsDeleteDbSnapshotOperator,
 )
 from airflow.providers.amazon.aws.sensors.rds import RdsSnapshotExistenceSensor

--- a/tests/system/providers/amazon/aws/example_rds_snapshot.py
+++ b/tests/system/providers/amazon/aws/example_rds_snapshot.py
@@ -20,7 +20,6 @@ from datetime import datetime
 
 from airflow import DAG
 from airflow.models.baseoperator import chain
-from airflow.providers.amazon.aws.hooks.rds import RdsHook
 from airflow.providers.amazon.aws.operators.rds import (
     RdsCopyDbSnapshotOperator,
     RdsCreateDbInstanceOperator,


### PR DESCRIPTION
Related: #24099 #25952

### Summary

This PR sets the `template_fields` property on `RdsCreateDbInstanceOperator` and `RdsDeleteDbInstanceOperator` to allow users to programmatically change the database id, instance size, allocated storage, etc..

It also replaces use of `@task` decorated functions with their appropriate operator in system tests.

### Todo

- [x] Add `template_fields` to RDS operators
- [x] Update/run system tests