### PR TITLE
Implement extra controls for SLAs

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3932,6 +3932,65 @@ class SlaMissModelView(AirflowModelView):
         'map_index': wwwutils.format_map_index,
     }
 
+    @action('muldelete', 'Delete', "Are you sure you want to delete selected records?", single=False)
+    def action_muldelete(self, items):
+        """Multiple delete action."""
+        self.datamodel.delete_all(items)
+        self.update_redirect()
+        return redirect(self.get_redirect())
+
+    @action(
+        "mulnotificationsent",
+        "Set notification sent to true",
+        "Are you sure you want to set all these notifications to sent?",
+        single=False,
+    )
+    def action_mulnotificationsent(self, items: list[SlaMiss]):
+        return self._set_notification_property(items, "notification_sent", True)
+
+    @action(
+        "mulnotificationsentfalse",
+        "Set notification sent to false",
+        "Are you sure you want to mark these SLA alerts as notification not sent yet?",
+        single=False,
+    )
+    def action_mulnotificationsentfalse(self, items: list[SlaMiss]):
+        return self._set_notification_property(items, "notification_sent", False)
+
+    @action(
+        "mulemailsent",
+        "Set email sent to true",
+        "Are you sure you want to mark these SLA alerts as emails were sent?",
+        single=False,
+    )
+    def action_mulemailsent(self, items: list[SlaMiss]):
+        return self._set_notification_property(items, "email_sent", True)
+
+    @action(
+        "mulemailsentfalse",
+        "Set email sent to false",
+        "Are you sure you want to mark these SLA alerts as emails not sent yet?",
+        single=False,
+    )
+    def action_mulemailsentfalse(self, items: list[SlaMiss]):
+        return self._set_notification_property(items, "email_sent", False)
+
+    @provide_session
+    def _set_notification_property(self, items: list[SlaMiss], attr: str, new_value: bool, session=None):
+        try:
+            count = 0
+            for sla in items:
+                count += 1
+                setattr(sla, attr, new_value)
+                session.merge(sla)
+            session.commit()
+            flash(f"{count} SLAMisses had {attr} set to {new_value}.")
+        except Exception as ex:
+            flash(str(ex), 'error')
+            flash('Failed to set state', 'error')
+        self.update_redirect()
+        return redirect(self.get_default_url())
+
 
 class XComModelView(AirflowModelView):
     """View to show records from XCom table"""


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While there is a new effort for SLAs to be completely rewritten, I think it's good to spend a little time to make the current situation a bit more usable.
We sometimes face cases were our SLA notifications fail, and we'd have 100+ notifications waiting. These waiting never really make it through for some reason.
Therefore, we'd like to manually set them to success.
I figured these options are a low-effort solution to making the current solution more workable.

<img width="360" alt="image" src="https://user-images.githubusercontent.com/20257392/200591451-437b2e0a-53b5-4f3e-879f-c261070915ff.png">

I considered creating tests, but saw that hardly any of the other actions really had tests and considered this to be so trivial that it doesn't need it.
Furthermore, with the move from FAB to React, this code won't last long anyway.