### PR TITLE
Resolve warning about DISTINCT ON query on dags view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -707,7 +707,7 @@ class Airflow(AirflowBaseView):
                 else:
                     dag.can_delete = (permissions.ACTION_CAN_DELETE, dag_resource_name) in user_permissions
 
-            dagtags = session.query(DagTag.name).distinct(DagTag.name).all()
+            dagtags = session.query(func.distinct(DagTag.name)).all()
             tags = [
                 {"name": name, "selected": bool(arg_tags_filter and name in arg_tags_filter)}
                 for name, in dagtags


### PR DESCRIPTION
Previously we'd get this warning:
```
/Users/dstandish/code/airflow/airflow/www/views.py:710 SADeprecationWarning: DISTINCT ON is currently supported only by the PostgreSQL dialect.  Use of DISTINCT ON for other backends is currently silently ignored, however this usage is deprecated, and will raise CompileError in a future release for all backends that do not support this syntax.
```
Closes #26607
