### PR TITLE
Fix flakey test `TestCliDags.test_trigger_dag_invalid_conf`

### DIFF
--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -59,6 +59,9 @@ class TestCliDags:
         clear_db_runs()
         clear_db_dags()
 
+    def setup_method(self):
+        clear_db_runs()  # clean-up all dag run before start each test
+
     def test_reserialize(self):
         # Assert that there are serialized Dags
         with create_session() as session:


### PR DESCRIPTION
Last couple of days quite a few CI tests failed with selected error

```
__________________ TestCliDags.test_trigger_dag_invalid_conf ___________________
  
  self = <tests.cli.commands.test_dag_command.TestCliDags object at 0x7effeda0e790>
  
      def test_trigger_dag_invalid_conf(self):
          with pytest.raises(ValueError):
              dag_command.dag_trigger(
                  self.parser.parse_args(
                      [
                          'dags',
                          'trigger',
                          'example_bash_operator',
                          '--run-id',
                          'trigger_dag_xxx',
                          '--conf',
  >                       'NOT JSON',
                      ]
                  ),
              )

...


E  airflow.exceptions.DagRunAlreadyExists: A Dag Run already exists for dag id example_bash_operator at 2022-10-16 14:41:31+00:00 with run id trigger_dag_xxx
  
  airflow/api/common/trigger_dag.py:79: DagRunAlreadyExists
```

This happen because we do not cleanup DagRuns between the tests within the test class and time to time it uses the same execution date / run_id.
It also might happen because config validation happen after create DagRun.

Current fix also might solve other race conditions in this test class