### PR TITLE
Added Boto3Operator, Boto3Sensor

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_boto3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_boto3.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.decorators import task
+from airflow.models.dag import DAG
+from airflow.providers.amazon.aws.operators.boto3 import Boto3Operator
+from airflow.providers.amazon.aws.sensors.boto3 import Boto3Sensor
+
+
+AWS_CONNECTION_ID = "aws_default_conn"
+
+
+@task
+def generate_db_instance_identifier(**kwargs):
+    return f"example-database-{datetime.now():%Y-%m-%d-%H-%M-%S%z}"
+
+
+with DAG(
+    dag_id="example-boto3-dag",
+) as dag:
+    """Example for boto3 DAG, in the case it interacts with RDS only. Can be used for any client that boto3 supports.
+    What it does:
+    - Looks for latest database instance snapshot
+    - Restores it into new DB instance
+    - Does some data manipulation (Not implemented in the example)
+    - Destroys created DB instance
+    """
+
+    latest_snapshot_arn = Boto3Operator(
+        task_id="get_latest_snapshot",
+        aws_conn_id=AWS_CONNECTION_ID,
+        boto3_callable="rds.describe_db_snapshots",
+        boto3_kwargs={
+            "DBInstanceIdentifier": "my-database",
+        },
+        # The operator itself lists all the snapshots, `result_handler` takes ARN of last one by creation date.
+        # The result will be saved as xcom and will be available for consequent tasks
+        result_handler=lambda results: sorted(
+            results["DBSnapshots"], key=lambda x: x["SnapshotCreateTime"], reverse=True
+        )[0]["DBSnapshotArn"],
+    )
+
+    db_instance_identifier = generate_db_instance_identifier()
+
+    restore_db_from_snapshot = Boto3Operator(
+        task_id="restore_db_from_snapshot",
+        aws_conn_id=AWS_CONNECTION_ID,
+        boto3_callable="rds.restore_db_instance_from_db_snapshot",
+        boto3_kwargs={
+            "DBInstanceIdentifier": db_instance_identifier,
+            "DBSnapshotIdentifier": latest_snapshot_arn.output,
+            "DBInstanceClass": "db.t2.small",
+            "DBSubnetGroupName": "my-subnet-group",
+            "VpcSecurityGroupIds": ["sg-my-security-group"],
+            "Tags": [
+                {"Key": "env", "Value": "example"},
+            ],
+        },
+        # Do not store any results as xcom
+        result_handler=lambda x: None,
+    )
+
+    wait_until_rds_instance_available = Boto3Sensor(
+        task_id="wait_until_rds_instance_available",
+        aws_conn_id=AWS_CONNECTION_ID,
+        boto3_callable="rds.describe_db_instances",
+        boto3_kwargs={"DBInstanceIdentifier": db_instance_identifier},
+        # Lambda function that returns True once criteria met
+        poke_handler=lambda x: x["DBInstances"][0]["DBInstanceStatus"] == "available",
+        mode="reschedule",
+        poke_interval=300,
+    )
+
+    get_rds_endpoint_hostname = Boto3Operator(
+        task_id="get_rds_endpoint_hostname",
+        aws_conn_id=AWS_CONNECTION_ID,
+        boto3_callable="rds.describe_db_instances",
+        boto3_kwargs={"DBInstanceIdentifier": db_instance_identifier},
+        # Extract endpoint address that we can connect to
+        result_handler=lambda result: result["DBInstances"][0]["Endpoint"]["Address"],
+    )
+
+    ############################################
+    ### Data processing opearators goes here ###
+    ############################################
+
+    destroy_db_instance = Boto3Operator(
+        task_id="destroy_db_instance",
+        aws_conn_id=AWS_CONNECTION_ID,
+        boto3_callable="rds.delete_db_instance",
+        boto3_kwargs={
+            "DBInstanceIdentifier": db_instance_identifier,
+            "SkipFinalSnapshot": True,
+        },
+    )
+
+    (
+        latest_snapshot_arn
+        >> db_instance_identifier
+        >> restore_db_from_snapshot
+        >> wait_until_rds_instance_available
+        >> get_rds_endpoint_hostname
+        >> destroy_db_instance
+    )

--- a/airflow/providers/amazon/aws/operators/boto3.py
+++ b/airflow/providers/amazon/aws/operators/boto3.py
@@ -30,7 +30,11 @@ if TYPE_CHECKING:
 class Boto3BaseOperator(BaseOperator):
     """Base boto3 operator for interating with AWS via boto3"""
 
-    template_fields: Sequence[str] = ("client_type", "client_method", "method_kwargs",)
+    template_fields: Sequence[str] = (
+        "client_type",
+        "client_method",
+        "method_kwargs",
+    )
 
     def __init__(
         self,
@@ -50,7 +54,7 @@ class Boto3BaseOperator(BaseOperator):
             method_kwargs (dict, optional): Parameters to pass to the client_method. Example: {"DBInstanceIdentifier": "my-database"} Defaults to None.
         """
         if not client_method.isidentifier():
-            raise ParamValidationError(f"\"{client_method}\" is not valid client_method")
+            raise ParamValidationError(f'"{client_method}" is not valid client_method')
 
         self.client_type = client_type
         self.client_method = client_method
@@ -70,7 +74,9 @@ class Boto3BaseOperator(BaseOperator):
     ):
         method = getattr(self.hook.conn, self.client_method)
         if not callable(method):
-            raise ParamValidationError(f"Method \"{self.client_method}\" does not exist on boto3 client \"{self.client_type}\"")
+            raise ParamValidationError(
+                f'Method "{self.client_method}" does not exist on boto3 client "{self.client_type}"'
+            )
         return method
 
 

--- a/airflow/providers/amazon/aws/operators/boto3.py
+++ b/airflow/providers/amazon/aws/operators/boto3.py
@@ -33,6 +33,7 @@ class Boto3BaseOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "client_type",
         "client_method",
+        "hook_params",
         "method_kwargs",
     )
 

--- a/airflow/providers/amazon/aws/operators/boto3.py
+++ b/airflow/providers/amazon/aws/operators/boto3.py
@@ -1,0 +1,92 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Sequence
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
+
+from airflow.models import BaseOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class Boto3BaseOperator(BaseOperator):
+    """Base boto3 operator for interating with AWS via boto3"""
+
+    template_fields: Sequence[str] = ("boto3_kwargs",)
+
+    def __init__(
+        self,
+        *args,
+        aws_conn_id: str = "aws_conn_id",
+        hook_params: dict = None,
+        boto3_callable: str = None,
+        boto3_kwargs: dict = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            aws_conn_id (str, optional): AWS connection id. Defaults to "aws_conn_id".
+            hook_params (dict, optional): Parameters to pass to AwsBaseHook. Defaults to None.
+            boto3_callable (str, optional): boto3 function that the operator should call. Format: <client>.<function>. Example: "rds.describe_db_snapshots". Defaults to None.
+            boto3_kwargs (dict, optional): Parameters to pass to the boto3_callable. Example: {"DBInstanceIdentifier": "my-database"} Defaults to None.
+        """
+        assert (
+            boto3_callable and len(boto3_callable.split(".")) == 2
+        ), f"Wrong boto3_callable: Got '{boto3_callable}' but expected format: '<boto3_client_type>.<function_to_call>'"
+
+        client_type, self.client_callable = boto3_callable.split(".")
+        self.boto3_kwargs = boto3_kwargs or {}
+
+        hook_params = hook_params or {}
+        self.hook = AwsBaseHook(aws_conn_id=aws_conn_id, **hook_params, client_type=client_type)
+        super().__init__(*args, **kwargs)
+
+    @property
+    def boto3_action(
+        self,
+    ):
+        return getattr(self.hook.conn, self.client_callable)
+
+
+class Boto3Operator(Boto3BaseOperator):
+    """boto3 operator that implements interacting with boto3 client"""
+
+    template_fields: Sequence[str] = ("boto3_kwargs",)
+
+    def __init__(self, *args, result_handler: Callable = None, **kwargs):
+        """
+        Args:
+            result_handler (Callable, optional): python function that accepts boto3 call result and does some data transformation. Return value from that function saved as xcom. Defaults to None.
+        """
+        self.handle_result = result_handler
+        super().__init__(*args, **kwargs)
+
+    def execute(self, context: Context) -> Any:
+        result = self.boto3_action(**self.boto3_kwargs)
+
+        if self.handle_result is not None:
+            result = self.handle_result(result)
+
+        if not isinstance(result, str):
+            import json
+
+            return json.dumps(result, default=str)
+
+        return result

--- a/airflow/providers/amazon/aws/operators/boto3.py
+++ b/airflow/providers/amazon/aws/operators/boto3.py
@@ -73,12 +73,11 @@ class Boto3BaseOperator(BaseOperator):
     def boto3_action(
         self,
     ):
-        method = getattr(self.hook.conn, self.client_method)
-        if not callable(method):
+        if self.client_method not in self.hook.conn.meta.method_to_api_mapping:
             raise ParamValidationError(
                 f'Method "{self.client_method}" does not exist on boto3 client "{self.client_type}"'
             )
-        return method
+        return getattr(self.hook.conn, self.client_method)
 
 
 class Boto3Operator(Boto3BaseOperator):

--- a/airflow/providers/amazon/aws/sensors/boto3.py
+++ b/airflow/providers/amazon/aws/sensors/boto3.py
@@ -32,22 +32,23 @@ class Boto3Sensor(BaseSensorOperator, Boto3BaseOperator):
         Boto3Sensor(
             task_id="wait_until_rds_instance_available",
             aws_conn_id=AWS_CONNECTION_ID,
-            boto3_callable="rds.describe_db_instances",
-            boto3_kwargs={"DBInstanceIdentifier": db_instance_identifier},
+            client_type="rds",
+            client_method="describe_db_instances",
+            method_kwargs={"DBInstanceIdentifier": db_instance_identifier},
             poke_handler=lambda x: x["DBInstances"][0]["DBInstanceStatus"] == "available",
             mode="reschedule",
             poke_interval=120,
         )
     """
 
-    def __init__(self, *args, poke_handler: Callable, **kwargs) -> None:
+    def __init__(self, poke_handler: Callable, **kwargs) -> None:
         """
         Args:
             poke_handler (Callable): python function that accepts boto3 call result and returns True if criteria met, False otherwise.
         """
         self.poke_handler = poke_handler
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
 
     def poke(self, context: Context) -> bool:
-        result = self.boto3_action(**self.boto3_kwargs)
+        result = self.boto3_action(**self.method_kwargs)
         return self.poke_handler(result)

--- a/airflow/providers/amazon/aws/sensors/boto3.py
+++ b/airflow/providers/amazon/aws/sensors/boto3.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from airflow.providers.amazon.aws.operators.boto3 import Boto3BaseOperator
+from airflow.sensors.base import BaseSensorOperator
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
+
+
+class Boto3Sensor(BaseSensorOperator, Boto3BaseOperator):
+    """Boto3Sensor can wait for some AWS resource parameter to meet some criteria
+
+    Example:
+        Boto3Sensor(
+            task_id="wait_until_rds_instance_available",
+            aws_conn_id=AWS_CONNECTION_ID,
+            boto3_callable="rds.describe_db_instances",
+            boto3_kwargs={"DBInstanceIdentifier": db_instance_identifier},
+            poke_handler=lambda x: x["DBInstances"][0]["DBInstanceStatus"] == "available",
+            mode="reschedule",
+            poke_interval=120,
+        )
+    """
+
+    def __init__(self, *args, poke_handler: Callable, **kwargs) -> None:
+        """
+        Args:
+            poke_handler (Callable): python function that accepts boto3 call result and returns True if criteria met, False otherwise.
+        """
+        self.poke_handler = poke_handler
+        super().__init__(*args, **kwargs)
+
+    def poke(self, context: Context) -> bool:
+        result = self.boto3_action(**self.boto3_kwargs)
+        return self.poke_handler(result)


### PR DESCRIPTION
Basic implementation of `Boto3Operator` and `Boto3Sensor`. Those are just wrappers of boto3 client, but can be used for creating resource-specific operators. Ex:

```python
class RDSMakeDatabaseSnanshot(Boto3Operator):

    def __init__(self, *args, db_instance_id, db_snapshot_id, result_handler: Callable = None, **kwargs):
        kwargs["boto3_callable"] = "rds.create_db_snapshot"
        kwargs["boto3_kwargs"] = {
            "DBSnapshotIdentifier": db_instance_id,
            "DBInstanceIdentifier": db_snapshot_id,
        }
        super().__init__(*args, result_handler=result_handler, **kwargs)
```

And then use like:
```python
with DAG(
    dag_id="my-dag",
) as dag:

    make_snapshot = RDSMakeDatabaseSnanshot(
        db_instance_id="my-db-instance",
        db_snapshot_id="my-snapshot"
    )
```