### PR TITLE
Use log.exception where more economical than log.error

### DIFF
--- a/airflow/providers/alibaba/cloud/log/oss_task_handler.py
+++ b/airflow/providers/alibaba/cloud/log/oss_task_handler.py
@@ -51,7 +51,7 @@ class OSSTaskHandler(FileTaskHandler, LoggingMixin):
         try:
             return OSSHook(oss_conn_id=remote_conn_id)
         except Exception as e:
-            self.log.error(e, exc_info=True)
+            self.log.exception(e)
             self.log.error(
                 'Could not create an OSSHook with connection id "%s". '
                 "Please make sure that airflow[oss] is installed and "

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -635,5 +635,5 @@ class _suppress(AbstractContextManager):
         if caught_error:
             self.exception = excinst
             logger = logging.getLogger(__name__)
-            logger.error(str(excinst), exc_info=True)
+            logger.exception(excinst)
         return caught_error

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -220,7 +220,7 @@ def validate_stat(fn: T) -> T:
                 stat = handler_stat_name_func(stat)
             return fn(_self, stat, *args, **kwargs)
         except InvalidStatsNameException:
-            log.error('Invalid stat name: %s.', stat, exc_info=True)
+            log.exception('Invalid stat name: %s.', stat)
             return None
 
     return cast(T, wrapper)

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -914,10 +914,8 @@ class TestKubernetesPodOperator:
         mock_delete_pod.assert_not_called()
 
 
-def test__suppress():
-    with patch("logging.Logger.error") as mock_error:
+def test__suppress(caplog):
+    with _suppress(ValueError):
+        raise ValueError("failure")
 
-        with _suppress(ValueError):
-            raise ValueError("failure")
-
-        mock_error.assert_called_once_with("failure", exc_info=True)
+    assert "ValueError: failure" in caplog.text


### PR DESCRIPTION
When we do log.error(..., exc_info=True), then log.exception is cleaner.
