### PR TITLE
Fix UI flash when triggering with dup logical date

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2052,10 +2052,14 @@ class Airflow(AirflowBaseView):
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
             )
-        # if run_id is not None, filter dag runs based on run id and ignore execution date
+
         dr = DagRun.find_duplicate(dag_id=dag_id, run_id=run_id, execution_date=execution_date)
         if dr:
-            flash(f"The run_id {dr.run_id} already exists", "error")
+            if dr.run_id == run_id:
+                message = f"The run ID {run_id} already exists"
+            else:
+                message = f"The logical date {execution_date} already exists"
+            flash(message, "error")
             return redirect(origin)
 
         # Flash a warning when slash is used, but still allow it to continue on.

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -63,7 +63,7 @@ def test_duplicate_run_id(admin_client):
     run_id = 'test_run'
     admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={run_id}', follow_redirects=True)
     response = admin_client.post(f'trigger?dag_id={test_dag_id}&run_id={run_id}', follow_redirects=True)
-    check_content_in_response(f'The run_id {run_id} already exists', response)
+    check_content_in_response(f'The run ID {run_id} already exists', response)
 
 
 def test_trigger_dag_conf(admin_client):


### PR DESCRIPTION
Previously the error message would always state that the run ID already exists, while in reality the error may be caused by a duplicated logical date. This adds additional logic to account for that.