### PR TITLE
Use self.parameters in SQLCheckOperator.execute

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -626,7 +626,7 @@ class SQLCheckOperator(BaseSQLOperator):
 
     def execute(self, context: Context):
         self.log.info("Executing SQL check: %s", self.sql)
-        records = self.get_db_hook().get_first(self.sql)
+        records = self.get_db_hook().get_first(self.sql, self.parameters)
 
         self.log.info("Record: %s", records)
         if not records:


### PR DESCRIPTION
The method `execute` of the class `SQLCheckOperator` is not using the parameter `parameters`.