### PR TITLE
Fix broken PyGithub link in github provider doc

### DIFF
--- a/docs/apache-airflow-providers-github/operators/index.rst
+++ b/docs/apache-airflow-providers-github/operators/index.rst
@@ -24,7 +24,7 @@ Use the :class:`~airflow.providers.github.operators.GithubOperator` to execute
 Operations in a `GitHub <https://www.github.com/>`__.
 
 You can build your own operator using :class:`~airflow.providers.github.operators.GithubOperator`
-and passing **github_method** and **github_method_args** from top level `PyGithub <https://www.pygithub.readthedocs.io/>`__ methods.
+and passing **github_method** and **github_method_args** from top level `PyGithub <https://pygithub.readthedocs.io/>`__ methods.
 You can further process the result using **result_processor** Callable as you like.
 
 An example of Listing all Repositories owned by a user, **client.get_user().get_repos()** can be implemented as following:


### PR DESCRIPTION
PyGithub url referenced on github provider documentation page was broken. Corrected to proper link.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
