### PR TITLE
Don't import kubernetes unless you have a V1Pod

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -399,7 +399,7 @@ class BaseSerialization:
             return cls._encode({str(k): cls.serialize(v) for k, v in var.items()}, type_=DAT.DICT)
         elif isinstance(var, list):
             return [cls.serialize(v) for v in var]
-        elif _has_kubernetes() and isinstance(var, k8s.V1Pod):
+        elif var.__class__.__name__ == 'V1Pod' and _has_kubernetes() and isinstance(var, k8s.V1Pod):
             json_pod = PodGenerator.serialize_pod(var)
             return cls._encode(json_pod, type_=DAT.POD)
         elif isinstance(var, DAG):


### PR DESCRIPTION
When serializing a DAG which doesn't involve a k8s pod, we can avoid importing the kubernetes library.
