### PR TITLE
Drop support for providing ``resource`` as dict in ``KubernetesPodOperator``

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -32,6 +32,8 @@ Breaking changes
 
 Previously KubernetesPodOperator considered some settings from the Airflow config's ``kubernetes`` section.  Such consideration was deprecated in 4.1.0 and is now removed.  If you previously relied on the Airflow config, and you want client generation to have non-default configuration, you will need to define your configuration in an Airflow connection and set KPO to use the connection.  See kubernetes provider documentation on defining a kubernetes Airflow connection for details.
 
+Drop support for providing ``resource`` as dict in ``KubernetesPodOperator``. You should use ``container_resources`` with ``V1ResourceRequirements``.
+
 Features
 ~~~~~~~~
 
@@ -97,6 +99,10 @@ Bug Fixes
 * ``Revert "Fix await_container_completion condition (#23883)" (#24474)``
 * ``Update providers to use functools compat for ''cached_property'' (#24582)``
 
+Misc
+~~~~
+* ``Rename 'resources' arg in Kub op to k8s_resources (#24673)``
+
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Only assert stuff for mypy when type checking (#24937)``
@@ -105,7 +111,6 @@ Bug Fixes
    * ``Move provider dependencies to inside provider folders (#24672)``
    * ``Use our yaml util in all providers (#24720)``
    * ``Remove 'hook-class-names' from provider.yaml (#24702)``
-   * ``Rename 'resources' arg in Kub op to k8s_resources (#24673)``
 
 4.1.0
 .....

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -62,20 +62,6 @@ def convert_volume_mount(volume_mount) -> k8s.V1VolumeMount:
     return _convert_kube_model_object(volume_mount, k8s.V1VolumeMount)
 
 
-def convert_resources(resources) -> k8s.V1ResourceRequirements:
-    """
-    Converts an airflow Resources object into a k8s.V1ResourceRequirements
-
-    :param resources:
-    :return: k8s.V1ResourceRequirements
-    """
-    if isinstance(resources, dict):
-        from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
-
-        resources = Resources(**resources)
-    return _convert_kube_model_object(resources, k8s.V1ResourceRequirements)
-
-
 def convert_port(port) -> k8s.V1ContainerPort:
     """
     Converts an airflow Port object into a k8s.V1ContainerPort

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -120,7 +120,6 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                         "command": ["bash", "-cx"],
                         "env": [],
                         "envFrom": [],
-                        "resources": {},
                         "name": "base",
                         "ports": [],
                         "volumeMounts": [],

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1150,3 +1150,26 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             with pytest.raises(AirflowException):
                 k.execute(context)
             create_mock.assert_called_once()
+
+    def test_using_resources(self):
+        exception_message = (
+            "Specifying resources for the launched pod with 'resources' is deprecated. "
+            "Use 'container_resources' instead."
+        )
+        with pytest.raises(AirflowException, match=exception_message):
+            resources = k8s.V1ResourceRequirements(
+                requests={"memory": "64Mi", "cpu": "250m", "ephemeral-storage": "1Gi"},
+                limits={"memory": "64Mi", "cpu": 0.25, "nvidia.com/gpu": None, "ephemeral-storage": "2Gi"},
+            )
+            KubernetesPodOperator(
+                namespace="default",
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["echo 10"],
+                labels=self.labels,
+                name="test-" + str(random.randint(0, 1000000)),
+                task_id="task" + self.get_current_task_name(),
+                in_cluster=False,
+                do_xcom_push=False,
+                resources=resources,
+            )

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -107,7 +107,6 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                         "command": ["bash", "-cx"],
                         "env": [],
                         "envFrom": [],
-                        "resources": {},
                         "name": "base",
                         "ports": [],
                         "volumeMounts": [],

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -193,36 +193,6 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod["spec"]["nodeSelector"] = node_selectors
         assert self.expected_pod == actual_pod
 
-    def test_pod_resources(self):
-        resources = {
-            "limit_cpu": 0.25,
-            "limit_memory": "64Mi",
-            "limit_ephemeral_storage": "2Gi",
-            "request_cpu": "250m",
-            "request_memory": "64Mi",
-            "request_ephemeral_storage": "1Gi",
-        }
-        k = KubernetesPodOperator(
-            namespace="default",
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["echo 10"],
-            labels={"foo": "bar"},
-            name="test",
-            task_id="task",
-            in_cluster=False,
-            do_xcom_push=False,
-            container_resources=resources,
-        )
-        context = create_context(k)
-        k.execute(context)
-        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        self.expected_pod["spec"]["containers"][0]["resources"] = {
-            "requests": {"memory": "64Mi", "cpu": "250m", "ephemeral-storage": "1Gi"},
-            "limits": {"memory": "64Mi", "cpu": 0.25, "ephemeral-storage": "2Gi"},
-        }
-        assert self.expected_pod == actual_pod
-
     def test_pod_affinity(self):
         affinity = {
             "nodeAffinity": {


### PR DESCRIPTION
Dropping support for resource parameter
Deprecation added in https://github.com/apache/airflow/pull/24673

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
