### PR TITLE
Allow and prefer non-prefixed extra fields for remaining azure

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -50,7 +50,6 @@ class AzureBatchHook(BaseHook):
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=False,
         )
 
     @staticmethod

--- a/airflow/providers/microsoft/azure/hooks/batch.py
+++ b/airflow/providers/microsoft/azure/hooks/batch.py
@@ -27,6 +27,7 @@ from azure.batch.models import JobAddParameter, PoolAddParameter, TaskAddParamet
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.models import Connection
+from airflow.providers.microsoft.azure.utils import get_field
 from airflow.utils import timezone
 
 
@@ -43,6 +44,15 @@ class AzureBatchHook(BaseHook):
     conn_type = "azure_batch"
     hook_name = "Azure Batch Service"
 
+    def _get_field(self, extras, name):
+        return get_field(
+            conn_id=self.conn_id,
+            conn_type=self.conn_type,
+            extras=extras,
+            field_name=name,
+            strict=False,
+        )
+
     @staticmethod
     def get_connection_form_widgets() -> dict[str, Any]:
         """Returns connection widgets to add to connection form"""
@@ -51,9 +61,7 @@ class AzureBatchHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_batch__account_url": StringField(
-                lazy_gettext("Batch Account URL"), widget=BS3TextFieldWidget()
-            ),
+            "account_url": StringField(lazy_gettext("Batch Account URL"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod
@@ -85,7 +93,7 @@ class AzureBatchHook(BaseHook):
         """
         conn = self._connection()
 
-        batch_account_url = conn.extra_dejson.get("extra__azure_batch__account_url")
+        batch_account_url = self._get_field(conn.extra_dejson, "account_url")
         if not batch_account_url:
             raise AirflowException("Batch Account URL parameter is missing.")
 

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -49,7 +49,6 @@ class AzureContainerVolumeHook(BaseHook):
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=False,
         )
 
     @staticmethod

--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -22,6 +22,7 @@ from typing import Any
 from azure.mgmt.containerinstance.models import AzureFileVolume, Volume
 
 from airflow.hooks.base import BaseHook
+from airflow.providers.microsoft.azure.utils import _ensure_prefixes, get_field
 
 
 class AzureContainerVolumeHook(BaseHook):
@@ -42,6 +43,15 @@ class AzureContainerVolumeHook(BaseHook):
         super().__init__()
         self.conn_id = azure_container_volume_conn_id
 
+    def _get_field(self, extras, name):
+        return get_field(
+            conn_id=self.conn_id,
+            conn_type=self.conn_type,
+            extras=extras,
+            field_name=name,
+            strict=False,
+        )
+
     @staticmethod
     def get_connection_form_widgets() -> dict[str, Any]:
         """Returns connection widgets to add to connection form"""
@@ -50,12 +60,13 @@ class AzureContainerVolumeHook(BaseHook):
         from wtforms import PasswordField
 
         return {
-            "extra__azure_container_volume__connection_string": PasswordField(
+            "connection_string": PasswordField(
                 lazy_gettext("Blob Storage Connection String (optional)"), widget=BS3PasswordFieldWidget()
             ),
         }
 
     @staticmethod
+    @_ensure_prefixes(conn_type="azure_container_volume")
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
@@ -67,17 +78,17 @@ class AzureContainerVolumeHook(BaseHook):
             "placeholders": {
                 "login": "client_id (token credentials auth)",
                 "password": "secret (token credentials auth)",
-                "extra__azure_container_volume__connection_string": "connection string auth",
+                "connection_string": "connection string auth",
             },
         }
 
     def get_storagekey(self) -> str:
         """Get Azure File Volume storage key"""
         conn = self.get_connection(self.conn_id)
-        service_options = conn.extra_dejson
-
-        if "extra__azure_container_volume__connection_string" in service_options:
-            for keyvalue in service_options["extra__azure_container_volume__connection_string"].split(";"):
+        extras = conn.extra_dejson
+        connection_string = self._get_field(extras, "connection_string")
+        if connection_string:
+            for keyvalue in connection_string.split(";"):
                 key, value = keyvalue.split("=", 1)
                 if key == "AccountKey":
                     return value

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -102,7 +102,6 @@ class AzureCosmosDBHook(BaseHook):
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=False,
         )
 
     def get_conn(self) -> CosmosClient:

--- a/airflow/providers/microsoft/azure/hooks/cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/cosmos.py
@@ -34,6 +34,7 @@ from azure.cosmos.exceptions import CosmosHttpResponseError
 
 from airflow.exceptions import AirflowBadRequest
 from airflow.hooks.base import BaseHook
+from airflow.providers.microsoft.azure.utils import _ensure_prefixes, get_field
 
 
 class AzureCosmosDBHook(BaseHook):
@@ -61,15 +62,16 @@ class AzureCosmosDBHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_cosmos__database_name": StringField(
+            "database_name": StringField(
                 lazy_gettext("Cosmos Database Name (optional)"), widget=BS3TextFieldWidget()
             ),
-            "extra__azure_cosmos__collection_name": StringField(
+            "collection_name": StringField(
                 lazy_gettext("Cosmos Collection Name (optional)"), widget=BS3TextFieldWidget()
             ),
         }
 
     @staticmethod
+    @_ensure_prefixes(conn_type="azure_cosmos")  # todo: remove when min airflow version >= 2.5
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
@@ -81,8 +83,8 @@ class AzureCosmosDBHook(BaseHook):
             "placeholders": {
                 "login": "endpoint uri",
                 "password": "master key",
-                "extra__azure_cosmos__database_name": "database name",
-                "extra__azure_cosmos__collection_name": "collection name",
+                "database_name": "database name",
+                "collection_name": "collection name",
             },
         }
 
@@ -94,6 +96,15 @@ class AzureCosmosDBHook(BaseHook):
         self.default_database_name = None
         self.default_collection_name = None
 
+    def _get_field(self, extras, name):
+        return get_field(
+            conn_id=self.conn_id,
+            conn_type=self.conn_type,
+            extras=extras,
+            field_name=name,
+            strict=False,
+        )
+
     def get_conn(self) -> CosmosClient:
         """Return a cosmos db client."""
         if not self._conn:
@@ -102,12 +113,8 @@ class AzureCosmosDBHook(BaseHook):
             endpoint_uri = conn.login
             master_key = conn.password
 
-            self.default_database_name = extras.get("database_name") or extras.get(
-                "extra__azure_cosmos__database_name"
-            )
-            self.default_collection_name = extras.get("collection_name") or extras.get(
-                "extra__azure_cosmos__collection_name"
-            )
+            self.default_database_name = self._get_field(extras, "database_name")
+            self.default_collection_name = self._get_field(extras, "collection_name")
 
             # Initialize the Python Azure Cosmos DB client
             self._conn = CosmosClient(endpoint_uri, {"masterKey": master_key})

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -31,6 +31,7 @@ from azure.datalake.store import core, lib, multithread
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+from airflow.providers.microsoft.azure.utils import _ensure_prefixes, get_field
 
 
 class AzureDataLakeHook(BaseHook):
@@ -57,15 +58,14 @@ class AzureDataLakeHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_data_lake__tenant": StringField(
-                lazy_gettext("Azure Tenant ID"), widget=BS3TextFieldWidget()
-            ),
-            "extra__azure_data_lake__account_name": StringField(
+            "tenant": StringField(lazy_gettext("Azure Tenant ID"), widget=BS3TextFieldWidget()),
+            "account_name": StringField(
                 lazy_gettext("Azure DataLake Store Name"), widget=BS3TextFieldWidget()
             ),
         }
 
     @staticmethod
+    @_ensure_prefixes(conn_type="azure_data_lake")
     def get_ui_field_behaviour() -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
@@ -77,8 +77,8 @@ class AzureDataLakeHook(BaseHook):
             "placeholders": {
                 "login": "client id",
                 "password": "secret",
-                "extra__azure_data_lake__tenant": "tenant id",
-                "extra__azure_data_lake__account_name": "datalake store",
+                "tenant": "tenant id",
+                "account_name": "datalake store",
             },
         }
 
@@ -88,16 +88,22 @@ class AzureDataLakeHook(BaseHook):
         self._conn: core.AzureDLFileSystem | None = None
         self.account_name: str | None = None
 
+    def _get_field(self, extras, name):
+        return get_field(
+            conn_id=self.conn_id,
+            conn_type=self.conn_type,
+            extras=extras,
+            field_name=name,
+            strict=False,
+        )
+
     def get_conn(self) -> core.AzureDLFileSystem:
         """Return a AzureDLFileSystem object."""
         if not self._conn:
             conn = self.get_connection(self.conn_id)
-            service_options = conn.extra_dejson
-            self.account_name = service_options.get("account_name") or service_options.get(
-                "extra__azure_data_lake__account_name"
-            )
-            tenant = service_options.get("tenant") or service_options.get("extra__azure_data_lake__tenant")
-
+            extras = conn.extra_dejson
+            self.account_name = self._get_field(extras, "account_name")
+            tenant = self._get_field(extras, "tenant")
             adl_creds = lib.auth(tenant_id=tenant, client_secret=conn.password, client_id=conn.login)
             self._conn = core.AzureDLFileSystem(adl_creds, store_name=self.account_name)
             self._conn.connect()

--- a/airflow/providers/microsoft/azure/hooks/data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/data_lake.py
@@ -94,7 +94,6 @@ class AzureDataLakeHook(BaseHook):
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=False,
         )
 
     def get_conn(self) -> core.AzureDLFileSystem:

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -25,6 +25,7 @@ from azure.synapse.spark.models import SparkBatchJobOptions
 
 from airflow.exceptions import AirflowTaskTimeout
 from airflow.hooks.base import BaseHook
+from airflow.providers.microsoft.azure.utils import get_field
 
 Credentials = Union[ClientSecretCredential, DefaultAzureCredential]
 
@@ -66,12 +67,8 @@ class AzureSynapseHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure_synapse__tenantId": StringField(
-                lazy_gettext("Tenant ID"), widget=BS3TextFieldWidget()
-            ),
-            "extra__azure_synapse__subscriptionId": StringField(
-                lazy_gettext("Subscription ID"), widget=BS3TextFieldWidget()
-            ),
+            "tenantId": StringField(lazy_gettext("Tenant ID"), widget=BS3TextFieldWidget()),
+            "subscriptionId": StringField(lazy_gettext("Subscription ID"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod
@@ -89,17 +86,27 @@ class AzureSynapseHook(BaseHook):
         self.spark_pool = spark_pool
         super().__init__()
 
+    def _get_field(self, extras, name, strict=False):
+        return get_field(
+            conn_id=self.conn_id,
+            conn_type=self.conn_type,
+            extras=extras,
+            field_name=name,
+            strict=strict,
+        )
+
     def get_conn(self) -> SparkClient:
         if self._conn is not None:
             return self._conn
 
         conn = self.get_connection(self.conn_id)
-        tenant = conn.extra_dejson.get("extra__azure_synapse__tenantId")
+        extras = conn.extra_dejson
+        tenant = self._get_field(extras, "tenantId")
         spark_pool = self.spark_pool
         livy_api_version = "2022-02-22-preview"
 
         try:
-            subscription_id = conn.extra_dejson["extra__azure_synapse__subscriptionId"]
+            subscription_id = self._get_field(extras, "subscriptionId", strict=True)
         except KeyError:
             raise ValueError("A Subscription ID is required to connect to Azure Synapse.")
 

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -86,13 +86,13 @@ class AzureSynapseHook(BaseHook):
         self.spark_pool = spark_pool
         super().__init__()
 
-    def _get_field(self, extras, name, strict=False):
+    def _get_field(self, extras, name):
         return get_field(
             conn_id=self.conn_id,
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=strict,
+            strict=False,
         )
 
     def get_conn(self) -> SparkClient:
@@ -105,9 +105,8 @@ class AzureSynapseHook(BaseHook):
         spark_pool = self.spark_pool
         livy_api_version = "2022-02-22-preview"
 
-        try:
-            subscription_id = self._get_field(extras, "subscriptionId", strict=True)
-        except KeyError:
+        subscription_id = self._get_field(extras, "subscriptionId")
+        if not subscription_id:
             raise ValueError("A Subscription ID is required to connect to Azure Synapse.")
 
         credential: Credentials

--- a/airflow/providers/microsoft/azure/hooks/synapse.py
+++ b/airflow/providers/microsoft/azure/hooks/synapse.py
@@ -92,7 +92,6 @@ class AzureSynapseHook(BaseHook):
             conn_type=self.conn_type,
             extras=extras,
             field_name=name,
-            strict=False,
         )
 
     def get_conn(self) -> SparkClient:

--- a/airflow/providers/microsoft/azure/utils.py
+++ b/airflow/providers/microsoft/azure/utils.py
@@ -49,10 +49,11 @@ def _ensure_prefixes(conn_type):
     return dec
 
 
-def get_field(*, conn_id: str, conn_type: str, extras: dict, field_name: str, strict=False):
+def get_field(*, conn_id: str, conn_type: str, extras: dict, field_name: str):
     """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
     backcompat_prefix = f"extra__{conn_type}__"
     backcompat_key = f"{backcompat_prefix}{field_name}"
+    ret = None
     if field_name.startswith("extra__"):
         raise ValueError(
             f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
@@ -65,8 +66,9 @@ def get_field(*, conn_id: str, conn_type: str, extras: dict, field_name: str, st
                 f"{conn_id}. Using value for `{field_name}`.  Please ensure this is the correct "
                 f"value and remove the backcompat key `{backcompat_key}`."
             )
-        return extras[field_name] or None
-    if backcompat_key in extras:
-        return extras.get(backcompat_key) or None
-    if strict:
-        raise KeyError(f"Field {field_name} not found in extras")
+        ret = extras[field_name]
+    elif backcompat_key in extras:
+        ret = extras.get(backcompat_key)
+    if ret == "":
+        return None
+    return ret

--- a/airflow/providers/microsoft/azure/utils.py
+++ b/airflow/providers/microsoft/azure/utils.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import warnings
 from functools import wraps
 
 
@@ -46,3 +47,26 @@ def _ensure_prefixes(conn_type):
         return inner
 
     return dec
+
+
+def get_field(*, conn_id: str, conn_type: str, extras: dict, field_name: str, strict=False):
+    """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
+    backcompat_prefix = f"extra__{conn_type}__"
+    backcompat_key = f"{backcompat_prefix}{field_name}"
+    if field_name.startswith("extra__"):
+        raise ValueError(
+            f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
+            "when using this method."
+        )
+    if field_name in extras:
+        if backcompat_key in extras:
+            warnings.warn(
+                f"Conflicting params `{field_name}` and `{backcompat_key}` found in extras for conn "
+                f"{conn_id}. Using value for `{field_name}`.  Please ensure this is the correct "
+                f"value and remove the backcompat key `{backcompat_key}`."
+            )
+        return extras[field_name] or None
+    if backcompat_key in extras:
+        return extras.get(backcompat_key) or None
+    if strict:
+        raise KeyError(f"Field {field_name} not found in extras")

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
@@ -23,6 +23,7 @@ import unittest
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook
 from airflow.utils import db
+from tests.test_utils.providers import get_provider_min_airflow_version
 
 
 class TestAzureContainerVolumeHook(unittest.TestCase):
@@ -65,3 +66,20 @@ class TestAzureContainerVolumeHook(unittest.TestCase):
         assert volume.azure_file.storage_account_key == "1"
         assert volume.azure_file.storage_account_name == "storage"
         assert volume.azure_file.read_only is True
+
+    def test_get_ui_field_behaviour_placeholders(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
+        """
+        assert list(AzureContainerVolumeHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+            "login",
+            "password",
+            "extra__azure_container_volume__connection_string",
+        ]
+        if get_provider_min_airflow_version("apache-airflow-providers-microsoft-azure") >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from azure utils."
+                " The functionality is now taken care of by providers manager."
+            )

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -31,6 +31,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.cosmos import AzureCosmosDBHook
 from airflow.utils import db
+from tests.test_utils.providers import get_provider_min_airflow_version
 
 
 class TestAzureCosmosDbHook(unittest.TestCase):
@@ -254,3 +255,21 @@ class TestAzureCosmosDbHook(unittest.TestCase):
         status, msg = hook.test_connection()
         assert status is False
         assert msg == "Authentication failed."
+
+    def test_get_ui_field_behaviour_placeholders(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
+        """
+        assert list(AzureCosmosDBHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+            "login",
+            "password",
+            "extra__azure_cosmos__database_name",
+            "extra__azure_cosmos__collection_name",
+        ]
+        if get_provider_min_airflow_version("apache-airflow-providers-microsoft-azure") >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from azure utils."
+                " The functionality is now taken care of by providers manager."
+            )

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -22,7 +22,9 @@ import unittest
 from unittest import mock
 
 from airflow.models import Connection
+from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 from airflow.utils import db
+from tests.test_utils.providers import get_provider_min_airflow_version
 
 
 class TestAzureDataLakeHook(unittest.TestCase):
@@ -132,3 +134,21 @@ class TestAzureDataLakeHook(unittest.TestCase):
         hook = AzureDataLakeHook(azure_data_lake_conn_id="adl_test_key")
         hook.remove("filepath", True)
         mock_fs.return_value.remove.assert_called_once_with("filepath", recursive=True)
+
+    def test_get_ui_field_behaviour_placeholders(self):
+        """
+        Check that ensure_prefixes decorator working properly
+
+        Note: remove this test and the _ensure_prefixes decorator after min airflow version >= 2.5.0
+        """
+        assert list(AzureDataLakeHook.get_ui_field_behaviour()["placeholders"].keys()) == [
+            "login",
+            "password",
+            "extra__azure_data_lake__tenant",
+            "extra__azure_data_lake__account_name",
+        ]
+        if get_provider_min_airflow_version("apache-airflow-providers-microsoft-azure") >= (2, 5):
+            raise Exception(
+                "You must now remove `_ensure_prefixes` from azure utils."
+                " The functionality is now taken care of by providers manager."
+            )

--- a/tests/providers/microsoft/azure/test_utils.py
+++ b/tests/providers/microsoft/azure/test_utils.py
@@ -25,14 +25,14 @@ from tests.test_utils.providers import get_provider_min_airflow_version, object_
 
 def test__ensure_prefixes_removal():
     """Ensure that _ensure_prefixes is removed from snowflake when airflow min version >= 2.5.0."""
-    path = 'airflow.providers.microsoft.azure.utils._ensure_prefixes'
+    path = "airflow.providers.microsoft.azure.utils._ensure_prefixes"
     if not object_exists(path):
         raise Exception(
             "You must remove this test. It only exists to "
             "remind us to remove decorator `_ensure_prefixes`."
         )
 
-    if get_provider_min_airflow_version('apache-airflow-providers-microsoft-azure') >= (2, 5):
+    if get_provider_min_airflow_version("apache-airflow-providers-microsoft-azure") >= (2, 5):
         raise Exception(
             "You must now remove `_ensure_prefixes` from azure utils."
             " The functionality is now taken care of by providers manager."
@@ -40,11 +40,11 @@ def test__ensure_prefixes_removal():
 
 
 def test_get_field_warns_on_dupe():
-    with pytest.warns(DeprecationWarning, match='abc'):
+    with pytest.warns(DeprecationWarning, match="abc"):
         value = get_field(
-            conn_id='my_conn',
-            conn_type='this_type',
-            extras=dict(extra__this_type__this_param='prefixed', this_param='non-prefixed'),
-            field_name='this_param',
+            conn_id="my_conn",
+            conn_type="this_type",
+            extras=dict(extra__this_type__this_param="prefixed", this_param="non-prefixed"),
+            field_name="this_param",
         )
-    assert value == 'non-prefixed'
+    assert value == "non-prefixed"

--- a/tests/providers/microsoft/azure/test_utils.py
+++ b/tests/providers/microsoft/azure/test_utils.py
@@ -17,6 +17,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from airflow.providers.microsoft.azure.utils import get_field
 from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
 
 
@@ -34,3 +37,14 @@ def test__ensure_prefixes_removal():
             "You must now remove `_ensure_prefixes` from azure utils."
             " The functionality is now taken care of by providers manager."
         )
+
+
+def test_get_field_warns_on_dupe():
+    with pytest.warns(DeprecationWarning, match='abc'):
+        value = get_field(
+            conn_id='my_conn',
+            conn_type='this_type',
+            extras=dict(extra__this_type__this_param='prefixed', this_param='non-prefixed'),
+            field_name='this_param',
+        )
+    assert value == 'non-prefixed'

--- a/tests/providers/microsoft/azure/test_utils.py
+++ b/tests/providers/microsoft/azure/test_utils.py
@@ -40,7 +40,7 @@ def test__ensure_prefixes_removal():
 
 
 def test_get_field_warns_on_dupe():
-    with pytest.warns(DeprecationWarning, match="abc"):
+    with pytest.warns(UserWarning, match=" Using value for `this_param`"):
         value = get_field(
             conn_id="my_conn",
             conn_type="this_type",

--- a/tests/providers/microsoft/azure/test_utils.py
+++ b/tests/providers/microsoft/azure/test_utils.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from tests.test_utils.providers import get_provider_min_airflow_version, object_exists
+
+
+def test__ensure_prefixes_removal():
+    """Ensure that _ensure_prefixes is removed from snowflake when airflow min version >= 2.5.0."""
+    path = 'airflow.providers.microsoft.azure.utils._ensure_prefixes'
+    if not object_exists(path):
+        raise Exception(
+            "You must remove this test. It only exists to "
+            "remind us to remove decorator `_ensure_prefixes`."
+        )
+
+    if get_provider_min_airflow_version('apache-airflow-providers-microsoft-azure') >= (2, 5):
+        raise Exception(
+            "You must now remove `_ensure_prefixes` from azure utils."
+            " The functionality is now taken care of by providers manager."
+        )

--- a/tests/providers/microsoft/azure/test_utils.py
+++ b/tests/providers/microsoft/azure/test_utils.py
@@ -40,7 +40,7 @@ def test__ensure_prefixes_removal():
 
 
 def test_get_field_warns_on_dupe():
-    with pytest.warns(UserWarning, match=" Using value for `this_param`"):
+    with pytest.warns(UserWarning, match="Using value for `this_param`"):
         value = get_field(
             conn_id="my_conn",
             conn_type="this_type",
@@ -48,3 +48,28 @@ def test_get_field_warns_on_dupe():
             field_name="this_param",
         )
     assert value == "non-prefixed"
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (dict(this_param="non-prefixed"), "non-prefixed"),
+        (dict(this_param=None), None),
+        (dict(extra__this_type__this_param="prefixed"), "prefixed"),
+        (dict(extra__this_type__this_param=""), None),
+        (dict(extra__this_type__this_param=None), None),
+        (dict(extra__this_type__this_param="prefixed", this_param="non-prefixed"), "non-prefixed"),
+        (dict(extra__this_type__this_param="prefixed", this_param=""), None),
+        (dict(extra__this_type__this_param="prefixed", this_param=0), 0),
+        (dict(extra__this_type__this_param="prefixed", this_param=False), False),
+        (dict(extra__this_type__this_param="prefixed", this_param=" "), " "),
+    ],
+)
+def test_get_field_non_prefixed(input, expected):
+    value = get_field(
+        conn_id="my_conn",
+        conn_type="this_type",
+        extras=input,
+        field_name="this_param",
+    )
+    assert value == expected


### PR DESCRIPTION
From airflow version 2.3, extra prefixes are not required so we enable them here.

Hooks updated:
* batch
* container volume
* cosmos
* data lake
* synapse
