### PR TITLE
Fix IntegrityError during webserver startup

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -414,6 +414,8 @@ def webserver(args):
 
         run_args += ["airflow.www.app:cached_app()"]
 
+        run_args += ['--preload']
+
         gunicorn_master_proc = None
 
         def kill_proc(signum, _):

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -405,6 +405,7 @@ class TestCliWebServer:
                     '--access-logformat',
                     'custom_log_format',
                     'airflow.www.app:cached_app()',
+                    '--preload',
                 ],
                 close_fds=True,
             )


### PR DESCRIPTION
When starting up the webserver, we create all the `gunicorn` workers needed and each of these workers would now have a copy of the webserver app. Running this copy by each worker causes a lot of IntegrityError in the database.

However, Gunicorn has a `--preload` option which helps to load the application code before
starting the workers. I have no idea why we are not using it but using it helped resolve the Integrity Errors.

Happy to hear from you.

closes: https://github.com/apache/airflow/issues/23512