### PR TITLE
The Check Operator should throw a Airflow Fail Exception instead of AirflowException when the condition is not met

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, Sequence, SupportsAbs
 from packaging.version import Version
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, SkipMixin
 from airflow.providers.common.sql.hooks.sql import DbApiHook, _backported_get_hook
@@ -250,7 +250,7 @@ class SQLColumnCheckOperator(BaseSQLOperator):
             records = hook.get_first(self.sql)
 
             if not records:
-                raise AirflowException(f"The following query returned zero rows: {self.sql}")
+                raise AirflowFailException(f"The following query returned zero rows: {self.sql}")
 
             self.log.info("Record: %s", records)
 
@@ -264,7 +264,7 @@ class SQLColumnCheckOperator(BaseSQLOperator):
 
             failed_tests.extend(_get_failed_checks(self.column_mapping[column], column))
         if failed_tests:
-            raise AirflowException(
+            raise AirflowFailException(
                 f"Test failed.\nResults:\n{records!s}\n"
                 "The following tests have failed:"
                 f"\n{''.join(failed_tests)}"
@@ -450,7 +450,7 @@ class SQLTableCheckOperator(BaseSQLOperator):
 
         failed_tests = _get_failed_checks(self.checks)
         if failed_tests:
-            raise AirflowException(
+            raise AirflowFailException(
                 f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}\n"
                 "The following tests have failed:"
                 f"\n{', '.join(failed_tests)}"
@@ -512,9 +512,9 @@ class SQLCheckOperator(BaseSQLOperator):
 
         self.log.info("Record: %s", records)
         if not records:
-            raise AirflowException("The query returned None")
+            raise AirflowFailException("The query returned None")
         elif not all(bool(r) for r in records):
-            raise AirflowException(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
+            raise AirflowFailException(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
 
         self.log.info("Success.")
 

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -29,7 +29,7 @@ from google.api_core.exceptions import Conflict
 from google.api_core.retry import Retry
 from google.cloud.bigquery import DEFAULT_RETRY, CopyJob, ExtractJob, LoadJob, QueryJob
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.models.xcom import XCom
 from airflow.providers.common.sql.operators.sql import (
@@ -262,9 +262,9 @@ class BigQueryCheckOperator(_BigQueryDbHookMixin, SQLCheckOperator):
 
         records = event["records"]
         if not records:
-            raise AirflowException("The query returned empty results")
+            raise AirflowFailException("The query returned empty results")
         elif not all(bool(r) for r in records):
-            raise AirflowException(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
+            raise AirflowFailException(f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}")
         self.log.info("Record: %s", event["records"])
         self.log.info("Success.")
 


### PR DESCRIPTION

The Airflow Check Operator fails when the conditions fail. In my opinion, there is not need to retry, as it will most likely fail again if it runs the query.

Therefore, the proposal is to use AirflowFailException to avoid retries. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: N/A
related: N/A

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
