### PR TITLE
[BUMP] helm chart - redis 7

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -602,7 +602,7 @@
                         "tag": {
                             "description": "The redis image tag.",
                             "type": "string",
-                            "default": "6-bullseye"
+                            "default": "7-bullseye"
                         },
                         "pullPolicy": {
                             "description": "The redis image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,7 +81,7 @@ images:
     pullPolicy: IfNotPresent
   redis:
     repository: redis
-    tag: 6-bullseye
+    tag: 7-bullseye
     pullPolicy: IfNotPresent
   pgbouncer:
     repository: apache/airflow


### PR DESCRIPTION
the official docker-compose is using redis:latest and redis 7 have been out for 6 month