### PR TITLE
Handle exception during serializing incompatible executor_config object.

### DIFF
--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -34,12 +34,9 @@ from airflow.utils.state import State
 
 
 class _ExecutorConfigField(fields.String):
-    def _super_serialize(self, value, attr, obj):
-        return super()._serialize(value, attr, obj)
-
     def _serialize(self, value, attr, obj, **kwargs):
         try:
-            return self._super_serialize(value, attr, obj)
+            return super().serialize(value, attr, obj, **kwargs)
         except Exception:
             return "{}"
 

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -69,7 +69,7 @@ class TaskInstanceSchema(SQLAlchemySchema):
     operator = auto_field()
     queued_dttm = auto_field(data_key="queued_when")
     pid = auto_field()
-    executor_config = auto_field()
+    executor_config = _ExecutorConfigField()
     note = auto_field()
     sla_miss = fields.Nested(SlaMissSchema, dump_default=None)
     rendered_fields = JsonObjectField(dump_default={})

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -33,6 +33,17 @@ from airflow.utils.helpers import exactly_one
 from airflow.utils.state import State
 
 
+class _ExecutorConfigField(fields.String):
+    def _super_serialize(self, value, attr, obj):
+        return super()._serialize(value, attr, obj)
+
+    def _serialize(self, value, attr, obj, **kwargs):
+        try:
+            return self._super_serialize(value, attr, obj)
+        except Exception:
+            return "{}"
+
+
 class TaskInstanceSchema(SQLAlchemySchema):
     """Task instance schema."""
 

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -36,7 +36,7 @@ from airflow.utils.state import State
 class _ExecutorConfigField(fields.String):
     def _serialize(self, value, attr, obj, **kwargs):
         try:
-            return super().serialize(value, attr, obj, **kwargs)
+            return super()._serialize(value, attr, obj, **kwargs)
         except Exception:
             return "{}"
 

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -221,12 +221,10 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         }
 
     @provide_session
-    @mock.patch(
-        "airflow.api_connexion.schemas.task_instance_schema.ExecutorConfigField._super_serialize",
-        side_effect=AttributeError(),
-    )
-    def test_task_instance_executor_config_exception(self, mock_executor_config, session):
-        self.create_task_instances(session)
+    def test_task_instance_executor_config_exception(self, session):
+        tis = self.create_task_instances(session)
+        print_the_context = next(ti for ti in tis if ti.task_id == "print_the_context")
+        print_the_context.executor_config = Exception()
         response = self.client.get(
             "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context",
             environ_overrides={"REMOTE_USER": "test"},
@@ -245,7 +243,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "pid": 100,
             "pool": "default_pool",
             "pool_slots": 1,
-            "priority_weight": 9,
+            "priority_weight": 11,
             "queue": "default_queue",
             "queued_when": None,
             "sla_miss": None,

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -220,6 +220,46 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "triggerer_job": None,
         }
 
+    @provide_session
+    @mock.patch(
+        "airflow.api_connexion.schemas.task_instance_schema.ExecutorConfigField._super_serialize",
+        side_effect=AttributeError(),
+    )
+    def test_task_instance_executor_config_exception(self, mock_executor_config, session):
+        self.create_task_instances(session)
+        response = self.client.get(
+            "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context",
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 200
+        assert response.json == {
+            "dag_id": "example_python_operator",
+            "duration": 10000.0,
+            "end_date": "2020-01-03T00:00:00+00:00",
+            "execution_date": "2020-01-01T00:00:00+00:00",
+            "executor_config": "{}",
+            "hostname": "",
+            "map_index": -1,
+            "max_tries": 0,
+            "operator": "_PythonDecoratedOperator",
+            "pid": 100,
+            "pool": "default_pool",
+            "pool_slots": 1,
+            "priority_weight": 9,
+            "queue": "default_queue",
+            "queued_when": None,
+            "sla_miss": None,
+            "start_date": "2020-01-02T00:00:00+00:00",
+            "state": "running",
+            "task_id": "print_the_context",
+            "try_number": 0,
+            "unixname": getuser(),
+            "dag_run_id": "TEST_DAG_RUN_ID",
+            "rendered_fields": {},
+            "trigger": None,
+            "triggerer_job": None,
+        }
+
     def test_should_respond_200_with_task_state_in_deferred(self, session):
         now = pendulum.now("UTC")
         ti = self.create_task_instances(

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -225,14 +225,14 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "triggerer_job": None,
         }
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "executor_config, expected_config",
         [
-            ("Exception serialization", _BadExecutorConfig(), "{}"),
-            ("Dict serialization", {"foo": "bar"}, "{'foo': 'bar'}"),
+            pytest.param(_BadExecutorConfig(), "{}", id="Exception serialization"),
+            pytest.param({"foo": "bar"}, "{'foo': 'bar'}", id="Dict serialization"),
         ],
     )
-    @provide_session
-    def test_task_instance_executor_config_exception(self, _, executor_config, expected_config, session):
+    def test_task_instance_executor_config_exception(self, executor_config, expected_config, session):
         tis = self.create_task_instances(session)
         print_the_context = next(ti for ti in tis if ti.task_id == "print_the_context")
         print_the_context.executor_config = executor_config
@@ -251,6 +251,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "map_index": -1,
             "max_tries": 0,
             "operator": "_PythonDecoratedOperator",
+            "note": "placeholder-note",
             "pid": 100,
             "pool": "default_pool",
             "pool_slots": 1,


### PR DESCRIPTION
Handle exception during serializing incompatible executor_config object across different kubernetes versions.

In case of an existing issue, reference it using one of the following:

closes: #27084 
related: #27084

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
