### PR TITLE
Add missing schedule DAG parameter to AWS system tests

### DIFF
--- a/tests/system/providers/amazon/aws/example_local_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_local_to_s3.py
@@ -47,6 +47,7 @@ def delete_temp_file():
 
 with DAG(
     dag_id=DAG_ID,
+    schedule='@once',
     start_date=datetime(2021, 1, 1),  # Override to match your needs
     tags=['example'],
     catchup=False,

--- a/tests/system/providers/amazon/aws/example_quicksight.py
+++ b/tests/system/providers/amazon/aws/example_quicksight.py
@@ -125,7 +125,7 @@ def delete_ingestion(aws_account_id: str, dataset_name: str, ingestion_name: str
 
 with DAG(
     dag_id=DAG_ID,
-    schedule_interval='@once',
+    schedule='@once',
     start_date=datetime(2021, 1, 1),
     tags=["example"],
     catchup=False,


### PR DESCRIPTION
Some system tests are missing the parameter `schedule` which leads to system tests failure