### PR TITLE
Add mapped task group info to serialization

### DIFF
--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -272,5 +272,5 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
             return self.downstream_list
 
     def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
-        """This is used by SerializedTaskGroup to serialize a task group's content."""
+        """This is used by TaskGroupSerialization to serialize a task group's content."""
         raise NotImplementedError()

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -280,6 +280,7 @@
       ],
       "properties": {
         "_group_id": {"anyOf": [{"type": "null"}, { "type": "string" }]},
+        "is_mapped": { "type": "boolean" },
         "prefix_group_id": { "type": "boolean" },
         "children":  { "$ref": "#/definitions/dict" },
         "tooltip": { "type": "string" },

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -391,9 +391,9 @@ class TaskGroup(DAGNode):
 
     def serialize_for_task_group(self) -> tuple[DagAttributeTypes, Any]:
         """Required by DAGNode."""
-        from airflow.serialization.serialized_objects import SerializedTaskGroup
+        from airflow.serialization.serialized_objects import TaskGroupSerialization
 
-        return DagAttributeTypes.TASK_GROUP, SerializedTaskGroup.serialize_task_group(self)
+        return DagAttributeTypes.TASK_GROUP, TaskGroupSerialization.serialize_task_group(self)
 
     def topological_sort(self, _include_subdag_tasks: bool = False):
         """


### PR DESCRIPTION
A new flag `is_mapped` is added to indicate a mapped task group, and a serialized mapped group contains an additional member to hold the ExpandInput value.

Serialization logic is moved to a common class so it can handle both normal (non-mapped) and mapped task groups.
