### PR TITLE
Allow and prefer non-prefixed extra fields for AsanaHook

### DIFF
--- a/airflow/providers/asana/CHANGELOG.rst
+++ b/airflow/providers/asana/CHANGELOG.rst
@@ -23,6 +23,20 @@
 Changelog
 ---------
 
+5.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* This release of provider is only available for Airflow 2.3+ as explained in the Apache Airflow
+  providers support policy https://github.com/apache/airflow/blob/main/README.md#support-for-providers
+
+Misc
+~~~~
+
+* In AsanaHook, non-prefixed extra fields are supported and are preferred.  So if you should update your connection to replace ``extra__asana__workspace`` with ``workspace`` etc.
+
 2.0.1
 .....
 

--- a/airflow/providers/asana/CHANGELOG.rst
+++ b/airflow/providers/asana/CHANGELOG.rst
@@ -23,7 +23,7 @@
 Changelog
 ---------
 
-5.0.0
+3.0.0
 .....
 
 Breaking changes

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -36,8 +36,8 @@ def _ensure_prefixes(conn_type):
 
     def dec(func):
         @wraps(func)
-        def inner(cls):
-            field_behaviors = func(cls)
+        def inner():
+            field_behaviors = func()
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -35,7 +35,9 @@ def _ensure_prefixes(conn_type):
     """
 
     def dec(func):
-        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+        @wraps(func)
+        def inner(cls):
+            field_behaviors = func(cls)
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):
@@ -47,12 +49,7 @@ def _ensure_prefixes(conn_type):
             if 'placeholders' in field_behaviors:
                 placeholders = field_behaviors['placeholders']
                 field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
-
             return field_behaviors
-
-        @wraps(func)
-        def inner():
-            return _ensure_prefix_for_placeholders(func(), conn_type)
 
         return inner
 

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -74,7 +74,7 @@ class AsanaHook(BaseHook):
     def _get_field(self, extras: dict, field_name: str):
         """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
         backcompat_prefix = "extra__asana__"
-        if field_name.startswith('extra_'):
+        if field_name.startswith('extra__'):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
                 "when using this method."

--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -18,6 +18,7 @@
 """Connect to Asana."""
 from __future__ import annotations
 
+from functools import wraps
 from typing import Any
 
 from asana import Client  # type: ignore[attr-defined]
@@ -25,6 +26,37 @@ from asana.error import NotFoundError  # type: ignore[attr-defined]
 
 from airflow.compat.functools import cached_property
 from airflow.hooks.base import BaseHook
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+            conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith('extra__'):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if 'placeholders' in field_behaviors:
+                placeholders = field_behaviors['placeholders']
+                field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+
+            return field_behaviors
+
+        @wraps(func)
+        def inner():
+            return _ensure_prefix_for_placeholders(func(), conn_type)
+
+        return inner
+
+    return dec
 
 
 class AsanaHook(BaseHook):
@@ -39,8 +71,21 @@ class AsanaHook(BaseHook):
         super().__init__(*args, **kwargs)
         self.connection = self.get_connection(conn_id)
         extras = self.connection.extra_dejson
-        self.workspace = extras.get("extra__asana__workspace") or None
-        self.project = extras.get("extra__asana__project") or None
+        self.workspace = self._get_field(extras, "workspace") or None
+        self.project = self._get_field(extras, "project") or None
+
+    def _get_field(self, extras: dict, field_name: str):
+        """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
+        backcompat_prefix = "extra__asana__"
+        if field_name.startswith('extra_'):
+            raise ValueError(
+                f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
+                "when using this method."
+            )
+        if field_name in extras:
+            return extras[field_name] or None
+        prefixed_name = f"{backcompat_prefix}{field_name}"
+        return extras.get(prefixed_name) or None
 
     def get_conn(self) -> Client:
         return self.client
@@ -53,11 +98,12 @@ class AsanaHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__asana__workspace": StringField(lazy_gettext("Workspace"), widget=BS3TextFieldWidget()),
-            "extra__asana__project": StringField(lazy_gettext("Project"), widget=BS3TextFieldWidget()),
+            "workspace": StringField(lazy_gettext("Workspace"), widget=BS3TextFieldWidget()),
+            "project": StringField(lazy_gettext("Project"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod
+    @_ensure_prefixes(conn_type='asana')
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
@@ -65,8 +111,8 @@ class AsanaHook(BaseHook):
             "relabeling": {},
             "placeholders": {
                 "password": "Asana personal access token",
-                "extra__asana__workspace": "Asana workspace gid",
-                "extra__asana__project": "Asana project gid",
+                "workspace": "Asana workspace gid",
+                "project": "Asana project gid",
             },
         }
 

--- a/tests/providers/asana/hooks/test_asana.py
+++ b/tests/providers/asana/hooks/test_asana.py
@@ -289,13 +289,10 @@ class TestAsanaHook(unittest.TestCase):
             assert hook.workspace == 'abc'
             assert hook.project == 'abc'
 
-    @patch('airflow.providers.microsoft.azure.hooks.fileshare.FileService')
     def test_backcompat_prefix_both_prefers_short(self, mock_service):
         with patch.dict(
             os.environ,
-            {
-                "AIRFLOW_CONN_MY_CONN": 'a://?workspace=non-prefixed&extra__azure_fileshare__workspace=prefixed'
-            },
+            {"AIRFLOW_CONN_MY_CONN": 'a://?workspace=non-prefixed&extra__asana__workspace=prefixed'},
         ):
             hook = AsanaHook('my_conn')
             assert hook.workspace == 'non-prefixed'

--- a/tests/providers/asana/hooks/test_asana.py
+++ b/tests/providers/asana/hooks/test_asana.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest.mock import patch
 
 import pytest
@@ -29,7 +28,7 @@ from airflow.providers.asana.hooks.asana import AsanaHook
 from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
 
 
-class TestAsanaHook(unittest.TestCase):
+class TestAsanaHook:
     """
     Tests for AsanaHook Asana client retrieval
     """
@@ -44,7 +43,7 @@ class TestAsanaHook(unittest.TestCase):
         ):
             hook = AsanaHook()
         client = hook.get_conn()
-        self.assertEqual(type(client), Client)
+        assert type(client) == Client
 
     def test_missing_password_raises(self):
         """
@@ -53,7 +52,7 @@ class TestAsanaHook(unittest.TestCase):
         """
         with patch.object(AsanaHook, "get_connection", return_value=Connection(conn_type="asana")):
             hook = AsanaHook()
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             hook.get_conn()
 
     def test_merge_create_task_parameters_default_project(self):
@@ -66,7 +65,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"name": "test", "projects": ["1"]}
-        self.assertEqual(expected_merged_params, hook._merge_create_task_parameters("test", {}))
+        assert hook._merge_create_task_parameters("test", {}) == expected_merged_params
 
     def test_merge_create_task_parameters_specified_project(self):
         """
@@ -78,10 +77,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"name": "test", "projects": ["1", "2"]}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_create_task_parameters("test", {"projects": ["1", "2"]}),
-        )
+        assert hook._merge_create_task_parameters("test", {"projects": ["1", "2"]}) == expected_merged_params
 
     def test_merge_create_task_parameters_specified_workspace(self):
         """
@@ -93,7 +89,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"name": "test", "workspace": "1"}
-        self.assertEqual(expected_merged_params, hook._merge_create_task_parameters("test", {}))
+        assert hook._merge_create_task_parameters("test", {}) == expected_merged_params
 
     def test_merge_create_task_parameters_default_project_overrides_default_workspace(self):
         """
@@ -109,7 +105,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"name": "test", "projects": ["1"]}
-        self.assertEqual(expected_merged_params, hook._merge_create_task_parameters("test", {}))
+        assert hook._merge_create_task_parameters("test", {}) == expected_merged_params
 
     def test_merge_create_task_parameters_specified_project_overrides_default_workspace(self):
         """
@@ -125,10 +121,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"name": "test", "projects": ["2"]}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_create_task_parameters("test", {"projects": ["2"]}),
-        )
+        assert hook._merge_create_task_parameters("test", {"projects": ["2"]}) == expected_merged_params
 
     def test_merge_find_task_parameters_default_project(self):
         """
@@ -140,7 +133,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"project": "1"}
-        self.assertEqual(expected_merged_params, hook._merge_find_task_parameters({}))
+        assert hook._merge_find_task_parameters({}) == expected_merged_params
 
     def test_merge_find_task_parameters_specified_project(self):
         """
@@ -152,10 +145,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"project": "2"}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_find_task_parameters({"project": "2"}),
-        )
+        assert hook._merge_find_task_parameters({"project": "2"}) == expected_merged_params
 
     def test_merge_find_task_parameters_default_workspace(self):
         """
@@ -167,10 +157,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"workspace": "1", "assignee": "1"}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_find_task_parameters({"assignee": "1"}),
-        )
+        assert hook._merge_find_task_parameters({"assignee": "1"}) == expected_merged_params
 
     def test_merge_find_task_parameters_specified_workspace(self):
         """
@@ -182,10 +169,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"workspace": "2", "assignee": "1"}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_find_task_parameters({"workspace": "2", "assignee": "1"}),
-        )
+        assert hook._merge_find_task_parameters({"workspace": "2", "assignee": "1"}) == expected_merged_params
 
     def test_merge_find_task_parameters_default_project_overrides_workspace(self):
         """
@@ -200,7 +184,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"project": "1"}
-        self.assertEqual(expected_merged_params, hook._merge_find_task_parameters({}))
+        assert hook._merge_find_task_parameters({}) == expected_merged_params
 
     def test_merge_find_task_parameters_specified_project_overrides_workspace(self):
         """
@@ -216,10 +200,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"project": "2"}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_find_task_parameters({"project": "2"}),
-        )
+        assert hook._merge_find_task_parameters({"project": "2"}) == expected_merged_params
 
     def test_merge_project_parameters(self):
         """
@@ -230,7 +211,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"workspace": "1", "name": "name"}
-        self.assertEqual(expected_merged_params, hook._merge_project_parameters({"name": "name"}))
+        assert hook._merge_project_parameters({"name": "name"}) == expected_merged_params
 
     def test_merge_project_parameters_override(self):
         """
@@ -241,10 +222,7 @@ class TestAsanaHook(unittest.TestCase):
         with patch.object(AsanaHook, "get_connection", return_value=conn):
             hook = AsanaHook()
         expected_merged_params = {"workspace": "2"}
-        self.assertEqual(
-            expected_merged_params,
-            hook._merge_project_parameters({"workspace": "2"}),
-        )
+        assert hook._merge_project_parameters({"workspace": "2"}) == expected_merged_params
 
     def test__ensure_prefixes_removal(self):
         """Ensure that _ensure_prefixes is removed from snowflake when airflow min version >= 2.5.0."""

--- a/tests/providers/asana/hooks/test_asana.py
+++ b/tests/providers/asana/hooks/test_asana.py
@@ -289,7 +289,7 @@ class TestAsanaHook(unittest.TestCase):
             assert hook.workspace == 'abc'
             assert hook.project == 'abc'
 
-    def test_backcompat_prefix_both_prefers_short(self, mock_service):
+    def test_backcompat_prefix_both_prefers_short(self):
         with patch.dict(
             os.environ,
             {"AIRFLOW_CONN_MY_CONN": 'a://?workspace=non-prefixed&extra__asana__workspace=prefixed'},

--- a/tests/providers/asana/hooks/test_asana.py
+++ b/tests/providers/asana/hooks/test_asana.py
@@ -283,7 +283,7 @@ class TestAsanaHook(unittest.TestCase):
             param('a://?workspace=abc&project=abc', id='no-prefix'),
         ],
     )
-    def test_backcompat_prefix_works(self, mock_service, uri):
+    def test_backcompat_prefix_works(self, uri):
         with patch.dict(os.environ, {"AIRFLOW_CONN_MY_CONN": uri}):
             hook = AsanaHook('my_conn')
             assert hook.workspace == 'abc'

--- a/tests/test_utils/providers.py
+++ b/tests/test_utils/providers.py
@@ -46,3 +46,13 @@ def get_provider_version(provider_name):
 
     info = ProvidersManager().providers[provider_name]
     return semver.VersionInfo.parse(info.version)
+
+
+def get_provider_min_airflow_version(provider_name):
+    from airflow.providers_manager import ProvidersManager
+
+    p = ProvidersManager()
+    deps = p.providers[provider_name].data['dependencies']
+    airflow_dep = [x for x in deps if x.startswith('apache-airflow')][0]
+    min_airflow_version = tuple(map(int, airflow_dep.split('>=')[1].split('.')))
+    return min_airflow_version


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.