### PR TITLE
Create path for downloaded dbt artefact (#27107)

### DIFF
--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -206,6 +206,7 @@ class DbtCloudGetJobRunArtifactOperator(BaseOperator):
         )
 
         with open(self.output_file_name, "w") as file:
+            file.parent.mkdir(exist_ok=True, parents=True)
             if self.path.endswith(".json"):
                 json.dump(response.json(), file)
             else:

--- a/airflow/providers/dbt/cloud/operators/dbt.py
+++ b/airflow/providers/dbt/cloud/operators/dbt.py
@@ -17,7 +17,9 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
 
 from airflow.models import BaseOperator, BaseOperatorLink, XCom
 from airflow.providers.dbt.cloud.hooks.dbt import DbtCloudHook, DbtCloudJobRunException, DbtCloudJobRunStatus
@@ -204,9 +206,8 @@ class DbtCloudGetJobRunArtifactOperator(BaseOperator):
         response = hook.get_job_run_artifact(
             run_id=self.run_id, path=self.path, account_id=self.account_id, step=self.step
         )
-
+        Path(self.output_file_name).parent.mkdir(parents=True, exist_ok=True)
         with open(self.output_file_name, "w") as file:
-            file.parent.mkdir(exist_ok=True, parents=True)
             if self.path.endswith(".json"):
                 json.dump(response.json(), file)
             else:


### PR DESCRIPTION
closes: #27107
related: #27107

As mentioned in the Issue #27107, when downloading a dbt cloud artefact to a path with parents not yet created it (logically) fails, as this is the default behaviour. However integration with mounted fs like s3 and gcs benefit from descriptive path names, and further exploration benefits from having those names split in keys (folders). This is a default use case.
