### PR TITLE
Allow MapXComArg to resolve after serialization 

### DIFF
--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -211,14 +211,14 @@ def test_xcom_zip(dag_maker, session, fillvalue, expected_results):
 
     # Run "push_letters" and "push_numbers".
     decision = dr.task_instance_scheduling_decisions(session=session)
-    assert decision.schedulable_tis and all(ti.task_id.startswith("push_") for ti in decision.schedulable_tis)
+    assert sorted(ti.task_id for ti in decision.schedulable_tis) == ["push_letters", "push_numbers"]
     for ti in decision.schedulable_tis:
         ti.run(session=session)
     session.commit()
 
     # Run "pull".
     decision = dr.task_instance_scheduling_decisions(session=session)
-    assert decision.schedulable_tis and all(ti.task_id == "pull" for ti in decision.schedulable_tis)
+    assert sorted(ti.task_id for ti in decision.schedulable_tis) == ["pull"] * len(expected_results)
     for ti in decision.schedulable_tis:
         ti.run(session=session)
 


### PR DESCRIPTION
This is useful for cases where we want to resolve an XCom without running a worker, e.g. to display the value in UI, logs, and OpenLineage.

Since we don't want to actually call the mapper function in this case (the function is arbitrary code, and not running it is the entire point to serialize operators), "resolving" the XComArg in this case would merely produce some kind of quasi-meaningful string representation,
instead of the actual value we'd get in the worker.

Also note that this only affects a very small number of cases, since once a worker is run for the task instance, RenderedTaskInstanceFields would store the real resolved value and take over UI representation, avoiding this fake resolving logic to be accessed at all.