### PR TITLE
FIX Make items nullable for TaskInstance related endpoints to avoid API errors

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2958,8 +2958,10 @@ components:
           type: integer
         queue:
           type: string
+          nullable: true
         priority_weight:
           type: integer
+          nullable: true
         operator:
           type: string
           nullable: true
@@ -3279,6 +3281,7 @@ components:
         queue:
           type: string
           readOnly: true
+          nullable: true
         pool:
           type: string
           readOnly: true

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1171,8 +1171,8 @@ export interface components {
       unixname?: string;
       pool?: string;
       pool_slots?: number;
-      queue?: string;
-      priority_weight?: number;
+      queue?: string | null;
+      priority_weight?: number | null;
       /** @description *Changed in version 2.1.1*&#58; Field becomes nullable. */
       operator?: string | null;
       queued_when?: string | null;
@@ -1349,7 +1349,7 @@ export interface components {
       is_mapped?: boolean;
       wait_for_downstream?: boolean;
       retries?: number;
-      queue?: string;
+      queue?: string | null;
       pool?: string;
       pool_slots?: number;
       execution_timeout?: components["schemas"]["TimeDelta"] | null;


### PR DESCRIPTION
Solves #26068.
As mentioned in the comment there, also noticed the TaskInstance endpoint raises errors, so fixed that as well.

I also verified both of them with curl commands that got 502, after which I made the changes, restarted the webserver and reran them. After the changes, the endpoints returned data without errors.