### PR TITLE
Move cleanup_generated_files up in release command

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -100,7 +100,6 @@ def run_docker_command_with_debug(
     output_outside_the_group: bool = False,
     **kwargs,
 ) -> RunCommandResult:
-    cleanup_python_generated_files()
     env_variables = get_env_variables_for_docker_commands(params)
     extra_docker_flags = get_extra_docker_flags(mount_sources=params.mount_sources)
     if enable_input or debug:
@@ -173,6 +172,7 @@ def prepare_airflow_packages(
     github_repository: str,
 ):
     perform_environment_checks()
+    cleanup_python_generated_files()
     assert_pre_commit_installed()
     run_compile_www_assets(dev=False, run_in_background=False)
     shell_params = ShellParams(
@@ -216,6 +216,7 @@ def prepare_provider_documentation(
     packages: list[str],
 ):
     perform_environment_checks()
+    cleanup_python_generated_files()
     shell_params = ShellParams(
         mount_sources=MOUNT_ALL,
         github_repository=github_repository,
@@ -260,6 +261,7 @@ def prepare_provider_packages(
     github_repository: str,
 ):
     perform_environment_checks()
+    cleanup_python_generated_files()
     packages_list = list(packages)
     if package_list_file:
         packages_list.extend([package.strip() for package in package_list_file.readlines()])
@@ -381,6 +383,7 @@ def generate_constraints(
     github_repository: str,
 ):
     perform_environment_checks()
+    cleanup_python_generated_files()
     if debug and run_in_parallel:
         get_console().print("\n[error]Cannot run --debug and --run-in-parallel at the same time[/]\n")
         sys.exit(1)
@@ -478,6 +481,7 @@ def verify_provider_packages(
     github_repository: str,
 ):
     perform_environment_checks()
+    cleanup_python_generated_files()
     shell_params = ShellParams(
         mount_sources=MOUNT_SELECTED,
         github_repository=github_repository,


### PR DESCRIPTION
Missed one more case where parallelisation of execution influenced cleanup_generated_files in release_commands (generating constraints)

This change moves all cleanup_generated_files up to right behind perform-environment_check - before parallelisaion efforts.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
