### PR TITLE
Better output of helm chart unit tests in CI.

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -464,5 +464,5 @@ def helm_tests(
     perform_environment_checks()
     cmd = [*DOCKER_COMPOSE_COMMAND, "run", "--service-ports", "--rm", "airflow"]
     cmd.extend(list(extra_pytest_args))
-    result = run_command(cmd, env=env_variables, check=False)
+    result = run_command(cmd, env=env_variables, check=False, output_outside_the_group=True)
     sys.exit(result.returncode)

--- a/dev/breeze/src/airflow_breeze/utils/run_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/run_utils.py
@@ -54,6 +54,7 @@ def run_command(
     cwd: Path | None = None,
     input: str | None = None,
     output: Output | None = None,
+    output_outside_the_group: bool = False,
     verbose_override: bool | None = None,
     dry_run_override: bool | None = None,
     **kwargs,
@@ -77,6 +78,8 @@ def run_command(
     :param cwd: working directory to set for the command
     :param input: input string to pass to stdin of the process
     :param output: redirects stderr/stdout to Output if set to Output class.
+    :param output_outside_the_group: if this is set to True, then output of the command will be done
+        outside the "CI folded group" in CI - so that it is immediately visible without unfolding.
     :param verbose_override: override verbose parameter with the one specified if not None.
     :param dry_run_override: override dry_run parameter with the one specified if not None.
     :param kwargs: kwargs passed to POpen
@@ -139,6 +142,8 @@ def run_command(
         if get_dry_run(dry_run_override):
             return subprocess.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
         try:
+            if output_outside_the_group:
+                get_console().print("::endgroup::")
             return subprocess.run(cmd, input=input, check=check, env=cmd_env, cwd=workdir, **kwargs)
         except subprocess.CalledProcessError as ex:
             if no_output_dump_on_exception:


### PR DESCRIPTION
This is one of the follow-ups after #27260. I am on a quest now to notice and fix all the cases where important failure information which should be visible to the user on CI is kept in folded part of the CI groups but should be printed outside.

This PR fixes helm unit tests to be printed directly in the CI log - unit tests and potential failures are now outside.

Stil, the verbose information about the commands run under the hood (verbose = True enabled in CI) is kept in the folded group to be able to be used for any kinds of investigations and when the user wants to repeat it locally.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
