### PR TITLE
Fix constraint upgrade

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -239,8 +239,10 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           PYTHON_VERSIONS: ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
       - name: "Show dependencies to be upgraded"
         run: >
-          breeze release-management generate-constraints
+          breeze release-management generate-constraints --run-in-parallel
           --airflow-constraints-mode constraints-source-providers
+        env:
+          PYTHON_VERSIONS: ${{ needs.build-info.outputs.python-versions-list-as-string }}
         if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
       - name: Push empty CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         if: failure() || cancelled()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,9 +411,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: needs.build-info.outputs.in-workflow-build == 'true'
       - name: "Show dependencies to be upgraded"
         run: >
-          breeze release-management generate-constraints
+          breeze release-management generate-constraints --run-in-parallel
           --airflow-constraints-mode constraints-source-providers
-        if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
+        env:
+          PYTHON_VERSIONS: ${{ needs.build-info.outputs.python-versions-list-as-string }}
+        if: >
+          needs.build-info.outputs.upgrade-to-newer-dependencies != 'false' &&
+          needs.build-info.outputs.in-workflow-build == 'true'
       - name: "Candidates for pip resolver backtrack triggers"
         if: failure() || cancelled()
         run: >


### PR DESCRIPTION
It turnded out that #27215 has a problem when runnning when in-workflow-build is False - additional condition has to be added for it.

Additionally, the constraint generation is run for all python versions in parallel instaed of running only for default python version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
