### PR TITLE
optimise task instances filtering

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2449,16 +2449,16 @@ class TaskInstance(Base, LoggingMixin):
             )
 
         filter_condition = []
-        # create 2 nested groups, both primarily grouped by dag_id and run_id, 
-        # and in the nested group 1 grouped by task_id the other by map_index
+        # create 2 nested groups, both primarily grouped by dag_id and run_id,
+        # and in the nested group 1 grouped by task_id the other by map_index.
         task_id_groups: dict[tuple, dict[Any, list[Any]]] = defaultdict(lambda: defaultdict(list))
         map_index_groups: dict[tuple, dict[Any, list[Any]]] = defaultdict(lambda: defaultdict(list))
         for t in tis:
             task_id_groups[(t.dag_id, t.run_id)][t.task_id].append(t.map_index)
             map_index_groups[(t.dag_id, t.run_id)][t.map_index].append(t.task_id)
 
-        # this assumes that most dags have dag_id as the largest grouping, followed by run_id. even if its not, this is still
-        # a significant optimization over querying for every single tuple key
+        # this assumes that most dags have dag_id as the largest grouping, followed by run_id. even
+        # if its not, this is still  a significant optimization over querying for every single tuple key
         for cur_dag_id in dag_ids:
             for cur_run_id in run_ids:
                 # we compare the group size between task_id and map_index and use the smaller group
@@ -2470,9 +2470,9 @@ class TaskInstance(Base, LoggingMixin):
                         filter_condition.append(
                             and_(
                                 TaskInstance.dag_id == cur_dag_id,
-                                TaskInstance.run_id == cur_run_id, 
+                                TaskInstance.run_id == cur_run_id,
                                 TaskInstance.task_id == cur_task_id,
-                                TaskInstance.map_index.in_(cur_map_indices)
+                                TaskInstance.map_index.in_(cur_map_indices),
                             )
                         )
                 else:
@@ -2484,10 +2484,9 @@ class TaskInstance(Base, LoggingMixin):
                                 TaskInstance.task_id.in_(cur_task_ids),
                                 TaskInstance.map_index == cur_map_index,
                             )
-                        )       
-                
-        return or_(*filter_condition)
+                        )
 
+        return or_(*filter_condition)
 
     @classmethod
     def ti_selector_condition(cls, vals: Collection[str | tuple[str, int]]) -> ColumnOperators:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2440,7 +2440,7 @@ class TaskInstance(Base, LoggingMixin):
                 TaskInstance.map_index == map_index,
                 TaskInstance.task_id == first_task_id,
             )
-        if dag_ids == {dag_id} and run_ids == {run_id} and task_ids == {task_id}:
+        if dag_ids == {dag_id} and run_ids == {run_id} and task_ids == {first_task_id}:
             return and_(
                 TaskInstance.dag_id == dag_id,
                 TaskInstance.run_id == run_id,
@@ -2484,10 +2484,7 @@ class TaskInstance(Base, LoggingMixin):
                             )
                         )       
                 
-        return and_(
-            TaskInstance.map_index == map_index,
-            or_(*filter_condition)
-        )   
+        return or_(*filter_condition)
 
 
     @classmethod

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2449,7 +2449,8 @@ class TaskInstance(Base, LoggingMixin):
             )
 
         filter_condition = []
-        # create 2 groups, 1 grouped by task_id the other by map_index and use the smaller group
+        # create 2 nested groups, both primarily grouped by dag_id and run_id, 
+        # and in the nested group 1 grouped by task_id the other by map_index
         task_id_groups, map_index_groups = defaultdict(lambda: defaultdict(list)), defaultdict(lambda: defaultdict(list))
         for t in tis:
             task_id_groups[(t.dag_id, t.run_id)][t.task_id].append(t.map_index)
@@ -2461,7 +2462,7 @@ class TaskInstance(Base, LoggingMixin):
             for cur_run_id in run_ids:
                 # we compare the group size between task_id and map_index and use the smaller group
                 dag_task_id_groups = task_id_groups[(cur_dag_id, cur_run_id)]
-                dag_map_index_groups = task_id_groups[(cur_dag_id, cur_run_id)]
+                dag_map_index_groups = map_index_groups[(cur_dag_id, cur_run_id)]
 
                 if len(dag_task_id_groups) <= len(dag_map_index_groups):
                     for cur_task_id, cur_map_indices in dag_task_id_groups.items():

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -11,7 +11,7 @@
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF dict[dict[int, list[int]]]
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2415,8 +2415,6 @@ class TaskInstance(Base, LoggingMixin):
         run_id = first.run_id
         map_index = first.map_index
         first_task_id = first.task_id
-        # Common path optimisations: when all TIs are for the same dag_id and run_id, or same dag_id
-        # and task_id -- this can be over 150x faster for huge numbers of TIs (20k+)
 
         # pre-compute the set of dag_id, run_id, map_indices and task_ids
         dag_ids, run_ids, map_indices, task_ids = set(), set(), set(), set()
@@ -2426,6 +2424,8 @@ class TaskInstance(Base, LoggingMixin):
             map_indices.add(t.map_index)
             task_ids.add(t.task_id)
 
+        # Common path optimisations: when all TIs are for the same dag_id and run_id, or same dag_id
+        # and task_id -- this can be over 150x faster for huge numbers of TIs (20k+)
         if dag_ids == {dag_id} and run_ids == {run_id} and map_indices == {map_index}:
             return and_(
                 TaskInstance.dag_id == dag_id,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -11,7 +11,7 @@
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF dict[dict[int, list[int]]]
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
@@ -2451,7 +2451,8 @@ class TaskInstance(Base, LoggingMixin):
         filter_condition = []
         # create 2 nested groups, both primarily grouped by dag_id and run_id, 
         # and in the nested group 1 grouped by task_id the other by map_index
-        task_id_groups, map_index_groups = defaultdict(lambda: defaultdict(list)), defaultdict(lambda: defaultdict(list))
+        task_id_groups: dict[tuple, dict[Any, list[Any]]] = defaultdict(lambda: defaultdict(list))
+        map_index_groups: dict[tuple, dict[Any, list[Any]]] = defaultdict(lambda: defaultdict(list))
         for t in tis:
             task_id_groups[(t.dag_id, t.run_id)][t.task_id].append(t.map_index)
             map_index_groups[(t.dag_id, t.run_id)][t.map_index].append(t.task_id)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -24,6 +24,7 @@ import tempfile
 import unittest
 import zipfile
 from datetime import time, timedelta
+from airflow.decorators import task
 
 import pytest
 
@@ -1116,6 +1117,10 @@ def dag_bag_head_tail():
     dag_bag = DagBag(dag_folder=DEV_NULL, include_examples=False)
 
     with DAG("head_tail", start_date=DEFAULT_DATE, schedule="@daily") as dag:
+        @task
+        def dummy_task(x: int):
+            return x
+
         head = ExternalTaskSensor(
             task_id="head",
             external_dag_id=dag.dag_id,
@@ -1123,7 +1128,8 @@ def dag_bag_head_tail():
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )
-        body = EmptyOperator(task_id="body")
+        
+        body = dummy_task.expand(x=[i for i in range(5)])
         tail = ExternalTaskMarker(
             task_id="tail",
             external_dag_id=dag.dag_id,
@@ -1153,15 +1159,20 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
         )
         session.add(dagrun)
         for task in dag.tasks:
-            ti = TaskInstance(task=task)
-            dagrun.task_instances.append(ti)
+            if task.task_id == "dummy_task":
+                for map_index in range(5):
+                    ti = TaskInstance(task=task, map_index=map_index)
+                    dagrun.task_instances.append(ti)
+            else:
+                ti = TaskInstance(task=task)
+                dagrun.task_instances.append(ti)
             ti.state = TaskInstanceState.SUCCESS
     session.flush()
 
     # The next two lines are doing the same thing. Clearing the first "head" with "Future"
     # selected is the same as not selecting "Future". They should take similar amount of
     # time too because dag.clear() uses visited_external_tis to keep track of visited ExternalTaskMarker.
-    assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
+    assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 70
     assert (
         dag.clear(
             start_date=DEFAULT_DATE,
@@ -1169,7 +1180,7 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
             dag_bag=dag_bag_head_tail,
             session=session,
         )
-        == 30
+        == 70
     )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Optimises the way airflow filters for task instances by constructing faster sql queries

Originally if the list of task instances does not fulfil the condition of 3 out of 4 parameters (dag_id, run_id, map_index, task_id) matching each other, the function `filter_for_tis` will naively create a sql filter clause using an `IN` operator to filter for each of the composite keys (dag_id, run_id, map_index, task_id) present.
This is extremely slow when you're filtering for over 20,000+ task instances.

This optimised way of filtering creates multiple sub groups by first grouping the task instances by their dag_id, followed by their run_id. Following which, the groups created for task_id and map_index are compared and the grouping that results in a smaller number of groups will be used.

This means that a sql query that would look like
`
SELECT ...
FROM ...
WHERE (task_instance.dag_id, task_instance.task_id, task_instance.run_id, task_instance.map_index) IN ((...), 20,000+ more tuples...)
` 
would instead look like this:
`
SELECT ...
FROM ...
WHERE (task_instance.dag_id = <dag_id1> AND task_instance.run_id = <run_id1> AND task_instance.map_index = <map_index1> AND task_instance.task_id IN (task_id1, ...) 
OR (task_instance.dag_id = <dag_id1> AND task_instance.run_id = <run_id2> AND task_instance.map_index = <map_index1> AND task_instance.task_id IN (task_id1, ...)
OR (...)
... 
`

this significantly improves the query time, such that clearing a dag with downstream and recursive set and running over 20,000+ task instances is much faster.

to test this in breeze:
`
 pytest tests/sensors/test_external_task_sensor.py -k test_clear_overlapping_external_task_marker
`


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
