### PR TITLE
Add min attrs version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ install_requires =
     # together with SQLAlchemy. Our experience with Alembic is that it very stable in minor version
     alembic>=1.5.1, <2.0
     argcomplete>=1.10
+    attrs>=22.1.0
     blinker
     cached_property>=1.5.0;python_version<="3.7"
     cattrs>=22.1.0


### PR DESCRIPTION
I'm not sure when we started using attrs directly, but we do and we need
\>=22.1.0 as we use the min_length validator.