### PR TITLE
fIx failing masking tests for python < 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ def write_version(filename: str = str(AIRFLOW_SOURCES_ROOT / "airflow" / "git_ve
     """
     Write the Semver version + git hash to file, e.g. ".dev0+2f635dc265e78db6708f59f68e8009abb92c1e65".
 
-    :param str filename: Destination file to write
+    :param str filename: Destination file to write.
     """
     text = f"{git_version(version)}"
     with open(filename, "w") as file:

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -170,7 +170,7 @@ class TestSecretsMasker:
             logger.exception("Err")
 
         assert "user:password" not in caplog.text
-        assert caplog.text.count("user:***") == 3
+        assert caplog.text.count("user:***") >= 2
 
     def test_masking_in_explicit_context_exceptions(self, logger, caplog):
         """


### PR DESCRIPTION
Seems that the number of times user is printed in stack trace depend on Python version. The fix in #27335 seems to only have worked for Python 3.10 with the 1.0.0 of exceptiongroup the stack trace has less stack levels.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
