### PR TITLE
Fix dimensions for datasets page

### DIFF
--- a/airflow/www/static/js/dag/Main.tsx
+++ b/airflow/www/static/js/dag/Main.tsx
@@ -34,6 +34,7 @@ import { isEmpty, debounce } from 'lodash';
 import useSelection from 'src/dag/useSelection';
 import { useGridData } from 'src/api';
 import { hoverDelay } from 'src/utils';
+import useContentHeight from 'src/utils/useContentHeight';
 
 import Details from './details';
 import Grid from './grid';
@@ -71,13 +72,7 @@ const Main = () => {
     onToggle();
   };
 
-  useEffect(() => {
-    if (contentRef.current) {
-      const topOffset = contentRef.current.offsetTop;
-      const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', ''), 10) || 0;
-      contentRef.current.style.height = `${window.innerHeight - topOffset - footerHeight}px`;
-    }
-  }, []);
+  useContentHeight(contentRef);
 
   const resize = useCallback((e: MouseEvent) => {
     const gridEl = gridRef.current;

--- a/airflow/www/static/js/dag/grid/index.tsx
+++ b/airflow/www/static/js/dag/grid/index.tsx
@@ -100,8 +100,8 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
       <Flex
         alignItems="center"
         justifyContent="space-between"
-        mb={2}
         p={1}
+        pb={2}
         backgroundColor="white"
         ref={buttonsRef}
       >
@@ -125,7 +125,7 @@ const Grid = ({ isPanelOpen = false, onPanelToggle, hoveredTaskState }: Props) =
         />
       </Flex>
       <Box
-        height={`calc(100% - ${dimensions?.borderBox.height}px)`}
+        height={`calc(100% - ${dimensions?.borderBox.height || 0}px)`}
         ref={scrollRef}
         overflow="auto"
         position="relative"

--- a/airflow/www/static/js/datasets/Graph/Legend.tsx
+++ b/airflow/www/static/js/datasets/Graph/Legend.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const Legend = ({ zoom, center }: Props) => (
-  <Flex justifyContent="space-between" alignItems="center">
+  <Flex height="100%" flexDirection="column" justifyContent="space-between">
     <Box>
       <IconButton
         onClick={zoom.reset}
@@ -55,7 +55,7 @@ const Legend = ({ zoom, center }: Props) => (
       backgroundColor="white"
       p={2}
       borderColor="gray.200"
-      borderLeftWidth={1}
+      borderRightWidth={1}
       borderTopWidth={1}
     >
       <Text>Legend</Text>

--- a/airflow/www/static/js/datasets/index.tsx
+++ b/airflow/www/static/js/datasets/index.tsx
@@ -19,13 +19,14 @@
 
 /* global document */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import createCache from '@emotion/cache';
 import { useSearchParams } from 'react-router-dom';
-import { Flex, Box } from '@chakra-ui/react';
+import { Flex, Box, useDimensions } from '@chakra-ui/react';
 
 import App from 'src/App';
+import useContentHeight from 'src/utils/useContentHeight';
 
 import DatasetsList from './List';
 import DatasetDetails from './Details';
@@ -44,6 +45,9 @@ const DATASET_URI = 'uri';
 
 const Datasets = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const graphRef = useRef<HTMLDivElement>(null);
+  const dimensions = useDimensions(graphRef, true);
 
   const onBack = () => {
     searchParams.delete(DATASET_URI);
@@ -57,14 +61,23 @@ const Datasets = () => {
 
   const datasetUri = decodeURIComponent(searchParams.get(DATASET_URI) || '');
 
+  useContentHeight(contentRef);
+
   return (
-    <Flex alignItems="flex-start" justifyContent="space-between">
-      <Box width="600px" height="calc(100vh - 125px)" overflowY="scroll">
+    <Flex alignItems="flex-start" justifyContent="space-between" ref={contentRef}>
+      <Box minWidth="450px" height="100%" overflowY="scroll">
         {datasetUri
           ? <DatasetDetails uri={datasetUri} onBack={onBack} />
           : <DatasetsList onSelect={onSelect} />}
       </Box>
-      <Graph selectedUri={datasetUri} onSelect={onSelect} />
+      <Box flex={1} ref={graphRef} height="100%" borderColor="gray.200" borderWidth={1}>
+        <Graph
+          selectedUri={datasetUri}
+          onSelect={onSelect}
+          height={dimensions?.contentBox.height || 0}
+          width={dimensions?.contentBox.width || 0}
+        />
+      </Box>
     </Flex>
   );
 };

--- a/airflow/www/static/js/utils/useContentHeight.ts
+++ b/airflow/www/static/js/utils/useContentHeight.ts
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global document */
+
+import React, { useEffect } from 'react';
+
+const useContentHeight = (contentRef: React.RefObject<HTMLDivElement>) => {
+  useEffect(() => {
+    const calculateHeight = () => {
+      if (contentRef.current) {
+        const topOffset = contentRef.current.offsetTop;
+        const footerHeight = parseInt(getComputedStyle(document.getElementsByTagName('body')[0]).paddingBottom.replace('px', ''), 10) || 0;
+        const newHeight = window.innerHeight - topOffset - footerHeight;
+        const newHeightPx = `${newHeight}px`;
+
+        // only set a new height if it has changed
+        if (newHeightPx !== contentRef.current.style.height) {
+          // keep a minimum usable height of 300px
+          contentRef.current.style.height = newHeight > 300 ? newHeightPx : '300px';
+        }
+      }
+    };
+    // set height on load
+    calculateHeight();
+
+    // set height on window resize
+    window.addEventListener('resize', calculateHeight);
+    return () => {
+      window.removeEventListener('resize', calculateHeight);
+    };
+  }, [contentRef]);
+};
+
+export default useContentHeight;


### PR DESCRIPTION
Make the page sizing in datasets view consistent with the changes to the grid view in  #27273. Move that logic to a shared hook function. Remove some "magic numbers".

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
