### PR TITLE
Replace `unittests` in helm chart tests by pure `pytest` [Wave-2]

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -255,7 +255,7 @@ add them in ``tests/charts``.
 
 .. code-block:: python
 
-    class TestBaseChartTest(unittest.TestCase):
+    class TestBaseChartTest:
         ...
 
 To render the chart create a YAML string with the nested dictionary of options you wish to test. You can then
@@ -277,7 +277,7 @@ Example test here:
     """
 
 
-    class TestGitSyncScheduler(unittest.TestCase):
+    class TestGitSyncScheduler:
         def test_basic(self):
             helm_settings = yaml.safe_load(git_sync_basic)
             res = render_chart(

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -106,13 +106,14 @@ CI_FILE_GROUP_MATCHES = HashableDict(
             r"^airflow/api",
         ],
         FileGroupForCi.API_CODEGEN_FILES: [
-            "^airflow/api_connexion/openapi/v1.yaml",
-            "^clients/gen",
+            r"^airflow/api_connexion/openapi/v1\.yaml",
+            r"^clients/gen",
         ],
         FileGroupForCi.HELM_FILES: [
-            "^chart",
-            "^airflow/kubernetes",
-            "^tests/kubernetes",
+            r"^chart",
+            r"^airflow/kubernetes",
+            r"^tests/kubernetes",
+            r"^tests/charts",
         ],
         FileGroupForCi.SETUP_FILES: [
             r"^pyproject.toml",

--- a/tests/charts/test_airflow_common.py
+++ b/tests/charts/test_airflow_common.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -32,7 +31,8 @@ class TestAirflowCommon:
     as it requires extra test setup.
     """
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "dag_values, expected_mount",
         [
             (
                 {"gitSync": {"enabled": True}},
@@ -70,7 +70,7 @@ class TestAirflowCommon:
                     "readOnly": False,
                 },
             ),
-        ]
+        ],
     )
     def test_dags_mount(self, dag_values, expected_mount):
         docs = render_chart(

--- a/tests/charts/test_celery_kubernetes_executor.py
+++ b/tests/charts/test_celery_kubernetes_executor.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class CeleryKubernetesExecutorTest(unittest.TestCase):
+class TestCeleryKubernetesExecutor:
     def test_should_create_a_worker_deployment_with_the_celery_executor(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_chart_quality.py
+++ b/tests/charts/test_chart_quality.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from pathlib import Path
 
 import yaml
@@ -26,7 +25,7 @@ from jsonschema import validate
 CHART_DIR = Path(__file__).parent / ".." / ".." / "chart"
 
 
-class ChartQualityTest(unittest.TestCase):
+class TestChartQuality:
     def test_values_validate_schema(self):
         values = yaml.safe_load((CHART_DIR / "values.yaml").read_text())
         schema = json.loads((CHART_DIR / "values.schema.json").read_text())

--- a/tests/charts/test_cleanup_pods.py
+++ b/tests/charts/test_cleanup_pods.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class CleanupPodsTest(unittest.TestCase):
+class TestCleanupPods:
     def test_should_create_cronjob_for_enabled_cleanup(self):
         docs = render_chart(
             values={
@@ -139,14 +137,8 @@ class CleanupPodsTest(unittest.TestCase):
             "spec.jobTemplate.spec.template.spec.containers[0].env", docs[0]
         )
 
-    @parameterized.expand(
-        [
-            (None, None),
-            (None, ["custom", "args"]),
-            (["custom", "command"], None),
-            (["custom", "command"], ["custom", "args"]),
-        ]
-    )
+    @pytest.mark.parametrize("command", [None, ["custom", "command"]])
+    @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
             values={"cleanup": {"enabled": True, "command": command, "args": args}},
@@ -248,7 +240,7 @@ class CleanupPodsTest(unittest.TestCase):
         assert 4 == jmespath.search("spec.successfulJobsHistoryLimit", docs[0])
 
 
-class CleanupServiceAccountTest(unittest.TestCase):
+class TestCleanupServiceAccount:
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_configmap.py
+++ b/tests/charts/test_configmap.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class ConfigmapTest(unittest.TestCase):
+class TestConfigmap:
     def test_single_annotation(self):
         docs = render_chart(
             values={
@@ -48,14 +46,15 @@ class ConfigmapTest(unittest.TestCase):
         assert "value" == annotations.get("key")
         assert "value-two" == annotations.get("key-two")
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "af_version, secret_key, secret_key_name, expected",
         [
             ('2.2.0', None, None, True),
             ('2.2.0', "foo", None, False),
             ('2.2.0', None, "foo", False),
             ('2.1.3', None, None, False),
             ('2.1.3', "foo", None, False),
-        ]
+        ],
     )
     def test_default_airflow_local_settings(self, af_version, secret_key, secret_key_name, expected):
         docs = render_chart(

--- a/tests/charts/test_create_user_job.py
+++ b/tests/charts/test_create_user_job.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class CreateUserJobTest(unittest.TestCase):
+class TestCreateUserJob:
     def test_should_run_by_default(self):
         docs = render_chart(show_only=["templates/jobs/create-user-job.yaml"])
         assert "Job" == docs[0]["kind"]
@@ -197,7 +195,8 @@ class CreateUserJobTest(unittest.TestCase):
             "spec.template.spec.containers[0].env", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, expected_arg",
         [
             ("1.10.14", "airflow create_user"),
             ("2.0.2", "airflow users create"),
@@ -231,14 +230,8 @@ class CreateUserJobTest(unittest.TestCase):
             "admin",
         ] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
-    @parameterized.expand(
-        [
-            (None, None),
-            (None, ["custom", "args"]),
-            (["custom", "command"], None),
-            (["custom", "command"], ["custom", "args"]),
-        ]
-    )
+    @pytest.mark.parametrize("command", [None, ["custom", "command"]])
+    @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
             values={"createUserJob": {"command": command, "args": args}},
@@ -297,7 +290,7 @@ class CreateUserJobTest(unittest.TestCase):
         ] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
 
-class CreateUserJobServiceAccountTest(unittest.TestCase):
+class TestCreateUserJobServiceAccount:
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_dags_persistent_volume_claim.py
+++ b/tests/charts/test_dags_persistent_volume_claim.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class DagsPersistentVolumeClaimTest(unittest.TestCase):
+class TestDagsPersistentVolumeClaim:
     def test_should_not_generate_a_document_if_persistence_is_disabled(self):
         docs = render_chart(
             values={"dags": {"persistence": {"enabled": False}}},

--- a/tests/charts/test_extra_configmaps_secrets.py
+++ b/tests/charts/test_extra_configmaps_secrets.py
@@ -17,19 +17,18 @@
 from __future__ import annotations
 
 import textwrap
-import unittest
 from base64 import b64encode
 from unittest import mock
 
+import pytest
 import yaml
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import prepare_k8s_lookup_dict, render_chart
 
 RELEASE_NAME = "test-extra-configmaps-secrets"
 
 
-class ExtraConfigMapsSecretsTest(unittest.TestCase):
+class TestExtraConfigMapsSecrets:
     def test_extra_configmaps(self):
         values_str = textwrap.dedent(
             """
@@ -151,12 +150,13 @@ class ExtraConfigMapsSecretsTest(unittest.TestCase):
         for k8s_object in k8s_objects:
             assert k8s_object['metadata']['labels'] == expected_labels
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "chart_labels, local_labels",
         [
             ({}, {"label3": "value3", "label4": "value4"}),
             ({"label1": "value1", "label2": "value2"}, {}),
             ({"label1": "value1", "label2": "value2"}, {"label3": "value3", "label4": "value4"}),
-        ]
+        ],
     )
     def test_extra_configmaps_secrets_additional_labels(self, chart_labels, local_labels):
         k8s_objects = render_chart(

--- a/tests/charts/test_extra_env_env_from.py
+++ b/tests/charts/test_extra_env_env_from.py
@@ -17,12 +17,11 @@
 from __future__ import annotations
 
 import textwrap
-import unittest
 from typing import Any
 
 import jmespath
+import pytest
 import yaml
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import prepare_k8s_lookup_dict, render_chart
 
@@ -73,12 +72,12 @@ PARAMS = [
 ]
 
 
-class ExtraEnvEnvFromTest(unittest.TestCase):
+class TestExtraEnvEnvFrom:
     k8s_objects: list[dict[str, Any]]
     k8s_objects_by_key: dict[tuple[str, str], dict[str, Any]]
 
     @classmethod
-    def setUpClass(cls) -> None:
+    def setup_class(cls) -> None:
         values_str = textwrap.dedent(
             """
             flower:
@@ -102,7 +101,7 @@ class ExtraEnvEnvFromTest(unittest.TestCase):
         cls.k8s_objects = render_chart(RELEASE_NAME, values=values)
         cls.k8s_objects_by_key = prepare_k8s_lookup_dict(cls.k8s_objects)
 
-    @parameterized.expand(PARAMS)
+    @pytest.mark.parametrize("k8s_obj_key, env_paths", PARAMS)
     def test_extra_env(self, k8s_obj_key, env_paths):
         expected_env_as_str = textwrap.dedent(
             f"""
@@ -120,7 +119,7 @@ class ExtraEnvEnvFromTest(unittest.TestCase):
             env = jmespath.search(f"{path}.env", k8s_object)
             assert expected_env_as_str in yaml.dump(env)
 
-    @parameterized.expand(PARAMS)
+    @pytest.mark.parametrize("k8s_obj_key, env_from_paths", PARAMS)
     def test_extra_env_from(self, k8s_obj_key, env_from_paths):
         expected_env_from_as_str = textwrap.dedent(
             f"""

--- a/tests/charts/test_flower.py
+++ b/tests/charts/test_flower.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -46,7 +45,10 @@ class TestFlowerDeployment:
             assert "release-name-flower" == jmespath.search("metadata.name", docs[0])
             assert "flower" == jmespath.search("spec.template.spec.containers[0].name", docs[0])
 
-    @parameterized.expand([(8, 10), (10, 8), (8, None), (None, 10), (None, None)])
+    @pytest.mark.parametrize(
+        "revision_history_limit, global_revision_history_limit",
+        [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
+    )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
         values = {
             "flower": {

--- a/tests/charts/test_git_sync_scheduler.py
+++ b/tests/charts/test_git_sync_scheduler.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class GitSyncSchedulerTest(unittest.TestCase):
+class TestGitSyncSchedulerTest:
     def test_should_add_dags_volume(self):
         docs = render_chart(
             values={"dags": {"gitSync": {"enabled": True}}},

--- a/tests/charts/test_git_sync_triggerer.py
+++ b/tests/charts/test_git_sync_triggerer.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class GitSyncTriggererTest(unittest.TestCase):
+class TestGitSyncTriggerer:
     def test_validate_sshkeysecret_not_added_when_persistence_is_enabled(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_git_sync_webserver.py
+++ b/tests/charts/test_git_sync_webserver.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class GitSyncWebserverTest(unittest.TestCase):
+class TestGitSyncWebserver:
     def test_should_add_dags_volume_to_the_webserver_if_git_sync_and_persistence_is_enabled(self):
         docs = render_chart(
             values={
@@ -71,28 +69,14 @@ class GitSyncWebserverTest(unittest.TestCase):
             "spec.template.spec.serviceAccountName", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, exclude_webserver",
         [
-            (
-                "2.0.0",
-                True,
-            ),
-            (
-                "2.0.2",
-                True,
-            ),
-            (
-                "1.10.14",
-                False,
-            ),
-            (
-                "1.9.0",
-                False,
-            ),
-            (
-                "2.1.0",
-                True,
-            ),
+            ("2.0.0", True),
+            ("2.0.2", True),
+            ("1.10.14", False),
+            ("1.9.0", False),
+            ("2.1.0", True),
         ],
     )
     def test_git_sync_with_different_airflow_versions(self, airflow_version, exclude_webserver):

--- a/tests/charts/test_git_sync_worker.py
+++ b/tests/charts/test_git_sync_worker.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class GitSyncWorkerTest(unittest.TestCase):
+class TestGitSyncWorker:
     def test_should_add_dags_volume_to_the_worker_if_git_sync_and_persistence_is_enabled(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_ingress_flower.py
+++ b/tests/charts/test_ingress_flower.py
@@ -17,15 +17,14 @@
 from __future__ import annotations
 
 import itertools
-import unittest
 
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class IngressFlowerTest(unittest.TestCase):
+class TestIngressFlower:
     def test_should_pass_validation_with_just_ingress_enabled_v1(self):
         render_chart(
             values={"flower": {"enabled": True}, "ingress": {"flower": {"enabled": True}}},
@@ -137,7 +136,8 @@ class IngressFlowerTest(unittest.TestCase):
         )
         assert not jmespath.search("spec.rules[*].host", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "global_value, flower_value, expected",
         [
             (None, None, False),
             (None, False, False),
@@ -146,7 +146,7 @@ class IngressFlowerTest(unittest.TestCase):
             (True, None, True),
             (False, True, True),  # We will deploy it if _either_ are true
             (True, False, True),
-        ]
+        ],
     )
     def test_ingress_created(self, global_value, flower_value, expected):
         values = {"flower": {"enabled": True}, "ingress": {}}

--- a/tests/charts/test_ingress_web.py
+++ b/tests/charts/test_ingress_web.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class IngressWebTest(unittest.TestCase):
+class TestIngressWeb:
     def test_should_pass_validation_with_just_ingress_enabled_v1(self):
         render_chart(
             values={"ingress": {"web": {"enabled": True}}},
@@ -132,7 +130,8 @@ class IngressWebTest(unittest.TestCase):
         )
         assert not jmespath.search("spec.rules[*].host", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "global_value, web_value, expected",
         [
             (None, None, False),
             (None, False, False),
@@ -141,7 +140,7 @@ class IngressWebTest(unittest.TestCase):
             (True, None, True),
             (False, True, True),  # We will deploy it if _either_ are true
             (True, False, True),
-        ]
+        ],
     )
     def test_ingress_created(self, global_value, web_value, expected):
         values = {"ingress": {}}

--- a/tests/charts/test_keda.py
+++ b/tests/charts/test_keda.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -32,11 +31,12 @@ class TestKeda:
         )
         assert docs == []
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "executor, is_created",
         [
             ('CeleryExecutor', True),
             ('CeleryKubernetesExecutor', True),
-        ]
+        ],
     )
     def test_keda_enabled(self, executor, is_created):
         """
@@ -54,12 +54,7 @@ class TestKeda:
         else:
             assert docs == []
 
-    @parameterized.expand(
-        [
-            ('CeleryExecutor'),
-            ('CeleryKubernetesExecutor'),
-        ]
-    )
+    @pytest.mark.parametrize("executor", ['CeleryExecutor', 'CeleryKubernetesExecutor'])
     def test_keda_advanced(self, executor):
         """
         Verify keda advanced config.
@@ -151,11 +146,12 @@ class TestKeda:
         expected_query = self.build_query(executor=executor, queue=queue)
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == expected_query
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "enabled, kind",
         [
             ('enabled', 'StatefulSet'),
             ('not_enabled', 'Deployment'),
-        ]
+        ],
     )
     def test_persistence(self, enabled, kind):
         """

--- a/tests/charts/test_kerberos.py
+++ b/tests/charts/test_kerberos.py
@@ -17,14 +17,13 @@
 from __future__ import annotations
 
 import json
-import unittest
 
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class KerberosTest(unittest.TestCase):
+class TestKerberos:
     def test_kerberos_not_mentioned_in_render_if_disabled(self):
         # the name is deliberately shorter as we look for "kerberos" in the rendered chart
         k8s_objects = render_chart(name="no-krbros", values={"kerberos": {'enabled': False}})

--- a/tests/charts/test_limit_ranges.py
+++ b/tests/charts/test_limit_ranges.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class LimitRangesTest(unittest.TestCase):
+class TestLimitRanges:
     def test_limit_ranges_template(self):
         docs = render_chart(
             values={"limits": [{"max": {"cpu": "500m"}, "min": {"min": "200m"}, "type": "Container"}]},

--- a/tests/charts/test_logs_persistent_volume_claim.py
+++ b/tests/charts/test_logs_persistent_volume_claim.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class LogsPersistentVolumeClaimTest(unittest.TestCase):
+class TestLogsPersistentVolumeClaim:
     def test_should_not_generate_a_document_if_persistence_is_disabled(self):
         docs = render_chart(
             values={"logs": {"persistence": {"enabled": False}}},

--- a/tests/charts/test_metadata_connection_secret.py
+++ b/tests/charts/test_metadata_connection_secret.py
@@ -17,14 +17,13 @@
 from __future__ import annotations
 
 import base64
-import unittest
 
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class MetadataConnectionSecretTest(unittest.TestCase):
+class TestMetadataConnectionSecret:
 
     non_chart_database_values = {
         "user": "someuser",

--- a/tests/charts/test_migrate_database_job.py
+++ b/tests/charts/test_migrate_database_job.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -220,7 +219,8 @@ class TestMigrateDatabaseJob:
             "spec.template.spec.containers[0].volumeMounts[-1]", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, expected_arg",
         [
             ("1.10.14", "airflow upgradedb"),
             ("2.0.2", "airflow db upgrade"),
@@ -241,14 +241,8 @@ class TestMigrateDatabaseJob:
             f"exec \\\n{expected_arg}",
         ] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
-    @parameterized.expand(
-        [
-            (None, None),
-            (None, ["custom", "args"]),
-            (["custom", "command"], None),
-            (["custom", "command"], ["custom", "args"]),
-        ]
-    )
+    @pytest.mark.parametrize("command", [None, ["custom", "command"]])
+    @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
             values={"migrateDatabaseJob": {"command": command, "args": args}},

--- a/tests/charts/test_pdb_pgbouncer.py
+++ b/tests/charts/test_pdb_pgbouncer.py
@@ -16,12 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 from tests.charts.helm_template_generator import render_chart
 
 
-class PgbouncerPdbTest(unittest.TestCase):
+class TestPgbouncerPdb:
     def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
             values={"pgbouncer": {"enabled": True, "podDisruptionBudget": {"enabled": True}}},

--- a/tests/charts/test_pdb_scheduler.py
+++ b/tests/charts/test_pdb_scheduler.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class SchedulerPdbTest(unittest.TestCase):
+class TestSchedulerPdb:
     def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
             values={"scheduler": {"podDisruptionBudget": {"enabled": True}}},

--- a/tests/charts/test_pdb_webserver.py
+++ b/tests/charts/test_pdb_webserver.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class WebserverPdbTest(unittest.TestCase):
+class TestWebserverPdb:
     def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
             values={"webserver": {"podDisruptionBudget": {"enabled": True}}},

--- a/tests/charts/test_pod_launcher_role.py
+++ b/tests/charts/test_pod_launcher_role.py
@@ -16,23 +16,22 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class PodLauncherTest(unittest.TestCase):
-    @parameterized.expand(
+class TestPodLauncher:
+    @pytest.mark.parametrize(
+        "executor, rbac, allow, expected_accounts",
         [
             ("CeleryKubernetesExecutor", True, True, ['scheduler', 'worker']),
             ("KubernetesExecutor", True, True, ['scheduler', 'worker']),
             ("CeleryExecutor", True, True, ['worker']),
             ("LocalExecutor", True, True, ['scheduler']),
             ("LocalExecutor", False, False, []),
-        ]
+        ],
     )
     def test_pod_launcher_role(self, executor, rbac, allow, expected_accounts):
         docs = render_chart(

--- a/tests/charts/test_pod_template_file.py
+++ b/tests/charts/test_pod_template_file.py
@@ -17,33 +17,31 @@
 from __future__ import annotations
 
 import re
-import unittest
 from pathlib import Path
 from shutil import copyfile, copytree
 from tempfile import TemporaryDirectory
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
-CHART_DIR = Path(__file__).parent / ".." / ".." / "chart"
+
+@pytest.fixture(scope="class", autouse=True)
+def isolate_chart(request):
+    chart_dir = Path(__file__).parent / ".." / ".." / "chart"
+    with TemporaryDirectory(prefix=request.cls.__name__) as tmp_dir:
+        temp_chart_dir = Path(tmp_dir) / "chart"
+        copytree(chart_dir, temp_chart_dir)
+        copyfile(
+            temp_chart_dir / "files/pod-template-file.kubernetes-helm-yaml",
+            temp_chart_dir / "templates/pod-template-file.yaml",
+        )
+        request.cls.temp_chart_dir = str(temp_chart_dir)
+        yield
 
 
-class PodTemplateFileTest(unittest.TestCase):
-    @classmethod
-    @pytest.fixture(autouse=True, scope="class")
-    def isolate_chart(cls):
-        with TemporaryDirectory() as tmp_dir:
-            cls.temp_chart_dir = tmp_dir + "/chart"
-            copytree(CHART_DIR, cls.temp_chart_dir)
-            copyfile(
-                cls.temp_chart_dir + "/files/pod-template-file.kubernetes-helm-yaml",
-                cls.temp_chart_dir + "/templates/pod-template-file.yaml",
-            )
-            yield
-
+class TestPodTemplateFile:
     def test_should_work(self):
         docs = render_chart(
             values={},
@@ -122,7 +120,8 @@ class PodTemplateFileTest(unittest.TestCase):
 
         assert jmespath.search("spec.initContainers", docs[0]) is None
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "dag_values, expected_read_only",
         [
             ({"gitSync": {"enabled": True}}, True),
             ({"persistence": {"enabled": True}}, False),
@@ -133,7 +132,7 @@ class PodTemplateFileTest(unittest.TestCase):
                 },
                 True,
             ),
-        ]
+        ],
     )
     def test_dags_mount(self, dag_values, expected_read_only):
         docs = render_chart(
@@ -259,7 +258,8 @@ class PodTemplateFileTest(unittest.TestCase):
 
         assert {"name": "dags", "emptyDir": {}} in jmespath.search("spec.volumes", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "log_persistence_values, expected",
         [
             ({"enabled": False}, {"emptyDir": {}}),
             ({"enabled": True}, {"persistentVolumeClaim": {"claimName": "release-name-logs"}}),
@@ -267,7 +267,7 @@ class PodTemplateFileTest(unittest.TestCase):
                 {"enabled": True, "existingClaim": "test-claim"},
                 {"persistentVolumeClaim": {"claimName": "test-claim"}},
             ),
-        ]
+        ],
     )
     def test_logs_persistence_changes_volume(self, log_persistence_values, expected):
         docs = render_chart(
@@ -500,7 +500,7 @@ class PodTemplateFileTest(unittest.TestCase):
             chart_dir=self.temp_chart_dir,
         )
 
-        self.assertEqual(5000, jmespath.search("spec.securityContext.fsGroup", docs[0]))
+        assert jmespath.search("spec.securityContext.fsGroup", docs[0]) == 5000
 
     def test_should_create_valid_volume_mount_and_volume(self):
         docs = render_chart(

--- a/tests/charts/test_rbac.py
+++ b/tests/charts/test_rbac.py
@@ -16,10 +16,8 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
@@ -106,7 +104,7 @@ CUSTOM_SERVICE_ACCOUNT_NAMES = (
 )
 
 
-class RBACTest(unittest.TestCase):
+class TestRBAC:
     def _get_values_with_version(self, values, version):
         if version != "default":
             values["airflowVersion"] = version
@@ -119,7 +117,7 @@ class RBACTest(unittest.TestCase):
             ] + DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
         return DEPLOYMENT_NO_RBAC_NO_SA_KIND_NAME_TUPLES
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_deployments_no_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "test-rbac",
@@ -155,13 +153,9 @@ class RBACTest(unittest.TestCase):
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
+        assert sorted(list_of_kind_names_tuples) == sorted(self._get_object_count(version))
 
-        self.assertCountEqual(
-            list_of_kind_names_tuples,
-            self._get_object_count(version),
-        )
-
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_deployments_no_rbac_with_sa(self, version):
         k8s_objects = render_chart(
             "test-rbac",
@@ -180,12 +174,9 @@ class RBACTest(unittest.TestCase):
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
         real_list_of_kind_names = self._get_object_count(version) + SERVICE_ACCOUNT_NAME_TUPLES
-        self.assertCountEqual(
-            list_of_kind_names_tuples,
-            real_list_of_kind_names,
-        )
+        assert sorted(list_of_kind_names_tuples) == sorted(real_list_of_kind_names)
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_deployments_with_rbac_no_sa(self, version):
         k8s_objects = render_chart(
             "test-rbac",
@@ -221,12 +212,9 @@ class RBACTest(unittest.TestCase):
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]
         real_list_of_kind_names = self._get_object_count(version) + RBAC_ENABLED_KIND_NAME_TUPLES
-        self.assertCountEqual(
-            list_of_kind_names_tuples,
-            real_list_of_kind_names,
-        )
+        assert sorted(list_of_kind_names_tuples) == sorted(real_list_of_kind_names)
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_deployments_with_rbac_with_sa(self, version):
         k8s_objects = render_chart(
             "test-rbac",
@@ -246,10 +234,7 @@ class RBACTest(unittest.TestCase):
         real_list_of_kind_names = (
             self._get_object_count(version) + SERVICE_ACCOUNT_NAME_TUPLES + RBAC_ENABLED_KIND_NAME_TUPLES
         )
-        self.assertCountEqual(
-            list_of_kind_names_tuples,
-            real_list_of_kind_names,
-        )
+        assert sorted(list_of_kind_names_tuples) == sorted(real_list_of_kind_names)
 
     def test_service_account_custom_names(self):
         k8s_objects = render_chart(
@@ -284,10 +269,7 @@ class RBACTest(unittest.TestCase):
             for k8s_object in k8s_objects
             if k8s_object['kind'] == "ServiceAccount"
         ]
-        self.assertCountEqual(
-            list_of_sa_names,
-            CUSTOM_SERVICE_ACCOUNT_NAMES,
-        )
+        assert sorted(list_of_sa_names) == sorted(CUSTOM_SERVICE_ACCOUNT_NAMES)
 
     def test_service_account_custom_names_in_objects(self):
         k8s_objects = render_chart(
@@ -330,10 +312,7 @@ class RBACTest(unittest.TestCase):
             if name and name not in list_of_sa_names_in_objects:
                 list_of_sa_names_in_objects.append(name)
 
-        self.assertCountEqual(
-            list_of_sa_names_in_objects,
-            CUSTOM_SERVICE_ACCOUNT_NAMES,
-        )
+        assert sorted(list_of_sa_names_in_objects) == sorted(CUSTOM_SERVICE_ACCOUNT_NAMES)
 
     def test_service_account_without_resource(self):
         k8s_objects = render_chart(
@@ -360,4 +339,4 @@ class RBACTest(unittest.TestCase):
             'test-rbac-triggerer',
             'test-rbac-migrate-database-job',
         ]
-        self.assertCountEqual(list_of_sa_names, service_account_names)
+        assert sorted(list_of_sa_names) == sorted(service_account_names)

--- a/tests/charts/test_redis.py
+++ b/tests/charts/test_redis.py
@@ -17,13 +17,11 @@
 from __future__ import annotations
 
 import re
-import unittest
 from base64 import b64decode
 from subprocess import CalledProcessError
 
 import jmespath
 import pytest
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import prepare_k8s_lookup_dict, render_chart
 
@@ -38,10 +36,10 @@ REDIS_OBJECTS = {
 }
 SET_POSSIBLE_REDIS_OBJECT_KEYS = set(REDIS_OBJECTS.values())
 
-CELERY_EXECUTORS_PARAMS = [("CeleryExecutor",), ("CeleryKubernetesExecutor",)]
+CELERY_EXECUTORS_PARAMS = ["CeleryExecutor", "CeleryKubernetesExecutor"]
 
 
-class RedisTest(unittest.TestCase):
+class TestRedis:
     @staticmethod
     def get_broker_url_in_broker_url_secret(k8s_obj_by_key):
         broker_url_in_obj = b64decode(
@@ -94,7 +92,7 @@ class RedisTest(unittest.TestCase):
         )
         assert broker_url_secret_in_worker == expected_broker_url_secret_name
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_redis_by_chart_default(self, executor):
         k8s_objects = render_chart(
             RELEASE_NAME_REDIS,
@@ -117,7 +115,7 @@ class RedisTest(unittest.TestCase):
 
         self.assert_broker_url_env(k8s_obj_by_key)
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_redis_by_chart_password(self, executor):
         k8s_objects = render_chart(
             RELEASE_NAME_REDIS,
@@ -142,7 +140,7 @@ class RedisTest(unittest.TestCase):
 
         self.assert_broker_url_env(k8s_obj_by_key)
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_redis_by_chart_password_secret_name_missing_broker_url_secret_name(self, executor):
         with pytest.raises(CalledProcessError):
             render_chart(
@@ -156,7 +154,7 @@ class RedisTest(unittest.TestCase):
                 },
             )
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_redis_by_chart_password_secret_name(self, executor):
         expected_broker_url_secret_name = "test-redis-broker-url-secret-name"
         k8s_objects = render_chart(
@@ -185,7 +183,7 @@ class RedisTest(unittest.TestCase):
 
         self.assert_broker_url_env(k8s_obj_by_key, expected_broker_url_secret_name)
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_external_redis_broker_url(self, executor):
         k8s_objects = render_chart(
             RELEASE_NAME_REDIS,
@@ -211,7 +209,7 @@ class RedisTest(unittest.TestCase):
 
         self.assert_broker_url_env(k8s_obj_by_key)
 
-    @parameterized.expand(CELERY_EXECUTORS_PARAMS)
+    @pytest.mark.parametrize("executor", CELERY_EXECUTORS_PARAMS)
     def test_external_redis_broker_url_secret_name(self, executor):
         expected_broker_url_secret_name = "redis-broker-url-secret-name"
         k8s_objects = render_chart(

--- a/tests/charts/test_resource_quota.py
+++ b/tests/charts/test_resource_quota.py
@@ -16,14 +16,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class ResourceQuotaTest(unittest.TestCase):
+class TestResourceQuota:
     def test_resource_quota_template(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_result_backend_connection_secret.py
+++ b/tests/charts/test_result_backend_connection_secret.py
@@ -17,15 +17,14 @@
 from __future__ import annotations
 
 import base64
-import unittest
 
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class ResultBackendConnectionSecretTest(unittest.TestCase):
+class TestResultBackendConnectionSecret:
     def _get_values_with_version(self, values, version):
         if version != "default":
             values["airflowVersion"] = version
@@ -55,12 +54,13 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
 
         assert 0 == len(docs)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "executor, expected_doc_count",
         [
             ("CeleryExecutor", 1),
             ("CeleryKubernetesExecutor", 1),
             ("LocalExecutor", 0),
-        ]
+        ],
     )
     def test_should_a_document_be_generated_for_executor(self, executor, expected_doc_count):
         docs = render_chart(
@@ -90,7 +90,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
         encoded_connection = jmespath.search("data.connection", docs[0])
         return base64.b64decode(encoded_connection).decode()
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_default_connection_old_version(self, version):
         connection = self._get_connection(self._get_values_with_version(version=version, values={}))
         self._assert_for_old_version(
@@ -100,7 +100,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             "-postgresql:5432/postgres?sslmode=disable",
         )
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_should_default_to_custom_metadata_db_connection_with_pgbouncer_overrides(self, version):
         values = {
             "pgbouncer": {"enabled": True},
@@ -116,7 +116,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             ":6543/release-name-result-backend?sslmode=allow",
         )
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_should_set_pgbouncer_overrides_when_enabled(self, version):
         values = {"pgbouncer": {"enabled": True}}
         connection = self._get_connection(self._get_values_with_version(values=values, version=version))
@@ -142,7 +142,7 @@ class ResultBackendConnectionSecretTest(unittest.TestCase):
             "/release-name-result-backend?sslmode=allow" == connection
         )
 
-    @parameterized.expand(["2.3.2", "2.4.0", "default"])
+    @pytest.mark.parametrize("version", ["2.3.2", "2.4.0", "default"])
     def test_should_default_to_custom_metadata_db_connection_in_old_version(self, version):
         values = {
             "data": {"metadataConnection": {**self.non_chart_database_values}},

--- a/tests/charts/test_statsd.py
+++ b/tests/charts/test_statsd.py
@@ -16,16 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
+import pytest
 import yaml
-from parameterized import parameterized
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class StatsdTest(unittest.TestCase):
+class TestStatsd:
     def test_should_create_statsd_default(self):
         docs = render_chart(show_only=["templates/statsd/statsd-deployment.yaml"])
 
@@ -85,7 +83,10 @@ class StatsdTest(unittest.TestCase):
             "subPath": "mappings.yml",
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-    @parameterized.expand([(8, 10), (10, 8), (8, None), (None, 10), (None, None)])
+    @pytest.mark.parametrize(
+        "revision_history_limit, global_revision_history_limit",
+        [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
+    )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
         values = {"statsd": {"enabled": True}}
         if revision_history_limit:

--- a/tests/charts/test_triggerer.py
+++ b/tests/charts/test_triggerer.py
@@ -16,20 +16,19 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class TriggererTest(unittest.TestCase):
-    @parameterized.expand(
+class TestTriggerer:
+    @pytest.mark.parametrize(
+        "airflow_version, num_docs",
         [
             ("2.1.0", 0),
             ("2.2.0", 1),
-        ]
+        ],
     )
     def test_only_exists_on_new_airflow_versions(self, airflow_version, num_docs):
         """Trigger was only added from Airflow 2.2 onwards"""
@@ -52,7 +51,10 @@ class TriggererTest(unittest.TestCase):
 
         assert 0 == len(docs)
 
-    @parameterized.expand([(8, 10), (10, 8), (8, None), (None, 10), (None, None)])
+    @pytest.mark.parametrize(
+        "revision_history_limit, global_revision_history_limit",
+        [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
+    )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
         values = {
             "triggerer": {
@@ -333,7 +335,8 @@ class TriggererTest(unittest.TestCase):
             "spec.template.spec.containers[0].livenessProbe.exec.command", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "log_persistence_values, expected_volume",
         [
             ({"enabled": False}, {"emptyDir": {}}),
             ({"enabled": True}, {"persistentVolumeClaim": {"claimName": "release-name-logs"}}),
@@ -341,7 +344,7 @@ class TriggererTest(unittest.TestCase):
                 {"enabled": True, "existingClaim": "test-claim"},
                 {"persistentVolumeClaim": {"claimName": "test-claim"}},
             ),
-        ]
+        ],
     )
     def test_logs_persistence_changes_volume(self, log_persistence_values, expected_volume):
         docs = render_chart(
@@ -389,14 +392,15 @@ class TriggererTest(unittest.TestCase):
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "strategy, expected_strategy",
         [
             (None, None),
             (
                 {"rollingUpdate": {"maxSurge": "100%", "maxUnavailable": "50%"}},
                 {"rollingUpdate": {"maxSurge": "100%", "maxUnavailable": "50%"}},
             ),
-        ]
+        ],
     )
     def test_strategy(self, strategy, expected_strategy):
         """strategy should be used when we aren't using both LocalExecutor and workers.persistence"""
@@ -419,14 +423,8 @@ class TriggererTest(unittest.TestCase):
             "spec.template.spec.containers[0].args", docs[0]
         )
 
-    @parameterized.expand(
-        [
-            (None, None),
-            (None, ["custom", "args"]),
-            (["custom", "command"], None),
-            (["custom", "command"], ["custom", "args"]),
-        ]
-    )
+    @pytest.mark.parametrize("command", [None, ["custom", "command"]])
+    @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
             values={"triggerer": {"command": command, "args": args}},
@@ -473,7 +471,7 @@ class TriggererTest(unittest.TestCase):
         ]
 
 
-class TriggererServiceAccountTest(unittest.TestCase):
+class TestTriggererServiceAccount:
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -16,15 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import jmespath
-from parameterized import parameterized
+import pytest
 
 from tests.charts.helm_template_generator import render_chart
 
 
-class WebserverDeploymentTest(unittest.TestCase):
+class TestWebserverDeployment:
     def test_should_add_host_header_to_liveness_and_readiness_probes(self):
         docs = render_chart(
             values={
@@ -61,7 +59,10 @@ class WebserverDeploymentTest(unittest.TestCase):
             == "/mypath/path/health"
         )
 
-    @parameterized.expand([(8, 10), (10, 8), (8, None), (None, 10), (None, None)])
+    @pytest.mark.parametrize(
+        "revision_history_limit, global_revision_history_limit",
+        [(8, 10), (10, 8), (8, None), (None, 10), (None, None)],
+    )
     def test_revision_history_limit(self, revision_history_limit, global_revision_history_limit):
         values = {"webserver": {}}
         if revision_history_limit:
@@ -75,12 +76,7 @@ class WebserverDeploymentTest(unittest.TestCase):
         expected_result = revision_history_limit if revision_history_limit else global_revision_history_limit
         assert jmespath.search("spec.revisionHistoryLimit", docs[0]) == expected_result
 
-    @parameterized.expand(
-        [
-            ({"config": {"webserver": {"base_url": ""}}},),
-            ({},),
-        ]
-    )
+    @pytest.mark.parametrize("values", [{"config": {"webserver": {"base_url": ""}}}, {}])
     def test_should_not_contain_host_header(self, values):
         print(values)
         docs = render_chart(values=values, show_only=["templates/webserver/webserver-deployment.yaml"])
@@ -200,7 +196,8 @@ class WebserverDeploymentTest(unittest.TestCase):
             "spec.template.spec.initContainers[0].env", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, expected_arg",
         [
             ("2.0.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
             ("2.1.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
@@ -387,12 +384,13 @@ class WebserverDeploymentTest(unittest.TestCase):
             "spec.template.spec.topologySpreadConstraints[0]", docs[0]
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "log_persistence_values, expected_claim_name",
         [
             ({"enabled": False}, None),
             ({"enabled": True}, "release-name-logs"),
             ({"enabled": True, "existingClaim": "test-claim"}, "test-claim"),
-        ]
+        ],
     )
     def test_logs_persistence_adds_volume_and_mount(self, log_persistence_values, expected_claim_name):
         docs = render_chart(
@@ -415,12 +413,13 @@ class WebserverDeploymentTest(unittest.TestCase):
                 v["name"] for v in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
             ]
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "af_version, pod_template_file_expected",
         [
             ("1.10.10", False),
             ("1.10.12", True),
             ("2.1.0", True),
-        ]
+        ],
     )
     def test_config_volumes_and_mounts(self, af_version, pod_template_file_expected):
         # setup
@@ -488,7 +487,8 @@ class WebserverDeploymentTest(unittest.TestCase):
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
         assert jmespath.search("spec.template.spec.initContainers[0].resources", docs[0]) == {}
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, expected_strategy",
         [
             ("2.0.2", {"type": "RollingUpdate", "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0}}),
             ("1.10.14", {"type": "Recreate"}),
@@ -540,14 +540,8 @@ class WebserverDeploymentTest(unittest.TestCase):
             "spec.template.spec.containers[0].args", docs[0]
         )
 
-    @parameterized.expand(
-        [
-            (None, None),
-            (None, ["custom", "args"]),
-            (["custom", "command"], None),
-            (["custom", "command"], ["custom", "args"]),
-        ]
-    )
+    @pytest.mark.parametrize("command", [None, ["custom", "command"]])
+    @pytest.mark.parametrize("args", [None, ["custom", "args"]])
     def test_command_and_args_overrides(self, command, args):
         docs = render_chart(
             values={"webserver": {"command": command, "args": args}},
@@ -566,7 +560,8 @@ class WebserverDeploymentTest(unittest.TestCase):
         assert ["release-name"] == jmespath.search("spec.template.spec.containers[0].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, dag_values",
         [
             ("1.10.15", {"gitSync": {"enabled": False}}),
             ("1.10.15", {"persistence": {"enabled": False}}),
@@ -576,7 +571,7 @@ class WebserverDeploymentTest(unittest.TestCase):
             ("2.0.0", {"persistence": {"enabled": True}}),
             ("2.0.0", {"persistence": {"enabled": False}}),
             ("2.0.0", {"gitSync": {"enabled": True}, "persistence": {"enabled": True}}),
-        ]
+        ],
     )
     def test_no_dags_mount_or_volume_or_gitsync_sidecar_expected(self, airflow_version, dag_values):
         docs = render_chart(
@@ -590,12 +585,13 @@ class WebserverDeploymentTest(unittest.TestCase):
         assert "dags" not in [vm["name"] for vm in jmespath.search("spec.template.spec.volumes", docs[0])]
         assert 1 == len(jmespath.search("spec.template.spec.containers", docs[0]))
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "airflow_version, dag_values, expected_read_only",
         [
             ("1.10.15", {"gitSync": {"enabled": True}}, True),
             ("1.10.15", {"persistence": {"enabled": True}}, False),
             ("1.10.15", {"gitSync": {"enabled": True}, "persistence": {"enabled": True}}, True),
-        ]
+        ],
     )
     def test_dags_mount(self, airflow_version, dag_values, expected_read_only):
         docs = render_chart(
@@ -621,12 +617,13 @@ class WebserverDeploymentTest(unittest.TestCase):
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "dags_values, expected_claim_name",
         [
             ({"persistence": {"enabled": True}}, "release-name-dags"),
             ({"persistence": {"enabled": True, "existingClaim": "test-claim"}}, "test-claim"),
             ({"persistence": {"enabled": True}, "gitSync": {"enabled": True}}, "release-name-dags"),
-        ]
+        ],
     )
     def test_dags_persistence_volume_no_sidecar(self, dags_values, expected_claim_name):
         docs = render_chart(
@@ -643,7 +640,7 @@ class WebserverDeploymentTest(unittest.TestCase):
         assert 1 == len(jmespath.search("spec.template.spec.initContainers", docs[0]))
 
 
-class WebserverServiceTest(unittest.TestCase):
+class TestWebserverService:
     def test_default_service(self):
         docs = render_chart(
             show_only=["templates/webserver/webserver-service.yaml"],
@@ -679,7 +676,8 @@ class WebserverServiceTest(unittest.TestCase):
         assert "127.0.0.1" == jmespath.search("spec.loadBalancerIP", docs[0])
         assert ["10.123.0.0/16"] == jmespath.search("spec.loadBalancerSourceRanges", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "ports, expected_ports",
         [
             ([{"port": 8888}], [{"port": 8888}]),  # name is optional with a single port
             (
@@ -697,7 +695,7 @@ class WebserverServiceTest(unittest.TestCase):
                     {"name": "sidecar", "port": 80, "targetPort": "sidecar"},
                 ],
             ),
-        ]
+        ],
     )
     def test_ports_overrides(self, ports, expected_ports):
         docs = render_chart(
@@ -722,7 +720,7 @@ class WebserverServiceTest(unittest.TestCase):
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
 
-class WebserverConfigmapTest(unittest.TestCase):
+class TestWebserverConfigmap:
     def test_no_webserver_config_configmap_by_default(self):
         docs = render_chart(show_only=["templates/configmaps/webserver-configmap.yaml"])
         assert 0 == len(docs)
@@ -741,7 +739,7 @@ class WebserverConfigmapTest(unittest.TestCase):
         )
 
 
-class WebserverNetworkPolicyTest(unittest.TestCase):
+class TestWebserverNetworkPolicy:
     def test_off_by_default(self):
         docs = render_chart(
             show_only=["templates/webserver/webserver-networkpolicy.yaml"],
@@ -770,7 +768,8 @@ class WebserverNetworkPolicyTest(unittest.TestCase):
         )
         assert [{"port": 8080}] == jmespath.search("spec.ingress[0].ports", docs[0])
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "ports, expected_ports",
         [
             ([{"port": "sidecar"}], [{"port": "sidecar"}]),
             (
@@ -832,7 +831,7 @@ class WebserverNetworkPolicyTest(unittest.TestCase):
         assert jmespath.search("metadata.labels", docs[0])["test_label"] == "test_label_value"
 
 
-class WebserverServiceAccountTest(unittest.TestCase):
+class TestWebserverServiceAccount:
     def test_should_add_component_specific_labels(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
Attempt to replace `unittests.TestCase` by native `pytest` classes for **all** charts tests.

All changes are straight forward:
- Get rid of `unittests.TestCase`
- Replace decorator `parameterized.expand` by `pytest.mark.parametrize`. I cant see any benefits if compare to builtin `pytest`.
- Rename ClassName**Test** to **Test**ClassName
- Replace `unittests.TestCase.assertRaises` by `pytest.raises`

Except two modules
- `tests/charts/test_pod_template_file.py` - move fixture out of the class
- `tests/charts/test_rbac.py` - `unittests.TestCase.assertCountEqual` has no equivalent in `pytest`, so i replace by compare sorted lists

----

Tested locally in breeze and did not have any differences if compare to current (local) main

_This PR (run 5 times)_
```
792 passed, 1 warning in 226.74s (0:03:46)
792 passed, 1 warning in 226.18s (0:03:46)
792 passed, 1 warning in 226.10s (0:03:46)
792 passed, 1 warning in 226.78s (0:03:46)
792 passed, 1 warning in 227.63s (0:03:47)
```

_Main (run 5 times)_
```
792 passed, 1 warning in 225.29s (0:03:45)
792 passed, 1 warning in 225.06s (0:03:45)
792 passed, 1 warning in 226.00s (0:03:46)
792 passed, 1 warning in 225.51s (0:03:45)
792 passed, 1 warning in 225.99s (0:03:45)
```

---

Just reminder that this PR remove all usage `pytest.mark.parametrize` within the charts tests so it can affect any of current [helm-chart](https://github.com/apache/airflow/pulls?q=is%3Apr+is%3Aopen+label%3Aarea%3Ahelm-chart) PRs which not merged yet and vice versa.
