### PR TITLE
Make sure pach_all for gevent worker happens before everything else

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -394,7 +394,9 @@ def webserver(args):
             '--pid',
             pid_file,
             '--config',
-            'python:airflow.www.gunicorn_config',
+            'python:airflow.www.gunicorn_config'
+            if args.workerclass != 'gevent'
+            else 'python:airflow.www.gunicorn_config_gevent',
         ]
 
         if args.access_logfile:

--- a/airflow/www/gunicorn_config_gevent.py
+++ b/airflow/www/gunicorn_config_gevent.py
@@ -18,26 +18,11 @@
 # under the License.
 from __future__ import annotations
 
-import setproctitle
+# DO NOT ADD MORE IMPORTS ABOVE THIS LINE!!!!  GEVENT MONKEY PATCHING SHOULD HAPPEN AS THE FIRST THING HERE #
+from gevent.monkey import patch_all
 
-from airflow import settings
-
-
-def post_worker_init(_):
-    """
-    Set process title.
-
-    This is used by airflow.cli.commands.webserver_command to track the status of the worker.
-    """
-    old_title = setproctitle.getproctitle()
-    setproctitle.setproctitle(settings.GUNICORN_WORKER_READY_PREFIX + old_title)
+patch_all()
+############################################
 
 
-def on_starting(server):
-    from airflow.providers_manager import ProvidersManager
-
-    # Load providers before forking workers
-    ProvidersManager().connection_form_widgets
-
-
-# IMPORTANT!!! MAKE SURE TO IMPORT ANY NEW FUNCTION YOU ADD HERE TO gunicorn_config_gevent.py
+from airflow.www.gunicorn_config import on_starting, post_worker_init  # noqa


### PR DESCRIPTION
This change makes sure that gevent performs monkey_patching before everything else. Gevent should make sure to patch all the classes that are non-cooperative via gevent into cooperative ones and it should be done as the first thing in the forked gunicorn process.

Usually GeventWorker does it automatically, however this happens after the configuration of gunicorn gets imported. In our case it means that it happens after airflow setting are loaded - and for example it means that if S3 remote logging is configured, then boto is initialzed before patch_all() and it breaks ssl that is patched by boto itself. Reversing the sequence and making gevent patches the ssl connection first, fixes the problem.

We could convert airflow settings to local imports, but this does not guarantee a success because some of the initilization methods might be executed before GeventWorker starts and it is also prone to mistakes (adding top-level import to settings broke it at some point in time and it went unnoticed).

This change does it slightly differently - in case of gevent worker, we use a different configuration for gunicorn and make sure that patch_all() is always executed first before any other import and initialization. This should fix the problem and be future-proof.

Fixes: #8212

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
