### PR TITLE
Respect max_active_runs setting when queuing dataset-driven dag runs

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1110,7 +1110,7 @@ class SchedulerJob(BaseJob):
                 )
                 continue
             if active_runs_of_dags[dag_model.dag_id] >= dag_model.max_active_runs:
-                self.log.info(
+                self.log.debug(
                     "DAG %s is at (or above) max_active_runs (%d of %d), not creating any more runs",
                     dag_model.dag_id,
                     active_runs_of_dags[dag_model.dag_id],


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/26259

i think this alternative is better: https://github.com/apache/airflow/pull/26287