### PR TITLE
Update build.rst for docker compose and helm chart

### DIFF
--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -180,7 +180,7 @@ In the simplest case building your image consists of those steps:
    In case you use some kind of registry where you will be using the image from, it is usually named
    in the form of ``registry/image-name``. The name of the image has to be configured for the deployment
    method your image will be deployed. This can be set for example as image name in the
-   :doc:`apache-airflow:howto/docker-compose/index` or in the :doc:`helm-chart:index>`.
+   :doc:`apache-airflow:howto/docker-compose/index` or in the :doc:`helm-chart:index`.
 
 .. code-block:: shell
 

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -180,7 +180,7 @@ In the simplest case building your image consists of those steps:
    In case you use some kind of registry where you will be using the image from, it is usually named
    in the form of ``registry/image-name``. The name of the image has to be configured for the deployment
    method your image will be deployed. This can be set for example as image name in the
-   `docker-compose file <running-airflow-in-docker>`_ or in the `Helm chart <helm-chart>`_.
+   `docker-compose file <https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html>`_ or in the `Helm chart <https://airflow.apache.org/docs/helm-chart/stable/index.html>`_.
 
 .. code-block:: shell
 

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -180,7 +180,7 @@ In the simplest case building your image consists of those steps:
    In case you use some kind of registry where you will be using the image from, it is usually named
    in the form of ``registry/image-name``. The name of the image has to be configured for the deployment
    method your image will be deployed. This can be set for example as image name in the
-   `docker-compose file <https://airflow.apache.org/docs/apache-airflow/stable/howto/docker-compose/index.html>`_ or in the `Helm chart <https://airflow.apache.org/docs/helm-chart/stable/index.html>`_.
+   :doc:`apache-airflow:howto/docker-compose/index` or in the :doc:`helm-chart:index>`.
 
 .. code-block:: shell
 


### PR DESCRIPTION
The links are broken for the docker compose and helm charts on the build instructions file

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The docker compose file and helm-charts links are broken on the build documentation page: https://airflow.apache.org/docs/docker-stack/build.html#

This PR fixes the broken links with the appropriate ones.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
