### PR TITLE
Add logging back to Sagemaker system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -182,11 +182,12 @@ def _build_and_upload_docker_image(preprocess_script, repository_uri):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        docker_build.communicate()
+        _, stderr = docker_build.communicate()
         if docker_build.returncode != 0:
-            # Note: The stderr output from communicate() contains an unrelated
-            # warning message, not the actual cause of the failure.
-            raise RuntimeError("Failed to push docker image to the repository.")
+            raise RuntimeError(
+                "Failed to push docker image to the repository.  The following error "
+                f"message may be useful, but can occasionally be misleading: {stderr}"
+            )
 
 
 @task


### PR DESCRIPTION
Previously, the stderr error message was removed because it was very misleading and unrelated to the actual error. While debugging a recent issue the message did prove useful, so I am adding it back into the logs with a note that it is sometimes misleading.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
