### PR TITLE
Bump FAB to 4.1.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ install_requires =
     # Every time we update FAB version here, please make sure that you review the classes and models in
     # `airflow/www/fab_security` with their upstream counterparts. In particular, make sure any breaking changes,
     # for example any new methods, are accounted for.
-    flask-appbuilder==4.1.3
+    flask-appbuilder==4.1.4
     flask-caching>=1.5.0
     flask-login>=0.6.2
     flask-session>=0.4.0


### PR DESCRIPTION
No changes that should be replicated in `airflow/www/fab_security` was found.

See https://github.com/dpgaspar/Flask-AppBuilder/compare/v4.1.3...v4.1.4

I expect that the constraints dependencies got updated to:

flask-wtf==1.0.1
wtforms==3.0.1

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
