### PR TITLE
Remove image-tag in CI job names

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -163,7 +163,7 @@ jobs:
       packages: write
     timeout-minutes: 80
     name: >
-      Build CI images ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      Build CI images ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info]
     if: |
@@ -219,7 +219,7 @@ jobs:
     timeout-minutes: 80
     name: >
       Build PROD images
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: ${{ needs.build-info.outputs.runs-on }}
     needs: [build-info, build-ci-images]
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1332,7 +1332,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     timeout-minutes: 50
     name: >
       Build CI ARM images
-      ${{needs.build-info.outputs.all-python-versions-list-as-string}}:${{env.IMAGE_TAG}}
+      ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs:
       - build-info


### PR DESCRIPTION
Even simple last minute changes are sometimes bad. This one fixes IMAGE_TAG env which should not be used in job name.

Fixes problem implemented in #27372

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
