### PR TITLE
Fix separator getting added to variables_prefix when empty

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -170,7 +170,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         """
         # when no prefix is given by default it adds sep for the key
         if path_prefix == "":
-            path = f'{secret_id}'    
+            path = f'{secret_id}'
         else:
             path = f'{path_prefix}{sep}{secret_id}'
         return path.replace('_', sep)

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -168,7 +168,11 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param secret_id: Name of the secret
         :param sep: Separator used to concatenate path_prefix and secret_id
         """
-        path = f'{path_prefix}{sep}{secret_id}'
+        # when no prefix is given by default it adds sep for the key
+        if path_prefix == "":
+            path = f'{secret_id}'    
+        else:
+            path = f'{path_prefix}{sep}{secret_id}'
         return path.replace('_', sep)
 
     def _get_secret(self, path_prefix: str, secret_id: str) -> str | None:

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -168,7 +168,7 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
         :param secret_id: Name of the secret
         :param sep: Separator used to concatenate path_prefix and secret_id
         """
-        # when no prefix is given by default it adds sep for the key
+        # When an empty prefix is given, do not add a separator to the secret name
         if path_prefix == "":
             path = f'{secret_id}'
         else:


### PR DESCRIPTION
Describe the bug
azure key vault adds a - between the key prefix and the secret name when it reads it from the azure key vault. It does this even when the variables prefix is "" so secrets end up named -my-secret instead of my-secret.

To Reproduce
Follow the instructions to set up an azure key vault integrated install with a variables_prefix of "".
Create a secret named -my-var in the azure key vault.
Use the example dag provided in the docs with Variable.get("my-var")
You will see that it fetches the variable because it is incorrectly mapping my-var to -my-var instead of my-var.

Expected Behaviour
connections_prefix and variables_prefix don't add a leading - when they are set to "".

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
