### PR TITLE
Fix typo in redshift sql hook `get_ui_field_behaviour`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -45,7 +45,7 @@ class RedshiftSQLHook(DbApiHook):
     supports_autocommit = True
 
     @staticmethod
-    def get_ui_field_behavior() -> dict:
+    def get_ui_field_behaviour() -> dict:
         """Returns custom field behavior"""
         return {
             "hidden_fields": [],


### PR DESCRIPTION
currently, there is a typo in `RedshiftSQLHook`  `get_ui_field_behaviour` method. it is `get_ui_field_behavior` instead of `get_ui_field_behaviour` so relabeling is not happing in UI as expected.

Now
<img width="1318" alt="Screenshot 2022-11-06 at 11 58 59 PM" src="https://user-images.githubusercontent.com/98807258/200189255-0eb705da-0fcf-41ba-b41c-55266067f7c7.png">

Earlier 
<img width="1331" alt="Screenshot 2022-11-07 at 12 16 55 AM" src="https://user-images.githubusercontent.com/98807258/200189282-d0d4ae29-744e-497d-bbaf-fb6de7b47a28.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
