### PR TITLE
Configure vscode dev-container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,10 @@
         "rogalmic.bash-debug"
     ],
     "service": "airflow",
-    "forwardPorts": [8080,5555,5432,6379]
+    "forwardPorts": [8080, 5555, 5432, 6379],
+    "workspaceFolder": "/opt/airflow",
+    // for users who use non-standard git config patterns
+    // https://github.com/microsoft/vscode-remote-release/issues/2084#issuecomment-989756268
+    "initializeCommand": "cd \"${localWorkspaceFolder}\" && git config --local user.email \"$(git config user.email)\" && git config --local user.name \"$(git config user.name)\"",
+    "overrideCommand": true
 }

--- a/scripts/ci/docker-compose/devcontainer.yml
+++ b/scripts/ci/docker-compose/devcontainer.yml
@@ -32,7 +32,8 @@ services:
     volumes:
       # Pass docker to inside of the container so that Kind and Moto tests can use it.
       - /var/run/docker.sock:/var/run/docker.sock
-      - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
+      - /dev/urandom:/dev/random  # Required to get non-blocking entropy source
       # Mount the cloned repo from codspaces docker host into the container,
       # this will keep /workspaces/airflow and /opt/airflow in sync.
-      - /var/lib/docker/codespacemount/workspace/airflow:/opt/airflow
+      - ../../../.:/opt/airflow
+      # - /var/lib/docker/codespacemount/workspace/airflow:/opt/airflow


### PR DESCRIPTION
## What this does and Why

* Configures `devcontainer.json` so that you can use vs-code dev containers for development

## How

1. Use `overrideCommand` to switch entryproint command for dev
1. Update mount path to relative from hardcoded

## To Test

1. Checkout this Branch 
1. Open Vs-Code install extension `ms-vscode-remote.vscode-remote-extensionpack`
1. Open command prompt & run `Dev Containers: Rebuild Container Without Cache`

## Misc

1. Follow up from #26922 
1. Had some conversations with @potiuk about this