### PR TITLE
Document the non-sensitive-only option for expose_config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1212,7 +1212,9 @@
       default: ""
     - name: expose_config
       description: |
-        Expose the configuration file in the web server
+        Expose the configuration file in the web server. Set to "non-sensitive-only" to show all values
+        except those that have security implications. "True" shows all values. "False" hides the
+        configuration completely.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -622,7 +622,9 @@ error_logfile = -
 # documentation - https://docs.gunicorn.org/en/stable/settings.html#access-log-format
 access_logformat =
 
-# Expose the configuration file in the web server
+# Expose the configuration file in the web server. Set to "non-sensitive-only" to show all values
+# except those that have security implications. "True" shows all values. "False" hides the
+# configuration completely.
 expose_config = False
 
 # Expose hostname in the web server


### PR DESCRIPTION
Documents the new `non-sensitive-only` option for webserver.expose_config.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
