### PR TITLE
Additional mask AWS Credentials

### DIFF
--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -26,6 +26,7 @@ from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.secrets_masker import mask_secret
 
 try:
     from airflow.utils.types import NOTSET, ArgNotSet
@@ -428,6 +429,7 @@ def _parse_s3_config(
         try:
             access_key = config.get(cred_section, key_id_option)
             secret_key = config.get(cred_section, secret_key_option)
+            mask_secret(secret_key)
         except Exception:
             raise AirflowException("Option Error in parsing s3 config file")
         return access_key, secret_key

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -26,6 +26,7 @@ from unittest import mock
 import boto3
 import pytest
 from botocore.config import Config
+from botocore.credentials import ReadOnlyCredentials
 from moto.core import ACCOUNT_ID
 
 from airflow.models import Connection
@@ -746,6 +747,26 @@ class TestAwsBaseHook:
             hook = AwsBaseHook(aws_conn_id="test_conn", verify=verify)
             expected = verify if verify is not None else conn_verify
             assert hook.verify == expected
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook.get_session")
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.mask_secret")
+    @pytest.mark.parametrize("token", [None, "mock-aws-session-token"])
+    @pytest.mark.parametrize("secret_key", ["mock-aws-secret-access-key"])
+    @pytest.mark.parametrize("access_key", ["mock-aws-access-key-id"])
+    def test_get_credentials_mask_secrets(
+        self, mock_mask_secret, mock_boto3_session, access_key, secret_key, token
+    ):
+        expected_credentials = ReadOnlyCredentials(access_key=access_key, secret_key=secret_key, token=token)
+        mock_credentials = mock.MagicMock(return_value=expected_credentials)
+        mock_boto3_session.return_value.get_credentials.return_value.get_frozen_credentials = mock_credentials
+        expected_calls = [mock.call(secret_key)]
+        if token:
+            expected_calls.append(mock.call(token))
+
+        hook = AwsBaseHook(aws_conn_id=None)
+        credentials = hook.get_credentials()
+        assert mock_mask_secret.mock_calls == expected_calls
+        assert credentials == expected_credentials
 
 
 class ThrowErrorUntilCount:


### PR DESCRIPTION
Right now not all credentials for AWS masked.
Some of them might retrieved outside of connection login, password and extra: environment variables, AWS shared credentials file, assume role and etc.

This PR additionally mask credentials when call `AwsGenericHook.get_credentials()` method

_DAG Sample_
```python
import os
from dataclasses import asdict

import pendulum

from airflow.decorators import task
from airflow.models.dag import dag
from airflow.providers.amazon.aws.hooks.s3 import S3Hook
from airflow.models.connection import Connection

DAG_KWARGS = {
    "start_date": pendulum.datetime(2021, 1, 1, tz="UTC"),
    "schedule_interval": None,
    "catchup": False,
    "tags": ["credentials", "aws", "mask-secrets"],
}
AWS_CONN_ID = "aws_sample_conn"
AWS_CONN_ENV_KEY = f"AIRFLOW_CONN_{AWS_CONN_ID.upper()}"


@dag(**DAG_KWARGS)
def aws_secrets_mask():
    @task
    def print_connection_info():
        """Print connection info"""
        conn = Connection(
            conn_id=AWS_CONN_ID,
            conn_type="aws",
            login="login-aws_access_key_id",
            password="password-aws_secret_access_key",
            extra={
                "aws_access_key_id": "extra-aws_access_key_id",
                "aws_secret_access_key": "extra-aws_secret_access_key",
                "aws_session_token": "extra-aws_session_token",
                "session_kwargs": {
                    "aws_access_key_id": "session-kw-aws_access_key_id",
                    "aws_secret_access_key": "session-kw-aws_secret_access_key",
                    "aws_session_token": "session-kw-aws_session_token"
                },
            },
        )
        os.environ[AWS_CONN_ENV_KEY] = conn.get_uri()
        hook = S3Hook(aws_conn_id=AWS_CONN_ID)
        # This case handle by airflow.models.connection.Connection
        print(f"Connection Info: {asdict(hook.conn_config)}")
        # Connection Info: {'region_name': None, 'botocore_config': None, 'verify': None, 
        # 'conn_id': 'aws_sample_conn', 'conn_type': 'aws', 'login': 'login-aws_access_key_id', 
        # 'password': '***', 'extra_config': {'aws_access_key_id': 'extra-aws_access_key_id', 
        # 'aws_secret_access_key': '***', 'aws_session_token': '***', 'session_kwargs': 
        # {'aws_access_key_id': 'session-kw-aws_access_key_id', 'aws_secret_access_key': '***', 
        # 'aws_session_token': '***'}}, 'aws_access_key_id': 'login-aws_access_key_id', 
        # 'aws_secret_access_key': '***', 'aws_session_token': '***', 'profile_name': None, 
        # 'endpoint_url': None, 'role_arn': None, 'assume_role_method': None, 'assume_role_kwargs': {}}


    @task
    def print_credentials():
        """Print credentials from Env Var."""
        os.environ["AWS_ACCESS_KEY_ID"] = "env-var-aws_access_key_id"
        os.environ["AWS_SECRET_ACCESS_KEY"] = "env-aws_secret_access_key"
        os.environ["AWS_SESSION_TOKEN"] = "env-var-aws_session_token"
        os.environ[AWS_CONN_ENV_KEY] = "aws://"
        hook = S3Hook(aws_conn_id=AWS_CONN_ID)
        # This case handle by airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook.get_credentials
        print(f"Credentials: {hook.get_credentials()}")
        # Credentials: 
        # ReadOnlyCredentials(access_key='env-var-aws_access_key_id', secret_key='***', token='***')

    print_connection_info() >> print_credentials()

_ = aws_secrets_mask()
```



cc: @mik-laj  