### PR TITLE
use label instead of id for dynamic task labels in graph

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -94,8 +94,9 @@ const updateNodeLabels = (node, instances) => {
       && instances[node.id].mapped_states
       ? instances[node.id].mapped_states.length
       : ' ';
-
-    label = `${node.id} [${count}]`;
+    if (!label.includes(`[${count}]`)) {
+      label = `${label} [${count}]`;
+    }
   }
   if (g.node(node.id) && g.node(node.id).label !== label) {
     g.node(node.id).label = label;


### PR DESCRIPTION
Now that the task labels are fixed in https://github.com/apache/airflow/pull/26081#event-7303073780, we should use that instead of `id` for the graph view

Fixes: https://github.com/apache/airflow/issues/25523

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
