### PR TITLE
FIX Incorrect typing information

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -36,7 +36,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
-    overload
+    overload,
 )
 
 from sqlalchemy import (

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -36,6 +36,7 @@ from typing import (
     TypeVar,
     Union,
     cast,
+    overload
 )
 
 from sqlalchemy import (
@@ -57,7 +58,6 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import joinedload, relationship, synonym
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import false, select, true
-from typing_extensions import Literal, overload
 
 from airflow import settings
 from airflow.callbacks.callback_requests import DagCallbackRequest
@@ -70,6 +70,7 @@ from airflow.models.tasklog import LogTemplate
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
+from airflow.typing_compat import Literal
 from airflow.utils import timezone
 from airflow.utils.helpers import is_container
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -844,6 +845,7 @@ class DagRun(Base, LoggingMixin):
         from airflow.settings import task_instance_mutation_hook
 
         # Set for the empty default in airflow.settings -- if it's not set this means it has been changed
+        # Note: Literal[True, False] instead of bool because otherwise it doesn't correctly find the overload.
         hook_is_noop: Literal[True, False] = getattr(task_instance_mutation_hook, 'is_noop', False)
 
         dag = self.get_dag()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -83,6 +83,9 @@ if TYPE_CHECKING:
     from airflow.models.operator import Operator
 
 
+CreatedTasksType = TypeVar("CreatedTasksType")
+
+
 class TISchedulingDecision(NamedTuple):
     """Type of return for DagRun.task_instance_scheduling_decisions"""
 
@@ -1000,8 +1003,6 @@ class DagRun(Base, LoggingMixin):
             creator = create_ti
         return creator
 
-    CreatedTasksType = TypeVar("CreatedTasksType")
-
     def _create_tasks(
         self,
         dag: "DAG",
@@ -1036,12 +1037,10 @@ class DagRun(Base, LoggingMixin):
 
         tasks_and_map_idxs = map(expand_mapped_literals, filter(task_filter, dag.task_dict.values()))
 
-        tasks: Union[Iterator[Dict[str, Any]], Iterator[TI]] = itertools.chain.from_iterable(
+        tasks: CreatedTasksType = itertools.chain.from_iterable(  # type: ignore
             itertools.starmap(task_creator, tasks_and_map_idxs)  # type: ignore
         )
-
-        # itertools.chain returns a chain[object] instead of the Iterator type we are looking for.
-        return tasks  # type: ignore
+        return tasks
 
     def _create_task_instances(
         self,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -587,7 +587,7 @@ class TaskInstance(Base, LoggingMixin):
         self.test_mode = False
 
     @staticmethod
-    def insert_mapping(run_id: str, task: "Operator", map_index: int) -> dict:
+    def insert_mapping(run_id: str, task: "Operator", map_index: int) -> Dict[str, Any]:
         """:meta private:"""
         return {
             'dag_id': task.dag_id,


### PR DESCRIPTION
When I was debugging the API and figuring out when which fields of a TaskInstance could be None for #26068, I stumbled across this code for which the typing information is incorrect.
It confused me completely and I even though this was some sort of magic function from SQLAlchemy at some point.
I figured this should be fixed so it hopefully doesn't confuse anyone else :)