### PR TITLE
Sorting plugins custom menu links by category before name

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -138,7 +138,9 @@ def init_plugins(app):
             log.debug("Adding view %s without menu", str(type(view["view"])))
             appbuilder.add_view_no_menu(view["view"])
 
-    for menu_link in sorted(plugins_manager.flask_appbuilder_menu_links, key=lambda x: (x["category"], x["name"])):
+    for menu_link in sorted(
+        plugins_manager.flask_appbuilder_menu_links, key=lambda x: (x["category"], x["name"])
+    ):
         log.debug("Adding menu link %s to %s", menu_link["name"], menu_link["href"])
         appbuilder.add_link(**menu_link)
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -138,7 +138,7 @@ def init_plugins(app):
             log.debug("Adding view %s without menu", str(type(view["view"])))
             appbuilder.add_view_no_menu(view["view"])
 
-    for menu_link in sorted(plugins_manager.flask_appbuilder_menu_links, key=lambda x: x["name"]):
+    for menu_link in sorted(plugins_manager.flask_appbuilder_menu_links, key=lambda x: (x["category"], x["name"])):
         log.debug("Adding menu link %s to %s", menu_link["name"], menu_link["href"])
         appbuilder.add_link(**menu_link)
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -139,7 +139,7 @@ def init_plugins(app):
             appbuilder.add_view_no_menu(view["view"])
 
     for menu_link in sorted(
-        plugins_manager.flask_appbuilder_menu_links, key=lambda x: (x["category"], x["name"])
+        plugins_manager.flask_appbuilder_menu_links, key=lambda x: (x.get("category", ""), x["name"])
     ):
         log.debug("Adding menu link %s to %s", menu_link["name"], menu_link["href"])
         appbuilder.add_link(**menu_link)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
In developing custom menu links through plugins, we found that our dropdown menus weren't sorted alphabetically. Digging into it a bit, I found that the menu_links are sorted by name, so the category order is currently somewhat random. Sorting by category and then name keeps the order within a category sorted alphabetically, and sorts the categories alphabetically. Made this change as a patch to our deployments of 2.2.5 and it works great.
Without change:
<img width="844" alt="Screen Shot 2022-10-19 at 5 37 52 PM" src="https://user-images.githubusercontent.com/40223998/196809640-31f57369-a63d-4c10-b614-c62187653e45.png">
With change:
<img width="702" alt="Screen Shot 2022-10-19 at 4 07 41 PM" src="https://user-images.githubusercontent.com/40223998/196809637-f119236c-21a8-49f6-8345-360a1e141c37.png">

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
