### PR TITLE
GCSToBigQueryOperator Resolve `max_id_key` job retrieval and xcom return

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -315,16 +315,15 @@ class GCSToBigQueryOperator(BaseOperator):
                 warnings.simplefilter("ignore", DeprecationWarning)
                 job_id = bq_hook.run_query(
                     sql=select_command,
+                    location=self.location,
                     use_legacy_sql=False,
                 )
-            row = list(bq_hook.get_job(job_id).result())
+            row = list(bq_hook.get_job(job_id=job_id, location=self.location).result())
             if row:
                 max_id = row[0] if row[0] else 0
                 self.log.info(
-                    'Loaded BQ data with max %s.%s=%s',
-                    self.destination_project_dataset_table,
-                    self.max_id_key,
-                    max_id,
+                    f'Loaded BQ data with max {self.destination_project_dataset_table}.{self.max_id_key}={max_id}',
                 )
+                return max_id
             else:
                 raise RuntimeError(f"The {select_command} returned no rows!")

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -322,7 +322,8 @@ class GCSToBigQueryOperator(BaseOperator):
             if row:
                 max_id = row[0] if row[0] else 0
                 self.log.info(
-                    f'Loaded BQ data with max {self.destination_project_dataset_table}.{self.max_id_key}={max_id}',
+                    f'Loaded BQ data with max '
+                    f'{self.destination_project_dataset_table}.{self.max_id_key}={max_id}',
                 )
                 return max_id
             else:

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -322,8 +322,10 @@ class GCSToBigQueryOperator(BaseOperator):
             if row:
                 max_id = row[0] if row[0] else 0
                 self.log.info(
-                    f'Loaded BQ data with max '
-                    f'{self.destination_project_dataset_table}.{self.max_id_key}={max_id}',
+                    'Loaded BQ data with max %s.%s=%s',
+                    self.destination_project_dataset_table,
+                    self.max_id_key,
+                    max_id,
                 )
                 return max_id
             else:

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -44,7 +44,9 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         bq_hook.return_value.get_job.return_value.result.return_value = ('1',)
 
-        operator.execute(None)
+        result = operator.execute(None)
+
+        self.assertEqual(result, '1')
 
         bq_hook.return_value.run_query.assert_called_once_with(
             sql="SELECT MAX(id) FROM `test-project.dataset.table`",

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -46,7 +46,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         result = operator.execute(None)
 
-        self.assertEqual(result, '1')
+        assert result == '1'
 
         bq_hook.return_value.run_query.assert_called_once_with(
             sql="SELECT MAX(id) FROM `test-project.dataset.table`",

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -50,6 +50,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         bq_hook.return_value.run_query.assert_called_once_with(
             sql="SELECT MAX(id) FROM `test-project.dataset.table`",
+            location=None,
             use_legacy_sql=False,
         )
 


### PR DESCRIPTION
closes: #26279
closes: #26283

Multiple issues with the `GCSToBigQueryOperator` operator feature `max_id_key`.
 - BQ Job was not retrievable after execution because of a change (about 2 years ago) with `@fallback_to_default_project_id`
 - Even if the value was retrievable, it was not being returned/set in XCOM, as specified in the parameter docs
