### PR TITLE
Added exclude_microseconds to cli

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -30,13 +30,14 @@ class Client:
         if auth:
             self._session.auth = auth
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None):
+    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True):
         """Create a dag run for the specified dag.
 
         :param dag_id:
         :param run_id:
         :param conf:
         :param execution_date:
+        :param replace_microseconds:
         :return:
         """
         raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -43,7 +43,7 @@ class Client(api_client.Client):
 
         return resp.json()
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None):
+    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True):
         endpoint = f"/api/experimental/dags/{dag_id}/dag_runs"
         url = urljoin(self._api_base_url, endpoint)
         data = self._request(
@@ -53,6 +53,7 @@ class Client(api_client.Client):
                 "run_id": run_id,
                 "conf": conf,
                 "execution_date": execution_date,
+                "replace_microseconds": replace_microseconds,
             },
         )
         return data["message"]

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -28,9 +28,13 @@ from airflow.models.pool import Pool
 class Client(api_client.Client):
     """Local API client implementation."""
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None):
+    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True):
         dag_run = trigger_dag.trigger_dag(
-            dag_id=dag_id, run_id=run_id, conf=conf, execution_date=execution_date
+            dag_id=dag_id,
+            run_id=run_id,
+            conf=conf,
+            execution_date=execution_date,
+            replace_microseconds=replace_microseconds,
         )
         return f"Created {dag_run}"
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -174,18 +174,6 @@ def string_lower_type(val):
     return val.strip().lower()
 
 
-def bool_type(val):
-    """Bool arg"""
-    if isinstance(val, bool):
-        return val
-    if val == "True":
-        return True
-    elif val == "False":
-        return False
-    else:
-        raise argparse.ArgumentTypeError(f"Boolean string expected, got={val}")
-
-
 # Shared
 ARG_DAG_ID = Arg(("dag_id",), help="The id of the dag")
 ARG_TASK_ID = Arg(("task_id",), help="The id of the task")
@@ -446,7 +434,10 @@ ARG_RUN_ID = Arg(("-r", "--run-id"), help="Helps to identify this run")
 ARG_CONF = Arg(("-c", "--conf"), help="JSON string that gets pickled into the DagRun's conf attribute")
 ARG_EXEC_DATE = Arg(("-e", "--exec-date"), help="The execution date of the DAG", type=parsedate)
 ARG_REPLACE_MICRO = Arg(
-    ("--replace-microseconds",), help="whether microseconds should be zeroed", default=True, type=bool_type
+    ("--replace-microseconds",),
+    help="whether microseconds should be zeroed",
+    action="store_false",
+    default=True,
 )
 
 # db

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -174,6 +174,18 @@ def string_lower_type(val):
     return val.strip().lower()
 
 
+def bool_type(val):
+    """Bool arg"""
+    if isinstance(val, bool):
+        return val
+    if val == "True":
+        return True
+    elif val == "False":
+        return False
+    else:
+        raise argparse.ArgumentTypeError(f"Boolean string expected, got={val}")
+
+
 # Shared
 ARG_DAG_ID = Arg(("dag_id",), help="The id of the dag")
 ARG_TASK_ID = Arg(("task_id",), help="The id of the task")
@@ -433,6 +445,9 @@ ARG_IMGCAT = Arg(("--imgcat",), help="Displays graph using the imgcat tool.", ac
 ARG_RUN_ID = Arg(("-r", "--run-id"), help="Helps to identify this run")
 ARG_CONF = Arg(("-c", "--conf"), help="JSON string that gets pickled into the DagRun's conf attribute")
 ARG_EXEC_DATE = Arg(("-e", "--exec-date"), help="The execution date of the DAG", type=parsedate)
+ARG_REPLACE_MICRO = Arg(
+    ("--replace-microseconds",), help="whether microseconds should be zeroed", default=True, type=bool_type
+)
 
 # db
 ARG_DB_TABLES = Arg(
@@ -1082,7 +1097,7 @@ DAGS_COMMANDS = (
         name="trigger",
         help="Trigger a DAG run",
         func=lazy_load_command("airflow.cli.commands.dag_command.dag_trigger"),
-        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_RUN_ID, ARG_CONF, ARG_EXEC_DATE, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_SUBDIR, ARG_RUN_ID, ARG_CONF, ARG_EXEC_DATE, ARG_VERBOSE, ARG_REPLACE_MICRO),
     ),
     ActionCommand(
         name="delete",

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -434,8 +434,9 @@ ARG_RUN_ID = Arg(("-r", "--run-id"), help="Helps to identify this run")
 ARG_CONF = Arg(("-c", "--conf"), help="JSON string that gets pickled into the DagRun's conf attribute")
 ARG_EXEC_DATE = Arg(("-e", "--exec-date"), help="The execution date of the DAG", type=parsedate)
 ARG_REPLACE_MICRO = Arg(
-    ("--replace-microseconds",),
+    ("--no-replace-microseconds",),
     help="whether microseconds should be zeroed",
+    dest="replace_microseconds",
     action="store_false",
     default=True,
 )

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -143,7 +143,11 @@ def dag_trigger(args):
     api_client = get_current_api_client()
     try:
         message = api_client.trigger_dag(
-            dag_id=args.dag_id, run_id=args.run_id, conf=args.conf, execution_date=args.exec_date
+            dag_id=args.dag_id,
+            run_id=args.run_id,
+            conf=args.conf,
+            execution_date=args.exec_date,
+            replace_microseconds=args.replace_microseconds,
         )
         print(message)
     except OSError as err:

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -570,6 +570,28 @@ class TestCliDags:
         assert dagrun.data_interval_start.isoformat(timespec="seconds") == "2021-06-03T00:00:00+00:00"
         assert dagrun.data_interval_end.isoformat(timespec="seconds") == "2021-06-04T00:00:00+00:00"
 
+    def test_trigger_dag_with_microseconds(self):
+        dag_command.dag_trigger(
+            self.parser.parse_args(
+                [
+                    "dags",
+                    "trigger",
+                    "example_bash_operator",
+                    "--run-id=test_trigger_dag_with_micro",
+                    "--exec-date=2021-06-04T09:00:00.000001+08:00",
+                    "--replace-microseconds=False",
+                ],
+            )
+        )
+
+        with create_session() as session:
+            dagrun = session.query(DagRun).filter(DagRun.run_id == "test_trigger_dag_with_micro").one()
+
+        assert dagrun, "DagRun not created"
+        assert dagrun.run_type == DagRunType.MANUAL
+        assert dagrun.external_trigger
+        assert dagrun.execution_date.isoformat(timespec="microseconds") == "2021-06-04T01:00:00.000001+00:00"
+
     def test_trigger_dag_invalid_conf(self):
         with pytest.raises(ValueError):
             dag_command.dag_trigger(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -579,7 +579,7 @@ class TestCliDags:
                     "example_bash_operator",
                     "--run-id=test_trigger_dag_with_micro",
                     "--exec-date=2021-06-04T09:00:00.000001+08:00",
-                    "--replace-microseconds=False",
+                    "--replace-microseconds",
                 ],
             )
         )

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -579,7 +579,7 @@ class TestCliDags:
                     "example_bash_operator",
                     "--run-id=test_trigger_dag_with_micro",
                     "--exec-date=2021-06-04T09:00:00.000001+08:00",
-                    "--replace-microseconds",
+                    "--no-replace-microseconds",
                 ],
             )
         )


### PR DESCRIPTION
This PR adds replace_microseconds argument to trigger dag cli.

See issues https://github.com/apache/airflow/issues/27519 & https://github.com/apache/airflow/issues/25836 for more details.
closes: https://github.com/apache/airflow/issues/25836