### PR TITLE
Allow and prefer non-prefixed extra fields for JdbcHook

### DIFF
--- a/airflow/providers/jdbc/CHANGELOG.rst
+++ b/airflow/providers/jdbc/CHANGELOG.rst
@@ -24,6 +24,21 @@
 Changelog
 ---------
 
+4.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* This release of provider is only available for Airflow 2.3+ as explained in the Apache Airflow
+  providers support policy https://github.com/apache/airflow/blob/main/README.md#support-for-providers
+
+Misc
+~~~~
+
+* In JdbcHook, non-prefixed extra fields are supported and are preferred.  E.g. ``drv_path`` will
+  be preferred if ``extra__jdbc__drv_path`` is also present.
+
 3.2.1
 .....
 

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -48,10 +48,8 @@ class JdbcHook(DbApiHook):
         from wtforms import StringField
 
         return {
-            "extra__jdbc__drv_path": StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget()),
-            "extra__jdbc__drv_clsname": StringField(
-                lazy_gettext('Driver Class'), widget=BS3TextFieldWidget()
-            ),
+            "drv_path": StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget()),
+            "drv_clsname": StringField(lazy_gettext('Driver Class'), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod
@@ -62,13 +60,27 @@ class JdbcHook(DbApiHook):
             "relabeling": {'host': 'Connection URL'},
         }
 
+    def _get_field(self, extras: dict, field_name: str):
+        """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
+        backcompat_prefix = "extra__jdbc__"
+        if field_name.startswith('extra_'):
+            raise ValueError(
+                f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
+                "when using this method."
+            )
+        if field_name in extras:
+            return extras[field_name] or None
+        prefixed_name = f"{backcompat_prefix}{field_name}"
+        return extras.get(prefixed_name) or None
+
     def get_conn(self) -> jaydebeapi.Connection:
         conn: Connection = self.get_connection(getattr(self, self.conn_name_attr))
+        extras = conn.extra_dejson
         host: str = conn.host
         login: str = conn.login
         psw: str = conn.password
-        jdbc_driver_loc: str | None = conn.extra_dejson.get('extra__jdbc__drv_path')
-        jdbc_driver_name: str | None = conn.extra_dejson.get('extra__jdbc__drv_clsname')
+        jdbc_driver_loc: str | None = self._get_field(extras, 'drv_path')
+        jdbc_driver_name: str | None = self._get_field(extras, 'drv_clsname')
 
         conn = jaydebeapi.connect(
             jclassname=jdbc_driver_name,

--- a/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
+++ b/docs/apache-airflow-providers-jdbc/connections/jdbc.rst
@@ -44,5 +44,5 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in JDBC connection. The following parameters out of the standard python parameters are supported:
 
     * ``conn_prefix`` - Used to build the connection url in ``JdbcOperator``, added in front of host (``conn_prefix`` ``host`` [: ``port`` ] / ``schema``)
-    * ``extra__jdbc__drv_clsname`` - Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
-    * ``extra__jdbc__drv_path`` - Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.
+    * ``drv_clsname`` - Full qualified Java class name of the JDBC driver. For ``JdbcOperator``.
+    * ``drv_path`` - Jar filename or sequence of filenames for the JDBC driver libs. For ``JdbcOperator``.

--- a/tests/providers/jdbc/hooks/test_jdbc.py
+++ b/tests/providers/jdbc/hooks/test_jdbc.py
@@ -18,8 +18,11 @@
 from __future__ import annotations
 
 import json
-import unittest
+import os
 from unittest.mock import Mock, patch
+
+import pytest
+from pytest import param
 
 from airflow.models import Connection
 from airflow.providers.jdbc.hooks.jdbc import JdbcHook
@@ -28,8 +31,8 @@ from airflow.utils import db
 jdbc_conn_mock = Mock(name="jdbc_conn")
 
 
-class TestJdbcHook(unittest.TestCase):
-    def setUp(self):
+class TestJdbcHook:
+    def set_up(self):
         db.merge_conn(
             Connection(
                 conn_id='jdbc_default',
@@ -66,3 +69,40 @@ class TestJdbcHook(unittest.TestCase):
         jdbc_conn = jdbc_hook.get_conn()
         jdbc_hook.get_autocommit(jdbc_conn)
         jdbc_conn.jconn.getAutoCommit.assert_called_once_with()
+
+    @pytest.mark.parametrize(
+        'uri',
+        [
+            param(
+                'a://?extra__jdbc__drv_path=abc&extra__jdbc__drv_clsname=abc',
+                id='prefix',
+            ),
+            param('a://?drv_path=abc&drv_clsname=abc', id='no-prefix'),
+        ],
+    )
+    @patch('airflow.providers.jdbc.hooks.jdbc.jaydebeapi.connect')
+    def test_backcompat_prefix_works(self, mock_connect, uri):
+        with patch.dict(os.environ, {"AIRFLOW_CONN_MY_CONN": uri}):
+            hook = JdbcHook('my_conn')
+            hook.get_conn()
+            mock_connect.assert_called_with(
+                jclassname='abc',
+                url='',
+                driver_args=['None', 'None'],
+                jars='abc'.split(","),
+            )
+
+    @patch('airflow.providers.jdbc.hooks.jdbc.jaydebeapi.connect')
+    def test_backcompat_prefix_both_prefers_short(self, mock_connect):
+        with patch.dict(
+            os.environ,
+            {"AIRFLOW_CONN_MY_CONN": 'a://?drv_path=non-prefixed&extra__jdbc__drv_path=prefixed'},
+        ):
+            hook = JdbcHook('my_conn')
+            hook.get_conn()
+            mock_connect.assert_called_with(
+                jclassname=None,
+                url='',
+                driver_args=['None', 'None'],
+                jars='non-prefixed'.split(","),
+            )

--- a/tests/providers/jdbc/hooks/test_jdbc.py
+++ b/tests/providers/jdbc/hooks/test_jdbc.py
@@ -32,7 +32,7 @@ jdbc_conn_mock = Mock(name="jdbc_conn")
 
 
 class TestJdbcHook:
-    def set_up(self):
+    def setup(self):
         db.merge_conn(
             Connection(
                 conn_id='jdbc_default',


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.