### PR TITLE
Add automated provider deprecation removal tests

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -353,3 +353,14 @@ class AirflowProviderDeprecationWarning(DeprecationWarning):
 
     deprecated_provider_since: str | None = None
     "Indicates the provider version that started raising this deprecation warning"
+
+
+def warn_provider_deprecation(
+    message,
+    *,
+    provider_version=None,
+    min_airflow_version=None,
+    category=AirflowProviderDeprecationWarning,
+    **kwargs,
+):
+    warnings.warn(message, category=category, **kwargs)

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -30,6 +30,10 @@ from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keep
 from airflow.utils import yaml
 
 
+def warn_provider_deprecation(message, *, provider_version=None, min_airflow_version=None, category=DeprecationWarning, **kwargs):
+    warnings.warn(message, category=DeprecationWarning, **kwargs)
+
+
 def _load_body_to_dict(body):
     try:
         body_dict = yaml.safe_load(body)
@@ -323,13 +327,13 @@ class KubernetesHook(BaseHook):
         """
         namespace = self._get_namespace()
         if self.conn_id and not namespace:
-            warnings.warn(
+            warn_provider_deprecation(
                 "Airflow connection defined but namespace is not set; returning 'default'.  In "
                 "cncf.kubernetes provider version 6.0 we will return None when namespace is "
                 "not defined in the connection so that it's clear whether user intends 'default' or "
                 "whether namespace is unset (which is required in order to apply precedence logic in "
                 "KubernetesPodOperator).",
-                DeprecationWarning,
+                provider_version=(6, 0),
             )
             return "default"
         return namespace

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -30,7 +30,11 @@ from airflow.kubernetes.kube_client import _disable_verify_ssl, _enable_tcp_keep
 from airflow.utils import yaml
 
 
-def warn_provider_deprecation(message, *, provider_version=None, min_airflow_version=None, category=DeprecationWarning, **kwargs):
+# todo: remove-on-min-airflow-version=2.5
+# when removing, import this from airflow.exceptions
+def warn_provider_deprecation(
+    message, *, provider_version=None, min_airflow_version=None, category=DeprecationWarning, **kwargs
+):
     warnings.warn(message, category=DeprecationWarning, **kwargs)
 
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import json
 import logging
 import re
-import warnings
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, Sequence
 
@@ -43,7 +42,7 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume,
     convert_volume_mount,
 )
-from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook, warn_provider_deprecation
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar  # type: ignore[attr-defined]
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchFailedException,
@@ -370,7 +369,9 @@ class KubernetesPodOperator(BaseOperator):
         return PodManager(kube_client=self.client)
 
     def get_hook(self):
-        warnings.warn("get_hook is deprecated. Please use hook instead.", DeprecationWarning, stacklevel=2)
+        warn_provider_deprecation(
+            "get_hook is deprecated. Please use hook instead.", provider_version=(5, 0), stacklevel=2
+        )
         return self.hook
 
     @cached_property

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -28,6 +28,7 @@ import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import wraps
+from pathlib import Path
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, MutableMapping, NamedTuple, TypeVar, cast
 
@@ -61,17 +62,17 @@ def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: 
     and consistency between the `get_ui_field_behaviour` method and the extra dict itself,
     we allow users to supply the unprefixed name.
     """
-    conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
+    conn_attrs = {"host", "schema", "login", "password", "port", "extra"}
 
     def ensure_prefix(field):
-        if field not in conn_attrs and not field.startswith('extra__'):
+        if field not in conn_attrs and not field.startswith("extra__"):
             return f"extra__{conn_type}__{field}"
         else:
             return field
 
-    if 'placeholders' in field_behaviors:
-        placeholders = field_behaviors['placeholders']
-        field_behaviors['placeholders'] = {ensure_prefix(k): v for k, v in placeholders.items()}
+    if "placeholders" in field_behaviors:
+        placeholders = field_behaviors["placeholders"]
+        field_behaviors["placeholders"] = {ensure_prefix(k): v for k, v in placeholders.items()}
 
     return field_behaviors
 
@@ -87,7 +88,7 @@ class LazyDictWithCache(MutableMapping):
     at first use - and returns and caches the result.
     """
 
-    __slots__ = ['_resolved', '_raw_dict']
+    __slots__ = ["_resolved", "_raw_dict"]
 
     def __init__(self, *args, **kw):
         self._resolved = set()
@@ -169,19 +170,21 @@ class ProviderInfo:
     :param data: dictionary with information about the provider
     :param source_or_package: whether the provider is source files or PyPI package. When installed from
         sources we suppress provider import errors.
+    :param root_path: root folder of provider
     """
 
     version: str
     data: dict
-    package_or_source: Literal['source'] | Literal['package']
+    package_or_source: Literal["source"] | Literal["package"]
+    root_path: Path | None = None
 
     def __post_init__(self):
-        if self.package_or_source not in ('source', 'package'):
+        if self.package_or_source not in ("source", "package"):
             raise ValueError(
                 f"Received {self.package_or_source!r} for `package_or_source`. "
                 "Must be either 'package' or 'source'."
             )
-        self.is_source = self.package_or_source == 'source'
+        self.is_source = self.package_or_source == "source"
 
 
 class HookClassProvider(NamedTuple):
@@ -453,22 +456,22 @@ class ProvidersManager(LoggingMixin):
         together with the code. The runtime version is more relaxed (allows for additional properties)
         and verifies only the subset of fields that are needed at runtime.
         """
-        for entry_point, dist in entry_points_with_dist('apache_airflow_provider'):
-            package_name = dist.metadata['name']
+        for entry_point, dist in entry_points_with_dist("apache_airflow_provider"):
+            package_name = dist.metadata["name"]
             if self._provider_dict.get(package_name) is not None:
                 continue
             log.debug("Loading %s from package %s", entry_point, package_name)
             version = dist.version
             provider_info = entry_point.load()()
             self._provider_schema_validator.validate(provider_info)
-            provider_info_package_name = provider_info['package-name']
+            provider_info_package_name = provider_info["package-name"]
             if package_name != provider_info_package_name:
                 raise Exception(
                     f"The package '{package_name}' from setuptools and "
                     f"{provider_info_package_name} do not match. Please make sure they are aligned"
                 )
             if package_name not in self._provider_dict:
-                self._provider_dict[package_name] = ProviderInfo(version, provider_info, 'package')
+                self._provider_dict[package_name] = ProviderInfo(version, provider_info, "package")
             else:
                 log.warning(
                     "The provider for package '%s' could not be registered from because providers for that "
@@ -522,9 +525,9 @@ class ProvidersManager(LoggingMixin):
                 provider_info = yaml.safe_load(provider_yaml_file)
             self._provider_schema_validator.validate(provider_info)
 
-            version = provider_info['versions'][0]
+            version = provider_info["versions"][0]
             if package_name not in self._provider_dict:
-                self._provider_dict[package_name] = ProviderInfo(version, provider_info, 'source')
+                self._provider_dict[package_name] = ProviderInfo(version, provider_info, "source")
             else:
                 log.warning(
                     "The providers for package '%s' could not be registered because providers for that "
@@ -557,8 +560,8 @@ class ProvidersManager(LoggingMixin):
         connection_types = provider.data.get("connection-types")
         if connection_types:
             for connection_type_dict in connection_types:
-                connection_type = connection_type_dict['connection-type']
-                hook_class_name = connection_type_dict['hook-class-name']
+                connection_type = connection_type_dict["connection-type"]
+                hook_class_name = connection_type_dict["hook-class-name"]
                 hook_class_names_registered.add(hook_class_name)
                 already_registered = self._hook_provider_dict.get(connection_type)
                 if already_registered:
@@ -705,7 +708,7 @@ class ProvidersManager(LoggingMixin):
         if name in self._taskflow_decorators:
             try:
                 existing = self._taskflow_decorators[name]
-                other_name = f'{existing.__module__}.{existing.__name__}'
+                other_name = f"{existing.__module__}.{existing.__name__}"
             except Exception:
                 # If problem importing, then get the value from the functools.partial
                 other_name = self._taskflow_decorators._raw_dict[name].args[0]  # type: ignore[attr-defined]
@@ -770,11 +773,11 @@ class ProvidersManager(LoggingMixin):
         if hook_class is None:
             return None
         try:
-            module, class_name = hook_class_name.rsplit('.', maxsplit=1)
+            module, class_name = hook_class_name.rsplit(".", maxsplit=1)
             # Do not use attr here. We want to check only direct class fields not those
             # inherited from parent hook. This way we add form fields only once for the whole
             # hierarchy and we add it only from the parent hook that provides those!
-            if 'get_connection_form_widgets' in hook_class.__dict__:
+            if "get_connection_form_widgets" in hook_class.__dict__:
                 widgets = hook_class.get_connection_form_widgets()
 
                 if widgets:
@@ -789,7 +792,7 @@ class ProvidersManager(LoggingMixin):
                             )
                             return None
                     self._add_widgets(package_name, hook_class, widgets)
-            if 'get_ui_field_behaviour' in hook_class.__dict__:
+            if "get_ui_field_behaviour" in hook_class.__dict__:
                 field_behaviours = hook_class.get_ui_field_behaviour()
                 if field_behaviours:
                     self._add_customized_fields(package_name, hook_class, field_behaviours)
@@ -801,7 +804,7 @@ class ProvidersManager(LoggingMixin):
                 e,
             )
             return None
-        hook_connection_type = self._get_attr(hook_class, 'conn_type')
+        hook_connection_type = self._get_attr(hook_class, "conn_type")
         if connection_type:
             if hook_connection_type != connection_type:
                 log.warning(
@@ -814,8 +817,8 @@ class ProvidersManager(LoggingMixin):
                     connection_type,
                 )
         connection_type = hook_connection_type
-        connection_id_attribute_name: str = self._get_attr(hook_class, 'conn_name_attr')
-        hook_name: str = self._get_attr(hook_class, 'hook_name')
+        connection_id_attribute_name: str = self._get_attr(hook_class, "conn_name_attr")
+        hook_name: str = self._get_attr(hook_class, "hook_name")
 
         if not connection_type or not connection_id_attribute_name or not hook_name:
             log.warning(
@@ -833,13 +836,13 @@ class ProvidersManager(LoggingMixin):
             package_name=package_name,
             hook_name=hook_name,
             connection_type=connection_type,
-            connection_testable=hasattr(hook_class, 'test_connection'),
+            connection_testable=hasattr(hook_class, "test_connection"),
         )
 
     def _add_widgets(self, package_name: str, hook_class: type, widgets: dict[str, Any]):
         conn_type = hook_class.conn_type  # type: ignore
         for field_identifier, field in widgets.items():
-            if field_identifier.startswith('extra__'):
+            if field_identifier.startswith("extra__"):
                 prefixed_field_name = field_identifier
             else:
                 prefixed_field_name = f"extra__{conn_type}__{field_identifier}"

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -28,7 +28,6 @@ import warnings
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import wraps
-from pathlib import Path
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Callable, MutableMapping, NamedTuple, TypeVar, cast
 
@@ -62,17 +61,17 @@ def _ensure_prefix_for_placeholders(field_behaviors: dict[str, Any], conn_type: 
     and consistency between the `get_ui_field_behaviour` method and the extra dict itself,
     we allow users to supply the unprefixed name.
     """
-    conn_attrs = {"host", "schema", "login", "password", "port", "extra"}
+    conn_attrs = {'host', 'schema', 'login', 'password', 'port', 'extra'}
 
     def ensure_prefix(field):
-        if field not in conn_attrs and not field.startswith("extra__"):
+        if field not in conn_attrs and not field.startswith('extra__'):
             return f"extra__{conn_type}__{field}"
         else:
             return field
 
-    if "placeholders" in field_behaviors:
-        placeholders = field_behaviors["placeholders"]
-        field_behaviors["placeholders"] = {ensure_prefix(k): v for k, v in placeholders.items()}
+    if 'placeholders' in field_behaviors:
+        placeholders = field_behaviors['placeholders']
+        field_behaviors['placeholders'] = {ensure_prefix(k): v for k, v in placeholders.items()}
 
     return field_behaviors
 
@@ -88,7 +87,7 @@ class LazyDictWithCache(MutableMapping):
     at first use - and returns and caches the result.
     """
 
-    __slots__ = ["_resolved", "_raw_dict"]
+    __slots__ = ['_resolved', '_raw_dict']
 
     def __init__(self, *args, **kw):
         self._resolved = set()
@@ -170,21 +169,19 @@ class ProviderInfo:
     :param data: dictionary with information about the provider
     :param source_or_package: whether the provider is source files or PyPI package. When installed from
         sources we suppress provider import errors.
-    :param root_path: root folder of provider
     """
 
     version: str
     data: dict
-    package_or_source: Literal["source"] | Literal["package"]
-    root_path: Path | None = None
+    package_or_source: Literal['source'] | Literal['package']
 
     def __post_init__(self):
-        if self.package_or_source not in ("source", "package"):
+        if self.package_or_source not in ('source', 'package'):
             raise ValueError(
                 f"Received {self.package_or_source!r} for `package_or_source`. "
                 "Must be either 'package' or 'source'."
             )
-        self.is_source = self.package_or_source == "source"
+        self.is_source = self.package_or_source == 'source'
 
 
 class HookClassProvider(NamedTuple):
@@ -456,22 +453,22 @@ class ProvidersManager(LoggingMixin):
         together with the code. The runtime version is more relaxed (allows for additional properties)
         and verifies only the subset of fields that are needed at runtime.
         """
-        for entry_point, dist in entry_points_with_dist("apache_airflow_provider"):
-            package_name = dist.metadata["name"]
+        for entry_point, dist in entry_points_with_dist('apache_airflow_provider'):
+            package_name = dist.metadata['name']
             if self._provider_dict.get(package_name) is not None:
                 continue
             log.debug("Loading %s from package %s", entry_point, package_name)
             version = dist.version
             provider_info = entry_point.load()()
             self._provider_schema_validator.validate(provider_info)
-            provider_info_package_name = provider_info["package-name"]
+            provider_info_package_name = provider_info['package-name']
             if package_name != provider_info_package_name:
                 raise Exception(
                     f"The package '{package_name}' from setuptools and "
                     f"{provider_info_package_name} do not match. Please make sure they are aligned"
                 )
             if package_name not in self._provider_dict:
-                self._provider_dict[package_name] = ProviderInfo(version, provider_info, "package")
+                self._provider_dict[package_name] = ProviderInfo(version, provider_info, 'package')
             else:
                 log.warning(
                     "The provider for package '%s' could not be registered from because providers for that "
@@ -525,9 +522,9 @@ class ProvidersManager(LoggingMixin):
                 provider_info = yaml.safe_load(provider_yaml_file)
             self._provider_schema_validator.validate(provider_info)
 
-            version = provider_info["versions"][0]
+            version = provider_info['versions'][0]
             if package_name not in self._provider_dict:
-                self._provider_dict[package_name] = ProviderInfo(version, provider_info, "source")
+                self._provider_dict[package_name] = ProviderInfo(version, provider_info, 'source')
             else:
                 log.warning(
                     "The providers for package '%s' could not be registered because providers for that "
@@ -560,8 +557,8 @@ class ProvidersManager(LoggingMixin):
         connection_types = provider.data.get("connection-types")
         if connection_types:
             for connection_type_dict in connection_types:
-                connection_type = connection_type_dict["connection-type"]
-                hook_class_name = connection_type_dict["hook-class-name"]
+                connection_type = connection_type_dict['connection-type']
+                hook_class_name = connection_type_dict['hook-class-name']
                 hook_class_names_registered.add(hook_class_name)
                 already_registered = self._hook_provider_dict.get(connection_type)
                 if already_registered:
@@ -708,7 +705,7 @@ class ProvidersManager(LoggingMixin):
         if name in self._taskflow_decorators:
             try:
                 existing = self._taskflow_decorators[name]
-                other_name = f"{existing.__module__}.{existing.__name__}"
+                other_name = f'{existing.__module__}.{existing.__name__}'
             except Exception:
                 # If problem importing, then get the value from the functools.partial
                 other_name = self._taskflow_decorators._raw_dict[name].args[0]  # type: ignore[attr-defined]
@@ -773,11 +770,11 @@ class ProvidersManager(LoggingMixin):
         if hook_class is None:
             return None
         try:
-            module, class_name = hook_class_name.rsplit(".", maxsplit=1)
+            module, class_name = hook_class_name.rsplit('.', maxsplit=1)
             # Do not use attr here. We want to check only direct class fields not those
             # inherited from parent hook. This way we add form fields only once for the whole
             # hierarchy and we add it only from the parent hook that provides those!
-            if "get_connection_form_widgets" in hook_class.__dict__:
+            if 'get_connection_form_widgets' in hook_class.__dict__:
                 widgets = hook_class.get_connection_form_widgets()
 
                 if widgets:
@@ -792,7 +789,7 @@ class ProvidersManager(LoggingMixin):
                             )
                             return None
                     self._add_widgets(package_name, hook_class, widgets)
-            if "get_ui_field_behaviour" in hook_class.__dict__:
+            if 'get_ui_field_behaviour' in hook_class.__dict__:
                 field_behaviours = hook_class.get_ui_field_behaviour()
                 if field_behaviours:
                     self._add_customized_fields(package_name, hook_class, field_behaviours)
@@ -804,7 +801,7 @@ class ProvidersManager(LoggingMixin):
                 e,
             )
             return None
-        hook_connection_type = self._get_attr(hook_class, "conn_type")
+        hook_connection_type = self._get_attr(hook_class, 'conn_type')
         if connection_type:
             if hook_connection_type != connection_type:
                 log.warning(
@@ -817,8 +814,8 @@ class ProvidersManager(LoggingMixin):
                     connection_type,
                 )
         connection_type = hook_connection_type
-        connection_id_attribute_name: str = self._get_attr(hook_class, "conn_name_attr")
-        hook_name: str = self._get_attr(hook_class, "hook_name")
+        connection_id_attribute_name: str = self._get_attr(hook_class, 'conn_name_attr')
+        hook_name: str = self._get_attr(hook_class, 'hook_name')
 
         if not connection_type or not connection_id_attribute_name or not hook_name:
             log.warning(
@@ -836,13 +833,13 @@ class ProvidersManager(LoggingMixin):
             package_name=package_name,
             hook_name=hook_name,
             connection_type=connection_type,
-            connection_testable=hasattr(hook_class, "test_connection"),
+            connection_testable=hasattr(hook_class, 'test_connection'),
         )
 
     def _add_widgets(self, package_name: str, hook_class: type, widgets: dict[str, Any]):
         conn_type = hook_class.conn_type  # type: ignore
         for field_identifier, field in widgets.items():
-            if field_identifier.startswith("extra__"):
+            if field_identifier.startswith('extra__'):
                 prefixed_field_name = field_identifier
             else:
                 prefixed_field_name = f"extra__{conn_type}__{field_identifier}"

--- a/tests/providers/test_core.py
+++ b/tests/providers/test_core.py
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+import semver
+import yaml
+
+import airflow
+from airflow.providers_manager import ProvidersManager
+from tests.test_utils.providers import get_provider_min_airflow_version
+
+repo_root = Path(airflow.__file__).parent.parent
+
+
+def get_version_kwarg(name, kwargs, ref):
+    raw = kwargs.get(name)
+    if not raw:
+        return None
+    if not isinstance(raw, tuple):
+        raise ValueError(
+            f"File {ref} has call to warn_provider_deprecation"
+            f"with improper arguments. `{name}` must be tuple."
+        )
+    provider_version = semver.VersionInfo(*raw)
+    return provider_version
+
+
+def iter_providers():
+    for name, info in ProvidersManager().providers.items():
+        package_name = info.data["package-name"]
+        rel_path = Path(*package_name.replace("apache-airflow-providers-", "").split("-"))
+        curr_prov_version = semver.VersionInfo.parse(info.version)
+        curr_min_airflow_version = get_provider_min_airflow_version(package_name, info.data)
+        provider_root = repo_root / "airflow/providers" / rel_path
+        yield curr_prov_version, curr_min_airflow_version, provider_root, info
+
+
+def test_provider_deprecation_removal():
+    failures = {}
+    for curr_prov_version, curr_min_airflow_version, provider_root, info in iter_providers():
+        provider_failures = defaultdict(list)
+        package_name = info.data["package-name"]
+        for file in provider_root.rglob("*.py"):
+            content = file.read_text()
+            file_rel_path = file.relative_to(repo_root)
+            tree = ast.parse(content)
+            for elem in [
+                x
+                for x in ast.walk(tree)
+                if isinstance(x, ast.Call)
+                and getattr(x.func, "id", "").lstrip("_") == "warn_provider_deprecation"
+            ]:
+                kwargs = {y.arg: ast.literal_eval(y.value) for y in elem.keywords}
+                ref = f"{file_rel_path}:{elem.lineno}"
+                provider_version = get_version_kwarg("provider_version", kwargs, ref)
+                if provider_version and curr_prov_version >= provider_version:
+                    provider_failures["provider version exceeded"].append(ref)
+                min_airflow_version = get_version_kwarg("min_airflow_version", kwargs, ref)
+                if min_airflow_version and curr_min_airflow_version >= min_airflow_version:
+                    provider_failures["min airflow version exceeded"].append(ref)
+                if not (min_airflow_version or provider_version):
+                    raise RuntimeError(
+                        f"`warn_provider_deprecation` is called at {ref} but "
+                        "neither provider_version nor min_airflow_version is specified."
+                    )
+            if provider_failures:
+                failures[package_name] = dict(provider_failures)
+    if failures:
+        message = (
+            "Found providers raising deprecation warning which must be addressed now.\n"
+            "There are two classes of warnings. One is when the provider version is now\n"
+            "greater than that specified in the warning.\n"
+            "The other is when the current min airflow version for the provider is greater\n"
+            "than specified in the warning.\n\n"
+        )
+        message += yaml.dump(dict(failures))
+        pytest.fail(message)
+
+
+def test_code_removal_todo_comments():
+    failures = {}
+    for curr_prov_version, curr_min_airflow_version, provider_root, info in iter_providers():
+        provider_failures = defaultdict(list)
+        package_name = info.data["package-name"]
+        for file in provider_root.rglob("*.py"):
+            for idx, line in enumerate(file.read_text().splitlines()):
+                if line.startswith("# todo: remove-on-min-airflow-version="):
+                    rel_path = file.relative_to(repo_root)
+                    ref = f"{rel_path}:{idx + 1}"
+                    version_str = line.split("=", maxsplit=1)[1]
+                    version = tuple(map(int, version_str.split(".")))
+                    if version and curr_min_airflow_version >= version:
+                        provider_failures["min airflow version exceeded"].append(ref)
+                if line.startswith("# todo: remove-on-provider-version="):
+                    rel_path = file.relative_to(repo_root)
+                    ref = f"{rel_path}:{idx + 1}"
+                    version_str = line.split("=", maxsplit=1)[1]
+                    version = tuple(map(int, version_str.split(".")))
+                    if version and curr_prov_version >= version:
+                        provider_failures["provider version exceeded"].append(ref)
+        if provider_failures:
+            failures[package_name] = dict(provider_failures)
+    if failures:
+        message = (
+            "Found providers raising deprecation warning which must be addressed now.\n"
+            "There are two classes of warnings. One is when the provider version is now\n"
+            "greater than that specified in the warning.\n"
+            "The other is when the current min airflow version for the provider is greater\n"
+            "than specified in the warning.\n\n"
+        )
+        message += yaml.dump(dict(failures))
+        pytest.fail(message)


### PR DESCRIPTION
OK so ... here I offer a way to automate enforcement of deprecation removals.

Enforcement may be triggered by two different means: warning messages and comments.

## Warning messages

Use function `warn_provider_deprecation` to warn of feature removal.
Specify either provider version or min airflow version.  When provider version or min airflow version is greater than the version specified, test will start failing.

Example:
```python
            warn_provider_deprecation(
                "This feature will be removed in provider version 6.0",
                provider_version=(6, 0),
            )
```

## Comments

Sometimes we either can't or won't add a warning message to force a code change or removal.  A common scenario is, a helper function is added in core but will not be available in the provider until the min airflow version catches up.  In this case, the helper code must be copied into the provider.  Then, when the min airflow version has caught up, the duplicated code should be removed and just use core code.

For this scenario, we add two syntaxes for todo comments:

For min airflow version we add comment `# todo: remove-on-min-airflow-version=2.5`:

```python
# todo: remove-on-min-airflow-version=2.5
# when removing, import this from airflow.exceptions
def warn_provider_deprecation(
    message, *, provider_version=None, min_airflow_version=None, category=DeprecationWarning, **kwargs
):
    warnings.warn(message, category=DeprecationWarning, **kwargs)
```

## What it looks like

Gives helpful test failure messages like this:
<img width="698" alt="image" src="https://user-images.githubusercontent.com/15932138/200950674-cae56bfc-67e6-44fe-b272-add2e5553b23.png">

And for provider version we add `# todo: remove-on-provider-version=2.5`