### PR TITLE
Metric for raw task return codes

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -157,6 +157,7 @@ class LocalTaskJob(BaseJob):
         # Without setting this, heartbeat may get us
         self.terminating = True
         self.log.info("Task exited with return code %s", return_code)
+        Stats.incr(f'ti.local_task_job_return_code.{self.dag_id}.{self.task_instance.task_id}.{return_code}')
 
         if not self.task_instance.test_mode:
             if conf.getboolean("scheduler", "schedule_after_task_execution", fallback=True):

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -157,7 +157,7 @@ class LocalTaskJob(BaseJob):
         # Without setting this, heartbeat may get us
         self.terminating = True
         self.log.info("Task exited with return code %s", return_code)
-        Stats.incr(f'ti.local_task_job_return_code.{self.dag_id}.{self.task_instance.task_id}.{return_code}')
+        Stats.incr(f'ti.raw_task_return_code.{self.dag_id}.{self.task_instance.task_id}.{return_code}')
 
         if not self.task_instance.test_mode:
             if conf.getboolean("scheduler", "schedule_after_task_execution", fallback=True):

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -157,7 +157,7 @@ class LocalTaskJob(BaseJob):
         # Without setting this, heartbeat may get us
         self.terminating = True
         self.log.info("Task exited with return code %s", return_code)
-        Stats.incr(f'ti.raw_task_return_code.{self.dag_id}.{self.task_instance.task_id}.{return_code}')
+        self._log_return_code_metric(return_code)
 
         if not self.task_instance.test_mode:
             if conf.getboolean("scheduler", "schedule_after_task_execution", fallback=True):
@@ -225,6 +225,11 @@ class LocalTaskJob(BaseJob):
                 )
                 self.terminating = True
             self._state_change_checks += 1
+
+    def _log_return_code_metric(self, return_code: int):
+        Stats.incr(
+            f"local_task_job.task_exit.{self.id}.{self.dag_id}.{self.task_instance.task_id}.{return_code}"
+        )
 
     @staticmethod
     def _enable_task_listeners():

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -374,16 +374,16 @@ class TestLocalTaskJob:
 
         session.close()
 
-    @patch.object(StandardTaskRunner, 'return_code')
-    @mock.patch('airflow.jobs.scheduler_job.Stats.incr')
-    def test_raw_task_return_code_metric(self, mock_stats_incr, mock_return_code, create_dummy_dag):
+    @patch.object(StandardTaskRunner, "return_code")
+    @mock.patch("airflow.jobs.scheduler_job.Stats.incr", autospec=True)
+    def test_local_task_return_code_metric(self, mock_stats_incr, mock_return_code, create_dummy_dag):
 
-        _, task = create_dummy_dag('test_localtaskjob_double_trigger')
-        mock_stats_incr.reset_mock()
+        _, task = create_dummy_dag("test_localtaskjob_code")
 
         ti_run = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti_run.refresh_from_db()
         job1 = LocalTaskJob(task_instance=ti_run, executor=SequentialExecutor())
+        job1.id = 95
 
         mock_return_code.side_effect = [None, -9, None]
 
@@ -392,9 +392,8 @@ class TestLocalTaskJob:
 
         mock_stats_incr.assert_has_calls(
             [
-                mock.call('ti.raw_task_return_code.test_localtaskjob_double_trigger.op1.-9'),
-            ],
-            any_order=True,
+                mock.call("local_task_job.task_exit.95.test_localtaskjob_code.op1.-9"),
+            ]
         )
 
     @pytest.mark.quarantined

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -376,7 +376,7 @@ class TestLocalTaskJob:
 
     @patch.object(StandardTaskRunner, 'return_code')
     @mock.patch('airflow.jobs.scheduler_job.Stats.incr')
-    def test_localtaskjob_report_return_code(self, mock_stats_incr, mock_return_code, create_dummy_dag):
+    def test_raw_task_return_code_metric(self, mock_stats_incr, mock_return_code, create_dummy_dag):
 
         _, task = create_dummy_dag('test_localtaskjob_double_trigger')
         mock_stats_incr.reset_mock()
@@ -392,7 +392,7 @@ class TestLocalTaskJob:
 
         mock_stats_incr.assert_has_calls(
             [
-                mock.call('ti.local_task_job_return_code.test_localtaskjob_double_trigger.op1.-9'),
+                mock.call('ti.raw_task_return_code.test_localtaskjob_double_trigger.op1.-9'),
             ],
             any_order=True,
         )


### PR DESCRIPTION
**Problem:** One of the challenges of running Celery workers in containerized environment is detecting system termination of a raw task instance. 
For example, if running task hits Airflow celery worker container memory limit and terminated by OOM killer, the only way for a DAG author to discover that task failed because of the memory pressure - is to guess it from the log entry "Task exited with return code negsignal.SIGKILL". 
![image](https://user-images.githubusercontent.com/2447492/196821258-e320070a-bca9-40c4-bfe3-b1f82abe7983.png)

This message is a bit cryptic and from the point of the engineer responsible for Airflow infrastructure management (who is often a different person from the DAG authors) it would be much nicer to setup the dashboard that could display such events and setup alerts for them. Of course, it is possible to parse the log entries of all tasks, but this is a fragile invariant which would require additional tooling.

**Proposed solution:**  Introduce a metric for task instances raw task execution return codes. The proposed structure is a counter with the name: `ti.raw_task_return_code.<dag-id>.<task-id>.<return code>`. This will allow to both detect the changes in the frequency of particular return codes (like SIGKILL or SIGTERM) across the whole Airflow deployment and to scope down failures to particular tasks.

*TODO:* Update documentation - I expect to have some discussion around the idea of this metric in this PR, so I want to have a consensus on the name/implementation before putting it in the docs. 

