### PR TITLE
Add better diagnostics on auto dependencies upgrade

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -237,6 +237,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           DOCKER_CACHE: ${{ needs.build-info.outputs.cache-directive }}
           IMAGE_TAG: ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           PYTHON_VERSIONS: ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
+      - name: "Show dependencies to be upgraded"
+        run: >
+          breeze release-management generate-constraints
+          --airflow-constraints-mode constraints-source-providers
+        if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
       - name: Push empty CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         if: failure() || cancelled()
         run: breeze ci-image build --push --empty-image --run-in-parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           PYTHON_VERSIONS: ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
           DEBUG_RESOURCES: ${{ needs.build-info.outputs.debug-resources }}
         if: needs.build-info.outputs.in-workflow-build == 'true'
+      - name: "Show dependencies to be upgraded"
+        run: >
+          breeze release-management generate-constraints
+          --airflow-constraints-mode constraints-source-providers
+        if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
       - name: "Candidates for pip resolver backtrack triggers"
         if: failure() || cancelled()
         run: >


### PR DESCRIPTION
Whenever upgrade-to-newer-dependencies is set, our CI will attempt to upgrade all dependencies to latest versions released. However so far it was not clear which dependencies were upgraded so if CI failed because of some dependency release, you had to guess and manually check which dependencies got upgraded.

This PR adds a step that will show the diff between the constraints in the target branch (`constraints-main` or `constraints-X-Y` in case upgrade-to-newer-dependencies is enabled.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
