### PR TITLE
Change host to endpoint_url in amazon remote logging docs

### DIFF
--- a/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
+++ b/docs/apache-airflow-providers-amazon/logging/s3-task-handler.rst
@@ -45,8 +45,8 @@ In the above example, Airflow will try to use ``S3Hook(aws_conn_id='my_s3_conn')
 
 You can also use `LocalStack <https://localstack.cloud/>`_ to emulate Amazon S3 locally.
 To configure it, you must additionally set the endpoint url to point to your local stack.
-You can do this via the Connection Extra ``host`` field.
-For example, ``{"host": "http://localstack:4572"}``
+You can do this via the Connection Extra ``endpoint_url`` field.
+For example, ``{"endpoint_url": "http://localstack:4572"}``
 
 Enabling remote logging for Amazon S3 with AWS IRSA
 '''''''''''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Update remote logging to S3 documentation after #25494 , where `extra[host]` was changed to `extra[endpoint_url]`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
