### PR TITLE
Fix task duration cumulative chart

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2931,10 +2931,11 @@ class Airflow(AirflowBaseView):
             if task_instance.duration:
                 date_time = wwwutils.epoch(task_instance.execution_date)
                 x_points[task_instance.task_id].append(date_time)
-                y_points[task_instance.task_id].append(float(task_instance.duration))
                 fails_dict_key = (task_instance.dag_id, task_instance.task_id, task_instance.run_id)
                 fails_total = fails_totals[fails_dict_key]
-                cumulative_y[task_instance.task_id].append(float(task_instance.duration + fails_total))
+                y_points[task_instance.task_id].append(float(task_instance.duration + fails_total))
+
+        cumulative_y = {k: list(itertools.accumulate(v)) for k, v in y_points.items()}
 
         # determine the most relevant time unit for the set of task instance
         # durations for the DAG


### PR DESCRIPTION
Previously the chart could go down, which should not happen for a cumulative chart.  We fix that here.

**ALSO** we add task fail duration to the non-cumulative

Before, it was only added to cumulative.

### After fix

<img width="954" alt="image" src="https://user-images.githubusercontent.com/15932138/192601369-bf6722ed-2966-4a3a-aed4-8a46d4809cc6.png">

### Before fix

<img width="935" alt="image" src="https://user-images.githubusercontent.com/15932138/192601476-e49a12c4-a28b-4b3d-8bef-df6794b6144c.png">



