### PR TITLE
Fix invalid RST in dataset concepts doc

### DIFF
--- a/docs/apache-airflow/concepts/datasets.rst
+++ b/docs/apache-airflow/concepts/datasets.rst
@@ -93,7 +93,7 @@ If required, an extra dictionary can be included in a Dataset:
         extra={'team': 'trainees'},
     )
 
-..note::
+.. note ::
 
     Security Note: Dataset URI and extra fields are not encrypted, they are stored in cleartext, in Airflow's metadata database. Do NOT store any sensitive values, especially credentials, in dataset URIs or extra key values!
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/34150/190626807-821301c3-c455-4f61-b040-610ea04ac707.png)

After:
![image](https://user-images.githubusercontent.com/34150/190626844-71af98c0-ab46-4d88-a85c-f6bf0c080eab.png)

@ephraimbuddy @jedcunningham We should use this when building the docs for 2.4.0 (doesn't need to stop the RC vote)