### PR TITLE
Fix flakey test test_disable_logging

### DIFF
--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -351,15 +351,6 @@ class TestGetGcpCredentialsAndProjectId(unittest.TestCase):
             )
         assert logs.output == ['DEBUG:root:nothing']
 
-        # assert no debug logs emitted from get_credentials_and_project_id
-        with self.assertLogs(level="DEBUG") as logs:
-            logging.debug('nothing')
-            get_credentials_and_project_id(
-                key_path='KEY.json',
-                disable_logging=True,
-            )
-        assert logs.output == ['DEBUG:root:nothing']
-
 
 class TestGetScopes(unittest.TestCase):
     def test_get_scopes_with_default(self):

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import unittest
@@ -327,22 +328,37 @@ class TestGetGcpCredentialsAndProjectId(unittest.TestCase):
     )
     def test_disable_logging(self, mock_default, mock_info, mock_file):
         # assert not logs
-        with pytest.raises(AssertionError), self.assertLogs(level="DEBUG"):
+        with self.assertLogs(level="DEBUG") as logs:
+            logging.debug('nothing')
             get_credentials_and_project_id(disable_logging=True)
+        assert logs.output == ['DEBUG:root:nothing']
 
-        # assert not logs
-        with pytest.raises(AssertionError), self.assertLogs(level="DEBUG"):
+        # assert no debug logs emitted from get_credentials_and_project_id
+        with self.assertLogs(level="DEBUG") as logs:
+            logging.debug('nothing')
             get_credentials_and_project_id(
                 keyfile_dict={'private_key': 'PRIVATE_KEY'},
                 disable_logging=True,
             )
+        assert logs.output == ['DEBUG:root:nothing']
 
-        # assert not logs
-        with pytest.raises(AssertionError), self.assertLogs(level="DEBUG"):
+        # assert no debug logs emitted from get_credentials_and_project_id
+        with self.assertLogs(level="DEBUG") as logs:
+            logging.debug('nothing')
             get_credentials_and_project_id(
                 key_path='KEY.json',
                 disable_logging=True,
             )
+        assert logs.output == ['DEBUG:root:nothing']
+
+        # assert no debug logs emitted from get_credentials_and_project_id
+        with self.assertLogs(level="DEBUG") as logs:
+            logging.debug('nothing')
+            get_credentials_and_project_id(
+                key_path='KEY.json',
+                disable_logging=True,
+            )
+        assert logs.output == ['DEBUG:root:nothing']
 
 
 class TestGetScopes(unittest.TestCase):


### PR DESCRIPTION
We expected an AssertionError arising from `self.assertLogs`, which means we expected that no logs would be emitted.

The problem is, when this fails, we don't know why -- we don't know what was logged that we did not expect to be logged.

We can improve this test by capturing the logs, then asserting that the logs captured are only the ones emitted explicitly in the test code (assertLogs will fail if we don't insert a dummy log record).
