### PR TITLE
Make namespace optional for KPO

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -37,7 +37,7 @@ Features
 
 * Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
 * KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied via KPO param or pod template file or full pod spec, then we'll check the airflow conn,
-then if in a k8s pod, try to infer the namespace from the container, then finally will use the ``default`` namespace.
+  then if in a k8s pod, try to infer the namespace from the container, then finally will use the ``default`` namespace.
 
 4.4.0
 .....

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -35,7 +35,9 @@ Previously KubernetesPodOperator considered some settings from the Airflow confi
 Features
 ~~~~~~~~
 
-Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
+* Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
+* KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied, we'll check the airflow conn,
+then if in a k8s pod, try to infer the namespace, then finally will use the ``default`` namespace.
 
 4.4.0
 .....

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -36,8 +36,8 @@ Features
 ~~~~~~~~
 
 * Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
-* KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied, we'll check the airflow conn,
-then if in a k8s pod, try to infer the namespace, then finally will use the ``default`` namespace.
+* KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied via KPO param or pod template file or full pod spec, then we'll check the airflow conn,
+then if in a k8s pod, try to infer the namespace from the container, then finally will use the ``default`` namespace.
 
 4.4.0
 .....

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -329,18 +329,11 @@ class KubernetesHook(BaseHook):
     def get_namespace(self) -> str | None:
         """Returns the namespace that defined in the connection"""
         if self.conn_id:
-            namespace = self.conn_extras.get("extra__kubernetes__namespace")
-            if not namespace:
-                warnings.warn(
-                    f"Param `namespace` found in conn `{self.conn_id}`. Returning value 'default'. "
-                    "In the future, we will return `None` in this case.  Please update your code.",
-                    category=DeprecationWarning,
-                )
-                return 'default'
-            else:
-                return namespace
-        else:
-            return None
+            connection = self.get_connection(self.conn_id)
+            extras = connection.extra_dejson
+            namespace = extras.get("extra__kubernetes__namespace", "default")
+            return namespace
+        return None
 
     def get_pod_log_stream(
         self,

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -329,11 +329,18 @@ class KubernetesHook(BaseHook):
     def get_namespace(self) -> str | None:
         """Returns the namespace that defined in the connection"""
         if self.conn_id:
-            connection = self.get_connection(self.conn_id)
-            extras = connection.extra_dejson
-            namespace = extras.get("extra__kubernetes__namespace", "default")
-            return namespace
-        return None
+            namespace = self.conn_extras.get("extra__kubernetes__namespace")
+            if not namespace:
+                warnings.warn(
+                    f"Param `namespace` found in conn `{self.conn_id}`. Returning value 'default'. "
+                    "In the future, we will return `None` in this case.  Please update your code.",
+                    category=DeprecationWarning,
+                )
+                return 'default'
+            else:
+                return namespace
+        else:
+            return None
 
     def get_pod_log_stream(
         self,

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -57,9 +57,7 @@ You can print out the Kubernetes manifest for the pod that would be created at r
 
 .. code-block:: python
 
-    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
-        KubernetesPodOperator,
-    )
+    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
     k = KubernetesPodOperator(
         name="hello-dry-run",
@@ -73,6 +71,18 @@ You can print out the Kubernetes manifest for the pod that would be created at r
 
     k.dry_run()
 
+Argument precedence
+^^^^^^^^^^^^^^^^^^^
+
+When building the pod object, there may be overlap between KPO params, pod spec, template and airflow connection.
+In general, the order of precedence is KPO argument > full pod spec > pod template file > airflow connection.
+
+For ``namespace``, if namespace is not provided via any of these methods, then we'll first try to
+get the current namespace (if the task is already running in kubernetes) and failing that we'll use
+the ``default`` namespace.
+
+For pod name, if not provided explicitly, we'll use the task_id. A random suffix is added by default so the pod
+name is not generally of great consequence.
 
 How to use cluster ConfigMaps, Secrets, and Volumes with Pod?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
In KPO, currently, if you do not provide namespace as a KPO arg (and it's not otherwise specified through pod template or full pod spec) the task will fail when trying to create the pod, because the kube client does not fill it in for you like e.g. kubectl does.
 
This PR makes it optional.

If it's not specified through KPO arg, or full pod spec, or pod template, then first we'll check the hook to see if you've configured a namespace there.  And if that is unspecified, if we're in a cluster already, we'll check /var/run/secrets/kubernetes.io/serviceaccount/namespace for the value.