### PR TITLE
Don't overwrite connection extra with invalid json

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -180,6 +180,7 @@ class ConnectionForm(DynamicForm):
     conn_id = StringField(
         lazy_gettext('Connection Id'), validators=[InputRequired()], widget=BS3TextFieldWidget()
     )
+    # conn_type is added later via lazy_add_provider_discovered_options_to_connection_form
     description = StringField(lazy_gettext('Description'), widget=BS3TextAreaFieldWidget())
     host = StringField(lazy_gettext('Host'), widget=BS3TextFieldWidget())
     schema = StringField(lazy_gettext('Schema'), widget=BS3TextFieldWidget())

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4229,14 +4229,15 @@ class ConnectionModelView(AirflowModelView):
                 flash(
                     Markup(
                         "<p>The <em>Extra</em> connection field contained an invalid value for Conn ID: "
-                        f"<q>{conn_id}</q>.</p>"
+                        "<q>{conn_id}</q>.</p>"
                         "<p>If connection parameters need to be added to <em>Extra</em>, "
                         "please make sure they are in the form of a single, valid JSON object.</p><br>"
                         "The following <em>Extra</em> parameters were <b>not</b> added to the connection:<br>"
-                        f"{extra_json}",
-                    ),
+                        "{extra_json}"
+                    ).format(conn_id=conn_id, extra_json=extra_json),
                     category="error",
                 )
+                del form.extra
         del extra_json
 
         for key in self.extra_fields:


### PR DESCRIPTION
If invalid json is provided for a connection's extra, don't actually overwrite it with the invalid data. This matches the intended behavior, based on the flash message we show the user.