### PR TITLE
Fix error message on gcs.py

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -328,7 +328,7 @@ class GCSHook(GoogleBaseHook):
                     self.log.error(
                         'Download attempt of object: %s from %s has failed. Attempt: %s, max %s.',
                         object_name,
-                        object_name,
+                        bucket_name,
                         num_file_attempts,
                         num_max_attempts,
                     )


### PR DESCRIPTION
No bucket name information is given in log messages

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
