### PR TITLE
fix WSGI root app

### DIFF
--- a/airflow/www/extensions/init_wsgi_middlewares.py
+++ b/airflow/www/extensions/init_wsgi_middlewares.py
@@ -26,7 +26,7 @@ from airflow.configuration import conf
 
 
 def _root_app(_, resp):
-    resp(b'404 Not Found', [('Content-Type', 'text/plain')])
+    resp('404 Not Found', [('Content-Type', 'text/plain')])
     return [b'Apache Airflow is not at this location']
 
 

--- a/airflow/www/extensions/init_wsgi_middlewares.py
+++ b/airflow/www/extensions/init_wsgi_middlewares.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Iterable
 from urllib.parse import urlparse
 
 from flask import Flask
@@ -24,22 +26,24 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from airflow.configuration import conf
 
+if TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse, WSGIEnvironment
 
-def _root_app(_, resp):
+
+def _root_app(env: WSGIEnvironment, resp: StartResponse) -> Iterable[bytes]:
     resp('404 Not Found', [('Content-Type', 'text/plain')])
     return [b'Apache Airflow is not at this location']
 
 
-def init_wsgi_middleware(flask_app: Flask):
+def init_wsgi_middleware(flask_app: Flask) -> None:
     """Handle X-Forwarded-* headers and base_url support"""
     # Apply DispatcherMiddleware
     base_url = urlparse(conf.get('webserver', 'base_url'))[2]
     if not base_url or base_url == '/':
         base_url = ""
     if base_url:
-        flask_app.wsgi_app = DispatcherMiddleware(  # type: ignore
-            _root_app, mounts={base_url: flask_app.wsgi_app}  # type: ignore
-        )
+        wsgi_app = DispatcherMiddleware(_root_app, mounts={base_url: flask_app.wsgi_app})
+        flask_app.wsgi_app = wsgi_app  # type: ignore[assignment]
 
     # Apply ProxyFix middleware
     if conf.getboolean('webserver', 'ENABLE_PROXY_FIX'):


### PR DESCRIPTION
The `start_response()` callable expects a string in argument `status`. See <https://peps.python.org/pep-0333/#the-start-response-callable>.

Signed-off-by: Steffen Prohaska <prohaska@zib.de>
