### PR TITLE
Move static checks to single-line ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,8 +555,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit-full
-          key: "pre-commit-${{steps.host-python-version.outputs.host-python-version}}-\
-${{ hashFiles('.pre-commit-config.yaml') }}"
+          # yamllint disable-line rule:line-length
+          key: "pre-commit-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
           restore-keys: |
             pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}
             pre-commit-full
@@ -597,8 +597,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
-          key: "pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}-\
-${{ hashFiles('.pre-commit-config.yaml') }}"
+          # yamllint disable-line rule:line-length
+          key: "pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
           restore-keys: |
             pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}
             pre-commit-basic-


### PR DESCRIPTION
Suddenly github stopped liking 3-years old (otherwise perfectly fine) double-quoted mutli-line strings indented in the way that they lacked spaces (even it is perfectly valid yaml). Seems they changed parser to be a lot more picky (and rather wrong because such multi-line entries when ended with \ are perfectly fine according to yaml specification.

This change fixes the problem by making those keys single line and telling yamlling to ignore their length (yammlint was the main reason why they were converted into multi-line keys).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
