### PR TITLE
Fix cleanup of multi-processing behaviour for pyc cleanup

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/testing_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/testing_commands.py
@@ -153,7 +153,6 @@ def _run_test(
         "--remove-orphans",
     ]
     run_command(down_cmd, env=env_variables, output=output, check=False)
-    cleanup_python_generated_files()
     run_cmd = [
         *DOCKER_COMPOSE_COMMAND,
         "--project-name",
@@ -410,6 +409,7 @@ def tests(
         forward_ports=False,
         test_type=test_type,
     )
+    cleanup_python_generated_files()
     if run_in_parallel:
         run_tests_in_parallel(
             exec_shell_params=exec_shell_params,


### PR DESCRIPTION
The recently introduced (in #27426i) for .pyc files cleaning caused problem on multi-processing/parallel tests when parallel tests were removing the same files at the same time.

This PR moves cleanup to before parallelising.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
