### PR TITLE
Add config to control Kubernetes Client retry behaviour

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2414,6 +2414,14 @@
       type: string
       example: ~
       default: ""
+    - name: client_retry_configuration_kwargs
+      description: |
+        Json dictionary of arguments to pass into urllib.Retry object used by the Kubernetes Client.
+        For details of all available options, see: https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.Retry
+      version_added: 2.4.2
+      type: string
+      example: '{ "total": 6, "backoff_factor": 0.8 }'
+      default: ""
     - name: delete_option_kwargs
       description: |
         Optional keyword arguments to pass to the ``delete_namespaced_pod`` kubernetes client

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1205,6 +1205,11 @@ in_cluster = True
 # https://raw.githubusercontent.com/kubernetes-client/python/41f11a09995efcd0142e25946adc7591431bfb2f/kubernetes/client/api/core_v1_api.py
 kube_client_request_args =
 
+# Json dictionary of arguments to pass into urllib.Retry object used by the Kubernetes Client.
+# For details of all available options, see: https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.Retry
+# Example: client_retry_configuration_kwargs = {{ "total": 6, "backoff_factor": 0.8 }}
+client_retry_configuration_kwargs =
+
 # Optional keyword arguments to pass to the ``delete_namespaced_pod`` kubernetes client
 # ``core_v1_api`` method when using the Kubernetes Executor.
 # This should be an object and can contain any of the options listed in the ``v1DeleteOptions``


### PR DESCRIPTION
Occasionally, a request to the Kubernetes API might fail due to temporary network glitches. By default, such requests are retried 3 times, without any delay between.
On the final failure, the entire scheduler crashes.

This configuration allows the urllib retry behaviour to be adjusted, mainly to allow some backoff in between each retry, giving the network time to recover before the final attempt.

Fixes #24748