### PR TITLE
Fix sqlalchemy primary key black-out error on DDRQ

### DIFF
--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -116,6 +116,7 @@ class DagScheduleDatasetReference(Base):
             DagScheduleDatasetReference.dataset_id == foreign(DatasetDagRunQueue.dataset_id),
             DagScheduleDatasetReference.dag_id == foreign(DatasetDagRunQueue.target_dag_id),
         )""",
+        cascade="all, delete, delete-orphan",
     )
 
     __tablename__ = "dag_schedule_dataset_reference"


### PR DESCRIPTION
What happened was that the DatasetDagRunQueue(DDRQ) was updated before the change in the consumer dag.
During sync to db, the dataset was marked for deletion from the dag causing the primary key in DDRQ to be nullified which threw an error. 
The solution was to add cascade deletion on DagScheduleDatasetReference relation to DDRQ so that when DagScheduleDatasetReference object is marked for deletion the DDRQ object will also be marked

closes: https://github.com/apache/airflow/issues/27509
