### PR TITLE
Make custom env vars optional for job templates

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -92,10 +92,14 @@ spec:
           {{- if .Values.createUserJob.args }}
           args: {{ tpl (toYaml .Values.createUserJob.args) . | nindent 12 }}
           {{- end }}
+          {{- if .Values.createUserJob.applyCustomEnv }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
+          {{ else }}
+          env:
+          {{- end }}
           {{- include "standard_airflow_environment" . | indent 10 }}
           {{- include "container_extra_envs" (list . .Values.createUserJob.env) | indent 10 }}
           resources:

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -92,12 +92,16 @@ spec:
           {{- if .Values.migrateDatabaseJob.args }}
           args: {{ tpl (toYaml .Values.migrateDatabaseJob.args) . | nindent 12 }}
           {{- end }}
+          {{- if .Values.migrateDatabaseJob.applyCustomEnv }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:
+          {{- include "custom_airflow_environment" . | indent 10 }}
+          {{ else }}
+          env:
+          {{- end }}
             - name: PYTHONUNBUFFERED
               value: "1"
-          {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
           resources:
 {{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2885,6 +2885,11 @@
                     "type": "boolean",
                     "default": true
                 },
+                "applyCustomEnv": {
+                    "description": "Specify if you want additional configured env vars applied to this job",
+                    "type": "boolean",
+                    "default": true
+                },
                 "env": {
                     "description": "Add additional env vars to the create user job pod.",
                     "type": "array",
@@ -3077,6 +3082,11 @@
                 },
                 "useHelmHooks": {
                     "description": "Specify if you want to use the default Helm Hook annotations",
+                    "type": "boolean",
+                    "default": true
+                },
+                "applyCustomEnv": {
+                    "description": "Specify if you want additional configured env vars applied to this job",
                     "type": "boolean",
                     "default": true
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -804,6 +804,8 @@ createUserJob:
   # In case you need to disable the helm hooks that create the jobs after install.
   # Disable this if you are using ArgoCD for example
   useHelmHooks: true
+  applyCustomEnv: true
+
   env: []
 
   resources: {}
@@ -872,6 +874,7 @@ migrateDatabaseJob:
   # In case you need to disable the helm hooks that create the jobs after install.
   # Disable this if you are using ArgoCD for example
   useHelmHooks: true
+  applyCustomEnv: true
 
 # Airflow webserver settings
 webserver:

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -132,7 +132,9 @@ will not start as the migrations will not be run:
 
     createUserJob:
       useHelmHooks: false
+      applyCustomEnv: false
     migrateDatabaseJob:
       useHelmHooks: false
+      applyCustomEnv: false
 
 This also applies if you install the chart using ``--wait`` in your ``helm install`` command.

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -125,7 +125,7 @@ The command removes all the Kubernetes components associated with the chart and 
 Installing the Chart with Argo CD, Flux or Terraform
 -----------------------------------------------------
 
-When installing the chart using Argo CD, Flux, or Terraform, you MUST set the two following values, or your application
+When installing the chart using Argo CD, Flux, or Terraform, you MUST set the four following values, or your application
 will not start as the migrations will not be run:
 
 .. code-block:: yaml
@@ -136,5 +136,7 @@ will not start as the migrations will not be run:
     migrateDatabaseJob:
       useHelmHooks: false
       applyCustomEnv: false
+
+This is so these CI/CD services can perform updates without issues and preserve the immutability of Kubernetes Job manifests.
 
 This also applies if you install the chart using ``--wait`` in your ``helm install`` command.

--- a/tests/charts/test_create_user_job.py
+++ b/tests/charts/test_create_user_job.py
@@ -195,6 +195,36 @@ class TestCreateUserJob:
             "spec.template.spec.containers[0].env", docs[0]
         )
 
+    def test_should_enable_custom_env(self):
+        docs = render_chart(
+            values={
+                "env": [
+                    {"name": "foo", "value": "bar"},
+                ],
+                "extraEnv": "- name: extraFoo\n  value: extraBar\n",
+                "createUserJob": {"applyCustomEnv": True},
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        envs = jmespath.search("spec.template.spec.containers[0].env", docs[0])
+        assert {"name": "foo", "value": "bar"} in envs
+        assert {"name": "extraFoo", "value": "extraBar"} in envs
+
+    def test_should_disable_custom_env(self):
+        docs = render_chart(
+            values={
+                "env": [
+                    {"name": "foo", "value": "bar"},
+                ],
+                "extraEnv": "- name: extraFoo\n  value: extraBar\n",
+                "createUserJob": {"applyCustomEnv": False},
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        envs = jmespath.search("spec.template.spec.containers[0].env", docs[0])
+        assert {"name": "foo", "value": "bar"} not in envs
+        assert {"name": "extraFoo", "value": "extraBar"} not in envs
+
     @pytest.mark.parametrize(
         "airflow_version, expected_arg",
         [


### PR DESCRIPTION
related: #26045

This addresses issue #26045, where an additional field is added to the job to determine whether or not any extra env fields are added to the job specification.

This helps remove the issue currently with using CI/CD platforms like Argo that attempt to apply the env overrides to the job templates post their initial deploy which are immutable.

I'm not 100% on the names of variables I've usd here, so happy for any suggestions

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
