### PR TITLE
Allow and prefer non-prefixed extra fields for AzureFileShareHook

### DIFF
--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -24,6 +24,17 @@
 Changelog
 ---------
 
+5.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* This release of provider is only available for Airflow 2.3+ as explained in the Apache Airflow
+  providers support policy https://github.com/apache/airflow/blob/main/README.md#support-for-providers
+* In AzureFileShareHook, if both ``extra__azure_fileshare__foo`` and ``foo`` existed in connection extra
+  dict, the prefixed version would be used; now, the non-prefixed version will be preferred.
+
 4.3.0
 .....
 

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -18,11 +18,40 @@
 from __future__ import annotations
 
 import warnings
+from functools import wraps
 from typing import IO, Any
 
 from azure.storage.file import File, FileService
 
 from airflow.hooks.base import BaseHook
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        @wraps(func)
+        def inner():
+            field_behaviors = func()
+            conn_attrs = {"host", "schema", "login", "password", "port", "extra"}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith("extra__"):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if "placeholders" in field_behaviors:
+                placeholders = field_behaviors["placeholders"]
+                field_behaviors["placeholders"] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+            return field_behaviors
+
+        return inner
+
+    return dec
 
 
 class AzureFileShareHook(BaseHook):
@@ -53,18 +82,17 @@ class AzureFileShareHook(BaseHook):
         from wtforms import PasswordField, StringField
 
         return {
-            "extra__azure_fileshare__sas_token": PasswordField(
-                lazy_gettext("SAS Token (optional)"), widget=BS3PasswordFieldWidget()
-            ),
-            "extra__azure_fileshare__connection_string": StringField(
+            "sas_token": PasswordField(lazy_gettext("SAS Token (optional)"), widget=BS3PasswordFieldWidget()),
+            "connection_string": StringField(
                 lazy_gettext("Connection String (optional)"), widget=BS3TextFieldWidget()
             ),
-            "extra__azure_fileshare__protocol": StringField(
+            "protocol": StringField(
                 lazy_gettext("Account URL or token (optional)"), widget=BS3TextFieldWidget()
             ),
         }
 
     @staticmethod
+    @_ensure_prefixes(conn_type="azure_fileshare")
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
@@ -76,41 +104,42 @@ class AzureFileShareHook(BaseHook):
             "placeholders": {
                 "login": "account name",
                 "password": "secret",
-                "extra__azure_fileshare__sas_token": "account url or token (optional)",
-                "extra__azure_fileshare__connection_string": "account url or token (optional)",
-                "extra__azure_fileshare__protocol": "account url or token (optional)",
+                "sas_token": "account url or token (optional)",
+                "connection_string": "account url or token (optional)",
+                "protocol": "account url or token (optional)",
             },
         }
 
     def get_conn(self) -> FileService:
         """Return the FileService object."""
-        prefix = "extra__azure_fileshare__"
+
+        def check_for_conflict(key):
+            backcompat_key = f"{backcompat_prefix}{key}"
+            if backcompat_key in extras:
+                warnings.warn(
+                    f"Conflicting params `{key}` and `{backcompat_key}` found in extras for conn "
+                    f"{self.conn_id}. Using value for `{key}`.  Please ensure this is the correct value "
+                    f"and remove the backcompat key `{backcompat_key}`."
+                )
+
+        backcompat_prefix = "extra__azure_fileshare__"
         if self._conn:
             return self._conn
         conn = self.get_connection(self.conn_id)
-        service_options_with_prefix = conn.extra_dejson
+        extras = conn.extra_dejson
         service_options = {}
-        for key, value in service_options_with_prefix.items():
-            # in case dedicated FileShareHook is used, the connection will use the extras from UI.
-            # in case deprecated wasb hook is used, the old extras will work as well
-            if key.startswith(prefix):
-                if value != "":
-                    service_options[key[len(prefix) :]] = value
-                else:
-                    # warn if the deprecated wasb_connection is used
-                    warnings.warn(
-                        "You are using deprecated connection for AzureFileShareHook."
-                        " Please change it to `Azure FileShare`.",
-                        DeprecationWarning,
-                    )
-            else:
+        for key, value in extras.items():
+            if value == "":
+                continue
+            if not key.startswith("extra__"):
                 service_options[key] = value
-                # warn if the old non-prefixed value is used
-                warnings.warn(
-                    "You are using deprecated connection for AzureFileShareHook."
-                    " Please change it to `Azure FileShare`.",
-                    DeprecationWarning,
-                )
+                check_for_conflict(key)
+            elif key.startswith(backcompat_prefix):
+                eff_key = key[len(backcompat_prefix) :]
+                if eff_key not in service_options:  # prefer values provided with short name
+                    service_options[eff_key] = value
+            else:
+                warnings.warn(f"Extra param `{key}` not recognized; ignoring.")
         self._conn = FileService(account_name=conn.login, account_key=conn.password, **service_options)
         return self._conn
 

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -135,9 +135,9 @@ class AzureFileShareHook(BaseHook):
                 service_options[key] = value
                 check_for_conflict(key)
             elif key.startswith(backcompat_prefix):
-                eff_key = key[len(backcompat_prefix) :]
-                if eff_key not in service_options:  # prefer values provided with short name
-                    service_options[eff_key] = value
+                short_name = key[len(backcompat_prefix) :]
+                if short_name not in service_options:  # prefer values provided with short name
+                    service_options[short_name] = value
             else:
                 warnings.warn(f"Extra param `{key}` not recognized; ignoring.")
         self._conn = FileService(account_name=conn.login, account_key=conn.password, **service_options)

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_fileshare.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_fileshare.rst
@@ -34,10 +34,10 @@ There are four ways to connect to Azure File Share using Airflow.
    i.e. add specific credentials (client_id, secret) and subscription id to the Airflow connection.
 2. Use a `SAS Token
    <https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas>`_
-   i.e. add a key config to ``extra__azure_fileshare__sas_token`` in the Airflow connection.
+   i.e. add a key config to ``sas_token`` in the Airflow connection.
 3. Use a `Connection String
    <https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/storage>`_
-   i.e. add connection string to ``extra__azure_fileshare__connection_string`` in the Airflow connection.
+   i.e. add connection string to ``connection_string`` in the Airflow connection.
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.
@@ -64,9 +64,9 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Azure connection.
     The following parameters are all optional:
 
-    * ``extra__azure_fileshare__connection_string``: Connection string for use with connection string authentication.
-    * ``extra__azure_fileshare__sas_token``: SAS Token for use with SAS Token authentication.
-    * ``extra__azure_fileshare__protocol``: Specify the protocol to use (default is ``https``).
+    * ``connection_string``: Connection string for use with connection string authentication.
+    * ``sas_token``: SAS Token for use with SAS Token authentication.
+    * ``protocol``: Specify the protocol to use (default is ``https``).
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -77,4 +77,4 @@ For example connect with token credentials:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_WASP_DEFAULT='azure_fileshare://blob%20username@myblob.com?extra__azure_fileshare__sas_token=token'
+   export AIRFLOW_CONN_WASP_DEFAULT='azure_fileshare://blob%20username@myblob.com?sas_token=token'


### PR DESCRIPTION
From 2.3, non-prefixed extras are fully supported so we make this the preferred way.
