### PR TITLE
Add missed import in the Trigger Rules example

### DIFF
--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -403,9 +403,9 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
         # dags/branch_without_trigger.py
         import pendulum
 
+        from airflow.decorators import task
         from airflow.models import DAG
         from airflow.operators.empty import EmptyOperator
-        from airflow.decorators import task
 
         dag = DAG(
             dag_id="branch_without_trigger",

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -405,6 +405,7 @@ You can also combine this with the :ref:`concepts:depends-on-past` functionality
 
         from airflow.models import DAG
         from airflow.operators.empty import EmptyOperator
+        from airflow.decorators import task
 
         dag = DAG(
             dag_id="branch_without_trigger",


### PR DESCRIPTION
An example of the Trigger Rules chapter raises the error while loading to UI:

```
Broken DAG: [/opt/airflow/dags/branch_without_trigger.py]
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/airflow/dags/branch_without_trigger.py", line 16, in <module>
    @task.branch(task_id="branching")
NameError: name 'task' is not defined
```

It is needed to add the next import:

```
from airflow.decorators import task
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
