### PR TITLE
Update documentation - baking DAGs into docker image

### DIFF
--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -24,9 +24,9 @@ When you create new or modify existing DAG files, it is necessary to deploy them
 Bake DAGs in Docker image
 -------------------------
 
-This option uses the Docker image containing the latest DAG code.
+With this approach, you include your dag files and related code in the airflow image.
 
-This method requires redeploying the services in the helm chart with the new docker image in order to use the new DAG code. This might be a good      option if DAG code is not expected to change frequently.
+This method requires redeploying the services in the helm chart with the new docker image in order to deploy the new DAG code. This can work well particularly if DAG code is not expected to change frequently.
 
 .. code-block:: bash
 

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -24,7 +24,7 @@ When you create new or modify existing DAG files, it is necessary to deploy them
 Bake DAGs in Docker image
 -------------------------
 
-This option uses the Docker image containing the latest DAG code. 
+This option uses the Docker image containing the latest DAG code.
 
 This method requires redeploying the services in the helm chart with the new docker image in order to use the new DAG code. This might be a good      option if DAG code is not expected to change frequently.
 

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -24,7 +24,9 @@ When you create new or modify existing DAG files, it is necessary to deploy them
 Bake DAGs in Docker image
 -------------------------
 
-The recommended way to update your DAGs with this chart is to build a new Docker image with the latest DAG code:
+This option uses the Docker image containing the latest DAG code. 
+
+This method requires redeploying the services in the helm chart with the new docker image in order to use the new DAG code. This might be a good      option if DAG code is not expected to change frequently.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This removes the wording that baking DAGs into a docker image is the recommended way. Additionally it calls out the downside of doing so. 

closes: [#26262](https://github.com/apache/airflow/issues/26262)
