### PR TITLE
Fix scroll overflow for ConfirmDialog

### DIFF
--- a/airflow/www/static/js/components/ConfirmDialog.tsx
+++ b/airflow/www/static/js/components/ConfirmDialog.tsx
@@ -47,6 +47,7 @@ const ConfirmDialog = ({
 }: Props) => {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const containerRef = useContainerRef();
+
   return (
     <AlertDialog
       isOpen={isOpen}
@@ -58,12 +59,12 @@ const ConfirmDialog = ({
       blockScrollOnMount={false}
     >
       <AlertDialogOverlay>
-        <AlertDialogContent>
+        <AlertDialogContent maxHeight="90vh">
           <AlertDialogHeader fontSize="4xl" fontWeight="bold">
             {title}
           </AlertDialogHeader>
 
-          <AlertDialogBody>
+          <AlertDialogBody overflowY="auto">
             <Text mb={2}>{description}</Text>
             {Array.isArray(body) && body.map((ti) => (<Code key={ti} fontSize="lg">{ti}</Code>))}
           </AlertDialogBody>


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/26622

When there is a lot of tasks to display in the ConfirmDialog component, content overflows out of the screen. (cf below) and we land directly at the bottom of the scroll without having the disclaimer.

**Before**:
![image](https://user-images.githubusercontent.com/14861206/192332520-71e8ef0f-e246-4834-86e2-2da2a554232d.png)

**After**
![image](https://user-images.githubusercontent.com/14861206/192332924-9cfac3fd-d627-4405-b1d8-cbcc0da87161.png)

