### PR TITLE
Remove <2 limit on google-cloud-storage

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -97,7 +97,7 @@ dependencies:
   - google-cloud-secret-manager>=0.2.0,<2.0.0
   - google-cloud-spanner>=1.10.0,<2.0.0
   - google-cloud-speech>=0.36.3,<2.0.0
-  - google-cloud-storage>=1.30,<2.0.0
+  - google-cloud-storage>=1.30,<3.0.0
   - google-cloud-tasks>=2.0.0
   - google-cloud-texttospeech>=0.4.0,<2.0.0
   - google-cloud-translate>=1.5.0,<2.0.0

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -132,7 +132,7 @@ PIP package                              Version required
 ``google-cloud-secret-manager``          ``>=0.2.0,<2.0.0``
 ``google-cloud-spanner``                 ``>=1.10.0,<2.0.0``
 ``google-cloud-speech``                  ``>=0.36.3,<2.0.0``
-``google-cloud-storage``                 ``>=1.30,<2.0.0``
+``google-cloud-storage``                 ``>=1.30,<3.0.0``
 ``google-cloud-tasks``                   ``>=2.0.0``
 ``google-cloud-texttospeech``            ``>=0.4.0,<2.0.0``
 ``google-cloud-translate``               ``>=1.5.0,<2.0.0``

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -334,7 +334,7 @@
       "google-cloud-secret-manager>=0.2.0,<2.0.0",
       "google-cloud-spanner>=1.10.0,<2.0.0",
       "google-cloud-speech>=0.36.3,<2.0.0",
-      "google-cloud-storage>=1.30,<2.0.0",
+      "google-cloud-storage>=1.30,<3.0.0",
       "google-cloud-tasks>=2.0.0",
       "google-cloud-texttospeech>=0.4.0,<2.0.0",
       "google-cloud-translate>=1.5.0,<2.0.0",


### PR DESCRIPTION
## What this does
* Removes <2 limit on google-cloud-storage for google provider

## Why
* newer versions of `google-cloud-storage` are required from some other python libraries
* the breaking changes made to [2.0](https://github.com/googleapis/python-storage/releases) was the removal of python 2.x support which airflow no longer supports regardless
* the breaking changes made to 2.1 was the removal of python 3.6 support which airflow no longer supports regardless

## Misc notes
* Made my best attempt to update all places where this could be referenced, unable to run `pre-commit --run-all` due to the following
* I attempted to use vscode in open in containers but hit error 1

```
Workspace folder not specified in devcontainer.json.
```

* After resolving error 1 by adding `workspace_folder=/var/lib/docker/codespacemount/workspace/airflow` I ran into error 2
```
[2022-10-06T18:58:11.339Z] Stop (53 ms): Run in container: /bin/sh
[2022-10-06T18:58:11.339Z] Start: Run in container: cat /etc/passwd
[2022-10-06T18:58:11.339Z] Stdin closed!
[2022-10-06T18:58:11.340Z] Shell server terminated (code: 1, signal: null)

Error response from daemon: Container 32d84eed30c292a7bd8b42d3b9a58e241e435f51388dbd5e437d20c32c108eef is not running
```