### PR TITLE
CloudWatch task handler doesn't fall back to local logs when Amazon CloudWatch logs aren't found

### DIFF
--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -154,6 +154,23 @@ class TestCloudwatchTaskHandler:
             [{"end_of_log": True}],
         )
 
+    def test_should_read_from_local(self):
+        """Check that local logs are displayed when remote logs are missing"""
+        self.cloudwatch_task_handler.set_context(self.ti)
+        with mock.patch.object(self.cloudwatch_task_handler, "get_cloudwatch_logs") as mock_get_logs:
+            mock_get_logs.side_effect = Exception("Failed to connect")
+            log, metadata = self.cloudwatch_task_handler._read(self.ti, self.ti.try_number)
+        expected_log = (
+            f"*** Unable to read remote logs from Cloudwatch (log_group: {self.remote_log_group}, "
+            f"log_stream: {self.remote_log_stream})\n*** Failed to connect\n\n"
+            # The value of "log_pos" is equal to the length of this next line
+            f"*** Reading local file: {self.local_log_location}/{self.remote_log_stream}\n"
+        )
+        assert log == expected_log
+        expected_log_pos = 26 + len(self.local_log_location) + len(self.remote_log_stream)
+        assert metadata == {"end_of_log": False, "log_pos": expected_log_pos}
+        mock_get_logs.assert_called_once_with(stream_name=self.remote_log_stream)
+
     def test_read_wrong_log_stream(self):
         generate_log_events(
             self.conn,

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -154,8 +154,8 @@ class TestCloudwatchTaskHandler:
             [{"end_of_log": True}],
         )
 
-    def test_should_read_from_local(self):
-        """Check that local logs are displayed when remote logs are missing"""
+    def test_should_read_from_local_on_failure_to_fetch_remote_logs(self):
+        """Check that local logs are displayed on failure to fetch remote logs"""
         self.cloudwatch_task_handler.set_context(self.ti)
         with mock.patch.object(self.cloudwatch_task_handler, "get_cloudwatch_logs") as mock_get_logs:
             mock_get_logs.side_effect = Exception("Failed to connect")
@@ -170,50 +170,6 @@ class TestCloudwatchTaskHandler:
         expected_log_pos = 26 + len(self.local_log_location) + len(self.remote_log_stream)
         assert metadata == {"end_of_log": False, "log_pos": expected_log_pos}
         mock_get_logs.assert_called_once_with(stream_name=self.remote_log_stream)
-
-    def test_read_wrong_log_stream(self):
-        generate_log_events(
-            self.conn,
-            self.remote_log_group,
-            "alternate_log_stream",
-            [
-                {"timestamp": 10000, "message": "First"},
-                {"timestamp": 20000, "message": "Second"},
-                {"timestamp": 30000, "message": "Third"},
-            ],
-        )
-
-        msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n"
-        error_msg = (
-            "Could not read remote logs from log_group: "
-            f"{self.remote_log_group} log_stream: {self.remote_log_stream}."
-        )
-        assert self.cloudwatch_task_handler.read(self.ti) == (
-            [[("", msg_template.format(self.remote_log_group, self.remote_log_stream, error_msg))]],
-            [{"end_of_log": True}],
-        )
-
-    def test_read_wrong_log_group(self):
-        generate_log_events(
-            self.conn,
-            "alternate_log_group",
-            self.remote_log_stream,
-            [
-                {"timestamp": 10000, "message": "First"},
-                {"timestamp": 20000, "message": "Second"},
-                {"timestamp": 30000, "message": "Third"},
-            ],
-        )
-
-        msg_template = "*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n"
-        error_msg = (
-            f"Could not read remote logs from log_group: "
-            f"{self.remote_log_group} log_stream: {self.remote_log_stream}."
-        )
-        assert self.cloudwatch_task_handler.read(self.ti) == (
-            [[("", msg_template.format(self.remote_log_group, self.remote_log_stream, error_msg))]],
-            [{"end_of_log": True}],
-        )
 
     def test_close_prevents_duplicate_calls(self):
         with mock.patch("watchtower.CloudWatchLogHandler.close") as mock_log_handler_close:


### PR DESCRIPTION
Closes #27396

### Summary

The CloudWatch task log handler does not default to local logs (like the documentation says it should) when remote logs are unavailable. This PR fixes the issue.

### Todo
- [x] Update CloudWatch log handler
- [x] Add/update unit tests
- [x] Manual check (see below for details)

### Manual check

#### Procedure

1. Run a test DAG with [AWS CloudWatch logging configured](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/logging/cloud-watch-task-handlers.html)
2. Verify that logs are sent to CloudWatch
3. Delete CloudWatch log stream associated with task
4. Create log file locally `echo "test" >> {log file path}`
5. Refresh the task log page

#### Expectations

* "Unable to read remote logs from Cloudwatch" should appear in the log because we deleted the log stream associated with the task.
* "Reading local file: ..." should appear in the log to show that the log handler falls back to local logs.
* The contents of the local log file should appear (in this case the contents are "test")

#### Screenshot

<img width="1482" alt="Screenshot 2022-11-09 at 7 09 49" src="https://user-images.githubusercontent.com/11639738/200686553-bddf87ee-99ff-4545-86ac-02501cb7aa87.png">
