### PR TITLE
Use COALESCE when ordering runs to handle NULL

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3456,10 +3456,7 @@ class Airflow(AirflowBaseView):
             if run_state:
                 query = query.filter(DagRun.state == run_state)
 
-            ordering = (DagRun.__table__.columns[name].desc() for name in dag.timetable.run_ordering)
-            dag_runs = query.order_by(*ordering, DagRun.id.desc()).limit(num_runs).all()
-            dag_runs.reverse()
-
+            dag_runs = wwwutils.sorted_dag_runs(query, ordering=dag.timetable.run_ordering, limit=num_runs)
             encoded_runs = [wwwutils.encode_dag_run(dr) for dr in dag_runs]
             data = {
                 'groups': dag_to_grid(dag, dag_runs, session),


### PR DESCRIPTION
Data interval columns are NULL for runs created before 2.3, but SQL's NULL-sorting logic would make those old runs always appear first. In a perfect world we'd want to sort by get_run_data_interval(), but that's not efficient, so instead the columns are coalesced into logical date, which is good enough in most cases.

This should #26505, I think. Not sure if the UI side needs some additional work. cc @bbovenzi 