### PR TITLE
Change dag audit log sort by date from asc to desc

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3606,7 +3606,7 @@ class Airflow(AirflowBaseView):
 
         current_page = request.args.get('page', default=0, type=int)
         arg_sorting_key = request.args.get('sorting_key', 'dttm')
-        arg_sorting_direction = request.args.get('sorting_direction', default='asc')
+        arg_sorting_direction = request.args.get('sorting_direction', default='desc')
 
         logs_per_page = PAGE_SIZE
         audit_logs_count = query.count()


### PR DESCRIPTION
In the dag audit log, we were showing the oldest events first. It should be the other way around

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
