### PR TITLE
Correctly set json_provider_class on Flask app so it uses our encoder

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -32,7 +32,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException, RemovedInAirflow3Warning
 from airflow.logging_config import configure_logging
 from airflow.models import import_all_models
-from airflow.utils.json import AirflowJsonEncoder
+from airflow.utils.json import AirflowJsonProvider
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
 from airflow.www.extensions.init_dagbag import init_dagbag
@@ -109,7 +109,8 @@ def create_app(config=None, testing=False):
         flask_app.config['SQLALCHEMY_ENGINE_OPTIONS'] = settings.prepare_engine_args()
 
     # Configure the JSON encoder used by `|tojson` filter from Flask
-    flask_app.json_provider_class = AirflowJsonEncoder
+    flask_app.json_provider_class = AirflowJsonProvider
+    flask_app.json = AirflowJsonProvider(flask_app)
 
     csrf.init_app(flask_app)
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -24,7 +24,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import sqlalchemy as sqla
-from flask import Response, request, url_for
+from flask import request, url_for
 from flask.helpers import flash
 from flask_appbuilder.forms import FieldConverter
 from flask_appbuilder.models.filters import BaseFilter
@@ -47,7 +47,6 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.utils import timezone
 from airflow.utils.code_utils import get_python_source
 from airflow.utils.helpers import alchemy_to_dict
-from airflow.utils.json import AirflowJsonEncoder
 from airflow.utils.state import State, TaskInstanceState
 from airflow.www.forms import DateTimeWithTimezoneField
 from airflow.www.widgets import AirflowDateTimePickerWidget
@@ -320,13 +319,6 @@ def generate_pages(current_page, num_of_pages, search=None, status=None, tags=No
 def epoch(dttm):
     """Returns an epoch-type date (tuple with no timezone)"""
     return (int(time.mktime(dttm.timetuple())) * 1000,)
-
-
-def json_response(obj):
-    """Returns a json response from a json serializable python object"""
-    return Response(
-        response=json.dumps(obj, indent=4, cls=AirflowJsonEncoder), status=200, mimetype="application/json"
-    )
 
 
 def make_cache_key(*args, **kwargs):

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -240,3 +240,13 @@ class TestFlaskCli:
 
         output = capsys.readouterr()
         assert "/login/" in output.out
+
+
+def test_app_can_json_serialize_k8s_pod():
+    # This is mostly testing that we have correctly configured the JSON provider to use. Testing the k8s pos
+    # is a side-effect of that.
+    k8s = pytest.importorskip('kubernetes.client.models')
+
+    pod = k8s.V1Pod(spec=k8s.V1PodSpec(containers=[k8s.V1Container(name="base")]))
+    app = application.cached_app(testing=True)
+    assert app.json.dumps(pod) == '{"spec": {"containers": [{"name": "base"}]}}'


### PR DESCRIPTION
Setting `json_provider_class` where we did had no effect, as it turns out `Flask()` sets `self.json = self.json_provider_class(self)`, so we were setting it too late to take any affect.

Closes #26546, #26527