### PR TITLE
Fix system tests for SnowflakeOperator

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,8 +47,7 @@ repos:
         exclude: |
           (?x)
           ^\.github/|
-          ^airflow/_vendor/|
-          ^tests/system/providers/snowflake/example_snowflake_snowflake_op_template_file\.sql$
+          ^airflow/_vendor/
         args:
           - --comment-style
           - "/*||*/"

--- a/tests/system/providers/snowflake/example_snowflake.py
+++ b/tests/system/providers/snowflake/example_snowflake.py
@@ -62,6 +62,7 @@ with DAG(
     snowflake_op_sql_multiple_stmts = SnowflakeOperator(
         task_id="snowflake_op_sql_multiple_stmts",
         sql=SQL_MULTIPLE_STMTS,
+        split_statements=True,
     )
 
     snowflake_op_template_file = SnowflakeOperator(

--- a/tests/system/providers/snowflake/example_snowflake_snowflake_op_template_file.sql
+++ b/tests/system/providers/snowflake/example_snowflake_snowflake_op_template_file.sql
@@ -1,3 +1,22 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+*/
+
 CREATE TABLE IF NOT EXISTS RANDOM_DATA AS SELECT
     UNIFORM(1, 10, 1234) AS COL1
 FROM


### PR DESCRIPTION
I ran the system tests again, but this time on GitHub Action, and I noticed that there is still one bug - the `split_statements = True` option was missing.


I have now used the YAML file below:
```yaml
name: CI

on:
  push:
    branches: [ "main" ]
  pull_request:
    branches: [ "main" ]
  schedule:
    - cron: '30 1 * * 1'
  workflow_dispatch:
    inputs:
      repository:
        required: true
        type: string
        default: 'apache/airflow'
      ref:
        required: true
        type: string
        default: 'main'

env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  ANSWER: "yes"
  VERBOSE: "true"

jobs:
  tests:
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v3
        with: 
           repository: ${{ inputs.repository || 'apache/airflow' }}
           ref: ${{ inputs.ref || 'main' }}
      - run: ./scripts/ci/install_breeze.sh
      - run: breeze ci-image build --python 3.8 --github-repository apache/airflow
      - name: Set up credentials
        env:
           SNOWFLAKE_CONN: ${{ secrets.SNOWFLAKE_CONN }}
        run: |
          mkdir -p files/airflow-breeze-config;
          (
            echo "export AIRFLOW_CONN_MY_SNOWFLAKE_CONN=${SNOWFLAKE_CONN@Q}"
            echo "export SYSTEM_TESTS_ENV_ID=snowflake-${RANDOM@Q}"
          ) >> files/airflow-breeze-config/variables.env;
      - run: |
          # Temporary disabled tests
          rm tests/system/providers/snowflake/example_snowflake_to_slack.py
          rm tests/system/providers/snowflake/example_s3_to_snowflake.py
      - run: breeze testing tests --test-type 'Providers[snowflake]'
      - run: breeze testing tests -- tests/system/providers/snowflake/example_snowflake.py --system snowflake
      - name: "Upload airflow logs"
        uses: actions/upload-artifact@v3
        if: failure()
        with:
          name: airflow-logs
          path: "./files/airflow_logs*"
          retention-days: 7
      - name: "Upload container logs"
        uses: actions/upload-artifact@v3
        if: failure()
        with:
          name: containers-logs
          path: "./files/container_logs*"
          retention-days: 7

```
and I used the command below to confirm everything is working.
```bash
gh workflow run ci.yml -f repository=mik-laj/airflow -f ref=fix-snowflake-system-tests-2
```
Here is the confirmation that everything is working now
<img width="1440" alt="Screenshot 2022-10-25 at 01 45 41" src="https://user-images.githubusercontent.com/12058428/197650786-fb7cebd0-4b7a-4b5e-a022-bcc0111b58c6.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
