### PR TITLE
Fix clearing child dag mapped tasks from parent dag

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1613,7 +1613,6 @@ class DAG(LoggingMixin):
 
         # Do we want full objects, or just the primary columns?
         if as_pk_tuple:
-            # try number is needed here since its used to construct TaskInstanceKey
             tis = session.query(TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
         else:
             tis = session.query(TaskInstance)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1613,7 +1613,8 @@ class DAG(LoggingMixin):
 
         # Do we want full objects, or just the primary columns?
         if as_pk_tuple:
-            tis = session.query(TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
+            # try number is needed here since its used to construct TaskInstanceKey
+            tis = session.query(TI.dag_id, TI.task_id, TI.run_id, TI._try_number, TI.map_index)
         else:
             tis = session.query(TaskInstance)
         tis = tis.join(TaskInstance.dag_run)

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1614,7 +1614,7 @@ class DAG(LoggingMixin):
         # Do we want full objects, or just the primary columns?
         if as_pk_tuple:
             # try number is needed here since its used to construct TaskInstanceKey
-            tis = session.query(TI.dag_id, TI.task_id, TI.run_id, TI._try_number, TI.map_index)
+            tis = session.query(TI.dag_id, TI.task_id, TI.run_id, TI.map_index)
         else:
             tis = session.query(TaskInstance)
         tis = tis.join(TaskInstance.dag_run)
@@ -1774,7 +1774,7 @@ class DAG(LoggingMixin):
         if result or as_pk_tuple:
             # Only execute the `ti` query if we have also collected some other results (i.e. subdags etc.)
             if as_pk_tuple:
-                result.update(TaskInstanceKey(*cols) for cols in tis.all())
+                result.update(TaskInstanceKey(**cols._mapping) for cols in tis.all())
             else:
                 result.update(ti.key for ti in tis)
 

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -1173,41 +1173,6 @@ def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
     )
 
 
-@provide_session
-def test_clear_overlapping_external_task_marker(dag_bag_head_tail, session):
-    dag: DAG = dag_bag_head_tail.get_dag("head_tail")
-
-    # "Run" 10 times.
-    for delta in range(0, 10):
-        execution_date = DEFAULT_DATE + timedelta(days=delta)
-        dagrun = DagRun(
-            dag_id=dag.dag_id,
-            state=DagRunState.SUCCESS,
-            execution_date=execution_date,
-            run_type=DagRunType.MANUAL,
-            run_id=f"test_{delta}",
-        )
-        session.add(dagrun)
-        for task in dag.tasks:
-            ti = TaskInstance(task=task)
-            dagrun.task_instances.append(ti)
-            ti.state = TaskInstanceState.SUCCESS
-    session.flush()
-
-    # The next two lines are doing the same thing. Clearing the first "head" with "Future"
-    # selected is the same as not selecting "Future". They should take similar amount of
-    # time too because dag.clear() uses visited_external_tis to keep track of visited ExternalTaskMarker.
-    assert dag.clear(start_date=DEFAULT_DATE, dag_bag=dag_bag_head_tail, session=session) == 30
-    assert (
-        dag.clear(
-            start_date=DEFAULT_DATE,
-            end_date=execution_date,
-            dag_bag=dag_bag_head_tail,
-            session=session,
-        )
-        == 30
-    )
-
 @pytest.fixture
 def dag_bag_head_tail_mapped_tasks():
     """


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/27462
related: https://github.com/apache/airflow/issues/27462

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This fixes the bug where clearing a parent dag will not clear the child dag's mapped task.

The bug was due to `TaskInstanceKey` accepting its attributes in the order (dag_id, task_id, run_id, try_number, map_index) while in `_get_task_instances`, the `pk_tuple` that we pass into `TaskInstanceKey` to get the `result` is (dag_id, task_id, run_id, map_index), missing out the try_number. So `TaskInstanceKey` assumes that the map_index value supplied is try_number and defaults the value of map_index to -1. This causes a bunch of problems downstream when we try and retrieve the `TaskInstance` from the table using the map_index as part of the filter. 

fixes: https://github.com/apache/airflow/issues/27462