### PR TITLE
Fix mini scheduler expansion of mapped task 

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -620,19 +620,18 @@ class MappedOperator(AbstractOperator):
         try:
             total_length = self._get_specified_expand_input().get_total_map_length(run_id, session=session)
         except NotFullyPopulated as e:
-            if self.dag and self.dag.partial:
-                # partial dags comes from the mini scheduler. It's
-                # likely that the upstream tasks are not yet done,
-                # so we ignore this exception.
-                total_length = None
-            else:
+            total_length = None
+            # partial dags comes from the mini scheduler. It's
+            # possible that the upstream tasks are not yet done,
+            # but we don't have upstream of upstreams in partial dags, 
+            # so we ignore this exception.
+            if not self.dag or not self.dag.partial:
                 self.log.error(
                     "Cannot expand %r for run %s; missing upstream values: %s",
                     self,
                     run_id,
                     sorted(e.missing),
                 )
-                total_length = None
 
         state: TaskInstanceState | None = None
         unmapped_ti: TaskInstance | None = (

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -620,13 +620,19 @@ class MappedOperator(AbstractOperator):
         try:
             total_length = self._get_specified_expand_input().get_total_map_length(run_id, session=session)
         except NotFullyPopulated as e:
-            self.log.info(
-                "Cannot expand %r for run %s; missing upstream values: %s",
-                self,
-                run_id,
-                sorted(e.missing),
-            )
-            total_length = None
+            if self.dag and self.dag.partial:
+                # partial dags comes from the mini scheduler. It's
+                # likely that the upstream tasks are not yet done,
+                # so we ignore this exception.
+                total_length = None
+            else:
+                self.log.error(
+                    "Cannot expand %r for run %s; missing upstream values: %s",
+                    self,
+                    run_id,
+                    sorted(e.missing),
+                )
+                total_length = None
 
         state: TaskInstanceState | None = None
         unmapped_ti: TaskInstance | None = (
@@ -647,10 +653,15 @@ class MappedOperator(AbstractOperator):
             # The unmapped task instance still exists and is unfinished, i.e. we
             # haven't tried to run it before.
             if total_length is None:
-                # If the map length cannot be calculated (due to unavailable
-                # upstream sources), fail the unmapped task.
-                unmapped_ti.state = TaskInstanceState.UPSTREAM_FAILED
-                indexes_to_map: Iterable[int] = ()
+                if self.dag and self.dag.partial:
+                    # If the DAG is partial, it's likely that the upstream tasks
+                    # are not done yet, so we do nothing
+                    indexes_to_map: Iterable[int] = ()
+                else:
+                    # If the map length cannot be calculated (due to unavailable
+                    # upstream sources), fail the unmapped task.
+                    unmapped_ti.state = TaskInstanceState.UPSTREAM_FAILED
+                    indexes_to_map = ()
             elif total_length < 1:
                 # If the upstream maps this to a zero-length value, simply mark
                 # the unmapped task instance as SKIPPED (if needed).

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -623,7 +623,7 @@ class MappedOperator(AbstractOperator):
             total_length = None
             # partial dags comes from the mini scheduler. It's
             # possible that the upstream tasks are not yet done,
-            # but we don't have upstream of upstreams in partial dags, 
+            # but we don't have upstream of upstreams in partial dags,
             # so we ignore this exception.
             if not self.dag or not self.dag.partial:
                 self.log.error(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2508,7 +2508,7 @@ class TaskInstance(Base, LoggingMixin):
 
             num = dag_run.schedule_tis(schedulable_tis, session=session)
             self.log.info("%d downstream tasks scheduled from follow-on schedule check", num)
-            
+
             session.flush()
 
         except OperationalError as e:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2506,8 +2506,10 @@ class TaskInstance(Base, LoggingMixin):
                 if not hasattr(schedulable_ti, "task"):
                     schedulable_ti.task = task.dag.get_task(schedulable_ti.task_id)
 
-            num = dag_run.schedule_tis(schedulable_tis)
+            num = dag_run.schedule_tis(schedulable_tis, session=session)
             self.log.info("%d downstream tasks scheduled from follow-on schedule check", num)
+            
+            session.flush()
 
         except OperationalError as e:
             # Any kind of DB error here is _non fatal_ as this block is just an optimisation.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -2459,6 +2459,65 @@ class TaskInstance(Base, LoggingMixin):
             return filters[0]
         return or_(*filters)
 
+    @Sentry.enrich_errors
+    @provide_session
+    def schedule_downstream_tasks(self, session=None):
+        """
+        The mini-scheduler for scheduling downstream tasks of this task instance
+        :meta: private
+        """
+        from sqlalchemy.exc import OperationalError
+
+        from airflow.models import DagRun
+
+        try:
+            # Re-select the row with a lock
+            dag_run = with_row_locks(
+                session.query(DagRun).filter_by(
+                    dag_id=self.dag_id,
+                    run_id=self.run_id,
+                ),
+                session=session,
+            ).one()
+
+            task = self.task
+            if TYPE_CHECKING:
+                assert task.dag
+
+            # Get a partial DAG with just the specific tasks we want to examine.
+            # In order for dep checks to work correctly, we include ourself (so
+            # TriggerRuleDep can check the state of the task we just executed).
+            partial_dag = task.dag.partial_subset(
+                task.downstream_task_ids,
+                include_downstream=True,
+                include_upstream=False,
+                include_direct_upstream=True,
+            )
+
+            dag_run.dag = partial_dag
+            info = dag_run.task_instance_scheduling_decisions(session)
+
+            skippable_task_ids = {
+                task_id for task_id in partial_dag.task_ids if task_id not in task.downstream_task_ids
+            }
+
+            schedulable_tis = [ti for ti in info.schedulable_tis if ti.task_id not in skippable_task_ids]
+            for schedulable_ti in schedulable_tis:
+                if not hasattr(schedulable_ti, "task"):
+                    schedulable_ti.task = task.dag.get_task(schedulable_ti.task_id)
+
+            num = dag_run.schedule_tis(schedulable_tis)
+            self.log.info("%d downstream tasks scheduled from follow-on schedule check", num)
+
+        except OperationalError as e:
+            # Any kind of DB error here is _non fatal_ as this block is just an optimisation.
+            self.log.info(
+                "Skipping mini scheduling run due to exception: %s",
+                e.statement,
+                exc_info=True,
+            )
+            session.rollback()
+
 
 # State of the task instance.
 # Stores string version of the task state.

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -739,7 +739,6 @@ class TestLocalTaskJob:
         ti2_l.refresh_from_db()
         assert ti2_k.state == State.SUCCESS
         assert ti2_l.state == State.NONE
-        assert "0 downstream tasks scheduled from follow-on schedule" in caplog.text
 
         failed_deps = list(ti2_l.get_failed_dep_statuses())
         assert len(failed_deps) == 1


### PR DESCRIPTION
We have a case where the mini scheduler tries to expand a mapped task even when the downstream tasks are not yet done.

The mini scheduler extracts a partial subset of a dag and in the process, some upstream tasks are dropped. 
If the task happens to be a mapped task, the expansion will fail since it needs the upstream output to make the expansion. When the expansion fails, the task is marked as `upstream_failed`. This leads to other downstream tasks being marked as upstream failed.

The solution was to ignore this error and not mark the mapped task as upstream_failed when the expansion fails and the dag is a partial subset

closes: https://github.com/apache/airflow/issues/27449
