### PR TITLE
Fix params reference for default_constraints_branch

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -610,7 +610,7 @@ DERIVE_ENV_VARIABLES_FROM_ATTRIBUTES = {
     "AIRFLOW_CI_IMAGE": "airflow_image_name",
     "AIRFLOW_CI_IMAGE_WITH_TAG": "airflow_image_name_with_tag",
     "AIRFLOW_EXTRAS": "airflow_extras",
-    "DEFAULT_CONSTRAINTS_BRANCH": "default-constraints-branch",
+    "DEFAULT_CONSTRAINTS_BRANCH": "default_constraints_branch",
     "AIRFLOW_CONSTRAINTS_MODE": "airflow_constraints_mode",
     "AIRFLOW_CONSTRAINTS_REFERENCE": "airflow_constraints_reference",
     "AIRFLOW_IMAGE_KUBERNETES": "airflow_image_kubernetes",


### PR DESCRIPTION
Fixes breeze commands that depend on the default constraints branch, such as the generated diff for `breeze release-management generate-constraints`.

Before:

<img width="974" alt="image" src="https://user-images.githubusercontent.com/1991286/190266073-c71bbba3-fc9e-4131-8e2f-5ed255555daa.png">

After:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1991286/190266183-c030ff7a-79fd-4b97-8b19-c05bd820acc1.png">

