### PR TITLE
Fix a bunch of deprecation warnings AWS tests

### DIFF
--- a/airflow/providers/amazon/aws/hooks/athena.py
+++ b/airflow/providers/amazon/aws/hooks/athena.py
@@ -207,8 +207,8 @@ class AthenaHook(AwsBaseHook):
         """
         if max_tries:
             warnings.warn(
-                f"Method `{self.__class__.__name__}.max_tries` is deprecated and will be removed "
-                "in a future release.  Please use method `max_polling_attempts` instead.",
+                f"Passing 'max_tries' to {self.__class__.__name__}.poll_query_status is deprecated "
+                f"and will be removed in a future release. Please use 'max_polling_attempts' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -82,7 +82,10 @@ class RedshiftSQLHook(DbApiHook):
         if 'user' in conn_params:
             conn_params['username'] = conn_params.pop('user')
 
-        return str(URL(drivername='redshift+redshift_connector', **conn_params))
+        # Compatibility: The 'create' factory method was added in SQLAlchemy 1.4
+        # to replace calling the default URL constructor directly.
+        create_url = getattr(URL, "create", URL)
+        return str(create_url(drivername='redshift+redshift_connector', **conn_params))
 
     def get_sqlalchemy_engine(self, engine_kwargs=None):
         """Overrides DbApiHook get_sqlalchemy_engine to pass redshift_connector specific kwargs"""

--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -63,8 +63,8 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
     def set_context(self, ti):
         super().set_context(ti)
         self.handler = watchtower.CloudWatchLogHandler(
-            log_group=self.log_group,
-            stream_name=self._render_filename(ti, ti.try_number),
+            log_group_name=self.log_group,
+            log_stream_name=self._render_filename(ti, ti.try_number),
             boto3_client=self.hook.get_conn(),
         )
 
@@ -98,12 +98,11 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         :return: string of all logs from the given log stream
         """
         try:
-            events = list(
-                self.hook.get_log_events(
-                    log_group=self.log_group, log_stream_name=stream_name, start_from_head=True
-                )
+            events = self.hook.get_log_events(
+                log_group=self.log_group,
+                log_stream_name=stream_name,
+                start_from_head=True,
             )
-
             return '\n'.join(self._event_to_str(event) for event in events)
         except Exception:
             msg = f'Could not read remote logs from log_group: {self.log_group} log_stream: {stream_name}.'

--- a/airflow/providers/amazon/aws/operators/athena.py
+++ b/airflow/providers/amazon/aws/operators/athena.py
@@ -112,7 +112,10 @@ class AthenaOperator(BaseOperator):
             self.client_request_token,
             self.workgroup,
         )
-        query_status = self.hook.poll_query_status(self.query_execution_id, self.max_polling_attempts)
+        query_status = self.hook.poll_query_status(
+            self.query_execution_id,
+            max_polling_attempts=self.max_polling_attempts,
+        )
 
         if query_status in AthenaHook.FAILURE_STATES:
             error_message = self.hook.get_state_change_reason(self.query_execution_id)

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -279,7 +279,9 @@ class EmrContainerOperator(BaseOperator):
         )
         if self.wait_for_completion:
             query_status = self.hook.poll_query_status(
-                self.job_id, self.max_polling_attempts, self.poll_interval
+                self.job_id,
+                max_polling_attempts=self.max_polling_attempts,
+                poll_interval=self.poll_interval,
             )
 
             if query_status in EmrContainerHook.FAILURE_STATES:

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -330,19 +330,19 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         if warn_user:
             msg = (
-                "When ``full_url_mode=True``, URL-encoding secret values is deprecated. In future versions, "
-                f" this value will not be un-escaped. For the conn_id {conn_id!r}, please remove the"
-                " URL-encoding."
-                "\n\nThis warning was raised because the SecretsManagerBackend detected that this connection"
-                " was URL-encoded."
+                "When full_url_mode=False, URL-encoding secret values is deprecated. In future versions, "
+                f"this value will not be un-escaped. For the conn_id {conn_id!r}, please remove the "
+                "URL-encoding.\n\n"
+                "This warning was raised because the SecretsManagerBackend detected that this "
+                "connection was URL-encoded."
             )
             if idempotent:
                 msg = f" Once the values for conn_id {conn_id!r} are decoded, this warning will go away."
             if not idempotent:
                 msg += (
                     " In addition to decoding the values for your connection, you must also set"
-                    " ``secret_values_are_urlencoded=False`` for your config variable"
-                    " ``secrets.backend_kwargs`` because this connection's URL encoding is not idempotent."
+                    " secret_values_are_urlencoded=False for your config variable"
+                    " secrets.backend_kwargs because this connection's URL encoding is not idempotent."
                     " For more information, see:"
                     " https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/secrets-backends"
                     "/aws-secrets-manager.html#url-encoding-of-secrets-when-full-url-mode-is-false"

--- a/airflow/providers/amazon/aws/sensors/emr.py
+++ b/airflow/providers/amazon/aws/sensors/emr.py
@@ -285,7 +285,11 @@ class EmrContainerSensor(BaseSensorOperator):
         self.max_retries = max_retries
 
     def poke(self, context: Context) -> bool:
-        state = self.hook.poll_query_status(self.job_id, self.max_retries, self.poll_interval)
+        state = self.hook.poll_query_status(
+            self.job_id,
+            max_polling_attempts=self.max_retries,
+            poll_interval=self.poll_interval,
+        )
 
         if state in self.FAILURE_STATES:
             raise AirflowException('EMR Containers sensor failed')

--- a/tests/providers/amazon/aws/hooks/test_athena.py
+++ b/tests/providers/amazon/aws/hooks/test_athena.py
@@ -164,7 +164,8 @@ class TestAthenaHook(unittest.TestCase):
     def test_hook_poll_query_with_timeout(self, mock_conn):
         mock_conn.return_value.get_query_execution.return_value = MOCK_RUNNING_QUERY_EXECUTION
         result = self.athena.poll_query_status(
-            query_execution_id=MOCK_DATA['query_execution_id'], max_tries=1
+            query_execution_id=MOCK_DATA['query_execution_id'],
+            max_polling_attempts=1,
         )
         mock_conn.return_value.get_query_execution.assert_called_once()
         assert result == 'RUNNING'

--- a/tests/providers/amazon/aws/hooks/test_batch_client.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_client.py
@@ -53,6 +53,9 @@ class TestBatchClient(unittest.TestCase):
             aws_conn_id='airflow_test',
             region_name=AWS_REGION,
         )
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        self.batch_client.get_connection = lambda _: None
         self.client_mock = get_client_type_mock.return_value
         assert self.batch_client.client == self.client_mock  # setup client property
 
@@ -307,6 +310,9 @@ class TestBatchClientDelays(unittest.TestCase):
     @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
     def setUp(self):
         self.batch_client = BatchClientHook(aws_conn_id='airflow_test', region_name=AWS_REGION)
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        self.batch_client.get_connection = lambda _: None
 
     def test_init(self):
         assert self.batch_client.max_retries == self.batch_client.MAX_RETRIES

--- a/tests/providers/amazon/aws/hooks/test_ec2.py
+++ b/tests/providers/amazon/aws/hooks/test_ec2.py
@@ -31,6 +31,9 @@ class TestEC2Hook(unittest.TestCase):
             aws_conn_id="aws_conn_test",
             region_name="region-test",
         )
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        ec2_hook.get_connection = lambda _: None
         assert ec2_hook.aws_conn_id == "aws_conn_test"
         assert ec2_hook.region_name == "region-test"
 

--- a/tests/providers/amazon/aws/hooks/test_eks.py
+++ b/tests/providers/amazon/aws/hooks/test_eks.py
@@ -1242,6 +1242,9 @@ class TestEksHook:
             'cluster': {'certificateAuthority': {'data': 'test-cert'}, 'endpoint': 'test-endpoint'}
         }
         hook = EksHook(aws_conn_id=aws_conn_id, region_name=region_name)
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        hook.get_connection = lambda _: None
         with hook.generate_config_file(
             eks_cluster_name='test-cluster', pod_namespace='k8s-namespace'
         ) as config_file:

--- a/tests/providers/amazon/aws/hooks/test_emr_containers.py
+++ b/tests/providers/amazon/aws/hooks/test_emr_containers.py
@@ -110,7 +110,7 @@ class TestEmrContainerHook(unittest.TestCase):
         mock_session.return_value = emr_session_mock
         emr_client_mock.describe_job_run.return_value = JOB2_RUN_DESCRIPTION
 
-        query_status = self.emr_containers.poll_query_status(job_id='job123456', max_tries=2)
+        query_status = self.emr_containers.poll_query_status(job_id='job123456', max_polling_attempts=2)
         # should poll until max_tries is reached since query is in non-terminal state
         assert emr_client_mock.describe_job_run.call_count == 2
         assert query_status == 'RUNNING'

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -46,6 +46,9 @@ class TestAwsS3HookNoMock:
         monkeypatch.delenv('AWS_ACCESS_KEY_ID', raising=False)
         monkeypatch.delenv('AWS_SECRET_ACCESS_KEY', raising=False)
         hook = S3Hook(aws_conn_id="does_not_exist")
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        hook.get_connection = lambda _: None
         with pytest.raises(NoCredentialsError):
             hook.check_for_bucket("test-non-existing-bucket")
 
@@ -587,6 +590,9 @@ class TestAwsS3Hook:
             "SSEKMSKeyId": "arn:aws:kms:region:acct-id:key/key-id",
         }
         s3_hook = S3Hook(aws_conn_id="s3_test", extra_args=original)
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        s3_hook.get_connection = lambda _: None
         assert s3_hook.extra_args == original
         assert s3_hook.extra_args is not original
 

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -60,7 +60,7 @@ class TestAthenaOperator(unittest.TestCase):
             output_location='s3://test_s3_bucket/',
             client_request_token='eac427d0-1c6d-4dfb-96aa-2835d3ac6595',
             sleep_time=0,
-            max_tries=3,
+            max_polling_attempts=3,
             dag=self.dag,
         )
 

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -66,6 +66,9 @@ class TestBatchOperator(unittest.TestCase):
             tags={},
         )
         self.client_mock = self.get_client_type_mock.return_value
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        self.batch.hook.get_connection = lambda _: None
         assert self.batch.hook.client == self.client_mock  # setup client property
 
         # don't pause in unit tests

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -130,7 +130,7 @@ class TestEmrContainerOperator(unittest.TestCase):
             job_driver={},
             configuration_overrides={},
             poll_interval=0,
-            max_tries=3,
+            max_polling_attempts=3,
         )
 
         with patch('boto3.session.Session', boto3_session_mock):

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from airflow import configuration
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
 from airflow.providers.amazon.aws.operators.emr import EmrContainerOperator, EmrEksCreateClusterOperator
@@ -41,7 +41,7 @@ GENERATED_UUID = '800647a9-adda-4237-94e6-f542c85fa55b'
 class TestEmrContainerOperator(unittest.TestCase):
     @mock.patch('airflow.providers.amazon.aws.hooks.emr.EmrContainerHook')
     def setUp(self, emr_hook_mock):
-        configuration.load_test_config()
+        conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock
         self.emr_container = EmrContainerOperator(
@@ -145,7 +145,7 @@ class TestEmrContainerOperator(unittest.TestCase):
 class TestEmrEksCreateClusterOperator(unittest.TestCase):
     @mock.patch('airflow.providers.amazon.aws.hooks.emr.EmrContainerHook')
     def setUp(self, emr_hook_mock):
-        configuration.load_test_config()
+        conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock
         self.emr_container = EmrEksCreateClusterOperator(

--- a/tests/providers/amazon/aws/secrets/test_secrets_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_secrets_manager.py
@@ -17,14 +17,15 @@
 from __future__ import annotations
 
 import json
-from unittest import TestCase, mock
+from unittest import mock
 
+import pytest
 from moto import mock_secretsmanager
 
 from airflow.providers.amazon.aws.secrets.secrets_manager import SecretsManagerBackend
 
 
-class TestSecretsManagerBackend(TestCase):
+class TestSecretsManagerBackend:
     @mock.patch("airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend.get_conn_value")
     def test_aws_secrets_manager_get_connection(self, mock_get_value):
         mock_get_value.return_value = "scheme://user:pass@host:100"
@@ -32,7 +33,7 @@ class TestSecretsManagerBackend(TestCase):
         assert conn.host == 'host'
 
     @mock_secretsmanager
-    def test_get_conn_uri_full_url_mode(self):
+    def test_get_conn_value_full_url_mode(self):
         secret_id = 'airflow/connections/test_postgres'
         create_param = {
             'Name': secret_id,
@@ -47,11 +48,18 @@ class TestSecretsManagerBackend(TestCase):
         secrets_manager_backend.client.create_secret(**create_param)
         secrets_manager_backend.client.put_secret_value(**param)
 
-        returned_uri = secrets_manager_backend.get_conn_uri(conn_id="test_postgres")
+        returned_uri = secrets_manager_backend.get_conn_value(conn_id="test_postgres")
         assert 'postgresql://airflow:airflow@host:5432/airflow' == returned_uri
 
+    @pytest.mark.parametrize(
+        "full_url_mode, login, host",
+        [
+            (False, "is url encoded", "not%20idempotent"),
+            (True, "is%20url%20encoded", "not%2520idempotent"),
+        ],
+    )
     @mock_secretsmanager
-    def test_get_connection_broken_field_mode_url_encoding(self):
+    def test_get_connection_broken_field_mode_url_encoding(self, full_url_mode, login, host):
         secret_id = 'airflow/connections/test_postgres'
         create_param = {
             'Name': secret_id,
@@ -62,7 +70,7 @@ class TestSecretsManagerBackend(TestCase):
             'SecretString': json.dumps(
                 {
                     'conn_type': 'postgresql',
-                    'user': 'is%20url%20encoded',
+                    'login': 'is%20url%20encoded',
                     'password': 'not url encoded',
                     'host': 'not%2520idempotent',
                     'extra': json.dumps({'foo': 'bar'}),
@@ -70,23 +78,20 @@ class TestSecretsManagerBackend(TestCase):
             ),
         }
 
-        secrets_manager_backend = SecretsManagerBackend(full_url_mode=False)
+        secrets_manager_backend = SecretsManagerBackend(full_url_mode=full_url_mode)
         secrets_manager_backend.client.create_secret(**create_param)
         secrets_manager_backend.client.put_secret_value(**param)
 
-        conn = secrets_manager_backend.get_connection(conn_id='test_postgres')
-        assert conn.login == 'is url encoded'
-        assert conn.password == 'not url encoded'
-        assert conn.host == 'not%20idempotent'
-        assert conn.conn_id == 'test_postgres'
+        if full_url_mode:
+            conn = secrets_manager_backend.get_connection(conn_id='test_postgres')
+        else:
+            warning_match = r"When full_url_mode=False, URL-encoding secret values is deprecated\..+"
+            with pytest.warns(DeprecationWarning, match=warning_match):
+                conn = secrets_manager_backend.get_connection(conn_id='test_postgres')
 
-        # Remove URL encoding
-        secrets_manager_backend.are_secret_values_urlencoded = False
-
-        conn = secrets_manager_backend.get_connection(conn_id='test_postgres')
-        assert conn.login == 'is%20url%20encoded'
+        assert conn.login == login
         assert conn.password == 'not url encoded'
-        assert conn.host == 'not%2520idempotent'
+        assert conn.host == host
         assert conn.conn_id == 'test_postgres'
         assert conn.extra_dejson['foo'] == 'bar'
 
@@ -118,7 +123,7 @@ class TestSecretsManagerBackend(TestCase):
         assert conn.extra_dejson['foo'] == 'bar'
 
     @mock_secretsmanager
-    def test_get_conn_uri_broken_field_mode(self):
+    def test_get_conn_value_broken_field_mode(self):
         secret_id = 'airflow/connections/test_postgres'
         create_param = {
             'Name': secret_id,
@@ -134,11 +139,16 @@ class TestSecretsManagerBackend(TestCase):
         secrets_manager_backend.client.create_secret(**create_param)
         secrets_manager_backend.client.put_secret_value(**param)
 
-        returned_uri = secrets_manager_backend.get_conn_uri(conn_id="test_postgres")
+        warning_match = (
+            r"In future versions, `SecretsManagerBackend\.get_conn_value` will return a JSON string when "
+            r"full_url_mode is False, not a URI\."
+        )
+        with pytest.warns(DeprecationWarning, match=warning_match):
+            returned_uri = secrets_manager_backend.get_conn_value(conn_id="test_postgres")
         assert 'postgresql://airflow:airflow@host:5432/airflow' == returned_uri
 
     @mock_secretsmanager
-    def test_get_conn_uri_broken_field_mode_extra_words_added(self):
+    def test_get_conn_value_broken_field_mode_extra_words_added(self):
         secret_id = 'airflow/connections/test_postgres'
         create_param = {
             'Name': secret_id,
@@ -156,7 +166,12 @@ class TestSecretsManagerBackend(TestCase):
         secrets_manager_backend.client.create_secret(**create_param)
         secrets_manager_backend.client.put_secret_value(**param)
 
-        returned_uri = secrets_manager_backend.get_conn_uri(conn_id="test_postgres")
+        warning_match = (
+            r"In future versions, `SecretsManagerBackend\.get_conn_value` will return a JSON string when "
+            r"full_url_mode is False, not a URI\."
+        )
+        with pytest.warns(DeprecationWarning, match=warning_match):
+            returned_uri = secrets_manager_backend.get_conn_value(conn_id="test_postgres")
         assert 'postgresql://airflow:airflow@host:5432/airflow' == returned_uri
 
     @mock_secretsmanager
@@ -170,7 +185,7 @@ class TestSecretsManagerBackend(TestCase):
         assert conn_string_with_extra == 'CS?key1=value1&key2=value2'
 
     @mock_secretsmanager
-    def test_get_conn_uri_non_existent_key(self):
+    def test_get_conn_value_non_existent_key(self):
         """
         Test that if the key with connection ID is not present,
         SecretsManagerBackend.get_connection should return None
@@ -191,7 +206,7 @@ class TestSecretsManagerBackend(TestCase):
         secrets_manager_backend.client.create_secret(**create_param)
         secrets_manager_backend.client.put_secret_value(**param)
 
-        assert secrets_manager_backend.get_conn_uri(conn_id=conn_id) is None
+        assert secrets_manager_backend.get_conn_value(conn_id=conn_id) is None
         assert secrets_manager_backend.get_connection(conn_id=conn_id) is None
 
     @mock_secretsmanager
@@ -233,14 +248,14 @@ class TestSecretsManagerBackend(TestCase):
     def test_connection_prefix_none_value(self, mock_get_secret):
         """
         Test that if Variable key is not present in AWS Secrets Manager,
-        SecretsManagerBackend.get_conn_uri should return None,
+        SecretsManagerBackend.get_conn_value should return None,
         SecretsManagerBackend._get_secret should not be called
         """
         kwargs = {'connections_prefix': None}
 
         secrets_manager_backend = SecretsManagerBackend(**kwargs)
 
-        assert secrets_manager_backend.get_conn_uri("test_mysql") is None
+        assert secrets_manager_backend.get_conn_value("test_mysql") is None
 
     @mock.patch("airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend._get_secret")
     def test_variable_prefix_none_value(self, mock_get_secret):

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -36,7 +36,7 @@ class TestSsmSecrets(TestCase):
         assert conn.host == 'host'
 
     @mock_ssm
-    def test_get_conn_uri(self):
+    def test_get_conn_value(self):
         param = {
             'Name': '/airflow/connections/test_postgres',
             'Type': 'String',
@@ -46,11 +46,11 @@ class TestSsmSecrets(TestCase):
         ssm_backend = SystemsManagerParameterStoreBackend()
         ssm_backend.client.put_parameter(**param)
 
-        returned_uri = ssm_backend.get_conn_uri(conn_id="test_postgres")
+        returned_uri = ssm_backend.get_conn_value(conn_id="test_postgres")
         assert 'postgresql://airflow:airflow@host:5432/airflow' == returned_uri
 
     @mock_ssm
-    def test_get_conn_uri_non_existent_key(self):
+    def test_get_conn_value_non_existent_key(self):
         """
         Test that if the key with connection ID is not present in SSM,
         SystemsManagerParameterStoreBackend.get_connection should return None
@@ -65,7 +65,7 @@ class TestSsmSecrets(TestCase):
         ssm_backend = SystemsManagerParameterStoreBackend()
         ssm_backend.client.put_parameter(**param)
 
-        assert ssm_backend.get_conn_uri(conn_id=conn_id) is None
+        assert ssm_backend.get_conn_value(conn_id=conn_id) is None
         assert ssm_backend.get_connection(conn_id=conn_id) is None
 
     @mock_ssm
@@ -158,14 +158,14 @@ class TestSsmSecrets(TestCase):
     def test_connection_prefix_none_value(self, mock_get_secret):
         """
         Test that if Variable key is not present in SSM,
-        SystemsManagerParameterStoreBackend.get_conn_uri should return None,
+        SystemsManagerParameterStoreBackend.get_conn_value should return None,
         SystemsManagerParameterStoreBackend._get_secret should not be called
         """
         kwargs = {'connections_prefix': None}
 
         ssm_backend = SystemsManagerParameterStoreBackend(**kwargs)
 
-        assert ssm_backend.get_conn_uri("test_mysql") is None
+        assert ssm_backend.get_conn_value("test_mysql") is None
         mock_get_secret.assert_not_called()
 
     @mock.patch(

--- a/tests/providers/amazon/aws/sensors/test_emr_containers.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_containers.py
@@ -37,6 +37,9 @@ class TestEmrContainerSensor(unittest.TestCase):
             max_retries=1,
             aws_conn_id='aws_default',
         )
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        self.sensor.hook.get_connection = lambda _: None
 
     @mock.patch.object(EmrContainerHook, 'check_query_status', side_effect=("PENDING",))
     def test_poke_pending(self, mock_check_query_status):

--- a/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_catalog_partition.py
@@ -79,6 +79,9 @@ class TestGlueCatalogPartitionSensor(unittest.TestCase):
             poke_interval=poke_interval,
             timeout=timeout,
         )
+        # We're mocking all actual AWS calls and don't need a connection. This
+        # avoids an Airflow warning about connection cannot be found.
+        op.get_hook().get_connection = lambda _: None
         op.poke({})
 
         assert op.hook.region_name == region_name

--- a/tests/providers/amazon/aws/transfers/test_google_api_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_google_api_to_s3.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from airflow import models
-from airflow.configuration import load_test_config
+from airflow.configuration import conf
 from airflow.models.xcom import MAX_XCOM_SIZE
 from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
 from airflow.utils import db
@@ -31,7 +31,7 @@ from airflow.utils import db
 
 class TestGoogleApiToS3(unittest.TestCase):
     def setUp(self):
-        load_test_config()
+        conf.load_test_config()
 
         db.merge_conn(
             models.Connection(

--- a/tests/providers/amazon/aws/utils/test_connection_wrapper.py
+++ b/tests/providers/amazon/aws/utils/test_connection_wrapper.py
@@ -44,7 +44,7 @@ class TestAwsConnectionWrapper:
             password="mock-password",
             extra=extra,
             # AwsBaseHook never use this attributes from airflow.models.Connection
-            host="mock-host",
+            host=None,
             schema="mock-schema",
             port=42,
         )
@@ -141,7 +141,8 @@ class TestAwsConnectionWrapper:
         }
         mock_conn = mock_connection_factory(login=None, password=None, extra=mock_conn_extra)
 
-        wrap_conn = AwsConnectionWrapper(conn=mock_conn)
+        with pytest.warns(DeprecationWarning, match=r"'session_kwargs' in extra config is deprecated"):
+            wrap_conn = AwsConnectionWrapper(conn=mock_conn)
         assert wrap_conn.aws_access_key_id == aws_access_key_id
         assert wrap_conn.aws_secret_access_key == aws_secret_access_key
         assert wrap_conn.aws_session_token == aws_session_token


### PR DESCRIPTION
TBH I originally set of to fix all warnings originate from the provider code base (i.e. exlucding those from Moto etc.) but eventually just got bored after this one provider.

Note to reviewers: It may be easier to read each commit in this PR individually (each of them fix one particular deprecation warning) instead of reading the diff in its entirety (which would have all kinds of changes intertwined).