### PR TITLE
Remove --force from manual refresh image script

### DIFF
--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -23,7 +23,7 @@ export ANSWER="yes"
 export CI="true"
 export GITHUB_TOKEN=""
 
-breeze setup self-upgrade --force --use-current-airflow-sources
+breeze setup self-upgrade --use-current-airflow-sources
 
 breeze ci-image build \
      --builder airflow_cache \


### PR DESCRIPTION
We have removed the `--force` flag from `self-upgrade` command but
the manual refresh script was not updated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
