### PR TITLE
Enable full static checks also when only dev file change

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -88,6 +88,7 @@ CI_FILE_GROUP_MATCHES = HashableDict(
         FileGroupForCi.ENVIRONMENT_FILES: [
             r"^.github/workflows",
             r"^dev/breeze",
+            r"^dev/.*\.py$",
             r"^Dockerfile",
             r"^scripts",
             r"^setup.py",


### PR DESCRIPTION
When only dev/ files change we should run all the static tests becuase our flake/mypy checks are also run for the dev files.

We have more scripts than "breeze" in dev and since those change rarely they should be all added to "environment" checks that will trigger full tests.

See #26605 for an example of such PR that did not trigger the full set of tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
