### PR TITLE
Fix grid view log try numbers

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.test.tsx
@@ -85,7 +85,7 @@ describe('Test Logs Component.', () => {
       dagRunId: 'dummyDagRunId',
       fullContent: false,
       taskId: 'dummyTaskId',
-      taskTryNumber: 1,
+      taskTryNumber: 2,
     });
   });
 
@@ -146,7 +146,7 @@ describe('Test Logs Component.', () => {
       fullContent: false,
       mapIndex: 1,
       taskId: 'dummyTaskId',
-      taskTryNumber: 1,
+      taskTryNumber: 2,
     });
   });
 
@@ -172,18 +172,18 @@ describe('Test Logs Component.', () => {
       dagRunId: 'dummyDagRunId',
       fullContent: false,
       taskId: 'dummyTaskId',
-      taskTryNumber: 1,
+      taskTryNumber: 2,
     });
-    const attemptButton2 = getByTestId('log-attempt-select-button-2');
+    const attemptButton1 = getByTestId('log-attempt-select-button-1');
 
-    fireEvent.click(attemptButton2);
+    fireEvent.click(attemptButton1);
 
     expect(useTaskLogMock).toHaveBeenLastCalledWith({
       dagId: 'dummyDagId',
       dagRunId: 'dummyDagRunId',
       fullContent: false,
       taskId: 'dummyTaskId',
-      taskTryNumber: 2,
+      taskTryNumber: 1,
     });
   });
 
@@ -203,7 +203,7 @@ describe('Test Logs Component.', () => {
       dagRunId: 'dummyDagRunId',
       fullContent: false,
       taskId: 'dummyTaskId',
-      taskTryNumber: 1,
+      taskTryNumber: 2,
     });
     const fullContentCheckbox = getByTestId('full-content-checkbox');
 
@@ -214,7 +214,7 @@ describe('Test Logs Component.', () => {
       dagRunId: 'dummyDagRunId',
       fullContent: true,
       taskId: 'dummyTaskId',
-      taskTryNumber: 1,
+      taskTryNumber: 2,
     });
   });
 });

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -61,13 +61,12 @@ const getLinkIndexes = (tryNumber: number | undefined): Array<Array<number>> => 
   const externalIndexes: Array<number> = [];
 
   if (tryNumber) {
-    [...Array(tryNumber + 1 || 0)].forEach((_, index) => {
-      if (index === 0 && tryNumber < 2) return;
-      const isExternal = index !== 0 && showExternalLogRedirect;
-      if (isExternal) {
-        externalIndexes.push(index);
+    [...Array(tryNumber)].forEach((_, index) => {
+      const tryNum = index + 1;
+      if (showExternalLogRedirect) {
+        externalIndexes.push(tryNum);
       } else {
-        internalIndexes.push(index);
+        internalIndexes.push(tryNum);
       }
     });
   }
@@ -99,12 +98,13 @@ const Logs = ({
   tryNumber,
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
-  const [selectedAttempt, setSelectedAttempt] = useState(1);
+  const [manuallySelectedAttempt, setSelectedAttempt] = useState<number | undefined>();
   const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
   const [wrap, setWrap] = useState(getMetaValue('default_wrap') === 'True');
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
   const { timezone } = useTimezone();
+  const selectedAttempt = manuallySelectedAttempt || tryNumber || 1;
   const { data, isSuccess } = useTaskLog({
     dagId,
     dagRunId,
@@ -144,8 +144,8 @@ const Logs = ({
   useEffect(() => {
     // Reset fileSourceFilters and selected attempt when changing to
     // a task that do not have those filters anymore.
-    if (!internalIndexes.includes(selectedAttempt) && internalIndexes.length) {
-      setSelectedAttempt(internalIndexes[0]);
+    if (selectedAttempt > (tryNumber || 1)) {
+      setSelectedAttempt(undefined);
     }
 
     if (data && fileSourceFilters.length > 0
@@ -155,7 +155,7 @@ const Logs = ({
       )) {
       setFileSourceFilters([]);
     }
-  }, [data, internalIndexes, fileSourceFilters, fileSources, selectedAttempt]);
+  }, [data, fileSourceFilters, fileSources, selectedAttempt, tryNumber]);
 
   return (
     <>

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -98,19 +98,21 @@ const Logs = ({
   tryNumber,
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
-  const [manuallySelectedAttempt, setSelectedAttempt] = useState<number | undefined>();
+  const [selectedTryNumber, setSelectedTryNumber] = useState<number | undefined>();
   const [shouldRequestFullContent, setShouldRequestFullContent] = useState(false);
   const [wrap, setWrap] = useState(getMetaValue('default_wrap') === 'True');
   const [logLevelFilters, setLogLevelFilters] = useState<Array<LogLevelOption>>([]);
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
   const { timezone } = useTimezone();
-  const selectedAttempt = manuallySelectedAttempt || tryNumber || 1;
+
+  //
+  const taskTryNumber = selectedTryNumber || tryNumber || 1;
   const { data, isSuccess } = useTaskLog({
     dagId,
     dagRunId,
     taskId,
     mapIndex,
-    taskTryNumber: selectedAttempt,
+    taskTryNumber,
     fullContent: shouldRequestFullContent,
   });
 
@@ -144,8 +146,8 @@ const Logs = ({
   useEffect(() => {
     // Reset fileSourceFilters and selected attempt when changing to
     // a task that do not have those filters anymore.
-    if (selectedAttempt > (tryNumber || 1)) {
-      setSelectedAttempt(undefined);
+    if (taskTryNumber > (tryNumber || 1)) {
+      setSelectedTryNumber(undefined);
     }
 
     if (data && fileSourceFilters.length > 0
@@ -155,7 +157,7 @@ const Logs = ({
       )) {
       setFileSourceFilters([]);
     }
-  }, [data, fileSourceFilters, fileSources, selectedAttempt, tryNumber]);
+  }, [data, fileSourceFilters, fileSources, taskTryNumber, tryNumber]);
 
   return (
     <>
@@ -167,9 +169,9 @@ const Logs = ({
               {internalIndexes.map((index) => (
                 <Button
                   key={index}
-                  variant={selectedAttempt === index ? 'solid' : 'ghost'}
+                  variant={taskTryNumber === index ? 'solid' : 'ghost'}
                   colorScheme="blue"
-                  onClick={() => setSelectedAttempt(index)}
+                  onClick={() => setSelectedTryNumber(index)}
                   data-testid={`log-attempt-select-button-${index}`}
                 >
                   {index}


### PR DESCRIPTION
The try numbers shown in the grid view logs were showing an extra count and just not consistent with how the regular logs page works.

Fixes https://github.com/apache/airflow/issues/26194#issuecomment-1249183346
Other fixes:
- Default selection to the latest try number
- Count try number at 1 instead of 0



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
