### PR TITLE
Significantly speed up installation of providers for Airflow 2.2 in CI

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -707,8 +707,26 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
                 installable_files+=( "${file}" )
             fi
         done
+        constraints=""
+        if [[ ${USE_AIRFLOW_VERSION} =~ ^[0-9\.]+$ ]]; then
+            echo "Limiting lower constraints to those not lower than in ${USE_AIRFLOW_VERSION}"
+            constraints_file="/tmp/constraints.txt"
+            lower_bound_constraints_file="/tmp/lower_bound_constraints.txt"
+            constraints_from="https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/constraints-${USE_AIRFLOW_VERSION}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"
+            echo "Downloading constraints from ${constraints_from}"
+            curl --silent "${constraints_from}" -o "${constraints_file}"
+            constraints="--constraint ${lower_bound_constraints_file}"
+            sed "s/==/>=/" < ${constraints_file} | grep -v "apache-airflow" >"${lower_bound_constraints_file}"
+            echo "Constraints used:"
+            echo "---------"
+            cat "${lower_bound_constraints_file}"
+            echo "---------"
+        fi
         if (( ${#installable_files[@]} )); then
-            pip install --root-user-action ignore "${installable_files[@]}"
+            # shellcheck disable=SC2086
+            echo "Running: pip install --root-user-action ignore ${installable_files[*]} ${constraints}"
+            # shellcheck disable=SC2086
+            pip install --root-user-action ignore "${installable_files[@]}" ${constraints}
         fi
     fi
 

--- a/scripts/docker/entrypoint_ci.sh
+++ b/scripts/docker/entrypoint_ci.sh
@@ -166,8 +166,26 @@ if [[ ${SKIP_ENVIRONMENT_INITIALIZATION=} != "true" ]]; then
                 installable_files+=( "${file}" )
             fi
         done
+        constraints=""
+        if [[ ${USE_AIRFLOW_VERSION} =~ ^[0-9\.]+$ ]]; then
+            echo "Limiting lower constraints to those not lower than in ${USE_AIRFLOW_VERSION}"
+            constraints_file="/tmp/constraints.txt"
+            lower_bound_constraints_file="/tmp/lower_bound_constraints.txt"
+            constraints_from="https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/constraints-${USE_AIRFLOW_VERSION}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"
+            echo "Downloading constraints from ${constraints_from}"
+            curl --silent "${constraints_from}" -o "${constraints_file}"
+            constraints="--constraint ${lower_bound_constraints_file}"
+            sed "s/==/>=/" < ${constraints_file} | grep -v "apache-airflow" >"${lower_bound_constraints_file}"
+            echo "Constraints used:"
+            echo "---------"
+            cat "${lower_bound_constraints_file}"
+            echo "---------"
+        fi
         if (( ${#installable_files[@]} )); then
-            pip install --root-user-action ignore "${installable_files[@]}"
+            # shellcheck disable=SC2086
+            echo "Running: pip install --root-user-action ignore ${installable_files[*]} ${constraints}"
+            # shellcheck disable=SC2086
+            pip install --root-user-action ignore "${installable_files[@]}" ${constraints}
         fi
     fi
 


### PR DESCRIPTION
We are installing Providers on Airflow 2.2 version and this installation on CI takes 29 minutes. This is super long. It turns out that vast mahjority of that time is PIP resolver trying to do backracking based on the requirements new providers have.

This is mostly google dependencies and `pip` downloading and trying many versions of the dependencies. However, we can make use of our 2.2 constraints to lower-bound the dependencies used by the resolver - simply by changing the 2.2 constraints into lower bounds (this is extremely unlikely new airflow will have lower version of any dependency that 2.2 had).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
