### PR TITLE
Fix defaultAirflowRepository comment

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -45,7 +45,7 @@ securityContext: {}
 # Used for mount paths
 airflowHome: /opt/airflow
 
-# Default airflow repository -- overrides all the specific images below
+# Default airflow repository -- overridden by all the specific images below
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy


### PR DESCRIPTION
closes: [23566](https://github.com/apache/airflow/issues/23566)

`defaultAirflowRepository` doesn't override the specific images, it is **overridden by** them. Thus the comment should be fixed.

