### PR TITLE
Fix error on running pre-commit without installing breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -145,7 +145,7 @@ def reinstall_if_setup_changed() -> bool:
         if "apache-airflow-breeze" in e.msg:
             print(
                 """Missing Package`apache-airflow-breeze`.
-                   Use `pip install -e ./dev/breeze` to install the package."""
+                   Use `pipx install -e ./dev/breeze` to install the package."""
             )
             return False
     sources_hash = get_installation_sources_config_metadata_hash()

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -144,7 +144,7 @@ def reinstall_if_setup_changed() -> bool:
             return False
         if "apache-airflow-breeze" in e.msg:
             print(
-                """Missing Package`apache-airflow-breeze`.
+                """Missing Package `apache-airflow-breeze`.
                    Use `pipx install -e ./dev/breeze` to install the package."""
             )
             return False

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -142,6 +142,12 @@ def reinstall_if_setup_changed() -> bool:
     except ModuleNotFoundError as e:
         if "importlib_metadata" in e.msg:
             return False
+        if "apache-airflow-breeze" in e.msg:
+            print(
+                """Missing Package`apache-airflow-breeze`.
+                   Use `pip install -e ./dev/breeze` to install the package."""
+            )
+            return False
     sources_hash = get_installation_sources_config_metadata_hash()
     if sources_hash != package_hash:
         installation_sources = get_installation_airflow_sources()


### PR DESCRIPTION
Fixes: #26984

Running pre-commit without installing breeze or having docker setup for the 1st time throws an exception.
This PR captures that exception and shows a message to the user reminding them to install breeze
