### PR TITLE
Bump azure-mgmt-datafactory version

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -237,8 +237,8 @@ class AzureDataFactoryHook(BaseHook):
     def update_factory(
         self,
         factory: Factory,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> Factory:
         """
@@ -262,8 +262,8 @@ class AzureDataFactoryHook(BaseHook):
     def create_factory(
         self,
         factory: Factory,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> Factory:
         """
@@ -284,9 +284,7 @@ class AzureDataFactoryHook(BaseHook):
         )
 
     @provide_targeted_factory
-    def delete_factory(
-        self, resource_group_name: str | None = None, factory_name: str | None = None, **config: Any
-    ) -> None:
+    def delete_factory(self, resource_group_name: str, factory_name: str, **config: Any) -> None:
         """
         Delete the factory.
 
@@ -300,8 +298,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_linked_service(
         self,
         linked_service_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> LinkedServiceResource:
         """
@@ -333,8 +331,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         linked_service_name: str,
         linked_service: LinkedServiceResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> LinkedServiceResource:
         """
@@ -360,8 +358,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         linked_service_name: str,
         linked_service: LinkedServiceResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> LinkedServiceResource:
         """
@@ -386,8 +384,8 @@ class AzureDataFactoryHook(BaseHook):
     def delete_linked_service(
         self,
         linked_service_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -406,8 +404,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_dataset(
         self,
         dataset_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DatasetResource:
         """
@@ -435,8 +433,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         dataset_name: str,
         dataset: DatasetResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DatasetResource:
         """
@@ -462,8 +460,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         dataset_name: str,
         dataset: DatasetResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DatasetResource:
         """
@@ -488,8 +486,8 @@ class AzureDataFactoryHook(BaseHook):
     def delete_dataset(
         self,
         dataset_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -506,8 +504,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_dataflow(
         self,
         dataflow_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DataFlow:
         """
@@ -524,8 +522,8 @@ class AzureDataFactoryHook(BaseHook):
     def _dataflow_exists(
         self,
         dataflow_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
     ) -> bool:
         """Return whether the dataflow already exists."""
         dataflows = {
@@ -540,8 +538,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         dataflow_name: str,
         dataflow: DataFlow,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DataFlow:
         """
@@ -571,8 +569,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         dataflow_name: str,
         dataflow: DataFlow,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> DataFlow:
         """
@@ -597,8 +595,8 @@ class AzureDataFactoryHook(BaseHook):
     def delete_dataflow(
         self,
         dataflow_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -615,8 +613,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_pipeline(
         self,
         pipeline_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> PipelineResource:
         """
@@ -644,8 +642,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         pipeline_name: str,
         pipeline: PipelineResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> PipelineResource:
         """
@@ -671,8 +669,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         pipeline_name: str,
         pipeline: PipelineResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> PipelineResource:
         """
@@ -697,8 +695,8 @@ class AzureDataFactoryHook(BaseHook):
     def delete_pipeline(
         self,
         pipeline_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -715,8 +713,8 @@ class AzureDataFactoryHook(BaseHook):
     def run_pipeline(
         self,
         pipeline_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> CreateRunResponse:
         """
@@ -736,8 +734,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_pipeline_run(
         self,
         run_id: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> PipelineRun:
         """
@@ -826,8 +824,8 @@ class AzureDataFactoryHook(BaseHook):
     def cancel_pipeline_run(
         self,
         run_id: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -844,8 +842,8 @@ class AzureDataFactoryHook(BaseHook):
     def get_trigger(
         self,
         trigger_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> TriggerResource:
         """
@@ -873,8 +871,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         trigger_name: str,
         trigger: TriggerResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> TriggerResource:
         """
@@ -900,8 +898,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         trigger_name: str,
         trigger: TriggerResource,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> TriggerResource:
         """
@@ -926,8 +924,8 @@ class AzureDataFactoryHook(BaseHook):
     def delete_trigger(
         self,
         trigger_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -944,8 +942,8 @@ class AzureDataFactoryHook(BaseHook):
     def start_trigger(
         self,
         trigger_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> LROPoller:
         """
@@ -963,8 +961,8 @@ class AzureDataFactoryHook(BaseHook):
     def stop_trigger(
         self,
         trigger_name: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> LROPoller:
         """
@@ -983,8 +981,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         trigger_name: str,
         run_id: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """
@@ -1005,8 +1003,8 @@ class AzureDataFactoryHook(BaseHook):
         self,
         trigger_name: str,
         run_id: str,
-        resource_group_name: str | None = None,
-        factory_name: str | None = None,
+        resource_group_name: str,
+        factory_name: str,
         **config: Any,
     ) -> None:
         """

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -55,7 +55,7 @@ dependencies:
   # Azure integration uses old libraries and the limits below reflect that
   # TODO: upgrade to newer versions of all the below libraries
   - azure-mgmt-containerinstance>=1.5.0,<2.0
-  - azure-mgmt-datafactory>=1.0.0,<2.0
+  - azure-mgmt-datafactory>=2.0.0
   - azure-mgmt-datalake-store>=0.5.0
   - azure-mgmt-resource>=2.2.0
   - azure-storage-blob>=12.14.0

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -433,7 +433,7 @@
       "azure-keyvault-secrets>=4.1.0,<5.0",
       "azure-kusto-data>=0.0.43,<0.1",
       "azure-mgmt-containerinstance>=1.5.0,<2.0",
-      "azure-mgmt-datafactory>=1.0.0,<2.0",
+      "azure-mgmt-datafactory>=2.0.0",
       "azure-mgmt-datalake-store>=0.5.0",
       "azure-mgmt-resource>=2.2.0",
       "azure-servicebus>=7.6.1; platform_machine != \"aarch64\"",

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -194,7 +194,10 @@ def test_get_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, MODEL)),
-    implicit_factory=((MODEL,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL)),
+    implicit_factory=(
+        (MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL),
+    ),
 )
 def test_create_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_factory(*user_args)
@@ -204,7 +207,10 @@ def test_create_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, MODEL)),
-    implicit_factory=((MODEL,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL)),
+    implicit_factory=(
+        (MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL),
+    ),
 )
 def test_update_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_factory_exists") as mock_factory_exists:
@@ -216,7 +222,10 @@ def test_update_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, MODEL)),
-    implicit_factory=((MODEL,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL)),
+    implicit_factory=(
+        (MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, MODEL),
+    ),
 )
 def test_update_factory_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_factory_exists") as mock_factory_exists:
@@ -228,7 +237,7 @@ def test_update_factory_non_existent(hook: AzureDataFactoryHook, user_args, sdk_
 
 @parametrize(
     explicit_factory=((RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY)),
-    implicit_factory=((), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY)),
+    implicit_factory=((DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY)),
 )
 def test_delete_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.delete_factory(*user_args)
@@ -238,7 +247,10 @@ def test_delete_factory(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_get_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_linked_service(*user_args)
@@ -248,7 +260,10 @@ def test_get_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_create_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_linked_service(*user_args)
@@ -258,7 +273,10 @@ def test_create_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_linked_service_exists") as mock_linked_service_exists:
@@ -270,7 +288,10 @@ def test_update_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_linked_service_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_linked_service_exists") as mock_linked_service_exists:
@@ -282,7 +303,10 @@ def test_update_linked_service_non_existent(hook: AzureDataFactoryHook, user_arg
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_delete_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.delete_linked_service(*user_args)
@@ -292,7 +316,10 @@ def test_delete_linked_service(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_get_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_dataset(*user_args)
@@ -302,7 +329,10 @@ def test_get_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_create_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_dataset(*user_args)
@@ -312,7 +342,10 @@ def test_create_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_dataset_exists") as mock_dataset_exists:
@@ -324,7 +357,10 @@ def test_update_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_dataset_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_dataset_exists") as mock_dataset_exists:
@@ -336,7 +372,10 @@ def test_update_dataset_non_existent(hook: AzureDataFactoryHook, user_args, sdk_
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_delete_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.delete_dataset(*user_args)
@@ -346,7 +385,10 @@ def test_delete_dataset(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_get_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_dataflow(*user_args)
@@ -356,7 +398,10 @@ def test_get_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_create_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_dataflow(*user_args)
@@ -366,7 +411,10 @@ def test_create_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_dataflow_exists") as mock_dataflow_exists:
@@ -378,7 +426,10 @@ def test_update_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_dataflow_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_dataflow_exists") as mock_dataflow_exists:
@@ -391,7 +442,7 @@ def test_update_dataflow_non_existent(hook: AzureDataFactoryHook, user_args, sdk
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
     implicit_factory=(
-        (NAME,),
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
         (
             DEFAULT_RESOURCE_GROUP,
             DEFAULT_FACTORY,
@@ -407,7 +458,10 @@ def test_delete_dataflow(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_get_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_pipeline(*user_args)
@@ -417,7 +471,10 @@ def test_get_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_create_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_pipeline(*user_args)
@@ -427,7 +484,10 @@ def test_create_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_pipeline_exists") as mock_pipeline_exists:
@@ -439,7 +499,10 @@ def test_update_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_pipeline_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_pipeline_exists") as mock_pipeline_exists:
@@ -451,7 +514,10 @@ def test_update_pipeline_non_existent(hook: AzureDataFactoryHook, user_args, sdk
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_delete_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.delete_pipeline(*user_args)
@@ -461,7 +527,10 @@ def test_delete_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_run_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.run_pipeline(*user_args)
@@ -471,7 +540,14 @@ def test_run_pipeline(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((ID, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, ID)),
-    implicit_factory=((ID,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, ID)),
+    implicit_factory=(
+        (
+            ID,
+            DEFAULT_RESOURCE_GROUP,
+            DEFAULT_FACTORY,
+        ),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, ID),
+    ),
 )
 def test_get_pipeline_run(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_pipeline_run(*user_args)
@@ -503,7 +579,14 @@ _wait_for_pipeline_run_status_test_args = [
     ],
 )
 def test_wait_for_pipeline_run_status(hook, pipeline_run_status, expected_status, expected_output):
-    config = {"run_id": ID, "timeout": 3, "check_interval": 1, "expected_statuses": expected_status}
+    config = {
+        "run_id": ID,
+        "timeout": 3,
+        "factory_name": "abc",
+        "resource_group_name": "zzz",
+        "check_interval": 1,
+        "expected_statuses": expected_status,
+    }
 
     with patch.object(AzureDataFactoryHook, "get_pipeline_run") as mock_pipeline_run:
         mock_pipeline_run.return_value.status = pipeline_run_status
@@ -517,7 +600,10 @@ def test_wait_for_pipeline_run_status(hook, pipeline_run_status, expected_status
 
 @parametrize(
     explicit_factory=((ID, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, ID)),
-    implicit_factory=((ID,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, ID)),
+    implicit_factory=(
+        (ID, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, ID),
+    ),
 )
 def test_cancel_pipeline_run(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.cancel_pipeline_run(*user_args)
@@ -527,7 +613,10 @@ def test_cancel_pipeline_run(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_get_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.get_trigger(*user_args)
@@ -537,7 +626,10 @@ def test_get_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_create_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.create_trigger(*user_args)
@@ -547,7 +639,10 @@ def test_create_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_trigger_exists") as mock_trigger_exists:
@@ -559,7 +654,10 @@ def test_update_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, MODEL, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, MODEL)),
-    implicit_factory=((NAME, MODEL), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL)),
+    implicit_factory=(
+        (NAME, MODEL, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, MODEL),
+    ),
 )
 def test_update_trigger_non_existent(hook: AzureDataFactoryHook, user_args, sdk_args):
     with patch.object(hook, "_trigger_exists") as mock_trigger_exists:
@@ -571,7 +669,10 @@ def test_update_trigger_non_existent(hook: AzureDataFactoryHook, user_args, sdk_
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_delete_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.delete_trigger(*user_args)
@@ -581,7 +682,10 @@ def test_delete_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_start_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.start_trigger(*user_args)
@@ -591,7 +695,10 @@ def test_start_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME)),
-    implicit_factory=((NAME,), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME)),
+    implicit_factory=(
+        (NAME, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME),
+    ),
 )
 def test_stop_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.stop_trigger(*user_args)
@@ -601,7 +708,10 @@ def test_stop_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, ID, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, ID)),
-    implicit_factory=((NAME, ID), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, ID)),
+    implicit_factory=(
+        (NAME, ID, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, ID),
+    ),
 )
 def test_rerun_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.rerun_trigger(*user_args)
@@ -611,7 +721,10 @@ def test_rerun_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
 
 @parametrize(
     explicit_factory=((NAME, ID, RESOURCE_GROUP, FACTORY), (RESOURCE_GROUP, FACTORY, NAME, ID)),
-    implicit_factory=((NAME, ID), (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, ID)),
+    implicit_factory=(
+        (NAME, ID, DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY),
+        (DEFAULT_RESOURCE_GROUP, DEFAULT_FACTORY, NAME, ID),
+    ),
 )
 def test_cancel_trigger(hook: AzureDataFactoryHook, user_args, sdk_args):
     hook.cancel_trigger(*user_args)


### PR DESCRIPTION
~~Version 2.0.0 contains 2 breaking changes which are very small and does not effect the current hook/operators. It should be safe to support all versions https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/datafactory/azure-mgmt-datafactory/CHANGELOG.md~~

While version 2.0.0 doesn't contain significant [breaking changes](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/datafactory/azure-mgmt-datafactory/CHANGELOG.md) However since we are changing hook functions parameters this is a **breaking change** for the Azure provider.

There are several typing issues to be addressed:

`TriggersOperations` [create_or_update](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_triggers_operations.py#L770-L776) function `resource_group_name` and `factory_name` are no longer optional.

`TriggersOperations` [begin_stop](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_triggers_operations.py#L1523-L1524) function `resource_group_name` and `factory_name` are no longer optional.

`TriggersOperations` [begin_start](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_triggers_operations.py#L1412) function `resource_group_name` and `factory_name` are no longer optional.


`PipelinesOperations` [get](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_pipelines_operations.py#L583-L589) function `resource_group_name` and `factory_name` are no longer optional.

`PipelinesOperations` [create_run](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_pipelines_operations.py#L815-L825) function `resource_group_name` and `factory_name` are no longer optional.

`PipelinesOperations` [delete](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_pipelines_operations.py#L658-L659) function `resource_group_name` and `factory_name` are no longer optional.


`TriggerRunsOperations` [rerun](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_trigger_runs_operations.py#L198-L214) function `resource_group_name` and `factory_name` are no longer optional.

`TriggerRunsOperations` [cancel](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_trigger_runs_operations.py#L260-L261) function `resource_group_name` and `factory_name` are no longer optional.




`PipelineRunsOperations ` [get](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_pipeline_runs_operations.py#L326) function `resource_group_name` and `factory_name` are no longer optional.


`PipelineRunsOperations ` [cancel](https://github.com/Azure/azure-sdk-for-python/blob/86684fb7d5b4580244a7967d42624209fea20a4e/sdk/datafactory/azure-mgmt-datafactory/azure/mgmt/datafactory/operations/_pipeline_runs_operations.py#L387) function `resource_group_name` and `factory_name` are no longer optional.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
