### PR TITLE
Revert "Rename schema to database in `PostgresHook` (#26436)"

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -42,8 +42,6 @@ class PostgresOperator(BaseOperator):
         (default value: False)
     :param parameters: (optional) the parameters to render the SQL query with.
     :param database: name of database which overwrite defined one in connection
-    :param runtime_parameters: a mapping of runtime params added to the final sql being executed.
-        For example, you could set the schema via `{"search_path": "CUSTOM_SCHEMA"}`.
     """
 
     template_fields: Sequence[str] = ('sql',)
@@ -75,7 +73,7 @@ class PostgresOperator(BaseOperator):
         self.hook: PostgresHook | None = None
 
     def execute(self, context: Context):
-        self.hook = PostgresHook(postgres_conn_id=self.postgres_conn_id, database=self.database)
+        self.hook = PostgresHook(postgres_conn_id=self.postgres_conn_id, schema=self.database)
         if self.runtime_parameters:
             final_sql = []
             sql_param = {}

--- a/docs/apache-airflow-providers-postgres/connections/postgres.rst
+++ b/docs/apache-airflow-providers-postgres/connections/postgres.rst
@@ -29,14 +29,7 @@ Host (required)
     The host to connect to.
 
 Schema (optional)
-    Specify the name of the database to connect to.
-
-    .. note::
-
-        If you want to define a default database schema:
-
-        * using ``PostgresOperator`` see :ref:`Passing Server Configuration Parameters into PostgresOperator <howto/operators:postgres>`
-        * using ``PostgresHook`` see `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>_`
+    Specify the schema name to be used in the database.
 
 Login (required)
     Specify the user name to connect.

--- a/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
+++ b/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-.. _howto/operators:postgres:
-
 How-to Guide for PostgresOperator
 =================================
 

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -33,7 +33,7 @@ from airflow.utils.types import NOTSET
 class TestPostgresHookConn:
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.connection = Connection(login='login', password='password', host='host', schema='database')
+        self.connection = Connection(login='login', password='password', host='host', schema='schema')
 
         class UnitTestPostgresHook(PostgresHook):
             conn_name_attr = 'test_conn_id'
@@ -47,7 +47,7 @@ class TestPostgresHookConn:
         self.db_hook.test_conn_id = 'non_default'
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user='login', password='password', host='host', dbname='database', port=None
+            user='login', password='password', host='host', dbname='schema', port=None
         )
         self.db_hook.get_connection.assert_called_once_with('non_default')
 
@@ -55,7 +55,7 @@ class TestPostgresHookConn:
     def test_get_conn(self, mock_connect):
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user='login', password='password', host='host', dbname='database', port=None
+            user='login', password='password', host='host', dbname='schema', port=None
         )
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
@@ -64,7 +64,7 @@ class TestPostgresHookConn:
         self.connection.conn_type = 'postgres'
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
-        assert self.db_hook.get_uri() == "postgresql://login:password@host/database?client_encoding=utf-8"
+        assert self.db_hook.get_uri() == "postgresql://login:password@host/schema?client_encoding=utf-8"
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
     def test_get_conn_cursor(self, mock_connect):
@@ -75,7 +75,7 @@ class TestPostgresHookConn:
             user='login',
             password='password',
             host='host',
-            dbname='database',
+            dbname='schema',
             port=None,
         )
 
@@ -87,20 +87,20 @@ class TestPostgresHookConn:
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
     def test_get_conn_from_connection(self, mock_connect):
-        conn = Connection(login='login-conn', password='password-conn', host='host', schema='database')
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
         hook = PostgresHook(connection=conn)
         hook.get_conn()
         mock_connect.assert_called_once_with(
-            user='login-conn', password='password-conn', host='host', dbname='database', port=None
+            user='login-conn', password='password-conn', host='host', dbname='schema', port=None
         )
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
-    def test_get_conn_from_connection_with_database(self, mock_connect):
-        conn = Connection(login='login-conn', password='password-conn', host='host', schema="database")
-        hook = PostgresHook(connection=conn, database='database-override')
+    def test_get_conn_from_connection_with_schema(self, mock_connect):
+        conn = Connection(login='login-conn', password='password-conn', host='host', schema='schema')
+        hook = PostgresHook(connection=conn, schema='schema-override')
         hook.get_conn()
         mock_connect.assert_called_once_with(
-            user='login-conn', password='password-conn', host='host', dbname='database-override', port=None
+            user='login-conn', password='password-conn', host='host', dbname='schema-override', port=None
         )
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
@@ -146,7 +146,7 @@ class TestPostgresHookConn:
         self.connection.extra = '{"connect_timeout": 3}'
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user='login', password='password', host='host', dbname='database', port=None, connect_timeout=3
+            user='login', password='password', host='host', dbname='schema', port=None, connect_timeout=3
         )
 
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
@@ -225,37 +225,32 @@ class TestPostgresHookConn:
             port=(port or 5439),
         )
 
-    def test_get_uri_from_connection_without_database_override(self):
+    def test_get_uri_from_connection_without_schema_override(self):
         self.db_hook.get_connection = mock.MagicMock(
             return_value=Connection(
                 conn_type="postgres",
                 host="host",
                 login="login",
                 password="password",
-                schema="database",
+                schema="schema",
                 port=1,
             )
         )
-        assert "postgresql://login:password@host:1/database" == self.db_hook.get_uri()
+        assert "postgresql://login:password@host:1/schema" == self.db_hook.get_uri()
 
-    def test_get_uri_from_connection_with_database_override(self):
-        hook = PostgresHook(database='database-override')
+    def test_get_uri_from_connection_with_schema_override(self):
+        hook = PostgresHook(schema='schema-override')
         hook.get_connection = mock.MagicMock(
             return_value=Connection(
                 conn_type="postgres",
                 host="host",
                 login="login",
                 password="password",
-                schema="database",
+                schema="schema",
                 port=1,
             )
         )
-        assert "postgresql://login:password@host:1/database-override" == hook.get_uri()
-
-    def test_schema_kwarg_database_kwarg_compatibility(self):
-        database = 'database-override'
-        hook = PostgresHook(schema=database)
-        assert hook.database == database
+        assert "postgresql://login:password@host:1/schema-override" == hook.get_uri()
 
 
 class TestPostgresHook(unittest.TestCase):

--- a/tests/providers/postgres/operators/test_postgres.py
+++ b/tests/providers/postgres/operators/test_postgres.py
@@ -79,14 +79,14 @@ class TestPostgres(unittest.TestCase):
         op = PostgresOperator(task_id='postgres_operator_test_vacuum', sql=sql, dag=self.dag, autocommit=True)
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
-    def test_overwrite_database(self):
+    def test_overwrite_schema(self):
         """
-        Verifies option to overwrite connection database
+        Verifies option to overwrite connection schema
         """
 
         sql = "SELECT 1;"
         op = PostgresOperator(
-            task_id='postgres_operator_test_database_overwrite',
+            task_id='postgres_operator_test_schema_overwrite',
             sql=sql,
             dag=self.dag,
             autocommit=True,


### PR DESCRIPTION
This reverts commit 642375f97de133edba1a6c1fa9397d840e8b5936.

The common sql tests didn't run in #26436, and there are failures there from this change.

I think they might point toward compatibility problems with the change, so reverting for now.