### PR TITLE
Add workeer log-groomer-sidecar enable option in helm chart

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -243,7 +243,7 @@ spec:
         {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
         {{- include "git_sync_container" . | indent 8 }}
         {{- end }}
-{{- if $persistence }}
+{{- if and $persistence .Values.workers.logGroomerSidecar.enabled }}
         - name: worker-log-groomer
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1561,6 +1561,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Whether to deploy the Airflow worker log groomer sidecar.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "command": {
                             "description": "Command to use when running the Airflow workers log groomer sidecar (templated).",
                             "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -600,6 +600,8 @@ workers:
   labels: {}
 
   logGroomerSidecar:
+    # Whether to deploy the Airflow worker log groomer sidecar.
+    enabled: true
     # Command to use when running the Airflow worker log groomer sidecar (templated).
     command: ~
     # Args to use when running the Airflow worker log groomer sidecar (templated).

--- a/tests/charts/test_worker.py
+++ b/tests/charts/test_worker.py
@@ -523,6 +523,23 @@ class TestWorker:
         assert ["release-name"] == jmespath.search("spec.template.spec.containers[0].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
 
+    def test_log_groomer_collector_default_enabled(self):
+        docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
+        assert 2 == len(jmespath.search("spec.template.spec.containers", docs[0]))
+        assert "worker-log-groomer" in [
+            c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])
+        ]
+
+    def test_log_groomer_collector_can_be_disabled(self):
+        docs = render_chart(
+            values={"workers": {"logGroomerSidecar": {"enabled": False}}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert 1 == len(jmespath.search("spec.template.spec.containers", docs[0]))
+        assert "worker-log-groomer" not in [
+            c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])
+        ]
+
     def test_log_groomer_default_command_and_args(self):
         docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
 


### PR DESCRIPTION
Signed-off-by: BobDu <i@bobdu.cc>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I see #16153 , add scheduler-log-groomer enable option, but not add a same option for worker.

I missing something? @jedcunningham 

My airflow cluster use shared efs persistence logs.
But, if every worker start a sidecar container to scan log directory, is unnecessary, and it will use up efs throughout capacity.

We need a option to turn off it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
