### PR TITLE
Make breeze works with latest docker-compose

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -69,6 +69,7 @@ from airflow_breeze.utils.confirm import set_forced_answer
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice, NotVerifiedBetterChoice
 from airflow_breeze.utils.docker_command_utils import (
+    DOCKER_COMPOSE_COMMAND,
     check_docker_resources,
     get_env_variables_for_docker_commands,
     get_extra_docker_flags,
@@ -468,7 +469,8 @@ def compile_www_assets(
     is_flag=True,
 )
 def stop(verbose: bool, dry_run: bool, preserve_volumes: bool):
-    command_to_execute = ['docker-compose', 'down', "--remove-orphans"]
+    perform_environment_checks(verbose=verbose)
+    command_to_execute = [*DOCKER_COMPOSE_COMMAND, 'down', "--remove-orphans"]
     if not preserve_volumes:
         command_to_execute.append("--volumes")
     shell_params = ShellParams(verbose=verbose, backend="all", include_mypy_volume=True)
@@ -544,7 +546,7 @@ def run_shell(verbose: bool, dry_run: bool, shell_params: ShellParams) -> RunCom
     :param shell_params: parameters of the execution
     """
     shell_params.print_badge_info()
-    cmd = ['docker-compose', 'run', '--service-ports', "-e", "BREEZE", '--rm', 'airflow']
+    cmd = [*DOCKER_COMPOSE_COMMAND, 'run', '--service-ports', "-e", "BREEZE", '--rm', 'airflow']
     cmd_added = shell_params.command_passed
     env_variables = get_env_variables_for_docker_commands(shell_params)
     if cmd_added is not None:
@@ -578,7 +580,7 @@ def find_airflow_container(verbose, dry_run) -> Optional[str]:
     check_docker_resources(exec_shell_params.airflow_image_name, verbose=verbose, dry_run=dry_run)
     exec_shell_params.print_badge_info()
     env_variables = get_env_variables_for_docker_commands(exec_shell_params)
-    cmd = ['docker-compose', 'ps', '--all', '--filter', 'status=running', 'airflow']
+    cmd = [*DOCKER_COMPOSE_COMMAND, 'ps', '--all', '--filter', 'status=running', 'airflow']
     docker_compose_ps_command = run_command(
         cmd, verbose=verbose, dry_run=dry_run, text=True, capture_output=True, env=env_variables, check=False
     )

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -50,6 +50,7 @@ from airflow_breeze.utils.common_options import (
 from airflow_breeze.utils.console import get_console, message_type_from_return_code
 from airflow_breeze.utils.custom_param_types import NotVerifiedBetterChoice
 from airflow_breeze.utils.docker_command_utils import (
+    DOCKER_COMPOSE_COMMAND,
     get_env_variables_for_docker_commands,
     perform_environment_checks,
 )
@@ -269,7 +270,7 @@ def tests(
     if db_reset:
         env_variables["DB_RESET"] = "true"
     perform_environment_checks(verbose=verbose)
-    cmd = ['docker-compose', 'run', '--service-ports', '--rm', 'airflow']
+    cmd = [*DOCKER_COMPOSE_COMMAND, 'run', '--service-ports', '--rm', 'airflow']
     cmd.extend(list(extra_pytest_args))
     version = (
         mssql_version
@@ -326,7 +327,7 @@ def helm_tests(
     env_variables['RUN_TESTS'] = "true"
     env_variables['TEST_TYPE'] = 'Helm'
     perform_environment_checks(verbose=verbose)
-    cmd = ['docker-compose', 'run', '--service-ports', '--rm', 'airflow']
+    cmd = [*DOCKER_COMPOSE_COMMAND, 'run', '--service-ports', '--rm', 'airflow']
     cmd.extend(list(extra_pytest_args))
     result = run_command(cmd, verbose=verbose, dry_run=dry_run, env=env_variables, check=False)
     sys.exit(result.returncode)

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -266,6 +266,9 @@ Please upgrade to at least {MIN_DOCKER_VERSION}[/]
                 )
 
 
+DOCKER_COMPOSE_COMMAND = ["docker-compose"]
+
+
 def check_docker_compose_version(verbose: bool):
     """
     Checks if the docker compose version is as expected, including some specific modifications done by
@@ -293,7 +296,8 @@ def check_docker_compose_version(verbose: bool):
             capture_output=True,
             text=True,
         )
-
+        DOCKER_COMPOSE_COMMAND.clear()
+        DOCKER_COMPOSE_COMMAND.extend(['docker', 'compose'])
     if docker_compose_version_result.returncode == 0:
         docker_compose_version = docker_compose_version_result.stdout
         version_extracted = version_pattern.search(docker_compose_version)


### PR DESCRIPTION
The latest docker-compose dropped an alias for `docker-compose` and we need to detect it and use "docker compose" instead.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
