### PR TITLE
Update CODEOWNERS for dbt Cloud provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@
 /airflow/providers/google/ @turbaszek
 /airflow/providers/snowflake/ @turbaszek @potiuk @mik-laj
 /airflow/providers/cncf/kubernetes @jedcunningham
+/airflow/providers/dbt/cloud/ @josh-fell
 /airflow/providers/tabular/ @Fokko
 /docs/apache-airflow-providers-cncf-kubernetes @jedcunningham
 


### PR DESCRIPTION
Adding myself as the code owner for the dbt Cloud provider (as the original author, I should take responsibility for it).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
