### PR TITLE
Make pgbouncer deployment size variable

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -38,7 +38,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.pgbouncer.replicas }}
   {{- if $revisionHistoryLimit }}
   revisionHistoryLimit: {{ $revisionHistoryLimit }}
   {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4148,6 +4148,12 @@
                     "x-docsSection": "Common",
                     "default": false
                 },
+                "replicas": {
+                    "description": "Number of pgbouncer pods to deploy",
+                    "type": "integer",
+                    "x-docsSection": "PgBouncer",
+                    "default": 1,
+                },
                 "revisionHistoryLimit": {
                     "description": "Number of old replicasets to retain.",
                     "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1372,6 +1372,8 @@ statsd:
 pgbouncer:
   # Enable PgBouncer
   enabled: false
+  # Number of pgbouncer pods to deploy
+  replicas: 1
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
   # Command to use for PgBouncer(templated).


### PR DESCRIPTION
This PR makes the pgbouncer deployment size configurable via helm chart. The linked issue raises concerns about running multiple pgbouncers - I believe this to only be the case when running them on a the same physical (or vm, etc) machine, and not in a kubernetes deployment.

I don't believe this will provide perfect HA - for that, anyone who raises this replica count should also be sure to enable the associated PDB to ensure some number of pgbouncer pods are always running. This also doesn't prevent breakages for anything with an active connection to pgbouncer - when one of these pods dies, those connections will be severed and will have to reconnect.

Closes #24954

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
