### PR TITLE
Remove limitation to pull latest images.

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -278,13 +278,6 @@ def pull(
     extra_pytest_args: Tuple,
 ):
     """Pull and optionally verify CI images - possibly in parallel for all Python versions."""
-    if image_tag == "latest":
-        get_console().print("[red]You cannot pull latest images because they are not published any more!\n")
-        get_console().print(
-            "[yellow]You need to specify commit tag to pull and image. If you wish to get"
-            " the latest image, you need to run `breeze ci-image build` command\n"
-        )
-        sys.exit(1)
     perform_environment_checks(verbose=verbose)
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -304,13 +304,6 @@ def pull_prod_image(
     extra_pytest_args: Tuple,
 ):
     """Pull and optionally verify Production images - possibly in parallel for all Python versions."""
-    if image_tag == "latest":
-        get_console().print("[red]You cannot pull latest images because they are not published any more!\n")
-        get_console().print(
-            "[yellow]You need to specify commit tag to pull and image. If you wish to get"
-            " the latest image, you need to run `breeze ci-image build` command\n"
-        )
-        sys.exit(1)
     perform_environment_checks(verbose=verbose)
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)


### PR DESCRIPTION
The #25380 restored regular pushing of "latest" images to ghcr.io
(after some period where we did not do it, because caching
is now solved differently - using separate "cache" images for
each of the architectures). We restored it because codespaces
were pulling the latest image rather than rebuilding the images using
cache. However we have not removed the protection against pulling
the latest image (because it could be old).

This PR removes the - now unnecessary - protection.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
