### PR TITLE
Clean-ups around task-mapping code

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -728,14 +728,22 @@ class MappedOperator(AbstractOperator):
     def parse_time_mapped_ti_count(self) -> int | None:
         """Number of mapped TaskInstances that can be created at DagRun create time.
 
+        This only considers literal mapped arguments, and would return *None*
+        when any non-literal values are used for mapping.
+
         :return: None if non-literal mapped arg encountered, or the total
             number of mapped TIs this task should have.
         """
         return self._get_specified_expand_input().get_parse_time_mapped_ti_count()
 
     @cache
-    def run_time_mapped_ti_count(self, run_id: str, *, session: Session) -> int | None:
+    def get_mapped_ti_count(self, run_id: str, *, session: Session) -> int | None:
         """Number of mapped TaskInstances that can be created at run time.
+
+        This considers both literal and non-literal mapped arguments, and the
+        result is therefore available when all depended tasks have finished. The
+        return value should be identical to ``parse_time_mapped_ti_count`` if
+        all mapped arguments are literal.
 
         :return: None if upstream tasks are not complete yet, or the total
             number of mapped TIs this task should have.

--- a/tests/test_utils/mapping.py
+++ b/tests/test_utils/mapping.py
@@ -42,4 +42,4 @@ def expand_mapped_task(
     session.flush()
 
     mapped.expand_mapped_task(run_id, session=session)
-    mapped.run_time_mapped_ti_count.cache_clear()  # type: ignore[attr-defined]
+    mapped.get_mapped_ti_count.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
I found several places where the code is awkward (although technically correct) and decided to change them. There should be no change in functionality. A few things are involved:

1. The `expand_mapped_literals` closure is declaring a `sequence` argument that is always `None`. Remove it.
2. The `run_time_mapped_ti_count` method is never used in isolation, but combined with `parse_time_mapped_ti_count`. We should just combine the calls—actually, the run-time variant already covers the parse-time variant, so the latter call can simply be removed.
3. The `TaskInstance` import in `_revise_mapped_task_indexes` is redundant (the class is already imported globally) and is removed.
4. Various typing fixups.