### PR TITLE
Remove `wait_for_completion` from documentation code snippets

### DIFF
--- a/tests/system/providers/amazon/aws/example_batch.py
+++ b/tests/system/providers/amazon/aws/example_batch.py
@@ -203,10 +203,11 @@ with DAG(
         job_queue=batch_job_queue_name,
         job_definition=batch_job_definition_name,
         overrides=JOB_OVERRIDES,
-        # Set this flag to False, so we can test the sensor below
-        wait_for_completion=False,
     )
     # [END howto_operator_batch]
+
+    # BatchOperator waits by default, setting as False to test the Sensor below.
+    submit_batch_job.wait_for_completion = False
 
     # [START howto_sensor_batch]
     wait_for_batch_job = BatchSensor(

--- a/tests/system/providers/amazon/aws/example_datasync.py
+++ b/tests/system/providers/amazon/aws/example_datasync.py
@@ -146,9 +146,11 @@ with models.DAG(
     execute_task_by_arn = DataSyncOperator(
         task_id='execute_task_by_arn',
         task_arn=created_task_arn,
-        wait_for_completion=False,
     )
     # [END howto_operator_datasync_specific_task]
+
+    # DataSyncOperator waits by default, setting as False to test the Sensor below.
+    execute_task_by_arn.wait_for_completion = False
 
     # [START howto_operator_datasync_search_task]
     # Search and execute a task
@@ -160,9 +162,11 @@ with models.DAG(
         task_execution_kwargs={
             'Includes': [{'FilterType': 'SIMPLE_PATTERN', 'Value': '/test/subdir'}],
         },
-        wait_for_completion=False,
     )
     # [END howto_operator_datasync_search_task]
+
+    # DataSyncOperator waits by default, setting as False to test the Sensor below.
+    execute_task_by_locations.wait_for_completion = False
 
     # [START howto_operator_datasync_create_task]
     # Create a task (the task does not exist)
@@ -186,9 +190,11 @@ with models.DAG(
             },
         },
         delete_task_after_execution=False,
-        wait_for_completion=False,
     )
     # [END howto_operator_datasync_create_task]
+
+    # DataSyncOperator waits by default, setting as False to test the Sensor below.
+    create_and_execute_task.wait_for_completion = False
 
     locations_task = list_locations(s3_bucket_source, s3_bucket_destination)
     delete_locations_task = delete_locations(locations_task)

--- a/tests/system/providers/amazon/aws/example_dms.py
+++ b/tests/system/providers/amazon/aws/example_dms.py
@@ -375,9 +375,9 @@ with DAG(
     delete_task = DmsDeleteTaskOperator(
         task_id='delete_task',
         replication_task_arn=task_arn,
-        trigger_rule=TriggerRule.ALL_DONE,
     )
     # [END howto_operator_dms_delete_task]
+    delete_task.trigger_rule = TriggerRule.ALL_DONE
 
     delete_assets = delete_dms_assets(
         replication_instance_arn=create_assets['replication_instance_arn'],

--- a/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
+++ b/tests/system/providers/amazon/aws/example_eks_with_nodegroup_in_one_step.py
@@ -94,11 +94,11 @@ with DAG(
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.
     delete_nodegroup_and_cluster = EksDeleteClusterOperator(
         task_id='delete_nodegroup_and_cluster',
-        trigger_rule=TriggerRule.ALL_DONE,
         cluster_name=cluster_name,
         force_delete_compute=True,
     )
     # [END howto_operator_eks_force_delete_cluster]
+    delete_nodegroup_and_cluster.trigger_rule = TriggerRule.ALL_DONE
 
     await_delete_cluster = EksClusterStateSensor(
         task_id='await_delete_cluster',

--- a/tests/system/providers/amazon/aws/example_emr_serverless.py
+++ b/tests/system/providers/amazon/aws/example_emr_serverless.py
@@ -71,9 +71,11 @@ with DAG(
         release_label='emr-6.6.0',
         job_type="SPARK",
         config={'name': 'new_application'},
-        wait_for_completion=False,
     )
     # [END howto_operator_emr_serverless_create_application]
+
+    # EmrServerlessCreateApplicationOperator waits by default, setting as False to test the Sensor below.
+    emr_serverless_app.wait_for_completion = False
 
     emr_serverless_app_id = emr_serverless_app.output
 
@@ -96,7 +98,9 @@ with DAG(
 
     # [START howto_sensor_emr_serverless_job]
     wait_for_job = EmrServerlessJobSensor(
-        task_id='wait_for_job', application_id=emr_serverless_app_id, job_run_id=start_job.output
+        task_id='wait_for_job',
+        application_id=emr_serverless_app_id,
+        job_run_id=start_job.output,
     )
     # [END howto_sensor_emr_serverless_job]
 
@@ -114,6 +118,7 @@ with DAG(
         force_delete=True,
         trigger_rule=TriggerRule.ALL_DONE,
     )
+
     chain(
         # TEST SETUP
         test_context,

--- a/tests/system/providers/amazon/aws/example_glue.py
+++ b/tests/system/providers/amazon/aws/example_glue.py
@@ -145,10 +145,11 @@ with DAG(
     crawl_s3 = GlueCrawlerOperator(
         task_id='crawl_s3',
         config=glue_crawler_config,
-        # Waits by default, set False to test the Sensor below
-        wait_for_completion=False,
     )
     # [END howto_operator_glue_crawler]
+
+    # GlueCrawlerOperator waits by default, setting as False to test the Sensor below.
+    crawl_s3.wait_for_completion = False
 
     # [START howto_sensor_glue_crawler]
     wait_for_crawl = GlueCrawlerSensor(
@@ -165,10 +166,11 @@ with DAG(
         s3_bucket=bucket_name,
         iam_role_name=role_name,
         create_job_kwargs={'GlueVersion': '3.0', 'NumberOfWorkers': 2, 'WorkerType': 'G.1X'},
-        # Waits by default, set False to test the Sensor below
-        wait_for_completion=False,
     )
     # [END howto_operator_glue]
+
+    # GlueJobOperator waits by default, setting as False to test the Sensor below.
+    submit_glue_job.wait_for_completion - False
 
     # [START howto_sensor_glue]
     wait_for_job = GlueJobSensor(

--- a/tests/system/providers/amazon/aws/example_local_to_s3.py
+++ b/tests/system/providers/amazon/aws/example_local_to_s3.py
@@ -63,7 +63,7 @@ with DAG(
     create_s3_bucket = S3CreateBucketOperator(task_id='create-s3-bucket', bucket_name=s3_bucket_name)
     # [START howto_transfer_local_to_s3]
     create_local_to_s3_job = LocalFilesystemToS3Operator(
-        task_id="create_local_to_s3_job",
+        task_id='create_local_to_s3_job',
         filename=TEMP_FILE_PATH,
         dest_key=s3_key,
         dest_bucket=s3_bucket_name,

--- a/tests/system/providers/amazon/aws/example_quicksight.py
+++ b/tests/system/providers/amazon/aws/example_quicksight.py
@@ -176,10 +176,11 @@ with DAG(
         task_id='create_ingestion',
         data_set_id=dataset_id,
         ingestion_id=ingestion_id,
-        # Waits by default, setting as False to demonstrate the Sensor below.
-        wait_for_completion=False,
     )
     # [END howto_operator_quicksight_create_ingestion]
+
+    # QuickSightCreateIngestionOperator waits by default, setting as False to test the Sensor below.
+    create_ingestion.wait_for_completion = False
 
     # If this sensor appears to freeze with a "QUEUED" status, see note above.
     # [START howto_sensor_quicksight]

--- a/tests/system/providers/amazon/aws/example_rds_export.py
+++ b/tests/system/providers/amazon/aws/example_rds_export.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -115,10 +114,11 @@ with DAG(
         s3_prefix='rds-test',
         iam_role_arn=test_context[ROLE_ARN_KEY],
         kms_key_id=test_context[KMS_KEY_ID_KEY],
-        # Waits by default, set False to test the CancelExportTaskOperator below
-        wait_for_completion=False,
     )
     # [END howto_operator_rds_start_export_task]
+
+    # RdsStartExportTaskOperator waits by default, setting as False to test the Sensor below.
+    start_export.wait_for_completion = False
 
     # [START howto_operator_rds_cancel_export]
     cancel_export = RdsCancelExportTaskOperator(

--- a/tests/system/providers/amazon/aws/example_rds_snapshot.py
+++ b/tests/system/providers/amazon/aws/example_rds_snapshot.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -256,9 +256,9 @@ with DAG(
     delete_cluster = RedshiftDeleteClusterOperator(
         task_id='delete_cluster',
         cluster_identifier=redshift_cluster_identifier,
-        trigger_rule=TriggerRule.ALL_DONE,
     )
     # [END howto_operator_redshift_delete_cluster]
+    delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
     # [START howto_operator_redshift_delete_cluster_snapshot]
     delete_cluster_snapshot = RedshiftDeleteClusterSnapshotOperator(


### PR DESCRIPTION
A recent PR pointed out this "trick" and I figure we can clean up the embedded code snippets by moving test-specific operator parameters out of the START/END blocks so the documentation only shows the actual operator examples, similar to https://github.com/apache/airflow/pull/26525 