### PR TITLE
set executor.job_id to BackfillJob.id for backfills

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -833,7 +833,7 @@ class BackfillJob(BaseJob):
             pickle_id = pickle.id
 
         executor = self.executor
-        executor.job_id = "backfill"
+        executor.job_id = self.id
         executor.start()
 
         ti_status.total_runs = len(dagrun_infos)  # total dag runs in backfill

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1609,8 +1609,8 @@ class TestBackfillJob:
         dr: DagRun = dag.get_last_dagrun()
         assert dr.creating_job_id == job.id
 
-    def test_backfill_has_job_id(self):
-        """Make sure that backfill jobs are assigned job_ids."""
+    def test_backfill_has_job_id_int(self):
+        """Make sure that backfill jobs are assigned job_ids and that the job_id is an int."""
         dag = self.dagbag.get_dag("test_start_date_scheduling")
         dag.clear()
 
@@ -1624,7 +1624,7 @@ class TestBackfillJob:
             run_backwards=True,
         )
         job.run()
-        assert executor.job_id is not None
+        assert isinstance(executor.job_id, int)
 
     @pytest.mark.long_running
     @pytest.mark.parametrize("executor_name", ["SequentialExecutor", "DebugExecutor"])


### PR DESCRIPTION
[BackfillJob](https://github.com/apache/airflow/blob/main/airflow/jobs/backfill_job.py#L836) sets `executor.job_id = "backfill"`, which results in a bug in the Celery executor's `stalled_task_timeout` feature. The query to select stalled tasks [is as follows](https://github.com/apache/airflow/blob/main/airflow/executors/celery_executor.py#L395-L398):

```
session.query(TaskInstance).filter(
    TaskInstance.filter_for_tis(keys),
    TaskInstance.state == State.QUEUED,
    TaskInstance.queued_by_job_id == self.job_id,
```

`TaskInstance.queued_by_job_id` [is an int](https://github.com/apache/airflow/blob/main/airflow/models/taskinstance.py#L452), but for backfill jobs, it is comparing against a string (i.e. `"backfill"`). This prevents stalled tasks from backfill jobs to remain stalled and not be retried.

Setting `executor.job_id = self.id` (where `self.id` is `BaseJob`'s `id` field should resolve this issue.