### PR TITLE
Replace javascript "get-workflow-origin" with Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,11 +168,11 @@ jobs:
       skip-pre-commits: ${{ steps.selective-checks.outputs.skip-pre-commits }}
       source-head-repo: ${{ steps.source-run-info.outputs.source-head-repo }}
       pull-request-labels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
-      runs-on: ${{ steps.set-runs-on.outputs.runs-on }}
-      run-coverage: ${{ steps.set-run-coverage.outputs.run-coverage }}
-      in-workflow-build: ${{ steps.set-in-workflow-build.outputs.in-workflow-build }}
-      build-job-description: ${{ steps.set-in-workflow-build.outputs.build-job-description }}
-      merge-run: ${{ steps.set-merge-run.outputs.merge-run }}
+      in-workflow-build: ${{ steps.source-run-info.outputs.in-workflow-build }}
+      build-job-description: ${{ steps.source-run-info.outputs.build-job-description }}
+      runs-on: ${{ steps.source-run-info.outputs.runs-on }}
+      merge-run: ${{ steps.source-run-info.outputs.merge-run }}
+      run-coverage: ${{ steps.source-run-info.outputs.run-coverage }}
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -181,11 +181,6 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Get information about the PR"
-        uses: ./.github/actions/get-workflow-origin
-        id: source-run-info
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fetch incoming commit ${{ github.sha }} with its parent
         uses: actions/checkout@v3
         with:
@@ -228,66 +223,15 @@ jobs:
           print(output, file=sys.stderr)
           EOF
       - run: ./scripts/ci/install_breeze.sh
+      - name: "Get information about the Workflow"
+        id: source-run-info
+        run: breeze ci get-workflow-info
       - name: Selective checks
         id: selective-checks
         env:
           PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
           COMMIT_REF: "${{ github.sha }}"
         run: breeze ci selective-check
-      # Avoid having to specify the runs-on logic every time. We use the custom
-      # env var AIRFLOW_SELF_HOSTED_RUNNER set only on our runners, but never
-      # on the public runners
-      - name: Set runs-on
-        id: set-runs-on
-        env:
-          PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
-        run: |
-          if [[ ${PR_LABELS=} == *"use public runners"* ]]; then
-            echo "Forcing running on Public Runners via `use public runners` label"
-            echo "::set-output name=runs-on::\"ubuntu-20.04\""
-          elif [[ ${AIRFLOW_SELF_HOSTED_RUNNER} == "" ]]; then
-            echo "Regular PR running with Public Runner"
-            echo "::set-output name=runs-on::\"ubuntu-20.04\""
-          else
-            echo "Maintainer or main run running with self-hosted runner"
-            echo "::set-output name=runs-on::\"self-hosted\""
-          fi
-      # Avoid having to specify the coverage logic every time.
-      - name: Set run coverage
-        id: set-run-coverage
-        run: echo "::set-output name=run-coverage::true"
-        if: >
-          github.ref == 'refs/heads/main' && github.repository == 'apache/airflow' &&
-          github.event_name == 'push' &&
-          steps.selective-checks.outputs.default-branch == 'main'
-      - name: Determine where to run image builds
-        id: set-in-workflow-build
-        # Run in-workflow build image when:
-        #  * direct push is run
-        #  * schedule build is run
-        #  * pull request is run not from fork
-        run: |
-          set -x
-          if [[  ${GITHUB_EVENT_NAME} == "push" || ${GITHUB_EVENT_NAME} == "push" || \
-                 ${{steps.source-run-info.outputs.sourceHeadRepo}} == "apache/airflow" ]]; then
-              echo "Images will be built in current workflow"
-              echo "::set-output name=in-workflow-build::true"
-              echo "::set-output name=build-job-description::Build"
-          else
-              echo "Images will be built in pull_request_target workflow"
-              echo "::set-output name=in-workflow-build::false"
-              echo "::set-output name=build-job-description::Skip Build (pull_request_target)"
-          fi
-      - name: Determine if this is merge run
-        id: set-merge-run
-        run: echo "::set-output name=merge-run::true"
-        # Only in Apache Airflow repo, when there is a merge run to main or any of v2*test branches
-        if: |
-          github.repository == 'apache/airflow' && github.event_name == 'push' &&
-          (
-              github.ref_name == 'main' ||
-              startsWith(github.ref_name, 'v2') && endsWith(github.ref_name, 'test')
-          )
       - name: env
         run: printenv
         env:
@@ -301,12 +245,12 @@ jobs:
     name: >-
       ${{needs.build-info.outputs.build-job-description}} CI images
       ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on)[0] }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -376,7 +320,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on)[0] }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: sqlite
       DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
       VERSION_SUFFIX_FOR_PYPI: "dev0"
@@ -467,7 +411,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   run-new-breeze-tests:
     timeout-minutes: 10
     name: Breeze unit tests
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     steps:
       - name: Cleanup repo
@@ -487,7 +431,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-ui:
     timeout-minutes: 10
     name: React UI tests
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     if: needs.build-info.outputs.run-ui-tests == 'true'
     steps:
@@ -514,7 +458,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-www:
     timeout-minutes: 10
     name: React WWW tests
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     if: needs.build-info.outputs.run-www-tests == 'true'
     steps:
@@ -542,7 +486,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   test-openapi-client-generation:
     timeout-minutes: 10
     name: "Test OpenAPI client generation"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     if: needs.build-info.outputs.needs-api-codegen == 'true'
     steps:
@@ -559,7 +503,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   test-examples-of-prod-image-building:
     timeout-minutes: 60
     name: "Test examples of production image building"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     if: needs.build-info.outputs.image-build == 'true'
     steps:
@@ -584,11 +528,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   wait-for-ci-images:
     timeout-minutes: 120
     name: "Wait for CI images"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, build-ci-images]
     if: needs.build-info.outputs.image-build == 'true'
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: sqlite
     steps:
       - name: Cleanup repo
@@ -619,10 +563,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   static-checks:
     timeout-minutes: 30
     name: "Static checks"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.default-python-version }}
     if: needs.build-info.outputs.basic-checks-only == 'false'
     steps:
@@ -674,10 +618,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   static-checks-basic-checks-only:
     timeout-minutes: 30
     name: "Static checks: basic checks only"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     if: needs.build-info.outputs.basic-checks-only == 'true'
     steps:
       - name: Cleanup repo
@@ -724,11 +668,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   docs:
     timeout-minutes: 45
     name: "Build docs"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     if: needs.build-info.outputs.docs-build == 'true'
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.default-python-version }}
     steps:
       - name: Cleanup repo
@@ -781,10 +725,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   prepare-test-provider-packages-wheel:
     timeout-minutes: 80
     name: "Build and test provider packages wheel"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.default-python-version }}
     if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'main'
     steps:
@@ -860,10 +804,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   prepare-test-provider-packages-sdist:
     timeout-minutes: 80
     name: "Build and test provider packages sdist"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.default-python-version }}
     if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'main'
     steps:
@@ -917,10 +861,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-helm:
     timeout-minutes: 80
     name: "Python unit tests for Helm chart"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       MOUNT_SELECTED_LOCAL_SOURCES: "true"
       TEST_TYPES: "Helm"
       BACKEND: ""
@@ -978,7 +922,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     name: >
       Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}:
       ${{needs.build-info.outputs.test-types}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
@@ -987,7 +931,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         exclude: ${{ fromJson(needs.build-info.outputs.postgres-exclude) }}
       fail-fast: false
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: postgres
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       TEST_TYPES: "${{needs.build-info.outputs.test-types}}"
@@ -1051,7 +995,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     timeout-minutes: 130
     name: >
       MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
@@ -1060,7 +1004,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         exclude: ${{ fromJson(needs.build-info.outputs.mysql-exclude) }}
       fail-fast: false
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: mysql
       MYSQL_VERSION: ${{ matrix.mysql-version }}
       TEST_TYPES: "${{needs.build-info.outputs.test-types}}"
@@ -1122,7 +1066,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     timeout-minutes: 130
     name: >
       MSSQL${{matrix.mssql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
@@ -1131,7 +1075,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         exclude: ${{ fromJson(needs.build-info.outputs.mssql-exclude) }}
       fail-fast: false
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: mssql
       MSSQL_VERSION: ${{ matrix.mssql-version }}
       TEST_TYPES: "${{needs.build-info.outputs.test-types}}"
@@ -1193,7 +1137,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     timeout-minutes: 130
     name: >
       Sqlite Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
@@ -1201,7 +1145,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         exclude: ${{ fromJson(needs.build-info.outputs.sqlite-exclude) }}
       fail-fast: false
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: sqlite
       TEST_TYPES: "${{needs.build-info.outputs.test-types}}"
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
@@ -1261,11 +1205,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-quarantined:
     timeout-minutes: 60
     name: "Quarantined tests"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     continue-on-error: true
     needs: [build-info, wait-for-ci-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       MYSQL_VERSION: ${{needs.build-info.outputs.default-mysql-version}}
       POSTGRES_VERSION: ${{needs.build-info.outputs.default-postgres-version}}
       TEST_TYPES: "Quarantined"
@@ -1342,7 +1286,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   upload-coverage:
     timeout-minutes: 15
     name: "Upload coverage"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     continue-on-error: true
     needs:
       - build-info
@@ -1352,7 +1296,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - tests-mssql
       - tests-quarantined
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     # Only upload coverage on merges to main
     if: needs.build-info.outputs.run-coverage == 'true'
     steps:
@@ -1377,11 +1321,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   wait-for-prod-images:
     timeout-minutes: 120
     name: "Wait for PROD images"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-ci-images, build-prod-images]
     if: needs.build-info.outputs.image-build == 'true'
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.default-python-version }}
     steps:
@@ -1421,7 +1365,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   test-docker-compose-quick-start:
     timeout-minutes: 60
     name: "Test docker-compose quick start"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-prod-images]
     if: needs.build-info.outputs.image-build == 'true'
     env:
@@ -1456,14 +1400,14 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-kubernetes:
     timeout-minutes: 240
     name: Helm Chart; ${{matrix.executor}} - ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-prod-images]
     strategy:
       matrix:
         executor: [KubernetesExecutor, CeleryExecutor, LocalExecutor]
       fail-fast: false
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: postgres
       RUN_TESTS: "true"
       RUNTIME: "kubernetes"
@@ -1526,10 +1470,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   tests-helm-executor-upgrade:
     timeout-minutes: 150
     name: Helm Chart Executor Upgrade - ${{needs.build-info.outputs.min-max-kubernetes-versions-as-string}}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, wait-for-prod-images]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
       BACKEND: postgres
       RUN_TESTS: "true"
       RUNTIME: "kubernetes"
@@ -1604,7 +1548,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       contents: write
     timeout-minutes: 40
     name: "Constraints"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs:
       - build-info
       - docs
@@ -1616,7 +1560,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - tests-mssql
       - tests-postgres
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
     steps:
       - name: Cleanup repo
@@ -1684,7 +1628,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       packages: write
     timeout-minutes: 50
     name: "Push Image Cache"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs:
       - build-info
       - constraints
@@ -1695,7 +1639,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       matrix:
         platform: ["linux/amd64", "linux/arm64"]
     env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -1777,7 +1721,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     name: >
       Build CI ARM images
       ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
-    runs-on: ${{ fromJson(needs.build-info.outputs.runs-on) }}
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs:
       - build-info
       - wait-for-ci-images
@@ -1790,7 +1734,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runs-on)[0] }}
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
     if: >
       needs.build-info.outputs.upgrade-to-newer-dependencies != 'false' &&
       needs.build-info.outputs.in-workflow-build == 'true' &&

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1037,6 +1037,19 @@ Those are all available flags of ``selective-check`` command:
   :width: 100%
   :alt: Breeze ci selective-check
 
+Getting workflow information
+............................
+
+When our CI runs a job, it might be within one of several workflows. Information about those workflows
+is stored in GITHUB_CONTEXT. Rather than using some jq/bash commands, we retrieve the necessary information
+(like PR labels, event_type, where the job runs on, job description and convert them into GA outputs.
+
+Those are all available flags of ``get-workflow-info`` command:
+
+.. image:: ./images/breeze/output_ci_get-workflow-info.svg
+  :width: 100%
+  :alt: Breeze ci get-workflow-info
+
 Tracking backtracking issues for CI builds
 ..........................................
 

--- a/dev/breeze/__init__.py
+++ b/dev/breeze/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/dev/breeze/src/__init__.py
+++ b/dev/breeze/src/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/dev/breeze/src/airflow_breeze/commands/ci_commands_config.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_commands_config.py
@@ -24,6 +24,7 @@ CI_COMMANDS: Dict[str, Union[str, List[str]]] = {
         "resource-check",
         "selective-check",
         "find-newer-dependencies",
+        "get-workflow-info",
     ],
 }
 CI_PARAMETERS: Dict[str, List[Dict[str, Union[str, List[str]]]]] = {
@@ -56,6 +57,15 @@ CI_PARAMETERS: Dict[str, List[Dict[str, Union[str, List[str]]]]] = {
                 "--airflow-constraints-reference",
                 "--updated-on-or-after",
                 "--max-age",
+            ],
+        }
+    ],
+    "breeze ci get-workflow-info": [
+        {
+            "name": "Get workflow info flags",
+            "options": [
+                "--github-context",
+                "--github-context-input",
             ],
         }
     ],

--- a/dev/breeze/src/airflow_breeze/global_constants.py
+++ b/dev/breeze/src/airflow_breeze/global_constants.py
@@ -25,6 +25,9 @@ from functools import lru_cache
 
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
 
+RUNS_ON_PUBLIC_RUNNER = "ubuntu-20.04"
+RUNS_ON_SELF_HOSTED_RUNNER = "self-hosted"
+
 # Commented this out as we are using buildkit and this vars became irrelevant
 # FORCE_PULL_IMAGES = False
 # CHECK_IF_BASE_PYTHON_IMAGE_UPDATED = False

--- a/dev/breeze/src/airflow_breeze/utils/github_actions.py
+++ b/dev/breeze/src/airflow_breeze/utils/github_actions.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any
+
+from rich.markup import escape
+
+from airflow_breeze.utils.console import get_console
+
+
+def get_ga_output(name: str, value: Any) -> str:
+    output_name = name.replace('_', '-')
+    printed_value = str(value).lower() if isinstance(value, bool) else value
+    get_console().print(f"[info]{output_name}[/] = [green]{escape(str(printed_value))}[/]")
+    return f"::set-output name={output_name}::{printed_value}"

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -22,8 +22,7 @@ import os
 import sys
 from enum import Enum
 
-from rich.markup import escape
-
+from airflow_breeze.utils.github_actions import get_ga_output
 from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT
 
 if sys.version_info >= (3, 8):
@@ -61,13 +60,6 @@ from airflow_breeze.global_constants import (
 from airflow_breeze.utils.console import get_console
 
 FULL_TESTS_NEEDED_LABEL = "full tests needed"
-
-
-def get_ga_output(name: str, value: Any) -> str:
-    output_name = name.replace('_', '-')
-    printed_value = str(value).lower() if isinstance(value, bool) else value
-    get_console().print(f"[info]{output_name}[/] = [green]{escape(str(printed_value))}[/]")
-    return f"::set-output name={output_name}::{printed_value}"
 
 
 class FileGroupForCi(Enum):

--- a/dev/breeze/tests/test_pr_info.py
+++ b/dev/breeze/tests/test_pr_info.py
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+from pathlib import Path
+from unittest import mock
+
+from airflow_breeze.commands.ci_commands import workflow_info
+
+TEST_PR_INFO_DIR = Path(__file__).parent / "test_pr_info_files"
+
+
+def test_pr_info():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": ""}):
+        json_string = (TEST_PR_INFO_DIR / "pr_github_context.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == [
+            'area:providers',
+            'area:dev-tools',
+            'area:logging',
+            'kind:documentation',
+        ]
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "test/airflow"
+        assert wi.event_name == 'pull_request'
+        assert wi.pr_number == 26004
+        assert wi.get_runs_on() == "ubuntu-20.04"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_push_info():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": ""}):
+        json_string = (TEST_PR_INFO_DIR / "push_github_context.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == []
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'push'
+        assert wi.pr_number is None
+        assert wi.get_runs_on() == "ubuntu-20.04"
+        assert wi.is_merge_run() == "true"
+        assert wi.run_coverage() == "true"
+
+
+def test_schedule():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": ""}):
+        json_string = (TEST_PR_INFO_DIR / "schedule_github_context.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == []
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'schedule'
+        assert wi.pr_number is None
+        assert wi.get_runs_on() == "ubuntu-20.04"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_runs_on_self_hosted():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": "true"}):
+        json_string = (TEST_PR_INFO_DIR / "simple_pr.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == ['another']
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'pull_request'
+        assert wi.pr_number == 1234
+        assert wi.get_runs_on() == "self-hosted"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_runs_on_forced_public_runner():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": "true"}):
+        json_string = (TEST_PR_INFO_DIR / "self_hosted_forced_pr.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == ['use public runners', 'another']
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'pull_request'
+        assert wi.pr_number == 1234
+        assert wi.get_runs_on() == "ubuntu-20.04"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_runs_on_simple_pr_other_repo():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": ""}):
+        json_string = (TEST_PR_INFO_DIR / "simple_pr_different_repo.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == ['another']
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "test/airflow"
+        assert wi.event_name == 'pull_request'
+        assert wi.pr_number == 1234
+        assert wi.get_runs_on() == "ubuntu-20.04"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_runs_on_push_other_branch():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": "true"}):
+        json_string = (TEST_PR_INFO_DIR / "push_other_branch.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == []
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'push'
+        assert wi.pr_number is None
+        assert wi.get_runs_on() == "self-hosted"
+        assert wi.is_merge_run() == "false"
+        assert wi.run_coverage() == "false"
+
+
+def test_runs_on_push_v_test_branch():
+    with mock.patch.dict(os.environ, {"AIRFLOW_SELF_HOSTED_RUNNER": "true"}):
+        json_string = (TEST_PR_INFO_DIR / "push_v_test_branch.json").read_text()
+        wi = workflow_info(json_string)
+        assert wi.pull_request_labels == []
+        assert wi.target_repo == "apache/airflow"
+        assert wi.head_repo == "apache/airflow"
+        assert wi.event_name == 'push'
+        assert wi.pr_number is None
+        assert wi.get_runs_on() == "self-hosted"
+        assert wi.is_merge_run() == "true"
+        assert wi.run_coverage() == "false"

--- a/dev/breeze/tests/test_pr_info_files/pr_github_context.json
+++ b/dev/breeze/tests/test_pr_info_files/pr_github_context.json
@@ -1,0 +1,35 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "pull_request",
+    "event": {
+        "pull_request": {
+            "number": 26004,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "test/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "area:providers"
+                },
+                {
+                    "name": "area:dev-tools"
+                },
+                {
+                    "name": "area:logging"
+                },
+                {
+                    "name": "kind:documentation"
+                }
+            ]
+        }
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/dev/breeze/tests/test_pr_info_files/push_github_context.json
+++ b/dev/breeze/tests/test_pr_info_files/push_github_context.json
@@ -1,0 +1,11 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "push",
+    "event": {
+        "repository": {
+            "full_name": "apache/airflow"
+        }
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/dev/breeze/tests/test_pr_info_files/push_other_branch.json
+++ b/dev/breeze/tests/test_pr_info_files/push_other_branch.json
@@ -1,0 +1,26 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "push",
+    "event": {
+        "pull_request": {
+            "number": 1234,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "another"
+                }
+            ]
+        }
+    },
+    "ref_name": "branch",
+    "ref": "refs/head/branch"
+}

--- a/dev/breeze/tests/test_pr_info_files/push_v_test_branch.json
+++ b/dev/breeze/tests/test_pr_info_files/push_v_test_branch.json
@@ -1,0 +1,26 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "push",
+    "event": {
+        "pull_request": {
+            "number": 1234,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "another"
+                }
+            ]
+        }
+    },
+    "ref_name": "v2-3-test",
+    "ref": "refs/head/v2-3-test"
+}

--- a/dev/breeze/tests/test_pr_info_files/schedule_github_context.json
+++ b/dev/breeze/tests/test_pr_info_files/schedule_github_context.json
@@ -1,0 +1,9 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "schedule",
+    "event": {
+        "schedule": "28 0 * * *"
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/dev/breeze/tests/test_pr_info_files/self_hosted_forced_pr.json
+++ b/dev/breeze/tests/test_pr_info_files/self_hosted_forced_pr.json
@@ -1,0 +1,29 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "pull_request",
+    "event": {
+        "pull_request": {
+            "number": 1234,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "use public runners"
+                },
+                {
+                    "name": "another"
+                }
+            ]
+        }
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/dev/breeze/tests/test_pr_info_files/simple_pr.json
+++ b/dev/breeze/tests/test_pr_info_files/simple_pr.json
@@ -1,0 +1,26 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "pull_request",
+    "event": {
+        "pull_request": {
+            "number": 1234,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "another"
+                }
+            ]
+        }
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/dev/breeze/tests/test_pr_info_files/simple_pr_different_repo.json
+++ b/dev/breeze/tests/test_pr_info_files/simple_pr_different_repo.json
@@ -1,0 +1,26 @@
+{
+    "repository": "apache/airflow",
+    "event_name": "pull_request",
+    "event": {
+        "pull_request": {
+            "number": 1234,
+            "base": {
+                "repo": {
+                    "full_name": "apache/airflow"
+                }
+            },
+            "head": {
+                "repo": {
+                    "full_name": "test/airflow"
+                }
+            },
+            "labels": [
+                {
+                    "name": "another"
+                }
+            ]
+        }
+    },
+    "ref_name": "main",
+    "ref": "refs/head/main"
+}

--- a/images/breeze/output-commands-hash.txt
+++ b/images/breeze/output-commands-hash.txt
@@ -7,6 +7,7 @@ build-docs:74c301f05bbd185a19fd185f1873e38a
 ci:find-newer-dependencies:00000f7afb289e36e8c573fcc654df44
 ci:fix-ownership:84902165a54467564fbdd3598fa273e2
 ci:free-space:bb8e7ac63d12ab3ede272a898de2f527
+ci:get-workflow-info:01ee34c33ad62fa5dc33e0ac8773223f
 ci:resource-check:0fb929ac3496dbbe97acfe99e35accd7
 ci:selective-check:d4e3c250cd6f2b0040fbe6557fa423f6
 ci-image:build:f2c38a416078b4ff6967d7857d7dbdcc

--- a/images/breeze/output_ci.svg
+++ b/images/breeze/output_ci.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 1482 416.0" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 1482 464.79999999999995" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,100 +19,108 @@
         font-weight: 700;
     }
 
-    .terminal-3965561644-matrix {
+    .terminal-1385492439-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3965561644-title {
+    .terminal-1385492439-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3965561644-r1 { fill: #c5c8c6;font-weight: bold }
-.terminal-3965561644-r2 { fill: #c5c8c6 }
-.terminal-3965561644-r3 { fill: #d0b344;font-weight: bold }
-.terminal-3965561644-r4 { fill: #868887 }
-.terminal-3965561644-r5 { fill: #68a0b3;font-weight: bold }
-.terminal-3965561644-r6 { fill: #98a84b;font-weight: bold }
+    .terminal-1385492439-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1385492439-r2 { fill: #c5c8c6 }
+.terminal-1385492439-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1385492439-r4 { fill: #868887 }
+.terminal-1385492439-r5 { fill: #68a0b3;font-weight: bold }
+.terminal-1385492439-r6 { fill: #98a84b;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-3965561644-clip-terminal">
-      <rect x="0" y="0" width="1463.0" height="365.0" />
+    <clipPath id="terminal-1385492439-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="413.79999999999995" />
     </clipPath>
-    <clipPath id="terminal-3965561644-line-0">
+    <clipPath id="terminal-1385492439-line-0">
     <rect x="0" y="1.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-1">
+<clipPath id="terminal-1385492439-line-1">
     <rect x="0" y="25.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-2">
+<clipPath id="terminal-1385492439-line-2">
     <rect x="0" y="50.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-3">
+<clipPath id="terminal-1385492439-line-3">
     <rect x="0" y="74.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-4">
+<clipPath id="terminal-1385492439-line-4">
     <rect x="0" y="99.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-5">
+<clipPath id="terminal-1385492439-line-5">
     <rect x="0" y="123.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-6">
+<clipPath id="terminal-1385492439-line-6">
     <rect x="0" y="147.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-7">
+<clipPath id="terminal-1385492439-line-7">
     <rect x="0" y="172.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-8">
+<clipPath id="terminal-1385492439-line-8">
     <rect x="0" y="196.7" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-9">
+<clipPath id="terminal-1385492439-line-9">
     <rect x="0" y="221.1" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-10">
+<clipPath id="terminal-1385492439-line-10">
     <rect x="0" y="245.5" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-11">
+<clipPath id="terminal-1385492439-line-11">
     <rect x="0" y="269.9" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-12">
+<clipPath id="terminal-1385492439-line-12">
     <rect x="0" y="294.3" width="1464" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3965561644-line-13">
+<clipPath id="terminal-1385492439-line-13">
     <rect x="0" y="318.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1385492439-line-14">
+    <rect x="0" y="343.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1385492439-line-15">
+    <rect x="0" y="367.5" width="1464" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="414" rx="8"/><text class="terminal-3965561644-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;ci</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="462.8" rx="8"/><text class="terminal-1385492439-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;ci</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3965561644-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1385492439-clip-terminal)">
     
-    <g class="terminal-3965561644-matrix">
-    <text class="terminal-3965561644-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-3965561644-line-0)">
-</text><text class="terminal-3965561644-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-3965561644-line-1)">Usage:&#160;</text><text class="terminal-3965561644-r1" x="97.6" y="44.4" textLength="451.4" clip-path="url(#terminal-3965561644-line-1)">breeze&#160;ci&#160;[OPTIONS]&#160;COMMAND&#160;[ARGS]...</text><text class="terminal-3965561644-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-1)">
-</text><text class="terminal-3965561644-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-3965561644-line-2)">
-</text><text class="terminal-3965561644-r2" x="12.2" y="93.2" textLength="732" clip-path="url(#terminal-3965561644-line-3)">Tools&#160;that&#160;CI&#160;workflows&#160;use&#160;to&#160;cleanup/manage&#160;CI&#160;environment</text><text class="terminal-3965561644-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-3965561644-line-3)">
-</text><text class="terminal-3965561644-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-3965561644-line-4)">
-</text><text class="terminal-3965561644-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-3965561644-line-5)">╭─</text><text class="terminal-3965561644-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-3965561644-line-5)">&#160;Common&#160;options&#160;────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3965561644-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-3965561644-line-5)">─╮</text><text class="terminal-3965561644-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-3965561644-line-5)">
-</text><text class="terminal-3965561644-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-6)">│</text><text class="terminal-3965561644-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-6)">-</text><text class="terminal-3965561644-r5" x="36.6" y="166.4" textLength="61" clip-path="url(#terminal-3965561644-line-6)">-help</text><text class="terminal-3965561644-r6" x="122" y="166.4" textLength="24.4" clip-path="url(#terminal-3965561644-line-6)">-h</text><text class="terminal-3965561644-r2" x="170.8" y="166.4" textLength="329.4" clip-path="url(#terminal-3965561644-line-6)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-3965561644-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-6)">│</text><text class="terminal-3965561644-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-6)">
-</text><text class="terminal-3965561644-r4" x="0" y="190.8" textLength="1464" clip-path="url(#terminal-3965561644-line-7)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3965561644-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-3965561644-line-7)">
-</text><text class="terminal-3965561644-r4" x="0" y="215.2" textLength="24.4" clip-path="url(#terminal-3965561644-line-8)">╭─</text><text class="terminal-3965561644-r4" x="24.4" y="215.2" textLength="1415.2" clip-path="url(#terminal-3965561644-line-8)">&#160;CI&#160;commands&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-3965561644-r4" x="1439.6" y="215.2" textLength="24.4" clip-path="url(#terminal-3965561644-line-8)">─╮</text><text class="terminal-3965561644-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-3965561644-line-8)">
-</text><text class="terminal-3965561644-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-3965561644-line-9)">│</text><text class="terminal-3965561644-r5" x="24.4" y="239.6" textLength="378.2" clip-path="url(#terminal-3965561644-line-9)">fix-ownership&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r2" x="427" y="239.6" textLength="1012.6" clip-path="url(#terminal-3965561644-line-9)">Fix&#160;ownership&#160;of&#160;source&#160;files&#160;to&#160;be&#160;same&#160;as&#160;host&#160;user.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3965561644-line-9)">│</text><text class="terminal-3965561644-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-3965561644-line-9)">
-</text><text class="terminal-3965561644-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-3965561644-line-10)">│</text><text class="terminal-3965561644-r5" x="24.4" y="264" textLength="378.2" clip-path="url(#terminal-3965561644-line-10)">free-space&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r2" x="427" y="264" textLength="1012.6" clip-path="url(#terminal-3965561644-line-10)">Free&#160;space&#160;for&#160;jobs&#160;run&#160;in&#160;CI.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-3965561644-line-10)">│</text><text class="terminal-3965561644-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-3965561644-line-10)">
-</text><text class="terminal-3965561644-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-11)">│</text><text class="terminal-3965561644-r5" x="24.4" y="288.4" textLength="378.2" clip-path="url(#terminal-3965561644-line-11)">resource-check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r2" x="427" y="288.4" textLength="1012.6" clip-path="url(#terminal-3965561644-line-11)">Check&#160;if&#160;available&#160;docker&#160;resources&#160;are&#160;enough.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-11)">│</text><text class="terminal-3965561644-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-3965561644-line-11)">
-</text><text class="terminal-3965561644-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-3965561644-line-12)">│</text><text class="terminal-3965561644-r5" x="24.4" y="312.8" textLength="378.2" clip-path="url(#terminal-3965561644-line-12)">selective-check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r2" x="427" y="312.8" textLength="1012.6" clip-path="url(#terminal-3965561644-line-12)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3965561644-line-12)">│</text><text class="terminal-3965561644-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-3965561644-line-12)">
-</text><text class="terminal-3965561644-r4" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-3965561644-line-13)">│</text><text class="terminal-3965561644-r5" x="24.4" y="337.2" textLength="378.2" clip-path="url(#terminal-3965561644-line-13)">find-newer-dependencies&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r2" x="427" y="337.2" textLength="1012.6" clip-path="url(#terminal-3965561644-line-13)">Finds&#160;which&#160;dependencies&#160;are&#160;being&#160;upgraded.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-3965561644-r4" x="1451.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3965561644-line-13)">│</text><text class="terminal-3965561644-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-3965561644-line-13)">
-</text><text class="terminal-3965561644-r4" x="0" y="361.6" textLength="1464" clip-path="url(#terminal-3965561644-line-14)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-3965561644-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-3965561644-line-14)">
+    <g class="terminal-1385492439-matrix">
+    <text class="terminal-1385492439-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1385492439-line-0)">
+</text><text class="terminal-1385492439-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1385492439-line-1)">Usage:&#160;</text><text class="terminal-1385492439-r1" x="97.6" y="44.4" textLength="451.4" clip-path="url(#terminal-1385492439-line-1)">breeze&#160;ci&#160;[OPTIONS]&#160;COMMAND&#160;[ARGS]...</text><text class="terminal-1385492439-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-1)">
+</text><text class="terminal-1385492439-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1385492439-line-2)">
+</text><text class="terminal-1385492439-r2" x="12.2" y="93.2" textLength="732" clip-path="url(#terminal-1385492439-line-3)">Tools&#160;that&#160;CI&#160;workflows&#160;use&#160;to&#160;cleanup/manage&#160;CI&#160;environment</text><text class="terminal-1385492439-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1385492439-line-3)">
+</text><text class="terminal-1385492439-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-4)">
+</text><text class="terminal-1385492439-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-1385492439-line-5)">╭─</text><text class="terminal-1385492439-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-1385492439-line-5)">&#160;Common&#160;options&#160;────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1385492439-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-1385492439-line-5)">─╮</text><text class="terminal-1385492439-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1385492439-line-5)">
+</text><text class="terminal-1385492439-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-6)">│</text><text class="terminal-1385492439-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-6)">-</text><text class="terminal-1385492439-r5" x="36.6" y="166.4" textLength="61" clip-path="url(#terminal-1385492439-line-6)">-help</text><text class="terminal-1385492439-r6" x="122" y="166.4" textLength="24.4" clip-path="url(#terminal-1385492439-line-6)">-h</text><text class="terminal-1385492439-r2" x="170.8" y="166.4" textLength="329.4" clip-path="url(#terminal-1385492439-line-6)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-1385492439-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-6)">│</text><text class="terminal-1385492439-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-6)">
+</text><text class="terminal-1385492439-r4" x="0" y="190.8" textLength="1464" clip-path="url(#terminal-1385492439-line-7)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1385492439-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1385492439-line-7)">
+</text><text class="terminal-1385492439-r4" x="0" y="215.2" textLength="24.4" clip-path="url(#terminal-1385492439-line-8)">╭─</text><text class="terminal-1385492439-r4" x="24.4" y="215.2" textLength="1415.2" clip-path="url(#terminal-1385492439-line-8)">&#160;CI&#160;commands&#160;───────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1385492439-r4" x="1439.6" y="215.2" textLength="24.4" clip-path="url(#terminal-1385492439-line-8)">─╮</text><text class="terminal-1385492439-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1385492439-line-8)">
+</text><text class="terminal-1385492439-r4" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-9)">│</text><text class="terminal-1385492439-r5" x="24.4" y="239.6" textLength="280.6" clip-path="url(#terminal-1385492439-line-9)">fix-ownership&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r2" x="329.4" y="239.6" textLength="1110.2" clip-path="url(#terminal-1385492439-line-9)">Fix&#160;ownership&#160;of&#160;source&#160;files&#160;to&#160;be&#160;same&#160;as&#160;host&#160;user.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-9)">│</text><text class="terminal-1385492439-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-9)">
+</text><text class="terminal-1385492439-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1385492439-line-10)">│</text><text class="terminal-1385492439-r5" x="24.4" y="264" textLength="280.6" clip-path="url(#terminal-1385492439-line-10)">free-space&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r2" x="329.4" y="264" textLength="1110.2" clip-path="url(#terminal-1385492439-line-10)">Free&#160;space&#160;for&#160;jobs&#160;run&#160;in&#160;CI.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-1385492439-line-10)">│</text><text class="terminal-1385492439-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1385492439-line-10)">
+</text><text class="terminal-1385492439-r4" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-11)">│</text><text class="terminal-1385492439-r5" x="24.4" y="288.4" textLength="280.6" clip-path="url(#terminal-1385492439-line-11)">resource-check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r2" x="329.4" y="288.4" textLength="1110.2" clip-path="url(#terminal-1385492439-line-11)">Check&#160;if&#160;available&#160;docker&#160;resources&#160;are&#160;enough.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="288.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-11)">│</text><text class="terminal-1385492439-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-11)">
+</text><text class="terminal-1385492439-r4" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-1385492439-line-12)">│</text><text class="terminal-1385492439-r5" x="24.4" y="312.8" textLength="280.6" clip-path="url(#terminal-1385492439-line-12)">selective-check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r2" x="329.4" y="312.8" textLength="1110.2" clip-path="url(#terminal-1385492439-line-12)">Checks&#160;what&#160;kind&#160;of&#160;tests&#160;should&#160;be&#160;run&#160;for&#160;an&#160;incoming&#160;commit.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="312.8" textLength="12.2" clip-path="url(#terminal-1385492439-line-12)">│</text><text class="terminal-1385492439-r2" x="1464" y="312.8" textLength="12.2" clip-path="url(#terminal-1385492439-line-12)">
+</text><text class="terminal-1385492439-r4" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-1385492439-line-13)">│</text><text class="terminal-1385492439-r5" x="24.4" y="337.2" textLength="280.6" clip-path="url(#terminal-1385492439-line-13)">find-newer-dependencies</text><text class="terminal-1385492439-r2" x="329.4" y="337.2" textLength="1110.2" clip-path="url(#terminal-1385492439-line-13)">Finds&#160;which&#160;dependencies&#160;are&#160;being&#160;upgraded.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1385492439-line-13)">│</text><text class="terminal-1385492439-r2" x="1464" y="337.2" textLength="12.2" clip-path="url(#terminal-1385492439-line-13)">
+</text><text class="terminal-1385492439-r4" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-14)">│</text><text class="terminal-1385492439-r5" x="24.4" y="361.6" textLength="280.6" clip-path="url(#terminal-1385492439-line-14)">get-workflow-info&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r2" x="329.4" y="361.6" textLength="1110.2" clip-path="url(#terminal-1385492439-line-14)">Retrieve&#160;information&#160;about&#160;current&#160;workflow&#160;in&#160;the&#160;CIand&#160;produce&#160;github&#160;actions&#160;output&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-14)">│</text><text class="terminal-1385492439-r2" x="1464" y="361.6" textLength="12.2" clip-path="url(#terminal-1385492439-line-14)">
+</text><text class="terminal-1385492439-r4" x="0" y="386" textLength="12.2" clip-path="url(#terminal-1385492439-line-15)">│</text><text class="terminal-1385492439-r2" x="329.4" y="386" textLength="1110.2" clip-path="url(#terminal-1385492439-line-15)">extracted&#160;from&#160;it.&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-1385492439-r4" x="1451.8" y="386" textLength="12.2" clip-path="url(#terminal-1385492439-line-15)">│</text><text class="terminal-1385492439-r2" x="1464" y="386" textLength="12.2" clip-path="url(#terminal-1385492439-line-15)">
+</text><text class="terminal-1385492439-r4" x="0" y="410.4" textLength="1464" clip-path="url(#terminal-1385492439-line-16)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1385492439-r2" x="1464" y="410.4" textLength="12.2" clip-path="url(#terminal-1385492439-line-16)">
 </text>
     </g>
     </g>

--- a/images/breeze/output_ci_get-workflow-info.svg
+++ b/images/breeze/output_ci_get-workflow-info.svg
@@ -1,0 +1,108 @@
+<svg class="rich-terminal" viewBox="0 0 1482 342.79999999999995" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1038436741-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1038436741-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1038436741-r1 { fill: #c5c8c6;font-weight: bold }
+.terminal-1038436741-r2 { fill: #c5c8c6 }
+.terminal-1038436741-r3 { fill: #d0b344;font-weight: bold }
+.terminal-1038436741-r4 { fill: #868887 }
+.terminal-1038436741-r5 { fill: #68a0b3;font-weight: bold }
+.terminal-1038436741-r6 { fill: #8d7b39 }
+.terminal-1038436741-r7 { fill: #98a84b;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1038436741-clip-terminal">
+      <rect x="0" y="0" width="1463.0" height="291.79999999999995" />
+    </clipPath>
+    <clipPath id="terminal-1038436741-line-0">
+    <rect x="0" y="1.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-1">
+    <rect x="0" y="25.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-2">
+    <rect x="0" y="50.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-3">
+    <rect x="0" y="74.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-4">
+    <rect x="0" y="99.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-5">
+    <rect x="0" y="123.5" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-6">
+    <rect x="0" y="147.9" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-7">
+    <rect x="0" y="172.3" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-8">
+    <rect x="0" y="196.7" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-9">
+    <rect x="0" y="221.1" width="1464" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1038436741-line-10">
+    <rect x="0" y="245.5" width="1464" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="1480" height="340.8" rx="8"/><text class="terminal-1038436741-title" fill="#c5c8c6" text-anchor="middle" x="740" y="27">Command:&#160;ci&#160;get-workflow-info</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1038436741-clip-terminal)">
+    
+    <g class="terminal-1038436741-matrix">
+    <text class="terminal-1038436741-r2" x="1464" y="20" textLength="12.2" clip-path="url(#terminal-1038436741-line-0)">
+</text><text class="terminal-1038436741-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#terminal-1038436741-line-1)">Usage:&#160;</text><text class="terminal-1038436741-r1" x="97.6" y="44.4" textLength="451.4" clip-path="url(#terminal-1038436741-line-1)">breeze&#160;ci&#160;get-workflow-info&#160;[OPTIONS]</text><text class="terminal-1038436741-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-1)">
+</text><text class="terminal-1038436741-r2" x="1464" y="68.8" textLength="12.2" clip-path="url(#terminal-1038436741-line-2)">
+</text><text class="terminal-1038436741-r2" x="12.2" y="93.2" textLength="1281" clip-path="url(#terminal-1038436741-line-3)">Retrieve&#160;information&#160;about&#160;current&#160;workflow&#160;in&#160;the&#160;CIand&#160;produce&#160;github&#160;actions&#160;output&#160;extracted&#160;from&#160;it.</text><text class="terminal-1038436741-r2" x="1464" y="93.2" textLength="12.2" clip-path="url(#terminal-1038436741-line-3)">
+</text><text class="terminal-1038436741-r2" x="1464" y="117.6" textLength="12.2" clip-path="url(#terminal-1038436741-line-4)">
+</text><text class="terminal-1038436741-r4" x="0" y="142" textLength="24.4" clip-path="url(#terminal-1038436741-line-5)">╭─</text><text class="terminal-1038436741-r4" x="24.4" y="142" textLength="1415.2" clip-path="url(#terminal-1038436741-line-5)">&#160;Get&#160;workflow&#160;info&#160;flags&#160;───────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1038436741-r4" x="1439.6" y="142" textLength="24.4" clip-path="url(#terminal-1038436741-line-5)">─╮</text><text class="terminal-1038436741-r2" x="1464" y="142" textLength="12.2" clip-path="url(#terminal-1038436741-line-5)">
+</text><text class="terminal-1038436741-r4" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-6)">│</text><text class="terminal-1038436741-r5" x="24.4" y="166.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-6)">-</text><text class="terminal-1038436741-r5" x="36.6" y="166.4" textLength="85.4" clip-path="url(#terminal-1038436741-line-6)">-github</text><text class="terminal-1038436741-r5" x="122" y="166.4" textLength="97.6" clip-path="url(#terminal-1038436741-line-6)">-context</text><text class="terminal-1038436741-r2" x="341.6" y="166.4" textLength="353.8" clip-path="url(#terminal-1038436741-line-6)">JSON-formatted&#160;github&#160;context</text><text class="terminal-1038436741-r6" x="707.6" y="166.4" textLength="73.2" clip-path="url(#terminal-1038436741-line-6)">(TEXT)</text><text class="terminal-1038436741-r4" x="1451.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-6)">│</text><text class="terminal-1038436741-r2" x="1464" y="166.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-6)">
+</text><text class="terminal-1038436741-r4" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-1038436741-line-7)">│</text><text class="terminal-1038436741-r5" x="24.4" y="190.8" textLength="12.2" clip-path="url(#terminal-1038436741-line-7)">-</text><text class="terminal-1038436741-r5" x="36.6" y="190.8" textLength="85.4" clip-path="url(#terminal-1038436741-line-7)">-github</text><text class="terminal-1038436741-r5" x="122" y="190.8" textLength="170.8" clip-path="url(#terminal-1038436741-line-7)">-context-input</text><text class="terminal-1038436741-r2" x="341.6" y="190.8" textLength="732" clip-path="url(#terminal-1038436741-line-7)">file&#160;input&#160;(might&#160;be&#160;`-`)&#160;with&#160;JSON-formatted&#160;github&#160;context</text><text class="terminal-1038436741-r6" x="1085.8" y="190.8" textLength="122" clip-path="url(#terminal-1038436741-line-7)">(FILENAME)</text><text class="terminal-1038436741-r4" x="1451.8" y="190.8" textLength="12.2" clip-path="url(#terminal-1038436741-line-7)">│</text><text class="terminal-1038436741-r2" x="1464" y="190.8" textLength="12.2" clip-path="url(#terminal-1038436741-line-7)">
+</text><text class="terminal-1038436741-r4" x="0" y="215.2" textLength="1464" clip-path="url(#terminal-1038436741-line-8)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1038436741-r2" x="1464" y="215.2" textLength="12.2" clip-path="url(#terminal-1038436741-line-8)">
+</text><text class="terminal-1038436741-r4" x="0" y="239.6" textLength="24.4" clip-path="url(#terminal-1038436741-line-9)">╭─</text><text class="terminal-1038436741-r4" x="24.4" y="239.6" textLength="1415.2" clip-path="url(#terminal-1038436741-line-9)">&#160;Common&#160;options&#160;────────────────────────────────────────────────────────────────────────────────────────────────────</text><text class="terminal-1038436741-r4" x="1439.6" y="239.6" textLength="24.4" clip-path="url(#terminal-1038436741-line-9)">─╮</text><text class="terminal-1038436741-r2" x="1464" y="239.6" textLength="12.2" clip-path="url(#terminal-1038436741-line-9)">
+</text><text class="terminal-1038436741-r4" x="0" y="264" textLength="12.2" clip-path="url(#terminal-1038436741-line-10)">│</text><text class="terminal-1038436741-r5" x="24.4" y="264" textLength="12.2" clip-path="url(#terminal-1038436741-line-10)">-</text><text class="terminal-1038436741-r5" x="36.6" y="264" textLength="61" clip-path="url(#terminal-1038436741-line-10)">-help</text><text class="terminal-1038436741-r7" x="122" y="264" textLength="24.4" clip-path="url(#terminal-1038436741-line-10)">-h</text><text class="terminal-1038436741-r2" x="170.8" y="264" textLength="329.4" clip-path="url(#terminal-1038436741-line-10)">Show&#160;this&#160;message&#160;and&#160;exit.</text><text class="terminal-1038436741-r4" x="1451.8" y="264" textLength="12.2" clip-path="url(#terminal-1038436741-line-10)">│</text><text class="terminal-1038436741-r2" x="1464" y="264" textLength="12.2" clip-path="url(#terminal-1038436741-line-10)">
+</text><text class="terminal-1038436741-r4" x="0" y="288.4" textLength="1464" clip-path="url(#terminal-1038436741-line-11)">╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-1038436741-r2" x="1464" y="288.4" textLength="12.2" clip-path="url(#terminal-1038436741-line-11)">
+</text>
+    </g>
+    </g>
+</svg>


### PR DESCRIPTION
Intially this action had much bigger scope and retrieved PR also for
build-images workflow. This Python breeze command replaces the
use of that action. Tests are added to cover the functionality.

Thanks to that we can also combine several separate steps in the
workflows into one testable step.

Closes: #25739

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
