### PR TITLE
Add documentation for BigQuery transfer operators

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_bigquery.py
@@ -34,6 +34,9 @@ class BigQueryToBigQueryOperator(BaseOperator):
     Copies data from one BigQuery table to another.
 
     .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigQueryToBigQueryOperator`
+    .. seealso::
         For more details about these parameters:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs#configuration.copy
 

--- a/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -38,6 +38,9 @@ class BigQueryToGCSOperator(BaseOperator):
     Transfers a BigQuery table to a Google Cloud Storage bucket.
 
     .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigQueryToGCSOperator`
+    .. seealso::
         For more details about these parameters:
         https://cloud.google.com/bigquery/docs/reference/v2/jobs
 

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -35,6 +35,9 @@ class BigQueryToMsSqlOperator(BaseOperator):
     Fetches the data from a BigQuery table (alternatively fetch data for selected columns)
     and insert that data into a MSSQL table.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigQueryToMsSqlOperator`
 
     .. note::
         If you pass fields to ``selected_fields`` which are in different order than the

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
@@ -48,7 +48,7 @@ class BigQueryToMySqlOperator(BaseOperator):
         to MySQL
 
     **Example**: ::
-    
+
        # [START howto_operator_bigquery_to_mysql]
        transfer_data = BigQueryToMySqlOperator(
             task_id='task_id',

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
@@ -34,6 +34,9 @@ class BigQueryToMySqlOperator(BaseOperator):
     Fetches the data from a BigQuery table (alternatively fetch data for selected columns)
     and insert that data into a MySQL table.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigQueryToMySqlOperator`
 
     .. note::
         If you pass fields to ``selected_fields`` which are in different order than the
@@ -45,13 +48,15 @@ class BigQueryToMySqlOperator(BaseOperator):
         to MySQL
 
     **Example**: ::
-
+    
+       # [START howto_operator_bigquery_to_mysql]
        transfer_data = BigQueryToMySqlOperator(
             task_id='task_id',
             dataset_table='origin_bq_table',
             mysql_table='dest_table_name',
             replace=True,
         )
+        # [END howto_operator_bigquery_to_mysql]
 
     :param dataset_table: A dotted ``<dataset>.<table>``: the big query table of origin
     :param selected_fields: List of fields to return (comma-separated). If

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -868,12 +868,15 @@ transfers:
     python-module: airflow.providers.google.cloud.transfers.postgres_to_gcs
   - source-integration-name: Google BigQuery
     target-integration-name: MySQL
+    how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mysql.rst
     python-module: airflow.providers.google.cloud.transfers.bigquery_to_mysql
   - source-integration-name: Google BigQuery
     target-integration-name: Microsoft SQL Server (MSSQL)
+    how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mssql.rst
     python-module: airflow.providers.google.cloud.transfers.bigquery_to_mssql
   - source-integration-name: Google Cloud Storage (GCS)
     target-integration-name: Google BigQuery
+    how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/gcs_to_bigquery.rst
     python-module: airflow.providers.google.cloud.transfers.gcs_to_bigquery
   - source-integration-name: Google Cloud Storage (GCS)
     target-integration-name: Google Cloud Storage (GCS)
@@ -892,6 +895,7 @@ transfers:
     python-module: airflow.providers.google.cloud.transfers.adls_to_gcs
   - source-integration-name: Google BigQuery
     target-integration-name: Google BigQuery
+    how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/bigquery_to_bigquery.rst
     python-module: airflow.providers.google.cloud.transfers.bigquery_to_bigquery
   - source-integration-name: MySQL
     target-integration-name: Google Cloud Storage (GCS)
@@ -915,6 +919,7 @@ transfers:
     python-module: airflow.providers.google.cloud.transfers.local_to_gcs
   - source-integration-name: Google BigQuery
     target-integration-name: Google Cloud Storage (GCS)
+    how-to-guide: /docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
     python-module: airflow.providers.google.cloud.transfers.bigquery_to_gcs
   - source-integration-name: Google Cloud Storage (GCS)
     target-integration-name: Local

--- a/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
@@ -32,30 +32,6 @@ Prerequisite Tasks
 Operators
 ^^^^^^^^^
 
-.. _howto/operator:GCSToBigQueryOperator:
-
-GCSToBigQueryOperator
----------------------
-
-Use the
-:class:`~airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator`
-to execute a BigQuery load job to load existing dataset from Google Cloud Storage to BigQuery table.
-
-.. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_gcs_to_bigquery]
-    :end-before: [END howto_operator_gcs_to_bigquery]
-
-Also you can use GCSToBigQueryOperator in the deferrable mode:
-
-.. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_gcs_to_bigquery_async]
-    :end-before: [END howto_operator_gcs_to_bigquery_async]
-
-
 .. _howto/operator:GCSTimeSpanFileTransformOperator:
 
 GCSTimeSpanFileTransformOperator

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_bigquery.rst
@@ -48,7 +48,7 @@ For more information, please refer to the links above.
 Copying BigQuery tables
 -----------------------
 
-The following Operator copies data from BigQuery table to another. 
+The following Operator copies data from one or more BigQuery tables to another.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_bigquery.py
     :language: python

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_bigquery.rst
@@ -1,0 +1,66 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Google Cloud BigQuery Transfer Operator to BigQuery
+===================================================
+
+`Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
+data warehouse offering.
+This operator can be used to copy data from one BigQuery table to another.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:BigQueryToBigQueryOperator:
+
+Operator
+^^^^^^^^
+
+Copying data from one BigQuery table to another is performed with the
+:class:`~airflow.providers.google.cloud.transfers.bigquery_to_bigquery.BigQueryToBigQueryOperator` operator.
+
+Use :ref:`Jinja templating <concepts:jinja-templating>` with
+:template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_bigquery.BigQueryToBigQueryOperator`
+to define values dynamically.
+
+You may include multiple source tables, as well as define a ``write_disposition`` and a ``create_disposition``.
+For more information, please refer to the links above.
+
+
+Copying BigQuery tables
+-----------------------
+
+The following Operator copies data from BigQuery table to another. 
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_bigquery.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_to_bigquery]
+    :end-before: [END howto_operator_bigquery_to_bigquery]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__
+* `Google Cloud BigQuery Documentation <https://cloud.google.com/bigquery/docs/managing-tables#copy-table>`__

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
@@ -1,0 +1,69 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Google Cloud BigQuery Transfer Operator to Google Cloud Storage
+===============================================================
+
+`Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
+data warehouse offering.
+`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for 
+storing unstructured data.
+This operator can be used to export data from BigQuery tables into files in a
+Cloud Storage bucket.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:BigQueryToGCSOperator:
+
+Operator
+^^^^^^^^
+
+File transfer from GCS to BigQuery is performed with the
+:class:`~airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryToGCSOperator` operator.
+
+Use :ref:`Jinja templating <concepts:jinja-templating>` with
+:template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_gcs.BigQueryToGCSOperator`
+to define values dynamically.
+
+You may define multiple destination URIs, as well as other settings such as ``compression`` and
+``export_format``. For more information, please refer to the links above.
+
+
+Importing files
+---------------
+
+The following Operator imports one or more files from GCS into a BigQuery table.
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_gcs.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_to_gcs]
+    :end-before: [END howto_operator_bigquery_to_gcs]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__
+* `Google Cloud BigQuery Documentation <https://cloud.google.com/bigquery/docs/exporting-data>`__

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_gcs.rst
@@ -21,7 +21,7 @@ Google Cloud BigQuery Transfer Operator to Google Cloud Storage
 
 `Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
 data warehouse offering.
-`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for 
+`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for
 storing unstructured data.
 This operator can be used to export data from BigQuery tables into files in a
 Cloud Storage bucket.

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mssql.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mssql.rst
@@ -1,0 +1,69 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Google Cloud BigQuery Transfer Operator to Microsoft SQL Server
+===============================================================
+
+`Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
+data warehouse offering.
+`Microsoft SQL Server (MsSQL) <https://www.microsoft.com/en-us/sql-server/sql-server-2019>`__
+is a relational database management system developed by Microsoft.
+This operator can be used to copy data from a BigQuery table to MSSQL.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:BigQueryToMsSqlOperator:
+
+Operator
+^^^^^^^^
+
+Copying data from one BigQuery table to another is performed with the
+:class:`~airflow.providers.google.cloud.transfers.bigquery_to_mssql.BigQueryToMsSqlOperator` operator.
+
+Use :ref:`Jinja templating <concepts:jinja-templating>` with
+:template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_mssql.BigQueryToMsSqlOperator`
+to define values dynamically.
+
+You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default), 
+as well as the parameter ``replace`` to overwrite the destination table instead of appending to it. 
+For more information, please refer to the links above.
+
+
+Transferring data
+-----------------
+
+The following Operator copies data from a BigQuery table to MsSQL.
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_mssql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_to_mssql]
+    :end-before: [END howto_operator_bigquery_to_mssql]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Google Cloud BigQuery Documentation <https://cloud.google.com/bigquery/docs/>`__
+* `Microsoft SQL Server Documentation <https://docs.microsoft.com/en-us/sql/?view=sql-server-ver15>`__

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mssql.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mssql.rst
@@ -43,8 +43,8 @@ Use :ref:`Jinja templating <concepts:jinja-templating>` with
 :template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_mssql.BigQueryToMsSqlOperator`
 to define values dynamically.
 
-You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default), 
-as well as the parameter ``replace`` to overwrite the destination table instead of appending to it. 
+You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default),
+as well as the parameter ``replace`` to overwrite the destination table instead of appending to it.
 For more information, please refer to the links above.
 
 

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mysql.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mysql.rst
@@ -42,8 +42,8 @@ Use :ref:`Jinja templating <concepts:jinja-templating>` with
 :template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_mysql.BigQueryToMySqlOperator`
 to define values dynamically.
 
-You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default), 
-as well as the parameter ``replace`` to overwrite the destination table instead of appending to it. 
+You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default),
+as well as the parameter ``replace`` to overwrite the destination table instead of appending to it.
 For more information, please refer to the links above.
 
 Transferring data

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mysql.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_mysql.rst
@@ -1,0 +1,67 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Google Cloud BigQuery Transfer Operator to MySQL
+================================================
+
+`Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
+data warehouse offering.
+`MySQL <https://www.mysql.com/>`__ is an open-source relational database management system.
+This operator can be used to copy data from a BigQuery table to MySQL.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:BigQueryToMySqlOperator:
+
+Operator
+^^^^^^^^
+
+Copying data from one BigQuery table to another is performed with the
+:class:`~airflow.providers.google.cloud.transfers.bigquery_to_mysql.BigQueryToMySqlOperator` operator.
+
+Use :ref:`Jinja templating <concepts:jinja-templating>` with
+:template-fields:`airflow.providers.google.cloud.transfers.bigquery_to_mysql.BigQueryToMySqlOperator`
+to define values dynamically.
+
+You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default), 
+as well as the parameter ``replace`` to overwrite the destination table instead of appending to it. 
+For more information, please refer to the links above.
+
+Transferring data
+-----------------
+
+The following Operator copies data from a BigQuery table to MySQL.
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_to_mysql]
+    :end-before: [END howto_operator_bigquery_to_mysql]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Google Cloud BigQuery Documentation <https://cloud.google.com/bigquery/docs/>`__
+* `MySQL Documentation <https://dev.mysql.com/doc/>`__

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_bigquery.rst
@@ -19,7 +19,7 @@
 Google Cloud Storage Transfer Operator to BigQuery
 ==================================================
 
-`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for 
+`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for
 storing unstructured data.
 `Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
 data warehouse offering.
@@ -44,20 +44,30 @@ Use :ref:`Jinja templating <concepts:jinja-templating>` with
 :template-fields:`airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator`
 to define values dynamically.
 
-You may load multiple objects from a single bucket using the ``source_objects`` parameter. 
-You may also define a schema, as well as additional settings such as the compression format. 
+You may load multiple objects from a single bucket using the ``source_objects`` parameter.
+You may also define a schema, as well as additional settings such as the compression format.
 For more information, please refer to the links above.
 
 Transferring files
 ------------------
 
-The following Operator transfers one or more files from GCS into a BigQuery table. 
+The following Operator transfers one or more files from GCS into a BigQuery table.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_gcs_to_bigquery]
     :end-before: [END howto_operator_gcs_to_bigquery]
+
+.. _howto/operator:GCSToBigQueryOperator:
+
+Also you can use GCSToBigQueryOperator in the deferrable mode:
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_to_bigquery_async]
+    :end-before: [END howto_operator_gcs_to_bigquery_async]
 
 
 Reference

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_bigquery.rst
@@ -1,0 +1,69 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Google Cloud Storage Transfer Operator to BigQuery
+==================================================
+
+`Google Cloud Storage (GCS) <https://cloud.google.com/storage/>`__ is a managed service for 
+storing unstructured data.
+`Google Cloud BigQuery <https://cloud.google.com/bigquery>`__ is Google Cloud's serverless
+data warehouse offering.
+This operator can be used to populate BigQuery tables with data from files stored in a
+Cloud Storage bucket.
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:GCSToBigQueryOperator:
+
+Operator
+^^^^^^^^
+
+File transfer from GCS to BigQuery is performed with the
+:class:`~airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator` operator.
+
+Use :ref:`Jinja templating <concepts:jinja-templating>` with
+:template-fields:`airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator`
+to define values dynamically.
+
+You may load multiple objects from a single bucket using the ``source_objects`` parameter. 
+You may also define a schema, as well as additional settings such as the compression format. 
+For more information, please refer to the links above.
+
+Transferring files
+------------------
+
+The following Operator transfers one or more files from GCS into a BigQuery table. 
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_to_bigquery]
+    :end-before: [END howto_operator_gcs_to_bigquery]
+
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Google Cloud Storage Documentation <https://cloud.google.com/storage/>`__
+* `Google Cloud BigQuery Documentation <https://cloud.google.com/bigquery/docs/batch-loading-data>`__

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_to_bigquery.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_to_bigquery.py
@@ -69,11 +69,13 @@ with models.DAG(
         ],
     )
 
+    # [START howto_operator_bigquery_to_bigquery]
     copy_selected_data = BigQueryToBigQueryOperator(
         task_id="copy_selected_data",
         source_project_dataset_tables=f"{DATASET_NAME}.{ORIGIN}",
         destination_project_dataset_table=f"{DATASET_NAME}.{TARGET}",
     )
+    # [END howto_operator_bigquery_to_bigquery]
 
     delete_dataset = BigQueryDeleteDatasetOperator(
         task_id="delete_dataset",

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_to_gcs.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_to_gcs.py
@@ -66,11 +66,13 @@ with models.DAG(
         ],
     )
 
+    # [START howto_operator_bigquery_to_gcs]
     bigquery_to_gcs = BigQueryToGCSOperator(
         task_id="bigquery_to_gcs",
         source_project_dataset_table=f"{DATASET_NAME}.{TABLE}",
         destination_cloud_storage_uris=[f"gs://{BUCKET_NAME}/{BUCKET_FILE}"],
     )
+    # [END howto_operator_bigquery_to_gcs]
 
     delete_bucket = GCSDeleteBucketOperator(
         task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE

--- a/tests/system/providers/google/cloud/bigquery/example_bigquery_to_mssql.py
+++ b/tests/system/providers/google/cloud/bigquery/example_bigquery_to_mssql.py
@@ -47,12 +47,14 @@ with models.DAG(
     catchup=False,
     tags=["example", "bigquery"],
 ) as dag:
+    # [START howto_operator_bigquery_to_mssql]
     bigquery_to_mssql = BigQueryToMsSqlOperator(
         task_id="bigquery_to_mssql",
         source_project_dataset_table=f"{PROJECT_ID}.{DATASET_NAME}.{TABLE}",
         mssql_table=destination_table,
         replace=False,
     )
+    # [END howto_operator_bigquery_to_mssql]
 
     create_dataset = BigQueryCreateEmptyDatasetOperator(task_id="create_dataset", dataset_id=DATASET_NAME)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #27093

Adds documentation for the following Google Cloud transfer operators: BigQueryToBigQueryOperator, BigQueryToGCSOperator, BigQueryToMsSqlOperator, BigQueryToMySqlOperator, GCSToBigQueryOperator

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
