### PR TITLE
Init all Airflow routes when testing API

### DIFF
--- a/tests/api_connexion/conftest.py
+++ b/tests/api_connexion/conftest.py
@@ -34,6 +34,7 @@ def minimal_app_for_api():
             "init_api_experimental_auth",
             "init_api_connexion",
             "init_airflow_session_interface",
+            "init_appbuilder_views",
         ]
     )
     def factory():


### PR DESCRIPTION
We should init all of the Airflow routes when testing the API, as we now have a code path that expects them.