### PR TITLE
Fix non-hidden cumulative chart on duration view

### DIFF
--- a/airflow/www/static/js/duration_chart.js
+++ b/airflow/www/static/js/duration_chart.js
@@ -29,5 +29,6 @@ function handleCheck() {
   }
 }
 $(document).on('chartload', handleCheck);
+$(document).ready(handleCheck);
 
 $('#isCumulative').on('click', handleCheck);


### PR DESCRIPTION
When you first load the page, cumulative is unchecked, but the chart itself is unhidden and appears below the non-cumulative chart.  Adding this line ensures that the initial value of the checkbox is respected.
