### PR TITLE
Handle transient state errors in `RedshiftResumeClusterOperator` and `RedshiftPauseClusterOperator`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -16,6 +16,7 @@
 # under the License.
 from __future__ import annotations
 
+import warnings
 from typing import Any, Sequence
 
 from botocore.exceptions import ClientError
@@ -157,13 +158,22 @@ class RedshiftHook(AwsBaseHook):
         )
         return response["Snapshot"] if response["Snapshot"] else None
 
-    def get_cluster_snapshot_status(self, snapshot_identifier: str):
+    def get_cluster_snapshot_status(self, snapshot_identifier: str, cluster_identifier: str | None = None):
         """
         Return Redshift cluster snapshot status. If cluster snapshot not found return ``None``
 
         :param snapshot_identifier: A unique identifier for the snapshot that you are requesting
-        :param cluster_identifier: The unique identifier of the cluster the snapshot was created from
+        :param cluster_identifier: (deprecated) The unique identifier of the cluster
+            the snapshot was created from
         """
+        if cluster_identifier:
+            warnings.warn(
+                "Parameter `cluster_identifier` is deprecated."
+                "This option will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         try:
             response = self.get_conn().describe_cluster_snapshots(
                 SnapshotIdentifier=snapshot_identifier,

--- a/airflow/providers/amazon/aws/hooks/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_cluster.py
@@ -157,7 +157,7 @@ class RedshiftHook(AwsBaseHook):
         )
         return response["Snapshot"] if response["Snapshot"] else None
 
-    def get_cluster_snapshot_status(self, snapshot_identifier: str, cluster_identifier: str):
+    def get_cluster_snapshot_status(self, snapshot_identifier: str):
         """
         Return Redshift cluster snapshot status. If cluster snapshot not found return ``None``
 
@@ -166,7 +166,6 @@ class RedshiftHook(AwsBaseHook):
         """
         try:
             response = self.get_conn().describe_cluster_snapshots(
-                ClusterIdentifier=cluster_identifier,
                 SnapshotIdentifier=snapshot_identifier,
             )
             snapshot = response.get("Snapshots")[0]

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -380,8 +380,6 @@ class RedshiftResumeClusterOperator(BaseOperator):
 
     :param cluster_identifier: id of the AWS Redshift Cluster
     :param aws_conn_id: aws connection to use
-    :param attempts: number of attempts to resume the cluster
-    :param attempt_interval: seconds to wait before each attempt
     """
 
     template_fields: Sequence[str] = ("cluster_identifier",)
@@ -393,15 +391,16 @@ class RedshiftResumeClusterOperator(BaseOperator):
         *,
         cluster_identifier: str,
         aws_conn_id: str = "aws_default",
-        attempts: int = 1,
-        attempt_interval: int = 30,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.aws_conn_id = aws_conn_id
-        self.attempts = attempts
-        self.attempt_interval = attempt_interval
+        # These parameters are added to address an issue with the boto3 API where the API
+        # prematurely reports the cluster as available to receive requests. This causes the cluster
+        # to reject initial attempts to resume the cluster despite reporting the correct state.
+        self.attempts = 10
+        self.attempt_interval = 15
 
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
@@ -443,15 +442,16 @@ class RedshiftPauseClusterOperator(BaseOperator):
         *,
         cluster_identifier: str,
         aws_conn_id: str = "aws_default",
-        attempts: int = 1,
-        attempt_interval: int = 30,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.cluster_identifier = cluster_identifier
         self.aws_conn_id = aws_conn_id
-        self.attempts = attempts
-        self.attempt_interval = attempt_interval
+        # These parameters are added to address an issue with the boto3 API where the API
+        # prematurely reports the cluster as available to receive requests. This causes the cluster
+        # to reject initial attempts to pause the cluster despite reporting the correct state.
+        self.attempts = 10
+        self.attempt_interval = 15
 
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/operators/redshift_cluster.py
+++ b/airflow/providers/amazon/aws/operators/redshift_cluster.py
@@ -399,22 +399,22 @@ class RedshiftResumeClusterOperator(BaseOperator):
         # These parameters are added to address an issue with the boto3 API where the API
         # prematurely reports the cluster as available to receive requests. This causes the cluster
         # to reject initial attempts to resume the cluster despite reporting the correct state.
-        self.attempts = 10
-        self.attempt_interval = 15
+        self._attempts = 10
+        self._attempt_interval = 15
 
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
 
-        while self.attempts >= 1:
+        while self._attempts >= 1:
             try:
                 redshift_hook.get_conn().resume_cluster(ClusterIdentifier=self.cluster_identifier)
                 return
             except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
-                self.attempts = self.attempts - 1
+                self._attempts = self._attempts - 1
 
-                if self.attempts > 0:
-                    self.log.error("Unable to resume cluster. %d attempts remaining.", self.attempts)
-                    time.sleep(self.attempt_interval)
+                if self._attempts > 0:
+                    self.log.error("Unable to resume cluster. %d attempts remaining.", self._attempts)
+                    time.sleep(self._attempt_interval)
                 else:
                     raise error
 
@@ -429,8 +429,6 @@ class RedshiftPauseClusterOperator(BaseOperator):
 
     :param cluster_identifier: id of the AWS Redshift Cluster
     :param aws_conn_id: aws connection to use
-    :param attempts: number of attempts to resume the cluster
-    :param attempt_interval: seconds to wait before each attempt
     """
 
     template_fields: Sequence[str] = ("cluster_identifier",)
@@ -450,22 +448,22 @@ class RedshiftPauseClusterOperator(BaseOperator):
         # These parameters are added to address an issue with the boto3 API where the API
         # prematurely reports the cluster as available to receive requests. This causes the cluster
         # to reject initial attempts to pause the cluster despite reporting the correct state.
-        self.attempts = 10
-        self.attempt_interval = 15
+        self._attempts = 10
+        self._attempt_interval = 15
 
     def execute(self, context: Context):
         redshift_hook = RedshiftHook(aws_conn_id=self.aws_conn_id)
 
-        while self.attempts >= 1:
+        while self._attempts >= 1:
             try:
                 redshift_hook.get_conn().pause_cluster(ClusterIdentifier=self.cluster_identifier)
                 return
             except redshift_hook.get_conn().exceptions.InvalidClusterStateFault as error:
-                self.attempts = self.attempts - 1
+                self._attempts = self._attempts - 1
 
-                if self.attempts > 0:
-                    self.log.error("Unable to pause cluster. %d attempts remaining.", self.attempts)
-                    time.sleep(self.attempt_interval)
+                if self._attempts > 0:
+                    self.log.error("Unable to pause cluster. %d attempts remaining.", self._attempts)
+                    time.sleep(self._attempt_interval)
                 else:
                     raise error
 

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -225,8 +225,6 @@ class TestResumeClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
-            attempts=5,
-            attempt_interval=10,
         )
         redshift_operator.execute(None)
         assert mock_conn.resume_cluster.call_count == 3
@@ -244,12 +242,10 @@ class TestResumeClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
-            attempts=5,
-            attempt_interval=10,
         )
         with pytest.raises(returned_exception):
             redshift_operator.execute(None)
-        assert mock_conn.resume_cluster.call_count == 5
+        assert mock_conn.resume_cluster.call_count == 10
 
 
 class TestPauseClusterOperator:
@@ -282,8 +278,6 @@ class TestPauseClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
-            attempts=5,
-            attempt_interval=10,
         )
 
         redshift_operator.execute(None)
@@ -302,12 +296,10 @@ class TestPauseClusterOperator:
             task_id="task_test",
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
-            attempts=5,
-            attempt_interval=10,
         )
         with pytest.raises(returned_exception):
             redshift_operator.execute(None)
-        assert mock_conn.pause_cluster.call_count == 5
+        assert mock_conn.pause_cluster.call_count == 10
 
 
 class TestDeleteClusterOperator:

--- a/tests/providers/amazon/aws/operators/test_redshift_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_cluster.py
@@ -205,10 +205,8 @@ class TestResumeClusterOperator:
         assert redshift_operator.cluster_identifier == "test_cluster"
         assert redshift_operator.aws_conn_id == "aws_conn_test"
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")
-    def test_resume_cluster_is_called_when_cluster_is_paused(self, mock_get_conn, mock_cluster_status):
-        mock_cluster_status.return_value = "paused"
+    def test_resume_cluster_is_called_when_cluster_is_paused(self, mock_get_conn):
         redshift_operator = RedshiftResumeClusterOperator(
             task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
         )
@@ -216,8 +214,9 @@ class TestResumeClusterOperator:
         mock_get_conn.return_value.resume_cluster.assert_called_once_with(ClusterIdentifier="test_cluster")
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.conn")
-    def test_resume_cluster_multiple_attempts(self, mock_conn):
-        exception = boto3.client('redshift').exceptions.InvalidClusterStateFault({}, 'test')
+    @mock.patch("time.sleep", return_value=None)
+    def test_resume_cluster_multiple_attempts(self, mock_sleep, mock_conn):
+        exception = boto3.client("redshift").exceptions.InvalidClusterStateFault({}, "test")
         returned_exception = type(exception)
 
         mock_conn.exceptions.InvalidClusterStateFault = returned_exception
@@ -227,10 +226,30 @@ class TestResumeClusterOperator:
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
             attempts=5,
-            attempt_interval=1,
+            attempt_interval=10,
         )
         redshift_operator.execute(None)
         assert mock_conn.resume_cluster.call_count == 3
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.conn")
+    @mock.patch("time.sleep", return_value=None)
+    def test_resume_cluster_multiple_attempts_fail(self, mock_sleep, mock_conn):
+        exception = boto3.client("redshift").exceptions.InvalidClusterStateFault({}, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.resume_cluster.side_effect = exception
+
+        redshift_operator = RedshiftResumeClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+            aws_conn_id="aws_conn_test",
+            attempts=5,
+            attempt_interval=10,
+        )
+        with pytest.raises(returned_exception):
+            redshift_operator.execute(None)
+        assert mock_conn.resume_cluster.call_count == 5
 
 
 class TestPauseClusterOperator:
@@ -242,10 +261,8 @@ class TestPauseClusterOperator:
         assert redshift_operator.cluster_identifier == "test_cluster"
         assert redshift_operator.aws_conn_id == "aws_conn_test"
 
-    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.cluster_status")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.get_conn")
-    def test_pause_cluster_is_called_when_cluster_is_available(self, mock_get_conn, mock_cluster_status):
-        mock_cluster_status.return_value = "available"
+    def test_pause_cluster_is_called_when_cluster_is_available(self, mock_get_conn):
         redshift_operator = RedshiftPauseClusterOperator(
             task_id="task_test", cluster_identifier="test_cluster", aws_conn_id="aws_conn_test"
         )
@@ -253,8 +270,9 @@ class TestPauseClusterOperator:
         mock_get_conn.return_value.pause_cluster.assert_called_once_with(ClusterIdentifier="test_cluster")
 
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.conn")
-    def test_pause_cluster_multiple_attempts(self, mock_conn):
-        exception = boto3.client('redshift').exceptions.InvalidClusterStateFault({}, 'test')
+    @mock.patch("time.sleep", return_value=None)
+    def test_pause_cluster_multiple_attempts(self, mock_sleep, mock_conn):
+        exception = boto3.client("redshift").exceptions.InvalidClusterStateFault({}, "test")
         returned_exception = type(exception)
 
         mock_conn.exceptions.InvalidClusterStateFault = returned_exception
@@ -265,11 +283,31 @@ class TestPauseClusterOperator:
             cluster_identifier="test_cluster",
             aws_conn_id="aws_conn_test",
             attempts=5,
-            attempt_interval=1,
+            attempt_interval=10,
         )
 
         redshift_operator.execute(None)
         assert mock_conn.pause_cluster.call_count == 3
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_cluster.RedshiftHook.conn")
+    @mock.patch("time.sleep", return_value=None)
+    def test_pause_cluster_multiple_attempts_fail(self, mock_sleep, mock_conn):
+        exception = boto3.client("redshift").exceptions.InvalidClusterStateFault({}, "test")
+        returned_exception = type(exception)
+
+        mock_conn.exceptions.InvalidClusterStateFault = returned_exception
+        mock_conn.pause_cluster.side_effect = exception
+
+        redshift_operator = RedshiftPauseClusterOperator(
+            task_id="task_test",
+            cluster_identifier="test_cluster",
+            aws_conn_id="aws_conn_test",
+            attempts=5,
+            attempt_interval=10,
+        )
+        with pytest.raises(returned_exception):
+            redshift_operator.execute(None)
+        assert mock_conn.pause_cluster.call_count == 5
 
 
 class TestDeleteClusterOperator:

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -26,7 +26,6 @@ from airflow import DAG, settings
 from airflow.decorators import task
 from airflow.models import Connection
 from airflow.models.baseoperator import chain
-from airflow.operators.python import get_current_context
 from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
 from airflow.providers.amazon.aws.operators.redshift_cluster import (
     RedshiftCreateClusterOperator,
@@ -90,24 +89,12 @@ def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     client.authorize_security_group_ingress(
         GroupId=security_group["GroupId"], GroupName=sec_group_name, IpPermissions=ip_permissions
     )
-    ti = get_current_context()["ti"]
-    ti.xcom_push(key="security_group_id", value=security_group["GroupId"])
+    return security_group['GroupId']
 
 
 @task(trigger_rule=TriggerRule.ALL_DONE)
 def delete_security_group(sec_group_id: str, sec_group_name: str):
     boto3.client("ec2").delete_security_group(GroupId=sec_group_id, GroupName=sec_group_name)
-
-
-@task
-def await_cluster_snapshot(cluster_identifier):
-    waiter = boto3.client("redshift").get_waiter("snapshot_available")
-    waiter.wait(
-        ClusterIdentifier=cluster_identifier,
-        WaiterConfig={
-            "MaxAttempts": 100,
-        },
-    )
 
 
 with DAG(
@@ -130,7 +117,7 @@ with DAG(
     create_cluster = RedshiftCreateClusterOperator(
         task_id="create_cluster",
         cluster_identifier=redshift_cluster_identifier,
-        vpc_security_group_ids=[set_up_sg["security_group_id"]],
+        vpc_security_group_ids=[set_up_sg],
         publicly_accessible=True,
         cluster_type="single-node",
         node_type="dc2.large",
@@ -145,7 +132,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
         poke_interval=15,
-        timeout=60 * 30,
+        timeout=60 * 15,
     )
     # [END howto_sensor_redshift_cluster]
 
@@ -161,10 +148,20 @@ with DAG(
     )
     # [END howto_operator_redshift_create_cluster_snapshot]
 
+    wait_cluster_available_before_pause = RedshiftClusterSensor(
+        task_id='wait_cluster_available_before_pause',
+        cluster_identifier=redshift_cluster_identifier,
+        target_status='available',
+        poke_interval=15,
+        timeout=60 * 15,
+    )
+
     # [START howto_operator_redshift_pause_cluster]
     pause_cluster = RedshiftPauseClusterOperator(
         task_id="pause_cluster",
         cluster_identifier=redshift_cluster_identifier,
+        attempts=30,
+        attempt_interval=15,
     )
     # [END howto_operator_redshift_pause_cluster]
 
@@ -173,13 +170,15 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="paused",
         poke_interval=15,
-        timeout=60 * 30,
+        timeout=60 * 15,
     )
 
     # [START howto_operator_redshift_resume_cluster]
     resume_cluster = RedshiftResumeClusterOperator(
         task_id="resume_cluster",
         cluster_identifier=redshift_cluster_identifier,
+        attempts=30,
+        attempt_interval=15,
     )
     # [END howto_operator_redshift_resume_cluster]
 
@@ -188,7 +187,7 @@ with DAG(
         cluster_identifier=redshift_cluster_identifier,
         target_status="available",
         poke_interval=15,
-        timeout=60 * 30,
+        timeout=60 * 15,
     )
 
     set_up_connection = create_connection(conn_id_name, cluster_id=redshift_cluster_identifier)
@@ -269,7 +268,7 @@ with DAG(
     # [END howto_operator_redshift_delete_cluster_snapshot]
 
     delete_sg = delete_security_group(
-        sec_group_id=set_up_sg["security_group_id"],
+        sec_group_id=set_up_sg,
         sec_group_name=sg_name,
     )
     chain(
@@ -280,7 +279,7 @@ with DAG(
         create_cluster,
         wait_cluster_available,
         create_cluster_snapshot,
-        await_cluster_snapshot(redshift_cluster_identifier),
+        wait_cluster_available_before_pause,
         pause_cluster,
         wait_cluster_paused,
         resume_cluster,

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -160,8 +160,6 @@ with DAG(
     pause_cluster = RedshiftPauseClusterOperator(
         task_id="pause_cluster",
         cluster_identifier=redshift_cluster_identifier,
-        attempts=30,
-        attempt_interval=15,
     )
     # [END howto_operator_redshift_pause_cluster]
 
@@ -177,8 +175,6 @@ with DAG(
     resume_cluster = RedshiftResumeClusterOperator(
         task_id="resume_cluster",
         cluster_identifier=redshift_cluster_identifier,
-        attempts=30,
-        attempt_interval=15,
     )
     # [END howto_operator_redshift_resume_cluster]
 

--- a/tests/system/providers/amazon/aws/example_redshift.py
+++ b/tests/system/providers/amazon/aws/example_redshift.py
@@ -89,7 +89,7 @@ def setup_security_group(sec_group_name: str, ip_permissions: list[dict]):
     client.authorize_security_group_ingress(
         GroupId=security_group["GroupId"], GroupName=sec_group_name, IpPermissions=ip_permissions
     )
-    return security_group['GroupId']
+    return security_group["GroupId"]
 
 
 @task(trigger_rule=TriggerRule.ALL_DONE)
@@ -149,9 +149,9 @@ with DAG(
     # [END howto_operator_redshift_create_cluster_snapshot]
 
     wait_cluster_available_before_pause = RedshiftClusterSensor(
-        task_id='wait_cluster_available_before_pause',
+        task_id="wait_cluster_available_before_pause",
         cluster_identifier=redshift_cluster_identifier,
-        target_status='available',
+        target_status="available",
         poke_interval=15,
         timeout=60 * 15,
     )


### PR DESCRIPTION
There were some issues with transient state changes with the `RedshiftResumeClusterOperator` and the `RedshiftPauseClusterOperator`, which resulted in errors being thrown, and causing system tests to fail. This PR solves the issue by allowing multiple attempts to pause or resume the cluster if desired.


Edit:
This PR also contains a minor fix on the `get_cluster_snapshot_status` function, which is to remove a redundant parameter `cluster_identifier`, which was originally being passed to the `describe_cluster_snapshots` function. The function only accepts one of the two parameters currently provided: either the `snapshot_identifier` or the `cluster_identifier`. Passing both to the function raises an `InvalidParameterCombination` exception.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
