### PR TITLE
Override also GitHub Actions from main in build-images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -81,6 +81,7 @@ jobs:
       # The labels in the event aren't updated when re-triggering the job, So lets hit the API to get
       # up-to-date values
       - name: Get latest PR labels
+      - name: Get latest PR labels
         id: get-latest-pr-labels
         run: |
           echo -n "pull-request-labels=" >> ${GITHUB_OUTPUT}
@@ -196,16 +197,18 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: >
-          Override "scripts/ci" with the "main" branch
+          Override "scripts/ci", "dev" and "./github/actions" with the "main" branch
           so that the PR does not override it
         # We should not override those scripts which become part of the image as they will not be
         # changed in the image built - we should only override those that are executed to build
         # the image.
         run: |
           rm -rfv "scripts/ci"
-          rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
+          rm -rfv "dev"
           mv -v "main-airflow/dev" "."
+          rm -rfv "./github/actions"
+          mv -v "main-airflow/.github/actions" "actions"
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
         run: |
           pip install rich>=12.4.4 pyyaml


### PR DESCRIPTION
In order to make sure that "main" version of the workflows are used in "build-images" workflow we need to also override ".github/actions" when we check out the latest sources.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
