### PR TITLE
Add Blackify commits to blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,6 @@
-# PEP-563 (Postponed Evaluation of Annotations)
+# PEP-563 (Postponed Evaluation of Annotations).
 d67ac5932dabbf06ae733fc57b48491a8029b8c2
+
+# Mass converting string literals to use double quotes.
+2a34dc9e8470285b0ed2db71109ef4265e29688b
+bfcae349b88fd959e32bfacd027a5be976fe2132


### PR DESCRIPTION
This can only be done when the commits are actually merged to main.

~~Waiting for #27206.~~ Done. The core part will be added later in another PR after 2.5 branches out.