### PR TITLE
Fix `.gitpod.yml` tasks init shell file directory

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,7 +20,7 @@
 # Docs: https://www.gitpod.io/docs/config-gitpod-file/
 
 tasks:
-  - init: ./script/ci/install_breeze.sh
+  - init: ./scripts/ci/install_breeze.sh
   - name: Install pre-commit
     openMode: split-right
     command: |


### PR DESCRIPTION
In the `.gitpod.yml` file, the bash file path specified in the tasks init has a small issue which results to `No such file or directory` at the init stage of the workspace. The file path was corrected.
![Screenshot from 2022-10-14 06-07-52](https://user-images.githubusercontent.com/63079698/195767983-32f55052-10ce-4942-9cd9-603451fc069b.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
