### PR TITLE
Add workflows permission

### DIFF
--- a/.github/workflows/sync_authors.yml
+++ b/.github/workflows/sync_authors.yml
@@ -26,6 +26,7 @@ on:  # yamllint disable-line rule:truthy
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 jobs:
   sync:


### PR DESCRIPTION
Without this, Github refuses to allow the workflow to update another workflow.