### PR TITLE
reverting json setting to use json_encoder despite warnings

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -109,7 +109,7 @@ def create_app(config=None, testing=False):
         flask_app.config['SQLALCHEMY_ENGINE_OPTIONS'] = settings.prepare_engine_args()
 
     # Configure the JSON encoder used by `|tojson` filter from Flask
-    flask_app.json_provider_class = AirflowJsonEncoder
+    flask_app.json_encoder = AirflowJsonEncoder
 
     csrf.init_app(flask_app)
 


### PR DESCRIPTION
closes: [26527](https://github.com/apache/airflow/issues/26527)

The `flask_app.json_provider_class` does not take a JsonEncoder as an argument. Reverting the setting to `flask_app.json_encoder` despite deprecation warnings until a provider can be written. 

