### PR TITLE
Remove --force option of breeze self-upgrade from docs

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -247,7 +247,7 @@ Those are all available commands for Breeze and details about the commands are d
 
 Breeze installed this way is linked to your checked out sources of Airflow so Breeze will
 automatically use latest version of sources from ``./dev/breeze``. Sometimes, when dependencies are
-updated ``breeze`` commands with offer you to run self-upgrade (you just need to answer ``y`` when asked).
+updated ``breeze`` commands with offer you to run self-upgrade.
 
 You can always run such self-upgrade at any time:
 

--- a/dev/breeze/src/airflow_breeze/commands/setup_commands_config.py
+++ b/dev/breeze/src/airflow_breeze/commands/setup_commands_config.py
@@ -34,7 +34,6 @@ SETUP_PARAMETERS: dict[str, list[dict[str, str | list[str]]]] = {
             "name": "Self-upgrade flags",
             "options": [
                 "--use-current-airflow-sources",
-                "--force",
             ],
         }
     ],

--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -47,7 +47,7 @@ def warn_non_editable():
         "\n[error]Breeze is installed in a wrong way.[/]\n"
         "\n[error]It should only be installed in editable mode[/]\n\n"
         "[info]Please go to Airflow sources and run[/]\n\n"
-        f"     {NAME} setup self-upgrade --force --use-current-airflow-sources\n"
+        f"     {NAME} setup self-upgrade --use-current-airflow-sources\n"
     )
 
 
@@ -56,6 +56,6 @@ def warn_dependencies_changed():
         f"\n[warning]Breeze dependencies changed since the installation![/]\n\n"
         f"[warning]This might cause various problems!![/]\n\n"
         f"If you experience problems - reinstall Breeze with:\n\n"
-        f"    {NAME} setup self-upgrade --force\n"
+        f"    {NAME} setup self-upgrade\n"
         "\nThis should usually take couple of seconds.\n"
     )


### PR DESCRIPTION
The option was removed some time ago but there were some docs remaining.

Fix: #27429

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
