### PR TITLE
Reduce extraneous task log requests

### DIFF
--- a/airflow/www/static/js/api/useTaskLog.ts
+++ b/airflow/www/static/js/api/useTaskLog.ts
@@ -20,15 +20,19 @@
 import axios, { AxiosResponse } from 'axios';
 import { useQuery } from 'react-query';
 import { useAutoRefresh } from 'src/context/autorefresh';
-import type { API } from 'src/types';
+import type { API, TaskInstance } from 'src/types';
 
 import { getMetaValue } from 'src/utils';
 
 const taskLogApi = getMetaValue('task_log_api');
 
+interface Props extends API.GetLogVariables {
+  state?: TaskInstance['state'];
+}
+
 const useTaskLog = ({
-  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent,
-}: API.GetLogVariables) => {
+  dagId, dagRunId, taskId, taskTryNumber, mapIndex, fullContent, state,
+}: Props) => {
   let url: string = '';
   if (taskLogApi) {
     url = taskLogApi.replace('_DAG_RUN_ID_', dagRunId).replace('_TASK_ID_', taskId).replace(/-1$/, taskTryNumber.toString());
@@ -36,12 +40,21 @@ const useTaskLog = ({
 
   const { isRefreshOn } = useAutoRefresh();
 
+  // Only refresh is the state is pending
+  const isStatePending = state === 'deferred'
+    || state === 'scheduled'
+    || state === 'running'
+    || state === 'up_for_reschedule'
+    || state === 'up_for_retry'
+    || state === 'queued'
+    || state === 'restarting';
+
   return useQuery(
-    ['taskLogs', dagId, dagRunId, taskId, mapIndex, taskTryNumber, fullContent],
+    ['taskLogs', dagId, dagRunId, taskId, mapIndex, taskTryNumber, fullContent, state],
     () => axios.get<AxiosResponse, string>(url, { headers: { Accept: 'text/plain' }, params: { map_index: mapIndex, full_content: fullContent } }),
     {
       placeholderData: '',
-      refetchInterval: isRefreshOn && (autoRefreshInterval || 1) * 1000,
+      refetchInterval: isStatePending && isRefreshOn && (autoRefreshInterval || 1) * 1000,
     },
   );
 };

--- a/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Logs/index.tsx
@@ -87,6 +87,7 @@ interface Props {
   mapIndex?: TaskInstance['mapIndex'];
   executionDate: DagRun['executionDate'];
   tryNumber: TaskInstance['tryNumber'];
+  state?: TaskInstance['state'];
 }
 
 const Logs = ({
@@ -96,6 +97,7 @@ const Logs = ({
   mapIndex,
   executionDate,
   tryNumber,
+  state,
 }: Props) => {
   const [internalIndexes, externalIndexes] = getLinkIndexes(tryNumber);
   const [selectedTryNumber, setSelectedTryNumber] = useState<number | undefined>();
@@ -105,7 +107,6 @@ const Logs = ({
   const [fileSourceFilters, setFileSourceFilters] = useState<Array<FileSourceOption>>([]);
   const { timezone } = useTimezone();
 
-  //
   const taskTryNumber = selectedTryNumber || tryNumber || 1;
   const { data, isSuccess } = useTaskLog({
     dagId,
@@ -114,6 +115,7 @@ const Logs = ({
     mapIndex,
     taskTryNumber,
     fullContent: shouldRequestFullContent,
+    state,
   });
 
   const params = new URLSearchParamsWrapper({

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -124,7 +124,7 @@ const TaskInstance = ({
           operator={operator}
         />
       )}
-      <Tabs size="lg" index={selectedTabIndex} onChange={handleTabsChange}>
+      <Tabs size="lg" index={selectedTabIndex} onChange={handleTabsChange} isLazy>
         <TabList>
           <Tab>
             <Text as="strong">Details</Text>
@@ -183,6 +183,7 @@ const TaskInstance = ({
                 mapIndex={mapIndex}
                 executionDate={executionDate}
                 tryNumber={instance?.tryNumber}
+                state={instance?.state}
               />
             </TabPanel>
           )}


### PR DESCRIPTION
Only refresh task logs request when the task state is pending.
Also, use `isLazy` to only load the tasks component when the tab is active, preventing background API calls.

Fixes: #26912

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
