### PR TITLE
Fix tasks stucked in queued states

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -539,7 +539,7 @@ class CeleryExecutor(BaseExecutor):
         self, key: TaskInstanceKey, timeout_type: Optional[_CeleryPendingTaskTimeoutType]
     ) -> None:
         """
-        We use the fact that dicts maintain insertion order, and the the timeout for a
+        We use the fact that dicts maintain insertion order, and the timeout for a
         task is always "now + delta" to maintain the property that oldest item = first to
         time out.
         """

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -818,6 +818,12 @@ class SchedulerJob(BaseJob):
             self.adopt_or_reset_orphaned_tasks,
         )
 
+        if self.executor_class == 'CeleryExecutor':
+            timers.call_regular_interval(
+                5,  # conf.getfloat('scheduler', 'orphaned_tasks_check_interval', fallback=300.0),
+                self.executor.reset_lost_tasks,
+            )
+
         timers.call_regular_interval(
             conf.getfloat('scheduler', 'trigger_timeout_check_interval', fallback=15.0),
             self.check_trigger_timeouts,

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -820,7 +820,7 @@ class SchedulerJob(BaseJob):
 
         if self.executor_class == 'CeleryExecutor':
             timers.call_regular_interval(
-                5,  # conf.getfloat('scheduler', 'orphaned_tasks_check_interval', fallback=300.0),
+                conf.getfloat('scheduler', 'orphaned_tasks_check_interval', fallback=300.0),
                 self.executor.reset_lost_tasks,
             )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Rare behaviour of Kubernetes bin packing leads to Celery workers being shutdown and tasks being stucked in queued states.
---

This is a PR to try to fix #21225. I opened it so that we can follow the work being done but this is still _Work In Progress_.
For more information, please see my [comment](https://github.com/apache/airflow/issues/21225#issuecomment-1229250816)

**First Edit**:
After a lot of debugging through Celery / Kombu API, I think this behavior is not dealt by Celery. Right now, if I understand correctly the code base (which is not so much the case), here is what happens in the celery worker : 

1. Celery workers consume Redis queue.
2. When Celery worker receives a message, before it executes it, it creates a Redis `set` called `unacked_index` for unacknowledged tasks, and one hashmap called `unacked`, to keep track of the message information.
3. If the task run last more than the `visibility_timeout`, then celery worker (through the Kombu API) recreates a message in the main queue, through the informations saved in `unacked` hash and `unacked_index` set.

The issue with this workflow is, there is nothing to deal with the case where a worker is being shutdown exactly at the same moment at it is reading a message, and there is nothing in Redis to handle this behavior as well (like a [Three-way handshake](https://fr.wikipedia.org/wiki/Three-way_handshake)). The best would be to fix this issue directly in Celery, but I am still a lot confused by the code, and Airflow would need to take the last release with the fix when it is out, which can takes months. 

So, to fix this bug, I suggest the following : 
1. Periodically take a look at the list of tasks contained in the redis queue, and noting those tasks which are **not** present but still with the status PENDING and not picked by any worker. This can only means two things:
   * Either the task is being consumed by the worker and is second away from being executed / updated in the db
   * The worker has actually shutdown while reading the message, popping the message from the queue, but never stored it in redis ackned hash
3.  ... Therefore, save those PENDING tasks in a temporary list (because a worker might just have pop the msg from the list and is starting its own worflow and still hasn't updated the db)
4. If after a second run, the task is still absent from the queue and that the state is still in PENDING, then re send the msg, because it has been lost definitely in the nothingness.

WDYT? Will try to implement this in the following days 