### PR TITLE
Fix sla checks being skipped when the preceding task instance misses the sla

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -425,7 +425,7 @@ class DagFileProcessor(LoggingMixin):
                 if next_info is None:
                     break
                 if (ti.dag_id, ti.task_id, next_info.logical_date) in recorded_slas_query:
-                    break
+                    continue
                 if next_info.logical_date + task.sla < ts:
 
                     sla_miss = SlaMiss(


### PR DESCRIPTION
If the preceding running task instance misses the sla,
sla check for subsequent task instances is skipped.

This seems to be happening at the following PR.
https://github.com/apache/airflow/pull/19553

I think we want to continue checking them.