### PR TITLE
Fix condition for k8 container completion check

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -267,6 +267,13 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
+        """
+        Monitors a container of a pod until it reaches its final state
+
+        :param pod: pod spec that will be monitored
+        :param container_name: name of the container of the pod that will be monitored
+        :return:
+        """
         while self.container_is_running(pod=pod, container_name=container_name):
             time.sleep(1)
 

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -267,7 +267,7 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
-        while not self.container_is_running(pod=pod, container_name=container_name):
+        while self.container_is_running(pod=pod, container_name=container_name):
             time.sleep(1)
 
     def await_pod_completion(self, pod: V1Pod) -> V1Pod:


### PR DESCRIPTION
As described in https://github.com/apache/airflow/issues/26796, the condition for checkin whether the k8 container is completed is incorrectly reversed. This was initially discovered and fixed in https://github.com/apache/airflow/pull/23883, but ultimately reverted due to failing tests.

This PR attempts to address the failing tests by extending the tests to cover this path.

closes: https://github.com/apache/airflow/issues/26796
related: https://github.com/apache/airflow/pull/23883, https://github.com/apache/airflow/pull/24479

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
