### PR TITLE
Correct the JSON style used for Run config in Grid View

### DIFF
--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -187,7 +187,8 @@ const DagRun = ({ runId }: Props) => {
                     <Td>
                       <ReactJson
                         src={JSON.parse(conf ?? '')}
-                        theme="tomorrow"
+                        name={false}
+                        theme="rjv-default"
                         iconStyle="triangle"
                         indentWidth={2}
                         displayDataTypes={false}


### PR DESCRIPTION
This PR correct the visual display of the *new* Run config view in GRID view (I like this!) which I saw appeatring on the dev branch. unfortunately it is generating white text on white background, this PR proposed to switch to default theme so that dumped JSON gets readable.

Before (Using Firefox, "Light" mode):
- JSON Keys are white text on white background

![image](https://user-images.githubusercontent.com/95105677/196538015-30aff2f0-7bcd-4102-82df-cd4a8f313f37.png)

After this PR:
- Black text on white background (=readable)
- Root element of the Dict is hidden "wars printed as "root" before

![image](https://user-images.githubusercontent.com/95105677/196538082-4411301c-429f-413b-9842-514e1263f63d.png)
