### PR TITLE
use `id` key to retrieve the dataflow job_id

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dataflow.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataflow.py
@@ -175,7 +175,7 @@ with models.DAG(
     # [START howto_sensor_wait_for_job_status]
     wait_for_python_job_async_done = DataflowJobStatusSensor(
         task_id="wait-for-python-job-async-done",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['dataflow_job_id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
         expected_statuses={DataflowJobStatus.JOB_STATE_DONE},
         location="europe-west3",
     )
@@ -199,7 +199,7 @@ with models.DAG(
 
     wait_for_python_job_async_metric = DataflowJobMetricsSensor(
         task_id="wait-for-python-job-async-metric",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['dataflow_job_id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
         location="europe-west3",
         callback=check_metric_scalar_gte(metric_name="Service-cpu_num_seconds", value=100),
         fail_on_terminal_state=False,
@@ -216,7 +216,7 @@ with models.DAG(
 
     wait_for_python_job_async_message = DataflowJobMessagesSensor(
         task_id="wait-for-python-job-async-message",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['dataflow_job_id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
         location="europe-west3",
         callback=check_message,
         fail_on_terminal_state=False,
@@ -233,7 +233,7 @@ with models.DAG(
 
     wait_for_python_job_async_autoscaling_event = DataflowJobAutoScalingEventsSensor(
         task_id="wait-for-python-job-async-autoscaling-event",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['dataflow_job_id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
         location="europe-west3",
         callback=check_autoscaling_event,
         fail_on_terminal_state=False,


### PR DESCRIPTION
When using any of the DataflowJob sensors ([example](https://github.com/apache/airflow/blob/9c73b3f7fc1d18925d0ed09e8719f53b8147b0f2/airflow/providers/google/cloud/example_dags/example_dataflow.py#L176-L181)), the `dataflow_job_id` key is used to extract the dataflow job id from the job returned by the dataflow task. This results in the error shown below
```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'dataflow_job_id'
```
The key that contains the job id is `id`. [Dataflow REST API reference](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
