### PR TITLE
Add *.jinja2 files to provider packages

### DIFF
--- a/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -37,6 +37,7 @@ def do_setup():
         packages=find_namespace_packages(
             include=['airflow.providers.{{ PROVIDER_PACKAGE_ID }}',
                      'airflow.providers.{{ PROVIDER_PACKAGE_ID }}.*']),
+        package_data={'airflow.providers.{{ PROVIDER_PACKAGE_ID }}': ['**/*.jinja2']},
     )
 
 


### PR DESCRIPTION
**UPDATE** this fix didn't quite work. The actual fix is https://github.com/apache/airflow/pull/27451 and should be out in 2.5.0

This ensures that any templates required as part of the provider are included in the distributed packages.

Resolves #26910.

To test this locally, I did this:

```python
./dev/provider_packages/prepare_provider_packages.py generate-setup-files --version-suffix rc1 --no-git-update --verbose --skip-tag-check cncf.kubernetes
```
then
```
./dev/provider_packages/prepare_provider_packages.py build-provider-packages --package-format sdist cncf.kubernetes --version-suffix rc1 --no-git-update --skip-tag-check
```

then check `dist` folder, expand package, and, there it is.