### PR TITLE
Add Spark's `appId` to xcom output

### DIFF
--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -141,10 +141,7 @@ class LivyOperator(BaseOperator):
         if self._polling_interval > 0:
             self.poll_for_termination(self._batch_id)
 
-        context["ti"].xcom_push(
-            key="app_id",
-            value=self.get_hook().get_batch(self._batch_id)["appId"]
-        )
+        context["ti"].xcom_push(key="app_id", value=self.get_hook().get_batch(self._batch_id)["appId"])
 
         return self._batch_id
 

--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -140,10 +140,9 @@ class LivyOperator(BaseOperator):
 
         if self._polling_interval > 0:
             self.poll_for_termination(self._batch_id)
-            
-        ti = context["ti"]
-        ti.xcom_push(
-            key="app_id", 
+
+        context["ti"].xcom_push(
+            key="app_id",
             value=self.get_hook().get_batch(self._batch_id)["appId"]
         )
 

--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -140,6 +140,12 @@ class LivyOperator(BaseOperator):
 
         if self._polling_interval > 0:
             self.poll_for_termination(self._batch_id)
+            
+        ti = context["ti"]
+        ti.xcom_push(
+            key="app_id", 
+            value=self.get_hook().get_batch(self._batch_id)["appId"]
+        )
 
         return self._batch_id
 

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -122,9 +122,7 @@ class TestLivyOperator(unittest.TestCase):
         mock_get.assert_called_once_with(BATCH_ID, retry_args=None)
         mock_dump_logs.assert_called_once_with(BATCH_ID)
         mock_get_batch.assert_called_once_with(BATCH_ID)
-        self.mock_context["ti"].xcom_push.assert_called_once_with(
-            key="app_id", value=APP_ID
-        )
+        self.mock_context["ti"].xcom_push.assert_called_once_with(key="app_id", value=APP_ID)
 
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.post_batch")
     @patch("airflow.providers.apache.livy.operators.livy.LivyHook.get_batch", return_value=GET_BATCH)

--- a/tests/providers/apache/livy/operators/test_livy.py
+++ b/tests/providers/apache/livy/operators/test_livy.py
@@ -45,6 +45,7 @@ class TestLivyOperator(unittest.TestCase):
                 conn_id="livyunittest", conn_type="livy", host="localhost:8998", port="8998", schema="http"
             )
         )
+        self.mock_context = dict(ti=MagicMock())
 
     @patch(
         "airflow.providers.apache.livy.operators.livy.LivyHook.dump_batch_logs",
@@ -115,7 +116,7 @@ class TestLivyOperator(unittest.TestCase):
             dag=self.dag,
             task_id="livy_example",
         )
-        task.execute(context={})
+        task.execute(context=self.mock_context)
 
         call_args = {k: v for k, v in mock_post.call_args[1].items() if v}
         assert call_args == {"file": "sparkapp"}
@@ -129,7 +130,7 @@ class TestLivyOperator(unittest.TestCase):
             file="sparkapp", dag=self.dag, task_id="livy_example", extra_options=extra_options
         )
 
-        task.execute(context={})
+        task.execute(context=self.mock_context)
 
         assert task.get_hook().extra_options == extra_options
 
@@ -139,7 +140,7 @@ class TestLivyOperator(unittest.TestCase):
         task = LivyOperator(
             livy_conn_id="livyunittest", file="sparkapp", dag=self.dag, task_id="livy_example"
         )
-        task.execute(context={})
+        task.execute(context=self.mock_context)
         task.kill()
 
         mock_delete.assert_called_once_with(BATCH_ID)
@@ -167,7 +168,7 @@ class TestLivyOperator(unittest.TestCase):
             polling_interval=1,
         )
         with self.assertLogs(task.get_hook().log, level=logging.INFO) as cm:
-            task.execute(context={})
+            task.execute(context=self.mock_context)
             assert "INFO:airflow.providers.apache.livy.hooks.livy.LivyHook:first_line" in cm.output
             assert "INFO:airflow.providers.apache.livy.hooks.livy.LivyHook:second_line" in cm.output
             assert "INFO:airflow.providers.apache.livy.hooks.livy.LivyHook:third_line" in cm.output


### PR DESCRIPTION
By adding Spark's `appId` to the `xcom` output, subsequent tasks can retrieve the application logs and resource usage.

Currently, the only available information is the `batch_id` which is *Livy* specific.