### PR TITLE
Exit on error in breeze command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -593,7 +593,7 @@ def run_shell(verbose: bool, dry_run: bool, shell_params: ShellParams) -> RunCom
         get_console().print(f"[red]Error {command_result.returncode} returned[/]")
         if verbose:
             get_console().print(command_result.stderr)
-        return command_result
+        sys.exit(1)
 
 
 def stop_exec_on_error(returncode: int):


### PR DESCRIPTION
We changed how we run the DB upgrade/downgrade commands but the new way does not error whenever there's migration error.

Exiting when a command has a returned code of >0 solves the issue

