### PR TITLE
Fix behavior of `_` when searching for DAGs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -654,9 +654,10 @@ class Airflow(AirflowBaseView):
             dags_query = session.query(DagModel).filter(~DagModel.is_subdag, DagModel.is_active)
 
             if arg_search_query:
+                escaped_arg_search_query = arg_search_query.replace("_", "\\_")
                 dags_query = dags_query.filter(
-                    DagModel.dag_id.ilike('%' + arg_search_query + '%')
-                    | DagModel.owners.ilike('%' + arg_search_query + '%')
+                    DagModel.dag_id.ilike("%" + escaped_arg_search_query + "%", escape="\\")
+                    | DagModel.owners.ilike("%" + escaped_arg_search_query + "%", escape="\\")
                 )
 
             if arg_tags_filter:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -654,7 +654,7 @@ class Airflow(AirflowBaseView):
             dags_query = session.query(DagModel).filter(~DagModel.is_subdag, DagModel.is_active)
 
             if arg_search_query:
-                escaped_arg_search_query = arg_search_query.replace("_", "\\_")
+                escaped_arg_search_query = arg_search_query.replace("_", r"\_")
                 dags_query = dags_query.filter(
                     DagModel.dag_id.ilike("%" + escaped_arg_search_query + "%", escape="\\")
                     | DagModel.owners.ilike("%" + escaped_arg_search_query + "%", escape="\\")

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -118,7 +118,7 @@ def client_single_dag(app, user_single_dag):
     )
 
 
-TEST_FILTER_DAG_IDS = ["filter_test_1", "filter_test_2", "a_first_dag_id_asc"]
+TEST_FILTER_DAG_IDS = ["filter_test_1", "filter_test_2", "a_first_dag_id_asc", "filter.test"]
 
 
 def _process_file(file_path, session):
@@ -183,6 +183,14 @@ def test_home_dag_list_filtered_singledag_user(working_dags, client_single_dag):
     # But not the rest
     for dag_id in TEST_FILTER_DAG_IDS[1:]:
         check_content_not_in_response(f"dag_id={dag_id}", resp)
+
+
+def test_home_dag_list_search(working_dags, user_client):
+    resp = user_client.get("home?search=filter_test", follow_redirects=True)
+    check_content_in_response("dag_id=filter_test_1", resp)
+    check_content_in_response("dag_id=filter_test_2", resp)
+    check_content_not_in_response("dag_id=filter.test", resp)
+    check_content_not_in_response("dag_id=a_first_dag_id_asc", resp)
 
 
 def test_home_robots_header_in_response(user_client):


### PR DESCRIPTION
On the homepage, when you search for DAGs, `_` wasn't behaving as most people might expect since it is a single character wildcard in SQL. We will automatically escape it now.