### PR TITLE
Allow and prefer non-prefixed extra fields for slack hooks

### DIFF
--- a/airflow/providers/slack/CHANGELOG.rst
+++ b/airflow/providers/slack/CHANGELOG.rst
@@ -24,13 +24,25 @@
 Changelog
 ---------
 
+7.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* This release of provider is only available for Airflow 2.3+ as explained in the Apache Airflow
+  providers support policy https://github.com/apache/airflow/blob/main/README.md#support-for-providers
+* In SlackHook and SlackWebhookHook, if both ``extra__<conn type>__foo`` and ``foo`` existed in connection extra
+  dict, the prefixed version would be used; now, the non-prefixed version will be preferred.  You'll see a warning
+  if there is such a collision.
+
 6.0.0
 .....
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-* The hook class  ``SlackWebhookHook`` dies not inherit from ``HttpHook`` anymore. In practice the
+* The hook class  ``SlackWebhookHook`` does not inherit from ``HttpHook`` anymore. In practice the
   only impact on user-defined classes based on **SlackWebhookHook** and you use attributes
   from **HttpHook**.
 * Drop support deprecated ``webhook_token`` parameter in ``slack-incoming-webhook`` extra.

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import warnings
+from functools import wraps
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -28,12 +29,43 @@ from slack_sdk.errors import SlackApiError
 from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
-from airflow.providers.slack.utils import ConnectionExtraConfig, prefixed_extra_field
+from airflow.providers.slack.utils import ConnectionExtraConfig
 from airflow.utils.log.secrets_masker import mask_secret
 
 if TYPE_CHECKING:
     from slack_sdk.http_retry import RetryHandler
     from slack_sdk.web.slack_response import SlackResponse
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+            conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith('extra__'):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if 'placeholders' in field_behaviors:
+                placeholders = field_behaviors['placeholders']
+                field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+
+            return field_behaviors
+
+        @wraps(func)
+        def inner(cls):
+            return _ensure_prefix_for_placeholders(func(cls), conn_type)
+
+        return inner
+
+    return dec
 
 
 class SlackHook(BaseHook):
@@ -296,19 +328,19 @@ class SlackHook(BaseHook):
         from wtforms.validators import NumberRange, Optional
 
         return {
-            prefixed_extra_field("timeout", cls.conn_type): IntegerField(
+            "timeout": IntegerField(
                 lazy_gettext("Timeout"),
                 widget=BS3TextFieldWidget(),
                 validators=[Optional(strip_whitespace=True), NumberRange(min=1)],
                 description="Optional. The maximum number of seconds the client will wait to connect "
                 "and receive a response from Slack API.",
             ),
-            prefixed_extra_field("base_url", cls.conn_type): StringField(
+            "base_url": StringField(
                 lazy_gettext('Base URL'),
                 widget=BS3TextFieldWidget(),
                 description="Optional. A string representing the Slack API base URL.",
             ),
-            prefixed_extra_field("proxy", cls.conn_type): StringField(
+            "proxy": StringField(
                 lazy_gettext('Proxy'),
                 widget=BS3TextFieldWidget(),
                 description="Optional. Proxy to make the Slack API call.",
@@ -316,6 +348,7 @@ class SlackHook(BaseHook):
         }
 
     @classmethod
+    @_ensure_prefixes(conn_type='slack')
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Returns custom field behaviour."""
         return {
@@ -325,8 +358,8 @@ class SlackHook(BaseHook):
             },
             "placeholders": {
                 "password": "xoxb-1234567890123-09876543210987-AbCdEfGhIjKlMnOpQrStUvWx",
-                prefixed_extra_field("timeout", cls.conn_type): "30",
-                prefixed_extra_field("base_url", cls.conn_type): "https://www.slack.com/api/",
-                prefixed_extra_field("proxy", cls.conn_type): "http://localhost:9000",
+                "timeout": "30",
+                "base_url": "https://www.slack.com/api/",
+                "proxy": "http://localhost:9000",
             },
         }

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -44,7 +44,9 @@ def _ensure_prefixes(conn_type):
     """
 
     def dec(func):
-        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+        @wraps(func)
+        def inner(cls):
+            field_behaviors = func(cls)
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):
@@ -56,12 +58,7 @@ def _ensure_prefixes(conn_type):
             if 'placeholders' in field_behaviors:
                 placeholders = field_behaviors['placeholders']
                 field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
-
             return field_behaviors
-
-        @wraps(func)
-        def inner(cls):
-            return _ensure_prefix_for_placeholders(func(cls), conn_type)
 
         return inner
 

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -62,7 +62,9 @@ def _ensure_prefixes(conn_type):
     """
 
     def dec(func):
-        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+        @wraps(func)
+        def inner(cls):
+            field_behaviors = func(cls)
             conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
             def _ensure_prefix(field):
@@ -74,12 +76,7 @@ def _ensure_prefixes(conn_type):
             if 'placeholders' in field_behaviors:
                 placeholders = field_behaviors['placeholders']
                 field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
-
             return field_behaviors
-
-        @wraps(func)
-        def inner():
-            return _ensure_prefix_for_placeholders(func(), conn_type)
 
         return inner
 

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -29,7 +29,7 @@ from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
-from airflow.providers.slack.utils import ConnectionExtraConfig, prefixed_extra_field
+from airflow.providers.slack.utils import ConnectionExtraConfig
 from airflow.utils.log.secrets_masker import mask_secret
 
 if TYPE_CHECKING:
@@ -53,6 +53,37 @@ def check_webhook_response(func: Callable) -> Callable:
         return resp
 
     return wrapper
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: str):
+            conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith('extra__'):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if 'placeholders' in field_behaviors:
+                placeholders = field_behaviors['placeholders']
+                field_behaviors['placeholders'] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+
+            return field_behaviors
+
+        @wraps(func)
+        def inner():
+            return _ensure_prefix_for_placeholders(func(), conn_type)
+
+        return inner
+
+    return dec
 
 
 class SlackWebhookHook(BaseHook):
@@ -423,14 +454,14 @@ class SlackWebhookHook(BaseHook):
         from wtforms.validators import NumberRange, Optional
 
         return {
-            prefixed_extra_field("timeout", cls.conn_type): IntegerField(
+            "timeout": IntegerField(
                 lazy_gettext("Timeout"),
                 widget=BS3TextFieldWidget(),
                 validators=[Optional(), NumberRange(min=1)],
                 description="Optional. The maximum number of seconds the client will wait to connect "
                 "and receive a response from Slack Incoming Webhook.",
             ),
-            prefixed_extra_field("proxy", cls.conn_type): StringField(
+            "proxy": StringField(
                 lazy_gettext('Proxy'),
                 widget=BS3TextFieldWidget(),
                 description="Optional. Proxy to make the Slack Incoming Webhook call.",
@@ -438,6 +469,7 @@ class SlackWebhookHook(BaseHook):
         }
 
     @classmethod
+    @_ensure_prefixes(conn_type='slackwebhook')
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Returns custom field behaviour."""
         return {
@@ -450,8 +482,8 @@ class SlackWebhookHook(BaseHook):
                 "schema": "https",
                 "host": "hooks.slack.com/services",
                 "password": "T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-                prefixed_extra_field("timeout", cls.conn_type): "30",
-                prefixed_extra_field("proxy", cls.conn_type): "http://localhost:9000",
+                "timeout": "30",
+                "proxy": "http://localhost:9000",
             },
         }
 

--- a/airflow/providers/slack/utils/__init__.py
+++ b/airflow/providers/slack/utils/__init__.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 try:
@@ -26,11 +27,6 @@ except ImportError:  # TODO: Remove when the provider has an Airflow 2.3+ requir
         """Sentinel type for annotations, useful when None is not viable."""
 
     NOTSET = ArgNotSet()  # type: ignore[assignment]
-
-
-def prefixed_extra_field(field: str, conn_type: str) -> str:
-    """Get prefixed extra field name."""
-    return f"extra__{conn_type}__{field}"
 
 
 class ConnectionExtraConfig:
@@ -53,20 +49,27 @@ class ConnectionExtraConfig:
         :param field: Connection extra field name.
         :param default: If specified then use as default value if field not present in Connection Extra.
         """
-        prefixed_field = prefixed_extra_field(field, self.conn_type)
-        if prefixed_field in self.extra and self.extra[prefixed_field] not in (None, ""):
+        backcompat_key = f"extra__{self.conn_type}__{field}"
+        if self.extra.get(field) not in (None, ''):
+            if self.extra.get(backcompat_key) not in (None, ''):
+                warnings.warn(
+                    f"Conflicting params `{field}` and `{backcompat_key}` found in extras for conn "
+                    f"{self.conn_id}. Using value for `{field}`.  Please ensure this is the correct value "
+                    f"and remove the backcompat key `{backcompat_key}`."
+                )
+            return self.extra[field]
+        elif backcompat_key in self.extra and self.extra[backcompat_key] not in (None, ""):
             # Addition validation with non-empty required for connection which created in the UI
             # in Airflow 2.2. In these connections always present key-value pair for all prefixed extras
             # even if user do not fill this fields.
             # In additional fields from `wtforms.IntegerField` might contain None value.
             # E.g.: `{'extra__slackwebhook__proxy': '', 'extra__slackwebhook__timeout': None}`
-            return self.extra[prefixed_field]
-        elif field in self.extra:
-            return self.extra[field]
+            # From Airflow 2.3, using the prefix is no longer required.
+            return self.extra[backcompat_key]
         else:
             if default is NOTSET:
                 raise KeyError(
-                    f"Couldn't find {prefixed_field!r} or {field!r} "
+                    f"Couldn't find {backcompat_key!r} or {field!r} "
                     f"in Connection ({self.conn_id!r}) Extra and no default value specified."
                 )
             return default

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -17,10 +17,14 @@
 # under the License.
 from __future__ import annotations
 
+import json
+import os
 from typing import Any
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
+from pytest import param
 from slack_sdk.errors import SlackApiError
 from slack_sdk.http_retry.builtin_handlers import ConnectionErrorRetryHandler, RateLimitErrorRetryHandler
 from slack_sdk.web.slack_response import SlackResponse
@@ -28,6 +32,7 @@ from slack_sdk.web.slack_response import SlackResponse
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.models.connection import Connection
 from airflow.providers.slack.hooks.slack import SlackHook
+from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
 
 MOCK_SLACK_API_TOKEN = "xoxb-1234567890123-09876543210987-AbCdEfGhIjKlMnOpQrStUvWx"
 SLACK_API_DEFAULT_CONN_ID = SlackHook.default_conn_name
@@ -439,3 +444,82 @@ class TestSlackHook:
             title=title,
             filetype=filetype,
         )
+
+    def test__ensure_prefixes_removal(self):
+        """Ensure that _ensure_prefixes is removed from snowflake when airflow min version >= 2.5.0."""
+        path = 'airflow.providers.slack.hooks.slack._ensure_prefixes'
+        if not object_exists(path):
+            raise Exception(
+                "You must remove this test. It only exists to "
+                "remind us to remove decorator `_ensure_prefixes`."
+            )
+
+        if get_provider_min_airflow_version('apache-airflow-providers-slack') >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from SlackHook."
+                " The functionality is now taken care of by providers manager."
+            )
+
+    def test___ensure_prefixes(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test when removing ensure_prefixes (after min airflow version >= 2.5.0
+        """
+        assert list(SlackHook.get_ui_field_behaviour()['placeholders'].keys()) == [
+            'password',
+            'extra__slack__timeout',
+            'extra__slack__base_url',
+            'extra__slack__proxy',
+        ]
+
+    @pytest.mark.parametrize(
+        'uri',
+        [
+            param(
+                'a://:abc@?extra__slack__timeout=123&extra__slack__base_url=base_url&extra__slack__proxy=proxy',
+                id='prefix',
+            ),
+            param('a://:abc@?timeout=123&base_url=base_url&proxy=proxy', id='no-prefix'),
+        ],
+    )
+    def test_backcompat_prefix_works(self, uri):
+        with patch.dict(os.environ, AIRFLOW_CONN_MY_CONN=uri):
+            hook = SlackHook(slack_conn_id='my_conn')
+            params = hook._get_conn_params()
+            assert params["token"] == "abc"
+            assert params["timeout"] == 123
+            assert params["base_url"] == "base_url"
+            assert params["proxy"] == "proxy"
+
+    def test_backcompat_prefix_both_causes_warning(self):
+        with patch.dict(
+            in_dict=os.environ,
+            AIRFLOW_CONN_MY_CONN='a://:abc@?extra__slack__timeout=111&timeout=222',
+        ):
+            hook = SlackHook(slack_conn_id='my_conn')
+            with pytest.warns(Warning, match='Using value for `timeout`'):
+                params = hook._get_conn_params()
+                assert params["timeout"] == 222
+
+    def test_empty_string_ignored_prefixed(self):
+        with patch.dict(
+            in_dict=os.environ,
+            AIRFLOW_CONN_MY_CONN=json.dumps(
+                {"password": "hi", "extra": {"extra__slack__base_url": "", "extra__slack__proxy": ""}}
+            ),
+        ):
+            hook = SlackHook(slack_conn_id='my_conn')
+            params = hook._get_conn_params()
+            assert 'proxy' not in params
+            assert 'base_url' not in params
+
+    def test_empty_string_ignored_non_prefixed(self):
+        with patch.dict(
+            in_dict=os.environ,
+            AIRFLOW_CONN_MY_CONN=json.dumps({"password": "hi", "extra": {"base_url": "", "proxy": ""}}),
+        ):
+            hook = SlackHook(slack_conn_id='my_conn')
+            params = hook._get_conn_params()
+            assert 'proxy' not in params
+            assert 'base_url' not in params

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -477,7 +477,9 @@ class TestSlackHook:
         'uri',
         [
             param(
-                'a://:abc@?extra__slack__timeout=123&extra__slack__base_url=base_url&extra__slack__proxy=proxy',
+                'a://:abc@?extra__slack__timeout=123'
+                '&extra__slack__base_url=base_url'
+                '&extra__slack__proxy=proxy',
                 id='prefix',
             ),
             param('a://:abc@?timeout=123&base_url=base_url&proxy=proxy', id='no-prefix'),

--- a/tests/providers/slack/utils/test_utils.py
+++ b/tests/providers/slack/utils/test_utils.py
@@ -57,7 +57,7 @@ class TestConnectionExtra:
             conn_id="test-conn-id",
             extra={"arg1": "foo", f"extra__{conn_type}__arg1": "bar"},
         )
-        assert extra_config.get("arg1") == "bar"
+        assert extra_config.get("arg1") == "foo"
 
     @pytest.mark.parametrize("conn_type", ["slack", "slack_incoming_webhook"])
     @pytest.mark.parametrize("empty_value", [None, ""])

--- a/tests/test_utils/providers.py
+++ b/tests/test_utils/providers.py
@@ -46,3 +46,13 @@ def get_provider_version(provider_name):
 
     info = ProvidersManager().providers[provider_name]
     return semver.VersionInfo.parse(info.version)
+
+
+def get_provider_min_airflow_version(provider_name):
+    from airflow.providers_manager import ProvidersManager
+
+    p = ProvidersManager()
+    deps = p.providers[provider_name].data['dependencies']
+    airflow_dep = [x for x in deps if x.startswith('apache-airflow')][0]
+    min_airflow_version = tuple(map(int, airflow_dep.split('>=')[1].split('.')))
+    return min_airflow_version


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.
