### PR TITLE
Fix TaskInstance.task not defined before handle_failure

### DIFF
--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -55,7 +55,7 @@ class Log(Base):
             self.task_id = task_instance.task_id
             self.execution_date = task_instance.execution_date
             self.map_index = task_instance.map_index
-            if task_instance.task:
+            if getattr(task_instance, 'task', None):
                 task_owner = task_instance.task.owner
 
         if 'task_id' in kwargs:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1877,7 +1877,7 @@ class TaskInstance(Base, LoggingMixin):
         self.clear_next_method_args()
 
         # In extreme cases (zombie in case of dag with parse error) we might _not_ have a Task.
-        if context is None and self.task:
+        if context is None and getattr(self, 'task', None):
             context = self.get_template_context(session)
 
         if context is not None:
@@ -1897,7 +1897,7 @@ class TaskInstance(Base, LoggingMixin):
 
         task: Optional[BaseOperator] = None
         try:
-            if self.task and context:
+            if getattr(self, 'task', None) and context:
                 task = self.task.unmap((context, session))
         except Exception:
             self.log.error("Unable to unmap task to determine if we need to send an alert email")
@@ -1936,7 +1936,7 @@ class TaskInstance(Base, LoggingMixin):
             # If a task is cleared when running, it goes into RESTARTING state and is always
             # eligible for retry
             return True
-        if not self.task:
+        if not getattr(self, 'task', None):
             # Couldn't load the task, don't know number of retries, guess:
             return self.try_number <= self.max_tries
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2290,6 +2290,16 @@ class TestTaskInstance:
         Stats_incr.assert_any_call('ti_failures')
         Stats_incr.assert_any_call('operator_failures_EmptyOperator')
 
+    def test_handle_failure_task_undefined(self, create_task_instance):
+        """
+        When the loaded taskinstance does not use refresh_from_task, the task may be undefined.
+        For example:
+            the DAG file has been deleted before executing _execute_task_callbacks
+        """
+        ti = create_task_instance()
+        del ti.task
+        ti.handle_failure("test ti.task undefined")
+
     def test_does_not_retry_on_airflow_fail_exception(self, dag_maker):
         def fail():
             raise AirflowFailException("hopeless")


### PR DESCRIPTION
When the local DAG file has been deleted, handle_failure method in DagFileProcessor._execute_task_callbacks throws the following exception:
```python
 AttributeError: 'TaskInstance' object has no attribute 'task'
```

I thought TaskInstance.task should be set to a default None to avoid this kind of problem, but I wasn't sure if this would affect other features, so I made minimal changes


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
