### PR TITLE
Fix show user info error

### DIFF
--- a/airflow/www/fab_security/views.py
+++ b/airflow/www/fab_security/views.py
@@ -219,7 +219,7 @@ class MultiResourceUserMixin:
     def show(self, pk):
         pk = self._deserialize_pk_if_composite(pk)
         widgets = self._show(pk)
-        widgets['show'].template_args['actions'].pop('userinfoedit')
+        widgets['show'].template_args['actions'].pop('userinfoedit', None)
         return self.render_template(
             self.show_template,
             pk=pk,


### PR DESCRIPTION
Hi,
closes: https://github.com/apache/airflow/issues/27479

I found that this code will permanently delete the userinfoedit key in the context of the entire process
`widgets['show'].template_args['actions'].pop('userinfoedit')`
In fact, it will affect self.actions so the next deletion will be reported key error.

An interesting phenomenon is that when you refresh the page, there is a certain probability of success, but the number of successes will not exceed the number of your workers, because the "actions" of each process are affected.

setting a default value can solve this problem.