### PR TITLE
Fix backfill occassional deadlocking

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -331,7 +331,7 @@ class BackfillJob(BaseJob):
         return run
 
     @provide_session
-    def _task_instances_for_dag_run(self, dag_run, session=None):
+    def _task_instances_for_dag_run(self, dag, dag_run, session=None):
         """
         Returns a map of task instance key to task instance object for the tasks to
         run in the given dag run.
@@ -351,10 +351,19 @@ class BackfillJob(BaseJob):
         dag_run.refresh_from_db()
         make_transient(dag_run)
 
-        for ti in dag_run.get_task_instances(session=session):
-            if ti.state != TaskInstanceState.REMOVED:
-                tasks_to_run[ti.key] = ti
-
+        dag_run.dag = dag
+        info = dag_run.task_instance_scheduling_decisions(session=session)
+        schedulable_tis = info.schedulable_tis
+        try:
+            for ti in dag_run.get_task_instances(session=session):
+                if ti in schedulable_tis:
+                    ti.set_state(TaskInstanceState.SCHEDULED)
+                if ti.state != TaskInstanceState.REMOVED:
+                    tasks_to_run[ti.key] = ti
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
         return tasks_to_run
 
     def _log_progress(self, ti_status):
@@ -714,7 +723,7 @@ class BackfillJob(BaseJob):
         for dagrun_info in dagrun_infos:
             for dag in self._get_dag_with_subdags():
                 dag_run = self._get_dag_run(dagrun_info, dag, session=session)
-                tis_map = self._task_instances_for_dag_run(dag_run, session=session)
+                tis_map = self._task_instances_for_dag_run(dag, dag_run, session=session)
                 if dag_run is None:
                     continue
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1783,3 +1783,30 @@ class TestBackfillJob:
         (dr,) = DagRun.find(dag_id=dag.dag_id, execution_date=DEFAULT_DATE, session=session)
         assert dr.start_date
         assert f'Failed to record duration of {dr}' not in caplog.text
+
+    def test_task_instances_are_not_set_to_scheduled_when_dagrun_reset(self, dag_maker, session):
+        """Test that when dagrun is reset, task instances are not set to scheduled"""
+
+        with dag_maker() as dag:
+            task1 = EmptyOperator(task_id='task1')
+            task2 = EmptyOperator(task_id='task2')
+            task3 = EmptyOperator(task_id='task3')
+            task1 >> task2 >> task3
+
+        for i in range(1, 4):
+            dag_maker.create_dagrun(
+                run_id=f'test_dagrun_{i}', execution_date=DEFAULT_DATE + datetime.timedelta(days=i)
+            )
+
+        dag.clear()
+
+        job = BackfillJob(
+            dag=dag,
+            start_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            end_date=DEFAULT_DATE + datetime.timedelta(days=4),
+            executor=MockExecutor(),
+            donot_pickle=True,
+        )
+        for dr in DagRun.find(dag_id=dag.dag_id, session=session):
+            job._task_instances_for_dag_run(dr, session=session)
+            assert [ti.state == State.NONE for ti in dr.get_task_instances()]


### PR DESCRIPTION
During backfilling, we set all task instances of the dagrun being run to scheduled,
this causes deadlocking of the dagrun whenever dagrun.update_state is called and
there's no running or schedulable task instances.
The fix was to remove the batch update of the task instances to scheduled state
 and have the executor queue the tasks that the dependencies have been met.


closes: https://github.com/apache/airflow/issues/25353, closes: https://github.com/apache/airflow/issues/26044
