### PR TITLE
Better error messsage for pre-common-sql providers

### DIFF
--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -224,7 +224,7 @@ class TestSQLCheckOperatorDbHook:
 
     def test_not_allowed_conn_type(self, mock_get_conn):
         mock_get_conn.return_value = Connection(conn_id='sql_default', conn_type='s3')
-        with pytest.raises(AirflowException, match=r"The connection type is not supported"):
+        with pytest.raises(AirflowException, match=r"You are trying to use `common-sql`"):
             self._operator._hook
 
     def test_sql_operator_hook_params_snowflake(self, mock_get_conn):


### PR DESCRIPTION
When you are using a common-sql provider functionality such
as SQLColumnCheckOperator with a provider from before common-sql
provider was released, attempts to instatiate such provider from
commmon-sql will fail because the Hooks in those providers derive from
the old airflow.hooks.dbapi_hook.DbApiHook rather than from
airflow.providers.common.sql.hooks.sql.DbApiHook.

We cannot do much about it, simply speaking the old providers
should be upgraded to a version that supports common.sql provider.

This PR raises a message that explicitly states the error.

Closes: #26046

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
