### PR TITLE
ECS Buglette

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -536,7 +536,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
             raise ValueError("must specify awslogs_group to fetch task logs")
         log_stream_name = f"{self.awslogs_stream_prefix}/{self.ecs_task_id}"
 
-        return EcsTaskLogFetcher(
+        return ecs.EcsTaskLogFetcher(
             aws_conn_id=self.aws_conn_id,
             region_name=self.awslogs_region,
             log_group=self.awslogs_group,


### PR DESCRIPTION
EcsTaskLogFetcher incorrectly displayed a deprecation notice when used correctly.

Fixes: https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1664397142464329

Details: EcsTaskLogFetcher was moved from the operator module to the hook module a while back.  `_get_task_log_fetcher` was still using the (old, deprecated) wrapper method which showed the deprecation notice each time even if the user wasn't calling the deprecated class themselves.

coauthor: Taragolis