### PR TITLE
remove "ssh://" prefix from git repo value in gitsync instructions in helm docs

### DIFF
--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -177,7 +177,7 @@ In this example, you will create a yaml file called ``override-values.yaml`` to 
     dags:
       gitSync:
         enabled: true
-        repo: ssh://git@github.com/<username>/<private-repo-name>.git
+        repo: git@github.com/<username>/<private-repo-name>.git
         branch: <branch-name>
         subPath: ""
         sshKeySecret: airflow-ssh-secret


### PR DESCRIPTION
### Documentation-only change.

Revises helm chart docs so that the [Mange DAGs Files >> Mounting DAGs From a Private Github Repo Using GitSync Sidecar](https://airflow.apache.org/docs/helm-chart/stable/manage-dags-files.html#mounting-dags-from-a-private-github-repo-using-git-sync-sidecar) section advises the correct format for specifying the private git repo address.

closes: https://github.com/apache/airflow/issues/21970

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
