### PR TITLE
Add kerberos environment variables to the docs

### DIFF
--- a/docs/apache-airflow/security/kerberos.rst
+++ b/docs/apache-airflow/security/kerberos.rst
@@ -64,9 +64,11 @@ your ``airflow.cfg``
 In case you are using Airflow in a docker container based environment,
 you can set the below environment variables in the ``Dockerfile`` instead of modifying ``airflow.cfg``
 
-ENV AIRFLOW__CORE__SECURITY kerberos
-ENV AIRFLOW__KERBEROS__KEYTAB /etc/airflow/airflow.keytab
-ENV AIRFLOW__KERBEROS__INCLUDE_IP False
+.. code-block:: dockerfile
+
+    ENV AIRFLOW__CORE__SECURITY kerberos
+    ENV AIRFLOW__KERBEROS__KEYTAB /etc/airflow/airflow.keytab
+    ENV AIRFLOW__KERBEROS__INCLUDE_IP False
 
 
 If you need more granular options for your Kerberos ticket the following options are available with the following default values:

--- a/docs/apache-airflow/security/kerberos.rst
+++ b/docs/apache-airflow/security/kerberos.rst
@@ -61,6 +61,14 @@ your ``airflow.cfg``
     reinit_frequency = 3600
     principal = airflow
 
+In case you are using Airflow in a docker container based environment,
+you can set the below environment variables in the ``Dockerfile`` instead of modifying ``airflow.cfg``
+
+ENV AIRFLOW__CORE__SECURITY kerberos
+ENV AIRFLOW__KERBEROS__KEYTAB /etc/airflow/airflow.keytab
+ENV AIRFLOW__KERBEROS__INCLUDE_IP False
+
+
 If you need more granular options for your Kerberos ticket the following options are available with the following default values:
 
 .. code-block:: ini


### PR DESCRIPTION
This PR adds additional info about using environment variables in the airflow kerberos documentation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
