### PR TITLE
Add container_resources as KubernetesPodOperator templatable

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -49,7 +49,6 @@ Features
 * Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
 * KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied via KPO param or pod template file or full pod spec, then we'll check the airflow conn,
   then if in a k8s pod, try to infer the namespace from the container, then finally will use the ``default`` namespace.
-* The ``container_resources`` field is now a templated field.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -49,6 +49,7 @@ Features
 * Previously, ``name`` was a required argument for KubernetesPodOperator (when also not supplying pod template or full pod spec). Now, if ``name`` is not supplied, ``task_id`` will be used.
 * KubernetsPodOperator argument ``namespace`` is now optional.  If not supplied via KPO param or pod template file or full pod spec, then we'll check the airflow conn,
   then if in a k8s pod, try to infer the namespace from the container, then finally will use the ``default`` namespace.
+* The ``container_resources`` field is now a templated field.
 
 Deprecations
 ~~~~~~~~~~~~

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -137,7 +137,7 @@ class KubernetesPodOperator(BaseOperator):
     :param annotations: non-identifying metadata you can attach to the Pod.
         Can be a large range of data, and can include characters
         that are not permitted by labels.
-    :param container_resources: resources for the launched pod.
+    :param container_resources: resources for the launched pod. (templated)
     :param affinity: affinity scheduling rules for the launched pod.
     :param config_file: The path to the Kubernetes config file. (templated)
         If not specified, default value is ``~/.kube/config``
@@ -185,6 +185,7 @@ class KubernetesPodOperator(BaseOperator):
         "config_file",
         "pod_template_file",
         "namespace",
+        "container_resources"
     )
     template_fields_renderers = {"env_vars": "py"}
 
@@ -318,6 +319,11 @@ class KubernetesPodOperator(BaseOperator):
         if id(content) not in seen_oids and isinstance(content, k8s.V1EnvVar):
             seen_oids.add(id(content))
             self._do_render_template_fields(content, ("value", "name"), context, jinja_env, seen_oids)
+            return
+
+        if id(content) not in seen_oids and isinstance(content, k8s.V1ResourceRequirements):
+            seen_oids.add(id(content))
+            self._do_render_template_fields(content, ("limits", "requests"), context, jinja_env, seen_oids)
             return
 
         super()._render_nested_template_fields(content, context, jinja_env, seen_oids)

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -185,7 +185,7 @@ class KubernetesPodOperator(BaseOperator):
         "config_file",
         "pod_template_file",
         "namespace",
-        "container_resources"
+        "container_resources",
     )
     template_fields_renderers = {"env_vars": "py"}
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -121,8 +121,8 @@ class TestKubernetesPodOperator:
             task_id='task-id',
             namespace='{{ dag.dag_id }}',
             container_resources=k8s.V1ResourceRequirements(
-                requests={'memory': 'my_requested_memory', 'cpu': 'my_requested_cpu'},
-                limits={'memory': 'my_memory_limit', 'cpu': 'my_cpu_limit'},
+                requests={'memory': '{{ dag.dag_id }}', 'cpu': '{{ dag.dag_id }}'},
+                limits={'memory': '{{ dag.dag_id }}', 'cpu': '{{ dag.dag_id }}'},
             ),
             pod_template_file='{{ dag.dag_id }}',
             config_file='{{ dag.dag_id }}',
@@ -135,10 +135,10 @@ class TestKubernetesPodOperator:
 
         rendered = ti.render_templates()
 
-        assert 'my_memory_limit' == rendered.container_resources.limits['memory']
-        assert 'my_cpu_limit' == rendered.container_resources.limits['cpu']
-        assert 'my_requested_memory' == rendered.container_resources.requests['memory']
-        assert 'my_requested_cpu' == rendered.container_resources.requests['cpu']
+        assert dag_id == rendered.container_resources.limits['memory']
+        assert dag_id == rendered.container_resources.limits['cpu']
+        assert dag_id == rendered.container_resources.requests['memory']
+        assert dag_id == rendered.container_resources.requests['cpu']
         assert dag_id == ti.task.image
         assert dag_id == ti.task.cmds
         assert dag_id == ti.task.namespace

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -101,44 +101,32 @@ class TestKubernetesPodOperator:
 
         patch.stopall()
 
-    def test_template_fields(self):
-        assert 9 == KubernetesPodOperator.template_fields.__len__()
-        KubernetesPodOperator.template_fields.__contains__('image')
-        KubernetesPodOperator.template_fields.__contains__('cmds')
-        KubernetesPodOperator.template_fields.__contains__('arguments')
-        KubernetesPodOperator.template_fields.__contains__('env_vars')
-        KubernetesPodOperator.template_fields.__contains__('labels')
-        KubernetesPodOperator.template_fields.__contains__('config_file')
-        KubernetesPodOperator.template_fields.__contains__('pod_template_file')
-        KubernetesPodOperator.template_fields.__contains__('namespace')
-        KubernetesPodOperator.template_fields.__contains__('container_resources')
-
     def test_templates(self, create_task_instance_of_operator):
-        dag_id = 'TestKubernetesPodOperator'
+        dag_id = "TestKubernetesPodOperator"
         ti = create_task_instance_of_operator(
             KubernetesPodOperator,
             dag_id=dag_id,
-            task_id='task-id',
-            namespace='{{ dag.dag_id }}',
+            task_id="task-id",
+            namespace="{{ dag.dag_id }}",
             container_resources=k8s.V1ResourceRequirements(
-                requests={'memory': '{{ dag.dag_id }}', 'cpu': '{{ dag.dag_id }}'},
-                limits={'memory': '{{ dag.dag_id }}', 'cpu': '{{ dag.dag_id }}'},
+                requests={"memory": "{{ dag.dag_id }}", "cpu": "{{ dag.dag_id }}"},
+                limits={"memory": "{{ dag.dag_id }}", "cpu": "{{ dag.dag_id }}"},
             ),
-            pod_template_file='{{ dag.dag_id }}',
-            config_file='{{ dag.dag_id }}',
-            labels='{{ dag.dag_id }}',
-            env_vars=['{{ dag.dag_id }}'],
-            arguments='{{ dag.dag_id }}',
-            cmds='{{ dag.dag_id }}',
-            image='{{ dag.dag_id }}',
+            pod_template_file="{{ dag.dag_id }}",
+            config_file="{{ dag.dag_id }}",
+            labels="{{ dag.dag_id }}",
+            env_vars=["{{ dag.dag_id }}"],
+            arguments="{{ dag.dag_id }}",
+            cmds="{{ dag.dag_id }}",
+            image="{{ dag.dag_id }}",
         )
 
         rendered = ti.render_templates()
 
-        assert dag_id == rendered.container_resources.limits['memory']
-        assert dag_id == rendered.container_resources.limits['cpu']
-        assert dag_id == rendered.container_resources.requests['memory']
-        assert dag_id == rendered.container_resources.requests['cpu']
+        assert dag_id == rendered.container_resources.limits["memory"]
+        assert dag_id == rendered.container_resources.limits["cpu"]
+        assert dag_id == rendered.container_resources.requests["memory"]
+        assert dag_id == rendered.container_resources.requests["cpu"]
         assert dag_id == ti.task.image
         assert dag_id == ti.task.cmds
         assert dag_id == ti.task.namespace


### PR DESCRIPTION
closes: #23529

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
This is my first PR (#26982) closed by accident when I rebased my fork.  That was my first PR for a mainstream large scale open source project, let alone Airflow.  
Sorry in advance if I've done anything improper, and thanks for your patience.

Thank you @nitinmuteja & @lior1990 for doing much of the work.  This is following up on this closed/abandoned PR:  https://github.com/apache/airflow/pull/23531

Here is how I tested:
`breeze testing tests --test-type "Providers[cncf]"`

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
