### PR TITLE
Fix IntegrityError during webserver startup

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -414,6 +414,12 @@ def webserver(args):
 
         run_args += ["airflow.www.app:cached_app()"]
 
+        # To prevent different workers creating the web app and
+        # all writing to the database at the same time, we use the --preload option.
+        # With the preload option, the app is loaded before the workers are forked, and each worker will
+        # then have a copy of the app
+        run_args += ['--preload']
+
         gunicorn_master_proc = None
 
         def kill_proc(signum, _):

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -405,6 +405,7 @@ class TestCliWebServer:
                     "--access-logformat",
                     "custom_log_format",
                     "airflow.www.app:cached_app()",
+                    "--preload",
                 ],
                 close_fds=True,
             )


### PR DESCRIPTION
When starting up the webserver, we create all the `gunicorn` workers needed and each of these workers creates the webserver app instead of getting a copy of the app. This results in all the workers trying to write to the database at the same time causing a lot of IntegrityError in the database.

The fix was to preload the app before forking workers

closes: https://github.com/apache/airflow/issues/23512