### PR TITLE
demote Removed state in priority for displaying task summaries

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -21,7 +21,7 @@
 
 /*
   global d3, document, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $,
-  autoRefreshInterval, moment, convertSecsToHumanReadable
+  autoRefreshInterval, moment, convertSecsToHumanReadable, priority
 */
 
 import { getMetaValue, finalStatesMap } from './utils';
@@ -599,12 +599,6 @@ function getNodeState(nodeId, tis) {
       childrenStates.add(state == null ? 'no_status' : state);
     }
   });
-
-  // In this order, if any of these states appeared in childrenStates, return it as
-  // the group state.
-  const priority = ['failed', 'upstream_failed', 'up_for_retry', 'up_for_reschedule',
-    'queued', 'scheduled', 'running', 'shutdown', 'restarting', 'removed',
-    'no_status', 'success', 'skipped'];
 
   return priority.find((state) => childrenStates.has(state)) || 'no_status';
 }

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -136,6 +136,7 @@
     const tasks = {{ tasks|tojson }};
     let taskInstances = {{ task_instances|tojson }};
     const autoRefreshInterval = {{ auto_refresh_interval }};
+    const priority = {{ state_priority|tojson }};
   </script>
   <script src="{{ url_for_asset('d3.min.js') }}"></script>
   <script src="{{ url_for_asset('dagre-d3.min.js') }}"></script>

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -93,10 +93,10 @@ priority = [
     TaskInstanceState.RUNNING,
     TaskInstanceState.SHUTDOWN,
     TaskInstanceState.RESTARTING,
-    TaskInstanceState.REMOVED,
     None,
     TaskInstanceState.SUCCESS,
     TaskInstanceState.SKIPPED,
+    TaskInstanceState.REMOVED,
 ]
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2810,6 +2810,8 @@ class Airflow(AirflowBaseView):
         else:
             external_log_name = None
 
+        state_priority = ['no_status' if p is None else p for p in wwwutils.priority]
+
         return self.render_template(
             'airflow/graph.html',
             dag=dag,
@@ -2832,6 +2834,7 @@ class Airflow(AirflowBaseView):
             dag_run_state=dt_nr_dr_data['dr_state'],
             dag_model=dag_model,
             auto_refresh_interval=conf.getint('webserver', 'auto_refresh_interval'),
+            state_priority=state_priority,
         )
 
     @expose('/duration')


### PR DESCRIPTION
Before, `removed` was being prioritized before `success` when displaying the state of a task group or mapped task. It can be perfectly okay to remove tasks, so it should be a lower priority.

Also, consolidate the priority list to a single source of truth and pass it from utils to the graph view.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
