### PR TITLE
Flag to deserialize value on custom XCom backend

### DIFF
--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import copy
 from typing import Optional
 
 from flask import g
@@ -68,7 +69,7 @@ def get_xcom_entries(
     query = query.order_by(DR.execution_date, XCom.task_id, XCom.dag_id, XCom.key)
     total_entries = query.count()
     query = query.offset(offset).limit(limit)
-    return xcom_collection_schema.dump(XComCollection(xcom_entries=query.all(), total_entries=total_entries))
+    return xcom_collection_schema.dump(XComCollection(xcom_entries=query, total_entries=total_entries))
 
 
 @security.requires_access(
@@ -86,14 +87,28 @@ def get_xcom_entry(
     task_id: str,
     dag_run_id: str,
     xcom_key: str,
+    deserialize: bool = False,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
     """Get an XCom entry"""
-    query = session.query(XCom).filter(XCom.dag_id == dag_id, XCom.task_id == task_id, XCom.key == xcom_key)
+    if deserialize:
+        query = session.query(XCom, XCom.value)
+    else:
+        query = session.query(XCom)
+
+    query = query.filter(XCom.dag_id == dag_id, XCom.task_id == task_id, XCom.key == xcom_key)
     query = query.join(DR, and_(XCom.dag_id == DR.dag_id, XCom.run_id == DR.run_id))
     query = query.filter(DR.run_id == dag_run_id)
 
-    query_object = query.one_or_none()
-    if not query_object:
+    item = query.one_or_none()
+    if item is None:
         raise NotFound("XCom entry not found")
-    return xcom_schema.dump(query_object)
+
+    if deserialize:
+        xcom, value = item
+        stub = copy.copy(xcom)
+        stub.value = value
+        stub.value = XCom.deserialize_value(stub)
+        item = stub
+
+    return xcom_schema.dump(item)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1412,6 +1412,23 @@ paths:
       x-openapi-router-controller: airflow.api_connexion.endpoints.xcom_endpoint
       operationId: get_xcom_entry
       tags: [XCom]
+      parameters:
+        - in: query
+          name: deserialize
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: |
+            Whether to deserialize an XCom value when using a custom XCom backend.
+
+            The XCom API endpoint calls `orm_deserialize_value` by default since an XCom may contain value
+            that is potentially expensive to deserialize in the web server. Setting this to true overrides
+            the consideration, and calls `deserialize_value` instead.
+
+            This parameter is not meaningful when using the default XCom backend.
+
+            *New in version 2.5.0*
       responses:
         '200':
           description: Success.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3413,6 +3413,20 @@ export interface operations {
         /** The XCom key. */
         xcom_key: components["parameters"]["XComKey"];
       };
+      query: {
+        /**
+         * Whether to deserialize an XCom value when using a custom XCom backend.
+         *
+         * The XCom API endpoint calls `orm_deserialize_value` by default since an XCom may contain value
+         * that is potentially expensive to deserialize in the web server. Setting this to true overrides
+         * the consideration, and calls `deserialize_value` instead.
+         *
+         * This parameter is not meaningful when using the default XCom backend.
+         *
+         * *New in version 2.5.0*
+         */
+        deserialize?: boolean;
+      };
     };
     responses: {
       /** Success. */
@@ -4221,7 +4235,7 @@ export type GetVariableVariables = CamelCasedPropertiesDeep<operations['get_vari
 export type DeleteVariableVariables = CamelCasedPropertiesDeep<operations['delete_variable']['parameters']['path']>;
 export type PatchVariableVariables = CamelCasedPropertiesDeep<operations['patch_variable']['parameters']['path'] & operations['patch_variable']['parameters']['query'] & operations['patch_variable']['requestBody']['content']['application/json']>;
 export type GetXcomEntriesVariables = CamelCasedPropertiesDeep<operations['get_xcom_entries']['parameters']['path'] & operations['get_xcom_entries']['parameters']['query']>;
-export type GetXcomEntryVariables = CamelCasedPropertiesDeep<operations['get_xcom_entry']['parameters']['path']>;
+export type GetXcomEntryVariables = CamelCasedPropertiesDeep<operations['get_xcom_entry']['parameters']['path'] & operations['get_xcom_entry']['parameters']['query']>;
 export type GetExtraLinksVariables = CamelCasedPropertiesDeep<operations['get_extra_links']['parameters']['path']>;
 export type GetLogVariables = CamelCasedPropertiesDeep<operations['get_log']['parameters']['path'] & operations['get_log']['parameters']['query']>;
 export type GetDagDetailsVariables = CamelCasedPropertiesDeep<operations['get_dag_details']['parameters']['path']>;


### PR DESCRIPTION
This adds an optional `deserialize=true` query param to the XCom entry retrieval endpoint. When set, the webserver would call `deserialize_value` against the XCom entry, instead of the cheaper `orm_deserialize_value`, for the user to retrieve the "real" XCom value.

Fix #26174.