### PR TITLE
Suppress SQLALCHEMY_TRACK_MODIFICATIONS warning in db init

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -656,6 +656,7 @@ def _create_db_from_orm(session):
     def _create_flask_session_tbl():
         flask_app = Flask(__name__)
         flask_app.config['SQLALCHEMY_DATABASE_URI'] = conf.get('database', 'SQL_ALCHEMY_CONN')
+        flask_app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
         db = SQLAlchemy(flask_app)
         AirflowDatabaseSessionInterface(app=flask_app, db=db, table='session', key_prefix='')
         db.create_all()


### PR DESCRIPTION
We already have it set false in the main flask app config, but now that we do db init from orm, and we create a distinct flask app for that, and it doesn't get the same setting.

Closes #26544

Seems much easier to just duplicate the setting than to try and DRY it?

Gets rid of this warning:

<img width="758" alt="image" src="https://user-images.githubusercontent.com/15932138/191901784-4f40f81b-4482-418f-8367-64ff9a146d34.png">

