### PR TITLE
Fix Dataset bugs in grid view

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -160,7 +160,7 @@ class TaskOutletDatasetReference(Base):
     created_at = Column(UtcDateTime, default=timezone.utcnow, nullable=False)
     updated_at = Column(UtcDateTime, default=timezone.utcnow, onupdate=timezone.utcnow, nullable=False)
 
-    dataset = relationship("DatasetModel")
+    dataset = relationship("DatasetModel", back_populates="producing_tasks")
 
     __tablename__ = "task_outlet_dataset_reference"
     __table_args__ = (

--- a/airflow/www/static/js/datasetUtils.js
+++ b/airflow/www/static/js/datasetUtils.js
@@ -38,7 +38,7 @@ export function openDatasetModal(dagId, summary = '', nextDatasets = [], error =
     uriCell.append(datasetLink);
 
     const timeCell = document.createElement('td');
-    if (d.created_at) timeCell.append(isoDateToTimeEl(d.created_at));
+    if (d.lastUpdate) timeCell.append(isoDateToTimeEl(d.lastUpdate));
 
     row.append(uriCell);
     row.append(timeCell);

--- a/airflow/www/templates/airflow/dataset_next_run_modal.html
+++ b/airflow/www/templates/airflow/dataset_next_run_modal.html
@@ -40,7 +40,7 @@
             <thead>
               <tr>
                 <th>Dataset URI</th>
-                <th>Timestamp</th>
+                <th>Latest Update</th>
               </tr>
             </thead>
             <tbody id="datasets_tbody">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -96,7 +96,7 @@ from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.dag import DAG, get_dataset_triggered_next_run_info
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
-from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue, DatasetModel
+from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue, DatasetEvent, DatasetModel
 from airflow.models.operator import Operator
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import TaskInstance
@@ -3481,19 +3481,28 @@ class Airflow(AirflowBaseView):
                 for info in session.query(
                     DatasetModel.id,
                     DatasetModel.uri,
-                    DatasetDagRunQueue.created_at,
+                    func.max(DatasetEvent.timestamp).label("lastUpdate"),
                 )
-                .join(DagScheduleDatasetReference, DatasetModel.id == DagScheduleDatasetReference.dataset_id)
+                .join(DagScheduleDatasetReference, DagScheduleDatasetReference.dataset_id == DatasetModel.id)
                 .join(
                     DatasetDagRunQueue,
                     and_(
-                        DatasetDagRunQueue.dataset_id == DagScheduleDatasetReference.dataset_id,
+                        DatasetDagRunQueue.dataset_id == DatasetModel.id,
                         DatasetDagRunQueue.target_dag_id == DagScheduleDatasetReference.dag_id,
                     ),
                     isouter=True,
                 )
+                .join(
+                    DatasetEvent,
+                    and_(
+                        DatasetEvent.dataset_id == DatasetModel.id,
+                        DatasetEvent.timestamp > DatasetDagRunQueue.created_at,
+                    ),
+                    isouter=True,
+                )
                 .filter(DagScheduleDatasetReference.dag_id == dag_id)
-                .order_by(DatasetModel.id)
+                .group_by(DatasetModel.id)
+                .order_by(DatasetModel.uri)
                 .all()
             ]
         return (

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3501,7 +3501,7 @@ class Airflow(AirflowBaseView):
                     isouter=True,
                 )
                 .filter(DagScheduleDatasetReference.dag_id == dag_id)
-                .group_by(DatasetModel.id)
+                .group_by(DatasetModel.id, DatasetModel.uri)
                 .order_by(DatasetModel.uri)
                 .all()
             ]


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

We should ignore DatasetEvents before the latest DatasetDagRunQueue for the dataset when we are displaying latest dataset updates. Once all of the dependent datasets for a DAG are updated, the DDRQ is created. That means that further DatasetEvents that are not sufficient to schedule a new DagRun (via DDRQ) are the only events that should be listed in "X of Y datasets".

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
