### PR TITLE
Correct the description of "schema"

### DIFF
--- a/airflow/providers/microsoft/mssql/hooks/mssql.py
+++ b/airflow/providers/microsoft/mssql/hooks/mssql.py
@@ -18,7 +18,7 @@
 """Microsoft SQLServer hook module"""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Dict
 
 import pymssql
 
@@ -50,6 +50,15 @@ class MsSqlHook(DbApiHook):
         super().__init__(*args, **kwargs)
         self.schema = kwargs.pop("schema", None)
         self._sqlalchemy_scheme = sqlalchemy_scheme
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict[str, Any]:
+        """Returns custom UI field behaviour for MSSQL Connection."""
+        return {
+            "relabeling": {
+                "schema": "Database",
+            },
+        }
 
     @property
     def connection_extra_lower(self) -> dict:

--- a/docs/apache-airflow-providers-microsoft-mssql/connections/mssql.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/connections/mssql.rst
@@ -34,7 +34,7 @@ Host (required)
     The host to connect to.
 
 Schema (optional)
-    Specify the schema name to be used in the database.
+    Specify the database name to be used
 
 Login (required)
     Specify the user name to connect.

--- a/docs/apache-airflow-providers-microsoft-mssql/connections/mssql.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/connections/mssql.rst
@@ -33,7 +33,7 @@ Configuring the Connection
 Host (required)
     The host to connect to.
 
-Schema (optional)
+Database (optional)
     Specify the database name to be used
 
 Login (required)


### PR DESCRIPTION
misleading - the schema property actually needs to be the database property, as [per source code](https://github.com/apache/airflow/blob/06acf40a4337759797f666d5bb27a5a393b74fed/airflow/providers/microsoft/mssql/hooks/mssql.py#L103)

I am not sure if there's a better way to write this - open to suggestions / edits