### PR TITLE
Fix coertion for VERBOSE and DRY_RUN env variables

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/coertions.py
+++ b/dev/breeze/src/airflow_breeze/utils/coertions.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+
+def coerce_bool_value(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    elif not value:  # handle "" and other false-y coerce-able values
+        return False
+    else:
+        return value[0].lower() in ["t", "y"]  # handle all kinds of truth-y/yes-y/false-y/non-sy strings

--- a/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
+++ b/dev/breeze/src/airflow_breeze/utils/custom_param_types.py
@@ -29,6 +29,7 @@ from airflow_breeze.utils.cache import (
     read_from_cache_file,
     write_to_cache_file,
 )
+from airflow_breeze.utils.coertions import coerce_bool_value
 from airflow_breeze.utils.console import get_console
 from airflow_breeze.utils.recording import generating_command_images
 from airflow_breeze.utils.shared_options import set_dry_run, set_forced_answer, set_verbose
@@ -112,7 +113,7 @@ class VerboseOption(ParamType):
     """
 
     def convert(self, value, param, ctx):
-        set_verbose(value)
+        set_verbose(coerce_bool_value(value))
         return super().convert(value, param, ctx)
 
 
@@ -122,7 +123,7 @@ class DryRunOption(ParamType):
     """
 
     def convert(self, value, param, ctx):
-        set_dry_run(value)
+        set_dry_run(coerce_bool_value(value))
         return super().convert(value, param, ctx)
 
 

--- a/dev/breeze/src/airflow_breeze/utils/shared_options.py
+++ b/dev/breeze/src/airflow_breeze/utils/shared_options.py
@@ -19,7 +19,15 @@ from __future__ import annotations
 
 import os
 
-__verbose_value: bool = os.environ.get("VERBOSE", "false")[0].lower() == "t"
+from airflow_breeze.utils.coertions import coerce_bool_value
+
+
+def __get_default_bool_value(env_var: str) -> bool:
+    string_val = os.environ.get(env_var, "")
+    return coerce_bool_value(string_val)
+
+
+__verbose_value: bool = __get_default_bool_value("VERBOSE")
 
 
 def set_verbose(verbose: bool):
@@ -33,7 +41,7 @@ def get_verbose(verbose_override: bool | None = None) -> bool:
     return verbose_override
 
 
-__dry_run_value: bool = os.environ.get("DRY_RUN", "false")[0].lower() == "t"
+__dry_run_value: bool = __get_default_bool_value("DRY_RUN")
 
 
 def set_dry_run(dry_run: bool):


### PR DESCRIPTION
The #27191 change introduced globally shareable flags for verbose and dry-run flags in Breeze however it also changed behaviour of the "false" string passed by VERBOSE/DRY_RUN env variables and crashed breeze when one of those variables was set to empty string.

As a result CI's "VERBOSE" "false" flag in static checks was treated as "truthy" and static checks output contained a lot of noise from non-failing static checks.

It turns out that "convert" method of click can also take "strings" as parameter because coertion of env variables happens inside the convert method (which mkes sense if you think about it) so the convert method should accept both string and target type values, This is explained in convert method docs but I missed it :(.

This change fixes both problems by introducing explicit coertion of the variables from all kinds of string values - both when the flags are parsed but also before (sometimes we need verbose flag from variable (when we run breeze in scripts) even before the flag is actually parsed by click so additionally to coercing the flag, we also pre-emptively run the same coertion when importing the "shared_options" module.

Also just for the sake of it, we accept all kinds of truth-y, falsy strings now - true/false/yes/no/t/f/y/n in all kinds of casing and shortcuts.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
