### PR TITLE
Correct mailmap for Jarek Potiuk 

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -40,7 +40,7 @@ Gerard Toonstra <gtoonstra@gmail.com>
 Greg Neiheisel <greg@astronomer.io>
 Hossein Torabi <hossein.torabi@alopeyk.com> <blcksrx@gmail.com>
 James Timmins <james@astronomer.io> <jameshtimmins@gmail.com>
-Jarek Potiuk <jarek.potiuk@polidea.com> <jarek@potiuk.com>
+Jarek Potiuk <jarek@potiuk.com> <jarek.potiuk@polidea.com> <potiuk@apache.org>
 Jeremiah Lowin <jlowin@apache.org>
 Jeremiah Lowin <jlowin@apache.org> <jlowin@gmail.com>
 Jeremiah Lowin <jlowin@apache.org> <jlowin@iHal.local>


### PR DESCRIPTION
I've noticed that mailmap for myself (set a long time ago by Ry)
has the old address of mine (alread non-functional) and despite
all commits being done as primary address, they were showing up
with the mail-mapped one

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
