### PR TITLE
Implement fast insert for mysql and sqlite

### DIFF
--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
 from typing import TYPE_CHECKING
 
 from sqlalchemy import exc
@@ -109,10 +108,7 @@ class DatasetManager(LoggingMixin):
 
             prefix = 'IGNORE'
         else:
-            raise ValueError("Only sqlite and postgres supported with this method.")
-        logger = logging.getLogger('sqlalchemy')
-        logger.setLevel(logging.DEBUG)
-
+            raise ValueError("Only sqlite, postgres, and mysql supported with this method.")
         params = [{'target_dag_id': target_dag.dag_id} for target_dag in dataset.consuming_dags]
         if params:
             stmt = insert(DatasetDagRunQueue).values(dataset_id=dataset.id)
@@ -120,7 +116,6 @@ class DatasetManager(LoggingMixin):
                 stmt = stmt.prefix_with(prefix)
             else:
                 stmt = stmt.on_conflict_do_nothing()
-            logger.warning(stmt.compile())
             session.execute(stmt, params)
             session.flush()
 

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -95,8 +95,6 @@ class DatasetManager(LoggingMixin):
             except exc.IntegrityError:
                 self.log.debug("Skipping record %s", item, exc_info=True)
 
-        session.flush()
-
     def _queue_dagruns_fast_path(self, dataset: DatasetModel, session: Session) -> None:
         prefix = None
         if session.bind.dialect.name == "postgresql":
@@ -117,7 +115,6 @@ class DatasetManager(LoggingMixin):
             else:
                 stmt = stmt.on_conflict_do_nothing()
             session.execute(stmt, params)
-            session.flush()
 
 
 def resolve_dataset_manager() -> "DatasetManager":


### PR DESCRIPTION
We presently have a "fast path" for postgres.  But we can use similar logic for mysql and sqlite.