### PR TITLE
Documentation fixes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -895,7 +895,7 @@ Details in the `SQLAlchemy Changelog <https://docs.sqlalchemy.org/en/14/changelo
 ``auth_backends`` replaces ``auth_backend`` configuration setting (#21472)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Previously, only one backend was used to authorize use of the REST API. In 2.3 this was changed to support multiple backends, separated by whitespace. Each will be tried in turn until a successful response is returned.
+Previously, only one backend was used to authorize use of the REST API. In 2.3 this was changed to support multiple backends, separated by comma. Each will be tried in turn until a successful response is returned.
 
 This setting is also used for the deprecated experimental API, which only uses the first option even if multiple are given.
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -577,7 +577,7 @@ ARG_DB_FROM_REVISION = Arg(
 ARG_DB_SQL_ONLY = Arg(
     ("-s", "--show-sql-only"),
     help="Don't actually run migrations; just print out sql scripts for offline migration. "
-    "Required if using either `--from-version` or `--from-version`.",
+    "Required if using either `--from-revision` or `--from-version`.",
     action="store_true",
     default=False,
 )


### PR DESCRIPTION
* `auth_backends` is separated by comma instead of whitespace in a7bccaacb9a35ed6dcd4c1cadda4b8f294332722 . Release notes can be updated.
* Fix duplicate options in docstring for db command.