### PR TITLE
Move TriggerDagRunOperator config validation from init to execute

### DIFF
--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -117,11 +117,6 @@ class TriggerDagRunOperator(BaseOperator):
 
         self.execution_date = execution_date
 
-        try:
-            json.dumps(self.conf)
-        except TypeError:
-            raise AirflowException("conf parameter should be JSON Serializable")
-
     def execute(self, context: Context):
         if isinstance(self.execution_date, datetime.datetime):
             parsed_execution_date = self.execution_date
@@ -129,6 +124,11 @@ class TriggerDagRunOperator(BaseOperator):
             parsed_execution_date = timezone.parse(self.execution_date)
         else:
             parsed_execution_date = timezone.utcnow()
+
+        try:
+            json.dumps(self.conf)
+        except TypeError:
+            raise AirflowException("conf parameter should be JSON Serializable")
 
         if self.trigger_run_id:
             run_id = self.trigger_run_id

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -215,14 +215,14 @@ class TestDagRunOperator:
 
     def test_trigger_dagrun_operator_templated_invalid_conf(self):
         """Test passing a conf that is not JSON Serializable raise error."""
-
+        task = TriggerDagRunOperator(
+            task_id="test_trigger_dagrun_with_invalid_conf",
+            trigger_dag_id=TRIGGERED_DAG_ID,
+            conf={"foo": "{{ dag.dag_id }}", "datetime": timezone.utcnow()},
+            dag=self.dag,
+        )
         with pytest.raises(AirflowException, match="^conf parameter should be JSON Serializable$"):
-            TriggerDagRunOperator(
-                task_id="test_trigger_dagrun_with_invalid_conf",
-                trigger_dag_id=TRIGGERED_DAG_ID,
-                conf={"foo": "{{ dag.dag_id }}", "datetime": timezone.utcnow()},
-                dag=self.dag,
-            )
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
     def test_trigger_dagrun_operator_templated_conf(self):
         """Test passing a templated conf to the triggered DagRun."""


### PR DESCRIPTION
-Hi all, this is my first PR to Airflow, so bear with me in case I've missing something :)

I'd like to update the `TriggerDagRunOperator` to add support for TaskFlow and allow reading the conf from the xcom directly, without having to encapsulate it in a wrapper function.
At the moment, in fact, the TriggerDagRunOperator performs the `conf` param type-validaton in the init, and this fails if we try to pass an xcom object directly with Taskflow as the xcom is deserialized only after the validation. The only solution to use it at the moment is to encapsulate it in a function, and manually run it:
```python
@dag
def taskflow_dag(**kwargs):
    @task
    def foo():
        return {"foo":"bar"}

    @task
    def trigger_wrapper(myconfig):
        TriggerDagRunOperator(..., conf=myconfig).execute(kwargs)

    myconfig = foo()
    trigger_wrapper(myconfig)
```

while I would like to be able to do:

```python
@dag
def taskflow_dag(**kwargs):
    @task
    def foo():
        return {"foo":"bar"}

    myconfig = foo()
    TriggerDagRunOperator(..., conf=myconfig) # this fails now because myconfig is deserialized after the init
```