### PR TITLE
Add authoring API for TaskGroup mapping

### DIFF
--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -25,57 +25,93 @@ together when the DAG is displayed graphically.
 from __future__ import annotations
 
 import functools
-from inspect import signature
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, overload
+import inspect
+import warnings
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, Mapping, Sequence, TypeVar, overload
 
 import attr
+from sqlalchemy.orm import Session
 
+from airflow.decorators.base import ExpandableFactory
+from airflow.models.expandinput import (
+    DictOfListsExpandInput,
+    ExpandInput,
+    ListOfDictsExpandInput,
+    OperatorExpandArgument,
+    OperatorExpandKwargsArgument,
+)
 from airflow.models.taskmixin import DAGNode
+from airflow.models.xcom_arg import XComArg
 from airflow.typing_compat import ParamSpec
-from airflow.utils.task_group import TaskGroup
+from airflow.utils.context import Context
+from airflow.utils.helpers import prevent_duplicates
+from airflow.utils.mixins import ResolveMixin
+from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
-    from airflow.models.expandinput import OperatorExpandArgument, OperatorExpandKwargsArgument
 
 FParams = ParamSpec("FParams")
 FReturn = TypeVar("FReturn", None, DAGNode)
 
-task_group_sig = signature(TaskGroup.__init__)
+task_group_sig = inspect.signature(TaskGroup.__init__)
 
 
-@attr.define
-class _TaskGroupFactory(Generic[FParams, FReturn]):
+@attr.define(kw_only=True)
+class _MappedArgument(ResolveMixin):
+    _input: ExpandInput
+    _key: str
+
+    @provide_session
+    def resolve(self, context: Context, *, session: Session = NEW_SESSION) -> Any:
+        data, _ = self._input.resolve(context, session=session)
+        return data[self._key]
+
+
+@attr.define()
+class _TaskGroupFactory(ExpandableFactory, Generic[FParams, FReturn]):
     function: Callable[FParams, FReturn] = attr.ib(validator=attr.validators.is_callable())
-    kwargs: dict[str, Any] = attr.ib(factory=dict)
+    tg_kwargs: dict[str, Any] = attr.ib(factory=dict)  # Parameters forwarded to TaskGroup.
+    partial_kwargs: dict[str, Any] = attr.ib(factory=dict)  # Parameters forwarded to 'function'.
 
-    @function.validator
-    def _validate_function(self, _, f: Callable[FParams, FReturn]):
-        if 'self' in signature(f).parameters:
-            raise TypeError('@task_group does not support methods')
+    _task_group_created: bool = attr.ib(False, init=False)
 
-    @kwargs.validator
+    tg_class: ClassVar[type[TaskGroup]] = TaskGroup
+
+    @tg_kwargs.validator
     def _validate(self, _, kwargs):
         task_group_sig.bind_partial(**kwargs)
 
     def __attrs_post_init__(self):
-        if not self.kwargs.get("group_id"):
-            self.kwargs["group_id"] = self.function.__name__
+        self.tg_kwargs.setdefault("group_id", self.function.__name__)
+
+    def __del__(self):
+        if self.partial_kwargs and not self._task_group_created:
+            try:
+                group_id = repr(self.tg_kwargs["group_id"])
+            except KeyError:
+                group_id = f"at {hex(id(self))}"
+            warnings.warn(f"Partial task group {group_id} was never mapped!")
 
     def __call__(self, *args: FParams.args, **kwargs: FParams.kwargs) -> DAGNode:
         """Instantiate the task group.
 
-        with self._make_task_group(add_suffix_on_collision=True, **self.kwargs) as task_group:
         This uses the wrapped function to create a task group. Depending on the
         return type of the wrapped function, this either returns the last task
         in the group, or the group itself, to support task chaining.
         """
-        with TaskGroup(add_suffix_on_collision=True, **self.kwargs) as task_group:
+        return self._create_task_group(TaskGroup, *args, **kwargs)
+
+    def _create_task_group(self, tg_factory: Callable[..., TaskGroup], *args: Any, **kwargs: Any) -> DAGNode:
+        with tg_factory(add_suffix_on_collision=True, **self.tg_kwargs) as task_group:
             if self.function.__doc__ and not task_group.tooltip:
                 task_group.tooltip = self.function.__doc__
 
             # Invoke function to run Tasks inside the TaskGroup
             retval = self.function(*args, **kwargs)
+
+        self._task_group_created = True
 
         # If the task-creating function returns a task, forward the return value
         # so dependencies bind to it. This is equivalent to
@@ -93,16 +129,54 @@ class _TaskGroupFactory(Generic[FParams, FReturn]):
         return task_group
 
     def override(self, **kwargs: Any) -> _TaskGroupFactory[FParams, FReturn]:
-        return attr.evolve(self, kwargs={**self.kwargs, **kwargs})
+        return attr.evolve(self, tg_kwargs={**self.tg_kwargs, **kwargs})
 
     def partial(self, **kwargs: Any) -> _TaskGroupFactory[FParams, FReturn]:
-        raise NotImplementedError("TODO: Implement me")
+        self._validate_arg_names("partial", kwargs)
+        prevent_duplicates(self.partial_kwargs, kwargs, fail_reason="duplicate partial")
+        kwargs.update(self.partial_kwargs)
+        return attr.evolve(self, partial_kwargs=kwargs)
 
-    def expand(self, **kwargs: OperatorExpandArgument) -> TaskGroup:
-        raise NotImplementedError("TODO: Implement me")
+    def expand(self, **kwargs: OperatorExpandArgument) -> DAGNode:
+        if not kwargs:
+            raise TypeError("no arguments to expand against")
+        self._validate_arg_names("expand", kwargs)
+        prevent_duplicates(self.partial_kwargs, kwargs, fail_reason="mapping already partial")
+        expand_input = DictOfListsExpandInput(kwargs)
+        return self._create_task_group(
+            functools.partial(MappedTaskGroup, expand_input=expand_input),
+            **self.partial_kwargs,
+            **{k: _MappedArgument(input=expand_input, key=k) for k in kwargs},
+        )
 
-    def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument, *, strict: bool = True) -> TaskGroup:
-        raise NotImplementedError("TODO: Implement me")
+    def expand_kwargs(self, kwargs: OperatorExpandKwargsArgument) -> DAGNode:
+        if isinstance(kwargs, Sequence):
+            for item in kwargs:
+                if not isinstance(item, (XComArg, Mapping)):
+                    raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
+        elif not isinstance(kwargs, XComArg):
+            raise TypeError(f"expected XComArg or list[dict], not {type(kwargs).__name__}")
+
+        # It's impossible to build a dict of stubs as keyword arguments if the
+        # function uses * or ** wildcard arguments.
+        function_has_vararg = any(
+            v.kind == inspect.Parameter.VAR_POSITIONAL or v.kind == inspect.Parameter.VAR_KEYWORD
+            for v in self.function_signature.parameters.values()
+        )
+        if function_has_vararg:
+            raise TypeError("calling expand_kwargs() on task group function with * or ** is not supported")
+
+        # We can't be sure how each argument is used in the function (well
+        # technically we can with AST but let's not), so we have to create stubs
+        # for every argument, including those with default values.
+        map_kwargs = (k for k in self.function_signature.parameters if k not in self.partial_kwargs)
+
+        expand_input = ListOfDictsExpandInput(kwargs)
+        return self._create_task_group(
+            functools.partial(MappedTaskGroup, expand_input=expand_input),
+            **self.partial_kwargs,
+            **{k: _MappedArgument(input=expand_input, key=k) for k in map_kwargs},
+        )
 
 
 # This covers the @task_group() case. Annotations are copied from the TaskGroup
@@ -123,7 +197,7 @@ def task_group(
     ui_color: str = "CornflowerBlue",
     ui_fgcolor: str = "#000",
     add_suffix_on_collision: bool = False,
-) -> Callable[FParams, _TaskGroupFactory[FParams, FReturn]]:
+) -> Callable[[Callable[FParams, FReturn]], _TaskGroupFactory[FParams, FReturn]]:
     ...
 
 
@@ -144,5 +218,5 @@ def task_group(python_callable=None, **tg_kwargs):
     :param tg_kwargs: Keyword arguments for the TaskGroup object.
     """
     if callable(python_callable) and not tg_kwargs:
-        return _TaskGroupFactory(function=python_callable, kwargs=tg_kwargs)
-    return functools.partial(_TaskGroupFactory, kwargs=tg_kwargs)
+        return _TaskGroupFactory(function=python_callable, tg_kwargs=tg_kwargs)
+    return functools.partial(_TaskGroupFactory, tg_kwargs=tg_kwargs)

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -28,6 +28,7 @@ from airflow.models.taskmixin import DAGNode
 from airflow.utils.context import Context
 from airflow.utils.helpers import render_template_as_native, render_template_to_string
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.mixins import ResolveMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
@@ -460,9 +461,6 @@ class AbstractOperator(LoggingMixin, DAGNode):
         if not jinja_env:
             jinja_env = self.get_template_env()
 
-        from airflow.models.param import DagParam
-        from airflow.models.xcom_arg import XComArg
-
         if isinstance(value, str):
             if any(value.endswith(ext) for ext in self.template_ext):  # A filepath.
                 template = jinja_env.get_template(value)
@@ -473,7 +471,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
                 return render_template_as_native(template, context)
             return render_template_to_string(template, context)
 
-        if isinstance(value, (DagParam, XComArg)):
+        if isinstance(value, ResolveMixin):
             return value.resolve(context)
 
         # Fast path for common built-in collections.

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -59,7 +59,7 @@ from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.mapped_task_expanded import MappedTaskIsExpanded
 from airflow.typing_compat import Literal
 from airflow.utils.context import Context, context_update_for_unmapped
-from airflow.utils.helpers import is_container
+from airflow.utils.helpers import is_container, prevent_duplicates
 from airflow.utils.operator_resources import Resources
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
@@ -107,16 +107,6 @@ def validate_mapping_kwargs(op: type[BaseOperator], func: ValidationSource, valu
         names = ", ".join(repr(n) for n in unknown_args)
         error = f"unexpected keyword arguments {names}"
     raise TypeError(f"{op.__name__}.{func}() got {error}")
-
-
-def prevent_duplicates(kwargs1: dict[str, Any], kwargs2: Mapping[str, Any], *, fail_reason: str) -> None:
-    duplicated_keys = set(kwargs1).intersection(kwargs2)
-    if not duplicated_keys:
-        return
-    if len(duplicated_keys) == 1:
-        raise TypeError(f"{fail_reason} argument: {duplicated_keys.pop()}")
-    duplicated_keys_display = ", ".join(sorted(duplicated_keys))
-    raise TypeError(f"{fail_reason} arguments: {duplicated_keys_display}")
 
 
 def ensure_xcomarg_return_value(arg: Any) -> None:

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, ItemsView, MutableMapping, ValuesView
 
 from airflow.exceptions import AirflowException, ParamValidationError, RemovedInAirflow3Warning
 from airflow.utils.context import Context
+from airflow.utils.mixins import ResolveMixin
 from airflow.utils.types import NOTSET, ArgNotSet
 
 if TYPE_CHECKING:
@@ -216,7 +217,7 @@ class ParamsDict(MutableMapping[str, Any]):
         return resolved_dict
 
 
-class DagParam:
+class DagParam(ResolveMixin):
     """
     Class that represents a DAG run parameter & binds a simple Param object to a name within a DAG instance,
     so that it can be resolved during the run time via ``{{ context }}`` dictionary. The ideal use case of

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -30,6 +30,7 @@ from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.utils.context import Context
 from airflow.utils.edgemodifier import EdgeModifier
+from airflow.utils.mixins import ResolveMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.types import NOTSET, ArgNotSet
 
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
 MapCallables = Sequence[Union[Callable[[Any], Any], str]]
 
 
-class XComArg(DependencyMixin):
+class XComArg(ResolveMixin, DependencyMixin):
     """Reference to an XCom value pushed from another operator.
 
     The implementation supports::

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -24,7 +24,7 @@ import warnings
 from datetime import datetime
 from functools import reduce
 from itertools import filterfalse, tee
-from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, MutableMapping, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Mapping, MutableMapping, TypeVar, cast
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning
@@ -367,3 +367,17 @@ def prune_dict(val: Any, mode='strict'):
         return new_list
     else:
         return val
+
+
+def prevent_duplicates(kwargs1: dict[str, Any], kwargs2: Mapping[str, Any], *, fail_reason: str) -> None:
+    """Ensure *kwargs1* and *kwargs2* do not contain common keys.
+
+    :raises TypeError: If common keys are found.
+    """
+    duplicated_keys = set(kwargs1).intersection(kwargs2)
+    if not duplicated_keys:
+        return
+    if len(duplicated_keys) == 1:
+        raise TypeError(f"{fail_reason} argument: {duplicated_keys.pop()}")
+    duplicated_keys_display = ", ".join(sorted(duplicated_keys))
+    raise TypeError(f"{fail_reason} arguments: {duplicated_keys_display}")

--- a/airflow/utils/mixins.py
+++ b/airflow/utils/mixins.py
@@ -15,11 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from __future__ import annotations
 
 import multiprocessing
+import typing
 
 from airflow.configuration import conf
+from airflow.utils.context import Context
 
 
 class MultiprocessingStartMethodMixin:
@@ -37,3 +40,10 @@ class MultiprocessingStartMethodMixin:
         if not method:
             raise ValueError("Failed to determine start method")
         return method
+
+
+class ResolveMixin:
+    """A runtime-resolved value."""
+
+    def resolve(self, context: Context) -> typing.Any:
+        raise NotImplementedError

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -39,6 +39,7 @@ from airflow.utils.helpers import validate_group_key
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG
+    from airflow.models.expandinput import ExpandInput
     from airflow.utils.edgemodifier import EdgeModifier
 
 
@@ -452,6 +453,21 @@ class TaskGroup(DAGNode):
                 raise AirflowDagCycleException(f"A cyclic dependency occurred in dag: {self.dag_id}")
 
         return graph_sorted
+
+
+class MappedTaskGroup(TaskGroup):
+    """A mapped task group.
+
+    This doesn't really do anything special, just holds some additional metadata
+    for expansion later.
+
+    Don't instantiate this class directly; call *expand* or *expand_kwargs* on
+    a ``@task_group`` function instead.
+    """
+
+    def __init__(self, *, expand_input: ExpandInput, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._expand_input = expand_input
 
 
 class TaskGroupContext:


### PR DESCRIPTION
This implements `partial()`, `expand()`, and `expand_kwargs()` on the `@task_group` decorator. The expand functions create a MappedTaskGroup instance that is TaskGroup + metadata for tasks to expand.

This PR only adds the constructs, but the mapped task group would not work as expected since it is NOT YET handled by the scheduler (it would behave identically to a normal TaskGroup). This will be corrected in a later PR.