### PR TITLE
Make "quick build" actually test build time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,7 +310,7 @@ jobs:
 
   # Check that after earlier cache push, breeze command will build quickly
   chcek-that-image-builds-quicklly:
-    timeout-minutes: 50
+    timeout-minutes: 5
     name: "Check that image builds quickly"
     runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,44 @@ jobs:
       - name: "Clean docker cache for ${{ matrix.platform }}"
         run: docker system prune --all --force
         if: matrix.platform == 'linux/amd64' && needs.build-info.outputs.merge-run == 'true'
-      - name: "Check that image builds quickly ${{ matrix.platform }}"
+      - name: "Fix ownership"
+        run: breeze ci fix-ownership
+        if: always() && needs.build-info.outputs.merge-run == 'true'
+
+  # Check that after earlier cache push, breeze command will build quickly
+  chcek-that-image-builds-quicklly:
+    timeout-minutes: 50
+    name: "Check that image builds quickly"
+    runs-on: ${{ needs.build-info.outputs.runs-on }}
+    needs:
+      - build-info
+      - push-early-buildx-cache-to-github-registry
+    env:
+      RUNS_ON: ${{ needs.build-info.outputs.runs-on }}
+      UPGRADE_TO_NEWER_DEPENDENCIES: false
+      PLATFORM: "linux/amd64"
+    steps:
+      - name: Cleanup repo
+        run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
+        if: needs.build-info.outputs.merge-run == 'true'
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+        if: needs.build-info.outputs.merge-run == 'true'
+      - name: "Setup python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ needs.build-info.outputs.default-python-version }}
+          cache: 'pip'
+          cache-dependency-path: ./dev/breeze/setup*
+        if: needs.build-info.outputs.merge-run == 'true'
+      - run: ./scripts/ci/install_breeze.sh
+        if: needs.build-info.outputs.merge-run == 'true'
+      - name: "Free space"
+        run: breeze ci free-space
+        if: needs.build-info.outputs.merge-run == 'true'
+      - name: "Check that image builds quickly"
         run: breeze shell --max-time 120
         if: matrix.platform == 'linux/amd64' && needs.build-info.outputs.merge-run == 'true'
       - name: "Fix ownership"

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -183,7 +183,7 @@ def shell(
         force_build=force_build,
         db_reset=db_reset,
         include_mypy_volume=include_mypy_volume,
-        extra_args=extra_args if not max_time else "exit",
+        extra_args=extra_args if not max_time else ["exit"],
         answer=answer,
         image_tag=image_tag,
         platform=platform,


### PR DESCRIPTION
There was a "string" instead of array passed in case of --max-time command flag which caused an error - regardless of the time it took to run the build, but it was also ignored because the job was run within "continue-on-error" cache push job.

This PR fixes it to use proper "exit" command and separates it out to a job where quick build failure will be noticed (not in PRs but in the merge-run)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
