### PR TITLE
Change links to `boto3` documentation

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -20,8 +20,8 @@ A client for AWS Batch services
 
 .. seealso::
 
-    - http://boto3.readthedocs.io/en/latest/guide/configuration.html
-    - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
 from __future__ import annotations
@@ -48,7 +48,7 @@ class BatchProtocol(Protocol):
     .. seealso::
 
         - https://mypy.readthedocs.io/en/latest/protocols.html
-        - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+        - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
     """
 
     def describe_jobs(self, jobs: list[str]) -> dict:

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -91,7 +91,7 @@ class BatchWaitersHook(BatchClientHook):
 
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
         credential boto3 strategy will be used
-        (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).
 
     :param region_name: region name to use in AWS client.
         Override the AWS region in connection (if provided)

--- a/airflow/providers/amazon/aws/hooks/ec2.py
+++ b/airflow/providers/amazon/aws/hooks/ec2.py
@@ -30,16 +30,17 @@ def only_client_type(func):
         if self._api_type == "client_type":
             return func(self, *args, **kwargs)
 
+        ec2_doc_link = "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html"
         raise AirflowException(
-            """
+            f"""
             This method is only callable when using client_type API for interacting with EC2.
             Create the EC2Hook object as follows to use this method
 
             ec2 = EC2Hook(api_type="client_type")
 
             Read following for details on client_type and resource_type APIs:
-            1. https://boto3.amazonaws.com/v1/documentation/api/1.9.42/reference/services/ec2.html#client
-            2. https://boto3.amazonaws.com/v1/documentation/api/1.9.42/reference/services/ec2.html#service-resource # noqa
+            1. {ec2_doc_link}#client
+            2. {ec2_doc_link}#service-resource
             """
         )
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -539,7 +539,7 @@ class S3Hook(AwsBaseHook):
 
         .. seealso::
             For more details about S3 Select parameters:
-            http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.select_object_content
+            https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.select_object_content
         """
         expression = expression or 'SELECT * FROM S3Object'
         expression_type = expression_type or 'SQL'

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -19,8 +19,8 @@ An Airflow operator for AWS Batch services
 
 .. seealso::
 
-    - http://boto3.readthedocs.io/en/latest/guide/configuration.html
-    - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+    - https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
 from __future__ import annotations

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -277,7 +277,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task
     :param aws_conn_id: connection id of AWS credentials / region name. If None,
         credential boto3 strategy will be used
-        (http://boto3.readthedocs.io/en/latest/guide/configuration.html).
+        (https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html).
     :param region_name: region name to use in AWS Hook.
         Override the region_name in connection (if provided)
     :param launch_type: the launch type on which to run your task ('EC2', 'EXTERNAL', or 'FARGATE')


### PR DESCRIPTION
Change `boto3.readthedocs.io/en` endpoint to `boto3.amazonaws.com/v1/documentation/api`
Change `http` schema to `https`
Use latests documentation rather than hardcoded to specific (outdated) version of `boto3`
