### PR TITLE
Fix Slack Connections created in the UI

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -293,11 +293,13 @@ class SlackHook(BaseHook):
         from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_babel import lazy_gettext
         from wtforms import IntegerField, StringField
+        from wtforms.validators import NumberRange, Optional
 
         return {
             prefixed_extra_field("timeout", cls.conn_type): IntegerField(
                 lazy_gettext("Timeout"),
                 widget=BS3TextFieldWidget(),
+                validators=[Optional(strip_whitespace=True), NumberRange(min=1)],
                 description="Optional. The maximum number of seconds the client will wait to connect "
                 "and receive a response from Slack API.",
             ),

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -420,11 +420,13 @@ class SlackWebhookHook(BaseHook):
         from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_babel import lazy_gettext
         from wtforms import IntegerField, StringField
+        from wtforms.validators import NumberRange, Optional
 
         return {
             prefixed_extra_field("timeout", cls.conn_type): IntegerField(
                 lazy_gettext("Timeout"),
                 widget=BS3TextFieldWidget(),
+                validators=[Optional(), NumberRange(min=1)],
                 description="Optional. The maximum number of seconds the client will wait to connect "
                 "and receive a response from Slack Incoming Webhook.",
             ),

--- a/airflow/providers/slack/utils/__init__.py
+++ b/airflow/providers/slack/utils/__init__.py
@@ -54,7 +54,12 @@ class ConnectionExtraConfig:
         :param default: If specified then use as default value if field not present in Connection Extra.
         """
         prefixed_field = prefixed_extra_field(field, self.conn_type)
-        if prefixed_field in self.extra:
+        if prefixed_field in self.extra and self.extra[prefixed_field] not in (None, ""):
+            # Addition validation with non-empty required for connection which created in the UI
+            # in Airflow 2.2. In these connections always present key-value pair for all prefixed extras
+            # even if user do not fill this fields.
+            # In additional fields from `wtforms.IntegerField` might contain None value.
+            # E.g.: `{'extra__slackwebhook__proxy': '', 'extra__slackwebhook__timeout': None}`
             return self.extra[prefixed_field]
         elif field in self.extra:
             return self.extra[field]


### PR DESCRIPTION
Follow up: [Status of testing Providers that were prepared on September 28, 2022: Provider slack: 6.0.0rc1](https://github.com/apache/airflow/issues/26752#issuecomment-1263625826)

During the test found different issues with connections created in the UI.

---

### Case 1. Extra fields which use `wtforms.IntegerField` should have `wtforms.validators.Optional` validator

**Timeout** is optional field, however if try to save connection without specified value in this field that selected error happen

![image](https://user-images.githubusercontent.com/3998685/193607528-65c2931e-7e27-47e8-b200-23ed815429f4.png)

**Fixed**: Add validators `[Optional(strip_whitespace=True), NumberRange(min=1)]`

---

### Case 2. Extra fields which use `wtforms.StringField` in Airflow 2.2 create empty value if user not specified anything

#### Airflow 2.2.0 and 2.2.5
```
id: slack_api. Host: , Port: None, Schema: , Login: , Password: ***, extra: {'extra__slack__base_url': '', 'extra__slack__proxy': '', 'extra__slack__timeout': None}
```

#### Airflow 2.3.0, 2.3.1, 2.3.4, 2.4.0

```
id: slack_api. Host: , Port: None, Schema: , Login: , Password: ***, extra: {'extra__slack__timeout': None}
```

**Fixed**: Ignore empty string and None values for prefixed extra

---

### Case 3. Extra fields which use `wtforms.IntegerField` create None value if user not specified anything

See, Case 2

---

### Case 4. In Airflow 2.2 if user specify anything in extra fields than test connection from the UI failed with bad request

Connections created in the UI work fine, only test connections won't work.

![image](https://user-images.githubusercontent.com/3998685/193610170-7d852d28-e87e-4f69-89ea-c0cf14f8d1e4.png)

I don't think it is possible to do anything with this except:
1. Do not use `get_connection_form_widgets` and user should specified in extra as a dictionary
2. Additional logic which create different output for `get_connection_form_widgets` and `get_ui_field_behaviour` depend on Airflow version