### PR TITLE
Update API version

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -229,7 +229,7 @@ info:
     This means that the server encountered an unexpected condition that prevented it from
     fulfilling the request.
 
-  version: '2.3.0'
+  version: '2.4.0'
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
We might have forgotten to upgrade the API and Python client version when releasing 2.4.

The stable release of the API is currently 2.3, we also have mentions of 'new in 2.4.0' in the current version.


![image](https://user-images.githubusercontent.com/14861206/201525008-1eea553e-5aa0-442f-8ced-ec9488350ef3.png)
![image](https://user-images.githubusercontent.com/14861206/201524988-dabd95e1-2919-43bb-8e76-613271e86d25.png)
