### PR TITLE
Decode url params for dataset searches

### DIFF
--- a/airflow/www/static/js/datasets/List.test.tsx
+++ b/airflow/www/static/js/datasets/List.test.tsx
@@ -116,4 +116,16 @@ describe('Test Datasets List', () => {
     expect(getByTestId('no-datasets-msg')).toBeInTheDocument();
     expect(getByText('No Data found.')).toBeInTheDocument();
   });
+
+  test('Correctly decodes search param and applies it to the input', () => {
+    jest.spyOn(useDatasetsModule, 'default').mockImplementation(() => returnValue);
+
+    const { getByDisplayValue } = render(
+      <Wrapper initialEntries={['/datasets?search=s3%253A%252F%252F']}>
+        <DatasetsList onSelect={() => {}} />
+      </Wrapper>,
+    );
+
+    expect(getByDisplayValue('s3://')).toBeInTheDocument();
+  });
 });

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -73,7 +73,7 @@ const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
   const [searchParams, setSearchParams] = useSearchParams();
-  const search = searchParams.get(SEARCH_PARAM) || '';
+  const search = decodeURIComponent(searchParams.get(SEARCH_PARAM) || '');
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'lastDatasetUpdate', desc: true }]);
 
   const sort = sortBy[0];

--- a/airflow/www/static/js/utils/testUtils.tsx
+++ b/airflow/www/static/js/utils/testUtils.tsx
@@ -20,13 +20,17 @@
 import React, { PropsWithChildren } from 'react';
 import { ChakraProvider, Table, Tbody } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, MemoryRouterProps } from 'react-router-dom';
 
-import { ContainerRefProvider } from '../context/containerRef';
-import { TimezoneProvider } from '../context/timezone';
-import { AutoRefreshProvider } from '../context/autorefresh';
+import { ContainerRefProvider } from 'src/context/containerRef';
+import { TimezoneProvider } from 'src/context/timezone';
+import { AutoRefreshProvider } from 'src/context/autorefresh';
 
-export const Wrapper = ({ children }: PropsWithChildren) => {
+interface WrapperProps extends PropsWithChildren {
+  initialEntries?: MemoryRouterProps['initialEntries'];
+}
+
+export const Wrapper = ({ initialEntries, children }: WrapperProps) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -41,7 +45,7 @@ export const Wrapper = ({ children }: PropsWithChildren) => {
         <ContainerRefProvider>
           <TimezoneProvider>
             <AutoRefreshProvider>
-              <MemoryRouter>
+              <MemoryRouter initialEntries={initialEntries}>
                 {children}
               </MemoryRouter>
             </AutoRefreshProvider>


### PR DESCRIPTION
When searching for a dataset, we encode the params in the URL. But we weren't then decoding those results to be human readable on the page. This PR fixes that and adds a test for the issue.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
