### PR TITLE
Fix running debuggers inside `airflow tasks test`

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -271,6 +271,7 @@ class RedactedIO(TextIO):
 
     def __init__(self):
         self.target = sys.stdout
+        self.fileno = sys.stdout.fileno
 
     def write(self, s: str) -> int:
         s = redact(s)

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import io
 import logging
 import logging.config
 import os
+import sys
 import textwrap
 
 import pytest
@@ -363,3 +365,13 @@ class TestRedactedIO:
         RedactedIO().write(p)
         stdout = capsys.readouterr().out
         assert stdout == "***"
+
+    def test_input_builtin(self, monkeypatch):
+        """
+        Test that when redirect is inplace the `input()` builtin works.
+
+        This is used by debuggers!
+        """
+        monkeypatch.setattr(sys, 'stdin', io.StringIO("a\n"))
+        with contextlib.redirect_stdout(RedactedIO()):
+            assert input() == "a"


### PR DESCRIPTION
Fixes #26802

As part of 2.3.3 we added redaction to output from the tasks test
command, but unfortunately that broke using a debugger with this error:

```
  File "/usr/lib/python3.10/pdb.py", line 262, in user_line
    self.interaction(frame, None)
  File "/home/ash/.virtualenvs/airflow/lib/python3.10/site-packages/pdb.py", line 231, in interaction
    self._cmdloop()
  File "/usr/lib/python3.10/pdb.py", line 322, in _cmdloop
    self.cmdloop()
  File "/usr/lib/python3.10/cmd.py", line 126, in cmdloop
    line = input(self.prompt)
TypeError: 'NoneType' object cannot be interpreted as an integer
```

(ipdb has a similar but different error)

The "fix" is to assign a fileno attribute to the object. `input()` needs
this to write the prompt. It feels like a "bug" that it doesn't work
without it, but as this class is only used in `tasks test` this is a
safe change


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).