### PR TITLE
Describe workaround for recent Docker Desktop mishap

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -66,6 +66,21 @@ Here is an example configuration with more than 200GB disk space for Docker:
              alt="Disk space MacOS">
     </div>
 
+
+- **Docker is not running** - even if it is running with Docker Desktop. The version of
+  Docker Desktop released late October 2022 (4.13.0) has ``/var/run/docker.sock`` removed.
+  If you install 4.13.0 for the first time you will miss ``/var/run/docker.sock`` and you will get
+  "docker is not running" error. This was done too hastily and they are likely to
+  `remove it <https://github.com/docker/for-mac/issues/6529#issuecomment-1292135881i>`_ in the
+  next patchlevel, but if you happen to see "docker is not running" when it is, you should not have
+  ``/var/run/docker.sock`` created. In order to fix it, check that you have
+  ``${HOME}/.docker/run/docker.sock`` and run the following command to fix it:
+
+.. code-block:: bash
+
+     sudo ln -sf "${HOME}/.docker/run/docker.sock" /var/run/docker.sock
+
+
 Docker Compose
 --------------
 


### PR DESCRIPTION
Recent Docker Desktop (4.13.0) introduced a breaking (seriously) change for new users where /var/run/docker.sock is removed.

They will likely restore it as result of backlash
https://github.com/docker/for-mac/issues/6529#issuecomment-1292135881 but this change adds check and workaround that such users might apply.

Related to: https://github.com/apache/airflow/discussions/27217

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
