### PR TITLE
Add more to the ignore list for non-core changes

### DIFF
--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -162,6 +162,12 @@ def is_core_commit(files: List[str]) -> bool:
         "docker_tests/",
         ".asf.yaml",
         ".mailmap",
+        "breeze-legacy",
+        "breeze-complete",
+        ".rat-excludes",
+        ".gitattributes",
+        ".gitpod.yml",
+        "generated/",
     ]
 
     for file in files:


### PR DESCRIPTION
Just some additional ignore I've run across while categorizing for 2.4.0.

Btw, a couple of these can go away after we release 2.4.0, and I suspect there might be more in the list as well, so probably worth doing some cleanup on the list after we release.