### PR TITLE
Move trigger rule outside of documentation

### DIFF
--- a/tests/system/providers/amazon/aws/example_cloudformation.py
+++ b/tests/system/providers/amazon/aws/example_cloudformation.py
@@ -83,10 +83,10 @@ with DAG(
     # [START howto_operator_cloudformation_delete_stack]
     delete_stack = CloudFormationDeleteStackOperator(
         task_id='delete_stack',
-        trigger_rule=TriggerRule.ALL_DONE,
         stack_name=cloudformation_stack_name,
     )
     # [END howto_operator_cloudformation_delete_stack]
+    delete_stack.trigger_rule = TriggerRule.ALL_DONE
 
     # [START howto_sensor_cloudformation_delete_stack]
     wait_for_stack_delete = CloudFormationDeleteStackSensor(

--- a/tests/system/providers/amazon/aws/example_emr_serverless.py
+++ b/tests/system/providers/amazon/aws/example_emr_serverless.py
@@ -104,9 +104,9 @@ with DAG(
     delete_app = EmrServerlessDeleteApplicationOperator(
         task_id='delete_application',
         application_id=emr_serverless_app_id,
-        trigger_rule=TriggerRule.ALL_DONE,
     )
     # [END howto_operator_emr_serverless_delete_application]
+    delete_app.trigger_rule = TriggerRule.ALL_DONE
 
     delete_s3_bucket = S3DeleteBucketOperator(
         task_id='delete_s3_bucket',

--- a/tests/system/providers/amazon/aws/example_rds_event.py
+++ b/tests/system/providers/amazon/aws/example_rds_event.py
@@ -95,6 +95,7 @@ with DAG(
         subscription_name=rds_subscription_name,
     )
     # [END howto_operator_rds_delete_event_subscription]
+    delete_subscription.trigger_rule = TriggerRule.ALL_DONE
 
     delete_db_instance = RdsDeleteDbInstanceOperator(
         task_id="delete_db_instance",

--- a/tests/system/providers/amazon/aws/example_rds_export.py
+++ b/tests/system/providers/amazon/aws/example_rds_export.py
@@ -137,16 +137,16 @@ with DAG(
 
     delete_snapshot = RdsDeleteDbSnapshotOperator(
         task_id='delete_snapshot',
-        trigger_rule=TriggerRule.ALL_DONE,
         db_type='instance',
         db_snapshot_identifier=rds_snapshot_name,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     delete_bucket = S3DeleteBucketOperator(
         task_id='delete_bucket',
-        trigger_rule=TriggerRule.ALL_DONE,
         bucket_name=bucket_name,
         force_delete=True,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     delete_db_instance = RdsDeleteDbInstanceOperator(

--- a/tests/system/providers/amazon/aws/example_rds_snapshot.py
+++ b/tests/system/providers/amazon/aws/example_rds_snapshot.py
@@ -112,6 +112,7 @@ with DAG(
         task_id='delete_snapshot_copy',
         db_type='instance',
         db_snapshot_identifier=rds_snapshot_copy_name,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     delete_db_instance = RdsDeleteDbInstanceOperator(


### PR DESCRIPTION
We decided we wanted to move out all `trigger_rule` attributes from documentation