### PR TITLE
Bump min version of jinja2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ install_requires =
     importlib_metadata>=1.7;python_version<"3.9"
     importlib_resources>=5.2;python_version<"3.9"
     itsdangerous>=2.0
-    jinja2>=2.10.1
+    jinja2>=3.0.0
     jsonschema>=3.2.0
     lazy-object-proxy
     linkify-it-py>=2.0.0


### PR DESCRIPTION
We use the `dumps` kwarg, which was added in 3.0 of jinja2.