### PR TITLE
Move validation `branch_task_ids` into `SkipMixin`

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -208,21 +208,7 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
 
     def execute(self, context: Context) -> Any:
         branch = super().execute(context)
-        # TODO: The logic should be moved to SkipMixin to be available to all branch operators.
-        if isinstance(branch, str):
-            branches = {branch}
-        elif isinstance(branch, list):
-            branches = set(branch)
-        elif branch is None:
-            branches = set()
-        else:
-            raise AirflowException("Branch callable must return either None, a task ID, or a list of IDs")
-        valid_task_ids = set(context["dag"].task_ids)
-        invalid_task_ids = branches - valid_task_ids
-        if invalid_task_ids:
-            raise AirflowException(
-                f"Branch callable must return valid task_ids. Invalid tasks found: {invalid_task_ids}"
-            )
+        self.log.info("Branch callable return %s", branch)
         self.skip_all_except(context['ti'], branch)
         return branch
 

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -574,7 +574,7 @@ class TestBranchOperator(unittest.TestCase):
         self.dag.clear()
         with pytest.raises(AirflowException) as ctx:
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        assert "Branch callable must return either None, a task ID, or a list of IDs" == str(ctx.value)
+        assert "must be either None, a task ID, or an Iterable of IDs" in str(ctx.value)
 
     def test_raise_exception_on_invalid_task_id(self):
         branch_op = BranchPythonOperator(
@@ -583,9 +583,7 @@ class TestBranchOperator(unittest.TestCase):
         self.dag.clear()
         with pytest.raises(AirflowException) as ctx:
             branch_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        assert """Branch callable must return valid task_ids. Invalid tasks found: {'some_task_id'}""" == str(
-            ctx.value
-        )
+        assert "Invalid tasks found: {'some_task_id'}" in str(ctx.value)
 
 
 class TestShortCircuitOperator:


### PR DESCRIPTION
closes: #27409

Move validation task IDs (types and is it existed) into the `SkipMixin` class.
In additional add validation types within `Iterable` objects.
