### PR TITLE
EMR Serverless Fix for Jobs marked as success even on failure

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -105,6 +105,15 @@ class EmrServerlessHook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
+    JOB_INTERMEDIATE_STATES = {'PENDING', 'RUNNING', 'SCHEDULED', 'SUBMITTED'}
+    JOB_FAILURE_STATES = {'FAILED', 'CANCELLING', 'CANCELLED'}
+    JOB_SUCCESS_STATES = {'SUCCESS'}
+    JOB_TERMINAL_STATES = JOB_SUCCESS_STATES.union(JOB_FAILURE_STATES)
+
+    APPLICATION_INTERMEDIATE_STATES = {'CREATING', 'STARTING', 'STOPPING'}
+    APPLICATION_FAILURE_STATES = {'STOPPED', 'TERMINATED'}
+    APPLICATION_SUCCESS_STATES = {'CREATED', 'STARTED'}
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["client_type"] = "emr-serverless"
         super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -26,7 +26,6 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
 from airflow.providers.amazon.aws.links.emr import EmrClusterLink
-from airflow.providers.amazon.aws.sensors.emr import EmrServerlessApplicationSensor, EmrServerlessJobSensor
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -552,7 +551,7 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
             get_state_args={'applicationId': application_id},
             parse_response=['application', 'state'],
             desired_state={'CREATED'},
-            failure_states=EmrServerlessApplicationSensor.FAILURE_STATES,
+            failure_states=EmrServerlessHook.APPLICATION_FAILURE_STATES,
             object_type='application',
             action='created',
         )
@@ -567,7 +566,7 @@ class EmrServerlessCreateApplicationOperator(BaseOperator):
                 get_state_args={'applicationId': application_id},
                 parse_response=['application', 'state'],
                 desired_state={'STARTED'},
-                failure_states=EmrServerlessApplicationSensor.FAILURE_STATES,
+                failure_states=EmrServerlessHook.APPLICATION_FAILURE_STATES,
                 object_type='application',
                 action='started',
             )
@@ -633,7 +632,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.log.info('Starting job on Application: %s', self.application_id)
 
         app_state = self.hook.conn.get_application(applicationId=self.application_id)['application']['state']
-        if app_state not in EmrServerlessApplicationSensor.SUCCESS_STATES:
+        if app_state not in EmrServerlessHook.JOB_SUCCESS_STATES:
             self.hook.conn.start_application(applicationId=self.application_id)
 
             self.hook.waiter(
@@ -641,7 +640,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
                 get_state_args={'applicationId': self.application_id},
                 parse_response=['application', 'state'],
                 desired_state={'STARTED'},
-                failure_states=EmrServerlessApplicationSensor.FAILURE_STATES,
+                failure_states=EmrServerlessHook.JOB_FAILURE_STATES,
                 object_type='application',
                 action='started',
             )
@@ -668,8 +667,8 @@ class EmrServerlessStartJobOperator(BaseOperator):
                     'jobRunId': response['jobRunId'],
                 },
                 parse_response=['jobRun', 'state'],
-                desired_state=EmrServerlessJobSensor.SUCCESS_STATES,
-                failure_states=EmrServerlessJobSensor.FAILURE_STATES,
+                desired_state=EmrServerlessHook.JOB_SUCCESS_STATES,
+                failure_states=EmrServerlessHook.JOB_FAILURE_STATES,
                 object_type='job',
                 action='run',
             )
@@ -719,7 +718,7 @@ class EmrServerlessDeleteApplicationOperator(BaseOperator):
                 'applicationId': self.application_id,
             },
             parse_response=['application', 'state'],
-            desired_state=EmrServerlessApplicationSensor.FAILURE_STATES,
+            desired_state=EmrServerlessHook.APPLICATION_FAILURE_STATES,
             failure_states=set(),
             object_type='application',
             action='stopped',
@@ -738,7 +737,7 @@ class EmrServerlessDeleteApplicationOperator(BaseOperator):
                 get_state_args={'applicationId': self.application_id},
                 parse_response=['application', 'state'],
                 desired_state={'TERMINATED'},
-                failure_states=EmrServerlessApplicationSensor.FAILURE_STATES,
+                failure_states=EmrServerlessHook.APPLICATION_FAILURE_STATES,
                 object_type='application',
                 action='deleted',
             )

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -668,7 +668,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
                     'jobRunId': response['jobRunId'],
                 },
                 parse_response=['jobRun', 'state'],
-                desired_state=EmrServerlessJobSensor.TERMINAL_STATES,
+                desired_state=EmrServerlessJobSensor.SUCCESS_STATES,
                 failure_states=EmrServerlessJobSensor.FAILURE_STATES,
                 object_type='job',
                 action='run',

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -632,7 +632,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.log.info('Starting job on Application: %s', self.application_id)
 
         app_state = self.hook.conn.get_application(applicationId=self.application_id)['application']['state']
-        if app_state not in EmrServerlessHook.JOB_SUCCESS_STATES:
+        if app_state not in EmrServerlessHook.APPLICATION_SUCCESS_STATES:
             self.hook.conn.start_application(applicationId=self.application_id)
 
             self.hook.waiter(

--- a/airflow/providers/amazon/aws/sensors/emr.py
+++ b/airflow/providers/amazon/aws/sensors/emr.py
@@ -129,11 +129,6 @@ class EmrServerlessJobSensor(BaseSensorOperator):
     :param aws_conn_id: aws connection to use, defaults to 'aws_default'
     """
 
-    INTERMEDIATE_STATES = {'PENDING', 'RUNNING', 'SCHEDULED', 'SUBMITTED'}
-    FAILURE_STATES = {'FAILED', 'CANCELLING', 'CANCELLED'}
-    SUCCESS_STATES = {'SUCCESS'}
-    TERMINAL_STATES = SUCCESS_STATES.union(FAILURE_STATES)
-
     template_fields: Sequence[str] = (
         'application_id',
         'job_run_id',
@@ -144,7 +139,7 @@ class EmrServerlessJobSensor(BaseSensorOperator):
         *,
         application_id: str,
         job_run_id: str,
-        target_states: set | frozenset = frozenset(SUCCESS_STATES),
+        target_states: set | frozenset = frozenset(EmrServerlessHook.JOB_SUCCESS_STATES),
         aws_conn_id: str = 'aws_default',
         **kwargs: Any,
     ) -> None:
@@ -159,7 +154,7 @@ class EmrServerlessJobSensor(BaseSensorOperator):
 
         state = response['jobRun']['state']
 
-        if state in self.FAILURE_STATES:
+        if state in EmrServerlessHook.JOB_FAILURE_STATES:
             failure_message = f"EMR Serverless job failed: {self.failure_message_from_response(response)}"
             raise AirflowException(failure_message)
 
@@ -198,15 +193,11 @@ class EmrServerlessApplicationSensor(BaseSensorOperator):
 
     template_fields: Sequence[str] = ('application_id',)
 
-    INTERMEDIATE_STATES = {'CREATING', 'STARTING', 'STOPPING'}
-    FAILURE_STATES = {'STOPPED', 'TERMINATED'}
-    SUCCESS_STATES = {'CREATED', 'STARTED'}
-
     def __init__(
         self,
         *,
         application_id: str,
-        target_states: set | frozenset = frozenset(SUCCESS_STATES),
+        target_states: set | frozenset = frozenset(EmrServerlessHook.APPLICATION_SUCCESS_STATES),
         aws_conn_id: str = 'aws_default',
         **kwargs: Any,
     ) -> None:
@@ -220,7 +211,7 @@ class EmrServerlessApplicationSensor(BaseSensorOperator):
 
         state = response['application']['state']
 
-        if state in self.FAILURE_STATES:
+        if state in EmrServerlessHook.APPLICATION_FAILURE_STATES:
             failure_message = f"EMR Serverless job failed: {self.failure_message_from_response(response)}"
             raise AirflowException(failure_message)
 


### PR DESCRIPTION
An [issue](https://github.com/aws-samples/emr-serverless-samples/issues/22) was found where Airflow would mark a task as SUCCESS even if the EMR job failed. 
The solution here is to set the desired state in EmrServerlessStartJobOperator to SUCCESS_STATES rather than TERMINAL_STATES. This makes it so that the task is marked as a failure if the job doesn't run successfully.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
