### PR TITLE
Rename  hook bigquery function `_bq_cast` to `bq_cast`

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2843,18 +2843,6 @@ def _escape(s: str) -> str:
     return e
 
 
-def _bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
-    """
-    Helper method that casts a BigQuery row to the appropriate data types.
-    This is useful because BigQuery returns all fields as strings.
-    """
-    warnings.warn(
-        "This function is deprecated and will be Remove in future. Please use `bq_cast` function",
-        DeprecationWarning,
-    )
-    return bq_cast(string_field=string_field, bq_type=bq_type)
-
-
 def bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
     """
     Helper method that casts a BigQuery row to the appropriate data types.

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -57,6 +57,7 @@ from sqlalchemy import create_engine
 
 from airflow.exceptions import AirflowException
 from airflow.providers.common.sql.hooks.sql import DbApiHook
+from airflow.providers.google.cloud.utils.bigquery import bq_cast
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.providers.google.common.hooks.base_google import GoogleBaseAsyncHook, GoogleBaseHook, get_field
 from airflow.utils.helpers import convert_camel_to_snake
@@ -2841,25 +2842,6 @@ def _escape(s: str) -> str:
     e = e.replace("'", "\\'")
     e = e.replace('"', '\\"')
     return e
-
-
-def bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
-    """
-    Helper method that casts a BigQuery row to the appropriate data types.
-    This is useful because BigQuery returns all fields as strings.
-    """
-    if string_field is None:
-        return None
-    elif bq_type == "INTEGER":
-        return int(string_field)
-    elif bq_type in ("FLOAT", "TIMESTAMP"):
-        return float(string_field)
-    elif bq_type == "BOOLEAN":
-        if string_field not in ["true", "false"]:
-            raise ValueError(f"{string_field} must have value 'true' or 'false'")
-        return string_field == "true"
-    else:
-        return string_field
 
 
 def split_tablename(

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -3080,7 +3080,7 @@ class BigQueryAsyncHook(GoogleBaseAsyncHook):
             fields = query_results["schema"]["fields"]
             col_types = [field["type"] for field in fields]
             for dict_row in rows:
-                typed_row = [_bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
+                typed_row = [bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
                 buffer.append(typed_row)
         return buffer
 

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -2738,7 +2738,7 @@ class BigQueryCursor(BigQueryBaseCursor):
                 rows = query_results["rows"]
 
                 for dict_row in rows:
-                    typed_row = [_bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
+                    typed_row = [bq_cast(vs["v"], col_types[idx]) for idx, vs in enumerate(dict_row["f"])]
                     self.buffer.append(typed_row)
 
                 if not self.page_token:
@@ -2844,6 +2844,18 @@ def _escape(s: str) -> str:
 
 
 def _bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
+    """
+    Helper method that casts a BigQuery row to the appropriate data types.
+    This is useful because BigQuery returns all fields as strings.
+    """
+    warnings.warn(
+        "This function is deprecated and will be Remove in future. Please use `bq_cast` function",
+        DeprecationWarning,
+    )
+    return bq_cast(string_field=string_field, bq_type=bq_type)
+
+
+def bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
     """
     Helper method that casts a BigQuery row to the appropriate data types.
     This is useful because BigQuery returns all fields as strings.

--- a/airflow/providers/google/cloud/utils/bigquery.py
+++ b/airflow/providers/google/cloud/utils/bigquery.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+
+def bq_cast(string_field: str, bq_type: str) -> None | int | float | bool | str:
+    """
+    Helper method that casts a BigQuery row to the appropriate data types.
+    This is useful because BigQuery returns all fields as strings.
+    """
+    if string_field is None:
+        return None
+    elif bq_type == "INTEGER":
+        return int(string_field)
+    elif bq_type in ("FLOAT", "TIMESTAMP"):
+        return float(string_field)
+    elif bq_type == "BOOLEAN":
+        if string_field not in ["true", "false"]:
+            raise ValueError(f"{string_field} must have value 'true' or 'false'")
+        return string_field == "true"
+    else:
+        return string_field


### PR DESCRIPTION
Recently, I have started using hook bigquery function `_bq_cast` but I'm afraid that this might get changed silently since it is a private function so I want to rename it to `bq_cast`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
