### PR TITLE
isort is now a dev dependency, add it to devel in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -372,6 +372,7 @@ devel_only = [
     'freezegun',
     'gitpython',
     'ipdb',
+    'isort',
     'jira',
     'jsondiff',
     'mongomock',


### PR DESCRIPTION
I was creating a DB migration today (`alembic revision -m "<my description here>"`) and the post write script was failing since it could not find the `isort` module. I made sure my dev virtualenv was up to date (`pip install --upgrade -e ".[devel,<OTHER EXTRAS>]"`) but still got the issue. It seems that setup.py does not include `isort` as a dependency, though it seems that it should be (after the PEP 563 work). This PR adds it to `devel`
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
