### PR TITLE
No missing user warning for public admin

### DIFF
--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -821,7 +821,8 @@ class BaseSecurityManager:
             self.add_role(self.auth_role_admin)
         self.add_role(self.auth_role_public)
         if self.count_users() == 0:
-            log.warning(LOGMSG_WAR_SEC_NO_USER)
+            if self.auth_role_public != self.auth_role_admin:
+                log.warning(LOGMSG_WAR_SEC_NO_USER)
 
     def reset_password(self, userid, password):
         """

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -820,9 +820,8 @@ class BaseSecurityManager:
         if self.auth_role_admin not in self.builtin_roles:
             self.add_role(self.auth_role_admin)
         self.add_role(self.auth_role_public)
-        if self.count_users() == 0:
-            if self.auth_role_public != self.auth_role_admin:
-                log.warning(LOGMSG_WAR_SEC_NO_USER)
+        if self.count_users() == 0 and self.auth_role_public != self.auth_role_admin:
+            log.warning(LOGMSG_WAR_SEC_NO_USER)
 
     def reset_password(self, userid, password):
         """


### PR DESCRIPTION
If airflow has been configured such that public role is admin, there's no need to add users, so we shouldn't warn if there are none.