### PR TITLE
Allow generation of connection URI to work when no conn type

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -212,7 +212,10 @@ class Connection(Base, LoggingMixin):
                 self.conn_type,
             )
 
-        uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
+        if self.conn_type:
+            uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
+        else:
+            uri = '//'
 
         authority_block = ""
         if self.login is not None:

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -215,7 +215,7 @@ class Connection(Base, LoggingMixin):
         if self.conn_type:
             uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
         else:
-            uri = '//'
+            uri = "//"
 
         authority_block = ""
         if self.login is not None:

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -212,7 +212,7 @@ class Connection(Base, LoggingMixin):
                 self.conn_type,
             )
 
-        uri = f"{str(self.conn_type or 'none').lower().replace('_', '-')}://"
+        uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
 
         authority_block = ""
         if self.login is not None:

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -206,13 +206,13 @@ class Connection(Base, LoggingMixin):
 
     def get_uri(self) -> str:
         """Return connection in URI format"""
-        if "_" in self.conn_type:
+        if self.conn_type and "_" in self.conn_type:
             self.log.warning(
                 "Connection schemes (type: %s) shall not contain '_' according to RFC3986.",
                 self.conn_type,
             )
 
-        uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
+        uri = f"{str(self.conn_type or 'none').lower().replace('_', '-')}://"
 
         authority_block = ""
         if self.login is not None:

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -213,7 +213,7 @@ class Connection(Base, LoggingMixin):
             )
 
         if self.conn_type:
-            uri = f"{str(self.conn_type).lower().replace('_', '-')}://"
+            uri = f"{self.conn_type.lower().replace('_', '-')}://"
         else:
             uri = "//"
 

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -738,8 +738,8 @@ class TestConnection(unittest.TestCase):
 
     def test_get_uri_no_conn_type(self):
         # no conn type --> scheme-relative URI
-        assert Connection().get_uri() == '//'
+        assert Connection().get_uri() == "//"
         # with host, still works
-        assert Connection(host='abc').get_uri() == '//abc'
+        assert Connection(host="abc").get_uri() == "//abc"
         # parsing back as conn still works
-        assert Connection(uri='//abc').host == 'abc'
+        assert Connection(uri="//abc").host == "abc"

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -735,3 +735,6 @@ class TestConnection(unittest.TestCase):
     def test_extra_warnings_non_dict_json(self):
         with pytest.warns(DeprecationWarning, match="not parse as a dictionary"):
             Connection(conn_id="test_extra", conn_type="none", extra='"hi"')
+
+    def test_get_uri_no_conn_type(self):
+        assert Connection().get_uri() == 'none://'

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -737,4 +737,9 @@ class TestConnection(unittest.TestCase):
             Connection(conn_id="test_extra", conn_type="none", extra='"hi"')
 
     def test_get_uri_no_conn_type(self):
-        assert Connection().get_uri() == 'none://'
+        # no conn type --> scheme-relative URI
+        assert Connection().get_uri() == '//'
+        # with host, still works
+        assert Connection(host='abc').get_uri() == '//abc'
+        # parsing back as conn still works
+        assert Connection(uri='//abc').host == 'abc'


### PR DESCRIPTION
Previously if get_uri was called it would fail with `NoneType not iterable`, because of the check `if '-' in conn_type`.
