### PR TITLE
Fix emr_eks system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_emr_eks.py
+++ b/tests/system/providers/amazon/aws/example_emr_eks.py
@@ -94,7 +94,7 @@ def enable_access_emr_on_eks(cluster, ns):
 
 @task
 def get_execution_role_name() -> str:
-    return boto3.client("sts").get_caller_identity()["Arn"].split("/")[-1]
+    return boto3.client("sts").get_caller_identity()["Arn"].split("/")[-2]
 
 
 @task


### PR DESCRIPTION
Fix emr_eks system test. In order to get the role name, we need to extract it from [sts:getCallerIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html). The role name is at the second last position.