### PR TITLE
Correct repo example for cloning via ssh - comments in helm chart

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1780,8 +1780,7 @@ dags:
     enabled: false
 
     # git repo clone url
-    # ssh examples ssh://git@github.com/apache/airflow.git
-    # git@github.com:apache/airflow.git
+    # ssh example: git@github.com:apache/airflow.git
     # https example: https://github.com/apache/airflow.git
     repo: https://github.com/apache/airflow.git
     branch: v2-2-stable


### PR DESCRIPTION
In `values.yaml` file of helm chart there are two options for the git clone url one if which doesn't work. When anyone generates values file using command ```helm show values apache-airflow/airflow > values.yam```  and uses wrong example it leads to errors in git-sync.

Related: 
#21970
https://github.com/apache/airflow/pull/26632
