### PR TITLE
Add `handler` to mssql and mysql operators

### DIFF
--- a/airflow/providers/jdbc/operators/jdbc.py
+++ b/airflow/providers/jdbc/operators/jdbc.py
@@ -44,6 +44,8 @@ class JdbcOperator(BaseOperator):
     :param autocommit: if True, each command is automatically committed.
         (default value: False)
     :param parameters: (optional) the parameters to render the SQL query with.
+    :param handler: A Python callable that will act on the cursor result.
+        By default, it will use ``fetchall``
     """
 
     template_fields: Sequence[str] = ('sql',)

--- a/tests/system/providers/microsoft/mssql/example_mssql.py
+++ b/tests/system/providers/microsoft/mssql/example_mssql.py
@@ -54,7 +54,6 @@ with DAG(
             continent TEXT
         );
         """,
-        dag=dag,
     )
 
     # [END howto_operator_mssql]
@@ -84,7 +83,6 @@ with DAG(
         task_id='create_table_from_external_file',
         mssql_conn_id='airflow_mssql',
         sql='create_table.sql',
-        dag=dag,
     )
     # [END mssql_operator_howto_guide_create_table_mssql_from_external_file]
 
@@ -106,10 +104,13 @@ with DAG(
     # [END mssql_operator_howto_guide_populate_user_table]
 
     # [START mssql_operator_howto_guide_get_all_countries]
+    from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+
     get_all_countries = MsSqlOperator(
         task_id="get_all_countries",
         mssql_conn_id='airflow_mssql',
         sql=r"""SELECT * FROM Country;""",
+        handler=fetch_all_handler,
     )
     # [END mssql_operator_howto_guide_get_all_countries]
 

--- a/tests/system/providers/mysql/example_mysql.py
+++ b/tests/system/providers/mysql/example_mysql.py
@@ -40,7 +40,12 @@ with DAG(
     # [START howto_operator_mysql]
 
     drop_table_mysql_task = MySqlOperator(
-        task_id='drop_table_mysql', sql=r"""DROP TABLE table_name;""", dag=dag
+        task_id='drop_table_mysql', sql=r"""DROP TABLE table_name;"""
+    )
+
+    from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+    get_results_task = MySqlOperator(
+        task_id='get_results_mysql', sql="SELECT 1;", handler=fetch_all_handler
     )
 
     # [END howto_operator_mysql]
@@ -50,7 +55,6 @@ with DAG(
     mysql_task = MySqlOperator(
         task_id='drop_table_mysql_external_file',
         sql='/scripts/drop_table.sql',
-        dag=dag,
     )
 
     # [END howto_operator_mysql_external_file]


### PR DESCRIPTION
Add `handler` parameter consistently to more SQL Operators
---
The `handler` property is mentioned in some operators, but not others, giving those operators no way to push SQL results as an XCOM. This is a very useful thing, for instance if you wanted to use `dynamic task mapping` over the results of a SQL query.

I updated some system tests to show usage, and updated doc strings.