### PR TITLE
Expand tasks in mapped group at parse time

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -55,13 +55,9 @@ from airflow.models.expandinput import (
     ListOfDictsExpandInput,
     OperatorExpandArgument,
     OperatorExpandKwargsArgument,
+    is_mappable,
 )
-from airflow.models.mappedoperator import (
-    MappedOperator,
-    ValidationSource,
-    ensure_xcomarg_return_value,
-    get_mappable_types,
-)
+from airflow.models.mappedoperator import MappedOperator, ValidationSource, ensure_xcomarg_return_value
 from airflow.models.pool import Pool
 from airflow.models.xcom_arg import XComArg
 from airflow.typing_compat import ParamSpec, Protocol
@@ -100,7 +96,7 @@ class ExpandableFactory(Protocol):
         kwargs_left = kwargs.copy()
         for arg_name in self._mappable_function_argument_names:
             value = kwargs_left.pop(arg_name, NOTSET)
-            if func != "expand" or value is NOTSET or isinstance(value, get_mappable_types()):
+            if func != "expand" or value is NOTSET or is_mappable(value):
                 continue
             tname = type(value).__name__
             raise ValueError(f"expand() got an unexpected type {tname!r} for keyword argument {arg_name!r}")

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -22,8 +22,12 @@ import functools
 import operator
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Mapping, NamedTuple, Sequence, Sized, Union
 
-from airflow.compat.functools import cache
+import attr
+
+from airflow.typing_compat import TypeGuard
 from airflow.utils.context import Context
+from airflow.utils.mixins import ResolveMixin
+from airflow.utils.session import NEW_SESSION, provide_session
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -34,19 +38,54 @@ ExpandInput = Union["DictOfListsExpandInput", "ListOfDictsExpandInput"]
 
 # Each keyword argument to expand() can be an XComArg, sequence, or dict (not
 # any mapping since we need the value to be ordered).
-OperatorExpandArgument = Union["XComArg", Sequence, Dict[str, Any]]
+OperatorExpandArgument = Union["MappedArgument", "XComArg", Sequence, Dict[str, Any]]
 
 # The single argument of expand_kwargs() can be an XComArg, or a list with each
 # element being either an XComArg or a dict.
 OperatorExpandKwargsArgument = Union["XComArg", Sequence[Union["XComArg", Mapping[str, Any]]]]
 
 
-# For isinstance() check.
-@cache
-def get_mappable_types() -> tuple[type, ...]:
+@attr.define(kw_only=True)
+class MappedArgument(ResolveMixin):
+    """Stand-in stub for task-group-mapping arguments.
+
+    This is very similar to an XComArg, but resolved differently. Declared here
+    (instead of in the task group module) to avoid import cycles.
+    """
+
+    _input: ExpandInput
+    _key: str
+
+    def get_task_map_length(self, run_id: str, *, session: Session) -> int | None:
+        # TODO (AIP-42): Implement run-time task map length inspection.
+        # This simply marks the value as un-expandable at parse-time.
+        return None
+
+    @provide_session
+    def resolve(self, context: Context, *, session: Session = NEW_SESSION) -> Any:
+        data, _ = self._input.resolve(context, session=session)
+        return data[self._key]
+
+
+# To replace tedious isinstance() checks.
+def is_mappable(v: Any) -> TypeGuard[OperatorExpandArgument]:
     from airflow.models.xcom_arg import XComArg
 
-    return (XComArg, list, tuple, dict)
+    return isinstance(v, (MappedArgument, XComArg, Mapping, Sequence)) and not isinstance(v, str)
+
+
+# To replace tedious isinstance() checks.
+def _is_parse_time_mappable(v: OperatorExpandArgument) -> TypeGuard[Mapping | Sequence]:
+    from airflow.models.xcom_arg import XComArg
+
+    return not isinstance(v, (MappedArgument, XComArg))
+
+
+# To replace tedious isinstance() checks.
+def _needs_run_time_resolution(v: OperatorExpandArgument) -> TypeGuard[MappedArgument | XComArg]:
+    from airflow.models.xcom_arg import XComArg
+
+    return isinstance(v, (MappedArgument, XComArg))
 
 
 class NotFullyPopulated(RuntimeError):
@@ -74,9 +113,7 @@ class DictOfListsExpandInput(NamedTuple):
 
     def _iter_parse_time_resolved_kwargs(self) -> Iterable[tuple[str, Sized]]:
         """Generate kwargs with values available on parse-time."""
-        from airflow.models.xcom_arg import XComArg
-
-        return ((k, v) for k, v in self.value.items() if not isinstance(v, XComArg))
+        return ((k, v) for k, v in self.value.items() if _is_parse_time_mappable(v))
 
     def get_parse_time_mapped_ti_count(self) -> int:
         if not self.value:
@@ -93,14 +130,18 @@ class DictOfListsExpandInput(NamedTuple):
         If any arguments are not known right now (upstream task not finished),
         they will not be present in the dict.
         """
-        from airflow.models.xcom_arg import XComArg
-
         # TODO: This initiates one database call for each XComArg. Would it be
         # more efficient to do one single db call and unpack the value here?
-        map_lengths_iterator = (
-            (k, (v.get_task_map_length(run_id, session=session) if isinstance(v, XComArg) else len(v)))
-            for k, v in self.value.items()
-        )
+        def _get_length(v: OperatorExpandArgument) -> int | None:
+            if _needs_run_time_resolution(v):
+                return v.get_task_map_length(run_id, session=session)
+            # Unfortunately a user-defined TypeGuard cannot apply negative type
+            # narrowing. https://github.com/python/typing/discussions/1013
+            if TYPE_CHECKING:
+                assert isinstance(v, Sized)
+            return len(v)
+
+        map_lengths_iterator = ((k, _get_length(v)) for k, v in self.value.items())
 
         map_lengths = {k: v for k, v in map_lengths_iterator if v is not None}
         if len(map_lengths) < len(self.value):
@@ -114,9 +155,7 @@ class DictOfListsExpandInput(NamedTuple):
         return functools.reduce(operator.mul, (lengths[name] for name in self.value), 1)
 
     def _expand_mapped_field(self, key: str, value: Any, context: Context, *, session: Session) -> Any:
-        from airflow.models.xcom_arg import XComArg
-
-        if isinstance(value, XComArg):
+        if _needs_run_time_resolution(value):
             value = value.resolve(context, session=session)
         map_index = context["ti"].map_index
         if map_index < 0:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -54,7 +54,7 @@ from airflow.models.expandinput import (
     NotFullyPopulated,
     OperatorExpandArgument,
     OperatorExpandKwargsArgument,
-    get_mappable_types,
+    is_mappable,
 )
 from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
@@ -97,7 +97,7 @@ def validate_mapping_kwargs(op: type[BaseOperator], func: ValidationSource, valu
                 continue
             if value is NOTSET:
                 continue
-            if isinstance(value, get_mappable_types()):
+            if is_mappable(value):
                 continue
             type_name = type(value).__name__
             error = f"{op.__name__}.expand() got an unexpected type {type_name!r} for keyword argument {name}"

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -31,7 +31,7 @@ from sqlalchemy import func, or_
 from sqlalchemy.orm.session import Session
 
 from airflow import settings
-from airflow.compat.functools import cache, cached_property
+from airflow.compat.functools import cache
 from airflow.exceptions import AirflowException, UnmappableOperator
 from airflow.models.abstractoperator import (
     DEFAULT_IGNORE_FIRST_DEPENDS_ON_PAST,
@@ -44,6 +44,7 @@ from airflow.models.abstractoperator import (
     DEFAULT_TRIGGER_RULE,
     DEFAULT_WEIGHT_RULE,
     AbstractOperator,
+    NotMapped,
     TaskStateChangeCallback,
 )
 from airflow.models.expandinput import (
@@ -724,34 +725,22 @@ class MappedOperator(AbstractOperator):
             for operator, _ in ref.iter_references():
                 yield operator
 
-    @cached_property
-    def parse_time_mapped_ti_count(self) -> int | None:
-        """Number of mapped TaskInstances that can be created at DagRun create time.
-
-        This only considers literal mapped arguments, and would return *None*
-        when any non-literal values are used for mapping.
-
-        :return: None if non-literal mapped arg encountered, or the total
-            number of mapped TIs this task should have.
-        """
-        return self._get_specified_expand_input().get_parse_time_mapped_ti_count()
-
     @cache
-    def get_mapped_ti_count(self, run_id: str, *, session: Session) -> int | None:
-        """Number of mapped TaskInstances that can be created at run time.
-
-        This considers both literal and non-literal mapped arguments, and the
-        result is therefore available when all depended tasks have finished. The
-        return value should be identical to ``parse_time_mapped_ti_count`` if
-        all mapped arguments are literal.
-
-        :return: None if upstream tasks are not complete yet, or the total
-            number of mapped TIs this task should have.
-        """
+    def get_parse_time_mapped_ti_count(self) -> int:
+        current_count = self._get_specified_expand_input().get_parse_time_mapped_ti_count()
         try:
-            return self._get_specified_expand_input().get_total_map_length(run_id, session=session)
-        except NotFullyPopulated:
-            return None
+            parent_count = super().get_parse_time_mapped_ti_count()
+        except NotMapped:
+            return current_count
+        return parent_count * current_count
+
+    def get_mapped_ti_count(self, run_id: str, *, session: Session) -> int:
+        current_count = self._get_specified_expand_input().get_total_map_length(run_id, session=session)
+        try:
+            parent_count = super().get_mapped_ti_count(run_id, session=session)
+        except NotMapped:
+            return current_count
+        return parent_count * current_count
 
     def render_template_fields(
         self,

--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -26,6 +26,7 @@ __all__ = [
     "ParamSpec",
     "Protocol",
     "TypedDict",
+    "TypeGuard",
     "runtime_checkable",
 ]
 
@@ -43,6 +44,6 @@ else:
     from typing_extensions import Literal
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec
+    from typing import ParamSpec, TypeGuard
 else:
-    from typing_extensions import ParamSpec
+    from typing_extensions import ParamSpec, TypeGuard

--- a/tests/decorators/test_task_group.py
+++ b/tests/decorators/test_task_group.py
@@ -21,8 +21,7 @@ import pendulum
 import pytest
 
 from airflow.decorators import dag, task_group
-from airflow.decorators.task_group import _MappedArgument
-from airflow.models.expandinput import DictOfListsExpandInput, ListOfDictsExpandInput
+from airflow.models.expandinput import DictOfListsExpandInput, ListOfDictsExpandInput, MappedArgument
 from airflow.utils.task_group import MappedTaskGroup
 
 
@@ -150,7 +149,7 @@ def test_expand_create_mapped():
     assert isinstance(tg, MappedTaskGroup)
     assert tg._expand_input == DictOfListsExpandInput({"b": ["x", "y"]})
 
-    assert saved == {"a": 1, "b": _MappedArgument(input=tg._expand_input, key="b")}
+    assert saved == {"a": 1, "b": MappedArgument(input=tg._expand_input, key="b")}
 
 
 def test_expand_kwargs_no_wildcard():
@@ -186,4 +185,4 @@ def test_expand_kwargs_create_mapped():
     assert isinstance(tg, MappedTaskGroup)
     assert tg._expand_input == ListOfDictsExpandInput([{"b": "x"}, {"b": None}])
 
-    assert saved == {"a": 1, "b": _MappedArgument(input=tg._expand_input, key="b")}
+    assert saved == {"a": 1, "b": MappedArgument(input=tg._expand_input, key="b")}

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -60,7 +60,7 @@ from airflow.models import (
     XCom,
 )
 from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel
-from airflow.models.expandinput import EXPAND_INPUT_EMPTY
+from airflow.models.expandinput import EXPAND_INPUT_EMPTY, NotFullyPopulated
 from airflow.models.param import process_params
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
@@ -3376,7 +3376,8 @@ class TestMappedTaskInstanceReceiveValue:
         ti.run()
 
         show_task = dag.get_task("show")
-        assert show_task.parse_time_mapped_ti_count is None
+        with pytest.raises(NotFullyPopulated):
+            assert show_task.get_parse_time_mapped_ti_count()
         mapped_tis, max_map_index = show_task.expand_mapped_task(dag_run.run_id, session=session)
         assert max_map_index + 1 == len(mapped_tis) == 4
 
@@ -3400,7 +3401,7 @@ class TestMappedTaskInstanceReceiveValue:
         dag_run = dag_maker.create_dagrun()
 
         show_task = dag.get_task("show")
-        assert show_task.parse_time_mapped_ti_count == 6
+        assert show_task.get_parse_time_mapped_ti_count() == 6
         mapped_tis, max_map_index = show_task.expand_mapped_task(dag_run.run_id, session=session)
         assert len(mapped_tis) == 0  # Expanded at parse!
         assert max_map_index == 5

--- a/tests/test_utils/mapping.py
+++ b/tests/test_utils/mapping.py
@@ -42,4 +42,3 @@ def expand_mapped_task(
     session.flush()
 
     mapped.expand_mapped_task(run_id, session=session)
-    mapped.get_mapped_ti_count.cache_clear()  # type: ignore[attr-defined]


### PR DESCRIPTION
~~Depends on #27027.~~ Merged; rebased to main.

This involves a few things:

* The mapped task group needs to implement parse-time and run-time ti count accessors, similar to the mapped operator.
* Since a non-mapped operator can be in a mapped task group and thus needs to be expanded, the parse-time and run-time ti count accessors are "raised" from MappedOperator to AbstractOperator (so they can be used by BaseOperator). These now also considers an operator's parent task groups.
* If a ti count accessor is called on a non-mapped operator that's not in any mapped task group, the accessor should return a special value of a sort. Since None is already used, we raise an exception in this case instead (simply called NotMapped). For consistency, the previous case where None was returned (upstreams not available) is also changed to raise an exception instead (reusing NotFullyPopulated). This means the ti count accessors now always return an int, and raise an exception whenever the count is not available.
* All of the above result in a coherant interface in AbstractOperator that can be used in DagRun to perform ti count revision.