### PR TITLE
Allow and prefer non-prefixed extra fields for AzureDataExplorerHook

### DIFF
--- a/airflow/providers/microsoft/azure/utils.py
+++ b/airflow/providers/microsoft/azure/utils.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from functools import wraps
+
+
+def _ensure_prefixes(conn_type):
+    """
+    Remove when provider min airflow version >= 2.5.0 since this is handled by
+    provider manager from that version.
+    """
+
+    def dec(func):
+        @wraps(func)
+        def inner():
+            field_behaviors = func()
+            conn_attrs = {"host", "schema", "login", "password", "port", "extra"}
+
+            def _ensure_prefix(field):
+                if field not in conn_attrs and not field.startswith("extra__"):
+                    return f"extra__{conn_type}__{field}"
+                else:
+                    return field
+
+            if "placeholders" in field_behaviors:
+                placeholders = field_behaviors["placeholders"]
+                field_behaviors["placeholders"] = {_ensure_prefix(k): v for k, v in placeholders.items()}
+            return field_behaviors
+
+        return inner
+
+    return dec

--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -18,24 +18,26 @@
 from __future__ import annotations
 
 import json
-import unittest
+import os
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from azure.kusto.data.request import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
+from pytest import param
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.adx import AzureDataExplorerHook
 from airflow.utils import db
 from airflow.utils.session import create_session
+from tests.test_utils.providers import get_provider_min_airflow_version
 
 ADX_TEST_CONN_ID = "adx_test_connection_id"
 
 
-class TestAzureDataExplorerHook(unittest.TestCase):
-    def tearDown(self):
-        super().tearDown()
+class TestAzureDataExplorerHook:
+    def teardown(self):
         with create_session() as session:
             session.query(Connection).filter(Connection.conn_id == ADX_TEST_CONN_ID).delete()
 
@@ -191,3 +193,53 @@ class TestAzureDataExplorerHook(unittest.TestCase):
         properties = ClientRequestProperties()
         properties.set_option("option1", "option_value")
         assert mock_execute.called_with("Database", "Logs | schema", properties=properties)
+
+    def test_get_ui_field_behaviour_placeholders(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
+        """
+        assert list(AzureDataExplorerHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+            "login",
+            "password",
+            "extra__azure_data_explorer__auth_method",
+            "extra__azure_data_explorer__tenant",
+            "extra__azure_data_explorer__certificate",
+            "extra__azure_data_explorer__thumbprint",
+        ]
+        if get_provider_min_airflow_version("apache-airflow-providers-microsoft-azure") >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from azure utils."
+                " The functionality is now taken care of by providers manager."
+            )
+
+    @pytest.mark.parametrize(
+        "uri",
+        [
+            param(
+                "a://usr:pw@host?extra__azure_data_explorer__tenant=my-tenant"
+                "&extra__azure_data_explorer__auth_method=AAD_APP",
+                id="prefix",
+            ),
+            param("a://usr:pw@host?tenant=my-tenant&auth_method=AAD_APP", id="no-prefix"),
+        ],
+    )
+    @patch("airflow.providers.microsoft.azure.hooks.adx.KustoConnectionStringBuilder")
+    def test_backcompat_prefix_works(self, mock_client, uri):
+        mock_with = mock_client.with_aad_application_key_authentication
+        with patch.dict(os.environ, AIRFLOW_CONN_MY_CONN=uri):
+            AzureDataExplorerHook(azure_data_explorer_conn_id="my_conn")  # get_conn is called in init
+        mock_with.assert_called_once_with("host", "usr", "pw", "my-tenant")
+
+    @patch("airflow.providers.microsoft.azure.hooks.adx.KustoConnectionStringBuilder")
+    def test_backcompat_prefix_both_causes_warning(self, mock_client):
+        mock_with = mock_client.with_aad_application_key_authentication
+        with patch.dict(
+            in_dict=os.environ,
+            AIRFLOW_CONN_MY_CONN="a://usr:pw@host?tenant=my-tenant&auth_method=AAD_APP"
+            "&extra__azure_data_explorer__auth_method=AAD_APP",
+        ):
+            with pytest.warns(Warning, match="Using value for `auth_method`"):
+                AzureDataExplorerHook(azure_data_explorer_conn_id="my_conn")  # get_conn is called in init
+        mock_with.assert_called_once_with("host", "usr", "pw", "my-tenant")


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.
