### PR TITLE
Add template field renderer to LivyOperator

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -60,6 +60,7 @@ class LivyOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = ("spark_params",)
+    template_fields_renderers = {"spark_params": "json"}
 
     def __init__(
         self,


### PR DESCRIPTION
Add template field renderer to `LivyOperator` to be displayed as `json`.