### PR TITLE
Clear TaskGroup

### DIFF
--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -474,10 +474,6 @@ class TaskGroup(DAGNode):
                 yield group
             group = group.task_group
 
-    def get_task_dict(self) -> dict[str, AbstractOperator]:
-        """Returns a flat dictionary of task_id: AbstractOperator"""
-        task_map: dict[str, AbstractOperator] = {}
-
     def iter_tasks(self) -> Iterator[AbstractOperator]:
         """Returns an iterator of the child tasks."""
         from airflow.models.abstractoperator import AbstractOperator

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -35,7 +35,6 @@ from airflow.exceptions import (
     DuplicateTaskIdFound,
     TaskAlreadyInTaskGroup,
 )
-from airflow.models.abstractoperator import AbstractOperator
 from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.serialization.enums import DagAttributeTypes
 from airflow.utils.helpers import validate_group_key
@@ -43,6 +42,7 @@ from airflow.utils.helpers import validate_group_key
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
+    from airflow.models.abstractoperator import AbstractOperator
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG
     from airflow.models.expandinput import ExpandInput
@@ -480,6 +480,8 @@ class TaskGroup(DAGNode):
 
     def iter_tasks(self) -> Iterator[AbstractOperator]:
         """Returns an iterator of the child tasks."""
+        from airflow.models.abstractoperator import AbstractOperator
+
         groups_to_visit = [self]
 
         while groups_to_visit:

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -476,7 +476,7 @@ class TaskGroup(DAGNode):
 
     def get_task_dict(self) -> dict[str, AbstractOperator]:
         """Returns a flat dictionary of task_id: AbstractOperator"""
-        task_map = {}
+        task_map: dict[str, AbstractOperator] = {}
         groups_to_visit = [self]
 
         while groups_to_visit:
@@ -487,6 +487,10 @@ class TaskGroup(DAGNode):
                     task_map[child.task_id] = child
                 elif isinstance(child, TaskGroup):
                     groups_to_visit.append(child)
+                else:
+                    raise ValueError(
+                        f"Encountered a DAGNode that is not a TaskGroup or an AbstractOperator: {type(child)}"
+                    )
 
         return task_map
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -477,6 +477,9 @@ class TaskGroup(DAGNode):
     def get_task_dict(self) -> dict[str, AbstractOperator]:
         """Returns a flat dictionary of task_id: AbstractOperator"""
         task_map: dict[str, AbstractOperator] = {}
+
+    def iter_tasks(self) -> Iterator[AbstractOperator]:
+        """Returns an iterator of the child tasks."""
         groups_to_visit = [self]
 
         while groups_to_visit:
@@ -484,15 +487,13 @@ class TaskGroup(DAGNode):
 
             for child in visiting.children.values():
                 if isinstance(child, AbstractOperator):
-                    task_map[child.task_id] = child
+                    yield child
                 elif isinstance(child, TaskGroup):
                     groups_to_visit.append(child)
                 else:
                     raise ValueError(
                         f"Encountered a DAGNode that is not a TaskGroup or an AbstractOperator: {type(child)}"
                     )
-
-        return task_map
 
 
 class MappedTaskGroup(TaskGroup):

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -477,16 +477,17 @@ class TaskGroup(DAGNode):
     def get_task_dict(self) -> dict[str, AbstractOperator]:
         """Returns a flat dictionary of task_id: AbstractOperator"""
         task_map = {}
+        groups_to_visit = [self]
 
-        def build_map(dag_node):
-            if not isinstance(dag_node, TaskGroup):
-                task_map[dag_node.task_id] = dag_node
-                return
+        while groups_to_visit:
+            visiting = groups_to_visit.pop(0)
 
-            for child in dag_node.children.values():
-                build_map(child)
+            for child in visiting.children.values():
+                if isinstance(child, AbstractOperator):
+                    task_map[child.task_id] = child
+                elif isinstance(child, TaskGroup):
+                    groups_to_visit.append(child)
 
-        build_map(self)
         return task_map
 
 

--- a/airflow/www/static/js/api/useClearTask.ts
+++ b/airflow/www/static/js/api/useClearTask.ts
@@ -28,11 +28,12 @@ const csrfToken = getMetaValue('csrf_token');
 const clearUrl = getMetaValue('clear_url');
 
 export default function useClearTask({
-  dagId, runId, taskId, executionDate,
+  dagId, runId, taskId, executionDate, isGroup,
 }: { dagId: string,
   runId: string,
   taskId: string,
-  executionDate: string }) {
+  executionDate: string,
+  isGroup: boolean }) {
   const queryClient = useQueryClient();
   const errorToast = useErrorToast();
   const { startRefresh } = useAutoRefresh();
@@ -53,7 +54,6 @@ export default function useClearTask({
         csrf_token: csrfToken,
         dag_id: dagId,
         dag_run_id: runId,
-        task_id: taskId,
         confirmed,
         execution_date: executionDate,
         past,
@@ -63,6 +63,12 @@ export default function useClearTask({
         recursive,
         only_failed: failed,
       });
+
+      if (isGroup) {
+        params.append('group_id', taskId);
+      } else {
+        params.append('task_id', taskId);
+      }
 
       mapIndexes.forEach((mi: number) => {
         params.append('map_index', mi.toString());

--- a/airflow/www/static/js/components/ConfirmDialog.tsx
+++ b/airflow/www/static/js/components/ConfirmDialog.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useRef } from 'react';
+import React, { PropsWithChildren, useRef } from 'react';
 import {
   AlertDialog,
   AlertDialogBody,
@@ -32,7 +32,7 @@ import {
 
 import { useContainerRef } from 'src/context/containerRef';
 
-interface Props {
+interface Props extends PropsWithChildren {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
@@ -43,7 +43,7 @@ interface Props {
 }
 
 const ConfirmDialog = ({
-  isOpen, onClose, title = 'Wait a minute', description, body = [], onConfirm, isLoading = false,
+  isOpen, onClose, title = 'Wait a minute', description, body = [], onConfirm, isLoading = false, children,
 }: Props) => {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const containerRef = useContainerRef();
@@ -65,6 +65,7 @@ const ConfirmDialog = ({
           </AlertDialogHeader>
 
           <AlertDialogBody overflowY="auto">
+            {children}
             <Text mb={2}>{description}</Text>
             {Array.isArray(body) && body.map((ti) => (<Code width="100%" key={ti} fontSize="lg">{ti}</Code>))}
           </AlertDialogBody>

--- a/airflow/www/static/js/components/ConfirmDialog.tsx
+++ b/airflow/www/static/js/components/ConfirmDialog.tsx
@@ -66,7 +66,7 @@ const ConfirmDialog = ({
 
           <AlertDialogBody overflowY="auto">
             <Text mb={2}>{description}</Text>
-            {Array.isArray(body) && body.map((ti) => (<Code key={ti} fontSize="lg">{ti}</Code>))}
+            {Array.isArray(body) && body.map((ti) => (<Code width="100%" key={ti} fontSize="lg">{ti}</Code>))}
           </AlertDialogBody>
 
           <AlertDialogFooter>

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -111,7 +111,7 @@ const TaskInstance = ({
 
   const { executionDate } = run;
 
-  let taskActionsTitle = 'Task Actions';
+  let taskActionsTitle = `${isGroup ? 'Task Group' : 'Task'} Actions`;
   if (isMapped) {
     taskActionsTitle += ` for ${actionsMapIndexes.length || 'all'} mapped task${actionsMapIndexes.length !== 1 ? 's' : ''}`;
   }
@@ -187,6 +187,7 @@ const TaskInstance = ({
                     dagId={dagId}
                     executionDate={executionDate}
                     mapIndexes={actionsMapIndexes}
+                    isGroup={isGroup}
                   />
                 </Box>
               )}

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -178,19 +178,17 @@ const TaskInstance = ({
                   key={dagId + runId + taskId + instance.mapIndex}
                 />
               )}
-              {!isGroup && (
-                <Box mb={8}>
-                  <TaskActions
-                    title={taskActionsTitle}
-                    runId={runId}
-                    taskId={taskId}
-                    dagId={dagId}
-                    executionDate={executionDate}
-                    mapIndexes={actionsMapIndexes}
-                    isGroup={isGroup}
-                  />
-                </Box>
-              )}
+              <Box mb={8}>
+                <TaskActions
+                  title={taskActionsTitle}
+                  runId={runId}
+                  taskId={taskId}
+                  dagId={dagId}
+                  executionDate={executionDate}
+                  mapIndexes={actionsMapIndexes}
+                  isGroup={isGroup}
+                />
+              </Box>
               <Details instance={instance} group={group} dagId={dagId} />
               {!isMapped && (
                 <ExtraLinks

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
@@ -30,16 +30,9 @@ import { useClearTask } from 'src/api';
 import { getMetaValue } from 'src/utils';
 
 import ActionButton from './ActionButton';
+import type { CommonActionProps } from './types';
 
 const canEdit = getMetaValue('can_edit') === 'True';
-
-interface Props {
-  dagId: string;
-  runId: string;
-  taskId: string;
-  executionDate: string;
-  mapIndexes: number[];
-}
 
 const Run = ({
   dagId,
@@ -47,7 +40,8 @@ const Run = ({
   taskId,
   executionDate,
   mapIndexes,
-}: Props) => {
+  isGroup,
+}: CommonActionProps) => {
   const [affectedTasks, setAffectedTasks] = useState('');
 
   // Options check/unchecked
@@ -73,7 +67,7 @@ const Run = ({
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const { mutateAsync: clearTask, isLoading } = useClearTask({
-    dagId, runId, taskId, executionDate,
+    dagId, runId, taskId, executionDate, isGroup: !!isGroup,
   });
 
   const onClick = async () => {
@@ -130,7 +124,7 @@ const Run = ({
         onClose={onClose}
         onConfirm={onConfirm}
         isLoading={isLoading}
-        description="Task instances you are about to clear:"
+        description={`Task instances you are about to clear (${affectedTasks.length}):`}
         body={affectedTasks}
       />
     </Flex>

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
@@ -23,6 +23,8 @@ import {
   Flex,
   ButtonGroup,
   useDisclosure,
+  Alert,
+  AlertIcon,
 } from '@chakra-ui/react';
 
 import ConfirmDialog from 'src/components/ConfirmDialog';
@@ -126,7 +128,17 @@ const Run = ({
         isLoading={isLoading}
         description={`Task instances you are about to clear (${affectedTasks.length}):`}
         body={affectedTasks}
-      />
+      >
+        { isGroup && (past || future) && (
+          <Alert status="warning" mb={3}>
+            <AlertIcon />
+            Clearing a TaskGroup in the future and/or past will affect all the tasks of this group
+            across multiple dag runs.
+            <br />
+            This can take a while to complete.
+          </Alert>
+        )}
+      </ConfirmDialog>
     </Flex>
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/index.tsx
@@ -37,38 +37,51 @@ type Props = {
 } & CommonActionProps;
 
 const TaskActions = ({
-  title, runId, taskId, dagId, executionDate, mapIndexes,
+  title, runId, taskId, dagId, executionDate, mapIndexes, isGroup,
 }: Props) => (
   <Box my={3}>
     <Text as="strong" size="lg">{title}</Text>
     <Divider my={2} />
-    <VStack justifyContent="center" divider={<StackDivider my={3} />}>
-      <RunAction
-        runId={runId}
-        taskId={taskId}
-        dagId={dagId}
-        mapIndexes={mapIndexes}
-      />
+    {/* For now only ClearAction is supported for groups */}
+    {isGroup ? (
       <ClearAction
         runId={runId}
         taskId={taskId}
         dagId={dagId}
         executionDate={executionDate}
         mapIndexes={mapIndexes}
+        isGroup={isGroup}
       />
-      <MarkFailedAction
-        runId={runId}
-        taskId={taskId}
-        dagId={dagId}
-        mapIndexes={mapIndexes}
-      />
-      <MarkSuccessAction
-        runId={runId}
-        taskId={taskId}
-        dagId={dagId}
-        mapIndexes={mapIndexes}
-      />
-    </VStack>
+    ) : (
+      <VStack justifyContent="center" divider={<StackDivider my={3} />}>
+        <RunAction
+          runId={runId}
+          taskId={taskId}
+          dagId={dagId}
+          mapIndexes={mapIndexes}
+        />
+        <ClearAction
+          runId={runId}
+          taskId={taskId}
+          dagId={dagId}
+          executionDate={executionDate}
+          mapIndexes={mapIndexes}
+          isGroup={!!isGroup}
+        />
+        <MarkFailedAction
+          runId={runId}
+          taskId={taskId}
+          dagId={dagId}
+          mapIndexes={mapIndexes}
+        />
+        <MarkSuccessAction
+          runId={runId}
+          taskId={taskId}
+          dagId={dagId}
+          mapIndexes={mapIndexes}
+        />
+      </VStack>
+    )}
     <Divider my={2} />
   </Box>
 );

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/types.ts
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/types.ts
@@ -24,5 +24,6 @@ export interface CommonActionProps {
   taskId: TaskInstance['taskId'],
   dagId: Dag['id'],
   executionDate: DagRun['executionDate'],
-  mapIndexes: number[]
+  mapIndexes: number[],
+  isGroup?: boolean;
 }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2071,7 +2071,7 @@ class Airflow(AirflowBaseView):
 
             # Lock the related dag runs to prevent from possible dead lock.
             # https://github.com/apache/airflow/pull/26658
-            dag_runs_query = session.query(DagRun).filter(DagRun.dag_id == dag_id).with_for_update()
+            dag_runs_query = session.query(DagRun.id).filter(DagRun.dag_id == dag_id).with_for_update()
             if start_date is None and end_date is None:
                 dag_runs_query = dag_runs_query.filter(DagRun.execution_date == start_date)
             else:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2028,7 +2028,7 @@ class Airflow(AirflowBaseView):
     )
     @action_logging
     def clear(self):
-        """Clears the dag tasks."""
+        """Clears DAG tasks."""
         dag_id = request.form.get("dag_id")
         task_id = request.form.get("task_id")
         origin = get_safe_url(request.form.get("origin"))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2056,7 +2056,7 @@ class Airflow(AirflowBaseView):
             task_group = task_group_dict.get(group_id)
             if task_group is None:
                 return redirect_or_json(
-                    origin, msg=f"TaskGroup {group_id} could not be found", status="error", status_code=500
+                    origin, msg=f"TaskGroup {group_id} could not be found", status="error", status_code=404
                 )
             tasks = task_group.get_task_dict()
             task_ids = list(tasks.keys())

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2060,21 +2060,19 @@ class Airflow(AirflowBaseView):
                 )
             tasks = task_group.get_task_dict()
             task_ids = list(tasks.keys())
-            dag = dag.partial_subset(
-                task_ids_or_regex=task_ids,
-                include_downstream=downstream,
-                include_upstream=upstream,
-            )
+            task_ids_or_regex = task_ids
         else:
             if map_indexes is None:
                 task_ids = [task_id]
             else:
                 task_ids = [(task_id, map_index) for map_index in map_indexes]
-            dag = dag.partial_subset(
-                task_ids_or_regex=[task_id],
-                include_downstream=downstream,
-                include_upstream=upstream,
-            )
+            task_ids_or_regex = [task_id]
+
+        dag = dag.partial_subset(
+            task_ids_or_regex=task_ids_or_regex,
+            include_downstream=downstream,
+            include_upstream=upstream,
+        )
 
         if len(dag.task_dict) > 1:
             # If we had upstream/downstream etc then also include those!

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2058,9 +2058,7 @@ class Airflow(AirflowBaseView):
                 return redirect_or_json(
                     origin, msg=f"TaskGroup {group_id} could not be found", status="error", status_code=404
                 )
-            tasks = task_group.get_task_dict()
-            task_ids = list(tasks.keys())
-            task_ids_or_regex = task_ids
+            task_ids = task_ids_or_regex = [t.task_id for t in task_group.iter_tasks()]
         else:
             if map_indexes is None:
                 task_ids = [task_id]

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1265,10 +1265,10 @@ def test_mapped_task_group_id_prefix_task_id():
     dag.get_task("g.t2") == t2
 
 
-def test_get_task_dict():
+def test_iter_tasks():
     with DAG("test_dag", start_date=pendulum.parse("20200101")) as dag:
         with TaskGroup("section_1") as tg1:
-            EmptyOperator(task_id='task1')
+            EmptyOperator(task_id="task1")
 
         with TaskGroup("section_2") as tg2:
             task2 = EmptyOperator(task_id="task2")
@@ -1284,20 +1284,17 @@ def test_get_task_dict():
 
     tg1 >> tg2
     root_group = dag.task_group
-    root_group_task_mapping = root_group.get_task_dict()
-    assert list(root_group_task_mapping.keys()) == [
-        'section_1.task1',
-        'section_2.task2',
-        'section_2.task3',
-        'section_2.bash_task',
+    assert [t.task_id for t in root_group.iter_tasks()] == [
+        "section_1.task1",
+        "section_2.task2",
+        "section_2.task3",
+        "section_2.bash_task",
     ]
-    section_1_task_mapping = tg1.get_task_dict()
-    assert list(section_1_task_mapping.keys()) == [
-        'section_1.task1',
+    assert [t.task_id for t in tg1.iter_tasks()] == [
+        "section_1.task1",
     ]
-    section_2_task_mapping = tg2.get_task_dict()
-    assert list(section_2_task_mapping.keys()) == [
-        'section_2.task2',
-        'section_2.task3',
-        'section_2.bash_task',
+    assert [t.task_id for t in tg2.iter_tasks()] == [
+        "section_2.task2",
+        "section_2.task3",
+        "section_2.bash_task",
     ]

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -1273,11 +1273,11 @@ def test_get_task_dict():
         with TaskGroup("section_2") as tg2:
             task2 = EmptyOperator(task_id="task2")
             task3 = EmptyOperator(task_id="task3")
-            mapped_bash_operator = BashOperator.partial(task_id="get_tag_template_result").expand(
+            mapped_bash_operator = BashOperator.partial(task_id="bash_task").expand(
                 bash_command=[
-                    "echo get_tag_template_result",
-                    "echo get_tag_template_result",
-                    "echo get_tag_template_result",
+                    "echo hello 1",
+                    "echo hello 2",
+                    "echo hello 3",
                 ]
             )
             task2 >> task3 >> mapped_bash_operator
@@ -1289,7 +1289,7 @@ def test_get_task_dict():
         'section_1.task1',
         'section_2.task2',
         'section_2.task3',
-        'section_2.get_tag_template_result',
+        'section_2.bash_task',
     ]
     section_1_task_mapping = tg1.get_task_dict()
     assert list(section_1_task_mapping.keys()) == [
@@ -1299,5 +1299,5 @@ def test_get_task_dict():
     assert list(section_2_task_mapping.keys()) == [
         'section_2.task2',
         'section_2.task3',
-        'section_2.get_tag_template_result',
+        'section_2.bash_task',
     ]


### PR DESCRIPTION
solves: https://github.com/apache/airflow/issues/14529

If you check at the issue thread, you will notice that there is quite a few concerns/inherent complexity to properly achieve TaskGroup clearing. (especially @potiuk who raised fair concerns about db deadlocks and topological order resolution for clearing tasks).

This implements a simple 'POC', I was able to successfully clear simple and nested task group.

The function clearing tasks handles multiple tasks into one single transaction and seems pretty fast even on moderate dag size . This code finds the requested `TaskGroup` for clearing, recursively find all child tasks, then extract the partial_subset, and clear all those tasks.

~~Note: I also had to update the `check-init-decorator-arguments` static check as `ast.unparse` was introduced in python 3.9. [doc](https://docs.python.org/3.10/library/ast.html#ast.unparse)~~ was fixed on main