### PR TITLE
Remove support for node_selectors param in KPO

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -34,6 +34,8 @@ Previously KubernetesPodOperator considered some settings from the Airflow confi
 
 Drop support for providing ``resource`` as dict in ``KubernetesPodOperator``. You should use ``container_resources`` with ``V1ResourceRequirements``.
 
+Param ``node_selectors`` has been removed in ``KubernetesPodOperator``; use ``node_selector`` instead.
+
 Features
 ~~~~~~~~
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -192,7 +192,6 @@ class KubernetesPodOperator(BaseOperator):
         container_resources: k8s.V1ResourceRequirements | None = None,
         affinity: k8s.V1Affinity | None = None,
         config_file: str | None = None,
-        node_selectors: dict | None = None,
         node_selector: dict | None = None,
         image_pull_secrets: list[k8s.V1LocalObjectReference] | None = None,
         service_account_name: str | None = None,
@@ -221,7 +220,13 @@ class KubernetesPodOperator(BaseOperator):
                 "Specifying resources for the launched pod with 'resources' is deprecated. "
                 "Use 'container_resources' instead."
             )
-
+        # TODO: remove in provider 6.0.0 release. This is a mitigate step to advise users to switch to the
+        # node_selector parameter.
+        if "node_selectors" in kwargs:
+            raise ValueError(
+                "Param `node_selectors` supplied. This param is no longer supported. "
+                "Use `node_selector` instead."
+            )
         super().__init__(**kwargs)
         self.kubernetes_conn_id = kubernetes_conn_id
         self.do_xcom_push = do_xcom_push
@@ -246,16 +251,7 @@ class KubernetesPodOperator(BaseOperator):
         self.reattach_on_restart = reattach_on_restart
         self.get_logs = get_logs
         self.image_pull_policy = image_pull_policy
-        if node_selectors:
-            # Node selectors is incorrect based on k8s API
-            warnings.warn(
-                "node_selectors is deprecated. Please use node_selector instead.", DeprecationWarning
-            )
-            self.node_selector = node_selectors
-        elif node_selector:
-            self.node_selector = node_selector
-        else:
-            self.node_selector = {}
+        self.node_selector = node_selector or {}
         self.annotations = annotations or {}
         self.affinity = convert_affinity(affinity) if affinity else {}
         self.container_resources = container_resources

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -116,8 +116,6 @@ class KubernetesPodOperator(BaseOperator):
     :param affinity: affinity scheduling rules for the launched pod.
     :param config_file: The path to the Kubernetes config file. (templated)
         If not specified, default value is ``~/.kube/config``
-    :param node_selectors: (Deprecated) A dict containing a group of scheduling rules.
-        Please use node_selector instead.
     :param node_selector: A dict containing a group of scheduling rules.
     :param image_pull_secrets: Any image pull secrets to be given to the pod.
         If more than one secret is required, provide a

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -341,8 +341,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod["spec"]["schedulerName"] = scheduler_name
         assert self.expected_pod == actual_pod
 
-    def test_pod_node_selectors(self):
-        node_selectors = {"beta.kubernetes.io/os": "linux"}
+    def test_pod_node_selector(self):
+        node_selector = {"beta.kubernetes.io/os": "linux"}
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -353,12 +353,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
-            node_selectors=node_selectors,
+            node_selector=node_selector,
         )
         context = create_context(k)
         k.execute(context)
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        self.expected_pod["spec"]["nodeSelector"] = node_selectors
+        self.expected_pod["spec"]["nodeSelector"] = node_selector
         assert self.expected_pod == actual_pod
 
     def test_pod_resources(self):

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -173,8 +173,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         assert self.expected_pod["spec"] == actual_pod["spec"]
         assert self.expected_pod["metadata"]["labels"] == actual_pod["metadata"]["labels"]
 
-    def test_pod_node_selectors(self):
-        node_selectors = {"beta.kubernetes.io/os": "linux"}
+    def test_pod_node_selector(self):
+        node_selector = {"beta.kubernetes.io/os": "linux"}
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -185,12 +185,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             task_id="task",
             in_cluster=False,
             do_xcom_push=False,
-            node_selectors=node_selectors,
+            node_selector=node_selector,
         )
         context = create_context(k)
         k.execute(context)
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        self.expected_pod["spec"]["nodeSelector"] = node_selectors
+        self.expected_pod["spec"]["nodeSelector"] = node_selector
         assert self.expected_pod == actual_pod
 
     def test_pod_affinity(self):

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -810,20 +810,6 @@ class TestKubernetesPodOperator:
         assert isinstance(pod.spec.node_selector, dict)
         assert sanitized_pod["spec"]["nodeSelector"] == node_selector
 
-        # repeat tests using deprecated parameter
-        with pytest.warns(
-            DeprecationWarning, match="node_selectors is deprecated. Please use node_selector instead."
-        ):
-            k = KubernetesPodOperator(
-                task_id="task",
-                node_selector=node_selector,
-            )
-
-        pod = k.build_pod_request_obj(create_context(k))
-        sanitized_pod = self.sanitize_for_serialization(pod)
-        assert isinstance(pod.spec.node_selector, dict)
-        assert sanitized_pod["spec"]["nodeSelector"] == node_selector
-
     @pytest.mark.parametrize("do_xcom_push", [True, False])
     @patch(f"{POD_MANAGER_CLASS}.extract_xcom")
     @patch(f"{POD_MANAGER_CLASS}.await_xcom_sidecar_container_start")

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -816,7 +816,7 @@ class TestKubernetesPodOperator:
         ):
             k = KubernetesPodOperator(
                 task_id="task",
-                node_selectors=node_selector,
+                node_selector=node_selector,
             )
 
         pod = k.build_pod_request_obj(create_context(k))


### PR DESCRIPTION
This was deprecated a long time ago.  I think we can safely remove.  Now we raise, so no one is caught by surprise.
