### PR TITLE
[docs] make consistency on markup title string levels on cluster policies docs

### DIFF
--- a/docs/apache-airflow/concepts/cluster-policies.rst
+++ b/docs/apache-airflow/concepts/cluster-policies.rst
@@ -55,7 +55,7 @@ This policy checks if each DAG has at least one tag defined:
     To avoid import cycles, if you use ``DAG`` in type annotations in your cluster policy, be sure to import from ``airflow.models`` and not from ``airflow``.
 
 Task policies
--------------
+~~~~~~~~~~~~~
 
 Here's an example of enforcing a maximum timeout policy on every task:
 
@@ -82,7 +82,7 @@ For example, your ``airflow_local_settings.py`` might follow this pattern:
 
 
 Task instance mutation
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 Here's an example of re-routing tasks that are on their second (or greater) retry to a different queue:
 


### PR DESCRIPTION
- current docs: https://airflow.apache.org/docs/apache-airflow/stable/concepts/cluster-policies.html
<img width="183" alt="image" src="https://user-images.githubusercontent.com/81631424/192431928-6597b1a4-43af-403b-8b48-0874370aff7c.png">
- make consistency on title string markup level
