### PR TITLE
Make Kubernetes Executor & Scheduler Resilient to error during PMH execution

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -337,6 +337,10 @@ class TaskDeferralError(AirflowException):
     """Raised when a task failed during deferral for some reason."""
 
 
+class PodMutationHookException(AirflowException):
+    """Raised when exception happens during Pod Mutation Hook execution"""
+
+
 class PodReconciliationError(AirflowException):
     """Raised when an error is encountered while trying to merge pod configs."""
 

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -652,7 +652,7 @@ class KubernetesExecutor(BaseExecutor):
                 except PodMutationHookException as e:
                     key, _, _, _ = task
                     self.log.warning(
-                        'Pod Mutation Hook failed for the task %s. Re-queueing. Details: %s',
+                        "Pod Mutation Hook failed for the task %s. Re-queueing. Details: %s",
                         key,
                         e,
                     )

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -651,12 +651,12 @@ class KubernetesExecutor(BaseExecutor):
                         self.task_queue.put(task)
                 except PodMutationHookException as e:
                     key, _, _, _ = task
-                    self.log.warning(
-                        "Pod Mutation Hook failed for the task %s. Re-queueing. Details: %s",
+                    self.log.error(
+                        "Pod Mutation Hook failed for the task %s. Failing task. Details: %s",
                         key,
                         e,
                     )
-                    self.task_queue.put(task)
+                    self.fail(key, e)
                 finally:
                     self.task_queue.task_done()
             except Empty:

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -37,7 +37,7 @@ from kubernetes.client import Configuration, models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3.exceptions import ReadTimeoutError
 
-from airflow.exceptions import AirflowException, PodReconciliationError, PodMutationHookException
+from airflow.exceptions import AirflowException, PodMutationHookException, PodReconciliationError
 from airflow.executors.base_executor import NOT_STARTED_MESSAGE, BaseExecutor, CommandType
 from airflow.kubernetes import pod_generator
 from airflow.kubernetes.kube_client import get_kube_client

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -325,8 +325,8 @@ class TestKubernetesExecutor:
         assert mock_pmh.call_count == 1
         # There should be no pod creation request sent
         assert mock_kube_client.create_namespaced_pod.call_count == 0
-        # The task should have been re-queued
-        assert not kubernetes_executor.task_queue.empty()
+        # The task is not re-queued
+        assert kubernetes_executor.task_queue.empty()
 
     @pytest.mark.skipif(
         AirflowKubernetesScheduler is None, reason="kubernetes python package is not installed"


### PR DESCRIPTION

Currently there is no try-catch logic when `pod_mutation_hook` is called in the Kubernetes Executor. So if there is any error/exception during the execution of the `pod_mutation_hook` user created, the whole executor/scheduler will crash. 

Such error may happen:
- user who authored the `pod_mutation_hook` made an error inside.
- if there is any code inside the `pod_mutation_hook` encounters transient error (e.g. it queries DB and the DB gives a timeout error).
- ... you name it. It can simply go wrong.


This PR aims to make Kubernetes Executor & Scheduler more resilient to such error during PMH execution (current behavior, directly crashing, is a bit scary)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
