### PR TITLE
Fix DagRun.start_date not set during backfill with --reset-dagruns True

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -299,6 +299,8 @@ class BackfillJob(BaseJob):
                 respect_dag_max_active_limit = False
             # Fixes --conf overwrite for backfills with already existing DagRuns
             run.conf = self.conf or {}
+            # start_date is cleared for existing DagRuns
+            run.start_date = timezone.utcnow()
         else:
             run = None
 


### PR DESCRIPTION
When we run backfill on an existing runs, the start_date is lost during the clearing
of the run and never set.

This PR sets it

closes: https://github.com/apache/airflow/issues/26000

