### PR TITLE
Allow datasets to be used in taskflow

### DIFF
--- a/airflow/datasets/__init__.py
+++ b/airflow/datasets/__init__.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import urlsplit
 
 import attr
@@ -28,6 +28,8 @@ class Dataset:
 
     uri: str = attr.field(validator=[attr.validators.min_len(1), attr.validators.max_len(3000)])
     extra: dict[str, Any] | None = None
+
+    version: ClassVar[int] = 1
 
     @uri.validator
     def _check_uri(self, attr, uri: str):

--- a/airflow/datasets/manager.py
+++ b/airflow/datasets/manager.py
@@ -53,7 +53,7 @@ class DatasetManager(LoggingMixin):
         """
         dataset_model = session.query(DatasetModel).filter(DatasetModel.uri == dataset.uri).one_or_none()
         if not dataset_model:
-            self.log.warning("DatasetModel %s not found", dataset_model)
+            self.log.warning("DatasetModel %s not found", dataset)
             return
         session.add(
             DatasetEvent(

--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -17,13 +17,18 @@
 # under the License.
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any
 
+import attr
 from flask.json.provider import JSONProvider
 
+from airflow.serialization.enums import Encoding
+from airflow.utils.module_loading import import_string
 from airflow.utils.timezone import convert_to_utc, is_naive
 
 try:
@@ -39,6 +44,16 @@ except ImportError:
 # Dates and JSON encoding/decoding
 
 log = logging.getLogger(__name__)
+
+CLASSNAME = "__classname__"
+VERSION = "__version__"
+DATA = "__data__"
+
+OLD_TYPE = "__type"
+OLD_SOURCE = "__source"
+OLD_DATA = "__var"
+
+DEFAULT_VERSION = 0
 
 
 class AirflowJsonEncoder(json.JSONEncoder):
@@ -107,7 +122,7 @@ class AirflowJsonEncoder(json.JSONEncoder):
                 log.debug("traceback for pod JSON encode error", exc_info=True)
                 return {}
 
-        raise TypeError(f"Object of type '{obj.__class__.__name__}' is not JSON serializable")
+        raise TypeError(f"Object of type '{obj.__class__.__qualname__}' is not JSON serializable")
 
 
 class AirflowJsonProvider(JSONProvider):
@@ -123,3 +138,113 @@ class AirflowJsonProvider(JSONProvider):
 
     def loads(self, s: str | bytes, **kwargs):
         return json.loads(s, **kwargs)
+
+
+# for now separate as AirflowJsonEncoder is non-standard
+class XComEncoder(json.JSONEncoder):
+    """This encoder serializes any object that has attr, dataclass or a custom serializer."""
+
+    def default(self, o: object) -> dict:
+        from airflow.serialization.serialized_objects import BaseSerialization
+
+        dct = {
+            CLASSNAME: o.__module__ + "." + o.__class__.__qualname__,
+            VERSION: getattr(o.__class__, "version", DEFAULT_VERSION),
+        }
+
+        if hasattr(o, "serialize"):
+            dct[DATA] = getattr(o, "serialize")()
+            return dct
+        elif dataclasses.is_dataclass(o.__class__):
+            data = dataclasses.asdict(o)
+            dct[DATA] = BaseSerialization.serialize(data)
+            return dct
+        elif attr.has(o.__class__):
+            # Only include attributes which we can pass back to the classes constructor
+            data = attr.asdict(o, recurse=True, filter=lambda a, v: a.init)  # type: ignore[arg-type]
+            dct[DATA] = BaseSerialization.serialize(data)
+            return dct
+        else:
+            return super().default(o)
+
+    def encode(self, o: Any) -> str:
+        if isinstance(o, dict) and CLASSNAME in o:
+            raise AttributeError(f"reserved key {CLASSNAME} found in dict to serialize")
+
+        return super().encode(o)
+
+
+class XComDecoder(json.JSONDecoder):
+    """
+    This decoder deserializes dicts to objects if they contain
+    the `__classname__` key otherwise it will return the dict
+    as is.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        if not kwargs.get("object_hook"):
+            kwargs["object_hook"] = self.object_hook
+
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def object_hook(dct: dict) -> object:
+        dct = XComDecoder._convert(dct)
+
+        if CLASSNAME in dct and VERSION in dct:
+            from airflow.serialization.serialized_objects import BaseSerialization
+
+            cls = import_string(dct[CLASSNAME])
+
+            if hasattr(cls, "deserialize"):
+                return getattr(cls, "deserialize")(dct[DATA], dct[VERSION])
+
+            version = getattr(cls, "version", 0)
+            if int(dct[VERSION]) > version:
+                raise TypeError(
+                    "serialized version of %s is newer than module version (%s > %s)",
+                    dct[CLASSNAME],
+                    dct[VERSION],
+                    version,
+                )
+
+            if not attr.has(cls) and not dataclasses.is_dataclass(cls):
+                raise TypeError(
+                    f"cannot deserialize: no deserialization method "
+                    f"for {dct[CLASSNAME]} and not attr/dataclass decorated"
+                )
+
+            return cls(**BaseSerialization.deserialize(dct[DATA]))
+
+        return dct
+
+    @staticmethod
+    def orm_object_hook(dct: dict) -> object:
+        """Creates a readable representation of a serialized object"""
+        dct = XComDecoder._convert(dct)
+        if CLASSNAME in dct and VERSION in dct:
+            from airflow.serialization.serialized_objects import BaseSerialization
+
+            if Encoding.VAR in dct[DATA] and Encoding.TYPE in dct[DATA]:
+                data = BaseSerialization.deserialize(dct[DATA])
+                if not isinstance(data, dict):
+                    raise TypeError(f"deserialized value should be a dict, but is {type(data)}")
+            else:
+                # custom serializer
+                data = dct[DATA]
+
+            s = f"{dct[CLASSNAME]}@version={dct[VERSION]}("
+            for k, v in data.items():
+                s += f"{k}={v},"
+            s = s[:-1] + ")"
+            return s
+
+        return dct
+
+    @staticmethod
+    def _convert(old: dict) -> dict:
+        """Converts an old style serialization to new style"""
+        if OLD_TYPE in old and OLD_SOURCE in old:
+            return {CLASSNAME: old[OLD_TYPE], VERSION: DEFAULT_VERSION, DATA: old[OLD_DATA]}
+
+        return old

--- a/docs/apache-airflow/concepts/taskflow.rst
+++ b/docs/apache-airflow/concepts/taskflow.rst
@@ -1,19 +1,19 @@
  .. Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
 
  ..   http://www.apache.org/licenses/LICENSE-2.0
 
  .. Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
 
 TaskFlow
 ========

--- a/docs/apache-airflow/concepts/taskflow.rst
+++ b/docs/apache-airflow/concepts/taskflow.rst
@@ -1,19 +1,19 @@
  .. Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
  ..   http://www.apache.org/licenses/LICENSE-2.0
 
  .. Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
 
 TaskFlow
 ========
@@ -80,6 +80,104 @@ To use logging from your task functions, simply import and use Python's logging 
    logger = logging.getlogger("airflow.task")
 
 Every logging line created this way will be recorded in the task log.
+
+Passing Arbitrary Objects As Arguments
+--------------------------------------
+
+.. versionadded:: 2.5.0
+
+As mentioned TaskFlow uses XCom to pass variables to each task. This requires that variables that are used as arguments
+need to be able to be serialized. Airflow out of the box supports all built-in types (like int or str) and it
+supports objects that are decorated with ``@dataclass`` or ``@attr.define``. The following example shows the use of
+a ``Dataset``, which is ``@attr.define`` decorated, together with TaskFlow.
+
+::
+
+  Note: An additional benefit of using ``Dataset`` is that it automatically registers as an ``inlet`` in case it is used as an input argument. It also auto registers as an ``outlet`` if the return value of your task is a ``dataset`` or a ``list[Dataset]]``.
+
+.. code-block:: python
+
+    import json
+    import pendulum
+    import requests
+
+    from airflow import Dataset
+    from airflow.decorators import dag, task
+
+    SRC = Dataset("https://www.ncei.noaa.gov/access/monitoring/climate-at-a-glance/global/time-series/globe/land_ocean/ytd/12/1880-2022.json")
+    now = pendulum.now()
+
+
+    @dag(start_date=now, schedule="daily", catchup=False)
+    def etl():
+      @task()
+      def retrieve(src: Dataset) -> dict:
+        resp = requests.get(url=src.uri)
+        data = resp.json()
+        return data["data"]
+
+      @task()
+      def to_fahrenheit(temps: dict[int, float]) -> dict[int, float]:
+        ret: dict[int, float] = {}
+        for year, celsius in temps.items():
+          ret[year] = float(celsius)*1.8+32
+
+        return ret
+
+      @task()
+      def load(fahrenheit: dict[int, float]) -> Dataset:
+        filename = "/tmp/fahrenheit.json"
+        s = json.dumps(fahrenheit)
+        f = open(filename, "w")
+        f.write(s)
+        f.close()
+
+        return Dataset(f"file:///{filename}")
+
+      data = retrieve(SRC)
+      fahrenheit = to_fahrenheit(data)
+      load(fahrenheit)
+
+    etl()
+
+Custom Objects
+^^^^^^^^^^^^^^
+It could be that you would like to pass custom objects. Typically you would decorate your classes with ``@dataclass`` or
+``@attr.define`` and Airflow will figure out what it needs to do. Sometime you might want to control serialization
+yourself. To do so add the ``serialize()`` method to your class and the staticmethod
+``deserialize(data: dict, version: int)`` to your class. Like so:
+
+.. code-block:: python
+
+    from typing import ClassVar
+
+
+    class MyCustom:
+        version: ClassVar[int] = 1
+
+        def __init__(self, x):
+            self.x = x
+
+        def serialize(self) -> dict:
+            return dict({"x": self.x})
+
+        @staticmethod
+        def deserialize(data: dict, version: int):
+            if version > 1:
+                raise TypeError(f"version > {MyCustom.version}")
+            return MyCustom(data["x"])
+
+Object Versioning
+^^^^^^^^^^^^^^^^^
+
+It is good practice to version the objects that will be used in serialization. To do this add
+``version: ClassVar[int] = <x>`` to your class. Airflow assumes that your classes are backwards compatible,
+so that a version 2 is able to deserialize a version 1. In case you need custom logic
+for deserialization ensure that ``deserialize(data: dict, version: int)`` is specified.
+
+::
+
+  Note: Typing of ``version`` is required and needs to be ``ClassVar[int]``
 
 History
 -------

--- a/docs/apache-airflow/concepts/taskflow.rst
+++ b/docs/apache-airflow/concepts/taskflow.rst
@@ -108,7 +108,7 @@ a ``Dataset``, which is ``@attr.define`` decorated, together with TaskFlow.
     now = pendulum.now()
 
 
-    @dag(start_date=now, schedule="daily", catchup=False)
+    @dag(start_date=now, schedule="@daily", catchup=False)
     def etl():
       @task()
       def retrieve(src: Dataset) -> dict:

--- a/tests/lineage/test_lineage.py
+++ b/tests/lineage/test_lineage.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from unittest import mock
 
+import attr
+
 from airflow.lineage import AUTO, apply_lineage, get_backend, prepare_lineage
 from airflow.lineage.backend import LineageBackend
 from airflow.lineage.entities import File
@@ -30,6 +32,12 @@ from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
+
+
+# helper
+@attr.define
+class A:
+    pass
 
 
 class CustomLineageBackend(LineageBackend):
@@ -122,10 +130,7 @@ class TestLineage:
         assert op1.inlets[0].url == f1s.format(DEFAULT_DATE)
         assert op1.outlets[0].url == f1s.format(DEFAULT_DATE)
 
-    def test_non_attr_outlet(self, dag_maker):
-        class A:
-            pass
-
+    def test_attr_outlet(self, dag_maker):
         a = A()
 
         f3s = "/tmp/does_not_exist_3"
@@ -150,7 +155,7 @@ class TestLineage:
         op1.post_execute(ctx1)
 
         op2.pre_execute(ctx2)
-        assert op2.inlets == [file3]
+        assert op2.inlets == [a, file3]
         op2.post_execute(ctx2)
 
     @mock.patch("airflow.lineage.get_backend")

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -19,13 +19,52 @@ from __future__ import annotations
 
 import decimal
 import json
+from dataclasses import dataclass
 from datetime import date, datetime
+from typing import ClassVar
 
+import attr
 import numpy as np
 import pendulum
 import pytest
 
+from airflow.datasets import Dataset
 from airflow.utils import json as utils_json
+
+
+class Z:
+    version = 1
+
+    def __init__(self, x):
+        self.x = x
+
+    def serialize(self) -> dict:
+        return dict({"x": self.x})
+
+    @staticmethod
+    def deserialize(data: dict, version: int):
+        if version != 1:
+            raise TypeError("version != 1")
+        return Z(data["x"])
+
+
+@attr.define
+class Y:
+    x: int
+    version: ClassVar[int] = 1
+
+    def __init__(self, x):
+        self.x = x
+
+
+class X:
+    pass
+
+
+@dataclass
+class U:
+    version: ClassVar[int] = 2
+    x: int
 
 
 class TestAirflowJsonEncoder:
@@ -84,3 +123,95 @@ class TestAirflowJsonEncoder:
                 Exception,
                 cls=utils_json.AirflowJsonEncoder,
             )
+
+    def test_encode_xcom_dataset(self):
+        dataset = Dataset("mytest://dataset")
+        s = json.dumps(dataset, cls=utils_json.XComEncoder)
+        obj = json.loads(s, cls=utils_json.XComDecoder)
+        assert dataset.uri == obj.uri
+
+    def test_backwards_compat(self):
+        uri = "s3://does_not_exist"
+        data = {
+            "__type": "airflow.datasets.Dataset",
+            "__source": None,
+            "__var": {
+                "__var": {
+                    "uri": uri,
+                    "extra": None,
+                },
+                "__type": "dict",
+            },
+        }
+        decoder = utils_json.XComDecoder()
+        dataset = decoder.object_hook(data)
+        assert dataset.uri == uri
+
+    def test_raise_on_reserved(self):
+        data = {"__classname__": "my.class"}
+        with pytest.raises(AttributeError):
+            json.dumps(data, cls=utils_json.XComEncoder)
+
+    def test_custom_serialize(self):
+        x = 11
+        z = Z(x)
+        s = json.dumps(z, cls=utils_json.XComEncoder)
+        o = json.loads(s, cls=utils_json.XComDecoder)
+
+        assert o.x == x
+
+    def test_raise_undeserializable(self):
+        data = dict(
+            {
+                "__classname__": X.__module__ + "." + X.__qualname__,
+                "__version__": 0,
+            }
+        )
+        s = json.dumps(data)
+        with pytest.raises(TypeError) as info:
+            json.loads(s, cls=utils_json.XComDecoder)
+
+        assert "cannot deserialize" in str(info.value)
+
+    def test_attr_version(self):
+        x = 14
+        y = Y(x)
+        s = json.dumps(y, cls=utils_json.XComEncoder)
+        o = json.loads(s, cls=utils_json.XComDecoder)
+
+        assert o.x == x
+
+    def test_incompatible_version(self):
+        data = dict(
+            {
+                "__classname__": Y.__module__ + "." + Y.__qualname__,
+                "__version__": 2,
+            }
+        )
+        s = json.dumps(data)
+        with pytest.raises(TypeError) as info:
+            json.loads(s, cls=utils_json.XComDecoder)
+
+        assert "newer than" in str(info.value)
+
+    def test_dataclass(self):
+        x = 12
+        u = U(x=x)
+        s = json.dumps(u, cls=utils_json.XComEncoder)
+        o = json.loads(s, cls=utils_json.XComDecoder)
+
+        assert o.x == x
+
+    def test_orm_deserialize(self):
+        x = 14
+        u = U(x=x)
+        s = json.dumps(u, cls=utils_json.XComEncoder)
+        o = json.loads(s, cls=utils_json.XComDecoder, object_hook=utils_json.XComDecoder.orm_object_hook)
+        assert o == f"{U.__module__}.{U.__qualname__}@version={U.version}(x={x})"
+
+    def test_orm_custom_deserialize(self):
+        x = 14
+        z = Z(x=x)
+        s = json.dumps(z, cls=utils_json.XComEncoder)
+        o = json.loads(s, cls=utils_json.XComDecoder, object_hook=utils_json.XComDecoder.orm_object_hook)
+        assert o == f"{Z.__module__}.{Z.__qualname__}@version={Z.version}(x={x})"


### PR DESCRIPTION
Datasets could not be passed as parameters to taskflow functions as they could not be serialized. This commit:

1) changes the xcom serializer so that it now can serialize objects that have attr, dataclass or custom serializer
2) removes the need to for a custom serializer in lineage 
3) adds a version check to the serializer/deserializer 
4) registers any datasets as either inlets or outlets in the task
5) inlets/outlets that fail to serialize now raise an error instead of being silently ignored

@ashb @jedcunningham @kaxil 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
