### PR TITLE
Add search to datasets list

### DIFF
--- a/airflow/www/static/js/datasets/List.test.tsx
+++ b/airflow/www/static/js/datasets/List.test.tsx
@@ -1,0 +1,119 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global describe, test, expect */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import * as useDatasetsModule from 'src/api/useDatasets';
+import { Wrapper } from 'src/utils/testUtils';
+
+import DatasetsList from './List';
+
+const datasets = [
+  {
+    id: 0,
+    uri: 'this_dataset',
+    extra: null,
+    lastDatasetUpdate: null,
+    totalUpdates: 0,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 1,
+    uri: 'that_dataset',
+    extra: null,
+    lastDatasetUpdate: new Date().toISOString(),
+    totalUpdates: 10,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: 1,
+    uri: 'extra_dataset',
+    extra: null,
+    lastDatasetUpdate: new Date().toISOString(),
+    totalUpdates: 1,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  },
+];
+
+const returnValue = {
+  data: {
+    datasets,
+    totalEntries: datasets.length,
+  },
+  isSuccess: true,
+} as any;
+
+const emptyReturnValue = {
+  data: {
+    datasets: [],
+    totalEntries: 0,
+  },
+  isSuccess: true,
+  isLoading: false,
+} as any;
+
+describe('Test Datasets List', () => {
+  test('Displays a list of datasets', () => {
+    jest.spyOn(useDatasetsModule, 'default').mockImplementation(() => returnValue);
+
+    const { getByText, queryAllByTestId } = render(
+      <DatasetsList
+        onSelect={() => {}}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const listItems = queryAllByTestId('dataset-list-item');
+
+    expect(listItems).toHaveLength(3);
+
+    expect(getByText(datasets[0].uri)).toBeDefined();
+    expect(getByText('Total Updates: 0')).toBeDefined();
+
+    expect(getByText(datasets[1].uri)).toBeDefined();
+    expect(getByText('Total Updates: 10')).toBeDefined();
+
+    expect(getByText(datasets[2].uri)).toBeDefined();
+    expect(getByText('Total Updates: 1')).toBeDefined();
+  });
+
+  test('Empty state displays when there are no datasets', () => {
+    jest.spyOn(useDatasetsModule, 'default').mockImplementation(() => emptyReturnValue);
+
+    const { getByText, queryAllByTestId, getByTestId } = render(
+      <DatasetsList
+        onSelect={() => {}}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    const listItems = queryAllByTestId('dataset-list-item');
+
+    expect(listItems).toHaveLength(0);
+
+    expect(getByTestId('no-datasets-msg')).toBeInTheDocument();
+    expect(getByText('No Data found.')).toBeInTheDocument();
+  });
+});

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -24,14 +24,20 @@ import {
   Flex,
   Text,
   Link,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  IconButton,
 } from '@chakra-ui/react';
+import { snakeCase } from 'lodash';
 import type { Row, SortingRule } from 'react-table';
 
 import { useDatasets } from 'src/api';
 import { Table, TimeCell } from 'src/components/Table';
 import type { API } from 'src/types';
 import { getMetaValue } from 'src/utils';
-import { snakeCase } from 'lodash';
+import { MdClose, MdSearch } from 'react-icons/md';
 
 interface Props {
   onSelect: (datasetId: string) => void;
@@ -49,7 +55,7 @@ interface CellProps {
 const DetailCell = ({ cell: { row } }: CellProps) => {
   const { totalUpdates, uri } = row.original;
   return (
-    <Box>
+    <Box data-testid="dataset-list-item">
       <Text>{uri}</Text>
       <Text fontSize="sm" mt={2}>
         Total Updates:
@@ -63,15 +69,18 @@ const DetailCell = ({ cell: { row } }: CellProps) => {
 const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
+  const [search, setSearch] = useState('');
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'lastDatasetUpdate', desc: true }]);
 
   const sort = sortBy[0];
   const order = sort ? `${sort.desc ? '-' : ''}${snakeCase(sort.id)}` : '';
+  const uri = search.length > 2 ? search : undefined;
 
   const { data: { datasets, totalEntries }, isLoading } = useDatasets({
     limit,
     offset,
     order,
+    uri,
   });
 
   const columns = useMemo(
@@ -109,8 +118,8 @@ const DatasetsList = ({ onSelect }: Props) => {
           Datasets
         </Heading>
       </Flex>
-      {!datasets.length && !isLoading && (
-        <Text mb={4}>
+      {!datasets.length && !isLoading && !search && (
+        <Text mb={4} data-testid="no-datasets-msg">
           Looks like you do not have any datasets yet. Check out the
           {' '}
           <Link color="blue" href={docsUrl} isExternal>docs</Link>
@@ -118,6 +127,21 @@ const DatasetsList = ({ onSelect }: Props) => {
           to learn how to create a dataset.
         </Text>
       )}
+      <InputGroup my={2} px={1}>
+        <InputLeftElement pointerEvents="none">
+          <MdSearch />
+        </InputLeftElement>
+        <Input
+          placeholder="Search by URI..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        {search.length > 0 && (
+          <InputRightElement>
+            <IconButton aria-label="Clear search" title="Clear search" icon={<MdClose />} variant="ghost" onClick={() => setSearch('')} />
+          </InputRightElement>
+        )}
+      </InputGroup>
       <Box borderWidth={1}>
         <Table
           data={data}

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -32,12 +32,13 @@ import {
 } from '@chakra-ui/react';
 import { snakeCase } from 'lodash';
 import type { Row, SortingRule } from 'react-table';
+import { MdClose, MdSearch } from 'react-icons/md';
+import { useSearchParams } from 'react-router-dom';
 
 import { useDatasets } from 'src/api';
 import { Table, TimeCell } from 'src/components/Table';
 import type { API } from 'src/types';
 import { getMetaValue } from 'src/utils';
-import { MdClose, MdSearch } from 'react-icons/md';
 
 interface Props {
   onSelect: (datasetId: string) => void;
@@ -66,10 +67,13 @@ const DetailCell = ({ cell: { row } }: CellProps) => {
   );
 };
 
+const SEARCH_PARAM = 'search';
+
 const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
-  const [search, setSearch] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const search = searchParams.get(SEARCH_PARAM) || '';
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'lastDatasetUpdate', desc: true }]);
 
   const sort = sortBy[0];
@@ -111,6 +115,16 @@ const DatasetsList = ({ onSelect }: Props) => {
 
   const docsUrl = getMetaValue('datasets_docs');
 
+  const onSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    searchParams.set(SEARCH_PARAM, encodeURIComponent(e.target.value));
+    setSearchParams(searchParams);
+  };
+
+  const onClear = () => {
+    searchParams.delete(SEARCH_PARAM);
+    setSearchParams(searchParams);
+  };
+
   return (
     <Box>
       <Flex justifyContent="space-between" alignItems="center">
@@ -134,11 +148,11 @@ const DatasetsList = ({ onSelect }: Props) => {
         <Input
           placeholder="Search by URI..."
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={onSearch}
         />
         {search.length > 0 && (
           <InputRightElement>
-            <IconButton aria-label="Clear search" title="Clear search" icon={<MdClose />} variant="ghost" onClick={() => setSearch('')} />
+            <IconButton aria-label="Clear search" title="Clear search" icon={<MdClose />} variant="ghost" onClick={onClear} />
           </InputRightElement>
         )}
       </InputGroup>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3568,6 +3568,7 @@ class Airflow(AirflowBaseView):
         limit = int(request.args.get("limit", 25))
         offset = int(request.args.get("offset", 0))
         order_by = request.args.get("order_by", "uri")
+        uri_pattern = request.args.get("uri_pattern", "")
         lstripped_orderby = order_by.lstrip('-')
 
         if lstripped_orderby not in allowed_attrs:
@@ -3617,6 +3618,7 @@ class Airflow(AirflowBaseView):
                     DatasetModel.id,
                     DatasetModel.uri,
                 )
+                .filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
                 .order_by(*order_by)
                 .offset(offset)
                 .limit(limit)


### PR DESCRIPTION
Add a search bar to the datasets view to look up a dataset by part of its URI. Also, have the search value in the page's url params so it can be shared within a team.

<img width="571" alt="Screen Shot 2022-10-05 at 1 07 56 PM" src="https://user-images.githubusercontent.com/4600967/194120308-4b707f90-a1ab-40b3-8455-b76d25ec20ff.png">
<img width="585" alt="Screen Shot 2022-10-05 at 1 08 04 PM" src="https://user-images.githubusercontent.com/4600967/194120306-d44d84e2-05a6-4c26-beb8-cc52d83e9021.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
