### PR TITLE
Allow setting TaskGroup tooltip via function docstring

### DIFF
--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -62,6 +62,9 @@ class TaskGroupDecorator(Generic[R]):
 
     def __call__(self, *args, **kwargs) -> Union[R, TaskGroup]:
         with self._make_task_group(add_suffix_on_collision=True, **self.kwargs) as task_group:
+            if self.function.__doc__ and not task_group.tooltip:
+                task_group.tooltip = self.function.__doc__
+
             # Invoke function to run Tasks inside the TaskGroup
             retval = self.function(*args, **kwargs)
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -523,7 +523,7 @@ If you want to see a more advanced use of TaskGroup, you can look at the ``examp
 
 .. note::
 
-    When using the ``@task_group`` decorator, the decorated-function's docstring will be used as the TaskGroups tooltip in the UI except when a ``toolip`` value is explicitly supplied.
+    When using the ``@task_group`` decorator, the decorated-function's docstring will be used as the TaskGroups tooltip in the UI except when a ``tooltip`` value is explicitly supplied.
 
 .. _concepts:edge-labels:
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -481,17 +481,22 @@ Unlike :ref:`concepts:subdags`, TaskGroups are purely a UI grouping concept. Tas
 
 Dependency relationships can be applied across all tasks in a TaskGroup with the ``>>`` and ``<<`` operators. For example, the following code puts ``task1`` and ``task2`` in TaskGroup ``group1`` and then puts both tasks upstream of ``task3``::
 
-    with TaskGroup("group1") as group1:
+    from airflow.decorators import task_group
+
+    @task_group()
+    def group1():
         task1 = EmptyOperator(task_id="task1")
         task2 = EmptyOperator(task_id="task2")
 
     task3 = EmptyOperator(task_id="task3")
 
-    group1 >> task3
+    group1() >> task3
 
 TaskGroup also supports ``default_args`` like DAG, it will overwrite the ``default_args`` in DAG level::
 
     import pendulum
+
+    from airflow.decorators import task_group
 
     with DAG(
         dag_id='dag1',
@@ -500,13 +505,15 @@ TaskGroup also supports ``default_args`` like DAG, it will overwrite the ``defau
         catchup=False,
         default_args={'retries': 1},
     ):
-        with TaskGroup('group1', default_args={'retries': 3}):
+        @task_group(default_args={'retries': 3}):
+        def group1():
+            """This docstring will become the tooltip for the TaskGroup."
             task1 = EmptyOperator(task_id='task1')
             task2 = BashOperator(task_id='task2', bash_command='echo Hello World!', retries=2)
             print(task1.retries) # 3
             print(task2.retries) # 2
 
-If you want to see a more advanced use of TaskGroup, you can look at the ``example_task_group.py`` example DAG that comes with Airflow.
+If you want to see a more advanced use of TaskGroup, you can look at the ``example_task_group_decorator.py`` example DAG that comes with Airflow.
 
 .. note::
 
@@ -514,6 +521,9 @@ If you want to see a more advanced use of TaskGroup, you can look at the ``examp
 
     To disable the prefixing, pass ``prefix_group_id=False`` when creating the TaskGroup, but note that you will now be responsible for ensuring every single task and group has a unique ID of its own.
 
+.. note::
+
+    When using the ``@task_group`` decorator, the decorated-function's docstring will be used as the TaskGroups tooltip in the UI except when a ``toolip`` value is explicitly supplied.
 
 .. _concepts:edge-labels:
 

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -15,8 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import pendulum
 
-from airflow.decorators import task_group
+from airflow.decorators import dag, task_group
 
 
 def test_task_group_with_overridden_kwargs():
@@ -50,3 +51,38 @@ def test_task_group_with_overridden_kwargs():
         },
         'add_suffix_on_collision': True,
     }
+
+
+def test_toolip_derived_from_function_docstring():
+    """Test that the tooltip for TaskGroup is the decorated-function's docsring."""
+
+    @dag(start_date=pendulum.datetime(2022, 1, 1))
+    def pipeline():
+        @task_group()
+        def tg():
+            """Function docstring."""
+
+        tg()
+
+    _ = pipeline()
+
+    assert _.task_group_dict["tg"].tooltip == "Function docstring."
+
+
+def test_toolip_not_overriden_by_function_docstring():
+    """
+    Test that the tooltip for TaskGroup is the explicitly set value even if the decorated function has a
+    docsring.
+    """
+
+    @dag(start_date=pendulum.datetime(2022, 1, 1))
+    def pipeline():
+        @task_group(tooltip="tooltip for the TaskGroup")
+        def tg():
+            """Function docstring."""
+
+        tg()
+
+    _ = pipeline()
+
+    assert _.task_group_dict["tg"].tooltip == "tooltip for the TaskGroup"

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -53,7 +53,7 @@ def test_task_group_with_overridden_kwargs():
     }
 
 
-def test_toolip_derived_from_function_docstring():
+def test_tooltip_derived_from_function_docstring():
     """Test that the tooltip for TaskGroup is the decorated-function's docstring."""
 
     @dag(start_date=pendulum.datetime(2022, 1, 1))
@@ -69,7 +69,7 @@ def test_toolip_derived_from_function_docstring():
     assert _.task_group_dict["tg"].tooltip == "Function docstring."
 
 
-def test_toolip_not_overriden_by_function_docstring():
+def test_tooltip_not_overriden_by_function_docstring():
     """
     Test that the tooltip for TaskGroup is the explicitly set value even if the decorated function has a
     docstring.

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -54,7 +54,7 @@ def test_task_group_with_overridden_kwargs():
 
 
 def test_toolip_derived_from_function_docstring():
-    """Test that the tooltip for TaskGroup is the decorated-function's docsring."""
+    """Test that the tooltip for TaskGroup is the decorated-function's docstring."""
 
     @dag(start_date=pendulum.datetime(2022, 1, 1))
     def pipeline():
@@ -72,7 +72,7 @@ def test_toolip_derived_from_function_docstring():
 def test_toolip_not_overriden_by_function_docstring():
     """
     Test that the tooltip for TaskGroup is the explicitly set value even if the decorated function has a
-    docsring.
+    docstring.
     """
 
     @dag(start_date=pendulum.datetime(2022, 1, 1))


### PR DESCRIPTION
DAG authors may find it useful to utilize the existing function's docstring as a TaskGroup tooltip for other users looking the the DAG itself; especially for those who wouldn't necessarily have access to the underlying code.

This PR will set the TaskGroup's tooltip of a `@task_group`-decorated function with its docstring should it exist. However, if a tooltip value is explicitly set, the docstring will _not_ be used.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
