### PR TITLE
Add default name to EMR Serverless jobs

### DIFF
--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -593,7 +593,8 @@ class EmrServerlessStartJobOperator(BaseOperator):
       Its value must be unique for each request.
     :param config: Optional dictionary for arbitrary parameters to the boto API start_job_run call.
     :param wait_for_completion: If true, waits for the job to start before returning. Defaults to True.
-    :param aws_conn_id: AWS connection to use
+    :param aws_conn_id: AWS connection to use.
+    :param name: Name for the EMR Serverless job. If not provided, a default name will be assigned.
     """
 
     template_fields: Sequence[str] = (
@@ -613,6 +614,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         config: dict | None = None,
         wait_for_completion: bool = True,
         aws_conn_id: str = "aws_default",
+        name: str | None = None,
         **kwargs,
     ):
         self.aws_conn_id = aws_conn_id
@@ -622,6 +624,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.configuration_overrides = configuration_overrides
         self.wait_for_completion = wait_for_completion
         self.config = config or {}
+        self.name = name or self.config.pop("name", f"emr_serverless_job_airflow_{str(uuid4())}")
         super().__init__(**kwargs)
 
         self.client_request_token = client_request_token or str(uuid4())
@@ -654,6 +657,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
             executionRoleArn=self.execution_role_arn,
             jobDriver=self.job_driver,
             configurationOverrides=self.configuration_overrides,
+            name=self.name,
             **self.config,
         )
 

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -624,7 +624,7 @@ class EmrServerlessStartJobOperator(BaseOperator):
         self.configuration_overrides = configuration_overrides
         self.wait_for_completion = wait_for_completion
         self.config = config or {}
-        self.name = name or self.config.pop("name", f"emr_serverless_job_airflow_{str(uuid4())}")
+        self.name = name or self.config.pop("name", f"emr_serverless_job_airflow_{uuid4()}")
         super().__init__(**kwargs)
 
         self.client_request_token = client_request_token or str(uuid4())

--- a/tests/providers/amazon/aws/operators/test_emr_serverless.py
+++ b/tests/providers/amazon/aws/operators/test_emr_serverless.py
@@ -266,7 +266,7 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
-
+        default_name = operator.name
         id = operator.execute(None)
 
         assert operator.wait_for_completion is True
@@ -278,6 +278,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
         mock_conn.get_job_run.assert_called_once_with(applicationId=application_id, jobRunId=job_run_id)
 
@@ -299,6 +300,7 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
+        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             id = operator.execute(None)
             assert id == job_run_id
@@ -311,6 +313,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.waiter")
@@ -331,6 +334,7 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
+        default_name = operator.name
 
         id = operator.execute(None)
 
@@ -344,6 +348,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn")
@@ -391,7 +396,7 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=configuration_overrides,
             wait_for_completion=False,
         )
-
+        default_name = operator.name
         id = operator.execute(None)
 
         mock_conn.get_application.assert_called_once_with(applicationId=application_id)
@@ -403,6 +408,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.waiter")
@@ -424,7 +430,7 @@ class TestEmrServerlessStartJobOperator:
             configuration_overrides=configuration_overrides,
             wait_for_completion=False,
         )
-
+        default_name = operator.name
         id = operator.execute(None)
         assert id == job_run_id
         mock_conn.start_job_run.assert_called_once_with(
@@ -433,6 +439,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
         assert not mock_waiter.called
 
@@ -454,6 +461,7 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
+        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             operator.execute(None)
 
@@ -466,6 +474,7 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
         )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn")
@@ -485,6 +494,7 @@ class TestEmrServerlessStartJobOperator:
             job_driver=job_driver,
             configuration_overrides=configuration_overrides,
         )
+        default_name = operator.name
         with pytest.raises(AirflowException) as ex_message:
             operator.execute(None)
 
@@ -496,6 +506,68 @@ class TestEmrServerlessStartJobOperator:
             executionRoleArn=execution_role_arn,
             jobDriver=job_driver,
             configurationOverrides=configuration_overrides,
+            name=default_name,
+        )
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn")
+    def test_start_job_default_name(self, mock_conn):
+        mock_conn.get_application.return_value = {"application": {"state": "STARTED"}}
+        mock_conn.start_job_run.return_value = {
+            "jobRunId": job_run_id,
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        mock_conn.get_job_run.return_value = {"jobRun": {"state": "SUCCESS"}}
+
+        operator = EmrServerlessStartJobOperator(
+            task_id=task_id,
+            client_request_token=client_request_token,
+            application_id=application_id,
+            execution_role_arn=execution_role_arn,
+            job_driver=job_driver,
+            configuration_overrides=configuration_overrides,
+        )
+        operator.execute(None)
+        default_name = operator.name
+        generated_name_uuid = default_name.split("_")[-1]
+        assert default_name.startswith("emr_serverless_job_airflow")
+
+        mock_conn.start_job_run.assert_called_once_with(
+            clientToken=client_request_token,
+            applicationId=application_id,
+            executionRoleArn=execution_role_arn,
+            jobDriver=job_driver,
+            configurationOverrides=configuration_overrides,
+            name=f"emr_serverless_job_airflow_{str(UUID(generated_name_uuid, version=4))}",
+        )
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrServerlessHook.conn")
+    def test_start_job_custom_name(self, mock_conn):
+        mock_conn.get_application.return_value = {"application": {"state": "STARTED"}}
+        custom_name = "test_name"
+        mock_conn.start_job_run.return_value = {
+            "jobRunId": job_run_id,
+            "ResponseMetadata": {"HTTPStatusCode": 200},
+        }
+        mock_conn.get_job_run.return_value = {"jobRun": {"state": "SUCCESS"}}
+
+        operator = EmrServerlessStartJobOperator(
+            task_id=task_id,
+            client_request_token=client_request_token,
+            application_id=application_id,
+            execution_role_arn=execution_role_arn,
+            job_driver=job_driver,
+            configuration_overrides=configuration_overrides,
+            name=custom_name,
+        )
+        operator.execute(None)
+
+        mock_conn.start_job_run.assert_called_once_with(
+            clientToken=client_request_token,
+            applicationId=application_id,
+            executionRoleArn=execution_role_arn,
+            jobDriver=job_driver,
+            configurationOverrides=configuration_overrides,
+            name=custom_name,
         )
 
 


### PR DESCRIPTION
Currently, if no `name` is provided to the `EmrServerlessStartJobOperator`, the `name` of the job is left as blank. The `name` can be specified via the `config` parameter. This PR allows the user to pass in the name directly to the operator. If no name is provided, a default name is given to the job.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
