### PR TITLE
Don't update backfill run from the scheduler

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -792,7 +792,6 @@ class SchedulerJob(BaseJob):
                         DagRun.state == DagRunState.RUNNING,
                         DagRun.run_type != DagRunType.BACKFILL_JOB,
                     )
-                    .all()
                 )
                 for dag_run in dag_runs:
                     dag_run.dag = dag

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -785,13 +785,10 @@ class SchedulerJob(BaseJob):
                 dag = SerializedDagModel.get_dag(dag_id)
                 if dag is None:
                     continue
-                dag_runs = (
-                    session.query(DagRun)
-                    .filter(
-                        DagRun.dag_id == dag_id,
-                        DagRun.state == DagRunState.RUNNING,
-                        DagRun.run_type != DagRunType.BACKFILL_JOB,
-                    )
+                dag_runs = session.query(DagRun).filter(
+                    DagRun.dag_id == dag_id,
+                    DagRun.state == DagRunState.RUNNING,
+                    DagRun.run_type != DagRunType.BACKFILL_JOB,
                 )
                 for dag_run in dag_runs:
                     dag_run.dag = dag

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -789,7 +789,7 @@ class SchedulerJob(BaseJob):
                     session.query(DagRun)
                     .filter(
                         DagRun.dag_id == dag_id,
-                        DagRun.state == State.RUNNING,
+                        DagRun.state == DagRunState.RUNNING,
                         DagRun.run_type != DagRunType.BACKFILL_JOB,
                     )
                     .all()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -774,7 +774,8 @@ class SchedulerJob(BaseJob):
                     self.log.exception("Exception when executing DagFileProcessorAgent.end")
             self.log.info("Exited execute loop")
 
-    def _update_dag_run_state_for_paused_dags(self) -> None:
+    @provide_session
+    def _update_dag_run_state_for_paused_dags(self, session: Session = NEW_SESSION) -> None:
         try:
             paused_dag_ids = DagModel.get_all_paused_dag_ids()
             for dag_id in paused_dag_ids:
@@ -784,7 +785,15 @@ class SchedulerJob(BaseJob):
                 dag = SerializedDagModel.get_dag(dag_id)
                 if dag is None:
                     continue
-                dag_runs = DagRun.find(dag_id=dag_id, state=DagRunState.RUNNING)
+                dag_runs = (
+                    session.query(DagRun)
+                    .filter(
+                        DagRun.dag_id == dag_id,
+                        DagRun.state == State.RUNNING,
+                        DagRun.run_type != DagRunType.BACKFILL_JOB,
+                    )
+                    .all()
+                )
                 for dag_run in dag_runs:
                     dag_run.dag = dag
                     _, callback_to_run = dag_run.update_state(execute_callbacks=False)


### PR DESCRIPTION
When updating the state of paused dags with 'running' dagruns in the scheduler, we should not update the state of backfill runs.
