### PR TITLE
Require dag_id arg for dags list-runs

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -265,7 +265,7 @@ ARG_REVISION_RANGE = Arg(
 # list_dag_runs
 ARG_DAG_ID_REQ_FLAG = Arg(
     ("-d", "--dag-id"), required=True, help="The id of the dag"
-)  # convert this to a positional arg in Airflow 3
+)  # TODO: convert this to a positional arg in Airflow 3
 ARG_NO_BACKFILL = Arg(
     ("--no-backfill",), help="filter all the backfill dagruns given the dag id", action="store_true"
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -263,13 +263,16 @@ ARG_REVISION_RANGE = Arg(
 )
 
 # list_dag_runs
-ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
+ARG_DAG_ID_REQ_FLAG = Arg(
+    ("-d", "--dag-id"), required=True, help="The id of the dag"
+)  # convert this to a positional arg in Airflow 3
 ARG_NO_BACKFILL = Arg(
     ("--no-backfill",), help="filter all the backfill dagruns given the dag id", action="store_true"
 )
 ARG_STATE = Arg(("--state",), help="Only list the dag runs corresponding to the state")
 
 # list_jobs
+ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
 ARG_LIMIT = Arg(("--limit",), help="Return a limited number of records")
 
 # next_execution
@@ -1008,7 +1011,7 @@ DAGS_COMMANDS = (
         ),
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_list_dag_runs'),
         args=(
-            ARG_DAG_ID_OPT,
+            ARG_DAG_ID_REQ_FLAG,
             ARG_NO_BACKFILL,
             ARG_STATE,
             ARG_OUTPUT,

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -263,13 +263,13 @@ ARG_REVISION_RANGE = Arg(
 )
 
 # list_dag_runs
+ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
 ARG_NO_BACKFILL = Arg(
     ("--no-backfill",), help="filter all the backfill dagruns given the dag id", action="store_true"
 )
 ARG_STATE = Arg(("--state",), help="Only list the dag runs corresponding to the state")
 
 # list_jobs
-ARG_DAG_ID_OPT = Arg(("-d", "--dag-id"), help="The id of the dag")
 ARG_LIMIT = Arg(("--limit",), help="Return a limited number of records")
 
 # next_execution
@@ -1008,7 +1008,7 @@ DAGS_COMMANDS = (
         ),
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_list_dag_runs'),
         args=(
-            ARG_DAG_ID,
+            ARG_DAG_ID_OPT,
             ARG_NO_BACKFILL,
             ARG_STATE,
             ARG_OUTPUT,

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -499,12 +499,13 @@ class TestCliDags(unittest.TestCase):
             [
                 'dags',
                 'list-runs',
+                '--dag-id',
+                'example_bash_operator',
                 '--no-backfill',
                 '--start-date',
                 DEFAULT_DATE.isoformat(),
                 '--end-date',
                 timezone.make_aware(datetime.max).isoformat(),
-                'example_bash_operator',
             ]
         )
         dag_command.dag_list_dag_runs(args)


### PR DESCRIPTION
While it would ideal to transition to a positional arg like was
attempted in https://github.com/apache/airflow/pull/25978, this unfortunately does result in a breaking change
so we cannot do it now.

By instead marking the existing arg as required, we maintain backcompat
while also providing a helpful error message to the user if they forget
it.

(It is possible to get both a flagged and positional arg working, but I didn't like the complexity necessary in the help docs and code to explain precedence etc. If someone feels strongly about supporting a positional arg, I can take another look at it, or we can do it down the road too.)