### PR TITLE
WIP - Fix k8s executor when home path different

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -51,7 +51,7 @@ from airflow.utils.cli import (
     get_dag_by_file_location,
     get_dag_by_pickle,
     get_dags,
-    suppress_logs_and_warning,
+    suppress_logs_and_warning, process_subdir,
 )
 from airflow.utils.dates import timezone
 from airflow.utils.log.logging_mixin import StreamLogWriter
@@ -243,6 +243,7 @@ def _run_task_by_local_task_job(args, ti):
         ignore_ti_state=args.force,
         pool=args.pool,
         external_executor_id=_extract_external_executor_id(args),
+        subdir=process_subdir(args.subdir),
     )
     try:
         run_job.run()

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -56,6 +56,7 @@ class LocalTaskJob(BaseJob):
         pickle_id: str | None = None,
         pool: str | None = None,
         external_executor_id: str | None = None,
+        subdir:str | None = None,
         *args,
         **kwargs,
     ):
@@ -69,6 +70,7 @@ class LocalTaskJob(BaseJob):
         self.pickle_id = pickle_id
         self.mark_success = mark_success
         self.external_executor_id = external_executor_id
+        self.subdir = subdir
 
         # terminating state is used so that a job don't try to
         # terminate multiple times

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -29,6 +29,7 @@ import warnings
 from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import partial
+from pathlib import Path
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -662,6 +663,7 @@ class TaskInstance(Base, LoggingMixin):
         job_id=None,
         pool=None,
         cfg_path=None,
+        subdir=None,
     ):
         """
         Returns a command that can be executed anywhere where airflow is
@@ -678,7 +680,9 @@ class TaskInstance(Base, LoggingMixin):
         should_pass_filepath = not pickle_id and dag
         path = None
         if should_pass_filepath:
-            if dag.is_subdag:
+            if subdir:
+                path = Path(subdir)
+            elif dag.is_subdag:
                 path = dag.parent_dag.relative_fileloc
             else:
                 path = dag.relative_fileloc

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -98,6 +98,7 @@ class BaseTaskRunner(LoggingMixin):
             job_id=local_task_job.id,
             pool=local_task_job.pool,
             cfg_path=cfg_path,
+            subdir=local_task_job.subdir,
         )
         self.process = None
 


### PR DESCRIPTION
Since #21877 we no longer parse the dag as part of --local task run.

As a consequence it reads dag file location from the database.  But if the dag file is in a different path on the k8s executor worker, then this will be the wrong path.  We can fix this by respecting the subdir from the top level command.

One problem is, at least with k8s executor (and maybe others too?), the way it builds the pod args, it sets subdir=DAGS_FOLDER which means that all dags in the folder get parsed, which, we should avoid somehow.  So, have to work on this more and see whether we can improve that.

It may be easier to just store the relative loc in the DB.

