### PR TITLE
Look for `extra__` instead of `extra_` in `get_field`

### DIFF
--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -150,7 +150,7 @@ class GrpcHook(BaseHook):
     def _get_field(self, field_name: str):
         """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
         backcompat_prefix = "extra__grpc__"
-        if field_name.startswith("extra_"):
+        if field_name.startswith("extra__"):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
                 "when using this method."

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -63,7 +63,7 @@ class JdbcHook(DbApiHook):
     def _get_field(self, extras: dict, field_name: str):
         """Get field from extra, first checking short name, then for backcompat we check for prefixed name."""
         backcompat_prefix = "extra__jdbc__"
-        if field_name.startswith("extra_"):
+        if field_name.startswith("extra__"):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the '{backcompat_prefix}' prefix "
                 "when using this method."

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -149,7 +149,7 @@ class WasbHook(BaseHook):
 
     def _get_field(self, extra_dict, field_name):
         prefix = "extra__wasb__"
-        if field_name.startswith("extra_"):
+        if field_name.startswith("extra__"):
             raise ValueError(
                 f"Got prefixed name {field_name}; please remove the '{prefix}' prefix "
                 f"when using this method."


### PR DESCRIPTION
This reduces likelihood of false positive.  It's not possible as currently used.  But if someone were to add an extra field `extra_info` for example, that would cause trouble avoided by this change.
