### PR TITLE
Suppress any Exception in wasb task handler

### DIFF
--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -62,7 +62,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             return WasbHook(remote_conn_id)
         except Exception:
             self.log.exception(
-                'Could not create an WasbHook with connection id "%s".'
+                'Could not create a WasbHook with connection id "%s".'
                 " Please make sure that apache-airflow[azure] is installed"
                 " and the Wasb connection exists.",
                 remote_conn_id,

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -62,7 +62,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             return WasbHook(remote_conn_id)
         except Exception:
             self.log.exception(
-                "Could not create an WasbHook with connection id '%s'. "
+                "Could not create a WasbHook with connection id '%s'. "
                 "Do you have apache-airflow[azure] installed? "
                 "Does connection the connection exist, and is it "
                 "configured properly?",

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -62,9 +62,10 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             return WasbHook(remote_conn_id)
         except Exception:
             self.log.exception(
-                'Could not create a WasbHook with connection id "%s".'
-                " Please make sure that apache-airflow[azure] is installed"
-                " and the Wasb connection exists.",
+                "Could not create an WasbHook with connection id '%s'. "
+                "Do you have apache-airflow[azure] installed? "
+                "Does connection the connection exist, and is it "
+                "configured properly?",
                 remote_conn_id,
             )
             return None

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -21,8 +21,6 @@ import os
 import shutil
 from typing import Any
 
-from azure.common import AzureHttpError
-
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.utils.log.file_task_handler import FileTaskHandler
@@ -62,7 +60,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
             return WasbHook(remote_conn_id)
-        except AzureHttpError:
+        except Exception:
             self.log.exception(
                 'Could not create an WasbHook with connection id "%s".'
                 " Please make sure that apache-airflow[azure] is installed"
@@ -158,7 +156,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         """
         try:
             return self.hook.read_file(self.wasb_container, remote_log_location)
-        except AzureHttpError:
+        except Exception:
             msg = f"Could not read logs from {remote_log_location}"
             self.log.exception(msg)
             # return error if needed
@@ -182,5 +180,5 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
 
         try:
             self.hook.load_string(log, self.wasb_container, remote_log_location, overwrite=True)
-        except AzureHttpError:
+        except Exception:
             self.log.exception("Could not write logs to %s", remote_log_location)


### PR DESCRIPTION
It's important that problems with the log handler don't cause the task itself to fail. We discovered that sometimes the blob client will throw an error from azure.core.AzureError (currently we catch from azure.common). Rather than just add azure.core.AzureError, it seems sensible to just catch anything.
