### PR TITLE
Allow session properties for trino connection

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -101,6 +101,7 @@ class TrinoHook(DbApiHook):
         extra = db.extra_dejson
         auth = None
         user = db.login
+        session_properties = extra.get('session_properties')
         if db.password and extra.get('auth') in ('kerberos', 'certs'):
             raise AirflowException(f"The {extra.get('auth')!r} authorization type doesn't support password.")
         elif db.password:
@@ -145,6 +146,7 @@ class TrinoHook(DbApiHook):
             # type: ignore[func-returns-value]
             isolation_level=self.get_isolation_level(),
             verify=_boolify(extra.get('verify', True)),
+            session_properties=session_properties if session_properties else None,
         )
 
         return trino_conn

--- a/docs/apache-airflow-providers-trino/connections.rst
+++ b/docs/apache-airflow-providers-trino/connections.rst
@@ -51,3 +51,4 @@ Extra (optional, connection parameters)
     * ``jwt__token`` - If jwt authentication should be used, the value of token is given via this parameter.
     * ``certs__client_cert_path``, ``certs__client_key_path``- If certificate authentication should be used, the path to the client certificate and key is given via these parameters.
     * ``kerberos__service_name``, ``kerberos__config``, ``kerberos__mutual_authentication``, ``kerberos__force_preemptive``, ``kerberos__hostname_override``, ``kerberos__sanitize_mutual_error_response``, ``kerberos__principal``,``kerberos__delegate``, ``kerberos__ca_bundle`` - These parameters can be set when enabling ``kerberos`` authentication.
+    * ``session_properties`` - JSON dictionary which allows to set session_properties. Example: ``{'session_properties':{'scale_writers':true,'task_writer_count:1'}}``


### PR DESCRIPTION
Hi, I was using the Trino provider package of airflow. While using I found out that I am not able to set `session_properties` for the Trino connector.  So I am creating this PR to fix this. This way if the user needs to add session_properties from Airflow UI they can add it like below

```
{"catalog": "hive", "protocol": "https", "session_properties": "{'hive.insert_existing_partitions_behavior':'OVERWRITE', 'scale_writers':'true','task_writer_count':'1','writer_min_size':'32MB'}"}
```

![image](https://user-images.githubusercontent.com/14219201/142755452-28c0a44b-ac7c-4059-adff-453d35b4d5e9.png)


Let me know if any changes or additional work is required


Stale PR was opened by me a long time ago, creating a new one again because the old one could not be reopened. 

https://github.com/apache/airflow/pull/19733