### PR TITLE
Return the correct error code from breeze shell

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -593,7 +593,7 @@ def run_shell(verbose: bool, dry_run: bool, shell_params: ShellParams) -> RunCom
         get_console().print(f"[red]Error {command_result.returncode} returned[/]")
         if verbose:
             get_console().print(command_result.stderr)
-        sys.exit(1)
+        sys.exit(command_result.returncode)
 
 
 def stop_exec_on_error(returncode: int):


### PR DESCRIPTION
After #27008 breeze always returned exit code 1 in error cases despite the actual error code returned by the command. This change plumbs the return code back to the caller.

Before this change (you can see the return code is one despite exiting with code 2):
```
onikolas@u1b5c5956eb1a59:$ breeze shell --answer n 'exit 2' > /dev/null; echo $?
Creating docker-compose_airflow_run ... done
ERROR: 2
1
```
After (code returned to called is the same as the command run in the breeze container):
```
onikolas@u1b5c5956eb1a59:~/code/oss/airflow/team_fork on branch main (Unstaged Changes)$ breeze shell --answer n 'exit 2' > /dev/null; echo $?
Creating docker-compose_airflow_run ... done
ERROR: 2
2
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
