### PR TITLE
Allow and prefer non-prefixed extra fields for AzureDataFactoryHook

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -119,7 +119,7 @@ class AzureDataFactoryPipelineRunException(AirflowException):
 def get_field(extras: dict, field_name: str, strict: bool = False):
     """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
     backcompat_prefix = "extra__azure_data_factory__"
-    if field_name.startswith("extra_"):
+    if field_name.startswith("extra__"):
         raise ValueError(
             f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
             "when using this method."

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -74,14 +74,17 @@ def provide_targeted_factory(func: Callable) -> Callable:
             if arg not in bound_args.arguments or bound_args.arguments[arg] is None:
                 self = args[0]
                 conn = self.get_connection(self.conn_id)
-                default_value = conn.extra_dejson.get(default_key)
+                extras = conn.extra_dejson
+                default_value = extras.get(default_key) or extras.get(
+                    f"extra__azure_data_factory__{default_key}"
+                )
                 if not default_value:
                     raise AirflowException("Could not determine the targeted data factory.")
 
-                bound_args.arguments[arg] = conn.extra_dejson[default_key]
+                bound_args.arguments[arg] = default_value
 
-        bind_argument("resource_group_name", "extra__azure_data_factory__resource_group_name")
-        bind_argument("factory_name", "extra__azure_data_factory__factory_name")
+        bind_argument("resource_group_name", "resource_group_name")
+        bind_argument("factory_name", "factory_name")
 
         return func(*bound_args.args, **bound_args.kwargs)
 
@@ -113,6 +116,23 @@ class AzureDataFactoryPipelineRunException(AirflowException):
     """An exception that indicates a pipeline run failed to complete."""
 
 
+def get_field(extras: dict, field_name: str, strict: bool = False):
+    """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
+    backcompat_prefix = "extra__azure_data_factory__"
+    if field_name.startswith("extra_"):
+        raise ValueError(
+            f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
+            "when using this method."
+        )
+    if field_name in extras:
+        return extras[field_name] or None
+    prefixed_name = f"{backcompat_prefix}{field_name}"
+    if prefixed_name in extras:
+        return extras[prefixed_name] or None
+    if strict:
+        raise KeyError(f"Field {field_name} not found in extras")
+
+
 class AzureDataFactoryHook(BaseHook):
     """
     A hook to interact with Azure Data Factory.
@@ -133,18 +153,12 @@ class AzureDataFactoryHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_data_factory__tenantId": StringField(
-                lazy_gettext("Tenant ID"), widget=BS3TextFieldWidget()
-            ),
-            "extra__azure_data_factory__subscriptionId": StringField(
-                lazy_gettext("Subscription ID"), widget=BS3TextFieldWidget()
-            ),
-            "extra__azure_data_factory__resource_group_name": StringField(
+            "tenantId": StringField(lazy_gettext("Tenant ID"), widget=BS3TextFieldWidget()),
+            "subscriptionId": StringField(lazy_gettext("Subscription ID"), widget=BS3TextFieldWidget()),
+            "resource_group_name": StringField(
                 lazy_gettext("Resource Group Name"), widget=BS3TextFieldWidget()
             ),
-            "extra__azure_data_factory__factory_name": StringField(
-                lazy_gettext("Factory Name"), widget=BS3TextFieldWidget()
-            ),
+            "factory_name": StringField(lazy_gettext("Factory Name"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod
@@ -168,10 +182,11 @@ class AzureDataFactoryHook(BaseHook):
             return self._conn
 
         conn = self.get_connection(self.conn_id)
-        tenant = conn.extra_dejson.get("extra__azure_data_factory__tenantId")
+        extras = conn.extra_dejson
+        tenant = get_field(extras, "tenantId")
 
         try:
-            subscription_id = conn.extra_dejson["extra__azure_data_factory__subscriptionId"]
+            subscription_id = get_field(extras, "subscriptionId", strict=True)
         except KeyError:
             raise ValueError("A Subscription ID is required to connect to Azure Data Factory.")
 

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -58,22 +58,22 @@ Tenant ID
     Specify the Azure tenant ID used for the initial connection.
     This is needed for *token credentials* authentication mechanism.
     It can be left out to fall back on ``DefaultAzureCredential``.
-    Use the key ``extra__azure_data_factory__tenantId`` to pass in the tenant ID.
+    Use extra param ``tenantId`` to pass in the tenant ID.
 
 Subscription ID
     Specify the ID of the subscription used for the initial connection.
     This is needed for all authentication mechanisms.
-    Use the key ``extra__azure_data_factory__subscriptionId`` to pass in the Azure subscription ID.
+    Use extra param ``subscriptionId`` to pass in the Azure subscription ID.
 
 Factory Name (optional)
     Specify the Azure Data Factory to interface with.
     If not specified in the connection, this needs to be passed in directly to hooks, operators, and sensors.
-    Use the key ``extra__azure_data_factory__factory_name`` to pass in the factory name.
+    Use extra param ``factory_name`` to pass in the factory name.
 
 Resource Group Name (optional)
     Specify the Azure Resource Group Name under which the desired data factory resides.
     If not specified in the connection, this needs to be passed in directly to hooks, operators, and sensors.
-    Use the key ``extra__azure_data_factory__resource_group_name`` to pass in the resource group name.
+    Use extra param ``resource_group_name`` to pass in the resource group name.
 
 
 When specifying the connection in environment variable you should specify
@@ -86,8 +86,8 @@ Examples
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://applicationid:serviceprincipalpassword@?extra__azure_data_factory__tenantId=tenant+id&extra__azure_data_factory__subscriptionId=subscription+id&extra__azure_data_factory__resource_group_name=group+name&extra__azure_data_factory__factory_name=factory+name'
+   export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://applicationid:serviceprincipalpassword@?tenantId=tenant+id&subscriptionId=subscription+id&resource_group_name=group+name&factory_name=factory+name'
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://applicationid:serviceprincipalpassword@?extra__azure_data_factory__tenantId=tenant+id&extra__azure_data_factory__subscriptionId=subscription+id'
+   export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://applicationid:serviceprincipalpassword@?tenantId=tenant+id&subscriptionId=subscription+id'

--- a/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
@@ -36,10 +36,10 @@ TASK_ID = "run_pipeline_op"
 AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_test"
 PIPELINE_NAME = "pipeline1"
 CONN_EXTRAS = {
-    "extra__azure_data_factory__subscriptionId": SUBSCRIPTION_ID,
-    "extra__azure_data_factory__tenantId": "my-tenant-id",
-    "extra__azure_data_factory__resource_group_name": "my-resource-group-name-from-conn",
-    "extra__azure_data_factory__factory_name": "my-factory-name-from-conn",
+    "subscriptionId": SUBSCRIPTION_ID,
+    "tenantId": "my-tenant-id",
+    "resource_group_name": "my-resource-group-name-from-conn",
+    "factory_name": "my-factory-name-from-conn",
 }
 PIPELINE_RUN_RESPONSE = {"additional_properties": {}, "run_id": "run_id"}
 EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
@@ -241,8 +241,8 @@ class TestAzureDataFactoryRunPipelineOperator:
         )
 
         conn = AzureDataFactoryHook.get_connection("azure_data_factory_test")
-        conn_resource_group_name = conn.extra_dejson["extra__azure_data_factory__resource_group_name"]
-        conn_factory_name = conn.extra_dejson["extra__azure_data_factory__factory_name"]
+        conn_resource_group_name = conn.extra_dejson["resource_group_name"]
+        conn_factory_name = conn.extra_dejson["factory_name"]
 
         assert url == (
             EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK.format(


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.
