### PR TITLE
Add info about JSON Connection format for AWS SSM Parameter Store Secrets Backend

### DIFF
--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import warnings
 
 from airflow.compat.functools import cached_property
-from airflow.providers.amazon.aws.utils import get_airflow_version, trim_none_values
+from airflow.providers.amazon.aws.utils import trim_none_values
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -131,16 +131,18 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
         As of Airflow version 2.3.0 this method is deprecated.
 
         :param conn_id: the connection id
-        :return: deserialized Connection
         """
-        if get_airflow_version() >= (2, 3):
-            warnings.warn(
-                f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
-                "in a future release.  Please use method `get_conn_value` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return self.get_conn_value(conn_id)
+        warnings.warn(
+            f"Method `{self.__class__.__name__}.get_conn_uri` is deprecated and will be removed "
+            "in a future release. Please use method `get_conn_value` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        value = self.get_conn_value(conn_id)
+        if value is None:
+            return None
+
+        return self.deserialize_connection(conn_id, value).get_uri()
 
     def get_variable(self, key: str) -> str | None:
         """

--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
@@ -69,7 +69,7 @@ Optionally you can supply a profile name to reference aws profile, e.g. defined 
 The value of the SSM parameter must be the :ref:`connection URI representation <generating_connection_uri>`
 or in the :ref:`JSON Format <connection-serialization-json-example>` of the connection object.
 
-In some cases, URI's you will need stored in AWS SSM Parameter Store may not be intuitive,
+In some cases, URI's that you will need to store in AWS SSM Parameter Store may not be intuitive,
 for example when using HTTP / HTTPS or SPARK, you may need URI's that will look like this:
 
 .. code-block:: ini

--- a/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
+++ b/docs/apache-airflow-providers-amazon/secrets-backends/aws-ssm-parameter-store.rst
@@ -67,9 +67,10 @@ you would want to store your connection at ``/airflow/connections/smtp_default``
 Optionally you can supply a profile name to reference aws profile, e.g. defined in ``~/.aws/config``.
 
 The value of the SSM parameter must be the :ref:`connection URI representation <generating_connection_uri>`
-of the connection object.
+or in the :ref:`JSON Format <connection-serialization-json-example>` of the connection object.
 
-In some cases, URI's you will need stored in Secrets Manager may not be intuitive, for example when using HTTP / HTTPS or SPARK, you may need URI's that will look like this:
+In some cases, URI's you will need stored in AWS SSM Parameter Store may not be intuitive,
+for example when using HTTP / HTTPS or SPARK, you may need URI's that will look like this:
 
 .. code-block:: ini
 
@@ -79,7 +80,19 @@ In some cases, URI's you will need stored in Secrets Manager may not be intuitiv
 
 This is a known situation, where schema and protocol parts of the URI are independent and in some cases, need to be specified explicitly.
 
-See GitHub issue `#10256 <https://github.com/apache/airflow/pull/10256>`__ and `#10913 <https://github.com/apache/airflow/issues/10913>`__ for more detailed discussion that led to this documentation update. This may get resolved in the future.
+See GitHub issue `#10256 <https://github.com/apache/airflow/pull/10256>`__
+and `#10913 <https://github.com/apache/airflow/issues/10913>`__ for more detailed discussion that led to this documentation update.
+This may get resolved in the future.
+
+
+The same connections could be represented in AWS SSM Parameter Store as a JSON Object
+
+.. code-block:: json
+
+    {"conn_type": "http", "host": "https://example.com"}
+
+    {"conn_type": "spark", "host": "spark://spark-master-0.spark-master.spark", "port": 7077}
+
 
 Storing and Retrieving Variables
 """"""""""""""""""""""""""""""""

--- a/tests/providers/amazon/aws/secrets/test_systems_manager.py
+++ b/tests/providers/amazon/aws/secrets/test_systems_manager.py
@@ -16,8 +16,10 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+import json
+from unittest import mock
 
+import pytest
 from moto import mock_ssm
 
 from airflow.configuration import initialize_secrets_backends
@@ -25,7 +27,7 @@ from airflow.providers.amazon.aws.secrets.systems_manager import SystemsManagerP
 from tests.test_utils.config import conf_vars
 
 
-class TestSsmSecrets(TestCase):
+class TestSsmSecrets:
     @mock.patch(
         "airflow.providers.amazon.aws.secrets.systems_manager."
         "SystemsManagerParameterStoreBackend.get_conn_value"
@@ -36,18 +38,84 @@ class TestSsmSecrets(TestCase):
         assert conn.host == "host"
 
     @mock_ssm
-    def test_get_conn_value(self):
+    @pytest.mark.parametrize(
+        "ssm_value",
+        [
+            "postgres://my-login:my-pass@my-host:5432/my-schema?param1=val1&param2=val2",
+            json.dumps(
+                {
+                    "conn_type": "postgres",
+                    "login": "my-login",
+                    "password": "my-pass",
+                    "host": "my-host",
+                    "port": 5432,
+                    "schema": "my-schema",
+                    "extra": {"param1": "val1", "param2": "val2"},
+                }
+            ),
+        ],
+        ids=["uri-conn", "json-conn"],
+    )
+    def test_get_conn_value(self, ssm_value):
         param = {
             "Name": "/airflow/connections/test_postgres",
             "Type": "String",
-            "Value": "postgresql://airflow:airflow@host:5432/airflow",
+            "Value": ssm_value,
         }
 
         ssm_backend = SystemsManagerParameterStoreBackend()
         ssm_backend.client.put_parameter(**param)
 
-        returned_uri = ssm_backend.get_conn_value(conn_id="test_postgres")
-        assert "postgresql://airflow:airflow@host:5432/airflow" == returned_uri
+        returned_conn_value = ssm_backend.get_conn_value(conn_id="test_postgres")
+        assert ssm_value == returned_conn_value
+
+        test_conn = ssm_backend.get_connection(conn_id="test_postgres")
+        assert test_conn.conn_id == "test_postgres"
+        assert test_conn.conn_type == "postgres"
+        assert test_conn.login == "my-login"
+        assert test_conn.password == "my-pass"
+        assert test_conn.host == "my-host"
+        assert test_conn.port == 5432
+        assert test_conn.schema == "my-schema"
+        assert test_conn.extra_dejson == {"param1": "val1", "param2": "val2"}
+
+    @mock_ssm
+    @pytest.mark.parametrize(
+        "ssm_value",
+        [
+            "postgres://my-login:my-pass@my-host:5432/my-schema?param1=val1&param2=val2",
+            json.dumps(
+                {
+                    "conn_type": "postgres",
+                    "login": "my-login",
+                    "password": "my-pass",
+                    "host": "my-host",
+                    "port": 5432,
+                    "schema": "my-schema",
+                    "extra": {"param1": "val1", "param2": "val2"},
+                }
+            ),
+        ],
+        ids=["uri-conn", "json-conn"],
+    )
+    def test_deprecated_get_conn_uri(self, ssm_value):
+        param = {
+            "Name": "/airflow/connections/test_postgres",
+            "Type": "String",
+            "Value": ssm_value,
+        }
+
+        ssm_backend = SystemsManagerParameterStoreBackend()
+        ssm_backend.client.put_parameter(**param)
+
+        warning_message = (
+            r"Method `.*\.get_conn_uri` is deprecated and will be removed in a future release\. "
+            r"Please use method `get_conn_value` instead\."
+        )
+        with pytest.warns(DeprecationWarning, match=warning_message):
+            returned_uri = ssm_backend.get_conn_uri(conn_id="test_postgres")
+
+        assert returned_uri == "postgres://my-login:my-pass@my-host:5432/my-schema?param1=val1&param2=val2"
 
     @mock_ssm
     def test_get_conn_value_non_existent_key(self):


### PR DESCRIPTION
Since Airflow 2.3 Connection could be represented as JSON object which perfectly work without any changes in `SystemsManagerParameterStoreBackend.get_conn_value`

- Add appropriate info in AWS SSM Parameter Store Secrets Backend doc
- Add tests that it actually works with SSM Parameter Store SB (also helps if something changed in the future)
- Add changes in deprecated method `SystemsManagerParameterStoreBackend.get_conn_uri` so it return always URI even if it stored as JSON objects. I do not know but might be better just remove this method since it should not use internally in Airflow since 2.3 however it might use in some user code.