### PR TITLE
Fix parsing of optional `mode` field in BigQuery Result Schema

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2999,6 +2999,7 @@ def _format_schema_for_description(schema: dict) -> list:
     """
     description = []
     for field in schema["fields"]:
+        mode = field.get("mode", "NULLABLE")
         field_description = (
             field["name"],
             field["type"],
@@ -3006,7 +3007,7 @@ def _format_schema_for_description(schema: dict) -> list:
             None,
             None,
             None,
-            field["mode"] == "NULLABLE",
+            mode == "NULLABLE",
         )
         description.append(field_description)
     return description

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1255,11 +1255,17 @@ class TestBigQueryCursor(_BigQueryBaseTestClass):
             "schema": {
                 "fields": [
                     {"name": "field_1", "type": "STRING", "mode": "NULLABLE"},
+                    {"name": "field_2", "type": "STRING"},
+                    {"name": "field_3", "type": "STRING", "mode": "REPEATED"},
                 ]
             },
         }
         description = _format_schema_for_description(test_query_result["schema"])
-        assert description == [('field_1', 'STRING', None, None, None, None, True)]
+        assert description == [
+            ('field_1', 'STRING', None, None, None, None, True),
+            ('field_2', 'STRING', None, None, None, None, True),
+            ('field_3', 'STRING', None, None, None, None, False),
+        ]
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")


### PR DESCRIPTION
closes: #26785

The code currently expects mode to be present in the returned Schema object from BigQuery, but according to the official docs, only name and type are required to be present. mode is listed as optional.

https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TableFieldSchema

I updated the code to make mode optional, with a default of `NULLABLE` which matches the docs:

> The default value is NULLABLE.

I improved the unit tests to account for more possible scenarios.