### PR TITLE
Add oracledb thick mode support for oracle provider

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import math
 import warnings
 from datetime import datetime
+from typing import Any
 
 import oracledb
 
@@ -49,42 +50,8 @@ class OracleHook(DbApiHook):
 
     :param oracle_conn_id: The :ref:`Oracle connection id <howto/connection:oracle>`
         used for Oracle credentials.
-    """
 
-    conn_name_attr = 'oracle_conn_id'
-    default_conn_name = 'oracle_default'
-    conn_type = 'oracle'
-    hook_name = 'Oracle'
-
-    supports_autocommit = True
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        if self.oracle_conn_id is not None:
-            conn = self.get_connection(self.oracle_conn_id)
-            if conn.extra is not None:
-                extra_options = conn.extra_dejson
-
-                # Check if thick_mode should be enabled in python-oracledb
-                thick_mode = extra_options.get('thick_mode', False)
-                if not isinstance(thick_mode, bool):
-                    raise AirflowException(f'thick_mode should be a boolean but type was {type(thick_mode)}')
-                if thick_mode:
-                    thick_mode_lib_dir = extra_options.get('thick_mode_lib_dir')
-                    thick_mode_config_dir = extra_options.get('thick_mode_config_dir')
-                    oracledb.init_oracle_client(lib_dir=thick_mode_lib_dir, config_dir=thick_mode_config_dir)
-
-                # Check if python-oracledb Defaults attributes should be set
-                # Values default to the initial values used by python-oracledb
-                fetch_decimals = extra_options.get('fetch_decimals', False)
-                oracledb.defaults.fetch_decimals = fetch_decimals
-                fetch_lobs = extra_options.get('fetch_lobs', True)
-                oracledb.defaults.fetch_lobs = fetch_lobs
-
-    def get_conn(self) -> oracledb.Connection:
-        """
-        Returns a oracle connection object
-        Optional parameters for using a custom DSN connection
+    Optional parameters for using a custom DSN connection
         (instead of using a server alias from tnsnames.ora)
         The dsn (data source name) is the TNS entry
         (from the Oracle names server or tnsnames.ora file)
@@ -105,76 +72,179 @@ class OracleHook(DbApiHook):
 
         see more param detail in `oracledb.connect
         <https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html#oracledb.connect>`_
+    """
 
+    conn_name_attr = 'oracle_conn_id'
+    default_conn_name = 'oracle_default'
+    conn_type = 'oracle'
+    hook_name = 'Oracle'
 
-        """
-        conn = self.get_connection(self.oracle_conn_id)  # type: ignore[attr-defined]
-        conn_config = {'user': conn.login, 'password': conn.password}
-        sid = conn.extra_dejson.get('sid')
-        mod = conn.extra_dejson.get('module')
-        schema = conn.schema
+    supports_autocommit = True
 
-        service_name = conn.extra_dejson.get('service_name')
-        port = conn.port if conn.port else 1521
-        if conn.host and sid and not service_name:
-            conn_config['dsn'] = oracledb.makedsn(conn.host, port, sid)
-        elif conn.host and service_name and not sid:
-            conn_config['dsn'] = oracledb.makedsn(conn.host, port, service_name=service_name)
+    def __init__(
+        self,
+        oracle_conn_id: str | None = 'oracle_default',
+        host: str | None = None,
+        schema: str | None = None,
+        login: str | None = None,
+        password: str | None = None,
+        sid: str | None = None,
+        mod: str | None = None,
+        service_name: str | None = None,
+        port: int = 1521,
+        dsn: str | None = None,
+        events: bool = False,
+        mode: int = oracledb.AUTH_MODE_DEFAULT,
+        purity: int = oracledb.PURITY_DEFAULT,
+        threaded: bool = True,
+        thick_mode: bool = False,
+        thick_mode_lib_dir: str | None = None,
+        thick_mode_config_dir: str | None = None,
+        fetch_decimals: bool = False,
+        fetch_lobs: bool = True,
+        *args,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.oracle_conn_id = oracle_conn_id
+        self.host = host
+        self.schema = schema
+        self.login = login
+        self.password = password
+        self.sid = sid
+        self.mod = mod
+        self.service_name = service_name
+        self.port = port
+        self.dsn = dsn
+        self.events = events
+        self.mode = mode
+        self.purity = purity
+        self.threaded = threaded
+        self.thick_mode = thick_mode
+        self.thick_mode_lib_dir = thick_mode_lib_dir
+        self.thick_mode_config_dir = thick_mode_config_dir
+        self.fetch_decimals = fetch_decimals
+        self.fetch_lobs = fetch_lobs
+
+        self.conn_config: dict[str, Any] = {}
+
+        # Use connection to override defaults
+        if self.oracle_conn_id is not None:
+            conn = self.get_connection(self.oracle_conn_id)
+            self.host = conn.host if conn.host else self.host
+            self.login = conn.login if conn.login else self.login
+            self.password = conn.password if conn.password else self.password
+            self.port = conn.port if conn.port else self.port
+            self.schema = conn.schema if conn.schema else self.schema
+
+            if conn.extra is not None:
+                extra_options = conn.extra_dejson
+
+                sid = extra_options.get('sid')
+                self.sid = sid if sid else self.sid
+
+                mod = extra_options.get('mod')
+                self.mod = mod if mod else self.mod
+
+                service_name = extra_options.get('service_name')
+                self.service_name = service_name if service_name else self.service_name
+
+                dsn = extra_options.get('dsn')
+                self.dsn = dsn if dsn else self.dsn
+
+                events = extra_options.get('events')
+                self.events = events if events is not None else self.events
+
+                threaded = extra_options.get('threaded')
+                self.threaded = threaded if threaded is not None else self.threaded
+
+                mode = extra_options.get('mode', '').lower()
+                if mode == 'sysdba':
+                    self.mode = oracledb.AUTH_MODE_SYSDBA
+                elif mode == 'sysasm':
+                    self.mode = oracledb.AUTH_MODE_SYSASM
+                elif mode == 'sysoper':
+                    self.mode = oracledb.AUTH_MODE_SYSOPER
+                elif mode == 'sysbkp':
+                    self.mode = oracledb.AUTH_MODE_SYSBKP
+                elif mode == 'sysdgd':
+                    self.mode = oracledb.AUTH_MODE_SYSDGD
+                elif mode == 'syskmt':
+                    self.mode = oracledb.AUTH_MODE_SYSKMT
+                elif mode == 'sysrac':
+                    self.mode = oracledb.AUTH_MODE_SYSRAC
+
+                purity = extra_options.get('purity', '').lower()
+                if purity == 'new':
+                    self.purity = oracledb.PURITY_NEW
+                elif purity == 'self':
+                    self.purity = oracledb.PURITY_SELF
+                elif purity == 'default':
+                    self.purity = oracledb.PURITY_DEFAULT
+
+                # Check if thick_mode should be enabled in python-oracledb
+                thick_mode = extra_options.get('thick_mode')
+                self.thick_mode = thick_mode if thick_mode is not None else self.thick_mode
+                if not isinstance(self.thick_mode, bool):
+                    raise AirflowException(
+                        f'thick_mode should be a boolean but type was {type(self.thick_mode)}'
+                    )
+                if self.thick_mode:
+                    thick_mode_lib_dir = extra_options.get('thick_mode_lib_dir')
+                    thick_mode_config_dir = extra_options.get('thick_mode_config_dir')
+                    oracledb.init_oracle_client(lib_dir=thick_mode_lib_dir, config_dir=thick_mode_config_dir)
+
+                # Check if python-oracledb Defaults attributes should be set
+                # Values default to the initial values used by python-oracledb
+                fetch_decimals = extra_options.get('fetch_decimals')
+                self.fetch_decimals = fetch_decimals if fetch_decimals is not None else self.fetch_decimals
+                oracledb.defaults.fetch_decimals = self.fetch_decimals
+                fetch_lobs = extra_options.get('fetch_lobs')
+                self.fetch_lobs = fetch_lobs if fetch_lobs is not None else self.fetch_lobs
+                oracledb.defaults.fetch_lobs = self.fetch_lobs
+
+        self.conn_config['user'] = self.login
+        self.conn_config['password'] = self.password
+        self.conn_config['events'] = self.events
+        self.conn_config['mode'] = self.mode
+        self.conn_config['purity'] = self.purity
+        self.conn_config['threaded'] = self.threaded
+
+        if self.host and self.sid and not self.service_name:
+            self.conn_config['dsn'] = oracledb.makedsn(self.host, self.port, self.sid)
+        elif self.host and self.service_name and not self.sid:
+            self.conn_config['dsn'] = oracledb.makedsn(self.host, self.port, service_name=self.service_name)
         else:
-            dsn = conn.extra_dejson.get('dsn')
-            if dsn is None:
-                dsn = conn.host
-                if conn.port is not None:
-                    dsn += ":" + str(conn.port)
-                if service_name:
-                    dsn += "/" + service_name
-                elif conn.schema:
+            if self.dsn is None:
+                dsn = str(self.host) if self.host is not None else ''
+                if self.port is not None:
+                    dsn += ":" + str(self.port)
+                if self.service_name:
+                    dsn += "/" + str(service_name)
+                elif self.schema:
                     warnings.warn(
                         """Using conn.schema to pass the Oracle Service Name is deprecated.
                         Please use conn.extra.service_name instead.""",
                         DeprecationWarning,
                         stacklevel=2,
                     )
-                    dsn += "/" + conn.schema
-            conn_config['dsn'] = dsn
+                    dsn += "/" + self.schema
+                self.dsn = dsn if dsn else self.dsn
+            self.conn_config['dsn'] = self.dsn
 
-        if 'events' in conn.extra_dejson:
-            conn_config['events'] = conn.extra_dejson.get('events')
-
-        mode = conn.extra_dejson.get('mode', '').lower()
-        if mode == 'sysdba':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSDBA
-        elif mode == 'sysasm':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSASM
-        elif mode == 'sysoper':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSOPER
-        elif mode == 'sysbkp':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSBKP
-        elif mode == 'sysdgd':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSDGD
-        elif mode == 'syskmt':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSKMT
-        elif mode == 'sysrac':
-            conn_config['mode'] = oracledb.AUTH_MODE_SYSRAC
-
-        purity = conn.extra_dejson.get('purity', '').lower()
-        if purity == 'new':
-            conn_config['purity'] = oracledb.PURITY_NEW
-        elif purity == 'self':
-            conn_config['purity'] = oracledb.PURITY_SELF
-        elif purity == 'default':
-            conn_config['purity'] = oracledb.PURITY_DEFAULT
-
-        conn = oracledb.connect(**conn_config)
-        if mod is not None:
-            conn.module = mod
+    def get_conn(self) -> oracledb.Connection:
+        """Returns a oracle connection object"""
+        conn = oracledb.connect(**self.conn_config)
+        if self.mod is not None:
+            conn.module = self.mod
 
         # if Connection.schema is defined, set schema after connecting successfully
         # cannot be part of conn_config
         # https://python-oracledb.readthedocs.io/en/latest/api_manual/connection.html?highlight=schema#Connection.current_schema
         # Only set schema when not using conn.schema as Service Name
-        if schema and service_name:
-            conn.current_schema = schema
+        if self.schema and self.service_name:
+            conn.current_schema = self.schema
 
         return conn
 

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -96,7 +96,6 @@ class OracleHook(DbApiHook):
         events: bool = False,
         mode: int = oracledb.AUTH_MODE_DEFAULT,
         purity: int = oracledb.PURITY_DEFAULT,
-        threaded: bool = True,
         thick_mode: bool = False,
         thick_mode_lib_dir: str | None = None,
         thick_mode_config_dir: str | None = None,
@@ -120,7 +119,6 @@ class OracleHook(DbApiHook):
         self.events = events
         self.mode = mode
         self.purity = purity
-        self.threaded = threaded
         self.thick_mode = thick_mode
         self.thick_mode_lib_dir = thick_mode_lib_dir
         self.thick_mode_config_dir = thick_mode_config_dir
@@ -155,9 +153,6 @@ class OracleHook(DbApiHook):
 
                 events = extra_options.get('events')
                 self.events = events if events is not None else self.events
-
-                threaded = extra_options.get('threaded')
-                self.threaded = threaded if threaded is not None else self.threaded
 
                 mode = extra_options.get('mode', '').lower()
                 if mode == 'sysdba':
@@ -209,7 +204,6 @@ class OracleHook(DbApiHook):
         self.conn_config['events'] = self.events
         self.conn_config['mode'] = self.mode
         self.conn_config['purity'] = self.purity
-        self.conn_config['threaded'] = self.threaded
 
         if self.host and self.sid and not self.service_name:
             self.conn_config['dsn'] = oracledb.makedsn(self.host, self.port, self.sid)

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -139,11 +139,23 @@ class OracleHook(DbApiHook):
         # Defaults to False (use thin mode) if not provided in params or connection config extra
         if self.thick_mode is None:
             self.thick_mode = conn.extra_dejson.get('thick_mode', False)
+            if not isinstance(self.thick_mode, bool):
+                raise TypeError(f'thick_mode expected bool, got {type(self.thick_mode).__name__}')
         if self.thick_mode:
             if self.thick_mode_lib_dir is None:
                 self.thick_mode_lib_dir = conn.extra_dejson.get('thick_mode_lib_dir')
+                if not isinstance(self.thick_mode_lib_dir, (str, type(None))):
+                    raise TypeError(
+                        f'thick_mode_lib_dir expected str or None, '
+                        f'got {type(self.thick_mode_lib_dir).__name__}'
+                    )
             if self.thick_mode_config_dir is None:
                 self.thick_mode_config_dir = conn.extra_dejson.get('thick_mode_config_dir')
+                if not isinstance(self.thick_mode_config_dir, (str, type(None))):
+                    raise TypeError(
+                        f'thick_mode_config_dir expected str or None, '
+                        f'got {type(self.thick_mode_config_dir).__name__}'
+                    )
             oracledb.init_oracle_client(
                 lib_dir=self.thick_mode_lib_dir, config_dir=self.thick_mode_config_dir
             )
@@ -154,10 +166,14 @@ class OracleHook(DbApiHook):
         # (https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html)
         if self.fetch_decimals is None:
             self.fetch_decimals = conn.extra_dejson.get('fetch_decimals', False)
+            if not isinstance(self.fetch_decimals, bool):
+                raise TypeError(f'fetch_decimals expected bool, got {type(self.fetch_decimals).__name__}')
         oracledb.defaults.fetch_decimals = self.fetch_decimals
 
         if self.fetch_lobs is None:
             self.fetch_lobs = conn.extra_dejson.get('fetch_lobs', True)
+            if not isinstance(self.fetch_lobs, bool):
+                raise TypeError(f'fetch_lobs expected bool, got {type(self.fetch_lobs).__name__}')
         oracledb.defaults.fetch_lobs = self.fetch_lobs
 
         # Set up DSN

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -423,6 +423,18 @@ def create_default_connections(session: Session = NEW_SESSION):
     )
     merge_conn(
         Connection(
+            conn_id="oracle_default",
+            conn_type="oracle",
+            host="localhost",
+            login="root",
+            password="password",
+            schema="schema",
+            port=1521,
+        ),
+        session,
+    )
+    merge_conn(
+        Connection(
             conn_id="oss_default",
             conn_type="oss",
             extra='''{

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -67,6 +67,10 @@ Extra (optional)
     * ``thick_mode_config_dir`` (str) - Path to use to find the Oracle Client library configuration files when using thick mode.
       If not specified, defaults to the standard way of locating the Oracle Client library configuration files on the OS.
       See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#optional-oracle-net-configuration-files>` for more info.
+    * ``fetch_decimals`` (bool) - Specify whether numbers should be fetched as ``decimal.Decimal`` values.  Defaults to False.
+      See `defaults.fetch_decimals<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
+    * ``fetch_lobs`` (bool) - Specify whether to fetch strings/bytes for CLOBs or BLOBs instead of locators.  Defaults to True.
+      See `defaults.fetch_lobs<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
 
     Connect using `dsn`, Host and `sid`, Host and `service_name`, or only Host `(OracleHook.getconn Documentation) <https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/_modules/airflow/providers/oracle/hooks/oracle.html#OracleHook.get_conn>`_.
 

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -60,9 +60,9 @@ Extra (optional)
     * ``thick_mode_config_dir`` (str) - Path to use to find the Oracle Client library configuration files when using thick mode.
       If not specified, defaults to the standard way of locating the Oracle Client library configuration files on the OS.
       See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#optional-oracle-net-configuration-files>` for more info.
-    * ``fetch_decimals`` (bool) - Specify whether numbers should be fetched as ``decimal.Decimal`` values.  Defaults to False.
+    * ``fetch_decimals`` (bool) - Specify whether numbers should be fetched as ``decimal.Decimal`` values.
       See `defaults.fetch_decimals<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
-    * ``fetch_lobs`` (bool) - Specify whether to fetch strings/bytes for CLOBs or BLOBs instead of locators.  Defaults to True.
+    * ``fetch_lobs`` (bool) - Specify whether to fetch strings/bytes for CLOBs or BLOBs instead of locators.
       See `defaults.fetch_lobs<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
 
 

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -58,6 +58,15 @@ Extra (optional)
       configuration parameter.
     * ``dsn``. Specify a Data Source Name (and ignore Host).
     * ``sid`` or ``service_name``. Use to form DSN instead of Schema.
+    * ``thick_mode`` (bool) - Specify whether to use python-oracledb in thick mode. Defaults to False.
+      If set to True, you must have the Oracle Client libraries installed.
+      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html>` for more info.
+    * ``thick_mode_lib_dir`` (str) - Path to use to find the Oracle Client libraries when using thick mode.
+      If not specified, defaults to the standard way of locating the Oracle Client library on the OS.
+      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#setting-the-oracle-client-library-directory>` for more info.
+    * ``thick_mode_config_dir`` (str) - Path to use to find the Oracle Client library configuration files when using thick mode.
+      If not specified, defaults to the standard way of locating the Oracle Client library configuration files on the OS.
+      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#optional-oracle-net-configuration-files>` for more info.
 
     Connect using `dsn`, Host and `sid`, Host and `service_name`, or only Host `(OracleHook.getconn Documentation) <https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/_modules/airflow/providers/oracle/hooks/oracle.html#OracleHook.get_conn>`_.
 

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -42,8 +42,6 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Oracle
     connection. The following parameters are supported:
 
-    * ``threaded`` - Whether or not Oracle should wrap accesses to connections with a mutex.
-      Default value is False.
     * ``events`` - Whether or not to initialize Oracle in events mode.
     * ``mode`` - one of ``sysdba``, ``sysasm``, ``sysoper``, ``sysbkp``, ``sysdgd``, ``syskmt`` or ``sysrac``
       which are defined at the module level, Default mode is connecting.
@@ -102,7 +100,6 @@ Extra (optional)
     .. code-block:: json
 
        {
-          "threaded": false,
           "events": false,
           "mode": "sysdba",
           "purity": "new"

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -42,13 +42,6 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Oracle
     connection. The following parameters are supported:
 
-    * ``encoding`` - The encoding to use for regular database strings. If not specified,
-      the environment variable ``NLS_LANG`` is used. If the environment variable ``NLS_LANG``
-      is not set, ``ASCII`` is used.
-    * ``nencoding`` - The encoding to use for national character set database strings.
-      If not specified, the environment variable ``NLS_NCHAR`` is used. If the environment
-      variable ``NLS_NCHAR`` is not used, the environment variable ``NLS_LANG`` is used instead,
-      and if the environment variable ``NLS_LANG`` is not set, ``ASCII`` is used.
     * ``threaded`` - Whether or not Oracle should wrap accesses to connections with a mutex.
       Default value is False.
     * ``events`` - Whether or not to initialize Oracle in events mode.
@@ -58,6 +51,8 @@ Extra (optional)
       configuration parameter.
     * ``dsn``. Specify a Data Source Name (and ignore Host).
     * ``sid`` or ``service_name``. Use to form DSN instead of Schema.
+    * ``module`` (str) - This write-only attribute sets the module column in the v$session table.
+      The maximum length for this string is 48 and if you exceed this length you will get ORA-24960.
     * ``thick_mode`` (bool) - Specify whether to use python-oracledb in thick mode. Defaults to False.
       If set to True, you must have the Oracle Client libraries installed.
       See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html>` for more info.
@@ -71,6 +66,7 @@ Extra (optional)
       See `defaults.fetch_decimals<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
     * ``fetch_lobs`` (bool) - Specify whether to fetch strings/bytes for CLOBs or BLOBs instead of locators.  Defaults to True.
       See `defaults.fetch_lobs<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
+
 
     Connect using `dsn`, Host and `sid`, Host and `service_name`, or only Host `(OracleHook.getconn Documentation) <https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/_modules/airflow/providers/oracle/hooks/oracle.html#OracleHook.get_conn>`_.
 
@@ -106,8 +102,6 @@ Extra (optional)
     .. code-block:: json
 
        {
-          "encoding": "UTF-8",
-          "nencoding": "UTF-8",
           "threaded": false,
           "events": false,
           "mode": "sysdba",

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -242,6 +242,36 @@ class TestOracleHookConn(unittest.TestCase):
         assert oracledb.defaults.fetch_decimals is True
         assert oracledb.defaults.fetch_lobs is False
 
+    def test_type_checking_thick_mode(self):
+        with pytest.raises(TypeError, match=r"thick_mode expected bool, got.*"):
+            thick_mode_test = {'thick_mode': 'bad'}
+            self.connection.extra = json.dumps(thick_mode_test)
+            self.db_hook.get_conn()
+
+    def test_type_checking_thick_mode_lib_dir(self):
+        with pytest.raises(TypeError, match=r"thick_mode_lib_dir expected str or None, got.*"):
+            thick_mode_lib_dir_test = {'thick_mode': True, 'thick_mode_lib_dir': 1}
+            self.connection.extra = json.dumps(thick_mode_lib_dir_test)
+            self.db_hook.get_conn()
+
+    def test_type_checking_thick_mode_config_dir(self):
+        with pytest.raises(TypeError, match=r"thick_mode_config_dir expected str or None, got.*"):
+            thick_mode_config_dir_test = {'thick_mode': True, 'thick_mode_config_dir': 1}
+            self.connection.extra = json.dumps(thick_mode_config_dir_test)
+            self.db_hook.get_conn()
+
+    def test_type_checking_fetch_decimals(self):
+        with pytest.raises(TypeError, match=r"fetch_decimals expected bool, got.*"):
+            fetch_decimals_test = {'fetch_decimals': 'bad'}
+            self.connection.extra = json.dumps(fetch_decimals_test)
+            self.db_hook.get_conn()
+
+    def test_type_checking_fetch_lobs(self):
+        with pytest.raises(TypeError, match=r"fetch_lobs expected bool, got.*"):
+            fetch_lobs_test = {'fetch_lobs': 'bad'}
+            self.connection.extra = json.dumps(fetch_lobs_test)
+            self.db_hook.get_conn()
+
 
 @unittest.skipIf(oracledb is None, 'oracledb package not present')
 class TestOracleHook(unittest.TestCase):

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -144,6 +144,21 @@ class TestOracleHookConn(unittest.TestCase):
         self.connection.extra = json.dumps({'service_name': 'service_name'})
         assert self.db_hook.get_conn().current_schema == self.connection.schema
 
+    @mock.patch('airflow.providers.oracle.hooks.oracle.oracledb.init_oracle_client')
+    def test_set_thick_mode(self, mock_init_client):
+        thick_mode_test = {
+            'thick_mode': True,
+            'thick_mode_lib_dir': '/opt/oracle/instantclient',
+            'thick_mode_config_dir': '/opt/oracle/config',
+        }
+        self.connection.extra = json.dumps(thick_mode_test)
+        self.db_hook.__init__()
+        assert mock_init_client.call_count == 1
+        args, kwargs = mock_init_client.call_args
+        assert args == ()
+        assert kwargs['lib_dir'] == thick_mode_test['thick_mode_lib_dir']
+        assert kwargs['config_dir'] == thick_mode_test['thick_mode_config_dir']
+
 
 @unittest.skipIf(oracledb is None, 'oracledb package not present')
 class TestOracleHook(unittest.TestCase):
@@ -157,6 +172,7 @@ class TestOracleHook(unittest.TestCase):
 
         class UnitTestOracleHook(OracleHook):
             conn_name_attr = 'test_conn_id'
+            oracle_conn_id = None
 
             def get_conn(self):
                 return conn


### PR DESCRIPTION
closes: #24618

Adds support for oracledb thick mode in the oracle provider, along with the option to set some defaults supported by oracledb (fetch_decimals and fetch_lobs).