### PR TITLE
More resilient test for secrets masker

### DIFF
--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -169,31 +169,8 @@ class TestSecretsMasker:
         except RuntimeError:
             logger.exception("Err")
 
-        line = lineno() - 8
-
-        assert caplog.text == textwrap.dedent(
-            f"""\
-            ERROR Err
-            Traceback (most recent call last):
-              File ".../test_secrets_masker.py", line {line}, in test_masking_in_implicit_context_exceptions
-                raise RuntimeError(f"Cannot connect to user:{{p}}")
-            RuntimeError: Cannot connect to user:***
-
-            During handling of the above exception, another exception occurred:
-
-            Traceback (most recent call last):
-              File ".../test_secrets_masker.py", line {line+2}, in test_masking_in_implicit_context_exceptions
-                raise RuntimeError(f"Exception: {{ex1}}")
-            RuntimeError: Exception: Cannot connect to user:***
-
-            During handling of the above exception, another exception occurred:
-
-            Traceback (most recent call last):
-              File ".../test_secrets_masker.py", line {line+4}, in test_masking_in_implicit_context_exceptions
-                raise RuntimeError(f"Exception: {{ex2}}")
-            RuntimeError: Exception: Exception: Cannot connect to user:***
-            """
-        )
+        assert "user:password" not in caplog.text
+        assert caplog.text.count("user:***") == 3
 
     def test_masking_in_explicit_context_exceptions(self, logger, caplog):
         """


### PR DESCRIPTION
The test expected exact stack trace, but we really want to check if the stacktrace contains masked passwords at all levels of context.

This PR makes the test more resilient to any changes in stacktrace.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
