### PR TITLE
Use all-python-versions-list-as-string in build-images.yml

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -242,7 +242,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           breeze release-management generate-constraints --run-in-parallel
           --airflow-constraints-mode constraints-source-providers
         env:
-          PYTHON_VERSIONS: ${{ needs.build-info.outputs.python-versions-list-as-string }}
+          PYTHON_VERSIONS: ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
         if: needs.build-info.outputs.upgrade-to-newer-dependencies != 'false'
       - name: Push empty CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         if: failure() || cancelled()


### PR DESCRIPTION
Build images uses different parameter than ci.yml for building the images (all-python* instead of python*). This is to account for the fact that we only have one build-image.yml workflow for all airflow versions (in main) and we need to account for the fact that different versions of airflow will have support for different Python versions. This was not happening for a while, but it will soon start being needed for Python 3.11 that will be supported in 2.5 but not supported in 3.11.

By mistake #27215 added displaying of upgraded dependencies with wrong parameter name in build-images.yml copied from ci.yml that caused a problem for PRs that were changing dependencies but did not trigger full build.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
