### PR TITLE
Better error messages when unable to find a DAG

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -540,7 +540,7 @@ class DagBag(LoggingMixin):
         # Ensure dag_folder is a str -- it may have been a pathlib.Path
         dag_folder = correct_maybe_zipped(str(dag_folder))
 
-        if not os.path.isfile(dag_folder):
+        if not os.path.exists(dag_folder):
             raise FileNotFoundError(f"The DAG folder {dag_folder!r} doesn't exist.")
 
         for filepath in list_py_file_paths(

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -539,6 +539,10 @@ class DagBag(LoggingMixin):
 
         # Ensure dag_folder is a str -- it may have been a pathlib.Path
         dag_folder = correct_maybe_zipped(str(dag_folder))
+
+        if not os.path.isfile(dag_folder):
+            raise FileNotFoundError(f"The DAG folder {dag_folder!r} doesn't exist.")
+
         for filepath in list_py_file_paths(
             dag_folder,
             safe_mode=safe_mode,

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -187,9 +187,12 @@ def get_dag(subdir: str | None, dag_id: str) -> DAG:
 
     dagbag = DagBag(process_subdir(subdir))
     if dag_id not in dagbag.dags:
-        raise AirflowException(
-            f"Dag {dag_id!r} could not be found; either it does not exist or it failed to parse."
-        )
+        if dagbag.import_errors:
+            details = "it failed to parse"
+        else:
+            details = "it does not exist"
+
+        raise AirflowException(f"Dag {dag_id!r} could not be found; {details}.")
     return dagbag.dags[dag_id]
 
 


### PR DESCRIPTION
I'm currently debugging a situation where the task runner isn't able to find the DAG in the dagbag, but there isn't enough information to know why. This attempts to add some extra details to make it easier to diagnose.

```
[2022-09-19, 20:44:00 UTC] {dagbag.py:525} INFO - Filling up the DagBag from {some_file.py}
[2022-09-19, 20:44:00 UTC] {standard_task_runner.py:102} ERROR - Failed to execute job 9 for task {some_task} (Dag '{some_dag}' could not be found; either it does not exist or it failed to parse.; 373)
```

This will now show different error messages based on the situation:

- If the "dag folder" (file in this case) doesn't exist at all: `FileNotFoundError: The DAG folder '/tmp/missing.py' doesn't exist.`
- If the DAG has import errors: `AirflowException: Dag 'with_errors' could not be found; it failed to parse.`
- And finally, if neither of the above happen: `AirflowException: Dag 'missing' could not be found; it does not exist.`