### PR TITLE
Allow retrieving error message from data.detail

### DIFF
--- a/airflow/www/static/js/utils/useErrorToast.ts
+++ b/airflow/www/static/js/utils/useErrorToast.ts
@@ -28,7 +28,7 @@ export const getErrorDescription = (error?: ErrorType, fallbackMessage?: string)
   if (error instanceof Error) {
     let { message } = error;
     if (axios.isAxiosError(error)) {
-      message = error.response?.data || error.message;
+      message = error.response?.data?.detail || error.response?.data || error.message;
     }
     return message;
   }


### PR DESCRIPTION
When testing edge cases for https://github.com/apache/airflow/pull/26457 I noticed that the toast error would not properly be displayed when the api response returns any error derived from a `ProblemException`. This would end up in an unhandled exception in the UI.

> Note: Certain endpoint like `/run` can return just a text when there is an error, so we need to keep the `error.response?.data` in case `data` is plain text and not an object.

### Before
![image](https://user-images.githubusercontent.com/14861206/192890426-093067d3-0fc9-4796-a162-3e109aa07bf4.png)

### After
![image](https://user-images.githubusercontent.com/14861206/192890606-173efd04-c989-4d14-ae34-6ddf75a12958.png)

