### PR TITLE
Betterize dataset update blurb

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -77,7 +77,7 @@ from airflow.models.base import Base, StringID
 from airflow.models.dagcode import DagCode
 from airflow.models.dagpickle import DagPickle
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue as DDRQ
+from airflow.models.dataset import DagScheduleDatasetReference, DatasetDagRunQueue as DDRQ, DatasetModel
 from airflow.models.operator import Operator
 from airflow.models.param import DagParam, ParamsDict
 from airflow.models.taskinstance import Context, TaskInstance, TaskInstanceKey, clear_task_instances
@@ -200,18 +200,24 @@ def get_last_dagrun(dag_id, session, include_externally_triggered=False):
     return query.first()
 
 
-def get_dataset_triggered_next_run_info(dag_ids: list[str], *, session: Session) -> dict[str, dict[str, int]]:
+def get_dataset_triggered_next_run_info(
+    dag_ids: list[str], *, session: Session
+) -> dict[str, dict[str, int | str]]:
     """
     Given a list of dag_ids, get string representing how close any that are dataset triggered are
     their next run, e.g. "1 of 2 datasets updated"
     """
     return {
         x.dag_id: {
+            "uri": x.uri,
             "ready": x.ready,
             "total": x.total,
         }
         for x in session.query(
             DagScheduleDatasetReference.dag_id,
+            # This is a dirty hack to workaround group by requiring an aggregate, since grouping by dataset
+            # is not what we want to do here...but it works
+            case((func.count() == 1, func.max(DatasetModel.uri)), else_='').label("uri"),
             func.count().label("total"),
             func.sum(case((DDRQ.target_dag_id.is_not(None), 1), else_=0)).label("ready"),
         )
@@ -223,7 +229,13 @@ def get_dataset_triggered_next_run_info(dag_ids: list[str], *, session: Session)
             ),
             isouter=True,
         )
-        .group_by(DagScheduleDatasetReference.dag_id)
+        .join(
+            DatasetModel,
+            DatasetModel.id == DagScheduleDatasetReference.dataset_id,
+        )
+        .group_by(
+            DagScheduleDatasetReference.dag_id,
+        )
         .filter(DagScheduleDatasetReference.dag_id.in_(dag_ids))
         .all()
     }
@@ -3419,7 +3431,7 @@ class DagModel(Base):
         )
 
     @provide_session
-    def get_dataset_triggered_next_run_info(self, *, session=NEW_SESSION) -> dict[str, int] | None:
+    def get_dataset_triggered_next_run_info(self, *, session=NEW_SESSION) -> dict[str, int | str] | None:
         if self.schedule_interval != "Dataset":
             return None
         return get_dataset_triggered_next_run_info([self.dag_id], session=session)[self.dag_id]

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -39,6 +39,7 @@ const logsWithMetadataUrl = getMetaValue('logs_with_metadata_url');
 const externalLogUrl = getMetaValue('external_log_url');
 const extraLinksUrl = getMetaValue('extra_links_url');
 const pausedUrl = getMetaValue('paused_url');
+const datasetsUrl = getMetaValue('datasets_url');
 const nextRun = {
   createAfter: getMetaValue('next_dagrun_create_after'),
   intervalStart: getMetaValue('next_dagrun_data_interval_start'),
@@ -65,7 +66,10 @@ $(window).on('load', function onLoad() {
   $(`a[href*="${this.location.pathname}"]`).parent().addClass('active');
   $('.never_active').removeClass('active');
   const run = $('#next-dataset-tooltip');
-  getDatasetTooltipInfo(dagId, run, setNextDatasets);
+  const singleDatasetUri = $(run).data('uri');
+  if (!singleDatasetUri) {
+    getDatasetTooltipInfo(dagId, run, setNextDatasets);
+  }
 });
 
 const buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce((obj, elm) => {
@@ -411,6 +415,12 @@ $('#next-run').on('mouseover', () => {
 });
 
 $('.next-dataset-triggered').on('click', (e) => {
+  const run = $('#next-dataset-tooltip');
   const summary = $(e.target).data('summary');
-  openDatasetModal(dagId, summary, nextDatasets, nextDatasetsError);
+  const singleDatasetUri = $(run).data('uri');
+  if (!singleDatasetUri) {
+    openDatasetModal(dagId, summary, nextDatasets, nextDatasetsError);
+  } else {
+    window.location.href = `${datasetsUrl}?uri=${encodeURIComponent(singleDatasetUri)}`;
+  }
 });

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -39,6 +39,7 @@ const lastDagRunsUrl = getMetaValue('last_dag_runs_url');
 const dagStatsUrl = getMetaValue('dag_stats_url');
 const taskStatsUrl = getMetaValue('task_stats_url');
 const gridUrl = getMetaValue('grid_url');
+const datasetsUrl = getMetaValue('datasets_url');
 
 const nextDatasets = {};
 let nextDatasetsError;
@@ -545,17 +546,30 @@ $('#auto_refresh').change(() => {
 $('.next-dataset-triggered').on('click', (e) => {
   const dagId = $(e.target).data('dag-id');
   const summary = $(e.target).data('summary');
-  if (dagId) openDatasetModal(dagId, summary, nextDatasets[dagId], nextDatasetsError);
+  const singleDatasetUri = $(e.target).data('uri');
+
+  // If there are multiple datasets, open a modal, otherwise link directly to the dataset
+  if (!singleDatasetUri) {
+    if (dagId) openDatasetModal(dagId, summary, nextDatasets[dagId], nextDatasetsError);
+  } else {
+    window.location.href = `${datasetsUrl}?uri=${encodeURIComponent(singleDatasetUri)}`;
+  }
 });
 
 $('.js-dataset-triggered').each((i, cell) => {
   $(cell).on('mouseover', () => {
     const run = $(cell).children();
     const dagId = $(run).data('dag-id');
+    const singleDatasetUri = $(run).data('uri');
+
     const setNextDatasets = (datasets, error) => {
       nextDatasets[dagId] = datasets;
       nextDatasetsError = error;
     };
-    getDatasetTooltipInfo(dagId, run, setNextDatasets);
+
+    // Only update the tooltip info if there are multiple datasets
+    if (!singleDatasetUri) {
+      getDatasetTooltipInfo(dagId, run, setNextDatasets);
+    }
   });
 });

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -137,21 +137,33 @@
         </p>
       {% endif %}
       {% if dag_model is defined and dag_model.schedule_interval is defined and dag_model.schedule_interval == 'Dataset' %}
-        <span
-          id="next-dataset-tooltip"
-          class="js-tooltip"
-          title="Click to see dataset details."
-          data-html="true"
-          data-placement="bottom"
-        >
-          <p
-            class="label label-default next-dataset-triggered"
-            style="margin-left: 5px;"
-            data-summary="{{ dag_model.get_dataset_triggered_next_run_info() }}"
+        {%- with ds_info = dag_model.get_dataset_triggered_next_run_info() -%}
+          <span
+            id="next-dataset-tooltip"
+            class="js-tooltip"
+            title="Click to see dataset details."
+            data-html="true"
+            data-placement="bottom"
+            data-uri="{{ ds_info.uri }}"
           >
-            Next Run: {{ dag_model.get_dataset_triggered_next_run_info() }}
-          </p>
-        </span>
+              <p
+                class="label label-default next-dataset-triggered"
+                style="margin-left: 5px;"
+                data-summary="
+                  {%- if ds_info.total == 1 -%}
+                  On {{ ds_info.uri }}
+                  {%- else -%}
+                  {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                  {%- endif -%}"
+                >
+                {% if ds_info.total == 1 -%}
+                  On {{ ds_info.uri }}
+                {%- else -%}
+                {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                {%- endif %}
+              </p>
+          </span>
+        {%- endwith -%}
       {% endif %}
     </h4>
   </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -303,15 +303,24 @@
                   title="Click to see dataset details."
                   data-html="true"
                 >
+                  {%- with ds_info = dataset_triggered_next_run_info[dag.dag_id] -%}
                   <div
                     class="label label-default next-dataset-triggered"
                     data-dag-id="{{ dag.dag_id }}"
-                    data-summary="{{ dataset_triggered_next_run_info[dag.dag_id] }}"
-                  >
-                    {% with ds_info = dataset_triggered_next_run_info[dag.dag_id] %}
+                    data-summary="
+                    {%- if ds_info.total == 1 -%}
+                    On {{ ds_info.uri }}
+                    {%- else -%}
                     {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
-                    {% endwith %}
+                    {%- endif -%}"
+                  >
+                    {% if ds_info.total == 1 -%}
+                    On {{ ds_info.uri }}
+                    {%- else -%}
+                    {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                    {%- endif %}
                   </div>
+                  {%- endwith -%}
                 </span>
               {% endif %}
               {% if dag.next_dagrun is not none %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -297,31 +297,33 @@
             </td>
             <td class="text-nowrap {{ 'js-dataset-triggered' if dag.dag_id in dataset_triggered_next_run_info }}">
               {% if dag.dag_id in dataset_triggered_next_run_info %}
-                <span
-                  data-dag-id="{{ dag.dag_id }}"
-                  class="js-tooltip js-next-dataset-run-tooltip"
-                  title="Click to see dataset details."
-                  data-html="true"
-                >
-                  {%- with ds_info = dataset_triggered_next_run_info[dag.dag_id] -%}
-                  <div
-                    class="label label-default next-dataset-triggered"
+                {%- with ds_info = dataset_triggered_next_run_info[dag.dag_id] -%}
+                  <span
                     data-dag-id="{{ dag.dag_id }}"
-                    data-summary="
-                    {%- if ds_info.total == 1 -%}
-                    On {{ ds_info.uri }}
-                    {%- else -%}
-                    {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
-                    {%- endif -%}"
+                    class="js-tooltip js-next-dataset-run-tooltip"
+                    title="Click to see dataset details."
+                    data-html="true"
+                    data-uri="{{ ds_info.uri }}"
                   >
-                    {% if ds_info.total == 1 -%}
-                    On {{ ds_info.uri }}
-                    {%- else -%}
-                    {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
-                    {%- endif %}
-                  </div>
-                  {%- endwith -%}
-                </span>
+                    <div
+                      class="label label-default next-dataset-triggered"
+                      data-dag-id="{{ dag.dag_id }}"
+                      data-uri="{{ ds_info.uri }}"
+                      data-summary="
+                      {%- if ds_info.total == 1 -%}
+                      On {{ ds_info.uri }}
+                      {%- else -%}
+                      {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                      {%- endif -%}"
+                    >
+                      {% if ds_info.total == 1 -%}
+                        On {{ ds_info.uri[0:40] + '…' if ds_info.uri and ds_info.uri|length > 40 else ds_info.uri|default('', true) }}
+                      {%- else -%}
+                      {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                      {%- endif %}
+                    </div>
+                  </span>
+                {%- endwith -%}
               {% endif %}
               {% if dag.next_dagrun is not none %}
                 <time datetime="{{ dag.next_dagrun }}">{{ dag.next_dagrun }}</time>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -308,7 +308,7 @@
                     data-dag-id="{{ dag.dag_id }}"
                     data-summary="{{ dataset_triggered_next_run_info[dag.dag_id] }}"
                   >
-                    {% with %}{% set ds_info = dataset_triggered_next_run_info[dag.dag_id] %}
+                    {% with ds_info = dataset_triggered_next_run_info[dag.dag_id] %}
                     {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
                     {% endwith %}
                   </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -308,7 +308,7 @@
                     data-dag-id="{{ dag.dag_id }}"
                     data-summary="{{ dataset_triggered_next_run_info[dag.dag_id] }}"
                   >
-                    {% with ds_info = dataset_triggered_next_run_info[dag.dag_id] %}
+                    {% with %}{% set ds_info = dataset_triggered_next_run_info[dag.dag_id] %}
                     {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
                     {% endwith %}
                   </div>

--- a/tests/utils/test_db_cleanup.py
+++ b/tests/utils/test_db_cleanup.py
@@ -32,16 +32,18 @@ from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.operators.python import PythonOperator
 from airflow.utils.db_cleanup import _build_query, _cleanup_table, config_dict, run_cleanup
 from airflow.utils.session import create_session
-from tests.test_utils.db import clear_db_dags, clear_db_runs, drop_tables_with_prefix
+from tests.test_utils.db import clear_db_dags, clear_db_datasets, clear_db_runs, drop_tables_with_prefix
 
 
 @pytest.fixture(autouse=True)
 def clean_database():
     """Fixture that cleans the database before and after every test."""
     clear_db_runs()
+    clear_db_datasets()
     clear_db_dags()
     yield  # Test runs here
     clear_db_dags()
+    clear_db_datasets()
     clear_db_runs()
 
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a follow-up PR to #26815. I will rebase this on `main` after that PR is merged.

In that PR, in the DAGs view, we display "X of Y Datasets" for all DAGs that are scheduled on one or more datasets.

This is functionally useful except for datasets that are only ever triggered on one dataset. In that case, as long as the consuming DAG isn't paused and isn't currently running (maybe), the Next Run column will always display "0 of 1 Datasets".

Instead of doing that, for DAGs that consume only one dataset, we now simply show that URI:

![The Airflow list of DAGs, including the Next Run column, but instead of displaying "0 of 1 Datasets" for DAGs that consume only one dataset it just displays the dataset URI. Everything else about the DAGs list view is unchanged.](https://user-images.githubusercontent.com/597113/193951605-9d24c23a-9c70-47ba-8a47-79baf8d96736.png)


**The merge commit for this should also be cherry-picked after that merge commit.**

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
