### PR TITLE
Limit Dask to under 2022.10.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,9 @@ dask = [
     # Dask support is limited, we need Dask team to upgrade support for dask if we were to continue
     # Supporting it in the future
     "cloudpickle>=1.4.1",
-    "dask>=2.9.0",
+    # Dask in version 2022.10.1 removed `bokeh` support and dask integration needs to be upgraded
+    # by someone from Dask team who can test it
+    "dask>=2.9.0,<2022.10.1",
     "distributed>=2.11.1",
 ]
 deprecated_api = [


### PR DESCRIPTION
We have very little knowledge and almost no involvement of the Dask team in their executor. The 2022.10.1 release of Dask have introduced some breaking changes (connected with bokeh removal) that break our tests.

Until someone (likely from Dask team) fixes it, we limit Dask to <2022.10.1.

m#

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
