### PR TITLE
Add option to add arguments to PSRP hook and operator

### DIFF
--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -219,7 +219,7 @@ class PsrpHook(BaseHook):
     def invoke_cmdlet(
         self,
         name: str,
-        use_local_scope=None,
+        use_local_scope: bool | None = None,
         arguments: list[str] | None = None,
         parameters: dict[str, str] | None = None,
         **kwargs: str,

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -21,6 +21,7 @@ from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR, INFO, WARNING
 from typing import Any, Callable, Generator
+from warnings import warn
 from weakref import WeakKeyDictionary
 
 from pypsrp.host import PSHost
@@ -215,11 +216,33 @@ class PsrpHook(BaseHook):
             if local_context:
                 self.__exit__(None, None, None)
 
-    def invoke_cmdlet(self, name: str, use_local_scope=None, **parameters: dict[str, str]) -> PowerShell:
+    def invoke_cmdlet(
+        self,
+        name: str,
+        use_local_scope=None,
+        arguments: list[str] | None = None,
+        parameters: dict[str, str] | None = None,
+        **kwargs: str,
+    ) -> PowerShell:
         """Invoke a PowerShell cmdlet and return session."""
+        if kwargs:
+            if parameters:
+                raise ValueError("**kwargs not allowed when 'parameters' is used at the same time.")
+            warn(
+                "Passing **kwargs to 'invoke_cmdlet' is deprecated "
+                "and will be removed in a future release. Please use 'parameters' "
+                "instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            parameters = kwargs
+
         with self.invoke() as ps:
             ps.add_cmdlet(name, use_local_scope=use_local_scope)
-            ps.add_parameters(parameters)
+            for argument in arguments or ():
+                ps.add_argument(argument)
+            if parameters:
+                ps.add_parameters(parameters)
         return ps
 
     def invoke_powershell(self, script: str) -> PowerShell:

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -189,7 +189,7 @@ class TestPsrpHook:
 
     def test_invoke_cmdlet(self, *mocks):
         arguments = ("a", "b", "c")
-        parameters = {"bar": 1, "baz": "2"}
+        parameters = {"bar": "1", "baz": "2"}
         with PsrpHook(CONNECTION_ID) as hook:
             ps = hook.invoke_cmdlet("foo", arguments=arguments, parameters=parameters)
             assert [call("foo", use_local_scope=None)] == ps.add_cmdlet.mock_calls

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -188,6 +188,15 @@ class TestPsrpHook:
         assert isinstance(kwargs["host"], PSHost)
 
     def test_invoke_cmdlet(self, *mocks):
+        arguments = ("a", "b", "c")
+        parameters = {"bar": 1, "baz": "2"}
+        with PsrpHook(CONNECTION_ID) as hook:
+            ps = hook.invoke_cmdlet("foo", arguments=arguments, parameters=parameters)
+            assert [call("foo", use_local_scope=None)] == ps.add_cmdlet.mock_calls
+            assert [call({"bar": "1", "baz": "2"})] == ps.add_parameters.mock_calls
+            assert [call(arg) for arg in arguments] == ps.add_argument.mock_calls
+
+    def test_invoke_cmdlet_deprecated_kwargs(self, *mocks):
         with PsrpHook(CONNECTION_ID) as hook:
             ps = hook.invoke_cmdlet("foo", bar="1", baz="2")
             assert [call("foo", use_local_scope=None)] == ps.add_cmdlet.mock_calls

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -58,10 +58,13 @@ class TestPsrpOperator:
         [
             # These tuples map the command parameter to an execution method and parameter set.
             pytest.param(
-                ExecuteParameter("command", call.add_script("cmd.exe /c @'\nfoo\n'@"), None, None), id="command"
+                ExecuteParameter("command", call.add_script("cmd.exe /c @'\nfoo\n'@"), None, None),
+                id="command",
             ),
             pytest.param(ExecuteParameter("powershell", call.add_script("foo"), None, None), id="powershell"),
-            pytest.param(ExecuteParameter("cmdlet", call.add_cmdlet("foo"), ["abc"], {"bar": "baz"}), id="cmdlet"),
+            pytest.param(
+                ExecuteParameter("cmdlet", call.add_cmdlet("foo"), ["abc"], {"bar": "baz"}), id="cmdlet"
+            ),
         ],
     )
     @patch(f"{PsrpOperator.__module__}.PsrpHook")

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -35,6 +35,7 @@ CONNECTION_ID = "conn_id"
 class ExecuteParameter(NamedTuple):
     name: str
     expected_method: str
+    expected_arguments: list[str] | None
     expected_parameters: dict[str, Any] | None
 
 
@@ -57,15 +58,17 @@ class TestPsrpOperator:
         [
             # These tuples map the command parameter to an execution method and parameter set.
             pytest.param(
-                ExecuteParameter("command", call.add_script("cmd.exe /c @'\nfoo\n'@"), None), id="command"
+                ExecuteParameter("command", call.add_script("cmd.exe /c @'\nfoo\n'@"), None, None), id="command"
             ),
-            pytest.param(ExecuteParameter("powershell", call.add_script("foo"), None), id="powershell"),
-            pytest.param(ExecuteParameter("cmdlet", call.add_cmdlet("foo"), {"bar": "baz"}), id="cmdlet"),
+            pytest.param(ExecuteParameter("powershell", call.add_script("foo"), None, None), id="powershell"),
+            pytest.param(ExecuteParameter("cmdlet", call.add_cmdlet("foo"), ["abc"], {"bar": "baz"}), id="cmdlet"),
         ],
     )
     @patch(f"{PsrpOperator.__module__}.PsrpHook")
     def test_execute(self, hook_impl, parameter, had_errors, rc, do_xcom_push):
         kwargs = {parameter.name: "foo"}
+        if parameter.expected_arguments:
+            kwargs["arguments"] = parameter.expected_arguments
         if parameter.expected_parameters:
             kwargs["parameters"] = parameter.expected_parameters
         psrp_session_init = Mock(spec=Command)
@@ -100,6 +103,8 @@ class TestPsrpOperator:
             call.add_command(psrp_session_init),
             parameter.expected_method,
         ]
+        if parameter.expected_arguments:
+            expected_ps_calls.append(call.add_argument("abc"))
         if parameter.expected_parameters:
             expected_ps_calls.extend([call.add_parameters({"bar": "baz"})])
         if parameter.name in ("cmdlet", "powershell") and do_xcom_push:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This adds an optional `arguments` parameter to the hook and operator which allows invoking cmdlets with arguments (rather than parameters, i.e. named arguments).

At the same time, passing parameters to `invoke_cmdlet` using **kwargs notation is deprecated; instead, parameters are now passed using the `parameters` optional keyword arguments.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
