### PR TITLE
Add "main" replacement for other places in build-image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -278,16 +278,18 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: >
-          Override "scripts/ci" with the "main" branch
+          Override "scripts/ci", "dev" and "./github/actions" with the "main" branch
           so that the PR does not override it
         # We should not override those scripts which become part of the image as they will not be
         # changed in the image built - we should only override those that are executed to build
         # the image.
         run: |
           rm -rfv "scripts/ci"
-          rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
+          rm -rfv "dev"
           mv -v "main-airflow/dev" "."
+          rm -rfv "./github/actions"
+          mv -v "main-airflow/.github/actions" "actions"
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
       - name: "Regenerate dependencies in case they was modified manually so that we can build an image"
@@ -375,19 +377,22 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: >
-          Override "scripts/ci" with the "main" branch
+          Override "scripts/ci", "dev" and "./github/actions" with the "main" branch
           so that the PR does not override it
         # We should not override those scripts which become part of the image as they will not be
         # changed in the image built - we should only override those that are executed to build
         # the image.
         run: |
           rm -rfv "scripts/ci"
-          rm -rfv "dev"
           mv -v "main-airflow/scripts/ci" "scripts"
+          rm -rfv "dev"
           mv -v "main-airflow/dev" "."
-
+          rm -rfv "./github/actions"
+          mv -v "main-airflow/.github/actions" "actions"
       - name: "Start ARM instance"
         run: ./scripts/ci/images/ci_start_arm_instance_and_connect_to_docker.sh
+      - name: "Install Breeze"
+        uses: ./.github/actions/breeze
       - name: >
           Build ARM CI images ${{ env.IMAGE_TAG_FOR_THE_BUILD }}
           ${{ needs.build-info.outputs.all-python-versions-list-as-string }}


### PR DESCRIPTION
This is follow up after #27378 - we had two more places where we also should use main version of actions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
