### PR TITLE
SFTP Provider: Fix default folder permissions 

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -159,15 +159,16 @@ class SFTPHook(SSHHook):
         files = sorted(conn.listdir(path))
         return files
 
-    def mkdir(self, path: str, mode: int = 777) -> None:
+    def mkdir(self, path: str, mode: int = 0o777) -> None:
         """
         Creates a directory on the remote system.
+        The default mode is 0777, but on some systems, the current umask value is first masked out.
 
         :param path: full path to the remote directory to create
-        :param mode: permissions to set the directory with
+        :param mode: int permissions (posix-style) of octal mode for directory
         """
         conn = self.get_conn()
-        conn.mkdir(path, mode=int(str(mode), 8))
+        conn.mkdir(path, mode=mode)
 
     def isdir(self, path: str) -> bool:
         """
@@ -195,12 +196,13 @@ class SFTPHook(SSHHook):
             result = False
         return result
 
-    def create_directory(self, path: str, mode: int = 777) -> None:
+    def create_directory(self, path: str, mode: int = 0o777) -> None:
         """
         Creates a directory on the remote system.
+        The default mode is 0777, but on some systems, the current umask value is first masked out.
 
         :param path: full path to the remote directory to create
-        :param mode: int representation of octal mode for directory
+        :param mode: int permissions (posix-style) of octal mode for directory
         """
         conn = self.get_conn()
         if self.isdir(path):
@@ -214,7 +216,7 @@ class SFTPHook(SSHHook):
                 self.create_directory(dirname, mode)
             if basename:
                 self.log.info("Creating %s", path)
-                conn.mkdir(path, mode=int(str(mode), 8))
+                conn.mkdir(path, mode=mode)
 
     def delete_directory(self, path: str) -> None:
         """

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -214,7 +214,7 @@ class SFTPHook(SSHHook):
                 self.create_directory(dirname, mode)
             if basename:
                 self.log.info("Creating %s", path)
-                conn.mkdir(path, mode=mode)
+                conn.mkdir(path, mode=int(str(mode), 8))
 
     def delete_directory(self, path: str) -> None:
         """

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -165,7 +165,7 @@ class SFTPHook(SSHHook):
         The default mode is 0777, but on some systems, the current umask value is first masked out.
 
         :param path: full path to the remote directory to create
-        :param mode: int permissions (posix-style) of octal mode for directory
+        :param mode: int permissions of octal mode for directory
         """
         conn = self.get_conn()
         conn.mkdir(path, mode=mode)
@@ -202,7 +202,7 @@ class SFTPHook(SSHHook):
         The default mode is 0777, but on some systems, the current umask value is first masked out.
 
         :param path: full path to the remote directory to create
-        :param mode: int permissions (posix-style) of octal mode for directory
+        :param mode: int permissions of octal mode for directory
         """
         conn = self.get_conn()
         if self.isdir(path):

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -109,7 +109,7 @@ class TestSFTPHook(unittest.TestCase):
         assert new_dir_name in output
         # test the directory has default permissions to 777 - umask
         umask = 0o022
-        output = self.hook.get_conn().lstat(new_dir_name)
+        output = self.hook.get_conn().lstat(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         assert output.st_mode & 0o777 == 0o777 - umask
 
     def test_create_and_delete_directory(self):
@@ -119,7 +119,7 @@ class TestSFTPHook(unittest.TestCase):
         assert new_dir_name in output
         # test the directory has default permissions to 777
         umask = 0o022
-        output = self.hook.get_conn().lstat(new_dir_name)
+        output = self.hook.get_conn().lstat(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         assert output.st_mode & 0o777 == 0o777 - umask
         # test directory already exists for code coverage, should not raise an exception
         self.hook.create_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -107,12 +107,18 @@ class TestSFTPHook(unittest.TestCase):
         self.hook.mkdir(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         output = self.hook.describe_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         assert new_dir_name in output
+        # test the directory has default permissions to 777
+        output = self.hook.get_conn().lstat(new_dir_name)
+        assert output.st_mode & 0o777 == 0o777
 
     def test_create_and_delete_directory(self):
         new_dir_name = "new_dir"
         self.hook.create_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         output = self.hook.describe_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         assert new_dir_name in output
+        # test the directory has default permissions to 777
+        output = self.hook.get_conn().lstat(new_dir_name)
+        assert output.st_mode & 0o777 == 0o777
         # test directory already exists for code coverage, should not raise an exception
         self.hook.create_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         # test path already exists and is a file, should raise an exception

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -107,9 +107,10 @@ class TestSFTPHook(unittest.TestCase):
         self.hook.mkdir(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         output = self.hook.describe_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         assert new_dir_name in output
-        # test the directory has default permissions to 777
+        # test the directory has default permissions to 777 - umask
+        umask = 0o022
         output = self.hook.get_conn().lstat(new_dir_name)
-        assert output.st_mode & 0o777 == 0o777
+        assert output.st_mode & 0o777 == 0o777 - umask
 
     def test_create_and_delete_directory(self):
         new_dir_name = "new_dir"
@@ -117,8 +118,9 @@ class TestSFTPHook(unittest.TestCase):
         output = self.hook.describe_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         assert new_dir_name in output
         # test the directory has default permissions to 777
+        umask = 0o022
         output = self.hook.get_conn().lstat(new_dir_name)
-        assert output.st_mode & 0o777 == 0o777
+        assert output.st_mode & 0o777 == 0o777 - umask
         # test directory already exists for code coverage, should not raise an exception
         self.hook.create_directory(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, new_dir_name))
         # test path already exists and is a file, should raise an exception


### PR DESCRIPTION
Relates #26226 

Fixing default mode when creating a directory with paramiko and convert decimal mode to octal mode ([paramiko documention](https://docs.paramiko.org/en/stable/api/sftp.html#paramiko.sftp_client.SFTPClient.mkdir))

+ Updating test cases to confirm permissions after masking out the default umask are as we expect whenever we create a new folder. 
