### PR TITLE
Fix MaxID logic for GCSToBigQueryOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -319,9 +319,9 @@ class GCSToBigQueryOperator(BaseOperator):
                     location=self.location,
                     use_legacy_sql=False,
                 )
-            result = list(bq_hook.get_job(job_id=job_id, location=self.location).result())
-            if result and len(result) > 0:
-                row = result[0]
+            result = bq_hook.get_job(job_id=job_id, location=self.location).result()
+            row = next(iter(result), None)
+            if row is not None:
                 max_id = row[0]
                 self.log.info(
                     'Loaded BQ data with max %s.%s=%s',

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -319,9 +319,10 @@ class GCSToBigQueryOperator(BaseOperator):
                     location=self.location,
                     use_legacy_sql=False,
                 )
-            row = list(bq_hook.get_job(job_id=job_id, location=self.location).result())
-            if row:
-                max_id = row[0] if row[0] else 0
+            result = list(bq_hook.get_job(job_id=job_id, location=self.location).result())
+            if result and len(result) > 0:
+                row = result[0]
+                max_id = row[0]
                 self.log.info(
                     'Loaded BQ data with max %s.%s=%s',
                     self.destination_project_dataset_table,

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -321,14 +321,13 @@ class GCSToBigQueryOperator(BaseOperator):
                 )
             result = bq_hook.get_job(job_id=job_id, location=self.location).result()
             row = next(iter(result), None)
-            if row is not None:
-                max_id = row[0]
-                self.log.info(
-                    'Loaded BQ data with max %s.%s=%s',
-                    self.destination_project_dataset_table,
-                    self.max_id_key,
-                    max_id,
-                )
-                return max_id
-            else:
+            if row is None:
                 raise RuntimeError(f"The {select_command} returned no rows!")
+            max_id = row[0]
+            self.log.info(
+                'Loaded BQ data with max %s.%s=%s',
+                self.destination_project_dataset_table,
+                self.max_id_key,
+                max_id,
+            )
+            return max_id

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import unittest
 from unittest import mock
 
+from google.cloud.bigquery.table import Row
+
 from airflow.providers.google.cloud.transfers.gcs_to_bigquery import GCSToBigQueryOperator
 
 TASK_ID = 'test-gcs-to-bq-operator'
@@ -43,11 +45,11 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             max_id_key=MAX_ID_KEY,
         )
 
-        bq_hook.return_value.get_job.return_value.result.return_value = ('1',)
+        bq_hook.return_value.get_job.return_value.result.return_value = [Row(('100',), {'f0_': 0})]
 
         result = operator.execute(None)
 
-        assert result == '1'
+        assert result == '100'
 
         bq_hook.return_value.run_query.assert_called_once_with(
             sql="SELECT MAX(id) FROM `test-project.dataset.table`",


### PR DESCRIPTION
related: #26283 
closes: #26767

The `max_id_key ` parameter, when used, causes an XCom serialization failure when trying to retrieve the value back out of XCom. This is because instead of storing a single column value in XCom, we were accidentally storing the entire Row.

The Unit Test was updated to reflect the return type of `get_job().result()`. This operation actually returns a Row iterator, but returning an array of `Row` works well for the test.