### PR TITLE
Breeze fix typo on image build warning message

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -396,7 +396,7 @@ def should_we_run_the_build(build_ci_params: BuildCiParams) -> bool:
                 return True
             else:
                 get_console().print(
-                    "\n[warning]This might take a lot of time (more than 10 minutes) even if you have"
+                    "\n[warning]This might take a lot of time (more than 10 minutes) even if you have "
                     "a good network connection. We think you should attempt to rebase first.[/]\n"
                 )
                 answer = user_confirm(


### PR DESCRIPTION
1 line PR to fix a typo in the warning message of breeze when building the image.

![image](https://user-images.githubusercontent.com/14861206/189101203-5e61df26-6c2b-4b27-948c-5841abefa308.png)
