### PR TITLE
Remove taskflow code from Airflow intro example

### DIFF
--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -40,27 +40,24 @@ Take a look at the following snippet of code:
     from datetime import datetime
 
     from airflow import DAG
-    from airflow.decorators import task
     from airflow.operators.bash import BashOperator
+    from airflow.operators.python import PythonOperator
 
     # A DAG represents a workflow, a collection of tasks
     with DAG(dag_id="demo", start_date=datetime(2022, 1, 1), schedule="0 0 * * *") as dag:
 
         # Tasks are represented as operators
         hello = BashOperator(task_id="hello", bash_command="echo hello")
-
-        @task()
-        def airflow():
-            print("airflow")
+        airflow = PythonOperator(task_id="airflow", python_callable=lambda: print("airflow"))
 
         # Set dependencies between tasks
-        hello >> airflow()
+        hello >> airflow
 
 
 Here you see:
 
 - A DAG named "demo", starting on Jan 1st 2022 and running once a day. A DAG is Airflow's representation of a workflow.
-- Two tasks, a BashOperator running a Bash script and a Python function defined using the ``@task`` decorator
+- Two tasks, a BashOperator running a Bash script and a PythonOperator running a Python script
 - ``>>`` between the tasks defines a dependency and controls in which order the tasks will be executed
 
 Airflow evaluates this script and executes the tasks at the set interval and in the defined order. The status

--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -44,7 +44,7 @@ Take a look at the following snippet of code:
     from airflow.operators.python import PythonOperator
 
     # A DAG represents a workflow, a collection of tasks
-    with DAG(dag_id="demo", start_date=datetime(2022, 1, 1), schedule="0 0 * * *") as dag:
+    with DAG(dag_id="demo", start_date=datetime(2022, 1, 1), schedule="0 0 * * *"):
 
         # Tasks are represented as operators
         hello = BashOperator(task_id="hello", bash_command="echo hello")


### PR DESCRIPTION
This PR reverts a change made in https://github.com/apache/airflow/pull/25657 to the Airflow docs home page. I understand the desire to push TaskFlow usage but don't think this is the right place. This is the very first piece of Airflow code a reader will see, and mixing multiple concepts adds unnecessary complexity. This example should be as simple as possible.

Also removed `as dag` now that it's not needed anymore since Airflow 2.4.0.

**Before:**
![image](https://user-images.githubusercontent.com/6249654/191015787-a6b558c9-1420-464b-9d7c-06c8c2bb2331.png)

**After:**
![image](https://user-images.githubusercontent.com/6249654/191015711-9093dc68-0dbe-40f0-bd01-797da18fbcbb.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
