### PR TITLE
need to change parameters to params

### DIFF
--- a/docs/apache-airflow-providers-snowflake/operators/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/operators/snowflake.rst
@@ -46,7 +46,7 @@ the connection metadata is structured as follows:
      - ``warehouse``, ``account``, ``database``, ``region``, ``role``, ``authenticator``
 
 An example usage of the SnowflakeOperator is as follows:
-
+# see comment
 .. exampleinclude:: /../../tests/system/providers/snowflake/example_snowflake.py
     :language: python
     :start-after: [START howto_operator_snowflake]


### PR DESCRIPTION
The parameters={"id": 56} in the embedded example does not work. It needs to be params = {"id": 56}

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
