### PR TITLE
Fix selective checks to run all python version tests on env change

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -306,7 +306,7 @@ class SelectiveChecks:
     def python_versions(self) -> list[str]:
         return (
             CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
-            if self.full_tests_needed
+            if self._run_everything or self.full_tests_needed
             else [DEFAULT_PYTHON_MAJOR_MINOR_VERSION]
         )
 

--- a/dev/breeze/tests/test_selective_checks.py
+++ b/dev/breeze/tests/test_selective_checks.py
@@ -36,6 +36,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "false",
                     "needs-helm-tests": "false",
                     "run-tests": "false",
@@ -52,6 +54,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "false",
                     "run-tests": "true",
@@ -71,6 +75,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "false",
                     "run-tests": "true",
@@ -87,6 +93,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "false",
                     "run-tests": "true",
@@ -104,6 +112,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "false",
                     "run-tests": "false",
@@ -124,6 +134,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -146,6 +158,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -168,6 +182,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -190,6 +206,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7']",
                     "all-python-versions-list-as-string": "3.7",
+                    "python-versions": "['3.7']",
+                    "python-versions-list-as-string": "3.7",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -208,6 +226,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -216,7 +236,7 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                     "test-types": "API Always CLI Core Integration Other Providers WWW",
                 },
                 id="Everything should run - including all providers and upgrading to "
-                "newer requirements as setup.py changed",
+                "newer requirements as setup.py changed and all Python versions",
             )
         ),
         (
@@ -225,6 +245,8 @@ def assert_outputs_are_printed(expected_outputs: dict[str, str], stderr: str):
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "needs-helm-tests": "true",
                     "run-tests": "true",
@@ -262,6 +284,8 @@ def test_expected_output_pull_request_main(
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "run-tests": "true",
                     "docs-build": "true",
@@ -283,6 +307,8 @@ def test_expected_output_pull_request_main(
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "run-tests": "true",
                     "docs-build": "true",
@@ -302,6 +328,8 @@ def test_expected_output_pull_request_main(
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "run-tests": "true",
                     "docs-build": "true",
@@ -321,6 +349,8 @@ def test_expected_output_pull_request_main(
                 {
                     "all-python-versions": "['3.7', '3.8', '3.9', '3.10']",
                     "all-python-versions-list-as-string": "3.7 3.8 3.9 3.10",
+                    "python-versions": "['3.7', '3.8', '3.9', '3.10']",
+                    "python-versions-list-as-string": "3.7 3.8 3.9 3.10",
                     "image-build": "true",
                     "run-tests": "true",
                     "docs-build": "true",


### PR DESCRIPTION
Selective checks for "environment files" changed had a small problem, where images were built for all python versions (all-python-versions) but tests were not run (python-versions). The "all" variant is foreseen for case where we have different set of Python versions in main and different in v2* branch.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
