### PR TITLE
trino: Support CertificateAuthentication in the trino hook

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -99,12 +99,17 @@ class TrinoHook(DbApiHook):
         extra = db.extra_dejson
         auth = None
         user = db.login
-        if db.password and extra.get('auth') == 'kerberos':
-            raise AirflowException("Kerberos authorization doesn't support password.")
+        if db.password and extra.get('auth') in ('kerberos', 'certs'):
+            raise AirflowException(f"The {extra.get('auth')!r} authorization type doesn't support password.")
         elif db.password:
             auth = trino.auth.BasicAuthentication(db.login, db.password)  # type: ignore[attr-defined]
         elif extra.get('auth') == 'jwt':
             auth = trino.auth.JWTAuthentication(token=extra.get('jwt__token'))
+        elif extra.get('auth') == 'certs':
+            auth = trino.auth.CertificateAuthentication(
+                extra.get('certs__client_cert_path'),
+                extra.get('certs__client_key_path'),
+            )
         elif extra.get('auth') == 'kerberos':
             auth = trino.auth.KerberosAuthentication(  # type: ignore[attr-defined]
                 config=extra.get('kerberos__config', os.environ.get('KRB5_CONFIG')),

--- a/docs/apache-airflow-providers-trino/connections.rst
+++ b/docs/apache-airflow-providers-trino/connections.rst
@@ -43,10 +43,11 @@ Password
 Extra (optional, connection parameters)
     Specify the extra parameters (as json dictionary) that can be used in Trino connection. The following parameters out of the standard python parameters are supported:
 
-    * ``auth`` - Specifies which type of authentication needs to be enabled. The value can be ``kerberos``, ``jwt``.
+    * ``auth`` - Specifies which type of authentication needs to be enabled. The value can be ``certs``, ``kerberos``, or ``jwt``
     * ``impersonate_as_owner`` - Boolean that allows to set ``AIRFLOW_CTX_DAG_OWNER`` as a user of the connection.
 
     The following extra parameters can be used to configure authentication:
 
     * ``jwt__token`` - If jwt authentication should be used, the value of token is given via this parameter.
+    * ``certs__client_cert_path``, ``certs__client_key_path``- If certificate authentication should be used, the path to the client certificate and key is given via these parameters.
     * ``kerberos__service_name``, ``kerberos__config``, ``kerberos__mutual_authentication``, ``kerberos__force_preemptive``, ``kerberos__hostname_override``, ``kerberos__sanitize_mutual_error_response``, ``kerberos__principal``,``kerberos__delegate``, ``kerberos__ca_bundle`` - These parameters can be set when enabling ``kerberos`` authentication.

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -35,6 +35,7 @@ BASIC_AUTHENTICATION = 'airflow.providers.trino.hooks.trino.trino.auth.BasicAuth
 KERBEROS_AUTHENTICATION = 'airflow.providers.trino.hooks.trino.trino.auth.KerberosAuthentication'
 TRINO_DBAPI_CONNECT = 'airflow.providers.trino.hooks.trino.trino.dbapi.connect'
 JWT_AUTHENTICATION = 'airflow.providers.trino.hooks.trino.trino.auth.JWTAuthentication'
+CERT_AUTHENTICATION = 'airflow.providers.trino.hooks.trino.trino.auth.CertificateAuthentication'
 
 
 class TestTrinoHookConn:
@@ -91,7 +92,7 @@ class TestTrinoHookConn:
             extra=json.dumps(extras),
         )
         with pytest.raises(
-            AirflowException, match=re.escape("Kerberos authorization doesn't support password.")
+            AirflowException, match=re.escape("The 'kerberos' authorization type doesn't support password.")
         ):
             TrinoHook().get_conn()
 
@@ -109,6 +110,23 @@ class TestTrinoHookConn:
         )
         TrinoHook().get_conn()
         self.assert_connection_called_with(mock_connect, auth=mock_jwt_auth)
+
+    @patch(CERT_AUTHENTICATION)
+    @patch(TRINO_DBAPI_CONNECT)
+    @patch(HOOK_GET_CONNECTION)
+    def test_get_conn_cert_auth(self, mock_get_connection, mock_connect, mock_cert_auth):
+        extras = {
+            'auth': 'certs',
+            'certs__client_cert_path': '/path/to/client.pem',
+            'certs__client_key_path': '/path/to/client.key',
+        }
+        self.set_get_connection_return_value(
+            mock_get_connection,
+            extra=json.dumps(extras),
+        )
+        TrinoHook().get_conn()
+        self.assert_connection_called_with(mock_connect, auth=mock_cert_auth)
+        mock_cert_auth.assert_called_once_with('/path/to/client.pem', '/path/to/client.key')
 
     @patch(KERBEROS_AUTHENTICATION)
     @patch(TRINO_DBAPI_CONNECT)


### PR DESCRIPTION
Allows authenticating to trino clusters with mtls