### PR TITLE
Run EmptyOperator tasks that have outlets

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -1155,7 +1155,7 @@ class DagRun(Base, LoggingMixin):
 
         Each element of ``schedulable_tis`` should have it's ``task`` attribute already set.
 
-        Any EmptyOperator without callbacks is instead set straight to the success state.
+        Any EmptyOperator without callbacks or outlets is instead set straight to the success state.
 
         All the TIs should belong to this DagRun, but this code is in the hot-path, this is not checked -- it
         is the caller's responsibility to call this function only with TIs from a single dag run.
@@ -1169,6 +1169,7 @@ class DagRun(Base, LoggingMixin):
                 ti.task.inherits_from_empty_operator
                 and not ti.task.on_execute_callback
                 and not ti.task.on_success_callback
+                and not ti.task.outlets
             ):
                 dummy_ti_ids.append(ti.task_id)
             else:

--- a/tests/dags/test_only_empty_tasks.py
+++ b/tests/dags/test_only_empty_tasks.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 from typing import Sequence
 
-from airflow.models import DAG
+from airflow import DAG, Dataset
 from airflow.operators.empty import EmptyOperator
 
 DEFAULT_DATE = datetime(2016, 1, 1)
@@ -47,8 +47,10 @@ with dag:
 
     task_a >> task_b
 
-    task_c = MyEmptyOperator(task_id="test_task_c", body={"hello": "world"})
+    MyEmptyOperator(task_id="test_task_c", body={"hello": "world"})
 
-    task_d = EmptyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: None)
+    EmptyOperator(task_id="test_task_on_execute", on_execute_callback=lambda *args, **kwargs: None)
 
-    task_e = EmptyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: None)
+    EmptyOperator(task_id="test_task_on_success", on_success_callback=lambda *args, **kwargs: None)
+
+    EmptyOperator(task_id="test_task_outlets", outlets=[Dataset("hello")])

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4198,13 +4198,14 @@ class TestSchedulerJob:
 
         dags = self.scheduler_job.dagbag.dags.values()
         assert ['test_only_empty_tasks'] == [dag.dag_id for dag in dags]
-        assert 5 == len(tis)
+        assert 6 == len(tis)
         assert {
             ('test_task_a', 'success'),
             ('test_task_b', None),
             ('test_task_c', 'success'),
             ('test_task_on_execute', 'scheduled'),
             ('test_task_on_success', 'scheduled'),
+            ('test_task_outlets', 'scheduled'),
         } == {(ti.task_id, ti.state) for ti in tis}
         for state, start_date, end_date, duration in [
             (ti.state, ti.start_date, ti.end_date, ti.duration) for ti in tis
@@ -4222,13 +4223,14 @@ class TestSchedulerJob:
         with create_session() as session:
             tis = session.query(TaskInstance).all()
 
-        assert 5 == len(tis)
+        assert 6 == len(tis)
         assert {
             ('test_task_a', 'success'),
             ('test_task_b', 'success'),
             ('test_task_c', 'success'),
             ('test_task_on_execute', 'scheduled'),
             ('test_task_on_success', 'scheduled'),
+            ('test_task_outlets', 'scheduled'),
         } == {(ti.task_id, ti.state) for ti in tis}
         for state, start_date, end_date, duration in [
             (ti.state, ti.start_date, ti.end_date, ti.duration) for ti in tis


### PR DESCRIPTION
Like when they have callbacks, we should actually run EmptyOperators
that have outlets (e.g. datasets).