### PR TITLE
Fix pre-commit for checking revision heads map

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_version_heads_map.py
+++ b/scripts/ci/pre_commit/pre_commit_version_heads_map.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     if airflow_version.is_devrelease or 'b' in (airflow_version.pre or ()):
         exit(0)
     versions = read_revision_heads_map()
-    if airflow_version not in versions:
+    if airflow_version.base_version not in versions:
         print("Current airflow version is not in the REVISION_HEADS_MAP")
         print("Current airflow version:", airflow_version)
         print("Please add the version to the REVISION_HEADS_MAP at:", DB_FILE)


### PR DESCRIPTION
We need to check with the base_version instead of the parsed version obj

