### PR TITLE
Enable template rendering for env_vars field for the @task.kubernetes decorator

### DIFF
--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -57,13 +57,11 @@ def _read_file_contents(filename):
 class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
-
     # This allows for jinja template rendering of the template_fields passed
     # to the KubernetesPodOperator.
     # cmds and arguments are specifically excluded as these are explicitly
     # used when running the python file generated from the code
     # below the decorator.
-
     template_fields: Sequence[str] = tuple(
         {"op_args", "op_kwargs"} | set(KubernetesPodOperator.template_fields) - {"cmds", "arguments"}
     )

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -57,8 +57,6 @@ def _read_file_contents(filename):
 class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
-    # This allows for jinja template rendering of the template_fields passed
-    # to the KubernetesPodOperator.
     # `cmds` and `arguments` are used internally by the operator
     template_fields: Sequence[str] = tuple(
         {"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"}

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -59,9 +59,7 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
 
     # This allows for jinja template rendering of the template_fields passed
     # to the KubernetesPodOperator.
-    # cmds and arguments are specifically excluded as these are explicitly
-    # used when running the python file generated from the code
-    # below the decorator.
+    # `cmds` and `arguments` are used internally by the operator
     template_fields: Sequence[str] = tuple(
         {"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"}
     )

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -63,7 +63,7 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     # used when running the python file generated from the code
     # below the decorator.
     template_fields: Sequence[str] = tuple(
-        {"op_args", "op_kwargs"} | set(KubernetesPodOperator.template_fields) - {"cmds", "arguments"}
+        {"op_args", "op_kwargs", *KubernetesPodOperator.template_fields} - {"cmds", "arguments"}
     )
 
     # since we won't mutate the arguments, we should just do the shallow copy

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -57,7 +57,7 @@ def _read_file_contents(filename):
 class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs")
+    template_fields: Sequence[str] = ("op_args", "op_kwargs", "env_vars")
 
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -57,7 +57,16 @@ def _read_file_contents(filename):
 class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
     custom_operator_name = "@task.kubernetes"
 
-    template_fields: Sequence[str] = ("op_args", "op_kwargs", "env_vars")
+
+    # This allows for jinja template rendering of the template_fields passed
+    # to the KubernetesPodOperator. 
+    # cmds and arguments are specifically excluded as these are explicitly 
+    # used when running the python file generated from the code
+    # below the decorator.
+
+    template_fields: Sequence[str] = tuple(
+        {"op_args", "op_kwargs"} | set(KubernetesPodOperator.template_fields) - {"cmds", "arguments"}
+    )
 
     # since we won't mutate the arguments, we should just do the shallow copy
     # there are some cases we can't deepcopy the objects (e.g protobuf).

--- a/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/decorators/kubernetes.py
@@ -59,8 +59,8 @@ class _KubernetesDecoratedOperator(DecoratedOperator, KubernetesPodOperator):
 
 
     # This allows for jinja template rendering of the template_fields passed
-    # to the KubernetesPodOperator. 
-    # cmds and arguments are specifically excluded as these are explicitly 
+    # to the KubernetesPodOperator.
+    # cmds and arguments are specifically excluded as these are explicitly
     # used when running the python file generated from the code
     # below the decorator.
 


### PR DESCRIPTION
While working through an [example](https://docs.astronomer.io/learn/kubepod-operator#example-use-the-kubernetespodoperator-with-xcoms) of doing XComs with the KubernetesPodOperator, the `env_vars` attribute is used to pass templated values into the kubernetes pod. The `@task.decorator` uses the `_KubernetesDecoratedOperator` class in [this](https://github.com/fletchjeff/airflow/blob/main/airflow/providers/cncf/kubernetes/decorators/kubernetes.py) file. It overrides the `template_fields` and excludes `env_vars` from being rendered. 

Given that `env_vars` seems to be the standard approach passing XComs into a kubernetes pod, I think this should be enabled. Its a quite a simple change.

This line https://github.com/fletchjeff/airflow/blob/main/airflow/providers/cncf/kubernetes/decorators/kubernetes.py#L60

goes from:

`template_fields: Sequence[str] = ("op_args", "op_kwargs",)`

to:

`template_fields: Sequence[str] = ("op_args", "op_kwargs", "env_vars")`

No other changes are made.

@uranusjr @dstandish Please can you review?
