### PR TITLE
Increase pytest execution timeout for Dask test backfill integration

### DIFF
--- a/tests/executors/test_dask_executor.py
+++ b/tests/executors/test_dask_executor.py
@@ -94,6 +94,7 @@ class TestDaskExecutor(TestBaseDask):
         executor = DaskExecutor(cluster_address=self.cluster.scheduler_address)
         self.assert_tasks_on_executor(executor, timeout_executor=120)
 
+    @pytest.mark.execution_timeout(180)
     def test_backfill_integration(self):
         """
         Test that DaskExecutor can be used to backfill example dags


### PR DESCRIPTION
Seems like https://github.com/apache/airflow/pull/26831 a bit broke main tests for Dask Executor.

```
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
  
  msg = 'Timeout >60.0s', pytrace = True
  
      @_with_exception(Failed)
      def fail(msg: str = "", pytrace: bool = True) -> "NoReturn":
          """Explicitly fail an executing test with the given message.
      
          :param str msg:
              The message to show the user as reason for the failure.
          :param bool pytrace:
              If False, msg represents the full failure information and no
              python traceback will be reported.
          """
          __tracebackhide__ = True
  >       raise Failed(msg=msg, pytrace=pytrace)
  E       Failed: Timeout >60.0s
  
  /usr/local/lib/python3.8/site-packages/_pytest/outcomes.py:153: Failed
  
  During handling of the above exception, another exception occurred:
```

**Testing API Always CLI Core Integration Other Providers WWW**. Test Core executed with this setup:
```
setup timeout: 60.0s, execution timeout: 60.0s, teardown timeout: 60.0s
```

I’m not sure but seems like test cases within `unittests.TestCase` ignore pytest timeouts.
I just grab randomly couple of previous success run before change base class for tests cases and time to time it ran more than 60s without interruption.

```
109.13s call     tests/executors/test_dask_executor.py::TestDaskExecutor::test_backfill_integration
77.16s call     tests/executors/test_dask_executor.py::TestDaskExecutor::test_backfill_integration
59.75s call     tests/executors/test_dask_executor.py::TestDaskExecutor::test_backfill_integration
112.74s call     tests/executors/test_dask_executor.py::TestDaskExecutor::test_backfill_integration
63.18s call     tests/executors/test_dask_executor.py::TestDaskExecutor::test_backfill_integration
```

BTW, seems like it is second slowest test in Test Core after after `TestStringifiedDAGs::test_serialization`