### PR TITLE
Skip overriding version from parameter with the one from tag

### DIFF
--- a/scripts/in_container/run_prepare_airflow_packages.sh
+++ b/scripts/in_container/run_prepare_airflow_packages.sh
@@ -54,18 +54,9 @@ function prepare_airflow_packages() {
             tag_build=('egg_info' '--tag-build' "${VERSION_SUFFIX_FOR_PYPI}")
         else
             if [[ ${AIRFLOW_VERSION} != *${VERSION_SUFFIX_FOR_PYPI} ]]; then
-                if [[ $AIRFLOW_VERSION =~ ^[0-9\.]+([a-z0-9]*)$ ]]; then
-                    echo
-                    echo "${COLOR_YELLOW}The requested PyPI suffix ${VERSION_SUFFIX_FOR_PYPI} does not match the one in ${AIRFLOW_VERSION}. Overriding it with one from ${AIRFLOW_VERSION}.${COLOR_RESET}"
-                    echo
-                    VERSION_SUFFIX_FOR_PYPI="${BASH_REMATCH[1]}"
-                    export VERSION_SUFFIX_FOR_PYPI
-                else
-                    echo
-                    echo "${COLOR_RED}The ${AIRFLOW_VERSION} does not follow the right version pattern 'X.Y.Zsuffix'. Quitting.${COLOR_RESET}"
-                    echo
-                    exit 1
-                fi
+                echo
+                echo "${COLOR_YELLOW}The requested PyPI suffix ${VERSION_SUFFIX_FOR_PYPI} does not match the one in ${AIRFLOW_VERSION}. Overriding it with one from ${VERSION_SUFFIX_FOR_PYPI}.${COLOR_RESET}"
+                echo
             fi
         fi
     fi


### PR DESCRIPTION
Since we are not always updating the version suffix in code (rc1/rc2/b1/b2), the tag specified via --tag-build prefix should override the one in code rathe than the other way round.

So what's left now - we will just print warning if the suffix does not match.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
