### PR TITLE
Add simple blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# PEP-563 (Postponed Evaluation of Annotations)
+d67ac5932dabbf06ae733fc57b48491a8029b8c2


### PR DESCRIPTION
Use `git config blame.ignoreRevsFile .git-blame-ignore-revs` to apply.

I only added the latest PEP 563 commit, more can be added later.
