### PR TITLE
Document that KubernetesExecutor overwrites container args

### DIFF
--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -126,7 +126,7 @@ pod_override
 
 When using the KubernetesExecutor, Airflow offers the ability to override system defaults on a per-task basis.
 To utilize this functionality, create a Kubernetes V1pod object and fill in your desired overrides.
-Please note that the scheduler will override the ``metadata.name`` of the V1pod before launching it.
+Please note that the scheduler will override the ``metadata.name`` and ``containers[0].args`` of the V1pod before launching it.
 
 To overwrite the base container of the pod launched by the KubernetesExecutor,
 create a V1pod with a single container, and overwrite the fields as follows:


### PR DESCRIPTION
The executor will overwrite the args for the container so that the worker runs the right task.

Closes #27358