### PR TITLE
Add requirements.txt example to "extending docker"

### DIFF
--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -27,7 +27,9 @@ Quick start scenarios of image extending
 ----------------------------------------
 
 The most common scenarios where you want to build your own image are adding a new ``apt`` package,
-adding a new ``PyPI`` dependency and embedding DAGs into the image.
+adding a new ``PyPI`` dependency (either individually or via requirements.txt) and embedding DAGs
+into the image.
+
 Example Dockerfiles for those scenarios are below, and you can read further
 for more complex cases which might involve either extending or customizing the image. You will find
 more information about more complex scenarios below, but if your goal is to quickly extend the Airflow
@@ -46,8 +48,8 @@ switch to the ``root`` user when running the ``apt`` commands, but do not forget
     :end-before: [END Dockerfile]
 
 
-Adding a new ``PyPI`` package
-.............................
+Adding new ``PyPI`` packages individually
+.........................................
 
 The following example adds ``lxml`` python package from PyPI to the image. When adding packages via
 ``pip`` you need to use the ``airflow`` user rather than ``root``. Attempts to install ``pip`` packages
@@ -57,6 +59,19 @@ as ``root`` will fail with an appropriate error message.
     :language: Dockerfile
     :start-after: [START Dockerfile]
     :end-before: [END Dockerfile]
+
+Adding packages from requirements.txt
+.....................................
+
+The following example adds few python packages from ``requirements.txt`` from PyPI to the image.
+Note that similarly when adding individual packages, you need to use the ``airflow`` user rather than
+``root``. Attempts to install ``pip`` packages as ``root`` will fail with an appropriate error message.
+
+.. exampleinclude:: docker-examples/extending/add-requirement-packages/Dockerfile
+    :language: Dockerfile
+    :start-after: [START Dockerfile]
+    :end-before: [END Dockerfile]
+
 
 Embedding DAGs
 ..............
@@ -362,6 +377,19 @@ The following example adds ``lxml`` python package from PyPI to the image.
     :language: Dockerfile
     :start-after: [START Dockerfile]
     :end-before: [END Dockerfile]
+
+Example of adding packages from requirements.txt
+................................................
+
+The following example adds few python packages from ``requirements.txt`` from PyPI to the image.
+Note that similarly when adding individual packages, you need to use the ``airflow`` user rather than
+``root``. Attempts to install ``pip`` packages as ``root`` will fail with an appropriate error message.
+
+.. exampleinclude:: docker-examples/extending/add-requirement-packages/Dockerfile
+    :language: Dockerfile
+    :start-after: [START Dockerfile]
+    :end-before: [END Dockerfile]
+
 
 Example when writable directory is needed
 .........................................

--- a/docs/docker-stack/docker-examples/extending/add-requirement-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-requirement-packages/Dockerfile
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an example Dockerfile. It is not intended for PRODUCTION use
+# [START Dockerfile]
+FROM apache/airflow:2.5.0.dev0
+COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt
+# [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/add-requirement-packages/requirements.txt
+++ b/docs/docker-stack/docker-examples/extending/add-requirement-packages/requirements.txt
@@ -1,0 +1,2 @@
+lxml
+beautifulsoup4


### PR DESCRIPTION
When extending the image, there was an example of adding individual packages via PyPI, but not requirements.txt. This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
