### PR TITLE
Code quality improvements on sagemaker operators/hook

### DIFF
--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -223,7 +223,6 @@ class SageMakerEndpointConfigOperator(SageMakerBaseOperator):
         **kwargs,
     ):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
 
     def _create_integer_fields(self) -> None:
@@ -304,7 +303,6 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
         **kwargs,
     ):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
@@ -433,7 +431,6 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
         **kwargs,
     ):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
@@ -546,7 +543,6 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
         **kwargs,
     ):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
@@ -609,7 +605,6 @@ class SageMakerModelOperator(SageMakerBaseOperator):
 
     def __init__(self, *, config: dict, aws_conn_id: str = DEFAULT_CONN_ID, **kwargs):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
 
     def expand_role(self) -> None:
@@ -746,7 +741,6 @@ class SageMakerDeleteModelOperator(SageMakerBaseOperator):
 
     def __init__(self, *, config: dict, aws_conn_id: str = DEFAULT_CONN_ID, **kwargs):
         super().__init__(config=config, **kwargs)
-        self.config = config
         self.aws_conn_id = aws_conn_id
 
     def execute(self, context: Context) -> Any:

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -61,7 +61,6 @@ class TestSageMakerModelOperator(unittest.TestCase):
 
 
 class TestSageMakerDeleteModelOperator(unittest.TestCase):
-
     @mock.patch.object(SageMakerHook, "delete_model")
     def test_execute(self, delete_model):
         op = SageMakerDeleteModelOperator(

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -24,7 +24,6 @@ import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.sagemaker import SageMakerHook
-from airflow.providers.amazon.aws.operators import sagemaker
 from airflow.providers.amazon.aws.operators.sagemaker import (
     SageMakerDeleteModelOperator,
     SageMakerModelOperator,
@@ -46,40 +45,27 @@ class TestSageMakerModelOperator(unittest.TestCase):
     def setUp(self):
         self.sagemaker = SageMakerModelOperator(task_id="test_sagemaker_operator", config=CREATE_MODEL_PARAMS)
 
-    @mock.patch.object(SageMakerHook, "get_conn")
+    @mock.patch.object(SageMakerHook, "describe_model", return_value="")
     @mock.patch.object(SageMakerHook, "create_model")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    def test_integer_fields(self, serialize, mock_model, mock_client):
-        mock_model.return_value = {"ModelArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 200}}
+    def test_execute(self, mock_create_model, _):
+        mock_create_model.return_value = {"ModelArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 200}}
         self.sagemaker.execute(None)
+        mock_create_model.assert_called_once_with(CREATE_MODEL_PARAMS)
         assert self.sagemaker.integer_fields == EXPECTED_INTEGER_FIELDS
 
-    @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "create_model")
-    @mock.patch.object(sagemaker, "serialize", return_value="")
-    def test_execute(self, serialize, mock_model, mock_client):
-        mock_model.return_value = {"ModelArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 200}}
-        self.sagemaker.execute(None)
-        mock_model.assert_called_once_with(CREATE_MODEL_PARAMS)
-
-    @mock.patch.object(SageMakerHook, "get_conn")
-    @mock.patch.object(SageMakerHook, "create_model")
-    def test_execute_with_failure(self, mock_model, mock_client):
-        mock_model.return_value = {"ModelArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 404}}
+    def test_execute_with_failure(self, mock_create_model):
+        mock_create_model.return_value = {"ModelArn": "test_arn", "ResponseMetadata": {"HTTPStatusCode": 404}}
         with pytest.raises(AirflowException):
             self.sagemaker.execute(None)
 
 
 class TestSageMakerDeleteModelOperator(unittest.TestCase):
-    def setUp(self):
-        delete_model_params = {"ModelName": "model_name"}
-        self.sagemaker = SageMakerDeleteModelOperator(
-            task_id="test_sagemaker_operator", config=delete_model_params
-        )
 
-    @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "delete_model")
-    def test_execute(self, delete_model, mock_client):
-        delete_model.return_value = None
-        self.sagemaker.execute(None)
+    def test_execute(self, delete_model):
+        op = SageMakerDeleteModelOperator(
+            task_id="test_sagemaker_operator", config={"ModelName": "model_name"}
+        )
+        op.execute(None)
         delete_model.assert_called_once_with(model_name="model_name")


### PR DESCRIPTION
No functional change here. I'm working on some new features in those files and wanted to extract the cosmetic changes in a separate PR to ease reviewing.

 - removed an unnecessary parameter init (`self.config = config` is done in the base class ctor)
 - removed some unnecessary mocks in tests
 - tried to factor some code in tests