### PR TITLE
System Test for EMR (AIP-47)

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -126,7 +126,14 @@ class EmrHook(AwsBaseHook):
 
     def add_job_flow_steps(
         self, job_flow_id: str, steps: list[dict] | str | None = None, wait_for_completion: bool = False
-    ):
+    ) -> list[str]:
+        """
+        Add new steps to a running cluster.
+
+        :param job_flow_id: The id of the job flow to which the steps are being added
+        :param steps: A list of the steps to be executed by the job flow
+        :param wait_for_completion: If True, wait for the steps to be completed. Default is False
+        """
         response = self.get_conn().add_job_flow_steps(JobFlowId=job_flow_id, Steps=steps)
 
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -22,6 +22,8 @@ import warnings
 from typing import TYPE_CHECKING, Any, Sequence
 from uuid import uuid4
 
+import boto3
+
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
@@ -50,6 +52,7 @@ class EmrAddStepsOperator(BaseOperator):
     :param aws_conn_id: aws connection to uses
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
+    :param wait_for_completion: If True, the operator will wait for all the steps to be completed.
     :param do_xcom_push: if True, job_flow_id is pushed to XCom with key job_flow_id.
     """
 
@@ -67,6 +70,7 @@ class EmrAddStepsOperator(BaseOperator):
         cluster_states: list[str] | None = None,
         aws_conn_id: str = "aws_default",
         steps: list[dict] | str | None = None,
+        wait_for_completion: bool = False,
         **kwargs,
     ):
         if not (job_flow_id is None) ^ (job_flow_name is None):
@@ -79,6 +83,7 @@ class EmrAddStepsOperator(BaseOperator):
         self.job_flow_name = job_flow_name
         self.cluster_states = cluster_states
         self.steps = steps
+        self.wait_for_completion = wait_for_completion
 
     def execute(self, context: Context) -> list[str]:
         emr_hook = EmrHook(aws_conn_id=self.aws_conn_id)
@@ -113,11 +118,21 @@ class EmrAddStepsOperator(BaseOperator):
 
         response = emr.add_job_flow_steps(JobFlowId=job_flow_id, Steps=steps)
 
-        if not response["ResponseMetadata"]["HTTPStatusCode"] == 200:
+        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Adding steps failed: {response}")
-        else:
-            self.log.info("Steps %s added to JobFlow", response["StepIds"])
-            return response["StepIds"]
+
+        self.log.info("Steps %s added to JobFlow", response["StepIds"])
+        if self.wait_for_completion:
+            for step_id in response["StepIds"]:
+                boto3.client("emr").get_waiter("step_complete").wait(
+                    ClusterId=self.job_flow_id,
+                    StepId=step_id,
+                    WaiterConfig={
+                        "Delay": 5,
+                        "MaxAttempts": 100,
+                    },
+                )
+        return response["StepIds"]
 
 
 class EmrEksCreateClusterOperator(BaseOperator):

--- a/airflow/providers/amazon/aws/sensors/emr.py
+++ b/airflow/providers/amazon/aws/sensors/emr.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
-from airflow.sensors.base import BaseSensorOperator
+from airflow.sensors.base import BaseSensorOperator, poke_mode_only
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -378,6 +378,7 @@ class EmrJobFlowSensor(EmrBaseSensor):
         return None
 
 
+@poke_mode_only
 class EmrStepSensor(EmrBaseSensor):
     """
     Asks for the state of the step until it reaches any of the target states.

--- a/docs/apache-airflow-providers-amazon/operators/emr.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr.rst
@@ -53,7 +53,7 @@ JobFlow configuration
 
 To create a job flow on EMR, you need to specify the configuration for the EMR cluster:
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :start-after: [START howto_operator_emr_steps_config]
     :end-before: [END howto_operator_emr_steps_config]
@@ -76,7 +76,7 @@ Create the Job Flow
 
 In the following code we are creating a new job flow using the configuration as explained above.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_emr_create_job_flow]
@@ -90,7 +90,7 @@ Add Steps to an EMR job flow
 To add steps to an existing EMR Job flow you can use
 :class:`~airflow.providers.amazon.aws.operators.emr.EmrAddStepsOperator`.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_emr_add_steps]
@@ -104,7 +104,7 @@ Terminate an EMR job flow
 To terminate an EMR Job Flow you can use
 :class:`~airflow.providers.amazon.aws.operators.emr.EmrTerminateJobFlowOperator`.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_emr_terminate_job_flow]
@@ -118,7 +118,7 @@ Modify Amazon EMR container
 To modify an existing EMR container you can use
 :class:`~airflow.providers.amazon.aws.sensors.emr.EmrContainerSensor`.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_operator_emr_modify_cluster]
@@ -135,7 +135,7 @@ Wait on an Amazon EMR job flow state
 To monitor the state of an EMR job flow you can use
 :class:`~airflow.providers.amazon.aws.sensors.emr.EmrJobFlowSensor`.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_sensor_emr_job_flow]
@@ -149,7 +149,7 @@ Wait on an Amazon EMR step state
 To monitor the state of a step running an existing EMR Job flow you can use
 :class:`~airflow.providers.amazon.aws.sensors.emr.EmrStepSensor`.
 
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_emr.py
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
     :language: python
     :dedent: 4
     :start-after: [START howto_sensor_emr_step]

--- a/docs/apache-airflow-providers-amazon/operators/emr.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr.rst
@@ -146,15 +146,6 @@ To monitor the state of an EMR job flow you can use
 Wait on an Amazon EMR step state
 ================================
 
-To monitor the state of a step running an existing EMR Job flow you can use
-:class:`~airflow.providers.amazon.aws.sensors.emr.EmrStepSensor`.
-
-.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_emr.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_sensor_emr_step]
-    :end-before: [END howto_sensor_emr_step]
-
 Reference
 ---------
 

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -400,6 +400,8 @@ class TestAmazonProviderProjectStructure(ExampleCoverageTest):
         "airflow.providers.amazon.aws.transfers.exasol_to_s3.ExasolToS3Operator",
         # Glue Catalog sensor difficult to test
         "airflow.providers.amazon.aws.sensors.glue_catalog_partition.GlueCatalogPartitionSensor",
+        # EMR Step sensor difficult to test, see: https://github.com/apache/airflow/pull/27286
+        "airflow.providers.amazon.aws.sensors.emr.EmrStepSensor",
     }
 
 

--- a/tests/providers/amazon/aws/hooks/test_emr.py
+++ b/tests/providers/amazon/aws/hooks/test_emr.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import re
 from unittest import mock
 
 import boto3
@@ -44,9 +45,8 @@ class TestEmrHook:
         assert client.list_clusters()["Clusters"][0]["Id"] == cluster["JobFlowId"]
 
     @mock_emr
-    def test_add_job_flow_steps_one_step(self):
-        boto3.client("emr", region_name="us-east-1")
-
+    @pytest.mark.parametrize("num_steps", [1, 2, 3, 4])
+    def test_add_job_flow_steps_one_step(self, num_steps):
         hook = EmrHook(aws_conn_id="aws_default", emr_conn_id="emr_default", region_name="us-east-1")
         cluster = hook.create_job_flow(
             {"Name": "test_cluster", "Instances": {"KeepJobFlowAliveWhenNoSteps": False}}
@@ -58,47 +58,18 @@ class TestEmrHook:
                     "Args": ["test args"],
                     "Jar": "test.jar",
                 },
-                "Name": "step_1",
+                "Name": f"step_{i}",
             }
+            for i in range(num_steps)
         ]
         response = hook.add_job_flow_steps(job_flow_id=cluster["JobFlowId"], steps=steps)
 
-        assert len(response) == 1
-
-    @mock_emr
-    def test_add_job_flow_steps_multiple_steps(self):
-        boto3.client("emr", region_name="us-east-1")
-
-        hook = EmrHook(aws_conn_id="aws_default", emr_conn_id="emr_default", region_name="us-east-1")
-        cluster = hook.create_job_flow(
-            {"Name": "test_cluster", "Instances": {"KeepJobFlowAliveWhenNoSteps": False}}
-        )
-
-        steps = [
-            {
-                "ActionOnFailure": "test_step",
-                "HadoopJarStep": {
-                    "Args": ["test args"],
-                    "Jar": "test.jar",
-                },
-                "Name": "step_1",
-            },
-            {
-                "ActionOnFailure": "test_step",
-                "HadoopJarStep": {
-                    "Args": ["test args"],
-                    "Jar": "test.jar",
-                },
-                "Name": "step_2",
-            },
-        ]
-        response = hook.add_job_flow_steps(job_flow_id=cluster["JobFlowId"], steps=steps)
-        assert len(response) == 2
+        assert len(response) == num_steps
+        for step_id in response:
+            assert re.match("s-[A-Z0-9]{13}$", step_id)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrHook.conn")
     def test_add_job_flow_steps_wait_for_completion(self, mock_conn):
-        boto3.client("emr", region_name="us-east-1")
-
         hook = EmrHook(aws_conn_id="aws_default", emr_conn_id="emr_default", region_name="us-east-1")
         mock_conn.run_job_flow.return_value = {
             "JobFlowId": "job_flow_id",


### PR DESCRIPTION
System test for EMR, using the template in #24643.

`EMRStepSensor` is removed from the system test, and being changed to poke mode only because of hitting throttling limits on the `describe_steps` call. Instead, a `wait_for_completion` parameter is added to the operator, which can be used to wait until all the steps are completed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
