### PR TITLE
Fix ECS with Fargate system test

### DIFF
--- a/tests/system/providers/amazon/aws/example_ecs_fargate.py
+++ b/tests/system/providers/amazon/aws/example_ecs_fargate.py
@@ -117,6 +117,7 @@ with DAG(
             "awsvpcConfiguration": {
                 "subnets": test_context[SUBNETS_KEY],
                 "securityGroups": test_context[SECURITY_GROUPS_KEY],
+                "assignPublicIp": "ENABLED",
             },
         },
     )


### PR DESCRIPTION
The ECS with Fargate system test was failing due to a network configuration issue, resulting in the task not being able to pull the container image. The solution is to assign a public IP to ECS task network interface to allow the task to pull container image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
