### PR TITLE
Fix ti._try_number for deferred and up_for_reschedule tasks

### DIFF
--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -156,7 +156,7 @@ def set_state(
         for task_instance in tis_altered:
             # The try_number was decremented when setting to up_for_reschedule and deferred.
             # Increment it back when changing the state again
-            if task_instance.state in State.waiting:
+            if task_instance.state in [State.DEFERRED, State.UP_FOR_RESCHEDULE]:
                 task_instance._try_number += 1
             task_instance.set_state(state, session=session)
         session.flush()
@@ -470,7 +470,7 @@ def set_dag_run_state_to_failed(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id == run_id,
         TaskInstance.task_id.in_(task_ids),
-        TaskInstance.state.in_(State.pending),
+        TaskInstance.state.in_([State.RUNNING, State.DEFERRED, State.UP_FOR_RESCHEDULE]),
     )
     task_ids_of_running_tis = [task_instance.task_id for task_instance in tis]
 
@@ -486,7 +486,7 @@ def set_dag_run_state_to_failed(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id == run_id,
         TaskInstance.state.not_in(State.finished),
-        TaskInstance.state.not_in(State.pending),
+        TaskInstance.state.not_in([State.RUNNING, State.DEFERRED, State.UP_FOR_RESCHEDULE]),
     )
 
     tis = [ti for ti in tis]

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -156,7 +156,9 @@ def set_state(
         for task_instance in tis_altered:
             # The try_number was decremented when setting to up_for_reschedule and deferred.
             # Increment it back when changing the state again
-            if task_instance.state in (State.UP_FOR_RESCHEDULE or State.DEFERRED):
+            if task_instance.state is not None and task_instance.state in (
+                State.UP_FOR_RESCHEDULE or State.DEFERRED
+            ):
                 task_instance._try_number += 1
             task_instance.set_state(state, session=session)
         session.flush()

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -154,6 +154,10 @@ def set_state(
             qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.with_for_update().all()
         for task_instance in tis_altered:
+            # The try_number was decremented when setting to up_for_reschedule and deferred.
+            # Increment it back when changing the state again
+            if task_instance.state in (State.UP_FOR_RESCHEDULE or State.DEFERRED):
+                task_instance._try_number += 1
             task_instance.set_state(state, session=session)
         session.flush()
     else:

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -156,9 +156,7 @@ def set_state(
         for task_instance in tis_altered:
             # The try_number was decremented when setting to up_for_reschedule and deferred.
             # Increment it back when changing the state again
-            if task_instance.state is not None and task_instance.state in (
-                State.UP_FOR_RESCHEDULE or State.DEFERRED
-            ):
+            if task_instance.state in State.waiting:
                 task_instance._try_number += 1
             task_instance.set_state(state, session=session)
         session.flush()

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -470,7 +470,7 @@ def set_dag_run_state_to_failed(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id == run_id,
         TaskInstance.task_id.in_(task_ids),
-        TaskInstance.state.in_(State.running),
+        TaskInstance.state.in_(State.pending),
     )
     task_ids_of_running_tis = [task_instance.task_id for task_instance in tis]
 
@@ -486,7 +486,7 @@ def set_dag_run_state_to_failed(
         TaskInstance.dag_id == dag.dag_id,
         TaskInstance.run_id == run_id,
         TaskInstance.state.not_in(State.finished),
-        TaskInstance.state.not_in(State.running),
+        TaskInstance.state.not_in(State.pending),
     )
 
     tis = [ti for ti in tis]

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -546,7 +546,7 @@ class TaskInstance(Base, LoggingMixin):
         database, in all other cases this will be incremented.
         """
         # This is designed so that task logs end up in the right file.
-        if self.state in State.running:
+        if self.state == State.RUNNING:
             return self._try_number
         return self._try_number + 1
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -264,7 +264,7 @@ class FileTaskHandler(logging.Handler):
                 return log, {"end_of_log": True}
 
         # Process tailing if log is not at it's end
-        end_of_log = ti.try_number != try_number or ti.state not in State.running
+        end_of_log = ti.try_number != try_number or ti.state not in [State.RUNNING, State.DEFERRED]
         log_pos = len(log)
         if metadata and "log_pos" in metadata:
             previous_chars = metadata["log_pos"]

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -78,7 +78,7 @@ class TaskLogReader:
             metadata.pop("offset", None)
             metadata.pop("log_pos", None)
             while "end_of_log" not in metadata or (
-                not metadata["end_of_log"] and ti.state not in State.running
+                not metadata["end_of_log"] and ti.state not in [State.RUNNING, State.DEFERRED]
             ):
                 logs, metadata = self.read_log_chunks(ti, current_try_number, metadata)
                 for host, log in logs[0]:

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -144,9 +144,14 @@ class State:
     A list of states indicating that a task is sensing or deferred
     """
 
-    running: frozenset[TaskInstanceState] = frozenset(
+    pending: frozenset[TaskInstanceState] = frozenset(
         [TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
     )
+    """
+    Running tasks + sensing tasks (task reschedules makes up_for_reschedule act a little differently)
+    """
+
+    running: frozenset[TaskInstanceState] = frozenset([TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED])
     """
     A list of states indicating that a task is being executed.
     """

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -137,6 +137,13 @@ class State:
             return "white"
         return "black"
 
+    waiting: frozenset[TaskInstanceState] = frozenset(
+        [TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
+    )
+    """
+    A list of states indicating that a task is sensing or deferred
+    """
+
     running: frozenset[TaskInstanceState] = frozenset(
         [TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
     )

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -137,7 +137,9 @@ class State:
             return "white"
         return "black"
 
-    running: frozenset[TaskInstanceState] = frozenset([TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED])
+    running: frozenset[TaskInstanceState] = frozenset(
+        [TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
+    )
     """
     A list of states indicating that a task is being executed.
     """

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -137,25 +137,6 @@ class State:
             return "white"
         return "black"
 
-    waiting: frozenset[TaskInstanceState] = frozenset(
-        [TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
-    )
-    """
-    A list of states indicating that a task is sensing or deferred
-    """
-
-    pending: frozenset[TaskInstanceState] = frozenset(
-        [TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED, TaskInstanceState.UP_FOR_RESCHEDULE]
-    )
-    """
-    Running tasks + sensing tasks (task reschedules makes up_for_reschedule act a little differently)
-    """
-
-    running: frozenset[TaskInstanceState] = frozenset([TaskInstanceState.RUNNING, TaskInstanceState.DEFERRED])
-    """
-    A list of states indicating that a task is being executed.
-    """
-
     finished: frozenset[TaskInstanceState] = frozenset(
         [
             TaskInstanceState.SUCCESS,

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -461,7 +461,7 @@ def dag_run_link(attr):
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 
-def task_try_count(ti: TaskInstance):
+def task_try_count(ti: TaskInstance) -> int:
     """Get the total try count for a task instance"""
     return ti._try_number if ti._try_number != 0 or ti.state in State.running else ti._try_number + 1
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -84,7 +84,7 @@ def get_instance_with_map(task_instance, session):
 
 
 def get_try_count(try_number: int, state: State):
-    return try_number + 1 if state in (State.UP_FOR_RESCHEDULE, State.DEFERRED) else try_number
+    return try_number + 1 if state in State.waiting else try_number
 
 
 priority: list[None | TaskInstanceState] = [

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -461,6 +461,11 @@ def dag_run_link(attr):
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 
+def task_try_count(ti: TaskInstance):
+    """Get the total try count for a task instance"""
+    return ti._try_number if ti._try_number != 0 or ti.state in State.running else ti._try_number + 1
+
+
 def _get_run_ordering_expr(name: str) -> ColumnOperators:
     expr = DagRun.__table__.columns[name]
     # Data interval columns are NULL for runs created before 2.3, but SQL's

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -83,6 +83,10 @@ def get_instance_with_map(task_instance, session):
     return get_mapped_summary(task_instance, mapped_instances)
 
 
+def get_try_count(try_number: int, state: State):
+    return try_number + 1 if state in (State.UP_FOR_RESCHEDULE, State.DEFERRED) else try_number
+
+
 priority: list[None | TaskInstanceState] = [
     TaskInstanceState.FAILED,
     TaskInstanceState.UPSTREAM_FAILED,
@@ -117,12 +121,6 @@ def get_mapped_summary(parent_instance, task_instances):
         max((ti.end_date for ti in task_instances if ti.end_date), default=None)
     )
 
-    try_count = (
-        parent_instance._try_number
-        if parent_instance._try_number != 0 or parent_instance.state in State.running
-        else parent_instance._try_number + 1
-    )
-
     return {
         "task_id": parent_instance.task_id,
         "run_id": parent_instance.run_id,
@@ -130,7 +128,7 @@ def get_mapped_summary(parent_instance, task_instances):
         "start_date": group_start_date,
         "end_date": group_end_date,
         "mapped_states": mapped_states,
-        "try_number": try_count,
+        "try_number": get_try_count(parent_instance._try_number, parent_instance.state),
     }
 
 

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -84,7 +84,7 @@ def get_instance_with_map(task_instance, session):
 
 
 def get_try_count(try_number: int, state: State):
-    return try_number + 1 if state in State.waiting else try_number
+    return try_number + 1 if state in [State.DEFERRED, State.UP_FOR_RESCHEDULE] else try_number
 
 
 priority: list[None | TaskInstanceState] = [

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -461,11 +461,6 @@ def dag_run_link(attr):
     return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)
 
 
-def task_try_count(ti: TaskInstance) -> int:
-    """Get the total try count for a task instance"""
-    return ti._try_number if ti._try_number != 0 or ti.state in State.running else ti._try_number + 1
-
-
 def _get_run_ordering_expr(name: str) -> ColumnOperators:
     expr = DagRun.__table__.columns[name]
     # Data interval columns are NULL for runs created before 2.3, but SQL's

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1590,7 +1590,7 @@ class Airflow(AirflowBaseView):
 
         num_logs = 0
         if ti is not None:
-            num_logs = wwwutils.get_try_count(ti.next_try_number - 1, ti.state)
+            num_logs = wwwutils.get_try_count(ti._try_number, ti.state)
         logs = [""] * num_logs
         root = request.args.get("root", "")
         return self.render_template(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -264,18 +264,18 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
             TaskInstance.task_id,
             TaskInstance.run_id,
             TaskInstance.state,
+            TaskInstance._try_number,
             func.min(TaskInstanceNote.content).label("note"),
             func.count(func.coalesce(TaskInstance.state, sqla.literal("no_status"))).label("state_count"),
             func.min(TaskInstance.start_date).label("start_date"),
             func.max(TaskInstance.end_date).label("end_date"),
-            func.max(TaskInstance._try_number).label("_try_number"),
         )
         .join(TaskInstance.task_instance_note, isouter=True)
         .filter(
             TaskInstance.dag_id == dag.dag_id,
             TaskInstance.run_id.in_([dag_run.run_id for dag_run in dag_runs]),
         )
-        .group_by(TaskInstance.task_id, TaskInstance.run_id, TaskInstance.state)
+        .group_by(TaskInstance.task_id, TaskInstance.run_id, TaskInstance.state, TaskInstance._try_number)
         .order_by(TaskInstance.task_id, TaskInstance.run_id)
     )
 
@@ -285,15 +285,13 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
         if isinstance(item, AbstractOperator):
 
             def _get_summary(task_instance):
-                try_count = wwwutils.task_try_count(task_instance)
-
                 return {
                     "task_id": task_instance.task_id,
                     "run_id": task_instance.run_id,
                     "state": task_instance.state,
                     "start_date": task_instance.start_date,
                     "end_date": task_instance.end_date,
-                    "try_number": try_count,
+                    "try_number": task_instance._try_number or 1,
                     "note": task_instance.note,
                 }
 
@@ -1590,8 +1588,10 @@ class Airflow(AirflowBaseView):
             .first()
         )
 
-        try_count = wwwutils.task_try_count(ti)
-        logs = [""] * try_count
+        num_logs = 0
+        if ti is not None:
+            num_logs = ti._try_number or 1
+        logs = [""] * num_logs
         root = request.args.get("root", "")
         return self.render_template(
             "airflow/ti_log.html",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -291,7 +291,7 @@ def dag_to_grid(dag: DagModel, dag_runs: Sequence[DagRun], session: Session):
                     "state": task_instance.state,
                     "start_date": task_instance.start_date,
                     "end_date": task_instance.end_date,
-                    "try_number": task_instance._try_number or 1,
+                    "try_number": wwwutils.get_try_count(task_instance._try_number, task_instance.state),
                     "note": task_instance.note,
                 }
 
@@ -1590,7 +1590,7 @@ class Airflow(AirflowBaseView):
 
         num_logs = 0
         if ti is not None:
-            num_logs = ti._try_number or 1
+            num_logs = wwwutils.get_try_count(ti.next_try_number - 1, ti.state)
         logs = [""] * num_logs
         root = request.args.get("root", "")
         return self.render_template(

--- a/tests/www/views/test_views_grid.py
+++ b/tests/www/views/test_views_grid.py
@@ -240,7 +240,7 @@ def test_one_run(admin_client, dag_with_runs: list[DagRun], session):
                             "note": None,
                             "state": "success",
                             "task_id": "task1",
-                            "try_number": 1,
+                            "try_number": 0,
                         },
                         {
                             "run_id": "run_2",
@@ -249,7 +249,7 @@ def test_one_run(admin_client, dag_with_runs: list[DagRun], session):
                             "note": None,
                             "state": "success",
                             "task_id": "task1",
-                            "try_number": 1,
+                            "try_number": 0,
                         },
                     ],
                     "is_mapped": False,


### PR DESCRIPTION
When a task is set to `deferred` or `up_for_reschedule`, we decrement the try number to keep it all in the same file. But the UI relies on try_number to display logs. 
Fixes:
- for UI logs: add 1 to the try_number when a task's state is deferred or up_for_reschedule
- when marking a task/run success or failure, increment the try_number back up if the previous state was deferred or up_for_reschedule

Fixes: #26960
Fixes: #27955

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
