### PR TITLE
Add stub 'yield' to BaseTrigger.run

### DIFF
--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -66,6 +66,7 @@ class BaseTrigger(abc.ABC, LoggingMixin):
         and then rely on cleanup() being called when they are no longer needed.
         """
         raise NotImplementedError("Triggers must implement run()")
+        yield  # To convince Mypy this is an async iterator.
 
     def cleanup(self) -> None:
         """


### PR DESCRIPTION
This allows Mypy to correctly recognize the method as an async generator and not emit errors when a subclass (correctly) implements it as so.

Mypy issue: https://github.com/python/mypy/issues/5070

Subclasses currently needs to “fix” the issue by ignoring the error:
https://github.com/astronomer/astronomer-providers/blob/d5446278489cdf774840b934beff900b330850e9/astronomer/providers/google/cloud/triggers/bigquery.py#L59