### PR TITLE
Fix jinja file inclusion in cncf.kubernetes provider package

### DIFF
--- a/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
+++ b/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
@@ -28,6 +28,8 @@ include airflow/providers/amazon/aws/hooks/batch_waiters.json
 {% elif PROVIDER_PACKAGE_ID == 'google' %}
 include airflow/providers/google/cloud/example_dags/*.yaml
 include airflow/providers/google/cloud/example_dags/*.sql
+{% elif PROVIDER_PACKAGE_ID == 'cncf.kubernetes' %}
+include airflow/providers/cncf/kubernetes/*.jinja2
 {% endif %}
 
 include NOTICE

--- a/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -37,7 +37,6 @@ def do_setup():
         packages=find_namespace_packages(
             include=['airflow.providers.{{ PROVIDER_PACKAGE_ID }}',
                      'airflow.providers.{{ PROVIDER_PACKAGE_ID }}.*']),
-        package_data={'airflow.providers.{{ PROVIDER_PACKAGE_ID }}': ['**/*.jinja2']},
     )
 
 


### PR DESCRIPTION
Should _actually_ resolve https://github.com/apache/airflow/issues/26910

Followup to #27171

Should be able to test with 

```
rm -rf dist/  \
    && breeze release-management prepare-provider-packages --package-format both cncf.kubernetes --version-suffix-for-pypi abc123  \
    && tar -xvf dist/apache-airflow-providers-cncf-kubernetes-4.4.0abc123.tar.gz -C dist/  \
    && ls -lah dist/apache-airflow-providers-cncf-kubernetes-4.4.0abc123/airflow/providers/cncf/kubernetes \
    && unzip dist/apache_airflow_providers_cncf_kubernetes-4.4.0abc123-py3-none-any.whl -d dist/here  \
    && ls -lah dist/here/airflow/providers/cncf/kubernetes/
```