### PR TITLE
Add ipc_mode for DockerOperator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -149,6 +149,7 @@ class DockerOperator(BaseOperator):
     :param log_opts_max_file: The maximum number of log files that can be present.
         If rolling the logs creates excess files, the oldest file is removed.
         Only effective when max-size is also set. A positive integer. Defaults to 1.
+    :param ipc_mode: Set the IPC mode for the container.
     """
 
     template_fields: Sequence[str] = ("image", "command", "environment", "env_file", "container_name")
@@ -202,6 +203,7 @@ class DockerOperator(BaseOperator):
         device_requests: list[DeviceRequest] | None = None,
         log_opts_max_size: str | None = None,
         log_opts_max_file: str | None = None,
+        ipc_mode: str | None = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -261,6 +263,7 @@ class DockerOperator(BaseOperator):
         self.device_requests = device_requests
         self.log_opts_max_size = log_opts_max_size
         self.log_opts_max_file = log_opts_max_file
+        self.ipc_mode = ipc_mode
 
     def get_hook(self) -> DockerHook:
         """
@@ -332,6 +335,7 @@ class DockerOperator(BaseOperator):
                 privileged=self.privileged,
                 device_requests=self.device_requests,
                 log_config=LogConfig(config=docker_log_config),
+                ipc_mode=self.ipc_mode
             ),
             image=self.image,
             user=self.user,

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -335,7 +335,7 @@ class DockerOperator(BaseOperator):
                 privileged=self.privileged,
                 device_requests=self.device_requests,
                 log_config=LogConfig(config=docker_log_config),
-                ipc_mode=self.ipc_mode
+                ipc_mode=self.ipc_mode,
             ),
             image=self.image,
             user=self.user,

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -152,6 +152,7 @@ class TestDockerOperator(unittest.TestCase):
             privileged=False,
             device_requests=[DeviceRequest(count=-1, capabilities=[["gpu"]])],
             log_config=LogConfig(config={"max-size": "10m", "max-file": "5"}),
+            ipc_mode=None,
         )
         self.tempdir_mock.assert_called_once_with(dir="/host/airflow", prefix="airflowtmp")
         self.client_mock.images.assert_called_once_with(name="ubuntu:latest")
@@ -224,6 +225,7 @@ class TestDockerOperator(unittest.TestCase):
             privileged=False,
             device_requests=None,
             log_config=LogConfig(config={}),
+            ipc_mode=None,
         )
         self.tempdir_mock.assert_not_called()
         self.client_mock.images.assert_called_once_with(name="ubuntu:latest")
@@ -328,6 +330,7 @@ class TestDockerOperator(unittest.TestCase):
                     privileged=False,
                     device_requests=None,
                     log_config=LogConfig(config={}),
+                    ipc_mode=None,
                 ),
                 call(
                     mounts=[
@@ -345,6 +348,7 @@ class TestDockerOperator(unittest.TestCase):
                     privileged=False,
                     device_requests=None,
                     log_config=LogConfig(config={}),
+                    ipc_mode=None,
                 ),
             ]
         )


### PR DESCRIPTION
Add ipc_mode to DockerOperator. IPC (POSIX/SysV IPC) namespace provides separation of named shared memory segments, semaphores and message queues (https://docs.docker.com/engine/reference/run/#ipc-settings---ipc). 

> ipc_mode (str) – Set the IPC mode for the container.
ref: https://docker-py.readthedocs.io/en/stable/containers.html