### PR TITLE
Don't error when multiple tasks produce the same dataset

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -17,6 +17,7 @@
 # under the License.
 from typing import TYPE_CHECKING
 
+from sqlalchemy import exc
 from sqlalchemy.orm.session import Session
 
 from airflow.configuration import conf
@@ -63,13 +64,47 @@ class DatasetManager(LoggingMixin):
         self._queue_dagruns(dataset_model, session)
 
     def _queue_dagruns(self, dataset: DatasetModel, session: Session) -> None:
+        # Possible race condition: if multiple dags or multiple (usually
+        # mapped) tasks update the same dataset, this can fail with a unique
+        # constraint violation.
+        #
+        # If we support it, use ON CONFLICT to do nothing, otherwise
+        # "fallback" to running this in a nested transaction. This is needed
+        # so that the adding of these rows happens in the same transaction
+        # where `ti.state` is changed.
+
+        if session.bind.dialect.name == "postgresql":
+            return self._postgres_queue_dagruns(dataset, session)
+        return self._slow_path_queue_dagruns(dataset, session)
+
+    def _slow_path_queue_dagruns(self, dataset: DatasetModel, session: Session) -> None:
         consuming_dag_ids = [x.dag_id for x in dataset.consuming_dags]
         self.log.debug("consuming dag ids %s", consuming_dag_ids)
+
+        # Don't error whole transaction when a single RunQueue item conflicts.
+        # https://docs.sqlalchemy.org/en/14/orm/session_transaction.html#using-savepoint
         for dag_id in consuming_dag_ids:
-            session.merge(DatasetDagRunQueue(dataset_id=dataset.id, target_dag_id=dag_id))
+            item = DatasetDagRunQueue(target_dag_id=dag_id, dataset_id=dataset.id)
+            try:
+                with session.begin_nested():
+                    session.merge(item)
+            except exc.IntegrityError:
+                self.log.debug("Skipping record %s", item, exc_info=True)
+
+        session.flush()
+
+    def _postgres_queue_dagruns(self, dataset: DatasetModel, session: Session) -> None:
+        from sqlalchemy.dialects.postgresql import insert
+
+        stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset.id).on_conflict_do_nothing()
+        session.get_bind().execute(
+            stmt,
+            [{'target_dag_id': target_dag.dag_id} for target_dag in dataset.consuming_dags],
+        )
+        session.flush()
 
 
-def resolve_dataset_manager():
+def resolve_dataset_manager() -> "DatasetManager":
     _dataset_manager_class = conf.getimport(
         section='core',
         key='dataset_manager_class',

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -97,7 +97,7 @@ class DatasetManager(LoggingMixin):
         from sqlalchemy.dialects.postgresql import insert
 
         stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset.id).on_conflict_do_nothing()
-        session.get_bind().execute(
+        session.execute(
             stmt,
             [{'target_dag_id': target_dag.dag_id} for target_dag in dataset.consuming_dags],
         )

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -117,6 +117,11 @@ class DagScheduleDatasetReference(Base):
             DagScheduleDatasetReference.dag_id == foreign(DatasetDagRunQueue.target_dag_id),
         )""",
     )
+    dag = relationship(
+        "DagModel",
+        primaryjoin="foreign(DagModel.dag_id) == DagScheduleDatasetReference.dag_id",
+        uselist=False,
+    )
 
     __tablename__ = "dag_schedule_dataset_reference"
     __table_args__ = (


### PR DESCRIPTION
Previously this was "racey", so running multiple dags all updating the
same outlet dataset (or how I ran in to this: mapped tasks) would cause
some of them to fail with a unique constraing violation.

The fix has two paths, one generic and an optimized version for
Postgres.

The generic one is likely slightly slower, and uses the pattern that the
SQLA docs have for exactly this case. To quote

> This pattern is ideal for situations such as using PostgreSQL and
> catching IntegrityError to detect duplicate rows; PostgreSQL normally
> aborts the entire tranasction when such an error is raised, however when
> using SAVEPOINT, the outer transaction is maintained. In the example
> below a list of data is persisted into the database, with the occasional
> "duplicate primary key" record skipped, without rolling back the entire
> operation:

However for PostgreSQL specifically, there is a better approach we can
do: use it's `ON CONFLICT DO NOTHING` approach. This also allows us to
do the whole process in a single SQL statement for all outlet datasets (vs
1 select + 1 insert per dataset for the slow path)

Fixes #25210