### PR TITLE
Don't consider airflow core conf for KPO

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -24,6 +24,14 @@
 Changelog
 ---------
 
+5.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Previously KubernetesPodOperator considered some settings from the Airflow config's ``kubernetes`` section.  Such consideration was deprecated in 4.1.0 and is now removed.  If you previously relied on the Airflow config, and you want client generation to have non-default configuration, you will need to define your configuration in an Airflow connection and set KPO to use the connection.  See kubernetes provider documentation on defining a kubernetes Airflow connection for details.
+
 4.4.0
 .....
 

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes.py
@@ -313,61 +313,6 @@ class TestKubernetesHook:
         assert isinstance(hook.api_client, kubernetes.client.ApiClient)
         assert isinstance(hook.get_conn(), kubernetes.client.ApiClient)
 
-    @patch(f"{HOOK_MODULE}._disable_verify_ssl")
-    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client", new=MagicMock)
-    def test_patch_core_settings_verify_ssl(self, mock_disable_verify_ssl):
-        hook = KubernetesHook()
-        hook.get_conn()
-        mock_disable_verify_ssl.assert_not_called()
-        mock_disable_verify_ssl.reset_mock()
-        hook._deprecated_core_disable_verify_ssl = True
-        hook.get_conn()
-        mock_disable_verify_ssl.assert_called()
-
-    @patch(f"{HOOK_MODULE}._enable_tcp_keepalive")
-    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client", new=MagicMock)
-    def test_patch_core_settings_tcp_keepalive(self, mock_enable_tcp_keepalive):
-        hook = KubernetesHook()
-        hook.get_conn()
-        mock_enable_tcp_keepalive.assert_called()
-        mock_enable_tcp_keepalive.reset_mock()
-        hook._deprecated_core_disable_tcp_keepalive = True
-        hook.get_conn()
-        mock_enable_tcp_keepalive.assert_not_called()
-
-    @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
-    @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
-    @patch("kubernetes.config.incluster_config.InClusterConfigLoader")
-    @patch(f"{HOOK_MODULE}.KubernetesHook._get_default_client")
-    def test_patch_core_settings_in_cluster(self, mock_get_default_client, mock_in_cluster_loader):
-        hook = KubernetesHook(conn_id=None)
-        hook.get_conn()
-        mock_in_cluster_loader.assert_not_called()
-        mock_in_cluster_loader.reset_mock()
-        hook._deprecated_core_in_cluster = False
-        hook.get_conn()
-        mock_in_cluster_loader.assert_not_called()
-        mock_get_default_client.assert_called()
-
-    @pytest.mark.parametrize(
-        'key, key_val, attr, attr_val',
-        [
-            ('in_cluster', False, '_deprecated_core_in_cluster', False),
-            ('verify_ssl', False, '_deprecated_core_disable_verify_ssl', True),
-            ('cluster_context', 'hi', '_deprecated_core_cluster_context', 'hi'),
-            ('config_file', '/path/to/file.txt', '_deprecated_core_config_file', '/path/to/file.txt'),
-            ('enable_tcp_keepalive', False, '_deprecated_core_disable_tcp_keepalive', True),
-        ],
-    )
-    @patch("kubernetes.config.incluster_config.InClusterConfigLoader", new=MagicMock())
-    @patch("kubernetes.config.kube_config.KubeConfigLoader", new=MagicMock())
-    @patch("kubernetes.config.kube_config.KubeConfigMerger", new=MagicMock())
-    def test_core_settings_warnings(self, key, key_val, attr, attr_val):
-        hook = KubernetesHook(conn_id=None)
-        setattr(hook, attr, attr_val)
-        with pytest.warns(DeprecationWarning, match=rf'.*Airflow settings.*\n.*{key}={key_val!r}.*'):
-            hook.get_conn()
-
 
 class TestKubernetesHookIncorrectConfiguration:
     @pytest.mark.parametrize(

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -31,7 +31,6 @@ from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 from tests.test_utils import db
-from tests.test_utils.config import conf_vars
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
 KPO_MODULE = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod"
@@ -936,27 +935,6 @@ class TestKubernetesPodOperator:
             k.execute(context=context)
         mock_patch_already_checked.assert_called_once()
         mock_delete_pod.assert_not_called()
-
-    @pytest.mark.parametrize(
-        'key, value, attr, patched_value',
-        [
-            ('verify_ssl', 'False', '_deprecated_core_disable_verify_ssl', True),
-            ('in_cluster', 'False', '_deprecated_core_in_cluster', False),
-            ('cluster_context', 'hi', '_deprecated_core_cluster_context', 'hi'),
-            ('config_file', '/path/to/file.txt', '_deprecated_core_config_file', '/path/to/file.txt'),
-            ('enable_tcp_keepalive', 'False', '_deprecated_core_disable_tcp_keepalive', True),
-        ],
-    )
-    def test_patch_core_settings(self, key, value, attr, patched_value):
-        # first verify the behavior for the default value
-        # the hook attr should be None
-        op = KubernetesPodOperator(task_id='abc', name='hi')
-        self.hook_patch.stop()
-        assert getattr(op.hook, attr) is None
-        # now check behavior with a non-default value
-        with conf_vars({('kubernetes', key): value}):
-            op = KubernetesPodOperator(task_id='abc', name='hi')
-            assert getattr(op.hook, attr) == patched_value
 
 
 def test__suppress():


### PR DESCRIPTION
**Note:** this should not be released until provider version 5.0

This was deprecated in provider version 4.1.0, and now we are removing the backcompat logic, so that core conf params will no longer be considered when creating the k8s client object; users will need to use Airflow connections if they want the client configured in a non-default way.
