### PR TITLE
Avoid 500 on dag redirect

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2454,7 +2454,8 @@ class Airflow(AirflowBaseView):
     @action_logging
     def dag(self, dag_id):
         """Redirect to default DAG view."""
-        return redirect(url_for('Airflow.grid', dag_id=dag_id, **request.args))
+        kwargs = {**request.args, "dag_id": dag_id}
+        return redirect(url_for('Airflow.grid', **kwargs))
 
     @expose('/legacy_tree')
     @auth.has_access(


### PR DESCRIPTION
A 500 could happen if the dag_id was passed in the path and as a query param. This always uses the path dag_id in that situation (ignoring the query param completely).