### PR TITLE
Fix removal of airflow home directory in installation script

### DIFF
--- a/LOCAL_VIRTUALENV.rst
+++ b/LOCAL_VIRTUALENV.rst
@@ -205,14 +205,14 @@ Activate your virtualenv, e.g. by using ``workon``, and once you are in it, run:
 
 .. code-block:: bash
 
-  ./scripts/ci/tools/initialize_virtualenv.py
+  ./scripts/tools/initialize_virtualenv.py
 
 By default Breeze installs the ``devel`` extra only. You can optionally control which extras are
 Adding extra dependencies as parameter.
 
 .. code-block:: bash
 
-  ./scripts/ci/tools/initialize_virtualenv.py devel,google,postgres
+  ./scripts/tools/initialize_virtualenv.py devel,google,postgres
 
 
 Developing Providers

--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -111,7 +111,7 @@ def main():
     """
     Setup local virtual environment.
     """
-    airflow_home_dir = os.environ.get("AIRFLOW_HOME", Path.home() / "airflow")
+    airflow_home_dir = Path(os.environ.get("AIRFLOW_HOME", Path.home() / "airflow"))
     airflow_sources = str(Path(__file__).parents[2])
 
     if not check_if_in_virtualenv():


### PR DESCRIPTION
Change type of `airflow_home` from `str` to `Path`. Update LOCAL_VIRTUALENV.rst to use correct path for script. apache#27338
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
