### PR TITLE
No extra__conn_type__ prefix required for UI behaviors

### DIFF
--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -274,12 +274,15 @@ An example:
             "relabeling": {},
             "placeholders": {
                 "password": "Asana personal access token",
-                "extra__my_conn_type__workspace": "My workspace gid",
-                "extra__my_conn_type__project": "My project gid",
+                "workspace": "My workspace gid",
+                "project": "My project gid",
             },
         }
 
-Note here that *here* (in contrast with ``get_connection_form_widgets``) we must add the prefix ``extra__<conn type>__`` when referencing a custom field.  This is because it's possible to create a custom field whose name overlaps with a built-in field and we need to be able to reference it unambiguously.
+.. note::
+
+    If you want to add a form placeholder for an ``extra`` field whose name conflicts with a standard connection attribute (i.e. login, password, host, scheme, port, extra) then
+    you must prefix it with ``extra__<conn type>__``.  E.g. ``extra__myservice__password``.
 
 Take a look at providers for examples of what you can do, for example :py:class:`~airflow.providers.jdbc.hooks.jdbc.JdbcHook`
 and :py:class:`~airflow.providers.asana.hooks.jdbc.AsanaHook` both make use of this feature.

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -189,6 +189,31 @@ class TestProviderManager:
         )
         assert provider_manager.connection_form_widgets['extra__test__my_param'].field == widget_field
 
+    def test_connection_field_behaviors_placeholders_prefix(self):
+        class MyHook:
+            conn_type = 'test'
+
+            @classmethod
+            def get_ui_field_behaviour(cls):
+                return {
+                    "hidden_fields": ['host', 'schema'],
+                    "relabeling": {},
+                    "placeholders": {"abc": "hi", "extra__anything": "n/a", "password": "blah"},
+                }
+
+        provider_manager = ProvidersManager()
+        provider_manager._add_customized_fields(
+            package_name='abc',
+            hook_class=MyHook,
+            customized_fields=MyHook.get_ui_field_behaviour(),
+        )
+        expected = {
+            "extra__test__abc": "hi",  # prefix should be added, since `abc` is not reserved
+            "extra__anything": "n/a",  # no change since starts with extra
+            "password": "blah",  # no change since it's a conn attr
+        }
+        assert provider_manager.field_behaviours['test']['placeholders'] == expected
+
     def test_connection_form_widgets_fields_order(self):
         """Check that order of connection for widgets preserved by original Hook order."""
         test_conn_type = 'test'


### PR DESCRIPTION
After making it so we can omit the prefix in `get_connection_form_widgets`, we left `get_ui_field_behaviour` alone because, even though maybe it's unlikely and probably not a great idea, it's *possible* that a user would want to add an extra field that shares a name with an existing conn attr _and_ want to provide a placeholder for that field.

But, after turning my attention back to this area, I think I arrived a at a reasonable way to solve this, which should make things easier for users when trying to implement extra fields for hooks.

What we do is, check the placeholders when processing the hook in the providers manager, and if there are any fields which are not conn attrs and are not prefixed already, we add the prefix.  We don't need to worry about "hidden fields" or "relabeling" because these are only used with the built-in conn attrs.
