### PR TITLE
When rendering template, unmap task in context

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -373,15 +373,15 @@ class AbstractOperator(LoggingMixin, DAGNode):
         self,
         context: Context,
         jinja_env: jinja2.Environment | None = None,
-    ) -> BaseOperator | None:
+    ) -> None:
         """Template all attributes listed in template_fields.
 
         If the operator is mapped, this should return the unmapped, fully
         rendered, and map-expanded operator. The mapped operator should not be
-        modified.
+        modified. However, ``context`` will be modified in-place to reference
+        the unmapped operator for template rendering.
 
-        If the operator is not mapped, this should modify the operator in-place
-        and return either *None* (for backwards compatibility) or *self*.
+        If the operator is not mapped, this should modify the operator in-place.
         """
         raise NotImplementedError()
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1179,7 +1179,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         self,
         context: Context,
         jinja_env: jinja2.Environment | None = None,
-    ) -> BaseOperator | None:
+    ) -> None:
         """Template all attributes listed in template_fields.
 
         This mutates the attributes in-place and is irreversible.
@@ -1190,7 +1190,6 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
         if not jinja_env:
             jinja_env = self.get_template_env()
         self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())
-        return self
 
     @provide_session
     def clear(

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -58,7 +58,7 @@ from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.typing_compat import Literal
-from airflow.utils.context import Context
+from airflow.utils.context import Context, context_update_for_unmapped
 from airflow.utils.helpers import is_container
 from airflow.utils.operator_resources import Resources
 from airflow.utils.state import State, TaskInstanceState
@@ -748,7 +748,7 @@ class MappedOperator(AbstractOperator):
         self,
         context: Context,
         jinja_env: jinja2.Environment | None = None,
-    ) -> BaseOperator | None:
+    ) -> None:
         if not jinja_env:
             jinja_env = self.get_template_env()
 
@@ -761,6 +761,8 @@ class MappedOperator(AbstractOperator):
 
         mapped_kwargs, seen_oids = self._expand_mapped_kwargs(context, session)
         unmapped_task = self.unmap(mapped_kwargs)
+        context_update_for_unmapped(context, unmapped_task)
+
         self._do_render_template_fields(
             parent=unmapped_task,
             template_fields=self.template_fields,
@@ -769,4 +771,3 @@ class MappedOperator(AbstractOperator):
             seen_oids=seen_oids,
             session=session,
         )
-        return unmapped_task

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2185,10 +2185,14 @@ class TaskInstance(Base, LoggingMixin):
         """
         if not context:
             context = self.get_template_context()
-        rendered_task = self.task.render_template_fields(context)
-        if rendered_task is None:  # Compatibility -- custom renderer, assume unmapped.
-            return self.task
-        original_task, self.task = self.task, rendered_task
+        original_task = self.task
+
+        # If self.task is mapped, this call replaces self.task to point to the
+        # unmapped BaseOperator created by this function! This is because the
+        # MappedOperator is useless for template rendering, and we need to be
+        # able to access the unmapped task instead.
+        original_task.render_template_fields(context)
+
         return original_task
 
     def render_k8s_pod_yaml(self) -> dict | None:

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -756,11 +756,13 @@ def test_mapped_render_template_fields(dag_maker, session):
 
     mapped_ti: TaskInstance = dr.get_task_instance(mapped.operator.task_id, session=session)
     mapped_ti.map_index = 0
-    op = mapped.operator.render_template_fields(context=mapped_ti.get_template_context(session=session))
-    assert op
 
-    assert op.op_kwargs['arg1'] == "{{ ds }}"
-    assert op.op_kwargs['arg2'] == "fn"
+    assert mapped_ti.task.is_mapped
+    mapped.operator.render_template_fields(context=mapped_ti.get_template_context(session=session))
+    assert not mapped_ti.task.is_mapped
+
+    assert mapped_ti.task.op_kwargs['arg1'] == "{{ ds }}"
+    assert mapped_ti.task.op_kwargs['arg2'] == "fn"
 
 
 def test_task_decorator_has_wrapped_attr():

--- a/tests/models/test_mappedoperator.py
+++ b/tests/models/test_mappedoperator.py
@@ -305,12 +305,14 @@ def test_mapped_render_template_fields_validating_operator(dag_maker, session):
 
     mapped_ti: TaskInstance = dr.get_task_instance(mapped.task_id, session=session)
     mapped_ti.map_index = 0
-    op = mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
-    assert isinstance(op, MyOperator)
 
-    assert op.value == "{{ ds }}", "Should not be templated!"
-    assert op.arg1 == "{{ ds }}", "Should not be templated!"
-    assert op.arg2 == "a"
+    assert isinstance(mapped_ti.task, MappedOperator)
+    mapped.render_template_fields(context=mapped_ti.get_template_context(session=session))
+    assert isinstance(mapped_ti.task, MyOperator)
+
+    assert mapped_ti.task.value == "{{ ds }}", "Should not be templated!"
+    assert mapped_ti.task.arg1 == "{{ ds }}", "Should not be templated!"
+    assert mapped_ti.task.arg2 == "a"
 
 
 def test_mapped_render_nested_template_fields(dag_maker, session):
@@ -430,10 +432,11 @@ def test_expand_kwargs_render_template_fields_validating_operator(dag_maker, ses
     ti: TaskInstance = dr.get_task_instance(mapped.task_id, session=session)
     ti.refresh_from_task(mapped)
     ti.map_index = map_index
-    op = mapped.render_template_fields(context=ti.get_template_context(session=session))
-    assert isinstance(op, MockOperator)
-    assert op.arg1 == expected
-    assert op.arg2 == "a"
+    assert isinstance(ti.task, MappedOperator)
+    mapped.render_template_fields(context=ti.get_template_context(session=session))
+    assert isinstance(ti.task, MockOperator)
+    assert ti.task.arg1 == expected
+    assert ti.task.arg2 == "a"
 
 
 def test_xcomarg_property_of_mapped_operator(dag_maker):


### PR DESCRIPTION
Currently, when a mapped task is being rendered (and unmapped during the process), the template context continues to reference the mapped task because the context is created before unmapping. This is however not useful, and creates obstacles for use cases needing to reference a task-mapping value (something passed to the expand function).

This patch adds logic to replace `context["task"]` and `context["ti"].task` in-place when a mapped task is being unmapped, so they always reference an unmapped task during template rendering. This makes writing a Jinja template for a mapped task more consistent to that for a non-mapped one.

To accommodate this change in reference, some peripheral code is modified so various task variables point to the right things at the right moment. A few tests are also modified to ensure this in-place replacement is done at the right moment.

Fix #24388.