### PR TITLE
Fix backwards compatibility for RedshiftSQLOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/redshift_sql.py
+++ b/airflow/providers/amazon/aws/operators/redshift_sql.py
@@ -42,15 +42,13 @@ class RedshiftSQLOperator(SQLExecuteQueryOperator):
 
     template_fields: Sequence[str] = (
         "sql",
-        "redshift_conn_id",
         "conn_id",
     )
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "postgresql"}
 
     def __init__(self, *, redshift_conn_id: str = "redshift_default", **kwargs) -> None:
-        self.redshift_conn_id = redshift_conn_id
-        super().__init__(conn_id=self.redshift_conn_id, **kwargs)
+        super().__init__(conn_id=redshift_conn_id, **kwargs)
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",

--- a/airflow/providers/amazon/aws/operators/redshift_sql.py
+++ b/airflow/providers/amazon/aws/operators/redshift_sql.py
@@ -43,12 +43,14 @@ class RedshiftSQLOperator(SQLExecuteQueryOperator):
     template_fields: Sequence[str] = (
         "sql",
         "redshift_conn_id",
+        "conn_id",
     )
     template_ext: Sequence[str] = (".sql",)
     template_fields_renderers = {"sql": "postgresql"}
 
     def __init__(self, *, redshift_conn_id: str = "redshift_default", **kwargs) -> None:
-        super().__init__(conn_id=redshift_conn_id, **kwargs)
+        self.redshift_conn_id = redshift_conn_id
+        super().__init__(conn_id=self.redshift_conn_id, **kwargs)
         warnings.warn(
             """This class is deprecated.
             Please use `airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator`.""",


### PR DESCRIPTION
With the introduction of `SQLExecuteQueryOperator`, the `RedshiftSQLOperator` was broken. This was due to the parameter `redshift_conn_id` not being used. This PR fixes the issue by introducing the `redshift_conn_id` as a variable to pass the connection id through to the base operator. 

related: #25717
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
