### PR TITLE
Filtering datasets by recent update events

### DIFF
--- a/airflow/www/static/js/api/useDatasets.ts
+++ b/airflow/www/static/js/api/useDatasets.ts
@@ -29,12 +29,17 @@ interface DatasetsData {
   totalEntries: number;
 }
 
+export interface DateOption {
+  count: number;
+  unit: unitOfTime.DurationConstructor;
+}
+
 interface Props {
   limit?: number;
   offset?: number;
   order?: string;
   uri?: string;
-  updatedAfter?: unitOfTime.DurationConstructor;
+  updatedAfter?: DateOption;
 }
 
 export default function useDatasets({
@@ -46,8 +51,8 @@ export default function useDatasets({
       const datasetsUrl = getMetaValue('datasets_api');
       const orderParam = order ? { order_by: order } : {};
       const uriParam = uri ? { uri_pattern: uri } : {};
-      const updatedAfterParam = updatedAfter
-        ? { updated_after: moment().subtract(1, updatedAfter).toISOString() }
+      const updatedAfterParam = updatedAfter && updatedAfter.count && updatedAfter.unit
+        ? { updated_after: moment().subtract(updatedAfter.count, updatedAfter.unit).toISOString() }
         : {};
       return axios.get<AxiosResponse, DatasetsData>(
         datasetsUrl,

--- a/airflow/www/static/js/api/useDatasets.ts
+++ b/airflow/www/static/js/api/useDatasets.ts
@@ -22,6 +22,7 @@ import { useQuery } from 'react-query';
 
 import { getMetaValue } from 'src/utils';
 import type { DatasetListItem } from 'src/types';
+import type { unitOfTime } from 'moment';
 
 interface DatasetsData {
   datasets: DatasetListItem[];
@@ -33,22 +34,30 @@ interface Props {
   offset?: number;
   order?: string;
   uri?: string;
+  updatedAfter?: unitOfTime.DurationConstructor;
 }
 
 export default function useDatasets({
-  limit, offset, order, uri,
+  limit, offset, order, uri, updatedAfter,
 }: Props) {
   const query = useQuery(
-    ['datasets', limit, offset, order, uri],
+    ['datasets', limit, offset, order, uri, updatedAfter],
     () => {
       const datasetsUrl = getMetaValue('datasets_api');
       const orderParam = order ? { order_by: order } : {};
       const uriParam = uri ? { uri_pattern: uri } : {};
+      const updatedAfterParam = updatedAfter
+        ? { updated_after: moment().subtract(1, updatedAfter).toISOString() }
+        : {};
       return axios.get<AxiosResponse, DatasetsData>(
         datasetsUrl,
         {
           params: {
-            offset, limit, ...orderParam, ...uriParam,
+            offset,
+            limit,
+            ...orderParam,
+            ...uriParam,
+            ...updatedAfterParam,
           },
         },
       );

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -147,7 +147,7 @@ const DatasetsList = ({ onSelect }: Props) => {
           Datasets
         </Heading>
       </Flex>
-      {!datasets.length && !isLoading && !search && (
+      {!datasets.length && !isLoading && !search && !dateFilter && (
         <Text mb={4} data-testid="no-datasets-msg">
           Looks like you do not have any datasets yet. Check out the
           {' '}

--- a/airflow/www/static/js/datasets/List.tsx
+++ b/airflow/www/static/js/datasets/List.tsx
@@ -29,8 +29,10 @@ import {
   InputLeftElement,
   InputRightElement,
   IconButton,
+  ButtonGroup,
+  Button,
 } from '@chakra-ui/react';
-import { snakeCase } from 'lodash';
+import { capitalize, snakeCase } from 'lodash';
 import type { Row, SortingRule } from 'react-table';
 import { MdClose, MdSearch } from 'react-icons/md';
 import { useSearchParams } from 'react-router-dom';
@@ -39,6 +41,7 @@ import { useDatasets } from 'src/api';
 import { Table, TimeCell } from 'src/components/Table';
 import type { API } from 'src/types';
 import { getMetaValue } from 'src/utils';
+import type { unitOfTime } from 'moment';
 
 interface Props {
   onSelect: (datasetId: string) => void;
@@ -72,8 +75,13 @@ const SEARCH_PARAM = 'search';
 const DatasetsList = ({ onSelect }: Props) => {
   const limit = 25;
   const [offset, setOffset] = useState(0);
+
   const [searchParams, setSearchParams] = useSearchParams();
   const search = decodeURIComponent(searchParams.get(SEARCH_PARAM) || '');
+
+  const dateOptions: unitOfTime.DurationConstructor[] = ['month', 'week', 'day', 'hour'];
+  const [dateFilter, setDateFilter] = useState<unitOfTime.DurationConstructor | undefined>();
+
   const [sortBy, setSortBy] = useState<SortingRule<object>[]>([{ id: 'lastDatasetUpdate', desc: true }]);
 
   const sort = sortBy[0];
@@ -85,6 +93,7 @@ const DatasetsList = ({ onSelect }: Props) => {
     offset,
     order,
     uri,
+    updatedAfter: dateFilter,
   });
 
   const columns = useMemo(
@@ -141,6 +150,21 @@ const DatasetsList = ({ onSelect }: Props) => {
           to learn how to create a dataset.
         </Text>
       )}
+      <Flex>
+        <Text mr={2}>Filter datasets with update in the past:</Text>
+        <ButtonGroup size="sm" isAttached variant="outline">
+          {dateOptions.map((option) => (
+            <Button
+              key={option}
+              onClick={() => setDateFilter(dateFilter === option ? undefined : option)}
+              variant={dateFilter === option ? 'solid' : 'outline'}
+              fontWeight={dateFilter === option ? 'bold' : 'normal'}
+            >
+              {capitalize(option)}
+            </Button>
+          ))}
+        </ButtonGroup>
+      </Flex>
       <InputGroup my={2} px={1}>
         <InputLeftElement pointerEvents="none">
           <MdSearch />

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3534,6 +3534,8 @@ class Airflow(AirflowBaseView):
         # Check and clean up query parameters
         limit = 50 if limit > 50 else limit
 
+        uri_pattern = uri_pattern[:4000]
+
         if lstripped_orderby not in allowed_attrs:
             return {
                 "detail": (
@@ -3598,9 +3600,12 @@ class Airflow(AirflowBaseView):
                     DatasetModel.id,
                     DatasetModel.uri,
                 )
-                .filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
                 .order_by(*order_by)
             )
+
+            if uri_pattern:
+                count_query = count_query.filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
+                query = query.filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
 
             if updated_after:
                 count_query = count_query.outerjoin(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3599,9 +3599,8 @@ class Airflow(AirflowBaseView):
             if updated_before:
                 filters.append(DatasetEvent.timestamp <= updated_before)
 
-            for filter in filters:
-                query = query.filter(filter)
-                count_query = count_query.filter(filter)
+            query = query.filter(*filters)
+            count_query = count_query.filter(*filters)
 
             query = query.offset(offset).limit(limit)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3591,12 +3591,17 @@ class Airflow(AirflowBaseView):
 
             if updated_before or updated_after:
                 count_query = count_query.outerjoin(DatasetEvent, DatasetEvent.dataset_id == DatasetModel.id)
+            filters = []
             if uri_pattern:
-                query = query.filter(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
+                filters.append(DatasetModel.uri.ilike(f"%{uri_pattern}%"))
             if updated_after:
-                query = query.filter(DatasetEvent.timestamp >= updated_after)
+                filters.append(DatasetEvent.timestamp >= updated_after)
             if updated_before:
-                query = query.filter(DatasetEvent.timestamp <= updated_before)
+                filters.append(DatasetEvent.timestamp <= updated_before)
+
+            for filter in filters:
+                query = query.filter(filter)
+                count_query = count_query.filter(filter)
 
             query = query.offset(offset).limit(limit)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3584,6 +3584,8 @@ class Airflow(AirflowBaseView):
                     if session.bind.dialect.name == "postgresql":
                         order_by = (order_by[0].nulls_first(), *order_by[1:])
 
+            count_query = session.query(func.count(DatasetModel.id))
+
             query = (
                 session.query(
                     DatasetModel.id,
@@ -3612,7 +3614,7 @@ class Airflow(AirflowBaseView):
             query = query.offset(offset).limit(limit)
 
             datasets = [dict(dataset) for dataset in query.all()]
-            data = {"datasets": datasets, "total_entries": len(datasets)}
+            data = {"datasets": datasets, "total_entries": count_query.scalar()}
 
             return (
                 htmlsafe_json_dumps(data, separators=(',', ':'), cls=utils_json.AirflowJsonEncoder),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -71,7 +71,7 @@ from pendulum.datetime import DateTime
 from pendulum.parsing.exceptions import ParserError
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
-from sqlalchemy import Date, and_, desc, func, inspect, union_all
+from sqlalchemy import Date, and_, case, desc, func, inspect, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 from wtforms import SelectField, validators
@@ -3581,9 +3581,7 @@ class Airflow(AirflowBaseView):
                     DatasetModel.id,
                     DatasetModel.uri,
                     func.max(DatasetEvent.timestamp).label("last_dataset_update"),
-                    func.count(func.sum(func.case((DatasetEvent.id.is_not(None), 1), else_=0))).label(
-                        "total_updates"
-                    ),
+                    func.sum(case((DatasetEvent.id.is_not(None), 1), else_=0)).label("total_updates"),
                 )
                 .join(DatasetEvent, DatasetEvent.dataset_id == DatasetModel.id, isouter=not has_event_filters)
                 .group_by(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3603,8 +3603,14 @@ class Airflow(AirflowBaseView):
             )
 
             if updated_after:
+                count_query = count_query.outerjoin(
+                    DatasetEvent, DatasetEvent.dataset_id == DatasetModel.id
+                ).filter(DatasetEvent.timestamp >= updated_after)
                 query = query.filter(DatasetEvent.timestamp >= updated_after)
             if updated_before:
+                count_query = count_query.outerjoin(
+                    DatasetEvent, DatasetEvent.dataset_id == DatasetModel.id
+                ).filter(DatasetEvent.timestamp <= updated_before)
                 query = query.filter(DatasetEvent.timestamp <= updated_before)
 
             # We haven't yet implemented tags for datasets, so you can remove this, or we can implement that

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3581,7 +3581,7 @@ class Airflow(AirflowBaseView):
                     DatasetModel.id,
                     DatasetModel.uri,
                     func.max(DatasetEvent.timestamp).label("last_dataset_update"),
-                    func.count(func.sum(func.case(DatasetEvent.id.is_not(None), 1, else_=0))).label(
+                    func.count(func.sum(func.case((DatasetEvent.id.is_not(None), 1), else_=0))).label(
                         "total_updates"
                     ),
                 )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3546,11 +3546,11 @@ class Airflow(AirflowBaseView):
         if untrusted_updated_after:
             # Try to figure out how other functions in this module safely parse datetimes submitted by users
             # and do the same thing here
-            updated_after = ...
+            updated_after = _safe_parse_datetime(untrusted_updated_after)
         updated_before = None
         if untrusted_updated_before:
             # Clean this data the same way you cleaned updated_after
-            updated_before = ...
+            updated_before = _safe_parse_datetime(untrusted_updated_before)
 
         # split_with_any_tags = []
         # if isinstance(tags, str):
@@ -3601,9 +3601,9 @@ class Airflow(AirflowBaseView):
             )
 
             if updated_after:
-                query = query.filter(...)
+                query = query.filter(DatasetEvent.timestamp >= updated_after)
             if updated_before:
-                query = query.filter(...)
+                query = query.filter(DatasetEvent.timestamp <= updated_before)
 
             # We haven't yet implemented tags for datasets, so you can remove this, or we can implement that
             # if split_with_any_tags:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -237,7 +237,7 @@ def get_date_time_num_runs_dag_runs_form_data(www_request, session, dag):
     }
 
 
-def _safe_parse_datetime(v: str, allow_empty=False):
+def _safe_parse_datetime(v, allow_empty=False):
     """
     Parse datetime and return error message for invalid dates
 

--- a/tests/www/views/test_views_dataset.py
+++ b/tests/www/views/test_views_dataset.py
@@ -89,6 +89,64 @@ class TestGetDatasets(TestDatasetEndpoint):
         msg = "Ordering with 'fake' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
+    def test_order_by_raises_400_for_invalid_datetimes(self, admin_client, session):
+        datasets = [
+            DatasetModel(
+                uri=f"s3://bucket/key/{i}",
+            )
+            for i in [1, 2]
+        ]
+        session.add_all(datasets)
+        session.commit()
+        assert session.query(DatasetModel).count() == 2
+
+        response = admin_client.get("/object/datasets_summary?updated_before=null")
+
+        assert response.status_code == 400
+        assert "Invalid datetime:" in response.text
+
+        response = admin_client.get("/object/datasets_summary?updated_after=null")
+
+        assert response.status_code == 400
+        assert "Invalid datetime:" in response.text
+
+    def test_filter_by_datetimes(self, admin_client, session):
+        today = pendulum.today('UTC')
+
+        datasets = [
+            DatasetModel(
+                id=i,
+                uri=f"s3://bucket/key/{i}",
+            )
+            for i in range(1, 4)
+        ]
+        session.add_all(datasets)
+        # Update datasets, one per day, starting with datasets[0], ending with datasets[2]
+        dataset_events = [
+            DatasetEvent(
+                dataset_id=datasets[i].id,
+                timestamp=today.add(days=-len(datasets) + i + 1),
+            )
+            for i in range(len(datasets))
+        ]
+        session.add_all(dataset_events)
+        session.commit()
+        assert session.query(DatasetModel).count() == len(datasets)
+
+        cutoff = today.add(days=-1).add(minutes=-5).to_iso8601_string()
+        response = admin_client.get(f"/object/datasets_summary?updated_after={cutoff}")
+
+        assert response.status_code == 200
+        assert response.json['total_entries'] == 2
+        assert [json_dict['id'] for json_dict in response.json['datasets']] == [2, 3]
+
+        cutoff = today.add(days=-1).add(minutes=5).to_iso8601_string()
+        response = admin_client.get(f"/object/datasets_summary?updated_before={cutoff}")
+
+        assert response.status_code == 200
+        assert response.json['total_entries'] == 2
+        assert [json_dict['id'] for json_dict in response.json['datasets']] == [1, 2]
+
     @pytest.mark.parametrize(
         "order_by, ordered_dataset_ids",
         [

--- a/tests/www/views/test_views_dataset.py
+++ b/tests/www/views/test_views_dataset.py
@@ -215,6 +215,29 @@ class TestGetDatasets(TestDatasetEndpoint):
                     "total_updates": 0,
                 },
             ],
+            "total_entries": 1,
+        }
+
+        uri_pattern = 's3://bucket/key_'
+        response = admin_client.get(f"/object/datasets_summary?uri_pattern={uri_pattern}")
+
+        assert response.status_code == 200
+        response_data = response.json
+        assert response_data == {
+            "datasets": [
+                {
+                    "id": 1,
+                    "uri": "s3://bucket/key_1",
+                    "last_dataset_update": None,
+                    "total_updates": 0,
+                },
+                {
+                    "id": 2,
+                    "uri": "s3://bucket/key_2",
+                    "last_dataset_update": None,
+                    "total_updates": 0,
+                },
+            ],
             "total_entries": 2,
         }
 


### PR DESCRIPTION
Add the ability to filter datasets by when the last update events were (eg: only show datasets that had events in the past 7 days)

<img width="587" alt="Screen Shot 2022-10-07 at 2 42 40 PM" src="https://user-images.githubusercontent.com/4600967/194627505-73ff1777-bedb-42d2-91a7-6124c592a5ed.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
