### PR TITLE
Add preserveAsciiControlCharacters to src_fmt_configs

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1769,7 +1769,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 "nullMarker",
                 "quote",
                 "encoding",
-                "preserveAsciiControlCharacters"
+                "preserveAsciiControlCharacters",
             ],
             "DATASTORE_BACKUP": ["projectionFields"],
             "NEWLINE_DELIMITED_JSON": ["autodetect", "ignoreUnknownValues"],

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1769,6 +1769,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                 "nullMarker",
                 "quote",
                 "encoding",
+                "preserveAsciiControlCharacters"
             ],
             "DATASTORE_BACKUP": ["projectionFields"],
             "NEWLINE_DELIMITED_JSON": ["autodetect", "ignoreUnknownValues"],


### PR DESCRIPTION
This PR add option "preserveAsciiControlCharacters" to valid key list of  "src_fmt_configs" of BigQueryHook.run_load()

It help us handle ascii control characters in our data when it is loaded to BigQuery table.

This option is implemented in job api [(docs)](https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload).
