### PR TITLE
Avoid circular imports in AWS Secrets Backends if obtain secrets from config

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -29,7 +29,7 @@ import json
 import logging
 import warnings
 from functools import wraps
-from typing import Any, Callable, Generic, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, Union
 
 import boto3
 import botocore
@@ -46,12 +46,15 @@ from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
-from airflow.models.connection import Connection
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 
 BaseAwsConnection = TypeVar("BaseAwsConnection", bound=Union[boto3.client, boto3.resource])
+
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection  # Avoid circular imports.
 
 
 class BaseSessionFactory(LoggingMixin):

--- a/airflow/providers/amazon/aws/utils/connection_wrapper.py
+++ b/airflow/providers/amazon/aws/utils/connection_wrapper.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import json
 import warnings
 from copy import deepcopy
 from dataclasses import MISSING, InitVar, dataclass, field, fields
@@ -39,7 +40,44 @@ except ImportError:  # TODO: Remove when the provider has an Airflow 2.3+ requir
     NOTSET = ArgNotSet()
 
 if TYPE_CHECKING:
-    from airflow.models.connection import Connection
+    from airflow.models.connection import Connection  # Avoid circular imports.
+
+
+@dataclass
+class _ConnectionMetadata:
+    """Connection metadata data-class.
+
+    This class implements main :ref:`~airflow.models.connection.Connection` attributes
+    and use in AwsConnectionWrapper for avoid circular imports.
+
+    Only for internal usage, this class might change or removed in the future.
+    """
+
+    conn_id: str | None = None
+    conn_type: str | None = None
+    description: str | None = None
+    host: str | None = None
+    login: str | None = None
+    password: str | None = None
+    schema: str | None = None
+    port: int | None = None
+    extra: str | dict | None = None
+
+    @property
+    def extra_dejson(self):
+        if not self.extra:
+            return {}
+        extra = deepcopy(self.extra)
+        if isinstance(extra, str):
+            try:
+                extra = json.loads(extra)
+            except json.JSONDecodeError as err:
+                raise AirflowException(
+                    f"'extra' expected valid JSON-Object string. Original error:\n * {err}"
+                ) from None
+        if not isinstance(extra, dict):
+            raise TypeError(f"Expected JSON-Object or dict, got {type(extra).__name__}.")
+        return extra
 
 
 @dataclass
@@ -61,7 +99,7 @@ class AwsConnectionWrapper(LoggingMixin):
         3. The wrapper's default value
     """
 
-    conn: InitVar[Connection | AwsConnectionWrapper | None]
+    conn: InitVar[Connection | AwsConnectionWrapper | _ConnectionMetadata | None]
     region_name: str | None = field(default=None)
     # boto3 client/resource configs
     botocore_config: Config | None = field(default=None)
@@ -242,11 +280,10 @@ class AwsConnectionWrapper(LoggingMixin):
         :param password: AWS Secret Access Key.
         :param extra: Connection Extra metadata.
         """
-        from airflow.models.connection import Connection
-
-        return cls(
-            conn=Connection(conn_id=conn_id, conn_type="aws", login=login, password=password, extra=extra)
+        conn_meta = _ConnectionMetadata(
+            conn_id=conn_id, conn_type="aws", login=login, password=password, extra=extra
         )
+        return cls(conn=conn_meta)
 
     @property
     def extra_dejson(self):

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -23,7 +23,7 @@ import pytest
 from botocore.config import Config
 
 from airflow.models import Connection
-from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
+from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper, _ConnectionMetadata
 
 MOCK_AWS_CONN_ID = "mock-conn-id"
 MOCK_CONN_TYPE = "aws"
@@ -34,6 +34,35 @@ def mock_connection_factory(
     conn_id: str | None = MOCK_AWS_CONN_ID, conn_type: str | None = MOCK_CONN_TYPE, **kwargs
 ) -> Connection:
     return Connection(conn_id=conn_id, conn_type=conn_type, **kwargs)
+
+
+class TestsConnectionMetadata:
+    @pytest.mark.parametrize("extra", [{"foo": "bar", "spam": "egg"}, '{"foo": "bar", "spam": "egg"}', None])
+    def test_compat_with_connection(self, extra):
+        """Simple compatibility test with `airflow.models.connection.Connection`."""
+        conn_kwargs = {
+            "conn_id": MOCK_AWS_CONN_ID,
+            "conn_type": "aws",
+            "login": "mock-login",
+            "password": "mock-password",
+            "extra": extra,
+            # AwsBaseHook never use this attributes from airflow.models.Connection
+            "host": "mock-host",
+            "schema": "mock-schema",
+            "port": 42,
+        }
+        conn = Connection(**conn_kwargs)
+        conn_meta = _ConnectionMetadata(**conn_kwargs)
+
+        assert conn.conn_id == conn_meta.conn_id
+        assert conn.conn_type == conn_meta.conn_type
+        assert conn.login == conn_meta.login
+        assert conn.password == conn_meta.password
+        assert conn.host == conn_meta.host
+        assert conn.schema == conn_meta.schema
+        assert conn.port == conn_meta.port
+
+        assert conn.extra_dejson == conn_meta.extra_dejson
 
 
 class TestAwsConnectionWrapper:


### PR DESCRIPTION
PR #25628 add new possibility with circular imports in Secrets Backends.
It affect both AWS secrets backends in case if user want to retrieve secrets configs from SB.

How to reproduce

```shell
❯ export AIRFLOW__SECRETS__BACKEND=airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
❯ export AIRFLOW__SECRETS__BACKEND_KWARGS='{"config_prefix": "/airflow/config", "region_name": "eu-west-1"}'
❯ export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_SECRET=boom
❯ airflow config get-value database sql_alchemy_conn

...

airflow.exceptions.AirflowConfigException: Cannot retrieve config from alternative secrets backend. Make sure it is configured properly and that the Backend is accessible.
Cannot retrieve config from alternative secrets backend. Make sure it is configured properly and that the Backend is accessible.
cannot import name 'SessionFactory' from partially initialized module 'airflow.providers.amazon.aws.hooks.base_aws' (most likely due to a circular import) (/Users/taragolis/Projects/common/airflow/airflow/providers/amazon/aws/hooks/base_aws.py)
```

After this changes
```shell
❯ export AIRFLOW__SECRETS__BACKEND=airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
❯ export AIRFLOW__SECRETS__BACKEND_KWARGS='{"config_prefix": "/airflow/config", "region_name": "eu-west-1"}'
❯ export AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_SECRET=boom
❯ airflow config get-value database sql_alchemy_conn

[2022-09-29 22:27:59,204] {credentials.py:1180} INFO - Found credentials in environment variables.
[2022-09-29 22:27:59,665] {credentials.py:1180} INFO - Found credentials in environment variables.
sqlite:////Users/taragolis/airflow/airflow-from-ssm.db
```

closes: #26754