### PR TITLE
Add separate error handler for 405(Method not allowed) errors

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -188,8 +188,7 @@ def init_api_connexion(app: Flask) -> None:
     from airflow.www import views
 
     @app.errorhandler(404)
-    @app.errorhandler(405)
-    def _handle_api_error(ex):
+    def _handle_api_not_found(ex):
         if request.path.startswith(base_path):
             # 404 errors are never handled on the blueprint level
             # unless raised from a view func so actual 404 errors,
@@ -198,6 +197,13 @@ def init_api_connexion(app: Flask) -> None:
             return common_error_handler(ex)
         else:
             return views.not_found(ex)
+
+    @app.errorhandler(405)
+    def _handle_method_not_allowed(ex):
+        if request.path.startswith(base_path):
+            return common_error_handler(ex)
+        else:
+            return views.method_not_allowed(ex)
 
     spec_dir = path.join(ROOT_APP_DIR, 'api_connexion', 'openapi')
     connexion_app = App(__name__, specification_dir=spec_dir, skip_error_handlers=True)

--- a/airflow/www/templates/airflow/error.html
+++ b/airflow/www/templates/airflow/error.html
@@ -20,14 +20,14 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Airflow 404</title>
+    <title>Airflow {{ status_code }}</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_32.png') }}">
   </head>
   <body>
     <div style="font-family: verdana; text-align: center; margin-top: 200px;">
       <img src="{{ url_for('static', filename='pin_100.png') }}" width="50px" alt="pin-logo" />
-      <h1>Airflow 404</h1>
-      <p>Page cannot be found.</p>
+      <h1>Airflow {{ status_code }}</h1>
+      <p>{{ error_message }}</p>
       <a href="/">Return to the main page</a>
       <p>{{ hostname }}</p>
     </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -489,12 +489,29 @@ def not_found(error):
     """Show Not Found on screen for any error in the Webserver"""
     return (
         render_template(
-            'airflow/not_found.html',
+            'airflow/error.html',
             hostname=get_hostname()
             if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
             else 'redact',
+            status_code=404,
+            error_message='Page cannot be found.',
         ),
         404,
+    )
+
+
+def method_not_allowed(error):
+    """Show Method Not Allowed on screen for any error in the Webserver"""
+    return (
+        render_template(
+            'airflow/error.html',
+            hostname=get_hostname()
+            if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
+            else 'redact',
+            status_code=405,
+            error_message='Received an invalid request.',
+        ),
+        405,
     )
 
 

--- a/tests/api_connexion/test_error_handling.py
+++ b/tests/api_connexion/test_error_handling.py
@@ -21,22 +21,55 @@ def test_incorrect_endpoint_should_return_json(minimal_app_for_api):
     client = minimal_app_for_api.test_client()
 
     # Given we have application with Connexion added
-    # When we hitting incorrect endpoint in API path
+    # When we are hitting incorrect endpoint in API path
 
-    resp_json = client.get("/api/v1/incorrect_endpoint").json
+    resp = client.get("/api/v1/incorrect_endpoint")
 
     # Then we have parsable JSON as output
 
-    assert 404 == resp_json["status"]
+    assert 'Not Found' == resp.json["title"]
+    assert 404 == resp.json["status"]
+    assert 404 == resp.status_code
+
+
+def test_incorrect_endpoint_should_return_html(minimal_app_for_api):
+    client = minimal_app_for_api.test_client()
 
     # When we are hitting non-api incorrect endpoint
 
-    resp_json = client.get("/incorrect_endpoint").json
+    resp = client.get("/incorrect_endpoint")
 
     # Then we do not have JSON as response, rather standard HTML
 
-    assert resp_json is None
+    assert resp.json is None
+    assert resp.mimetype == 'text/html'
+    assert resp.status_code == 404
 
-    resp_json = client.put("/api/v1/variables").json
 
-    assert 'Method Not Allowed' == resp_json["title"]
+def test_incorrect_method_should_return_json(minimal_app_for_api):
+    client = minimal_app_for_api.test_client()
+
+    # Given we have application with Connexion added
+    # When we are hitting incorrect HTTP method in API path
+
+    resp = client.put("/api/v1/version")
+
+    # Then we have parsable JSON as output
+
+    assert 'Method Not Allowed' == resp.json["title"]
+    assert 405 == resp.json["status"]
+    assert 405 == resp.status_code
+
+
+def test_incorrect_method_should_return_html(minimal_app_for_api):
+    client = minimal_app_for_api.test_client()
+
+    # When we are hitting non-api incorrect HTTP method
+
+    resp = client.put("/")
+
+    # Then we do not have JSON as response, rather standard HTML
+
+    assert resp.json is None
+    assert resp.mimetype == 'text/html'
+    assert resp.status_code == 405


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #26375 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


Previously, the webserver was using the same error handler for both 404 and 405 errors, and returning a 'Not Found' response for both cases. Hence the response status code was always 404, even when a 405(Method not allowed) was raised internally.

This PR creates a separate error handler for 405 errors, so it will return an appropriate response and status code.

closes: #26375

### Results of manual testing

- Returns a JSON response when hitting the REST APIs
```bash
dakshin@bluepenguin:~/projects/airflow$ curl -X PATCH -D - http://localhost:28080/api/v1/version
HTTP/1.1 405 METHOD NOT ALLOWED
Server: gunicorn
Date: Wed, 05 Oct 2022 08:35:30 GMT
Connection: close
Content-Type: application/problem+json
Content-Length: 142
X-Robots-Tag: noindex, nofollow
Set-Cookie: session=e2b057f0-12bb-4275-8d7c-ec10f86f291f.T49QxckJWF1FK5zE-nOHZMkMVg8; Expires=Fri, 04 Nov 2022 08:35:30 GMT; HttpOnly; Path=/; SameSite=Lax

{
  "detail": "The method is not allowed for the requested URL.",
  "status": 405,
  "title": "Method Not Allowed",
  "type": "about:blank"
}
```
- Returns a HTML response for other URLs
```bash
dakshin@bluepenguin:~/projects/airflow$ curl -X PATCH -D - http://localhost:28080/home
HTTP/1.1 405 METHOD NOT ALLOWED
Server: Werkzeug/2.2.2 Python/3.7.14
Date: Wed, 05 Oct 2022 08:42:30 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 475
X-Robots-Tag: noindex, nofollow
Set-Cookie: session=1b653de3-8dfa-477f-a4b5-72bbef8bfaa9.vuiHP-jyaAoquKD_OAd5DEdQVmQ; Expires=Fri, 04 Nov 2022 08:42:30 GMT; HttpOnly; Path=/; SameSite=Lax
Connection: close



<!DOCTYPE html>
<html lang="en">
  <head>
    <title>Airflow 405</title>
    <link rel="icon" type="image/png" href="/static/pin_32.png">
  </head>
  <body>
    <div style="font-family: verdana; text-align: center; margin-top: 200px;">
      <img src="/static/pin_100.png" width="50px" alt="pin-logo" />
      <h1>Airflow 405</h1>
      <p>Received an invalid request.</p>
      <a href="/">Return to the main page</a>
      <p>bdb986291012</p>
    </div>
  </body>
</html>
```
