### PR TITLE
Summary of test errors printed outside of the folded output in CI

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -263,6 +263,7 @@ def _run_tests_in_pool(
         outputs=outputs,
         include_success_outputs=include_success_outputs,
         skip_cleanup=skip_cleanup,
+        print_summary_after_line_matching=r".*= FAILURES.*|.*= ERRORS.*",
     )
 
 

--- a/tests/always/test_connection.py
+++ b/tests/always/test_connection.py
@@ -82,6 +82,7 @@ class TestConnection(unittest.TestCase):
         test_connection = Connection(extra="testextra")
         assert not test_connection.is_extra_encrypted
         assert test_connection.extra == "testextra"
+        assert True is False
 
     @conf_vars({("core", "fernet_key"): Fernet.generate_key().decode()})
     def test_connection_extra_with_encryption(self):


### PR DESCRIPTION
When there is an error in tests, we should now see the (only the part containing error and traceback) see the failure details outside of the folded content - the folded content will still contain all the details of the test run, but you would not have to unfold it in order to see the actual error.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
