### PR TITLE
Fix Deferrable stuck as "scheduled" during backfill

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -218,6 +218,16 @@ class BackfillJob(BaseJob):
                 ti_status.running.pop(reduced_key)
                 ti_status.to_run[ti.key] = ti
 
+            elif ti.state == TaskInstanceState.SCHEDULED:
+                # Deferrable task can go from DEFERRED to SCHEDULED,
+                # when that happens, we need to remove it from running
+                # and add it to to_run
+                ti_status.running.pop(ti.key)
+                ti_status.to_run[ti.key] = ti
+
+            elif ti.state == TaskInstanceState.DEFERRED:
+                self.log.warning("The triggerer is not running. Please start the triggerer")
+
         # Batch schedule of task instances
         if tis_to_be_scheduled:
             filter_for_tis = TI.filter_for_tis(tis_to_be_scheduled)

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -217,11 +217,10 @@ class BackfillJob(BaseJob):
                 tis_to_be_scheduled.append(ti)
                 ti_status.running.pop(reduced_key)
                 ti_status.to_run[ti.key] = ti
-
+            # special case: Deferrable task can go from DEFERRED to SCHEDULED;
+            # when that happens, we need to put it back as in UP_FOR_RESCHEDULE
             elif ti.state == TaskInstanceState.SCHEDULED:
-                # Deferrable task can go from DEFERRED to SCHEDULED,
-                # when that happens, we need to remove it from running
-                # and add it to to_run
+                self.log.debug("Task instance %s is resumed from deferred state", ti)
                 ti_status.running.pop(ti.key)
                 ti_status.to_run[ti.key] = ti
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -225,9 +225,6 @@ class BackfillJob(BaseJob):
                 ti_status.running.pop(ti.key)
                 ti_status.to_run[ti.key] = ti
 
-            elif ti.state == TaskInstanceState.DEFERRED:
-                self.log.warning("The triggerer is not running. Please start the triggerer")
-
         # Batch schedule of task instances
         if tis_to_be_scheduled:
             filter_for_tis = TI.filter_for_tis(tis_to_be_scheduled)


### PR DESCRIPTION
When the `triggerer` puts the task to `scheduled`, it gets stuck because it's already in `ti_status.running`. We need to move it to `ti_status.to_run` for it to continue running

closes: https://github.com/apache/airflow/issues/25653