### PR TITLE
Speed-up release management and shell Breeze commands on Mac

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -75,7 +75,11 @@ from airflow_breeze.utils.docker_command_utils import (
     get_extra_docker_flags,
     perform_environment_checks,
 )
-from airflow_breeze.utils.path_utils import AIRFLOW_SOURCES_ROOT, create_mypy_volume_if_needed
+from airflow_breeze.utils.path_utils import (
+    AIRFLOW_SOURCES_ROOT,
+    cleanup_python_generated_files,
+    create_mypy_volume_if_needed,
+)
 from airflow_breeze.utils.run_utils import (
     RunCommandResult,
     assert_pre_commit_installed,
@@ -324,6 +328,7 @@ def build_docs(
         get_console().print("\n[warning]When building docs for production, clan-build is forced\n")
         clean_build = True
     perform_environment_checks()
+    cleanup_python_generated_files()
     params = BuildCiParams(github_repository=github_repository, python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION)
     rebuild_or_pull_ci_image_if_needed(command_params=params)
     if clean_build:
@@ -523,6 +528,7 @@ def enter_shell(**kwargs) -> RunCommandResult:
 
     """
     perform_environment_checks()
+    cleanup_python_generated_files()
     if read_from_cache_file("suppress_asciiart") is None:
         get_console().print(ASCIIART, style=ASCIIART_STYLE)
     if read_from_cache_file("suppress_cheatsheet") is None:

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -74,6 +74,7 @@ from airflow_breeze.utils.parallel import (
     check_async_run_results,
     run_with_pool,
 )
+from airflow_breeze.utils.path_utils import cleanup_python_generated_files
 from airflow_breeze.utils.python_versions import get_python_version_list
 from airflow_breeze.utils.run_utils import (
     RunCommandResult,
@@ -91,7 +92,7 @@ option_debug_release_management = click.option(
 )
 
 
-def run_with_debug(
+def run_docker_command_with_debug(
     params: ShellParams,
     command: list[str],
     debug: bool,
@@ -99,6 +100,7 @@ def run_with_debug(
     output_outside_the_group: bool = False,
     **kwargs,
 ) -> RunCommandResult:
+    cleanup_python_generated_files()
     env_variables = get_env_variables_for_docker_commands(params)
     extra_docker_flags = get_extra_docker_flags(mount_sources=params.mount_sources)
     if enable_input or debug:
@@ -183,7 +185,7 @@ def prepare_airflow_packages(
         mount_sources=MOUNT_ALL,
     )
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
-    result_command = run_with_debug(
+    result_command = run_docker_command_with_debug(
         params=shell_params,
         command=["/opt/airflow/scripts/in_container/run_prepare_airflow_packages.sh"],
         debug=debug,
@@ -224,7 +226,7 @@ def prepare_provider_documentation(
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
     cmd_to_run = ["/opt/airflow/scripts/in_container/run_prepare_provider_documentation.sh", *packages]
     answer = get_forced_answer()
-    result_command = run_with_debug(
+    result_command = run_docker_command_with_debug(
         params=shell_params,
         command=cmd_to_run,
         enable_input=answer is None or answer[0].lower() != "y",
@@ -271,7 +273,7 @@ def prepare_provider_packages(
     )
     rebuild_or_pull_ci_image_if_needed(command_params=shell_params)
     cmd_to_run = ["/opt/airflow/scripts/in_container/run_prepare_provider_packages.sh", *packages_list]
-    result_command = run_with_debug(
+    result_command = run_docker_command_with_debug(
         params=shell_params,
         command=cmd_to_run,
         debug=debug,
@@ -287,7 +289,7 @@ def run_generate_constraints(
     cmd_to_run = [
         "/opt/airflow/scripts/in_container/run_generate_constraints.sh",
     ]
-    generate_constraints_result = run_with_debug(
+    generate_constraints_result = run_docker_command_with_debug(
         params=shell_params,
         command=cmd_to_run,
         debug=debug,
@@ -492,7 +494,7 @@ def verify_provider_packages(
         "-c",
         "python /opt/airflow/scripts/in_container/verify_providers.py",
     ]
-    result_command = run_with_debug(
+    result_command = run_docker_command_with_debug(
         params=shell_params,
         command=cmd_to_run,
         debug=debug,

--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -66,7 +66,7 @@ from airflow_breeze.utils.parallel import (
     check_async_run_results,
     run_with_pool,
 )
-from airflow_breeze.utils.path_utils import FILES_DIR
+from airflow_breeze.utils.path_utils import FILES_DIR, cleanup_python_generated_files
 from airflow_breeze.utils.run_tests import run_docker_compose_tests
 from airflow_breeze.utils.run_utils import get_filesystem_type, run_command
 
@@ -153,6 +153,7 @@ def _run_test(
         "--remove-orphans",
     ]
     run_command(down_cmd, env=env_variables, output=output, check=False)
+    cleanup_python_generated_files()
     run_cmd = [
         *DOCKER_COMPOSE_COMMAND,
         "--project-name",
@@ -465,6 +466,7 @@ def helm_tests(
     env_variables["RUN_TESTS"] = "true"
     env_variables["TEST_TYPE"] = "Helm"
     perform_environment_checks()
+    cleanup_python_generated_files()
     cmd = [*DOCKER_COMPOSE_COMMAND, "run", "--service-ports", "--rm", "airflow"]
     cmd.extend(list(extra_pytest_args))
     result = run_command(cmd, env=env_variables, check=False, output_outside_the_group=True)

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -60,44 +60,6 @@ function in_container_script_start() {
 }
 
 #
-# Cleans up PYC files (in case they come in mounted folders)
-#
-function in_container_cleanup_pyc() {
-    set +o pipefail
-    if [[ ${CLEANED_PYC=} == "true" ]]; then
-        return
-    fi
-    sudo find . \
-        -path "./airflow/www/node_modules" -prune -o \
-        -path "./provider_packages/airflow/www/node_modules" -prune -o \
-        -path "./.eggs" -prune -o \
-        -path "./docs/_build" -prune -o \
-        -path "./build" -prune -o \
-        -name "*.pyc" | grep ".pyc$" | sudo xargs rm -f
-    set -o pipefail
-    export CLEANED_PYC="true"
-}
-
-#
-# Cleans up __pycache__ directories (in case they come in mounted folders)
-#
-function in_container_cleanup_pycache() {
-    set +o pipefail
-    if [[ ${CLEANED_PYCACHE=} == "true" ]]; then
-        return
-    fi
-    find . \
-        -path "./airflow/www/node_modules" -prune -o \
-        -path "./provider_packages/airflow/www/node_modules" -prune -o \
-        -path "./.eggs" -prune -o \
-        -path "./docs/_build" -prune -o \
-        -path "./build" -prune -o \
-        -name "__pycache__" | grep "__pycache__" | sudo xargs rm -rf
-    set -o pipefail
-    export CLEANED_PYCACHE="true"
-}
-
-#
 # Fixes ownership of files generated in container - if they are owned by root, they will be owned by
 # The host user. Only needed if the host is Linux - on Mac, ownership of files is automatically
 # changed to the Host user via osxfs filesystem
@@ -137,8 +99,6 @@ function in_container_go_to_airflow_sources() {
 function in_container_basic_sanity_check() {
     assert_in_container
     in_container_go_to_airflow_sources
-    in_container_cleanup_pyc
-    in_container_cleanup_pycache
 }
 
 export DISABLE_CHECKS_FOR_TESTS="missing-docstring,no-self-use,too-many-public-methods,protected-access,do-not-use-asserts"

--- a/scripts/in_container/run_prepare_provider_packages.sh
+++ b/scripts/in_container/run_prepare_provider_packages.sh
@@ -23,11 +23,10 @@ function copy_sources() {
     echo "==================================================================================="
     echo " Copying sources for provider packages"
     echo "==================================================================================="
-    pushd "${AIRFLOW_SOURCES}"
-    rm -rf "provider_packages/airflow"
-    cp -r airflow "provider_packages"
-    popd
-
+    mkdir -pv "${AIRFLOW_SOURCES}/provider_packages/airflow/"
+    rsync -avz --exclude '*node_modules*' --delete \
+        "${AIRFLOW_SOURCES}/airflow"  \
+        "${AIRFLOW_SOURCES}/provider_packages/"
     group_end
 }
 


### PR DESCRIPTION
The release management and shell Breeze command on Mac should be now quite a bit faster:

1) The .pyc and __pycache__ are now deleted at entry of shell
   command and when docker commands are run - on the host. This
   will not remove all files sometimes - if they are root owned
   but we print warning in this case and suggest to use the
   `breeze ci fix-ownership` command

2) When preparing packages we are now using rsync rather than
   removing/copying sources. This should be way faster even on
   Mounted Mac system.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
