### PR TITLE
SLAMiss is nullable and not always given back when pulling task instances

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2989,6 +2989,7 @@ components:
           nullable: true
         notification_sent:
           type: boolean
+      nullable: true
 
     Trigger:
       type: object

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -1156,7 +1156,7 @@ export interface components {
       timestamp?: string;
       description?: string | null;
       notification_sent?: boolean;
-    };
+    } | null;
     Trigger: {
       id?: number;
       classpath?: string;


### PR DESCRIPTION
related: https://github.com/apache/airflow-client-python/issues/50

It appears as though the API doesn't have to return an SLAMiss value, so therefore it can be nullable. Without this change (and rebuilding of the client) we get a failure like so: 

```
>>> ti = TaskInstanceApi(api_client)
>>> ti.get_task_instances('tutorial', 'manual__2022-10-31T20:32:58.139267+00:00')
...
ApiValueError: Invalid inputs given to generate an instance of 'TaskInstanceCollectionAllOf'. The input data was invalid for the allOf schema 'TaskInstanceCollectionAllOf' in the composed schema 'TaskInstanceCollection'. Error=Invalid type for variable 'sla_miss'. Required value type is SLAMiss and passed type was NoneType at ['received_data']['task_instances'][0]['sla_miss']
```

With this change (and rebuilding of the client) it works fine.

```
In [6]: ti.get_task_instances('tutorial', 'manual__2022-10-31T20:32:58.139267+00:00')
Out[6]:
{'task_instances': [{'dag_id': 'tutorial',
                     'dag_run_id': 'manual__2022-10-31T20:32:58.139267+00:00',
                     'duration': 0.116132,
                     'end_date': '2022-10-31T20:32:59.352991+00:00',
                     'execution_date': '2022-10-31T20:32:58.139267+00:00',
                     'executor_config': '{}',
...
```
