### PR TITLE
Fix static checks from sync_authors script

### DIFF
--- a/scripts/ci/runners/sync_authors.py
+++ b/scripts/ci/runners/sync_authors.py
@@ -22,7 +22,6 @@ import re
 import requests
 import toml
 
-
 # The list of users in the 'build-info' job looks like:
 #
 #       contains(fromJSON('[
@@ -52,7 +51,6 @@ for author in sorted(author_set):
 authors = authors[:-2]
 
 with open('ci.yml') as handle:
-
 
     new_ci = re.sub(
         r'''


### PR DESCRIPTION
The #26275 introduced static check problem (isort). This PR fixes it

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
