### PR TITLE
Credentials are needed in order to push branch

### DIFF
--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -35,8 +35,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          persist-credentials: false
 
       - name: Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
In order to push the new branch, the credentials used to checkout the repo need to persist.