### PR TITLE
Remove duplicated connection-type within the provider

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -554,8 +554,6 @@ connection-types:
     connection-type: emr
   - hook-class-name: airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook
     connection-type: redshift
-  - hook-class-name: airflow.providers.amazon.aws.hooks.redshift_data.RedshiftDataHook
-    connection-type: aws
 
 secrets-backends:
   - airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -93,8 +93,6 @@ hooks:
 connection-types:
   - hook-class-name: airflow.providers.databricks.hooks.databricks.DatabricksHook
     connection-type: databricks
-  - hook-class-name: airflow.providers.databricks.hooks.databricks_sql.DatabricksSqlHook
-    connection-type: databricks
 
 extra-links:
   - airflow.providers.databricks.operators.databricks.DatabricksJobRunLink


### PR DESCRIPTION
Remove duplicated connection type for **amazon** and **databricks** providers.

`aws` provided by `airflow.providers.amazon.aws.hooks.base_aws.AwsGenericHook`
`databricks` provided by `airflow.providers.databricks.hooks.databricks.DatabricksHook`

Seem like the actual order in _connection-types_ in `provider.yaml` the only thing that really matter, if provider contains multiple different `hook-class-name` with the same `connection-type`:
- The first `hook-class-name` with listed would use in the UI/API/CLI for fields names and testing connection
- All other would be ignored, the warning only shows if same `connection-type` exists in the different providers

https://github.com/apache/airflow/blob/55d11464c047d2e74f34cdde75d90b633a231df2/airflow/providers_manager.py#L529-L539

Might be also good idea to warn users if already_registered  `connection-type` exists in the same provider.