### PR TITLE
Grid, fix 404 taskInstance errors

### DIFF
--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -25,7 +25,7 @@ import {
   Tbody,
   Tr,
   Td,
-  Heading,
+  Divider,
 } from '@chakra-ui/react';
 
 import { finalStatesMap } from 'src/utils';
@@ -34,8 +34,8 @@ import { SimpleStatus } from 'src/dag/StatusBox';
 import Time from 'src/components/Time';
 import { ClipboardText } from 'src/components/Clipboard';
 import type { Task, TaskInstance, TaskState } from 'src/types';
+import useTaskInstance from 'src/api/useTaskInstance';
 import DatasetUpdateEvents from './DatasetUpdateEvents';
-import useTaskInstance from '../../../api/useTaskInstance';
 
 interface Props {
   instance: TaskInstance;
@@ -57,15 +57,20 @@ const Details = ({ instance, group, dagId }: Props) => {
     mapIndex,
   } = instance;
 
-  const { data: apiTI } = useTaskInstance({
-    dagId, dagRunId: runId, taskId, mapIndex, enabled: true,
-  });
   const {
     isMapped,
     tooltip,
     operator,
     hasOutletDatasets,
   } = group;
+
+  const { data: apiTI } = useTaskInstance({
+    dagId,
+    dagRunId: runId,
+    taskId,
+    mapIndex,
+    enabled: !isGroup && !isMapped,
+  });
 
   const numMap = finalStatesMap();
   let numMapped = 0;
@@ -109,21 +114,12 @@ const Details = ({ instance, group, dagId }: Props) => {
   const isOverall = (isMapped || isGroup) && 'Overall ';
   return (
     <Flex flexWrap="wrap" justifyContent="space-between">
-      <Table variant="striped">
-        <Tbody>
-          {tooltip && (
-            <Tr>
-              <Td colSpan={2}>{tooltip}</Td>
-            </Tr>
-          )}
-          {state === 'deferred' && (
-            <>
-              <Tr borderBottomWidth={2} borderBottomColor="gray.300">
-                <Td>
-                  <Heading size="sm">Triggerer info</Heading>
-                </Td>
-                <Td />
-              </Tr>
+      {state === 'deferred' && (
+        <>
+          <Text as="strong">Triggerer info</Text>
+          <Divider my={2} />
+          <Table variant="striped" mb={3}>
+            <Tbody>
               <Tr>
                 <Td>Trigger class</Td>
                 <Td>{`${apiTI?.trigger?.classpath}`}</Td>
@@ -140,17 +136,20 @@ const Details = ({ instance, group, dagId }: Props) => {
                 <Td>Latest triggerer heartbeat</Td>
                 <Td>{`${apiTI?.triggererJob?.latestHeartbeat}`}</Td>
               </Tr>
-            </>
+            </Tbody>
+          </Table>
+        </>
+      )}
+
+      <Text as="strong">Task Instance Details</Text>
+      <Divider my={2} />
+      <Table variant="striped">
+        <Tbody>
+          {tooltip && (
+            <Tr>
+              <Td colSpan={2}>{tooltip}</Td>
+            </Tr>
           )}
-          <Tr
-            borderBottomWidth={2}
-            borderBottomColor="gray.300"
-          >
-            <Td>
-              <Heading size="sm">Task Instance Details</Heading>
-            </Td>
-            <Td />
-          </Tr>
           <Tr>
             <Td>
               {isOverall}
@@ -173,16 +172,20 @@ const Details = ({ instance, group, dagId }: Props) => {
               </Td>
             </Tr>
           )}
-          {summary.length > 0 && (
-            summary
-          )}
+          {summary.length > 0 && summary}
           <Tr>
             <Td>{taskIdTitle}</Td>
-            <Td><ClipboardText value={taskId} /></Td>
+            <Td>
+              <ClipboardText value={taskId} />
+            </Td>
           </Tr>
           <Tr>
             <Td>Run ID</Td>
-            <Td><Text whiteSpace="nowrap"><ClipboardText value={runId} /></Text></Td>
+            <Td>
+              <Text whiteSpace="nowrap">
+                <ClipboardText value={runId} />
+              </Text>
+            </Td>
           </Tr>
           {mapIndex !== undefined && (
             <Tr>
@@ -206,13 +209,17 @@ const Details = ({ instance, group, dagId }: Props) => {
           {startDate && (
             <Tr>
               <Td>Started</Td>
-              <Td><Time dateTime={startDate} /></Td>
+              <Td>
+                <Time dateTime={startDate} />
+              </Td>
             </Tr>
           )}
           {endDate && isStateFinal && (
             <Tr>
               <Td>Ended</Td>
-              <Td><Time dateTime={endDate} /></Td>
+              <Td>
+                <Time dateTime={endDate} />
+              </Td>
             </Tr>
           )}
         </Tbody>

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -190,14 +190,14 @@ const TaskInstance = ({
           {/* Mapped Task Instances Tab */}
           {
             isMappedTaskSummary && (
-            <TabPanel>
-              <MappedInstances
-                dagId={dagId}
-                runId={runId}
-                taskId={taskId}
-                onRowClicked={(row) => onSelect({ runId, taskId, mapIndex: row.values.mapIndex })}
-              />
-            </TabPanel>
+              <TabPanel>
+                <MappedInstances
+                  dagId={dagId}
+                  runId={runId}
+                  taskId={taskId}
+                  onRowClicked={(row) => onSelect({ runId, taskId, mapIndex: row.values.mapIndex })}
+                />
+              </TabPanel>
             )
           }
         </TabPanels>


### PR DESCRIPTION
~~We had a few warnings due to `validateDOMNesting` in the grid view (cf screenshot) -> split the table into two distinct tables with separate 'titles'. Took the opportunity to slightly improve spacing between the tables.~~ (fixed in https://github.com/apache/airflow/pull/26551)
![image](https://user-images.githubusercontent.com/14861206/191604630-dfa73c4c-c166-484c-bb96-6c39d34333c8.png)
![image](https://user-images.githubusercontent.com/14861206/191604666-2ff223ba-edef-474c-bcce-327519adb5f4.png)


We also had a few 404 errors when requesting the `useTaskInstance` for groups, by clicking on the details of a task group. (cf screenshot):
![image](https://user-images.githubusercontent.com/14861206/191604775-fcf13369-9743-456c-ba4c-0e555b3cb131.png)

