### PR TITLE
Prepare to release cncf.kubernetes provider

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -24,6 +24,26 @@
 Changelog
 ---------
 
+4.4.0
+.....
+
+Features
+~~~~~~~~
+
+* ``feat(KubernetesPodOperator): Add support of container_security_context (#25530)``
+* ``Add @task.kubernetes taskflow decorator (#25663)``
+* ``pretty print KubernetesPodOperator rendered template env_vars (#25850)``
+
+Bug Fixes
+~~~~~~~~~
+
+* ``Avoid calculating all elements when one item is needed (#26377)``
+* ``Apply PEP-563 (Postponed Evaluation of Annotations) to non-core airflow (#26289)``
+* ``Wait for xcom sidecar container to start before sidecar exec (#25055)``
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+
 4.3.0
 .....
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -38,11 +38,11 @@ Bug Fixes
 ~~~~~~~~~
 
 * ``Avoid calculating all elements when one item is needed (#26377)``
-* ``Apply PEP-563 (Postponed Evaluation of Annotations) to non-core airflow (#26289)``
 * ``Wait for xcom sidecar container to start before sidecar exec (#25055)``
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
+    * ``Apply PEP-563 (Postponed Evaluation of Annotations) to non-core airflow (#26289)``
 
 4.3.0
 .....

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Kubernetes <https://kubernetes.io/>`__
 
 versions:
+  - 4.4.0
   - 4.3.0
   - 4.2.0
   - 4.1.0

--- a/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/commits.rst
@@ -28,17 +28,34 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+4.4.0
+.....
+
+Latest change: 2022-09-14
+
+=================================================================================================  ===========  ====================================================================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  ====================================================================================
+`e60a459d56 <https://github.com/apache/airflow/commit/e60a459d560e6f9caa83392a1901963c4bc7e15d>`_  2022-09-14   ``Avoid calculating all elements when one item is needed (#26377)``
+`06acf40a43 <https://github.com/apache/airflow/commit/06acf40a4337759797f666d5bb27a5a393b74fed>`_  2022-09-13   ``Apply PEP-563 (Postponed Evaluation of Annotations) to non-core airflow (#26289)``
+`4b26c8c541 <https://github.com/apache/airflow/commit/4b26c8c541a720044fa96475620fc70f3ac6ccab>`_  2022-09-09   ``feat(KubernetesPodOperator): Add support of container_security_context (#25530)``
+`0eb0b543a9 <https://github.com/apache/airflow/commit/0eb0b543a9751f3d458beb2f03d4c6ff22fcd1c7>`_  2022-08-23   ``Add @task.kubernetes taskflow decorator (#25663)``
+`db5543ef60 <https://github.com/apache/airflow/commit/db5543ef608bdd7aefdb5fefea150955d369ddf4>`_  2022-08-22   ``pretty print KubernetesPodOperator rendered template env_vars (#25850)``
+`ccdd73ec50 <https://github.com/apache/airflow/commit/ccdd73ec50ab9fb9d18d1cce7a19a95fdedcf9b9>`_  2022-08-22   ``Wait for xcom sidecar container to start before sidecar exec (#25055)``
+=================================================================================================  ===========  ====================================================================================
+
 4.3.0
 .....
 
-Latest change: 2022-07-26
+Latest change: 2022-08-10
 
-=================================================================================================  ===========  =======================================================
+=================================================================================================  ===========  =================================================================
 Commit                                                                                             Committed    Subject
-=================================================================================================  ===========  =======================================================
+=================================================================================================  ===========  =================================================================
+`e5ac6c7cfb <https://github.com/apache/airflow/commit/e5ac6c7cfb189c33e3b247f7d5aec59fe5e89a00>`_  2022-08-10   ``Prepare docs for new providers release (August 2022) (#25618)``
 `c8af0592c0 <https://github.com/apache/airflow/commit/c8af0592c08017ee48f69f608ad4a6529ee14292>`_  2022-07-26   ``Improve taskflow type hints with ParamSpec (#25173)``
 `f05a06537b <https://github.com/apache/airflow/commit/f05a06537be4d12276862eae1960515c76aa11d1>`_  2022-07-16   ``Fix xcom_sidecar stuck problem (#24993)``
-=================================================================================================  ===========  =======================================================
+=================================================================================================  ===========  =================================================================
 
 4.2.0
 .....

--- a/docs/apache-airflow-providers-cncf-kubernetes/index.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/index.rst
@@ -65,7 +65,7 @@ Package apache-airflow-providers-cncf-kubernetes
 `Kubernetes <https://kubernetes.io/>`__
 
 
-Release: 4.3.0
+Release: 4.4.0
 
 Provider package
 ----------------


### PR DESCRIPTION
This one adds `@task.kubernetes` which we call out specifically in the 2.4.0 changelog, so lets get this one released!

(We'll follow up with a full provider release batch next week)