### PR TITLE
As of #26400 dag.test command no longer uses DebugExecutor

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1178,8 +1178,7 @@ DAGS_COMMANDS = (
         name='test',
         help="Execute one single DagRun",
         description=(
-            "Execute one single DagRun for a given DAG and execution date, "
-            "using the DebugExecutor.\n"
+            "Execute one single DagRun for a given DAG and execution date.\n"
             "\n"
             "The --imgcat-dagrun option only works in iTerm.\n"
             "\n"

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -449,7 +449,7 @@ def dag_list_dag_runs(args, dag=None, session=NEW_SESSION):
 @provide_session
 @cli_utils.action_cli
 def dag_test(args, dag=None, session=None):
-    """Execute one single DagRun for a given DAG and execution date, using the DebugExecutor."""
+    """Execute one single DagRun for a given DAG and execution date."""
     run_conf = None
     if args.conf:
         try:


### PR DESCRIPTION
Cleanup the docstrings which were still mentioning the usage of the DebugExecutor

related: #26400 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
