### PR TITLE
Chart: add hostaliases to pod template file

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -90,6 +90,10 @@ spec:
   imagePullSecrets:
     - name: {{ template "registry_secret" . }}
   {{- end }}
+{{- if .Values.workers.hostAliases }}
+  hostAliases:
+{{ toYaml .Values.workers.hostAliases | indent 4 }}
+{{- end }}
   restartPolicy: Never
   securityContext: {{ $securityContext | nindent 4 }}
   nodeSelector: {{ toYaml $nodeSelector | nindent 4 }}

--- a/tests/charts/test_pod_template_file.py
+++ b/tests/charts/test_pod_template_file.py
@@ -704,3 +704,17 @@ class TestPodTemplateFile:
             chart_dir=self.temp_chart_dir,
         )
         assert {} == jmespath.search("spec.containers[0].resources", docs[0])
+
+    def test_workers_host_aliases(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}],
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert "127.0.0.2" == jmespath.search("spec.hostAliases[0].ip", docs[0])
+        assert "test.hostname" == jmespath.search("spec.hostAliases[0].hostnames[0]", docs[0])


### PR DESCRIPTION
This PR adds hostAliases support for pod template file for k8s executor workers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
