### PR TITLE
Add support for extraContainers in pgbouncer pods

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -167,6 +167,9 @@ spec:
                 - health
             initialDelaySeconds: 10
             periodSeconds: 10
+{{- if .Values.pgbouncer.extraContainers }}
+{{- toYaml .Values.pgbouncer.extraContainers | nindent 8 }}
+{{- end }}
       volumes:
         - name: pgbouncer-config
           secret:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4367,6 +4367,14 @@
                         }
                     }
                 },
+                "extraContainers": {
+                    "description": "Launch additional containers into pgbouncer pods.",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "#/definitions/io.k8s.api.core.v1.Container"
+                    }
+                },
                 "extraIniMetadata": {
                     "description": "Add extra metadata database specific PgBouncer ini configuration: https://www.pgbouncer.org/config.html#section-databases",
                     "type": [

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1468,6 +1468,8 @@ pgbouncer:
     cert: ~
     key: ~
 
+  # Launch additional containers into pgbouncer pods.
+  extraContainers: []
   # Add extra PgBouncer ini configuration in the databases section:
   # https://www.pgbouncer.org/config.html#section-databases
   extraIniMetadata: ~


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds support for specifiying extra containers in pgbouncer pods. One use case for this is while trying to run pgbouncer with a Postgres server on a private IP. Here, we will need a cloud_sql_proxy sidecar(extraContainer) in the pod.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
