### PR TITLE
Update zombie message to be more descriptive

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4044,7 +4044,7 @@ class TestSchedulerJob:
             requests = self.scheduler_job.executor.callback_sink.send.call_args[0]
             assert 1 == len(requests)
             assert requests[0].full_filepath == dag.fileloc
-            assert requests[0].msg == f"Detected {ti} as zombie"
+            assert requests[0].msg == str(self.scheduler_job._generate_zombie_message_details(ti))
             assert requests[0].is_failure_callback is True
             assert isinstance(requests[0].simple_task_instance, SimpleTaskInstance)
             assert ti.dag_id == requests[0].simple_task_instance.dag_id
@@ -4054,6 +4054,68 @@ class TestSchedulerJob:
 
             session.query(TaskInstance).delete()
             session.query(LocalTaskJob).delete()
+
+    def test_zombie_message(self):
+        """
+        Check that the zombie message comes out as expected
+        """
+
+        dagbag = DagBag(TEST_DAG_FOLDER, read_dags_from_db=False)
+        with create_session() as session:
+            session.query(LocalTaskJob).delete()
+            dag = dagbag.get_dag('example_branch_operator')
+            dag.sync_to_db()
+
+            dag_run = dag.create_dagrun(
+                state=DagRunState.RUNNING,
+                execution_date=DEFAULT_DATE,
+                run_type=DagRunType.SCHEDULED,
+                session=session,
+            )
+
+            self.scheduler_job = SchedulerJob(subdir=os.devnull)
+            self.scheduler_job.executor = MockExecutor()
+            self.scheduler_job.processor_agent = mock.MagicMock()
+
+            # We will provision 2 tasks so we can check we only find zombies from this scheduler
+            tasks_to_setup = ['branching', 'run_this_first']
+
+            for task_id in tasks_to_setup:
+                task = dag.get_task(task_id=task_id)
+                ti = TaskInstance(task, run_id=dag_run.run_id, state=State.RUNNING)
+                ti.queued_by_job_id = 999
+
+                local_job = LocalTaskJob(ti)
+                local_job.state = State.SHUTDOWN
+
+                session.add(local_job)
+                session.flush()
+
+                ti.job_id = local_job.id
+                session.add(ti)
+                session.flush()
+
+            assert task.task_id == 'run_this_first'  # Make sure we have the task/ti we expect
+
+            ti.queued_by_job_id = self.scheduler_job.id
+            session.flush()
+
+            zombie_message = self.scheduler_job._generate_zombie_message_details(ti)
+            assert zombie_message == {'DAG Id': 'example_branch_operator',
+                                      'Task Id': 'run_this_first',
+                                     'Run Id': 'scheduled__2016-01-01T00:00:00+00:00'}
+
+            ti.hostname = "10.10.10.10"
+            ti.map_index = 2
+            ti.external_executor_id = "abcdefg"
+
+            zombie_message = self.scheduler_job._generate_zombie_message_details(ti)
+            assert zombie_message == {'DAG Id': 'example_branch_operator',
+                                      'Task Id': 'run_this_first',
+                                      'Run Id': 'scheduled__2016-01-01T00:00:00+00:00',
+                                      "Hostname": "10.10.10.10",
+                                      "Map Index": 2,
+                                      "External Executor Id": "abcdefg"}
 
     def test_find_zombies_handle_failure_callbacks_are_correctly_passed_to_dag_processor(self):
         """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -4101,21 +4101,25 @@ class TestSchedulerJob:
             session.flush()
 
             zombie_message = self.scheduler_job._generate_zombie_message_details(ti)
-            assert zombie_message == {'DAG Id': 'example_branch_operator',
-                                      'Task Id': 'run_this_first',
-                                     'Run Id': 'scheduled__2016-01-01T00:00:00+00:00'}
+            assert zombie_message == {
+                'DAG Id': 'example_branch_operator',
+                'Task Id': 'run_this_first',
+                'Run Id': 'scheduled__2016-01-01T00:00:00+00:00',
+            }
 
             ti.hostname = "10.10.10.10"
             ti.map_index = 2
             ti.external_executor_id = "abcdefg"
 
             zombie_message = self.scheduler_job._generate_zombie_message_details(ti)
-            assert zombie_message == {'DAG Id': 'example_branch_operator',
-                                      'Task Id': 'run_this_first',
-                                      'Run Id': 'scheduled__2016-01-01T00:00:00+00:00',
-                                      "Hostname": "10.10.10.10",
-                                      "Map Index": 2,
-                                      "External Executor Id": "abcdefg"}
+            assert zombie_message == {
+                'DAG Id': 'example_branch_operator',
+                'Task Id': 'run_this_first',
+                'Run Id': 'scheduled__2016-01-01T00:00:00+00:00',
+                "Hostname": "10.10.10.10",
+                "Map Index": 2,
+                "External Executor Id": "abcdefg",
+            }
 
     def test_find_zombies_handle_failure_callbacks_are_correctly_passed_to_dag_processor(self):
         """


### PR DESCRIPTION
Because the zombie detection method comes from the scheduler job, in a distributed environment it can be cumbersome to find the worker that actually had the problem that led to the zombie. In editing this, I also noticed that the zombie message had some redundant and unhelpful elements (e.g. printing the memory address of the SimpleTaskInstance) so I've cleaned it up.

closes: #26067 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
