### PR TITLE
Fix ExternalTaskSensor cant check zipped dag

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -33,6 +33,7 @@ from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
 from airflow.operators.empty import EmptyOperator
 from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import build_airflow_url_with_query
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
@@ -262,7 +263,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         if not dag_to_wait:
             raise AirflowException(f"The external DAG {self.external_dag_id} does not exist.")
 
-        if not os.path.exists(dag_to_wait.fileloc):
+        if not os.path.exists(correct_maybe_zipped(dag_to_wait.fileloc)):
             raise AirflowException(f"The external DAG {self.external_dag_id} was deleted.")
 
         if self.external_task_ids:

--- a/tests/dags/test_external_task_sensor_check_existense.py
+++ b/tests/dags/test_external_task_sensor_check_existense.py
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from airflow.models import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.sensors.external_task import ExternalTaskSensor
+from tests.models import DEFAULT_DATE
+
+with DAG(dag_id="test_external_task_sensor_check_existence_ext", start_date=DEFAULT_DATE) as dag1:
+    EmptyOperator(task_id="empty")
+
+with DAG(dag_id="test_external_task_sensor_check_existence", start_date=DEFAULT_DATE) as dag2:
+    ExternalTaskSensor(
+        task_id="external_task_sensor",
+        external_dag_id="test_external_task_sensor_check_existence_ext",
+        external_task_id="empty",
+        check_existence=True,
+    )


### PR DESCRIPTION

closes: #14264

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
