### PR TITLE
Allow serialization of custom objects

### DIFF
--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -28,6 +28,7 @@ class Encoding(str, Enum):
 
     TYPE = '__type'
     VAR = '__var'
+    IMPORT_PATH = '__path'
 
 
 # Supported types for encoding. primitives and list are not encoded.
@@ -50,3 +51,4 @@ class DagAttributeTypes(str, Enum):
     PARAM = 'param'
     XCOM_REF = 'xcomref'
     DATASET = 'dataset'
+    CUSTOM = 'custom'


### PR DESCRIPTION
We can make the serializer handle arbitrary custom objects provided they implement methods `airflow_serialize` and `airflow_deserialize`.

Why?

Well..... one potential use is it could provide flexibility to handle user-defined objects through XCom.

Additionally, it could be desirable to manage serialization protocol in the objects themselves rather than always having to update the base serialization class.