### PR TITLE
Docs - align with other documentation

### DIFF
--- a/docs/apache-airflow/installation/setting-up-the-database.rst
+++ b/docs/apache-airflow/installation/setting-up-the-database.rst
@@ -22,7 +22,7 @@ Airflow requires a database. If you're just experimenting and learning Airflow, 
 default SQLite option. If you don't want to use SQLite, then take a look at
 :doc:`/howto/set-up-database` to setup a different database.
 
-Usually, you need to run ``airflow db upgrade`` in order to create the database schema that Airflow can use.
+Usually, you need to run ``airflow db init`` in order to create the database schema that Airflow can use.
 
 Similarly, upgrading Airflow usually requires an extra step of upgrading the database. This is done
 with ``airflow db upgrade`` CLI command. You should make sure that Airflow components are


### PR DESCRIPTION
[here](https://airflow.apache.org/docs/apache-airflow/stable/howto/set-up-database.html#initialize-the-database) it says:

> you should create the database schema: `airflow db init`

and in [this](https://airflow.apache.org/docs/apache-airflow/stable/installation/setting-up-the-database.html) (proposal) it says:
> Usually, you need to run `airflow db upgrade` in order to create the database schema that Airflow can use.

I guess they are both doing the same, but it make more sense to do `init` on the first time - unless I'm missing something?


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
