### PR TITLE
[DOC] fix K8S hook with KPO

### DIFF
--- a/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
@@ -20,7 +20,7 @@
 Kubernetes cluster Connection
 =============================
 
-The Kubernetes cluster Connection type enables connection to a Kubernetes cluster by :class:`~airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator` tasks. They are not used by ``KubernetesPodOperator`` tasks.
+The Kubernetes cluster Connection type enables connection to a Kubernetes cluster by :class:`~airflow.providers.cncf.kubernetes.operators.spark_kubernetes.SparkKubernetesOperator` tasks and :class:`~airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator` tasks.
 
 
 Authenticating to Kubernetes cluster


### PR DESCRIPTION
the doc was not updated after theses changes  -> https://github.com/apache/airflow/pull/20578 and https://github.com/apache/airflow/pull/22086

by the way, is there a way to fix the current deployed documentation and not wait for the next release ?