### PR TITLE
Update Node.js in Github Actions to Node 16

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -100,7 +100,7 @@ jobs:
       # we checkout the target commit and it's parent to be able to compare them
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_COMMIT_SHA }}
           persist-credentials: false
@@ -383,7 +383,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.build-info.outputs.target-commit-sha }}
           persist-credentials: false
@@ -391,7 +391,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - name: >
           Checkout "main" branch to 'main-airflow' folder
           to use ci/scripts from there.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: "main-airflow"
           ref: "main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -617,7 +617,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     needs: [build-info]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
           persist-credentials: false
@@ -950,7 +950,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           breeze release-management prepare-airflow-package
           --package-format sdist --version-suffix-for-pypi dev0
       - name: "Upload provider distribution artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: airflow-provider-packages
           path: "./dist/apache-airflow-providers-*.tar.gz"
@@ -1842,7 +1842,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ needs.build-info.outputs.targetCommitSha }}
           persist-credentials: false

--- a/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
+++ b/dev/breeze/doc/adr/0005-preventing-using-contributed-code-when-building-images.md
@@ -108,7 +108,7 @@ but to make sure that the following rules are in-place:
    to our repository
 
 ```yaml
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_COMMIT_SHA }}
           persist-credentials: false

--- a/scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
+++ b/scripts/ci/pre_commit/pre_commit_checkout_no_credentials.py
@@ -80,7 +80,7 @@ set to False.[/]
 For security reasons - make sure all of the checkout actions have persist_credentials set, similar to:
 
   - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-    uses: actions/checkout@v2
+    uses: actions/checkout@v3
     with:
       persist-credentials: false
 


### PR DESCRIPTION
We were using an old version of some actions  that used Node 12 and node 12 has been deprecated. This PR bumps all necessary actions to use Node 16.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
