### PR TITLE
Make tracebacks opt-in

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1232,7 +1232,7 @@
       version_added: 1.10.8
       type: string
       example: ~
-      default: "True"
+      default: "False"
     - name: dag_default_view
       description: |
         Default DAG view. Valid values are: ``grid``, ``graph``, ``duration``, ``gantt``, ``landing_times``

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -631,7 +631,7 @@ expose_config = False
 expose_hostname = True
 
 # Expose stacktrace in the web server
-expose_stacktrace = True
+expose_stacktrace = False
 
 # Default DAG view. Valid values are: ``grid``, ``graph``, ``duration``, ``gantt``, ``landing_times``
 dag_default_view = grid

--- a/newsfragments/000.significant.rst
+++ b/newsfragments/000.significant.rst
@@ -1,0 +1,3 @@
+Default for ``[webserver] expose_stacktrace`` changed to ``False``
+
+The default for ``[webserver] expose_stacktrace`` has been set to ``False``, instead of ``True``. This means administrators must opt-in to expose tracebacks to end users.


### PR DESCRIPTION
Instead of showing tracebacks by default, make the end user opt-in instead.