### PR TITLE
make some tests run faster by skipping useless sleep()

### DIFF
--- a/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
@@ -79,7 +79,7 @@ class TestSageMakerEndpointSensor(unittest.TestCase):
             DESCRIBE_ENDPOINT_INSERVICE_RESPONSE,
         ]
         sensor = SageMakerEndpointSensor(
-            task_id="test_task", poke_interval=1, aws_conn_id="aws_test", endpoint_name="test_job_name"
+            task_id="test_task", poke_interval=0, aws_conn_id="aws_test", endpoint_name="test_job_name"
         )
 
         sensor.execute(None)

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
@@ -80,7 +80,7 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         ]
         sensor = SageMakerTrainingSensor(
             task_id="test_task",
-            poke_interval=2,
+            poke_interval=0,
             aws_conn_id="aws_test",
             job_name="test_job_name",
             print_log=False,
@@ -113,7 +113,7 @@ class TestSageMakerTrainingSensor(unittest.TestCase):
         ]
         sensor = SageMakerTrainingSensor(
             task_id="test_task",
-            poke_interval=2,
+            poke_interval=0,
             aws_conn_id="aws_test",
             job_name="test_job_name",
             print_log=True,

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
@@ -77,7 +77,7 @@ class TestSageMakerTransformSensor(unittest.TestCase):
             DESCRIBE_TRANSFORM_COMPLETED_RESPONSE,
         ]
         sensor = SageMakerTransformSensor(
-            task_id="test_task", poke_interval=2, aws_conn_id="aws_test", job_name="test_job_name"
+            task_id="test_task", poke_interval=0, aws_conn_id="aws_test", job_name="test_job_name"
         )
 
         sensor.execute(None)

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
@@ -80,7 +80,7 @@ class TestSageMakerTuningSensor(unittest.TestCase):
             DESCRIBE_TUNING_COMPLETED_RESPONSE,
         ]
         sensor = SageMakerTuningSensor(
-            task_id="test_task", poke_interval=2, aws_conn_id="aws_test", job_name="test_job_name"
+            task_id="test_task", poke_interval=0, aws_conn_id="aws_test", job_name="test_job_name"
         )
 
         sensor.execute(None)


### PR DESCRIPTION
pretty straightforward change, a bunch of tests were waiting between polls of the API where it wasn't necessary, as all the expected calls were mocked in order, time not playing any role.

from 22s to 4s on my machine for all aws/sensor tests
