### PR TITLE
Move docker installation to inside the os_dependencies script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ FROM scratch as scripts
 COPY <<"EOF" /install_os_dependencies.sh
 set -euo pipefail
 
+DOCKER_CLI_VERSION=20.10.9
+
 if [[ "$#" != 1 ]]; then
     echo "ERROR! There should be 'runtime' or 'dev' parameter passed as argument.".
     exit 1
@@ -108,6 +110,18 @@ ldap-utils libffi7 libldap-2.4-2 libsasl2-2 libsasl2-modules libssl1.1 locales \
 lsb-release netcat openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc"
         export RUNTIME_APT_DEPS
     fi
+}
+
+function install_docker_cli() {
+    local platform
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        platform="aarch64"
+    else
+        platform="x86_64"
+    fi
+    curl --silent \
+        "https://download.docker.com/linux/static/stable/${platform}/docker-${DOCKER_CLI_VERSION}.tgz" \
+        |  tar -C /usr/bin --strip-components=1 -xvzf - docker/docker
 }
 
 function install_debian_dev_dependencies() {
@@ -150,9 +164,12 @@ function install_debian_runtime_dependencies() {
 if [[ "${INSTALLATION_TYPE}" == "RUNTIME" ]]; then
     get_runtime_apt_deps
     install_debian_runtime_dependencies
+    install_docker_cli
+
 else
     get_dev_apt_deps
     install_debian_dev_dependencies
+    install_docker_cli
 fi
 EOF
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -35,6 +35,8 @@ FROM ${PYTHON_BASE_IMAGE} as scripts
 COPY <<"EOF" /install_os_dependencies.sh
 set -euo pipefail
 
+DOCKER_CLI_VERSION=20.10.9
+
 if [[ "$#" != 1 ]]; then
     echo "ERROR! There should be 'runtime' or 'dev' parameter passed as argument.".
     exit 1
@@ -68,6 +70,18 @@ ldap-utils libffi7 libldap-2.4-2 libsasl2-2 libsasl2-modules libssl1.1 locales \
 lsb-release netcat openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc"
         export RUNTIME_APT_DEPS
     fi
+}
+
+function install_docker_cli() {
+    local platform
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        platform="aarch64"
+    else
+        platform="x86_64"
+    fi
+    curl --silent \
+        "https://download.docker.com/linux/static/stable/${platform}/docker-${DOCKER_CLI_VERSION}.tgz" \
+        |  tar -C /usr/bin --strip-components=1 -xvzf - docker/docker
 }
 
 function install_debian_dev_dependencies() {
@@ -110,9 +124,12 @@ function install_debian_runtime_dependencies() {
 if [[ "${INSTALLATION_TYPE}" == "RUNTIME" ]]; then
     get_runtime_apt_deps
     install_debian_runtime_dependencies
+    install_docker_cli
+
 else
     get_dev_apt_deps
     install_debian_dev_dependencies
+    install_docker_cli
 fi
 EOF
 
@@ -1017,12 +1034,6 @@ ENV DEV_APT_COMMAND=${DEV_APT_COMMAND} \
 
 COPY --from=scripts install_os_dependencies.sh /scripts/docker/
 RUN bash /scripts/docker/install_os_dependencies.sh dev
-
-ARG DOCKER_CLI_VERSION=20.10.9
-ENV DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION}
-
-RUN  curl --silent "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz" \
-    |  tar -C /usr/bin --strip-components=1 -xvzf - docker/docker
 
 # Only copy mysql/mssql installation scripts for now - so that changing the other
 # scripts which are needed much later will not invalidate the docker layer here.

--- a/docs/docker-stack/changelog.rst
+++ b/docs/docker-stack/changelog.rst
@@ -55,6 +55,14 @@ here so that users affected can find the reason for the changes.
 |              |                     |                                         | on 17 Jan 2022         |                                              |
 +--------------+---------------------+-----------------------------------------+------------------------+----------------------------------------------+
 
+Airflow 2.5
+~~~~~~~~~~~
+
+* 2.5.0
+
+  * The docker CLI binary is now added to the images by default (available on PATH). Version 20.10.9 is used.
+
+
 Airflow 2.4
 ~~~~~~~~~~~
 

--- a/scripts/docker/install_os_dependencies.sh
+++ b/scripts/docker/install_os_dependencies.sh
@@ -17,6 +17,8 @@
 # shellcheck shell=bash
 set -euo pipefail
 
+DOCKER_CLI_VERSION=20.10.9
+
 if [[ "$#" != 1 ]]; then
     echo "ERROR! There should be 'runtime' or 'dev' parameter passed as argument.".
     exit 1
@@ -50,6 +52,18 @@ ldap-utils libffi7 libldap-2.4-2 libsasl2-2 libsasl2-modules libssl1.1 locales \
 lsb-release netcat openssh-client python3-selinux rsync sasl2-bin sqlite3 sudo unixodbc"
         export RUNTIME_APT_DEPS
     fi
+}
+
+function install_docker_cli() {
+    local platform
+    if [[ $(uname -m) == "arm64" || $(uname -m) == "aarch64" ]]; then
+        platform="aarch64"
+    else
+        platform="x86_64"
+    fi
+    curl --silent \
+        "https://download.docker.com/linux/static/stable/${platform}/docker-${DOCKER_CLI_VERSION}.tgz" \
+        |  tar -C /usr/bin --strip-components=1 -xvzf - docker/docker
 }
 
 function install_debian_dev_dependencies() {
@@ -92,7 +106,10 @@ function install_debian_runtime_dependencies() {
 if [[ "${INSTALLATION_TYPE}" == "RUNTIME" ]]; then
     get_runtime_apt_deps
     install_debian_runtime_dependencies
+    install_docker_cli
+
 else
     get_dev_apt_deps
     install_debian_dev_dependencies
+    install_docker_cli
 fi


### PR DESCRIPTION
The Dockerfile.ci had a bug - installation of docker CLI for ARM images was done with the x86 docker. This caused the binary to be ~15 slower on emulated devices but it also seemed to break the cache for the ARM images (or so it seems).

This change fixes this in two ways:

1) the docker installation happens inside the scripts which are
   shared between the PROD and CI image - this means that the
   docker binary should be available in PROD and CI image.

2) the installation picks the right binary, depending on the
   platform and likely not causing cache invalidation

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
