### PR TITLE
Allow for the overriding of stringify_dict for json/jsonb column data…

### DIFF
--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -54,7 +54,7 @@ class BaseSQLToGCSOperator(BaseOperator):
         to see the maximum allowed file size for a single object.
     :param export_format: Desired format of files to be exported. (json, csv or parquet)
     :param stringify_dict: Whether to dump Dictionary type objects
-        (such as JSON columns) as a string. Applies only to JSON export format.
+        (such as JSON columns) as a string. Applies only to CSV/JSON export format.
     :param field_delimiter: The delimiter to be used for CSV files.
     :param null_marker: The null marker to be used for CSV files.
     :param gzip: Option to compress file for upload (does not apply to schemas).
@@ -189,10 +189,10 @@ class BaseSQLToGCSOperator(BaseOperator):
 
         return file_meta
 
-    def convert_types(self, schema, col_type_dict, row, stringify_dict=False) -> list:
+    def convert_types(self, schema, col_type_dict, row) -> list:
         """Convert values from DBAPI to output-friendly formats."""
         return [
-            self.convert_type(value, col_type_dict.get(name), stringify_dict=stringify_dict)
+            self.convert_type(value, col_type_dict.get(name), stringify_dict=self.stringify_dict)
             for name, value in zip(schema, row)
         ]
 
@@ -247,7 +247,7 @@ class BaseSQLToGCSOperator(BaseOperator):
                 tbl = pa.Table.from_pydict(row_pydic, parquet_schema)
                 parquet_writer.write_table(tbl)
             else:
-                row = self.convert_types(schema, col_type_dict, row, stringify_dict=self.stringify_dict)
+                row = self.convert_types(schema, col_type_dict, row)
                 row_dict = dict(zip(schema, row))
 
                 tmp_file_handle.write(


### PR DESCRIPTION
closes: #26875

This change allows you to dump dict type objects returned from Postgres to a string.

No change to default behavior, must be enabled by setting stringify_dict=True

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
