### PR TITLE
Deduplicate type hints

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -81,7 +81,7 @@ def expand_env_var(env_var: str) -> str:
     ...
 
 
-def expand_env_var(env_var: str | None) -> str | None | None:
+def expand_env_var(env_var: str | None) -> str | None:
     """
     Expands (potentially nested) env vars by repeatedly applying
     `expandvars` and `expanduser` until interpolation stops having

--- a/airflow/decorators/__init__.pyi
+++ b/airflow/decorators/__init__.pyi
@@ -228,7 +228,7 @@ class TaskDecoratorCollection:
         shm_size: int | None = None,
         tty: bool = False,
         privileged: bool = False,
-        cap_add: str | None | None = None,
+        cap_add: str | None = None,
         extra_hosts: dict[str, str] | None = None,
         **kwargs,
     ) -> TaskDecorator:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1261,12 +1261,12 @@ class DAG(LoggingMixin):
         return self.get_concurrency_reached()
 
     @provide_session
-    def get_is_active(self, session=NEW_SESSION) -> None | None:
+    def get_is_active(self, session=NEW_SESSION) -> None:
         """Returns a boolean indicating whether this DAG is active"""
         return session.query(DagModel.is_active).filter(DagModel.dag_id == self.dag_id).scalar()
 
     @provide_session
-    def get_is_paused(self, session=NEW_SESSION) -> None | None:
+    def get_is_paused(self, session=NEW_SESSION) -> None:
         """Returns a boolean indicating whether this DAG is paused"""
         return session.query(DagModel.is_paused).filter(DagModel.dag_id == self.dag_id).scalar()
 


### PR DESCRIPTION
https://github.com/apache/airflow/pull/26290 introduced a few duplicate type hints e.g.`str | None | None`. This is meaningless to Python, so this PR deduplicates those type hints.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
