### PR TITLE
Update snowflake hook to not use extra prefix

### DIFF
--- a/airflow/providers/snowflake/CHANGELOG.rst
+++ b/airflow/providers/snowflake/CHANGELOG.rst
@@ -24,6 +24,17 @@
 Changelog
 ---------
 
+5.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* This release of provider is only available for Airflow 2.3+ as explained in the Apache Airflow
+  providers support policy https://github.com/apache/airflow/blob/main/README.md#support-for-providers
+* In SnowflakeHook, if both ``extra__snowflake__foo`` and ``foo`` existed in connection extra
+  dict, the prefixed version would be used; now, the non-prefixed version will be preferred.
+
 3.3.0
 .....
 

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -180,15 +180,24 @@ class SnowflakeHook(DbApiHook):
         self.query_ids: list[str] = []
 
     def _get_field(self, extra_dict, field_name):
-        prefix = 'extra__snowflake__'
+        backcompat_prefix = 'extra__snowflake__'
+        backcompat_key = f"{backcompat_prefix}{field_name}"
         if field_name.startswith('extra__'):
             raise ValueError(
-                f"Got prefixed name {field_name}; please remove the '{prefix}' prefix "
+                f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
                 f"when using this method."
             )
         if field_name in extra_dict:
+            import warnings
+
+            if backcompat_key in extra_dict:
+                warnings.warn(
+                    f"Conflicting params `{field_name}` and `{backcompat_key}` found in extras. "
+                    f"Using value for `{field_name}`.  Please ensure this is the correct "
+                    f"value and remove the backcompat key `{backcompat_key}`."
+                )
             return extra_dict[field_name] or None
-        return extra_dict.get(f"{prefix}{field_name}") or None
+        return extra_dict.get(backcompat_key) or None
 
     def _get_conn_params(self) -> dict[str, str | None]:
         """

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -181,7 +181,7 @@ class SnowflakeHook(DbApiHook):
 
     def _get_field(self, extra_dict, field_name):
         prefix = 'extra__snowflake__'
-        if field_name.startswith('extra_'):
+        if field_name.startswith('extra__'):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the '{prefix}' prefix "
                 f"when using this method."

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -50,8 +50,8 @@ def _ensure_prefixes(conn_type):
 
     def dec(func):
         @wraps(func)
-        def inner(cls):
-            field_behaviors = func(cls)
+        def inner():
+            field_behaviors = func()
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -49,7 +49,9 @@ def _ensure_prefixes(conn_type):
     """
 
     def dec(func):
-        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+        @wraps(func)
+        def inner(cls):
+            field_behaviors = func(cls)
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):
@@ -61,12 +63,7 @@ def _ensure_prefixes(conn_type):
             if 'placeholders' in field_behaviors:
                 placeholders = field_behaviors['placeholders']
                 field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
-
             return field_behaviors
-
-        @wraps(func)
-        def inner():
-            return _ensure_prefix_for_placeholders(func(), conn_type)
 
         return inner
 

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -29,9 +29,9 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from airflow.compat.functools import cached_property
 from airflow.models import Connection
 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
 
 _PASSWORD = 'snowflake42'
 
@@ -587,18 +587,38 @@ class TestPytestSnowflakeHook:
                 hook.run(sql=empty_statement)
             assert err.value.args[0] == "List of SQL statements is empty"
 
-    @cached_property
-    def provider_min_airflow_version(self):
-        from airflow.providers_manager import ProvidersManager
-
-        p = ProvidersManager()
-        deps = p.providers['apache-airflow-providers-snowflake'].data['dependencies']
-        airflow_dep = [x for x in deps if x.startswith('apache-airflow')][0]
-        min_airflow_version = tuple(map(int, airflow_dep.split('>=')[1].split('.')))
-        return min_airflow_version
-
-    def test_maybe_add_prefix_removal(self):
-        if self.provider_min_airflow_version >= (2, 3):
+    def test__ensure_prefixes_removal(self):
+        """Ensure that _ensure_prefixes is removed from snowflake when airflow min version >= 2.5.0."""
+        path = 'airflow.providers.snowflake.hooks.snowflake._ensure_prefixes'
+        if not object_exists(path):
             raise Exception(
-                'Helper function _maybe_add_prefix should be removed when min airflow version is >= 2.3'
+                "You must remove this test. It only exists to "
+                "remind us to remove decorator `_ensure_prefixes`."
             )
+
+        if get_provider_min_airflow_version('apache-airflow-providers-snowflake') >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from SnowflakeHook.  The functionality is now taken"
+                "care of by providers manager."
+            )
+
+    def test___ensure_prefixes(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
+        """
+        assert list(SnowflakeHook.get_ui_field_behaviour()['placeholders'].keys()) == [
+            'extra',
+            'schema',
+            'login',
+            'password',
+            'extra__snowflake__account',
+            'extra__snowflake__warehouse',
+            'extra__snowflake__database',
+            'extra__snowflake__region',
+            'extra__snowflake__role',
+            'extra__snowflake__private_key_file',
+            'extra__snowflake__private_key_content',
+            'extra__snowflake__insecure_mode',
+        ]

--- a/tests/test_utils/providers.py
+++ b/tests/test_utils/providers.py
@@ -46,3 +46,13 @@ def get_provider_version(provider_name):
 
     info = ProvidersManager().providers[provider_name]
     return semver.VersionInfo.parse(info.version)
+
+
+def get_provider_min_airflow_version(provider_name):
+    from airflow.providers_manager import ProvidersManager
+
+    p = ProvidersManager()
+    deps = p.providers[provider_name].data['dependencies']
+    airflow_dep = [x for x in deps if x.startswith('apache-airflow')][0]
+    min_airflow_version = tuple(map(int, airflow_dep.split('>=')[1].split('.')))
+    return min_airflow_version


### PR DESCRIPTION
As of Airflow 2.3 it's no longer necessary to use the `extra__<conn_type>__` prefix for connection extras.

We're bumping min airflow version to 2.3 now, so we can remove the prefix.

We handle back compat with method get_field.

And in version 2.5 we will support no prefix in `get_ui_field_behaviors` (pr https://github.com/apache/airflow/pull/26995), so we prepare for that here.  What we do is update the placeholders to remove the prefix but add in the logic (which in 2.5 is added to providers manager) to add the prefix.  This way all we need to do when min airflow version is 2.5 is remove the decorator.  And in the meantime, we don't ever have to see the prefix.

