### PR TITLE
Remove extra__kubernetes__ prefix from k8s hook extras

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -140,7 +140,7 @@ class KubernetesHook(BaseHook):
         we needed to store them with the prefix ``extra__kubernetes__``. This method
         handles the backcompat, i.e. if the extra dict contains prefixed fields.
         """
-        if field_name.startswith('extra_'):
+        if field_name.startswith('extra__'):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the 'extra__kubernetes__' prefix "
                 f"when using this method."

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -42,10 +42,10 @@ class KubernetesHook(BaseHook):
     """
     Creates Kubernetes API connection.
 
-    - use in cluster configuration by using ``extra__kubernetes__in_cluster`` in connection
-    - use custom config by providing path to the file using ``extra__kubernetes__kube_config_path``
+    - use in cluster configuration by using extra field ``in_cluster`` in connection
+    - use custom config by providing path to the file using extra field ``kube_config_path`` in connection
     - use custom configuration by providing content of kubeconfig file via
-        ``extra__kubernetes__kube_config`` in connection
+        extra field ``kube_config`` in connection
     - use default config by providing no extras
 
     This hook check for configuration option in the above order. Once an option is present it will
@@ -80,21 +80,15 @@ class KubernetesHook(BaseHook):
         from wtforms import BooleanField, StringField
 
         return {
-            "extra__kubernetes__in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
-            "extra__kubernetes__kube_config_path": StringField(
-                lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
-            ),
-            "extra__kubernetes__kube_config": StringField(
+            "in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
+            "kube_config_path": StringField(lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()),
+            "kube_config": StringField(
                 lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
             ),
-            "extra__kubernetes__namespace": StringField(
-                lazy_gettext('Namespace'), widget=BS3TextFieldWidget()
-            ),
-            "extra__kubernetes__cluster_context": StringField(
-                lazy_gettext('Cluster context'), widget=BS3TextFieldWidget()
-            ),
-            "extra__kubernetes__disable_verify_ssl": BooleanField(lazy_gettext('Disable SSL')),
-            "extra__kubernetes__disable_tcp_keepalive": BooleanField(lazy_gettext('Disable TCP keepalive')),
+            "namespace": StringField(lazy_gettext('Namespace'), widget=BS3TextFieldWidget()),
+            "cluster_context": StringField(lazy_gettext('Cluster context'), widget=BS3TextFieldWidget()),
+            "disable_verify_ssl": BooleanField(lazy_gettext('Disable SSL')),
+            "disable_tcp_keepalive": BooleanField(lazy_gettext('Disable TCP keepalive')),
         }
 
     @staticmethod
@@ -141,6 +135,11 @@ class KubernetesHook(BaseHook):
         return extras
 
     def _get_field(self, field_name):
+        """
+        Prior to Airflow 2.3, in order to make use of UI customizations for extra fields,
+        we needed to store them with the prefix ``extra__kubernetes__``. This method
+        handles the backcompat, i.e. if the extra dict contains prefixed fields.
+        """
         if field_name.startswith('extra_'):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the 'extra__kubernetes__' prefix "
@@ -164,17 +163,10 @@ class KubernetesHook(BaseHook):
 
     def get_conn(self) -> client.ApiClient:
         """Returns kubernetes api session for use with requests"""
-        in_cluster = self._coalesce_param(
-            self.in_cluster, self.conn_extras.get("extra__kubernetes__in_cluster") or None
-        )
-        cluster_context = self._coalesce_param(
-            self.cluster_context, self.conn_extras.get("extra__kubernetes__cluster_context") or None
-        )
-        kubeconfig_path = self._coalesce_param(
-            self.config_file, self.conn_extras.get("extra__kubernetes__kube_config_path") or None
-        )
-
-        kubeconfig = self.conn_extras.get("extra__kubernetes__kube_config") or None
+        in_cluster = self._coalesce_param(self.in_cluster, self._get_field("in_cluster"))
+        cluster_context = self._coalesce_param(self.cluster_context, self._get_field("cluster_context"))
+        kubeconfig_path = self._coalesce_param(self.config_file, self._get_field("kube_config_path"))
+        kubeconfig = self._get_field("kube_config")
         num_selected_configuration = len([o for o in [in_cluster, kubeconfig, kubeconfig_path] if o])
 
         if num_selected_configuration > 1:
@@ -329,10 +321,7 @@ class KubernetesHook(BaseHook):
     def get_namespace(self) -> str | None:
         """Returns the namespace that defined in the connection"""
         if self.conn_id:
-            connection = self.get_connection(self.conn_id)
-            extras = connection.extra_dejson
-            namespace = extras.get("extra__kubernetes__namespace", "default")
-            return namespace
+            return self._get_field("namespace") or "default"
         return None
 
     def get_pod_log_stream(

--- a/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
@@ -72,4 +72,10 @@ Example storing connection in env var using URI format:
 
 .. code-block:: bash
 
-    AIRFLOW_CONN_KUBERNETES_DEFAULT='kubernetes://?extra__kubernetes__in_cluster=True&extra__kubernetes__kube_config_path=~%2F.kube%2Fconfig&extra__kubernetes__kube_config=kubeconfig+json&extra__kubernetes__namespace=namespace'
+    AIRFLOW_CONN_KUBERNETES_DEFAULT='kubernetes://?in_cluster=True&kube_config_path=~%2F.kube%2Fconfig&kube_config=kubeconfig+json&namespace=namespace'
+
+And using JSON format:
+
+.. code-block:: bash
+
+    AIRFLOW_CONN_KUBERNETES_DEFAULT='{"conn_type": "kubernetes", "extra": {"in_cluster": true, "kube_config_path": "~/.kube/config", "namespace": "my-namespace"}}'

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -170,7 +170,7 @@ class TestSparkKubernetesOperator(unittest.TestCase):
             Connection(
                 conn_id='kubernetes_with_namespace',
                 conn_type='kubernetes',
-                extra=json.dumps({'extra__kubernetes__namespace': 'mock_namespace'}),
+                extra=json.dumps({'namespace': 'mock_namespace'}),
             )
         )
         args = {'owner': 'airflow', 'start_date': timezone.datetime(2020, 2, 1)}

--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -564,7 +564,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
             Connection(
                 conn_id="kubernetes_with_namespace",
                 conn_type="kubernetes",
-                extra=json.dumps({"extra__kubernetes__namespace": "mock_namespace"}),
+                extra=json.dumps({"namespace": "mock_namespace"}),
             )
         )
         args = {"owner": "airflow", "start_date": timezone.datetime(2020, 2, 1)}


### PR DESCRIPTION
We still support connections defined the old way; but we no longer need to use this prefix.
