### PR TITLE
sagemaker operators: mutualize init of aws_conn_id

### DIFF
--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -51,9 +51,10 @@ class SageMakerBaseOperator(BaseOperator):
     ui_color: str = "#ededed"
     integer_fields: list[list[Any]] = []
 
-    def __init__(self, *, config: dict, **kwargs):
+    def __init__(self, *, config: dict, aws_conn_id: str, **kwargs):
         super().__init__(**kwargs)
         self.config = config
+        self.aws_conn_id = aws_conn_id
 
     def parse_integer(self, config: dict, field: list[str] | str) -> None:
         """Recursive method for parsing string fields holding integer values to integers."""
@@ -150,14 +151,13 @@ class SageMakerProcessingOperator(SageMakerBaseOperator):
         action_if_job_exists: str = "increment",
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         if action_if_job_exists not in ("increment", "fail"):
             raise AirflowException(
                 f"Argument action_if_job_exists accepts only 'increment' and 'fail'. \
                 Provided value: '{action_if_job_exists}'."
             )
         self.action_if_job_exists = action_if_job_exists
-        self.aws_conn_id = aws_conn_id
         self.wait_for_completion = wait_for_completion
         self.print_log = print_log
         self.check_interval = check_interval
@@ -222,8 +222,7 @@ class SageMakerEndpointConfigOperator(SageMakerBaseOperator):
         aws_conn_id: str = DEFAULT_CONN_ID,
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
 
     def _create_integer_fields(self) -> None:
         """Set fields which should be cast to integers."""
@@ -302,8 +301,7 @@ class SageMakerEndpointOperator(SageMakerBaseOperator):
         operation: str = "create",
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
         self.max_ingestion_time = max_ingestion_time
@@ -430,8 +428,7 @@ class SageMakerTransformOperator(SageMakerBaseOperator):
         action_if_job_exists: str = "increment",
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
         self.max_ingestion_time = max_ingestion_time
@@ -542,8 +539,7 @@ class SageMakerTuningOperator(SageMakerBaseOperator):
         max_ingestion_time: int | None = None,
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         self.wait_for_completion = wait_for_completion
         self.check_interval = check_interval
         self.max_ingestion_time = max_ingestion_time
@@ -604,8 +600,7 @@ class SageMakerModelOperator(SageMakerBaseOperator):
     """
 
     def __init__(self, *, config: dict, aws_conn_id: str = DEFAULT_CONN_ID, **kwargs):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
 
     def expand_role(self) -> None:
         """Expands an IAM role name into an ARN."""
@@ -665,8 +660,7 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
         action_if_job_exists: str = "increment",
         **kwargs,
     ):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
         self.wait_for_completion = wait_for_completion
         self.print_log = print_log
         self.check_interval = check_interval
@@ -740,8 +734,7 @@ class SageMakerDeleteModelOperator(SageMakerBaseOperator):
     """
 
     def __init__(self, *, config: dict, aws_conn_id: str = DEFAULT_CONN_ID, **kwargs):
-        super().__init__(config=config, **kwargs)
-        self.aws_conn_id = aws_conn_id
+        super().__init__(config=config, aws_conn_id=aws_conn_id, **kwargs)
 
     def execute(self, context: Context) -> Any:
         sagemaker_hook = SageMakerHook(aws_conn_id=self.aws_conn_id)

--- a/airflow/providers/amazon/aws/operators/sagemaker.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker.py
@@ -51,7 +51,7 @@ class SageMakerBaseOperator(BaseOperator):
     ui_color: str = "#ededed"
     integer_fields: list[list[Any]] = []
 
-    def __init__(self, *, config: dict, aws_conn_id: str, **kwargs):
+    def __init__(self, *, config: dict, aws_conn_id: str = DEFAULT_CONN_ID, **kwargs):
         super().__init__(**kwargs)
         self.config = config
         self.aws_conn_id = aws_conn_id


### PR DESCRIPTION
this is done in all initializations, and we even rely on it being there in the `hook` property [on l.112](https://github.com/aws-mwaa/upstream-to-airflow/blob/b3dbcf91196de3f07434f16d2fae00d1ceaa0a5a/airflow/providers/amazon/aws/operators/sagemaker.py#L112)