### PR TITLE
Update airflow release note to export AIRFLOW_RELEASE_SVN before use

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -882,7 +882,8 @@ cd ..
 [ -d asf-dist ] || svn checkout --depth=immediates https://dist.apache.org/repos/dist asf-dist
 svn update --set-depth=infinity asf-dist/{release,dev}/airflow
 AIRFLOW_DEV_SVN="${PWD}/asf-dist/dev/airflow"
-cd asf-dist/release/airflow
+AIRFLOW_RELEASE_SVN="${PWD}/asf-dist/release/airflow"
+cd "${AIRFLOW_RELEASE_SVN}"
 
 export RC=2.0.2rc5
 export VERSION=${RC/rc?/}


### PR DESCRIPTION
AIRFLOW_RELEASE_SVN was used later in the guide but was not exported

