### PR TITLE
Separate dataset deps into individual graphs

### DIFF
--- a/airflow/www/static/js/api/useDatasetDependencies.ts
+++ b/airflow/www/static/js/api/useDatasetDependencies.ts
@@ -169,7 +169,7 @@ const separateGraphs = ({ edges, nodes }: DatasetDependencies): DatasetDependenc
         .findIndex((g) => g.nodes.some((n) => connectedNodes.some((nn) => nn.id === n.id)));
 
       if (nodesInUse > -1) {
-        // if the node is in use, merge the graphs
+        // if one of the nodes is already in use, merge the graphs
         const { nodes: existingNodes, edges: existingEdges } = separatedGraphs[nodesInUse];
         separatedGraphs[nodesInUse] = { nodes: unionBy(existingNodes, connectedNodes, 'id'), edges: [...existingEdges, edge] };
       } else {

--- a/airflow/www/static/js/api/useDatasetDependencies.ts
+++ b/airflow/www/static/js/api/useDatasetDependencies.ts
@@ -164,7 +164,7 @@ const separateGraphs = ({ edges, nodes }: DatasetDependencies): DatasetDependenc
     if (!isDownstream) {
       const connectedNodes = nodes.filter((n) => n.id === edge.source || n.id === edge.target);
 
-      // check if the node is already connected to a separated graph
+      // check if one of the nodes is already connected to a separated graph
       const nodesInUse = separatedGraphs
         .findIndex((g) => g.nodes.some((n) => connectedNodes.some((nn) => nn.id === n.id)));
 

--- a/airflow/www/static/js/api/useDatasetDependencies.ts
+++ b/airflow/www/static/js/api/useDatasetDependencies.ts
@@ -113,7 +113,7 @@ const findDownstreamGraph = (
           edges: [...newGraphs[i].edges, e],
         };
         filteredEdges = filteredEdges
-          .filter((fe) => fe.source !== e.source && fe.target !== e.target);
+          .filter((fe) => !(fe.source === e.source && fe.target === e.target));
       }
     });
   });
@@ -125,7 +125,10 @@ const findDownstreamGraph = (
       values.forEach((v) => {
         newGraphs[realKey] = {
           nodes: unionBy(newGraphs[realKey].nodes, newGraphs[v].nodes, 'id'),
-          edges: [...newGraphs[realKey].edges, ...newGraphs[v].edges],
+          edges: [...newGraphs[realKey].edges, ...newGraphs[v].edges]
+            .filter((e, i, s) => (
+              i === s.findIndex((t) => t.source === e.source && t.target === e.target)
+            )),
         };
       });
     });

--- a/airflow/www/static/js/datasets/Graph/index.tsx
+++ b/airflow/www/static/js/datasets/Graph/index.tsx
@@ -55,8 +55,8 @@ const Graph = ({ onSelect, selectedUri }: Props) => {
   });
 
   if (isLoading && !data) return <Spinner />;
-  if (!data || !data.length) return null;
-  const graph = data.find((g) => g?.children.some((n) => n.id === `dataset:${selectedUri}`));
+  if (!data || !data.fullGraph || !data.subGraphs) return null;
+  const graph = selectedUri ? data.subGraphs.find((g) => g.children.some((n) => n.id === `dataset:${selectedUri}`)) : data.fullGraph;
   if (!graph) return null;
   const {
     edges, children, width: graphWidth, height: graphHeight,

--- a/airflow/www/static/js/datasets/Graph/index.tsx
+++ b/airflow/www/static/js/datasets/Graph/index.tsx
@@ -17,10 +17,11 @@
  * under the License.
  */
 
-import React, { RefObject } from 'react';
+import React, { useState, useEffect, RefObject } from 'react';
 import { Box, Spinner } from '@chakra-ui/react';
 import { Zoom } from '@visx/zoom';
 import { Group } from '@visx/group';
+import { debounce } from 'lodash';
 
 import { useDatasetDependencies } from 'src/api';
 
@@ -31,17 +32,35 @@ import Legend from './Legend';
 interface Props {
   onSelect: (datasetId: string) => void;
   selectedUri: string | null;
-  height: number;
-  width: number;
 }
 
-const Graph = ({
-  onSelect, selectedUri, height, width,
-}: Props) => {
+const Graph = ({ onSelect, selectedUri }: Props) => {
   const { data, isLoading } = useDatasetDependencies();
+  const [dimensions, setDimensions] = useState({
+    height: window.innerHeight,
+    width: window.innerWidth,
+  });
+
+  // Reset the graph div when the window size changes
+  useEffect(() => {
+    const handleResize = debounce(() => {
+      setDimensions({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      });
+    }, 200);
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  });
 
   if (isLoading && !data) return <Spinner />;
-  if (!data) return null;
+  if (!data || !data.length) return null;
+  const graph = data.find((g) => g?.children.some((n) => n.id === `dataset:${selectedUri}`));
+  if (!graph) return null;
+  const {
+    edges, children, width: graphWidth, height: graphHeight,
+  } = graph;
 
   const initialTransform = {
     scaleX: 1,
@@ -53,68 +72,73 @@ const Graph = ({
   };
 
   const selectedEdges = selectedUri
-    ? data.edges?.filter(({ sources, targets }) => (
+    ? edges?.filter(({ sources, targets }) => (
       sources[0].includes(selectedUri) || targets[0].includes(selectedUri)))
     : [];
-  const highlightedNodes = data?.children
+  const highlightedNodes = children
     .filter((n) => (
       selectedEdges.some(({ sources, targets }) => (
         sources[0] === n.id || targets[0] === n.id))));
 
+  const width = dimensions.width - 600 || 200;
+  const height = dimensions.height - 125 || 200;
+
   return (
-    <Zoom
-      width={width}
-      height={height}
-      scaleXMin={1 / 4}
-      scaleXMax={1}
-      scaleYMin={1 / 4}
-      scaleYMax={1}
-      initialTransformMatrix={initialTransform}
-    >
-      {(zoom) => (
-        <Box>
-          <svg
-            id="GRAPH"
-            width={width}
-            height={height}
-            ref={zoom.containerRef as RefObject<SVGSVGElement>}
-            style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
-          >
-            <g transform={zoom.toString()}>
-              <g height={data.height} width={data.width}>
-                {data.edges.map((edge) => (
-                  <Edge
-                    key={edge.id}
-                    edge={edge}
-                    isSelected={selectedEdges.some((e) => e.id === edge.id)}
-                  />
-                ))}
-                {data.children.map((node) => (
-                  <Node
-                    key={node.id}
-                    node={node}
-                    onSelect={onSelect}
-                    isSelected={node.id === `dataset:${selectedUri}`}
-                    isHighlighted={highlightedNodes.some((n) => n.id === node.id)}
-                  />
-                ))}
+    <Box position="relative" alignSelf="center" borderColor="gray.200" borderWidth={1}>
+      <Zoom
+        width={width}
+        height={height}
+        scaleXMin={1 / 4}
+        scaleXMax={1}
+        scaleYMin={1 / 4}
+        scaleYMax={1}
+        initialTransformMatrix={initialTransform}
+      >
+        {(zoom) => (
+          <Box>
+            <svg
+              id="GRAPH"
+              width={width}
+              height={height}
+              ref={zoom.containerRef as RefObject<SVGSVGElement>}
+              style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
+            >
+              <g transform={zoom.toString()}>
+                <g height={graphHeight} width={graphWidth}>
+                  {edges.map((edge) => (
+                    <Edge
+                      key={edge.id}
+                      edge={edge}
+                      isSelected={selectedEdges.some((e) => e.id === edge.id)}
+                    />
+                  ))}
+                  {children.map((node) => (
+                    <Node
+                      key={node.id}
+                      node={node}
+                      onSelect={onSelect}
+                      isSelected={node.id === `dataset:${selectedUri}`}
+                      isHighlighted={highlightedNodes.some((n) => n.id === node.id)}
+                    />
+                  ))}
+                </g>
               </g>
-            </g>
-            <Group top={height - 100} left={0} height={100} width={width}>
-              <foreignObject width={150} height={100}>
-                <Legend
-                  zoom={zoom}
-                  center={() => zoom.translateTo({
-                    x: (width - (data.width ?? 0)) / 2,
-                    y: (height - (data.height ?? 0)) / 2,
-                  })}
-                />
-              </foreignObject>
-            </Group>
-          </svg>
-        </Box>
-      )}
-    </Zoom>
+              <Group top={height - 50} left={0} height={50} width={width}>
+                <foreignObject width={width} height={50}>
+                  <Legend
+                    zoom={zoom}
+                    center={() => zoom.translateTo({
+                      x: (width - (graphWidth ?? 0)) / 2,
+                      y: (height - (graphHeight ?? 0)) / 2,
+                    })}
+                  />
+                </foreignObject>
+              </Group>
+            </svg>
+          </Box>
+        )}
+      </Zoom>
+    </Box>
   );
 };
 

--- a/airflow/www/static/js/datasets/Graph/index.tsx
+++ b/airflow/www/static/js/datasets/Graph/index.tsx
@@ -17,11 +17,10 @@
  * under the License.
  */
 
-import React, { useState, useEffect, RefObject } from 'react';
+import React, { RefObject } from 'react';
 import { Box, Spinner } from '@chakra-ui/react';
 import { Zoom } from '@visx/zoom';
 import { Group } from '@visx/group';
-import { debounce } from 'lodash';
 
 import { useDatasetDependencies } from 'src/api';
 
@@ -32,27 +31,14 @@ import Legend from './Legend';
 interface Props {
   onSelect: (datasetId: string) => void;
   selectedUri: string | null;
+  height: number;
+  width: number;
 }
 
-const Graph = ({ onSelect, selectedUri }: Props) => {
+const Graph = ({
+  onSelect, selectedUri, height, width,
+}: Props) => {
   const { data, isLoading } = useDatasetDependencies();
-  const [dimensions, setDimensions] = useState({
-    height: window.innerHeight,
-    width: window.innerWidth,
-  });
-
-  // Reset the graph div when the window size changes
-  useEffect(() => {
-    const handleResize = debounce(() => {
-      setDimensions({
-        height: window.innerHeight,
-        width: window.innerWidth,
-      });
-    }, 200);
-
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  });
 
   if (isLoading && !data) return <Spinner />;
   if (!data || !data.fullGraph || !data.subGraphs) return null;
@@ -80,65 +66,60 @@ const Graph = ({ onSelect, selectedUri }: Props) => {
       selectedEdges.some(({ sources, targets }) => (
         sources[0] === n.id || targets[0] === n.id))));
 
-  const width = dimensions.width - 600 || 200;
-  const height = dimensions.height - 125 || 200;
-
   return (
-    <Box position="relative" alignSelf="center" borderColor="gray.200" borderWidth={1}>
-      <Zoom
-        width={width}
-        height={height}
-        scaleXMin={1 / 4}
-        scaleXMax={1}
-        scaleYMin={1 / 4}
-        scaleYMax={1}
-        initialTransformMatrix={initialTransform}
-      >
-        {(zoom) => (
-          <Box>
-            <svg
-              id="GRAPH"
-              width={width}
-              height={height}
-              ref={zoom.containerRef as RefObject<SVGSVGElement>}
-              style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
-            >
-              <g transform={zoom.toString()}>
-                <g height={graphHeight} width={graphWidth}>
-                  {edges.map((edge) => (
-                    <Edge
-                      key={edge.id}
-                      edge={edge}
-                      isSelected={selectedEdges.some((e) => e.id === edge.id)}
-                    />
-                  ))}
-                  {children.map((node) => (
-                    <Node
-                      key={node.id}
-                      node={node}
-                      onSelect={onSelect}
-                      isSelected={node.id === `dataset:${selectedUri}`}
-                      isHighlighted={highlightedNodes.some((n) => n.id === node.id)}
-                    />
-                  ))}
-                </g>
-              </g>
-              <Group top={height - 50} left={0} height={50} width={width}>
-                <foreignObject width={width} height={50}>
-                  <Legend
-                    zoom={zoom}
-                    center={() => zoom.translateTo({
-                      x: (width - (graphWidth ?? 0)) / 2,
-                      y: (height - (graphHeight ?? 0)) / 2,
-                    })}
+    <Zoom
+      width={width}
+      height={height}
+      scaleXMin={1 / 4}
+      scaleXMax={1}
+      scaleYMin={1 / 4}
+      scaleYMax={1}
+      initialTransformMatrix={initialTransform}
+    >
+      {(zoom) => (
+        <Box>
+          <svg
+            id="GRAPH"
+            width={width}
+            height={height}
+            ref={zoom.containerRef as RefObject<SVGSVGElement>}
+            style={{ cursor: zoom.isDragging ? 'grabbing' : 'grab', touchAction: 'none' }}
+          >
+            <g transform={zoom.toString()}>
+              <g height={graphHeight} width={graphWidth}>
+                {edges.map((edge) => (
+                  <Edge
+                    key={edge.id}
+                    edge={edge}
+                    isSelected={selectedEdges.some((e) => e.id === edge.id)}
                   />
-                </foreignObject>
-              </Group>
-            </svg>
-          </Box>
-        )}
-      </Zoom>
-    </Box>
+                ))}
+                {children.map((node) => (
+                  <Node
+                    key={node.id}
+                    node={node}
+                    onSelect={onSelect}
+                    isSelected={node.id === `dataset:${selectedUri}`}
+                    isHighlighted={highlightedNodes.some((n) => n.id === node.id)}
+                  />
+                ))}
+              </g>
+            </g>
+            <Group top={height - 100} left={0} height={100} width={width}>
+              <foreignObject width={150} height={100}>
+                <Legend
+                  zoom={zoom}
+                  center={() => zoom.translateTo({
+                    x: (width - (graphWidth ?? 0)) / 2,
+                    y: (height - (graphHeight ?? 0)) / 2,
+                  })}
+                />
+              </foreignObject>
+            </Group>
+          </svg>
+        </Box>
+      )}
+    </Zoom>
   );
 };
 


### PR DESCRIPTION
Calculate the individual dataset "pipelines" and when a dataset is selected only show its pipeline.
This is just a frontend implementation. Later, we will move this logic to the webserver.

Before:
<img width="1529" alt="Screen Shot 2022-10-28 at 1 44 32 PM" src="https://user-images.githubusercontent.com/4600967/198719581-7f243ffe-b1d9-4f06-8018-480850ebf65e.png">

After:
<img width="1586" alt="Screen Shot 2022-10-28 at 1 42 39 PM" src="https://user-images.githubusercontent.com/4600967/198719288-20facee9-96a0-4f90-9ad4-1515a6cd6b80.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
