### PR TITLE
Remove comon provider docs from ad-hoc releases

### DIFF
--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -314,7 +314,6 @@ If we want to just release some providers you can release them in this way:
 ```shell script
 cd "${AIRFLOW_REPO_ROOT}"
 breeze build-docs --clean-build --for-production \
-  --package-filter apache-airflow-providers \
   --package-filter 'apache-airflow-providers-PACKAGE1' \
   --package-filter 'apache-airflow-providers-PACKAGE2' \
   ...

--- a/dev/provider_packages/build_provider_documentation.sh
+++ b/dev/provider_packages/build_provider_documentation.sh
@@ -31,6 +31,5 @@ done
 .breeze build-docs \
     --for-production \
     --clean-build \
-    --package-filter apache-airflow-providers \
     "${provider_filters[@]}"
 cd "${AIRFLOW_SITE_DIRECTORY}"

--- a/dev/provider_packages/publish_provider_documentation.sh
+++ b/dev/provider_packages/publish_provider_documentation.sh
@@ -29,6 +29,5 @@ do
 done
 
 ./docs/publish_docs.py \
-    --package-filter apache-airflow-providers \
     "${provider_filters[@]}"
 cd "${AIRFLOW_SITE_DIRECTORY}"


### PR DESCRIPTION
When we are releasing ad-hoc providers rather than all of them, we rarely add new stuff (they are mostly bugfixes), so we should rather not update the "common provider documentation", because for example when we add (but not yet release) a new provider, the common indexes might include it and confuse the users.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
