### PR TITLE
`GoogleApiToS3Operator` : add `gcp_conn_id` to template fields

### DIFF
--- a/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/google_api_to_s3.py
@@ -93,6 +93,7 @@ class GoogleApiToS3Operator(BaseOperator):
         'google_api_endpoint_params',
         's3_destination_key',
         'google_impersonation_chain',
+        'gcp_conn_id',
     )
     template_ext: Sequence[str] = ()
     ui_color = '#cc181e'


### PR DESCRIPTION
The system test for this operator was failing due to the connection ID not being a templated field. This was missed during the initial PR. 
<!-- 
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
