### PR TITLE
Make amazon provider tests compatible with latest `moto`

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_dynamodb.py
+++ b/tests/providers/amazon/aws/hooks/test_dynamodb.py
@@ -20,23 +20,18 @@ from __future__ import annotations
 import unittest
 import uuid
 
-from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
+from moto import mock_dynamodb
 
-try:
-    from moto import mock_dynamodb2
-except ImportError:
-    mock_dynamodb2 = None
+from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 
 
 class TestDynamoDBHook(unittest.TestCase):
-    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
-    @mock_dynamodb2
+    @mock_dynamodb
     def test_get_conn_returns_a_boto3_connection(self):
         hook = DynamoDBHook(aws_conn_id='aws_default')
         assert hook.get_conn() is not None
 
-    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
-    @mock_dynamodb2
+    @mock_dynamodb
     def test_insert_batch_items_dynamodb_table(self):
 
         hook = DynamoDBHook(

--- a/tests/providers/amazon/aws/hooks/test_eks.py
+++ b/tests/providers/amazon/aws/hooks/test_eks.py
@@ -29,7 +29,12 @@ import yaml
 from _pytest._code import ExceptionInfo
 from botocore.exceptions import ClientError
 from freezegun import freeze_time
-from moto.core import ACCOUNT_ID
+
+try:
+    from moto.core import DEFAULT_ACCOUNT_ID
+except ImportError:
+    from moto.core import ACCOUNT_ID as DEFAULT_ACCOUNT_ID
+
 from moto.core.exceptions import AWSError
 from moto.eks.exceptions import (
     InvalidParameterException,
@@ -294,7 +299,7 @@ class TestEksHooks:
         expected_arn_values: list = [
             PARTITION,
             REGION,
-            ACCOUNT_ID,
+            DEFAULT_ACCOUNT_ID,
             generated_test_data.cluster_names,
         ]
 
@@ -509,7 +514,7 @@ class TestEksHooks:
         expected_arn_values: list = [
             PARTITION,
             REGION,
-            ACCOUNT_ID,
+            DEFAULT_ACCOUNT_ID,
             generated_test_data.cluster_name,
             generated_test_data.nodegroup_names,
             None,
@@ -911,7 +916,7 @@ class TestEksHooks:
         expected_arn_values: list = [
             PARTITION,
             REGION,
-            ACCOUNT_ID,
+            DEFAULT_ACCOUNT_ID,
             generated_test_data.cluster_name,
             generated_test_data.fargate_profile_names,
             None,

--- a/tests/providers/amazon/aws/transfers/test_hive_to_dynamodb.py
+++ b/tests/providers/amazon/aws/transfers/test_hive_to_dynamodb.py
@@ -23,6 +23,7 @@ import unittest
 from unittest import mock
 
 import pandas as pd
+from moto import mock_dynamodb
 
 import airflow.providers.amazon.aws.transfers.hive_to_dynamodb
 from airflow.models.dag import DAG
@@ -31,11 +32,6 @@ from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 DEFAULT_DATE = datetime.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
-
-try:
-    from moto import mock_dynamodb2
-except ImportError:
-    mock_dynamodb2 = None
 
 
 class TestHiveToDynamoDBOperator(unittest.TestCase):
@@ -50,8 +46,7 @@ class TestHiveToDynamoDBOperator(unittest.TestCase):
     def process_data(data, *args, **kwargs):
         return json.loads(data.to_json(orient='records'))
 
-    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
-    @mock_dynamodb2
+    @mock_dynamodb
     def test_get_conn_returns_a_boto3_connection(self):
         hook = DynamoDBHook(aws_conn_id='aws_default')
         assert hook.get_conn() is not None
@@ -60,8 +55,7 @@ class TestHiveToDynamoDBOperator(unittest.TestCase):
         'airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_pandas_df',
         return_value=pd.DataFrame(data=[('1', 'sid')], columns=['id', 'name']),
     )
-    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
-    @mock_dynamodb2
+    @mock_dynamodb
     def test_get_records_with_schema(self, mock_get_pandas_df):
         # this table needs to be created in production
         self.hook.get_conn().create_table(
@@ -91,8 +85,7 @@ class TestHiveToDynamoDBOperator(unittest.TestCase):
         'airflow.providers.apache.hive.hooks.hive.HiveServer2Hook.get_pandas_df',
         return_value=pd.DataFrame(data=[('1', 'sid'), ('1', 'gupta')], columns=['id', 'name']),
     )
-    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamodb2 package not present')
-    @mock_dynamodb2
+    @mock_dynamodb
     def test_pre_process_records_with_schema(self, mock_get_pandas_df):
         # this table needs to be created in production
         self.hook.get_conn().create_table(


### PR DESCRIPTION
This should fix broken main and remove some depreciation warnings.

- `mock_dynamodb2` decorator deprecated by `mock_dynamodb` in moto >= 3.1.0 and remove in moto >= 4
- Since [Multi-Account support](http://docs.getmoto.org/en/latest/docs/multi_account.html) `moto.core.ACCOUNT_ID` replaced by `moto.core.DEFAULT_ACCOUNT_ID`
