### PR TITLE
Fix PinotDB dependencies

### DIFF
--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -36,9 +36,11 @@ versions:
 dependencies:
   - apache-airflow>=2.2.0
   - apache-airflow-providers-common-sql>=1.1.0
-  # pinotdb v0.1.1 may still work with older versions of Apache Pinot, but we've confirmed that it
-  # causes a problem with newer versions.
   - pinotdb>0.1.2
+  # Pinotdb 0.4.7 lacks ciso8601 as install_requires dependency, yet it has implicit dependency on it
+  # Until https://github.com/python-pinot-dbapi/pinot-dbapi/issues/47 is fixed we add the dependency in
+  # the provider dependency
+  - ciso8601
 
 integrations:
   - integration-name: Apache Pinot

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -133,6 +133,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.1.0",
       "apache-airflow>=2.2.0",
+      "ciso8601",
       "pinotdb>0.1.2"
     ],
     "cross-providers-deps": [


### PR DESCRIPTION
Our canary builds detected that PinotDB released 7 hours ago lacks ciso8601 dependency, which make import fail during test collection.

This PR adds the dependency in provider until the issue is fixed. PR has been raised to PinotDB

https://github.com/python-pinot-dbapi/pinot-dbapi/issues/47

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
