### PR TITLE
External task sensor fail fix

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -224,7 +224,8 @@ class ExternalTaskSensor(BaseSensorOperator):
         if self.failed_states:
             count_failed = self.get_count(dttm_filter, session, self.failed_states)
 
-        if count_failed == len(dttm_filter):
+        # Fail if anything in the list has failed.
+        if count_failed > 0:
             if self.external_task_ids:
                 if self.soft_fail:
                     raise AirflowSkipException(

--- a/newsfragments/27190.significant.rst
+++ b/newsfragments/27190.significant.rst
@@ -1,0 +1,3 @@
+``ExternalTaskSensor`` no longer hangs indefinitely when ``failed_states`` is set, an ``execute_date_fn`` is used, and some but not all of the dependent tasks fail. Instead, an ``AirflowException`` is thrown as soon as any of the dependent tasks fail.
+
+Any code handling this failure in addition to timeouts should move to cathing the ``AirflowException`` baseclass and not juse the ``AirflowSensorTimeout`` subclass.

--- a/newsfragments/27190.significant.rst
+++ b/newsfragments/27190.significant.rst
@@ -1,3 +1,3 @@
 ``ExternalTaskSensor`` no longer hangs indefinitely when ``failed_states`` is set, an ``execute_date_fn`` is used, and some but not all of the dependent tasks fail. Instead, an ``AirflowException`` is thrown as soon as any of the dependent tasks fail.
 
-Any code handling this failure in addition to timeouts should move to cathing the ``AirflowException`` baseclass and not juse the ``AirflowSensorTimeout`` subclass.
+Any code handling this failure in addition to timeouts should move to cathing the ``AirflowException`` baseclass and not only the ``AirflowSensorTimeout`` subclass.

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -422,12 +422,12 @@ exit 0
         # ExternalTaskSensor will also report a failure and return without
         # waiting for a timeout.
         task_chain_with_failure = ExternalTaskSensor(
-            task_id='task_chain_with_failure',
+            task_id="task_chain_with_failure",
             external_dag_id=dag_external_id,
-            external_task_id='task_external_with_failure',
+            external_task_id="task_external_with_failure",
             execution_date_fn=lambda dt: [dt + timedelta(seconds=i) for i in range(3)],
-            allowed_states=['success'],
-            failed_states=['failed'],
+            allowed_states=["success"],
+            failed_states=["failed"],
             retries=0,
             timeout=5,
             poke_interval=1,

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -431,7 +431,7 @@ exit 0
             retries=0,
             timeout=5,
             poke_interval=1,
-            dag=dag
+            dag=dag,
         )
 
         # We need to test for an AirflowException explicitly since

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -418,6 +418,31 @@ exit 0
         with pytest.raises(AirflowSensorTimeout):
             task_with_failure.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+        # Test to ensure that if one task in a chain of tasks fails, the
+        # ExternalTaskSensor will also report a failure and return without
+        # waiting for a timeout.
+        task_chain_with_failure = ExternalTaskSensor(
+            task_id='task_chain_with_failure',
+            external_dag_id=dag_external_id,
+            external_task_id='task_external_with_failure',
+            execution_date_fn=lambda dt: [dt + timedelta(seconds=i) for i in range(3)],
+            allowed_states=['success'],
+            failed_states=['failed'],
+            retries=0,
+            timeout=5,
+            poke_interval=1,
+            dag=dag
+        )
+
+        # We need to test for an AirflowException explicitly since
+        # AirflowSensorTimeout is a subclass that will be raised if this does
+        # not execute properly.
+        try:
+            task_chain_with_failure.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        except AirflowException as ex:
+            assert type(ex) == AirflowException
+
+
     def test_external_task_sensor_delta(self):
         self.add_time_sensor()
         op = ExternalTaskSensor(

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -442,7 +442,6 @@ exit 0
         except AirflowException as ex:
             assert type(ex) == AirflowException
 
-
     def test_external_task_sensor_delta(self):
         self.add_time_sensor()
         op = ExternalTaskSensor(


### PR DESCRIPTION
At @o-nikolas request, I'm creating a new PR to attempt to fix #16204 where the ExternalTaskSensor would hang indefinitely when an execution_date_fn is used, failed_states/allowed_states are set, and external DAGs have mixed states upstream.