### PR TITLE
Implements SqlToSlackApiFileOperator

### DIFF
--- a/airflow/providers/slack/utils/__init__.py
+++ b/airflow/providers/slack/utils/__init__.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import Any, Sequence
 
 from airflow.utils.types import NOTSET
 
@@ -77,3 +77,41 @@ class ConnectionExtraConfig:
         if value != default:
             value = int(value)
         return value
+
+
+def parse_filename(
+    filename: str, supported_file_formats: Sequence[str], fallback: str | None = None
+) -> tuple[str, str | None]:
+    """
+    Parse filetype and compression from given filename.
+    :param filename: filename to parse.
+    :param supported_file_formats: list of supported file extensions.
+    :param fallback: fallback to given file format.
+    :returns: filetype and compression (if specified)
+    """
+    if not filename:
+        raise ValueError("Expected 'filename' parameter is missing.")
+    if fallback and fallback not in supported_file_formats:
+        raise ValueError(f"Invalid fallback value {fallback!r}, expected one of {supported_file_formats}.")
+
+    parts = filename.rsplit(".", 2)
+    try:
+        if len(parts) == 1:
+            raise ValueError(f"No file extension specified in filename {filename!r}.")
+        if parts[-1] in supported_file_formats:
+            return parts[-1], None
+        elif len(parts) == 2:
+            raise ValueError(
+                f"Unsupported file format {parts[-1]!r}, expected one of {supported_file_formats}."
+            )
+        else:
+            if parts[-2] not in supported_file_formats:
+                raise ValueError(
+                    f"Unsupported file format '{parts[-2]}.{parts[-1]}', "
+                    f"expected one of {supported_file_formats} with compression extension."
+                )
+            return parts[-2], parts[-1]
+    except ValueError as ex:
+        if fallback:
+            return fallback, None
+        raise ex from None

--- a/tests/providers/slack/transfers/test_sql_to_slack.py
+++ b/tests/providers/slack/transfers/test_sql_to_slack.py
@@ -23,12 +23,87 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, Connection
-from airflow.providers.slack.transfers.sql_to_slack import SqlToSlackOperator
+from airflow.providers.slack.transfers.sql_to_slack import (
+    BaseSqlToSlackOperator,
+    SqlToSlackApiFileOperator,
+    SqlToSlackOperator,
+)
 from airflow.utils import timezone
 
 TEST_DAG_ID = "sql_to_slack_unit_test"
 TEST_TASK_ID = "sql_to_slack_unit_test_task"
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
+
+
+class TestBaseSqlToSlackOperator:
+    def setup_method(self):
+        self.default_op_kwargs = {
+            "sql": "SELECT 1",
+            "sql_conn_id": "test-sql-conn-id",
+            "sql_hook_params": None,
+            "parameters": None,
+        }
+
+    def test_execute_not_implemented(self):
+        """Test that no base implementation for ``BaseSqlToSlackOperator.execute()``."""
+        op = BaseSqlToSlackOperator(task_id="test_base_not_implements", **self.default_op_kwargs)
+        with pytest.raises(NotImplementedError):
+            op.execute(mock.MagicMock())
+
+    @mock.patch("airflow.providers.common.sql.operators.sql.BaseHook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_hook")
+    @pytest.mark.parametrize("conn_type", ["postgres", "snowflake"])
+    @pytest.mark.parametrize("sql_hook_params", [None, {"foo": "bar"}])
+    def test_get_hook(self, mock_get_hook, mock_get_conn, conn_type, sql_hook_params):
+        class SomeDummyHook:
+            """Hook which implements ``get_pandas_df`` method"""
+
+            def get_pandas_df(self):
+                pass
+
+        expected_hook = SomeDummyHook()
+        mock_get_conn.return_value = Connection(conn_id=f"test_connection_{conn_type}", conn_type=conn_type)
+        mock_get_hook.return_value = expected_hook
+        op_kwargs = {
+            **self.default_op_kwargs,
+            "sql_hook_params": sql_hook_params,
+        }
+        op = BaseSqlToSlackOperator(task_id="test_get_hook", **op_kwargs)
+        hook = op._get_hook()
+        mock_get_hook.assert_called_once_with(hook_params=sql_hook_params)
+        assert hook == expected_hook
+
+    @mock.patch("airflow.providers.common.sql.operators.sql.BaseHook.get_connection")
+    @mock.patch("airflow.models.connection.Connection.get_hook")
+    def test_get_not_supported_hook(self, mock_get_hook, mock_get_conn):
+        class SomeDummyHook:
+            """Hook which not implemented ``get_pandas_df`` method"""
+
+        mock_get_conn.return_value = Connection(conn_id="test_connection", conn_type="test_connection")
+        mock_get_hook.return_value = SomeDummyHook()
+        op = BaseSqlToSlackOperator(task_id="test_get_not_supported_hook", **self.default_op_kwargs)
+        error_message = r"This hook is not supported. The hook class must have get_pandas_df method\."
+        with pytest.raises(AirflowException, match=error_message):
+            op._get_hook()
+
+    @mock.patch("airflow.providers.slack.transfers.sql_to_slack.BaseSqlToSlackOperator._get_hook")
+    @pytest.mark.parametrize("sql", ["SELECT 42", "SELECT 1 FROM DUMMY WHERE col = ?"])
+    @pytest.mark.parametrize("parameters", [None, {"col": "spam-egg"}])
+    def test_get_query_results(self, mock_op_get_hook, sql, parameters):
+        test_df = pd.DataFrame({"a": "1", "b": "2"}, index=[0, 1])
+        mock_get_pandas_df = mock.MagicMock(return_value=test_df)
+        mock_hook = mock.MagicMock()
+        mock_hook.get_pandas_df = mock_get_pandas_df
+        mock_op_get_hook.return_value = mock_hook
+        op_kwargs = {
+            **self.default_op_kwargs,
+            "sql": sql,
+            "parameters": parameters,
+        }
+        op = BaseSqlToSlackOperator(task_id="test_get_query_results", **op_kwargs)
+        df = op._get_query_results()
+        mock_get_pandas_df.assert_called_once_with(sql, parameters=parameters)
+        assert df is test_df
 
 
 class TestSqlToSlackOperator:
@@ -215,3 +290,90 @@ class TestSqlToSlackOperator:
         assert hook.database == "database"
         assert hook.role == "role"
         assert hook.schema == "schema"
+
+
+class TestSqlToSlackApiFileOperator:
+    def setup_method(self):
+        self.default_op_kwargs = {
+            "sql": "SELECT 1",
+            "sql_conn_id": "test-sql-conn-id",
+            "slack_conn_id": "test-slack-conn-id",
+            "sql_hook_params": None,
+            "parameters": None,
+        }
+
+    @mock.patch("airflow.providers.slack.transfers.sql_to_slack.BaseSqlToSlackOperator._get_query_results")
+    @mock.patch("airflow.providers.slack.transfers.sql_to_slack.SlackHook")
+    @pytest.mark.parametrize(
+        "filename,df_method",
+        [
+            ("awesome.json", "to_json"),
+            ("awesome.json.zip", "to_json"),
+            ("awesome.csv", "to_csv"),
+            ("awesome.csv.xz", "to_csv"),
+            ("awesome.html", "to_html"),
+        ],
+    )
+    @pytest.mark.parametrize("df_kwargs", [None, {}, {"foo": "bar"}])
+    @pytest.mark.parametrize("channels", ["#random", "#random,#general", None])
+    @pytest.mark.parametrize("initial_comment", [None, "Test Comment"])
+    @pytest.mark.parametrize("title", [None, "Test File Title"])
+    def test_send_file(
+        self,
+        mock_slack_hook_cls,
+        mock_get_query_results,
+        filename,
+        df_method,
+        df_kwargs,
+        channels,
+        initial_comment,
+        title,
+    ):
+        # Mock Hook
+        mock_send_file = mock.MagicMock()
+        mock_slack_hook_cls.return_value.send_file = mock_send_file
+
+        # Mock returns pandas.DataFrame and expected method
+        mock_df = mock.MagicMock()
+        mock_df_output_method = mock.MagicMock()
+        setattr(mock_df, df_method, mock_df_output_method)
+        mock_get_query_results.return_value = mock_df
+
+        op_kwargs = {
+            **self.default_op_kwargs,
+            "slack_conn_id": "expected-test-slack-conn-id",
+            "slack_filename": filename,
+            "slack_channels": channels,
+            "slack_initial_comment": initial_comment,
+            "slack_title": title,
+            "df_kwargs": df_kwargs,
+        }
+        op = SqlToSlackApiFileOperator(task_id="test_send_file", **op_kwargs)
+        op.execute(mock.MagicMock())
+
+        mock_slack_hook_cls.assert_called_once_with(slack_conn_id="expected-test-slack-conn-id")
+        mock_get_query_results.assert_called_once_with()
+        mock_df_output_method.assert_called_once_with(mock.ANY, **(df_kwargs or {}))
+        mock_send_file.assert_called_once_with(
+            channels=channels,
+            filename=filename,
+            initial_comment=initial_comment,
+            title=title,
+            file=mock.ANY,
+        )
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "foo.parquet",
+            "bat.parquet.snappy",
+            "spam.xml",
+            "egg.xlsx",
+        ],
+    )
+    def test_unsupported_format(self, filename):
+        op = SqlToSlackApiFileOperator(
+            task_id="test_send_file", slack_filename=filename, **self.default_op_kwargs
+        )
+        with pytest.raises(ValueError):
+            op.execute(mock.MagicMock())


### PR DESCRIPTION
closes: #9145
follow-up: #24660

Rather than extend existed `SqlToSlackOperator` I've decided to create new transfer operator `SqlToSlackApiFileOperator`.

cc: @eladkal 
    