### PR TITLE
Make sure ast has attr unparse in pre-commit

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
+++ b/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
@@ -42,8 +42,10 @@ def _find_dag_deco(mod: ast.Module) -> ast.FunctionDef:
     return next(n for n in ast.iter_child_nodes(mod) if isinstance(n, ast.FunctionDef) and n.name == "dag")
 
 
+import ast
+
 # The new unparse() output is much more readable; fallback to dump() otherwise.
-if sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8) and hasattr(ast, 'unparse'):
     _reveal = ast.unparse  # type: ignore[attr-defined]
 else:
     _reveal = ast.dump

--- a/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
+++ b/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
@@ -45,7 +45,7 @@ def _find_dag_deco(mod: ast.Module) -> ast.FunctionDef:
 import ast
 
 # The new unparse() output is much more readable; fallback to dump() otherwise.
-if sys.version_info >= (3, 8) and hasattr(ast, 'unparse'):
+if sys.version_info >= (3, 9):
     _reveal = ast.unparse  # type: ignore[attr-defined]
 else:
     _reveal = ast.dump

--- a/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
+++ b/scripts/ci/pre_commit/pre_commit_sync_dag_init_decorator.py
@@ -42,8 +42,6 @@ def _find_dag_deco(mod: ast.Module) -> ast.FunctionDef:
     return next(n for n in ast.iter_child_nodes(mod) if isinstance(n, ast.FunctionDef) and n.name == "dag")
 
 
-import ast
-
 # The new unparse() output is much more readable; fallback to dump() otherwise.
 if sys.version_info >= (3, 9):
     _reveal = ast.unparse  # type: ignore[attr-defined]


### PR DESCRIPTION
My version of ast in python 3.8 (3.8.13) does not have `unparse`.

We can check that the function is there before using it.
