### PR TITLE
Allow `.git-blame-ignore-revs` file to not have license header

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,6 +1,7 @@
 # Note: these patterns are applied to single files or directories, not full paths
 # coverage/* will ignore any coverage dir, but airflow/www/static/coverage/* will match nothing
 
+.git-blame-ignore-revs
 .github/*
 .gitignore
 .gitattributes


### PR DESCRIPTION
Over-zealous merge caused failing static checks