### PR TITLE
Set proper extension for sdist files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,7 +705,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: pipx install twine && twine check dist/*.whl
         if: matrix.package-format == 'wheel'
       - name: "Verify sdist packages with twine"
-        run: pipx install twine && twine check dist/*.tgz
+        run: pipx install twine && twine check dist/*.tar.gz
         if: matrix.package-format == 'sdist'
       - name: "Install and test provider packages and airflow via ${{matrix.package-format}} files"
         run: breeze release-management verify-provider-packages --use-packages-from-dist

--- a/dev/refresh_images.sh
+++ b/dev/refresh_images.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 rm -rf docker-context-files/*.whl
-rm -rf docker-context-files/*.tgz
+rm -rf docker-context-files/*.tar.gz
 export ANSWER="yes"
 export CI="true"
 export GITHUB_TOKEN=""


### PR DESCRIPTION
The `sdist` packages have .tar.gz extension but in a few places we used .tgz. This now should be fixed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
