### PR TITLE
ExecutorConfigType should be cacheable

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -161,6 +161,8 @@ class ExecutorConfigType(PickleType):
     Airflow's serializer before pickling.
     """
 
+    cache_ok = True
+
     def bind_processor(self, dialect):
 
         from airflow.serialization.serialized_objects import BaseSerialization


### PR DESCRIPTION
Apparently the cache_ok attribute must be applied to all subclasses too.  So we must apply it here.  This allows sqlalchemy to use the caching behavior introduced with version 1.4.  See https://docs.sqlalchemy.org/en/14/core/type_api.html#sqlalchemy.types.ExternalType.cache_ok for more info.
