### PR TITLE
Add group prefix to decorated mapped task

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -359,6 +359,8 @@ class _TaskDecorator(Generic[FParams, FReturn, OperatorSubclass]):
         partial_kwargs.update(task_kwargs)
 
         task_id = get_unique_task_id(partial_kwargs.pop("task_id"), dag, task_group)
+        if task_group:
+            task_id = task_group.child_id(task_id)
         params = partial_kwargs.pop("params", None) or default_params
 
         # Logic here should be kept in sync with BaseOperatorMeta.partial().

--- a/tests/decorators/test_mapped.py
+++ b/tests/decorators/test_mapped.py
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.models.dag import DAG
+from airflow.utils.task_group import TaskGroup
+from tests.models import DEFAULT_DATE
+
+
+def test_mapped_task_group_id_prefix_task_id():
+    def f(z):
+        pass
+
+    with DAG(dag_id="d", start_date=DEFAULT_DATE) as dag:
+        x1 = dag.task(task_id="t1")(f).expand(z=[])
+        with TaskGroup("g"):
+            x2 = dag.task(task_id="t2")(f).expand(z=[])
+
+    assert x1.operator.task_id == "t1"
+    assert x2.operator.task_id == "g.t2"
+
+    dag.get_task("t1") == x1.operator
+    dag.get_task("g.t2") == x2.operator

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1247,3 +1247,18 @@ def test_task_group_edge_modifier_chain():
     assert tg.downstream_task_ids == {t3.node_id}
     # Check that we can perform a topological_sort
     dag.topological_sort()
+
+
+def test_mapped_task_group_id_prefix_task_id():
+    from tests.test_utils.mock_operators import MockOperator
+
+    with DAG(dag_id="d", start_date=DEFAULT_DATE) as dag:
+        t1 = MockOperator.partial(task_id="t1").expand(arg1=[])
+        with TaskGroup("g"):
+            t2 = MockOperator.partial(task_id="t2").expand(arg1=[])
+
+    assert t1.task_id == "t1"
+    assert t2.task_id == "g.t2"
+
+    dag.get_task("t1") == t1
+    dag.get_task("g.t2") == t2


### PR DESCRIPTION
Also add a test for non-decorated tasks having the same behaviour (they already do and do not need fixing).

Close #25165.