### PR TITLE
Create a workflow to sync the list of authors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,11 @@ jobs:
     # is checked again by the runner using it's own list, so a PR author cannot
     # change this and get access to our self-hosted runners
     #
-    # When changing this list, ensure that it is kept in sync with the
-    # /runners/apache/airflow/configOverlay
-    # parameter in AWS SSM ParameterStore (which is what the runner uses)
-    # and restart the self-hosted runners.
-    #
-    # This list of committers can be generated with:
-    #   https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers
+    # This list is kept up-to-date from the list of authors found in the
+    # 'airflow-ci-infra' by the 'sync_authors' Github workflow. It uses a regexp
+    # to find the list of authors and replace them, so any changes to the
+    # formatting of the contains(fromJSON()) structure below will need to be
+    # reflected in that workflow too.
     runs-on: >-
       ${{ (
         (

--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -22,7 +22,9 @@ on:
   schedule:
     #        min   hr    dom   mon   dow
     - cron: '11    01    *     *     *'     # daily at 1.11am
-  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   sync:

--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -18,7 +18,7 @@
 ---
 name: Sync authors list
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     #        min   hr    dom   mon   dow
     - cron: '11    01    *     *     *'     # daily at 1.11am
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Python
         uses: actions/setup-python@v4

--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: Sync authors list
+
+on:
+  schedule:
+    #        min   hr    dom   mon   dow
+    - cron: '11    01    *     *     *'     # daily at 1.11am
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: Sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Requests
+        run: |
+          pip install requests toml
+
+      - name: Sync the authors list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/ci/runners/sync_authors.py
+          git config user.name "GitHub Actions"
+          git config user.email "actions@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            branch=update-$(date +%s)
+            git add -A
+            git checkout -b $branch
+            git commit --message "Authors list automatic update"
+            git push origin $branch
+            gh pr create --title "Authors list automatic update" --body ''
+          fi

--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -25,6 +25,7 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   sync:

--- a/scripts/ci/runners/sync_authors.py
+++ b/scripts/ci/runners/sync_authors.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import re
+import requests
+import toml
+
+AUTHORS = 'https://raw.githubusercontent.com/apache/airflow-ci-infra/main/authors.toml'
+
+
+req = requests.get(AUTHORS)
+author_list = toml.loads(req.text)
+
+author_set = set()
+for membership in author_list:
+    author_set.update([ author for author in author_list[membership] ])
+
+authors = ''
+for author in sorted(author_set):
+    authors += f'            "{author}",\n'
+
+authors = authors[:-2]
+
+with open('ci.yml') as handle:
+    new_ci = re.sub(
+        r'''
+            ^
+            ( .*? contains.fromJSON \( ' \[ \n )
+            .*?
+            ( \s+ \] ' \), . github\.event\.pull_request\.user\.login .*? )
+            $
+        ''',
+        f'\\1{authors}\\2',
+        handle.read(),
+        flags=re.DOTALL | re.VERBOSE,
+    )
+
+with open('ci.yml', 'w') as handle:
+    handle.write(new_ci)

--- a/scripts/ci/runners/sync_authors.py
+++ b/scripts/ci/runners/sync_authors.py
@@ -17,8 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 import re
+
 import requests
 import toml
 
@@ -30,7 +30,7 @@ author_list = toml.loads(req.text)
 
 author_set = set()
 for membership in author_list:
-    author_set.update([ author for author in author_list[membership] ])
+    author_set.update([author for author in author_list[membership]])
 
 authors = ''
 for author in sorted(author_set):


### PR DESCRIPTION
The CI jobs caused by Pull Requests run on Airflow infrastructure only when an author is trusted, which currently means a core committer. The list is currently duplicated in the ci.yml workflow.

As part of being able to open up the infra to other trusted authors, this list needs to be updated based on a list of trusted authors kept in the `airflow-ci-infra` repository.
