### PR TITLE
Add nodePort declaration to chart/values.schema.json

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3465,6 +3465,12 @@
                                             "integer"
                                         ]
                                     },
+                                    "nodePort": {
+                                        "type": [
+                                            "string",
+                                            "integer"
+                                        ]
+                                    },
                                     "protocol": {
                                         "type": "string"
                                     }

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -723,12 +723,12 @@ class TestWebserverService:
         "ports, expected_ports",
         [
             (
-                [{"name": "webserver-nodeport", "nodePort": "31000", "port": "8080"}],
-                [{"name": "webserver-nodeport", "nodePort": 31000, "port": 8080}],
+                [{"nodePort": "31000", "port": "8080"}],
+                [{"nodePort": 31000, "port": 8080}],
             ),
             (
-                [{"name": "webserver-nodeport", "port": "8080"}],
-                [{"name": "webserver-nodeport", "port": 8080}],
+                [{"port": "8080"}],
+                [{"port": 8080}],
             ),
         ],
     )

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -738,7 +738,7 @@ class TestWebserverService:
                 "webserver": {
                     "service": {
                         "type": "NodePort",
-                        "ports": (ports),
+                        "ports": ports,
                     }
                 },
             },

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -719,6 +719,30 @@ class TestWebserverService:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
+    @parameterized.expand(
+        [
+            (
+                [{"name": "webserver-nodeport", "nodePort": "31000", "port": "8080"}],
+                [{"name": "webserver-nodeport", "nodePort": 31000, "port": 8080}],
+            )
+        ]
+    )
+    def test_nodeport_service(self, ports, expected_ports):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "service": {
+                        "type": "NodePort",
+                        "ports": (ports),
+                    }
+                },
+            },
+            show_only=["templates/webserver/webserver-service.yaml"],
+        )
+
+        assert "NodePort" == jmespath.search("spec.type", docs[0])
+        assert expected_ports == jmespath.search("spec.ports", docs[0])
+
 
 class TestWebserverConfigmap:
     def test_no_webserver_config_configmap_by_default(self):

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -728,7 +728,7 @@ class TestWebserverService:
             (
                 [{"name": "webserver-nodeport", "port": "8080"}],
                 [{"name": "webserver-nodeport", "port": 8080}],
-            )
+            ),
         ]
     )
     def test_nodeport_service(self, ports, expected_ports):

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -719,7 +719,8 @@ class TestWebserverService:
         assert "test_label" in jmespath.search("metadata.labels", docs[0])
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "ports, expected_ports",
         [
             (
                 [{"name": "webserver-nodeport", "nodePort": "31000", "port": "8080"}],

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -724,6 +724,10 @@ class TestWebserverService:
             (
                 [{"name": "webserver-nodeport", "nodePort": "31000", "port": "8080"}],
                 [{"name": "webserver-nodeport", "nodePort": 31000, "port": 8080}],
+            ),
+            (
+                [{"name": "webserver-nodeport", "port": "8080"}],
+                [{"name": "webserver-nodeport", "port": 8080}],
             )
         ]
     )

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -730,7 +730,7 @@ class TestWebserverService:
                 [{"name": "webserver-nodeport", "port": "8080"}],
                 [{"name": "webserver-nodeport", "port": 8080}],
             ),
-        ]
+        ],
     )
     def test_nodeport_service(self, ports, expected_ports):
         docs = render_chart(


### PR DESCRIPTION


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #26812 
Adding a nodePort declaration to the chart/values.schema.json file to allow users to explicitly define exactly which port the nodePort setting should use when deploying with the Helm chart. 

This is important for users who have external load balancers and firewalls/security groups that have predefined traffic ports for Airflow. (e.g. a load balancer is expecting the airflow-webserver to listen on port 31000, and it's set up via Terraform, so I'd rather be able to specify a known port in Terraform beforehand rather than have to grab a new port every time I build Airflow)

Tested locally on minikube with the following values.yaml override. 
```
webserver:
    service:
      type: NodePort
      ports:
        - name: airflow-ui
          port: 80
          targetPort: airflow-ui
          nodePort: 31000
```

Cluster comes up successfully with airflow-webserver service listening on expected nodePort. Output of the deployed `airflow-webserver` service object's YAML below:
```
Name:                     airflow-webserver
Namespace:                default
Labels:                   app.kubernetes.io/managed-by=Helm
                          chart=airflow-1.7.0-dev
                          component=webserver
                          heritage=Helm
                          release=airflow
                          tier=airflow
Annotations:              meta.helm.sh/release-name: airflow
                          meta.helm.sh/release-namespace: default
Selector:                 component=webserver,release=airflow,tier=airflow
Type:                     NodePort
IP Family Policy:         SingleStack
IP Families:              IPv4
IP:                       10.104.151.191
IPs:                      10.104.151.191
Port:                     airflow-ui  80/TCP
TargetPort:               airflow-ui/TCP
NodePort:                 airflow-ui  31000/TCP
Endpoints:                <none>
Session Affinity:         None
External Traffic Policy:  Cluster
Events:                   <none>
```


Also tested _without_ specifying a nodePort option (defaulting to ClusterIP) to ensure new schema doesn't break backwards compatibility.
