### PR TITLE
DAG Deps extends `base_template`

### DIFF
--- a/airflow/www/templates/airflow/dag_dependencies.html
+++ b/airflow/www/templates/airflow/dag_dependencies.html
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 #}
 
-{% extends "airflow/main.html" %}
+{% extends base_template %}
 
 {% block title %}Airflow - DAG Dependencies{% endblock %}
 


### PR DESCRIPTION
The DAG Deps page should extend `base_template` instead of Airflow's main template (which is the default `base_template`). This is consistent with all other pages and allows for proper UI customization.