### PR TITLE
Limit when git clone tests is run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,6 +630,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           fetch-depth: 2
           persist-credentials: false
+    if: needs.build-info.outputs.runs-on != 'self-hosted'
 
   wait-for-ci-images:
     timeout-minutes: 120


### PR DESCRIPTION
The "Test git clone on Windows" job is always run on GitHub
Public runners (we have no self-hosted windows runners). This
means that when the "Public runner queue" is full, the PRs from
maintainers that are using self-hosted-runners might not
complete even if all the self-hosted runners job complete.

This is not a big issue if that one gets broken, it has no
impact on other tests, so this is fine to only leave this one
running for "Public" PRs - i.e. when non-maintainers make
PRs from their forks or when "use public runners" label is set
on maintainer's PR.

The job is small and fast so it introduces almost no overhead
for "Public Runner's PRs" - while there are public runners
available, it takes literally < 20s to complete. But for
self-hosted runners it might introduce unnecessary "hold" on
complete status.

This should be enough to detect any problems - we will see it
failing in user's PRs and will be able to fix it, while it will
not block PRs of commiters and "canary" builds from completing
when the Public Job Queue gets busy.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
