### PR TITLE
Add fixture for CLI tests requiring sample dags

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -54,7 +54,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import MAX_DB_RETRIES, run_with_db_retries
 from airflow.utils.session import provide_session
 from airflow.utils.timeout import timeout
-from airflow.utils.types import NOTSET
+from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
     import pathlib
@@ -93,8 +93,8 @@ class DagBag(LoggingMixin):
     def __init__(
         self,
         dag_folder: str | pathlib.Path | None = None,
-        include_examples: bool = NOTSET,
-        safe_mode: bool = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+        include_examples: bool | ArgNotSet = NOTSET,
+        safe_mode: bool | ArgNotSet = NOTSET,
         read_dags_from_db: bool = False,
         store_serialized_dags: bool | None = None,
         load_op_links: bool = True,
@@ -106,6 +106,9 @@ class DagBag(LoggingMixin):
 
         if include_examples is NOTSET:
             include_examples = conf.getboolean('core', 'LOAD_EXAMPLES')
+
+        if safe_mode is NOTSET:
+            safe_mode = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE')
 
         if store_serialized_dags:
             warnings.warn(

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -104,11 +104,14 @@ class DagBag(LoggingMixin):
 
         super().__init__()
 
-        if include_examples is NOTSET:
-            include_examples = conf.getboolean('core', 'LOAD_EXAMPLES')
-
-        if safe_mode is NOTSET:
-            safe_mode = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE')
+        include_examples = (
+            include_examples
+            if isinstance(include_examples, bool)
+            else conf.getboolean('core', 'LOAD_EXAMPLES')
+        )
+        safe_mode = (
+            safe_mode if isinstance(safe_mode, bool) else conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE')
+        )
 
         if store_serialized_dags:
             warnings.warn(

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -54,6 +54,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.retries import MAX_DB_RETRIES, run_with_db_retries
 from airflow.utils.session import provide_session
 from airflow.utils.timeout import timeout
+from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
     import pathlib
@@ -92,7 +93,7 @@ class DagBag(LoggingMixin):
     def __init__(
         self,
         dag_folder: str | pathlib.Path | None = None,
-        include_examples: bool = conf.getboolean('core', 'LOAD_EXAMPLES'),
+        include_examples: bool = NOTSET,
         safe_mode: bool = conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
         read_dags_from_db: bool = False,
         store_serialized_dags: bool | None = None,
@@ -102,6 +103,9 @@ class DagBag(LoggingMixin):
         from airflow.models.dag import DAG
 
         super().__init__()
+
+        if include_examples is NOTSET:
+            include_examples = conf.getboolean('core', 'LOAD_EXAMPLES')
 
         if store_serialized_dags:
             warnings.warn(

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -24,6 +24,7 @@ import pytest
 from airflow import models
 from airflow.cli import cli_parser
 from airflow.executors import celery_executor, celery_kubernetes_executor
+from tests.test_utils.config import conf_vars
 
 # Create custom executors here because conftest is imported first
 custom_executor_module = type(sys)('custom_executor')
@@ -34,6 +35,12 @@ custom_executor_module.CustomCeleryKubernetesExecutor = type(  # type: ignore
     'CustomCeleryKubernetesExecutor', (celery_kubernetes_executor.CeleryKubernetesExecutor,), {}
 )
 sys.modules['custom_executor'] = custom_executor_module
+
+
+@pytest.fixture(autouse=True)
+def load_examples():
+    with conf_vars({('core', 'load_examples'): 'True'}):
+        yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -104,6 +104,12 @@ def dagbag():
     return DagBag(read_dags_from_db=True)
 
 
+@pytest.fixture
+def load_examples():
+    with conf_vars({('core', 'load_examples'): 'True'}):
+        yield
+
+
 @pytest.mark.usefixtures("disable_load_example")
 @pytest.mark.need_serialized_dag
 class TestSchedulerJob:
@@ -4014,7 +4020,7 @@ class TestSchedulerJob:
 
             self.scheduler_job.executor.callback_sink.send.assert_not_called()
 
-    def test_find_zombies(self):
+    def test_find_zombies(self, load_examples):
         dagbag = DagBag(TEST_DAG_FOLDER, read_dags_from_db=False)
         with create_session() as session:
             session.query(LocalTaskJob).delete()
@@ -4072,7 +4078,7 @@ class TestSchedulerJob:
             session.query(TaskInstance).delete()
             session.query(LocalTaskJob).delete()
 
-    def test_zombie_message(self):
+    def test_zombie_message(self, load_examples):
         """
         Check that the zombie message comes out as expected
         """


### PR DESCRIPTION
Add fixture for CLI tests requiring sample dags

I noticed that various CLI tests were failing (specifically in test_task_command.py) when run locally but not when run in breeze.  I figured out the cause is that breeze has ('core', 'load_examples') set to true but I had it false locally.  To fix this we can add a fixture that patches the conf settings.  But we have to go one step further.  If we grab the conf value in the default for the argument in DagBag, this means the value is fixed at the time the class gets defined.  So the value cannot be changed later in runtime!  The solution is to resolve the default on the fly each time an instance is created.