### PR TITLE
Respect max_active_runs for dataset-triggered dags

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -58,6 +58,7 @@ import pendulum
 from dateutil.relativedelta import relativedelta
 from pendulum.tz.timezone import Timezone
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, and_, case, func, not_, or_
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import backref, joinedload, relationship
 from sqlalchemy.orm.query import Query
 from sqlalchemy.orm.session import Session
@@ -3070,6 +3071,7 @@ class DagModel(Base):
         "DagScheduleDatasetReference",
         cascade='all, delete, delete-orphan',
     )
+    schedule_datasets = association_proxy('schedule_dataset_references', 'dataset')
     task_outlet_dataset_references = relationship(
         "TaskOutletDatasetReference",
         cascade='all, delete, delete-orphan',
@@ -3239,7 +3241,7 @@ class DagModel(Base):
         transaction is committed it will be unlocked.
         """
         # these dag ids are triggered by datasets, and they are ready to go.
-        dataset_triggered_dag_info_list = {
+        dataset_triggered_dag_info = {
             x.dag_id: (x.first_queued_time, x.last_queued_time)
             for x in session.query(
                 DagScheduleDatasetReference.dag_id,
@@ -3251,12 +3253,27 @@ class DagModel(Base):
             .having(func.count() == func.sum(case((DDRQ.target_dag_id.is_not(None), 1), else_=0)))
             .all()
         }
-        dataset_triggered_dag_ids = list(dataset_triggered_dag_info_list.keys())
+        dataset_triggered_dag_ids = set(dataset_triggered_dag_info.keys())
+        if dataset_triggered_dag_ids:
+            exclusion_list = {
+                x.dag_id
+                for x in (
+                    session.query(DagModel.dag_id)
+                    .join(DagRun.dag)
+                    .filter(DagRun.state.in_((DagRunState.QUEUED, DagRunState.RUNNING)))
+                    .filter(DagModel.dag_id.in_(dataset_triggered_dag_ids))
+                    .group_by(DagModel.dag_id)
+                    .having(func.count() >= DagModel.max_active_runs)
+                    .all()
+                )
+            }
+            if exclusion_list:
+                dataset_triggered_dag_ids -= exclusion_list
+                dataset_triggered_dag_info = {
+                    k: v for k, v in dataset_triggered_dag_info.items() if k not in exclusion_list
+                }
 
-        # TODO[HA]: Bake this query, it is run _A lot_
-        # We limit so that _one_ scheduler doesn't try to do all the creation
-        # of dag runs
-
+        # We limit so that _one_ scheduler doesn't try to do all the creation of dag runs
         query = (
             session.query(cls)
             .filter(
@@ -3274,7 +3291,7 @@ class DagModel(Base):
 
         return (
             with_row_locks(query, of=cls, session=session, **skip_locked(session=session)),
-            dataset_triggered_dag_info_list,
+            dataset_triggered_dag_info,
         )
 
     def calculate_dagrun_date_fields(

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3259,7 +3259,7 @@ class DagModel(Base):
                 x.dag_id
                 for x in (
                     session.query(DagModel.dag_id)
-                    .join(DagRun.dag)
+                    .join(DagRun.dag_model)
                     .filter(DagRun.state.in_((DagRunState.QUEUED, DagRunState.RUNNING)))
                     .filter(DagModel.dag_id.in_(dataset_triggered_dag_ids))
                     .group_by(DagModel.dag_id)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3263,7 +3263,7 @@ class DagModel(Base):
                     .filter(DagRun.state.in_((DagRunState.QUEUED, DagRunState.RUNNING)))
                     .filter(DagModel.dag_id.in_(dataset_triggered_dag_ids))
                     .group_by(DagModel.dag_id)
-                    .having(func.count() >= DagModel.max_active_runs)
+                    .having(func.count() >= func.max(DagModel.max_active_runs))
                     .all()
                 )
             }

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -3255,18 +3255,9 @@ class DagModel(Base):
         }
         dataset_triggered_dag_ids = set(dataset_triggered_dag_info.keys())
         if dataset_triggered_dag_ids:
-            exclusion_list = {
-                x.dag_id
-                for x in (
-                    session.query(DagModel.dag_id)
-                    .join(DagRun.dag)
-                    .filter(DagRun.state.in_((DagRunState.QUEUED, DagRunState.RUNNING)))
-                    .filter(DagModel.dag_id.in_(dataset_triggered_dag_ids))
-                    .group_by(DagModel.dag_id)
-                    .having(func.count() >= DagModel.max_active_runs)
-                    .all()
-                )
-            }
+            exclusion_list = set(
+                DagRun.active_runs_of_dags(dataset_triggered_dag_ids, session=session).keys()
+            )
             if exclusion_list:
                 dataset_triggered_dag_ids -= exclusion_list
                 dataset_triggered_dag_info = {

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -168,7 +168,10 @@ class DagRun(Base, LoggingMixin):
         TI, back_populates="dag_run", cascade='save-update, merge, delete, delete-orphan'
     )
     dag_model = relationship(
-        "DagModel", primaryjoin="foreign(DagRun.dag_id) == DagModel.dag_id", uselist=False
+        "DagModel",
+        primaryjoin="foreign(DagRun.dag_id) == DagModel.dag_id",
+        uselist=False,
+        viewonly=True,
     )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -167,7 +167,9 @@ class DagRun(Base, LoggingMixin):
     task_instances = relationship(
         TI, back_populates="dag_run", cascade='save-update, merge, delete, delete-orphan'
     )
-    dag = relationship("DagModel", primaryjoin="DagRun.dag_id == foreign(DagModel.dag_id)")
+    dag_model = relationship(
+        "DagModel", primaryjoin="DagRun.dag_id == foreign(DagModel.dag_id)", uselist=False
+    )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         'scheduler',

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -167,6 +167,7 @@ class DagRun(Base, LoggingMixin):
     task_instances = relationship(
         TI, back_populates="dag_run", cascade='save-update, merge, delete, delete-orphan'
     )
+    dag = relationship("DagModel", primaryjoin="DagRun.dag_id == foreign(DagModel.dag_id)")
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         'scheduler',

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -168,7 +168,7 @@ class DagRun(Base, LoggingMixin):
         TI, back_populates="dag_run", cascade='save-update, merge, delete, delete-orphan'
     )
     dag_model = relationship(
-        "DagModel", primaryjoin="DagRun.dag_id == foreign(DagModel.dag_id)", uselist=False
+        "DagModel", primaryjoin="foreign(DagRun.dag_id) == DagModel.dag_id", uselist=False
     )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1144,6 +1144,7 @@ class Airflow(AirflowBaseView):
         owner_links = session.query(DagOwnerAttributes).filter_by(dag_id=dag_id).all()
 
         attrs_to_avoid = [
+            "schedule_datasets",
             "schedule_dataset_references",
             "task_outlet_dataset_references",
             "NUM_DAGS_PER_DAGRUN_QUERY",

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -65,7 +65,7 @@ from airflow.utils.types import DagRunType
 from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.asserts import assert_queries_count
-from tests.test_utils.db import clear_db_dags, clear_db_datasets, clear_db_runs
+from tests.test_utils.db import clear_db_dags, clear_db_runs
 from tests.test_utils.mapping import expand_mapped_task
 from tests.test_utils.timetables import cron_timetable, delta_timetable
 
@@ -76,14 +76,12 @@ class TestDag:
     def setup_method(self) -> None:
         clear_db_runs()
         clear_db_dags()
-        clear_db_datasets()
         self.patcher_dag_code = mock.patch('airflow.models.dag.DagCode.bulk_sync_to_db')
         self.patcher_dag_code.start()
 
     def teardown_method(self) -> None:
         clear_db_runs()
         clear_db_dags()
-        clear_db_datasets()
         self.patcher_dag_code.stop()
 
     @staticmethod
@@ -2104,11 +2102,6 @@ class TestDag:
 
 
 class TestDagModel:
-    def setup_method(self) -> None:
-        clear_db_runs()
-        clear_db_dags()
-        clear_db_datasets()
-
     def test_dags_needing_dagruns_not_too_early(self):
         dag = DAG(dag_id='far_future_dag', start_date=timezone.datetime(2038, 1, 1))
         EmptyOperator(task_id='dummy', dag=dag, owner='airflow')

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2132,58 +2132,46 @@ class TestDagModel:
         session.rollback()
         session.close()
 
-    def test_dags_needing_dagruns_datasets(self, session):
+    def test_dags_needing_dagruns_datasets(self, dag_maker, session):
         dataset = Dataset(uri='hello')
-        dag = DAG(
-            dag_id='my_dag', max_active_runs=1, schedule=[dataset], start_date=pendulum.now().add(days=-2)
-        )
-        EmptyOperator(task_id='dummy', dag=dag)
-        DAG.bulk_write_to_db([dag], session=session)
-        session.commit()
+        with dag_maker(
+            session=session,
+            dag_id='my_dag',
+            max_active_runs=1,
+            schedule=[dataset],
+            start_date=pendulum.now().add(days=-2),
+        ) as dag:
+            EmptyOperator(task_id='dummy')
 
         # there's no queue record yet, so no runs needed at this time.
         query, _ = DagModel.dags_needing_dagruns(session)
         dag_models = query.all()
         assert dag_models == []
-        session.commit()
 
         # add queue records so we'll need a run
         dag_model = session.query(DagModel).filter(DagModel.dag_id == dag.dag_id).one()
         dataset_model: DatasetModel = dag_model.schedule_datasets[0]
         session.add(DatasetDagRunQueue(dataset_id=dataset_model.id, target_dag_id=dag_model.dag_id))
-        session.commit()
+        session.flush()
         query, _ = DagModel.dags_needing_dagruns(session)
         dag_models = query.all()
-        session.commit()
         assert dag_models == [dag_model]
 
         # create run so we don't need a run anymore (due to max active runs)
-        session.add(
-            DagRun(
-                dag_id=dag_model.dag_id,
-                run_id='abc',
-                run_type=DagRunType.DATASET_TRIGGERED,
-                state=DagRunState.QUEUED,
-            )
+        dag_maker.create_dagrun(
+            run_type=DagRunType.DATASET_TRIGGERED,
+            state=DagRunState.QUEUED,
+            execution_date=pendulum.now('UTC'),
         )
-        session.commit()
         query, _ = DagModel.dags_needing_dagruns(session)
         dag_models = query.all()
         assert dag_models == []
 
         # increase max active runs and we should now need another run
-        dag = DAG(
-            dag_id='my_dag',
-            max_active_runs=2,
-            schedule=[dataset],
-            start_date=pendulum.now().add(days=-2),
-        )
-        EmptyOperator(task_id='dummy', dag=dag)
-        DAG.bulk_write_to_db([dag], session=session)
-        session.commit()
+        dag_maker.dag_model.max_active_runs = 2
+        session.flush()
         query, _ = DagModel.dags_needing_dagruns(session)
         dag_models = query.all()
-        session.commit()
         assert dag_models == [dag_model]
 
     def test_max_active_runs_not_none(self):

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -65,7 +65,7 @@ from airflow.utils.types import DagRunType
 from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.asserts import assert_queries_count
-from tests.test_utils.db import clear_db_dags, clear_db_runs
+from tests.test_utils.db import clear_db_dags, clear_db_datasets, clear_db_runs
 from tests.test_utils.mapping import expand_mapped_task
 from tests.test_utils.timetables import cron_timetable, delta_timetable
 
@@ -2102,6 +2102,11 @@ class TestDag:
 
 
 class TestDagModel:
+    def setup_method(self):
+        clear_db_dags()
+        clear_db_datasets()
+        clear_db_runs()
+
     def test_dags_needing_dagruns_not_too_early(self):
         dag = DAG(dag_id='far_future_dag', start_date=timezone.datetime(2038, 1, 1))
         EmptyOperator(task_id='dummy', dag=dag, owner='airflow')

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -2102,10 +2102,16 @@ class TestDag:
 
 
 class TestDagModel:
-    def setup_method(self):
+    def _clean(self):
         clear_db_dags()
         clear_db_datasets()
         clear_db_runs()
+
+    def setup_method(self):
+        self._clean()
+
+    def teardown_method(self):
+        self._clean()
 
     def test_dags_needing_dagruns_not_too_early(self):
         dag = DAG(dag_id='far_future_dag', start_date=timezone.datetime(2038, 1, 1))


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/26259


Alternative to https://github.com/apache/airflow/pull/26287

Moves the filtering out of unschedulable dags to DagModel.dags_needing_dagruns