### PR TITLE
Mount dags folder to /root/airflow/dags/ in Breeze

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,8 @@ pip-wheel-metadata
 .pypirc
 
 /.docs-venv
+# Dags
+/dags
 
 # Dev files
 /dev/packages.txt

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -87,6 +87,7 @@ VOLUMES_FOR_SELECTED_MOUNTS = [
     ("airflow", "/opt/airflow/airflow"),
     ("provider_packages", "/opt/airflow/provider_packages"),
     ("dags", "/opt/airflow/dags"),
+    ("dags", "/root/airflow/dags"),
     ("dev", "/opt/airflow/dev"),
     ("docs", "/opt/airflow/docs"),
     ("generated", "/opt/airflow/generated"),

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -76,6 +76,9 @@ services:
         source: ../../../dags
         target: /opt/airflow/dags
       - type: bind
+        source: ../../../dags
+        target: /root/airflow/dags
+      - type: bind
         source: ../../../dev
         target: /opt/airflow/dev
       - type: bind


### PR DESCRIPTION
The dags folder should be mounted also to /root/airflow/dags, not only to /opt/airflow/dags

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
