### PR TITLE
Add backward compatibility with old versions of Apache Beam

### DIFF
--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -36,7 +36,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-beam>=2.39.0
+  - apache-beam>=2.33.0
 
 integrations:
   - integration-name: Apache Beam

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -80,6 +80,11 @@ class DataflowConfiguration:
         If set as a sequence, the identities from the list must grant
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
+
+        .. warning::
+
+            This option requires Apache Beam 2.39.0 or newer.
+
     :param drain_pipeline: Optional, set to True if want to stop streaming job by draining it
         instead of canceling during killing task instance. See:
         https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -45,7 +45,7 @@
   "apache.beam": {
     "deps": [
       "apache-airflow>=2.3.0",
-      "apache-beam>=2.39.0"
+      "apache-beam>=2.33.0"
     ],
     "cross-providers-deps": [
       "google"

--- a/tests/providers/apache/beam/hooks/test_beam.py
+++ b/tests/providers/apache/beam/hooks/test_beam.py
@@ -60,7 +60,8 @@ INFO: To cancel the job using the 'gcloud' tool, run:
 
 class TestBeamHook(unittest.TestCase):
     @mock.patch(BEAM_STRING.format("BeamCommandRunner"))
-    def test_start_python_pipeline(self, mock_runner):
+    @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.39.0")
+    def test_start_python_pipeline(self, mock_check_output, mock_runner):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         wait_for_done = mock_runner.return_value.wait_for_done
         process_line_callback = MagicMock()
@@ -85,16 +86,13 @@ class TestBeamHook(unittest.TestCase):
         )
         wait_for_done.assert_called_once_with()
 
-    @mock.patch("subprocess.check_output", return_value=b"2.35.0")
+    @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.35.0")
     def test_start_python_pipeline_unsupported_option(self, mock_check_output):
         hook = BeamHook(runner=DEFAULT_RUNNER)
 
         with pytest.raises(
             AirflowException,
-            match=re.escape(
-                "The impersonateServiceAccount option requires Apache Beam 2.39.0 or newer. "
-                "Current version: 2.35.0"
-            ),
+            match=re.escape("The impersonateServiceAccount option requires Apache Beam 2.39.0 or newer."),
         ):
             hook.start_python_pipeline(
                 variables={
@@ -117,7 +115,10 @@ class TestBeamHook(unittest.TestCase):
         ]
     )
     @mock.patch(BEAM_STRING.format("BeamCommandRunner"))
-    def test_start_python_pipeline_with_custom_interpreter(self, _, py_interpreter, mock_runner):
+    @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.39.0")
+    def test_start_python_pipeline_with_custom_interpreter(
+        self, _, py_interpreter, mock_check_output, mock_runner
+    ):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         wait_for_done = mock_runner.return_value.wait_for_done
         process_line_callback = MagicMock()
@@ -152,8 +153,14 @@ class TestBeamHook(unittest.TestCase):
     )
     @mock.patch(BEAM_STRING.format("prepare_virtualenv"))
     @mock.patch(BEAM_STRING.format("BeamCommandRunner"))
+    @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.39.0")
     def test_start_python_pipeline_with_non_empty_py_requirements_and_without_system_packages(
-        self, current_py_requirements, current_py_system_site_packages, mock_runner, mock_virtualenv
+        self,
+        current_py_requirements,
+        current_py_system_site_packages,
+        mock_check_output,
+        mock_runner,
+        mock_virtualenv,
     ):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         wait_for_done = mock_runner.return_value.wait_for_done
@@ -189,7 +196,10 @@ class TestBeamHook(unittest.TestCase):
         )
 
     @mock.patch(BEAM_STRING.format("BeamCommandRunner"))
-    def test_start_python_pipeline_with_empty_py_requirements_and_without_system_packages(self, mock_runner):
+    @mock.patch("airflow.providers.apache.beam.hooks.beam.subprocess.check_output", return_value=b"2.39.0")
+    def test_start_python_pipeline_with_empty_py_requirements_and_without_system_packages(
+        self, mock_check_output, mock_runner
+    ):
         hook = BeamHook(runner=DEFAULT_RUNNER)
         wait_for_done = mock_runner.return_value.wait_for_done
         process_line_callback = MagicMock()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The PR https://github.com/apache/airflow/pull/23961 added support for impersonation of service accounts, but at the same time limited the supported versions of Apache Beam to 2.39.0.  This is a very big limitation considering that this functionality is not critical and many existing pipelines require an older version.  On the other hand, this restriction is not checked if the user installs beam in a separate virtual environment. On the other hand, this restriction is not checked if the user installs beam in a separate virtual environment. Then Apache Beam starts, but unsupported options are passed.

To solve these two problems, I moved the Apache Beam version check to runtime and use the old version restrictions in `providers.yaml`.

Additionally, I will unblock the work on Snowpark integration which requires `cloudpickle` 2.0.0 while Apache Beam 2.39.0 requires `cloudpickle` 2.1.0.


CC: @lwyszomi  
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
