### PR TITLE
Bump sphinx and sphinx-autoapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -266,15 +266,11 @@ doc = [
     'importlib-metadata>=4.4; python_version < "3.8"',
     'sphinx-airflow-theme',
     'sphinx-argparse>=0.1.13',
-    'sphinx-autoapi>=1.8.0',
+    'sphinx-autoapi>=2.0.0',
     'sphinx-copybutton',
     'sphinx-jinja>=2.0',
     'sphinx-rtd-theme>=0.1.6',
-    # Spinx 5.2.0 introduced deprecation for property documentation and autoapi 1.9.0 generates
-    # documentation that uses the old way of documenting it. This is tracked in
-    # https://github.com/readthedocs/sphinx-autoapi/issues/352 of autoapi and until it is solved
-    # we need to limit Sphinx to <5.2.0
-    'sphinx>=4.4.0,<5.2.0',
+    'sphinx>=5.2.0',
     'sphinxcontrib-httpdomain>=1.7.0',
     'sphinxcontrib-redoc>=1.6.0',
     'sphinxcontrib-spelling>=7.3',


### PR DESCRIPTION
The sphinx-autoapi bug https://github.com/readthedocs/sphinx-autoapi/issues/352 has been resolved and 2.0.0 version has been released. Since we are using sphinx/sphinx-autoapi only for `doc` extra, we can safely bump the minimum version of both to latest released minor versions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
