### PR TITLE
Fix saving hash on image build.

### DIFF
--- a/dev/breeze/src/airflow_breeze/params/common_build_params.py
+++ b/dev/breeze/src/airflow_breeze/params/common_build_params.py
@@ -151,7 +151,11 @@ class CommonBuildParams:
         return "," in self.platform
 
     def preparing_latest_image(self) -> bool:
-        return self.tag_as_latest or self.airflow_image_name == self.airflow_image_name_with_tag
+        return (
+            self.tag_as_latest
+            or self.airflow_image_name == self.airflow_image_name_with_tag
+            or self.airflow_image_name_with_tag.endswith("latest")
+        )
 
     @property
     def platforms(self) -> List[str]:


### PR DESCRIPTION
There was a case when image was build with breeze, when the hash
of important files were not modified after image has been built because
the "latest" tag was set and comparision did not include it.

This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
