### PR TITLE
Add all dependent providers when running selective checks

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -216,8 +216,12 @@ def add_dependent_providers(
     providers: set[str], provider_to_check: str, dependencies: dict[str, dict[str, list[str]]]
 ):
     for provider, provider_info in dependencies.items():
+        # Providers that use this provider
         if provider_to_check in provider_info['cross-providers-deps']:
             providers.add(provider)
+        # and providers we use directly
+        for dep_name in dependencies[provider_to_check]["cross-providers-deps"]:
+            providers.add(dep_name)
 
 
 def find_all_providers_affected(changed_files: tuple[str, ...]) -> set[str]:

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -66,7 +66,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], output: str):
             pytest.param(
                 (
                     "airflow/api/file.py",
-                    "tests/providers/google/file.py",
+                    "tests/providers/postgres/file.py",
                 ),
                 {
                     "all-python-versions": "['3.7']",
@@ -76,8 +76,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], output: str):
                     "run-tests": "true",
                     "docs-build": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "test-types": "API Always Providers[amazon,apache.beam,google,hashicorp,"
-                    "microsoft.azure,presto,trino]",
+                    "test-types": "API Always Providers[amazon,common.sql,google,postgres]",
                 },
                 id="API and providers tests and docs should run",
             )
@@ -120,7 +119,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], output: str):
             pytest.param(
                 (
                     "chart/aaaa.txt",
-                    "tests/providers/google/file.py",
+                    "tests/providers/postgres/file.py",
                 ),
                 {
                     "all-python-versions": "['3.7']",
@@ -131,10 +130,10 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], output: str):
                     "docs-build": "true",
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "test-types": "Always Providers[amazon,apache.beam,google,"
-                    "hashicorp,microsoft.azure,presto,trino]",
+                    "test-types": "Always Providers[amazon,common.sql,google,postgres]",
                 },
-                id="Helm tests, providers, kubernetes tests and docs should run",
+                id="Helm tests, providers (both upstream and downstream),"
+                "kubernetes tests and docs should run",
             )
         ),
         (
@@ -175,9 +174,9 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], output: str):
                     "docs-build": "true",
                     "run-kubernetes-tests": "true",
                     "upgrade-to-newer-dependencies": "false",
-                    "test-types": "Always Providers[airbyte]",
+                    "test-types": "Always Providers[airbyte,http]",
                 },
-                id="Helm tests, airbyte providers, kubernetes tests and "
+                id="Helm tests, airbyte/http providers, kubernetes tests and "
                 "docs should run even if unimportant files were added",
             )
         ),


### PR DESCRIPTION
Like we run tests for providers that use a changing provider, we need to run tests for any providers we use directly.

So for example, if we change the `postgres` provider, both `common.sql` (which `postgres` uses) and `google` (which uses `postgres`) should be run.

Related: #26734