### PR TITLE
Don't use provide session in MetastoreBackend methods

### DIFF
--- a/docs/apache-airflow/concepts/timetable.rst
+++ b/docs/apache-airflow/concepts/timetable.rst
@@ -51,6 +51,10 @@ As such, Airflow allows for custom timetables to be written in plugins and used 
 DAGs. An example demonstrating a custom timetable can be found in the
 :doc:`/howto/timetable` how-to guide.
 
+*Note*: As a general rule, always access Variables, Connections etc or anything that would access
+the database as late as possible in your code. See :doc:`best_practices/top_level_code`
+for more best practices to follow.
+
 Built-in Timetables
 -------------------
 


### PR DESCRIPTION
This helps to use the available `session` instead of creating a new session when accessing variables/connections.

This class and methods should be private, however, there's a possibility that users are using it hence I'm leaving the session argument on the method but it's unused

closes: https://github.com/apache/airflow/issues/26529