### PR TITLE
Remove unused backcompat method in k8s hook

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -152,17 +152,6 @@ class KubernetesHook(BaseHook):
         prefixed_name = f"extra__kubernetes__{field_name}"
         return self.conn_extras.get(prefixed_name) or None
 
-    @staticmethod
-    def _deprecation_warning_core_param(deprecation_warnings):
-        settings_list_str = "".join([f"\n\t{k}={v!r}" for k, v in deprecation_warnings])
-        warnings.warn(
-            f"\nApplying core Airflow settings from section [kubernetes] with the following keys:"
-            f"{settings_list_str}\n"
-            "In a future release, KubernetesPodOperator will no longer consider core\n"
-            "Airflow settings; define an Airflow connection instead.",
-            DeprecationWarning,
-        )
-
     def get_conn(self) -> client.ApiClient:
         """Returns kubernetes api session for use with requests"""
         in_cluster = self._coalesce_param(self.in_cluster, self._get_field("in_cluster"))


### PR DESCRIPTION
We simply missed removing this method when doing the backcompat removal.
