### PR TITLE
Make grid view widths adjustable

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -41,6 +41,7 @@ import FilterBar from './nav/FilterBar';
 import LegendRow from './nav/LegendRow';
 
 const detailsPanelKey = 'hideDetailsPanel';
+const minPanelWidth = 300;
 
 const Main = () => {
   const { data: { groups }, isLoading } = useGridData();
@@ -73,14 +74,14 @@ const Main = () => {
   useEffect(() => {
     if (contentRef.current) {
       const topOffset = contentRef.current.offsetTop;
-      const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', '').replace('em', ''), 10) || 0;
+      const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', ''), 10) || 0;
       contentRef.current.style.height = `${window.innerHeight - topOffset - footerHeight}px`;
     }
   }, []);
 
   const resize = useCallback((e: MouseEvent) => {
     const gridEl = gridRef.current;
-    if (gridEl && e.x > 350 && e.x < window.innerWidth - 400) {
+    if (gridEl && e.x > minPanelWidth && e.x < window.innerWidth - minPanelWidth) {
       gridEl.style.width = `${e.x}px`;
     }
   }, [gridRef]);
@@ -103,20 +104,20 @@ const Main = () => {
       };
     }
     return () => {};
-  }, [resize, isLoading]);
+  }, [resize, isLoading, isOpen]);
 
   return (
     <Box flex={1}>
       <FilterBar />
       <LegendRow onStatusHover={onStatusHover} onStatusLeave={onStatusLeave} />
       <Divider mb={5} borderBottomWidth={2} />
-      <Flex ref={contentRef}>
+      <Flex ref={contentRef} overflow="hidden">
         {isLoading || isEmpty(groups)
           ? (<Spinner />)
           : (
             <>
               <Box
-                minWidth="350px"
+                minWidth={minPanelWidth}
                 flex={isOpen ? undefined : 1}
                 ref={gridRef}
                 height="100%"
@@ -137,8 +138,8 @@ const Main = () => {
                     zIndex={1}
                   />
                   <Box
-                    flexGrow={1}
-                    minWidth="400px"
+                    flex={1}
+                    minWidth={minPanelWidth}
                     zIndex={1}
                     bg="white"
                     height="100%"

--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -19,7 +19,9 @@
 
 /* global localStorage */
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, {
+  useState, useRef, useEffect, useCallback,
+} from 'react';
 import {
   Box,
   Flex,
@@ -76,29 +78,32 @@ const Main = () => {
     }
   }, []);
 
-  useEffect(() => {
-    const resize = (e: any) => {
-      if (gridRef.current && e.x > 350 && e.x < window.innerWidth - 400) {
-        gridRef.current.style.width = `${e.x}px`;
-      }
-    };
+  const resize = useCallback((e: MouseEvent) => {
+    const gridEl = gridRef.current;
+    if (gridEl && e.x > 350 && e.x < window.innerWidth - 400) {
+      gridEl.style.width = `${e.x}px`;
+    }
+  }, [gridRef]);
 
+  useEffect(() => {
     const resizeEl = resizeRef.current;
     if (resizeEl) {
-      resizeEl?.addEventListener('mousedown', (e) => {
+      resizeEl.addEventListener('mousedown', (e) => {
         e.preventDefault();
-        document.addEventListener('mousemove', resize, false);
-      }, false);
+        document.addEventListener('mousemove', resize);
+      });
 
       document.addEventListener('mouseup', () => {
-        document.removeEventListener('mousemove', resize, false);
-      }, false);
+        document.removeEventListener('mousemove', resize);
+      });
+
+      return () => {
+        resizeEl?.removeEventListener('mousedown', resize);
+        document.removeEventListener('mouseup', resize);
+      };
     }
-    return () => {
-      resizeEl?.removeEventListener('mousedown', resize);
-      document.removeEventListener('mouseup', resize);
-    };
-  }, []);
+    return () => {};
+  }, [resize, isLoading]);
 
   return (
     <Box flex={1}>

--- a/airflow/www/static/js/dag/details/index.tsx
+++ b/airflow/www/static/js/dag/details/index.tsx
@@ -34,10 +34,10 @@ import DagContent from './Dag';
 const Details = () => {
   const { selected: { runId, taskId, mapIndex }, onSelect } = useSelection();
   return (
-    <Flex flexDirection="column" pl={3} mr={3} flexGrow={1} maxWidth="750px">
+    <Flex flexDirection="column" pl={3} mr={3} height="100%">
       <Header />
       <Divider my={2} />
-      <Box minWidth="750px">
+      <Box overflowY="scroll">
         {!runId && !taskId && <DagContent />}
         {runId && !taskId && (
           <DagRunContent runId={runId} />

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -125,7 +125,7 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
         />
       </Flex>
       <Box
-        height={`calc(100% - ${dimensions?.borderBox.height || 36}px)`}
+        height={`calc(100% - ${dimensions?.borderBox.height}px)`}
         ref={scrollRef}
         overflow="auto"
         position="relative"

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -27,6 +27,7 @@ import {
   Thead,
   Flex,
   IconButton,
+  useDimensions,
 } from '@chakra-ui/react';
 
 import { MdReadMore } from 'react-icons/md';
@@ -51,6 +52,8 @@ interface Props {
 const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef<HTMLTableSectionElement>(null);
+  const buttonsRef = useRef<HTMLDivElement>(null);
+  const dimensions = useDimensions(buttonsRef);
 
   const { data: { groups, dagRuns } } = useGridData();
   const dagRunIds = dagRuns.map((dr) => dr.runId);
@@ -90,10 +93,9 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
 
   return (
     <Box
-      minWidth={isPanelOpen ? '350px' : undefined}
-      flexGrow={1}
       m={3}
       mt={0}
+      height="100%"
     >
       <Flex
         alignItems="center"
@@ -101,6 +103,7 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
         mb={2}
         p={1}
         backgroundColor="white"
+        ref={buttonsRef}
       >
         <Flex alignItems="center">
           <AutoRefresh />
@@ -122,9 +125,9 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
         />
       </Flex>
       <Box
-        overflow="auto"
+        height={`calc(100% - ${dimensions?.borderBox.height || 36}px)`}
         ref={scrollRef}
-        maxHeight="900px"
+        overflow="auto"
         position="relative"
         pr={4}
       >


### PR DESCRIPTION
Make the border between the grid and details panel draggable so users can adjust the width as they want.


![Oct-25-2022 12-42-14](https://user-images.githubusercontent.com/4600967/197856139-18fde2ad-e652-4c71-9c28-ad4da48068ac.gif)
![Oct-25-2022 08-24-36](https://user-images.githubusercontent.com/4600967/197856147-ff9e3929-3387-48df-8b63-0a150e2cc3de.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
