### PR TITLE
Add azure, google, authentication library limits to eager upgrade

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1153,7 +1153,9 @@ RUN echo "Airflow version: ${AIRFLOW_VERSION}"
 # are compatible with the new protobuf version. All the google python client libraries need
 # to be upgraded to >= 2.0.0 in order to able to lift that limitation
 # https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0"
+# * authlib, gcloud_aio_auth, adal are needed to generate constraints for PyPI packages and can be removed after we release
+#   new google, azure providers
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="dill<0.3.3 pyarrow>=6.0.0 protobuf<4.21.0 authlib>=1.0.0 gcloud_aio_auth>=4.0.0 adal>=1.2.7"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
     UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -64,7 +64,7 @@ dependencies:
   # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191
   - azure-servicebus>=7.6.1; platform_machine != "aarch64"
   - azure-synapse-spark
-  - adal>=.1.2.7
+  - adal>=1.2.7
 
 integrations:
   - integration-name: Microsoft Azure Batch

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -427,7 +427,7 @@
   },
   "microsoft.azure": {
     "deps": [
-      "adal>=.1.2.7",
+      "adal>=1.2.7",
       "apache-airflow>=2.3.0",
       "azure-batch>=8.0.0",
       "azure-cosmos>=4.0.0",


### PR DESCRIPTION
When generating constraints for released providers we hit the same `pip` resolver backtracking issue - where it took very, very long time to resolve the dependencies for installing released providers on latest airflow from sources.

In #27531 we've added limits to provider.yaml but currently released providers do not have those limits, so until we release them, we should add the limits to "eager upgrade dependencies" in our CI image - to help `pip` to figure out the right set of dependencies much faster.

Also fixed a problem with extra "." in adal specification (seems it's
been ignored by `pip` anyway)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
