### PR TITLE
Limit eager upgrade of protobuf library to < 4.21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1212,7 +1212,7 @@ ARG ADDITIONAL_PYTHON_DEPS=""
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
 # We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
-# Are compatible with the new protobuf version. All the google python client libraries need
+# are compatible with the new protobuf version. All the google python client libraries need
 # to be upgraded to >=2.0.0 in order to able to lift that limitation
 # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
 ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1211,7 +1211,11 @@ ARG ADDITIONAL_PYTHON_DEPS=""
 # * dill<0.3.3 required by apache-beam
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0"
+# We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
+# Are compatible with the new protobuf version. All the google python client libraries need
+# to be upgraded to >=2.0.0 in order to able to lift that limitation
+# https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0"
 
 ENV ADDITIONAL_PYTHON_DEPS=${ADDITIONAL_PYTHON_DEPS} \
     INSTALL_PACKAGES_FROM_CONTEXT=${INSTALL_PACKAGES_FROM_CONTEXT} \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1134,7 +1134,7 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
 # We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
-# Are compatible with the new protobuf version. All the google python client libraries need
+# are compatible with the new protobuf version. All the google python client libraries need
 # to be upgraded to >= 2.0.0 in order to able to lift that limitation
 # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
 ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0"

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1133,7 +1133,11 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # * dill<0.3.3 required by apache-beam
 # * pyarrow>=6.0.0 is because pip resolver decides for Python 3.10 to downgrade pyarrow to 5 even if it is OK
 #   for python 3.10 and other dependencies adding the limit helps resolver to make better decisions
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0"
+# We need to limit the protobuf library to < 4.21.0 because not all google libraries we use
+# Are compatible with the new protobuf version. All the google python client libraries need
+# to be upgraded to >= 2.0.0 in order to able to lift that limitation
+# https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
     UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}


### PR DESCRIPTION
Until all the Google client libraries get upgraded to >= 2.0.0, we need to limit the protobuf version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
