### PR TITLE
Improve testing AWS Connection response

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -635,21 +635,21 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         .. seealso::
             https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
         """
-        orig_client_type, self.client_type = self.client_type, 'sts'
         try:
-            res = self.get_client_type().get_caller_identity()
-            metadata = res.pop("ResponseMetadata", {})
-            if metadata.get("HTTPStatusCode") == 200:
-                return True, json.dumps(res)
-            else:
+            session = self.get_session()
+            conn_info = session.client("sts").get_caller_identity()
+            metadata = conn_info.pop("ResponseMetadata", {})
+            if metadata.get("HTTPStatusCode") != 200:
                 try:
                     return False, json.dumps(metadata)
                 except TypeError:
                     return False, str(metadata)
+            conn_info["credentials_method"] = session.get_credentials().method
+            conn_info["region_name"] = session.region_name
+            return True, ", ".join(f"{k}={v!r}" for k, v in conn_info.items())
+
         except Exception as e:
-            return False, str(e)
-        finally:
-            self.client_type = orig_client_type
+            return False, str(f"{type(e).__name__!r} error occurred while testing connection: {e}")
 
 
 class AwsBaseHook(AwsGenericHook[Union[boto3.client, boto3.resource]]):


### PR DESCRIPTION
Right not we have public method for create boto3.session.Session in `AwsBaseHook` so instead of replace hook attribute just create sts client by new session.

Also add information about botocore credentials method and region, which might help endusers for debug their connection.
If something wrong with credentials, also show name of original Exception
