### PR TITLE
KPO should use hook's get namespace method to get namespace

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -577,7 +577,9 @@ class KubernetesPodOperator(BaseOperator):
             pod.metadata.name = PodGenerator.make_unique_pod_id(pod.metadata.name)
 
         if not pod.metadata.namespace:
-            hook_namespace = self.hook.conn_extras.get("extra__kubernetes__namespace")
+            # todo: replace with call to `hook.get_namespace` in 6.0, when it doesn't default to `default`.
+            # if namespace not actually defined in hook, we want to check k8s if in cluster
+            hook_namespace = self.hook._get_namespace()
             pod_namespace = self.namespace or hook_namespace or self._incluster_namespace or "default"
             pod.metadata.namespace = pod_namespace
 


### PR DESCRIPTION
Recently hook was updated to allow non-prefixed extra fields.  So we need to check non-prefixed also.  Best to use the hook's "get namespace" method.  But the public one has a problem; it defaults to `default`, so we don't know if it was set to that intentionally.  So we use the "protected" method `_get_namespace`, which doesn't return a default.  This allows us, in this case to check if we can derive from cluster, and only _then_ default to `default`.
In 6.0, get_namespace will have the correct behavior, and we'll update this again to use it instead.