### PR TITLE
Clear autoregistered DAGs if there are any import errors

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -326,6 +326,7 @@ class DagBag(LoggingMixin):
                 loader.exec_module(new_module)
                 return [new_module]
             except Exception as e:
+                DagContext.autoregistered_dags.clear()
                 self.log.exception("Failed to import: %s", filepath)
                 if self.dagbag_import_error_tracebacks:
                     self.import_errors[filepath] = traceback.format_exc(
@@ -391,6 +392,7 @@ class DagBag(LoggingMixin):
                     current_module = importlib.import_module(mod_name)
                     mods.append(current_module)
                 except Exception as e:
+                    DagContext.autoregistered_dags.clear()
                     fileloc = os.path.join(filepath, zip_info.filename)
                     self.log.exception("Failed to import: %s", fileloc)
                     if self.dagbag_import_error_tracebacks:

--- a/tests/dags/test_invalid_dup_task.py
+++ b/tests/dags/test_invalid_dup_task.py
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+
+with DAG(
+    "test_invalid_dup_task",
+    start_date=datetime(2021, 1, 1),
+    schedule="@once",
+):
+    EmptyOperator(task_id="hi")
+    EmptyOperator(task_id="hi")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2766,6 +2766,7 @@ class TestSchedulerJob:
         ignored_files = {
             'no_dags.py',
             'test_invalid_cron.py',
+            'test_invalid_dup_task.py',
             'test_ignore_this.py',
             'test_invalid_param.py',
             'test_nested_dag.py',


### PR DESCRIPTION
We need to clear any autoregistered DAGs that may have been already registered if we encounter any import errors while parsing a given DAG file.

This maintains the behavior before we autoregistered DAGs.