### PR TITLE
create gitSync container in dag-processor pod when gitSync is enabled regardless the persistence conf

### DIFF
--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -131,7 +131,7 @@ spec:
 {{ tpl (toYaml .Values.dagProcessor.waitForMigrations.env) $ | indent 12 }}
 {{- end }}
         {{- end }}
-        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
+        {{- if .Values.dags.gitSync.enabled }}
         {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | nindent 8 }}
         {{- end }}
         {{- if .Values.dagProcessor.extraInitContainers }}
@@ -186,7 +186,7 @@ spec:
                   {{- else }}
                   {{- include "dag_processor_liveness_check_command" . | nindent 16 }}
                   {{- end }}
-        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
+        {{- if .Values.dags.gitSync.enabled }}
         {{- include "git_sync_container" . | indent 8 }}
         {{- end }}
         {{- if .Values.dagProcessor.extraContainers }}

--- a/tests/charts/test_dag_processor.py
+++ b/tests/charts/test_dag_processor.py
@@ -483,7 +483,7 @@ class DagProcessorTest(unittest.TestCase):
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]
 
-    def test_dags_gitsync_with_persistence_no_sidecar_or_init_container(self):
+    def test_dags_gitsync_with_persistence_sidecar_and_init_container(self):
         docs = render_chart(
             values={
                 "dagProcessor": {"enabled": True},
@@ -492,10 +492,8 @@ class DagProcessorTest(unittest.TestCase):
             show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
         )
 
-        # No gitsync sidecar or init container
-        assert "git-sync" not in [
-            c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])
-        ]
-        assert "git-sync-init" not in [
+        # gitsync sidecar and init container should be created
+        assert "git-sync" in [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        assert "git-sync-init" in [
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/27080

Before this [PR](https://github.com/apache/airflow/pull/23711) which added the standalone Dag Processors to the helm chart, the git sync logic was:
- if `dags.gitSync.enabled` then:
  1. add `git_sync_container-init` and  `git_sync_container` to scheduler pods containers
  2. load the volume `dags` from:
     -  a PVC if `dags.persistence.enabled`: claim existing PVC if `dags.persistence.existingClaim` is defined or create a new PVC if not
     -  `emptyDir` volume if not
  4. mount the volume `dags` to scheduler container as readOnly
  5. mount the volume `dags` to `git_sync_container`
- elif `dags.persistence.enabled` then:
  -  load the volume `dags` from an existing PVC if `dags.persistence.existingClaim` is defined or create a new PVC if not
  - add this volume to schedulers container
 
So when `dags.gitSync.enabled` we always had a `git_sync_container` running in the schedulers pods, and the `dags.persistence.enabled` is used to specify the volume type

After the PR, we create the `git_sync_container` in the scheduler pods only if:
- executor is one of the Local Executors and `gitSync` is enabled
- or `dagProcessor` is not enabled and `gitSync` is enabled

which I find logical ([code](https://github.com/gmsantos/airflow/blob/main/chart/templates/scheduler/scheduler-deployment.yaml#L221-L223))

But we create the `git_sync_container` in the `dag-processor` only if `gitSync` is enabled and `dags.persistence` is not enabled ([code](https://github.com/gmsantos/airflow/blob/main/chart/templates/dag-processor/dag-processor-deployment.yaml#L189-L191))

I think we can always create `git_sync_container` in the `dag-processor` pod when it is enabled and `gitSync` is enabled, and we use `dags.persistence` to switch between PVC and emptyDir