### PR TITLE
Extract breeze setup to composite action

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: 'Setup Breeze'
+description: 'Sets up Python and Breeze'
+runs:
+  using: "composite"
+  steps:
+    - name: "Setup python"
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.7
+        cache: 'pip'
+        cache-dependency-path: ./dev/breeze/setup*
+    - name: Cache breeze
+      uses: actions/cache@v3
+      with:
+        path: ~/.local/pipx
+        key: "breeze-${{ hashFiles('dev/breeze/README.md') }}"  # README has the latest breeze's hash
+        restore-keys: breeze-
+    - name: "Install Breeze"
+      shell: bash
+      run: ./scripts/ci/install_breeze.sh
+    - name: "Free space"
+      shell: bash
+      run: breeze ci free-space
+    - name: "Get Python version"
+      shell: bash
+      run: >
+        echo "host-python-version=$(python -c 'import platform; print(platform.python_version())')"
+        >> ${GITHUB_OUTPUT}
+      id: host-python-version

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -108,10 +108,7 @@ jobs:
       - name: "Setup python"
         uses: actions/setup-python@v4
         with:
-          # We do not have output from selective checks yet, so we need to hardcode python
           python-version: 3.7
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
       - name: "Retrieve defaults from branch_defaults.py"
         # We cannot "execute" the branch_defaults.py python code here because that would be
         # a security problem (we cannot run any code that comes from the sources coming from the PR.
@@ -147,7 +144,8 @@ jobs:
           ref: "main"
           persist-credentials: false
           submodules: recursive
-      - run: ./scripts/ci/install_breeze.sh
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Selective checks
         id: selective-checks
         env:
@@ -208,19 +206,13 @@ jobs:
           rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
           mv -v "main-airflow/dev" "."
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
         run: |
           pip install rich>=12.4.4 pyyaml
           python scripts/ci/pre_commit/pre_commit_update_providers_dependencies.py
         if: needs.build-info.outputs.default-branch == 'main'
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >-
           Build & Push AMD64 CI images ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           ${{ needs.build-info.outputs.all-python-versions-list-as-string }}
@@ -274,10 +266,6 @@ jobs:
           ref: ${{ needs.build-info.outputs.target-commit-sha }}
           persist-credentials: false
           submodules: recursive
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
       - name: >
           Checkout "main" branch to 'main-airflow' folder
           to use ci/scripts from there.
@@ -298,19 +286,8 @@ jobs:
           rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
           mv -v "main-airflow/dev" "."
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
-      - name: "Get Python version"
-        run: >
-          echo "host-python-version=$(python -c 'import platform; print(platform.python_version())')"
-          >> ${GITHUB_OUTPUT}
-        id: host-python-version
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
         run: |
           pip install rich>=12.4.4 pyyaml
@@ -406,13 +383,7 @@ jobs:
           rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
           mv -v "main-airflow/dev" "."
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
       - name: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,13 +181,8 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          # We do not have output from selective checks yet, so we need to hardcode python
-          python-version: 3.7
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: "Retrieve defaults from branch_defaults.py"
         id: defaults
         # We could retrieve it differently here - by just importing the variables and
@@ -216,7 +211,6 @@ jobs:
           # Stdout is redirected to GITHUB_ENV but we also print it to stderr to see it in ci log
           print(output, file=sys.stderr)
           EOF
-      - run: ./scripts/ci/install_breeze.sh
       - name: "Get information about the Workflow"
         id: source-run-info
         run: breeze ci get-workflow-info 2>> ${GITHUB_OUTPUT}
@@ -264,17 +258,8 @@ jobs:
         with:
           persist-credentials: false
         if: needs.build-info.outputs.canary-run == 'true'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-        if: needs.build-info.outputs.canary-run == 'true'
-      - run: ./scripts/ci/install_breeze.sh
-        if: needs.build-info.outputs.canary-run == 'true'
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
         if: needs.build-info.outputs.canary-run == 'true'
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
@@ -331,17 +316,8 @@ jobs:
         with:
           persist-credentials: false
         if: needs.build-info.outputs.canary-run == 'true'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-        if: needs.build-info.outputs.canary-run == 'true'
-      - run: ./scripts/ci/install_breeze.sh
-        if: needs.build-info.outputs.canary-run == 'true'
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
         if: needs.build-info.outputs.canary-run == 'true'
       - name: "Check that image builds quickly"
         run: breeze shell --max-time 120
@@ -373,15 +349,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
         if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-        if: needs.build-info.outputs.in-workflow-build == 'true'
-      - run: ./scripts/ci/install_breeze.sh
-        if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
         if: needs.build-info.outputs.in-workflow-build == 'true'
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
         run: |
@@ -446,21 +415,9 @@ jobs:
           persist-credentials: false
           submodules: recursive
         if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
         if: needs.build-info.outputs.in-workflow-build == 'true'
-      - run: ./scripts/ci/install_breeze.sh
-        if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: "Free space"
-        run: breeze ci free-space
-        if: needs.build-info.outputs.in-workflow-build == 'true'
-      - name: "Get Python version"
-        run: >
-          echo "host-python-version=$(python -c 'import platform; print(platform.python_version())')"
-          >> ${GITHUB_OUTPUT}
-        id: host-python-version
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
         run: |
           pip install rich>=12.4.4 pyyaml
@@ -635,15 +592,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Wait for CI images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         id: wait-for-images
         run: breeze ci-image pull --run-in-parallel --verify --wait-for-image --tag-as-latest
@@ -671,27 +621,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - name: "Get Python version"
-        run: >
-          echo "host-python-version=$(python -c 'import platform; print(platform.python_version())')"
-          >> ${GITHUB_OUTPUT}
-        id: host-python-version
-      - name: Cache pre-commit envs
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: "pre-commit-${{steps.host-python-version.outputs.host-python-version}}-\
-${{ hashFiles('.pre-commit-config.yaml') }}"
-          restore-keys: pre-commit-${{steps.host-python-version.outputs.host-python-version}}
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
@@ -728,11 +659,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           python-version: ${{ needs.build-info.outputs.default-python-version }}
           cache: 'pip'
           cache-dependency-path: ./dev/breeze/setup*
-      - name: "Get Python version"
-        run: >
-          echo "host-python-version=$(python -c 'import platform; print(platform.python_version())')"
-          >> ${GITHUB_OUTPUT}
-        id: host-python-version
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Cache pre-commit envs
         uses: actions/cache@v3
         with:
@@ -746,9 +674,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
       - name: "Static checks: basic checks only"
         run: >
           breeze static-checks --all-files --show-diff-on-failure --color always
@@ -779,14 +704,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{needs.build-info.outputs.default-python-version}}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -836,15 +755,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           persist-credentials: false
         if: needs.build-info.outputs.default-branch == 'main'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
@@ -911,16 +823,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-        if: needs.build-info.outputs.default-branch == 'main'
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
@@ -974,15 +878,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
@@ -1038,15 +935,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -1131,15 +1021,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -1218,15 +1101,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -1303,15 +1179,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -1382,12 +1251,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: "Set issue id for main"
         if: github.ref == 'refs/heads/main'
         run: |
@@ -1400,9 +1265,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: github.ref == 'refs/heads/v1-10-test'
         run: |
           echo "ISSUE_ID=10128" >> ${GITHUB_ENV}
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
       - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --tag-as-latest
         env:
@@ -1498,15 +1360,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Wait for PROD images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         # We wait for the images to be available either from "build-images.yml' run as pull_request_target
         # or from build-prod-images above.
@@ -1537,15 +1392,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           fetch-depth: 2
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull PROD image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze prod-image pull --tag-as-latest
         env:
@@ -1579,15 +1427,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull PROD images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze prod-image pull --run-in-parallel --tag-as-latest
         env:
@@ -1656,15 +1497,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Pull CI images ${{ env.PYTHON_VERSIONS }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}
         run: breeze ci-image pull --run-in-parallel --tag-as-latest
         env:
@@ -1733,15 +1567,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Pull CI image ${{ needs.build-info.outputs.default-python-version }} for PROD build
           ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG_FOR_THE_BUILD }}"
@@ -1838,13 +1665,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           ref: ${{ needs.build-info.outputs.targetCommitSha }}
           persist-credentials: false
           submodules: recursive
-      - name: "Setup python"
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ needs.build-info.outputs.default-python-version }}
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
       - name: >

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,14 +43,8 @@ jobs:
         with:
           fetch-depth: 2
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          # We do not have output from selective checks yet, so we need to hardcode python
-          python-version: 3.7
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Selective checks
         id: selective-checks
         env:

--- a/.github/workflows/release_dockerhub_image.yml
+++ b/.github/workflows/release_dockerhub_image.yml
@@ -53,14 +53,8 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          # We do not have output from selective checks yet, so we need to hardcode python
-          python-version: 3.7
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Selective checks
         id: selective-checks
         run: breeze ci selective-check 2>> ${GITHUB_OUTPUT}
@@ -89,15 +83,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-          cache: 'pip'
-          cache-dependency-path: ./dev/breeze/setup*
-      - run: ./scripts/ci/install_breeze.sh
-      - name: "Free space"
-        run: breeze ci free-space
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: Build CI image for PROD build ${{ needs.build-info.outputs.defaultPythonVersion }}
         run: breeze ci-image build
         env:


### PR DESCRIPTION
We've been long waiting for an opportunity to simplify our
workflows by extracting some steps of the workflow and waiting
for something like yaml anchor supoprt... But the solution was
under our noses for quite some time.

No idea how I missed that - since August 2021 we should be
able to use composite actions to simplify our GitHub Actions.

The only explanation I have is that I have not connected two
facts:

* you can have composite actions defined as separate workflows you
  can use as step in your Job

* the documentation for composite actions does not mention the
  case that your action can be INSIDE your repository. All the
  examples refer to an action defined in ANOTHER repository.
  That made it confusing to understand that you can actually do
  it all as an action inside your repo.

Let me rectify the mistake and extract some of the common yaml
entries one-by-one - first is Installing Breeze which is pretty
common and most of the jobs use it.

This one will be followed up with some other jobs simplified in
the same matter.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
