### PR TITLE
Add readOnly flag to gitSync section

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -432,7 +432,11 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{ if .Values.dags.persistence.subPath -}}
   subPath: {{ .Values.dags.persistence.subPath }}
   {{- end }}
-  readOnly: {{ .Values.dags.gitSync.enabled | ternary "True" "False" }}
+  {{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.readOnly -}}
+  readOnly: true
+  {{- else -}}
+  readOnly: false
+  {{- end -}}
 {{- end -}}
 
 {{ define "airflow_config_path" -}}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -5249,6 +5249,11 @@
                                 }
                             ]
                         },
+                        "readOnly": {
+                            "description": "Manage write access to a directory with dags, when gitSync enabled.",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "uid": {
                             "description": "Git sync container run as user parameter.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1825,6 +1825,10 @@ dags:
     # interval between git sync attempts in seconds
     wait: 60
     containerName: git-sync
+    # If you need write permission to dir with dags, you can additionally
+    # specify uid the same as for airflow user
+    readOnly: true
+
     uid: 65533
 
     # When not set, the values defined in the global securityContext will be used


### PR DESCRIPTION
**Before**
With gitsync enabled, mounting the directory with dag to the pod was **always** done with read-only rights.

**After**
Added the readOnly flag to the gitSync section, which allows you to control the mount permissions of the volume to the pod.

**The reason for adding**
The development teams in my organization use the ability to write to the dags directory at the time the dags are initialized. When switching from custom charts, dugs with this code are no longer initialized in Airflow. Rewriting the code of dags without using the ability to manipulate files in a directory is a rather laborious task. Therefore, it was decided to add this flag. I think that it will be right to provide a choice of how to mount a volume with dags.