### PR TITLE
Optimize TI.xcom_pull() with explicit task_ids and map_indexes

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -699,6 +699,8 @@ class LazyXComAccess(collections.abc.Sequence):
     Note that since the session bound to the parent query may have died when we
     actually access the sequence's content, we must create a new session
     for every function call with ``with_session()``.
+
+    :meta private:
     """
 
     _query: Query = attr.ib(repr=False)

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -701,28 +701,12 @@ class LazyXComAccess(collections.abc.Sequence):
     for every function call with ``with_session()``.
     """
 
-    dag_id: str
-    run_id: str
-    task_id: str
     _query: Query = attr.ib(repr=False)
     _len: int | None = attr.ib(init=False, repr=False, default=None)
 
     @classmethod
-    def build_from_single_xcom(cls, first: XCom, query: Query) -> LazyXComAccess:
-        return cls(
-            dag_id=first.dag_id,
-            run_id=first.run_id,
-            task_id=first.task_id,
-            query=query.with_entities(XCom.value)
-            .filter(
-                XCom.run_id == first.run_id,
-                XCom.task_id == first.task_id,
-                XCom.dag_id == first.dag_id,
-                XCom.map_index >= 0,
-            )
-            .order_by(None)
-            .order_by(XCom.map_index.asc()),
-        )
+    def build_from_xcom_query(cls, query: Query) -> LazyXComAccess:
+        return cls(query=query.with_entities(XCom.value))
 
     def __len__(self):
         if self._len is None:

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -21,6 +21,7 @@ import collections.abc
 import contextlib
 import datetime
 import inspect
+import itertools
 import json
 import logging
 import pickle
@@ -703,12 +704,24 @@ class LazyXComAccess(collections.abc.Sequence):
     :meta private:
     """
 
-    _query: Query = attr.ib(repr=False)
-    _len: int | None = attr.ib(init=False, repr=False, default=None)
+    _query: Query
+    _len: int | None = attr.ib(init=False, default=None)
 
     @classmethod
     def build_from_xcom_query(cls, query: Query) -> LazyXComAccess:
         return cls(query=query.with_entities(XCom.value))
+
+    def __repr__(self) -> str:
+        return f"LazyXComAccess([{len(self)} items])"
+
+    def __str__(self) -> str:
+        return str(list(self))
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, (list, LazyXComAccess)):
+            z = itertools.zip_longest(iter(self), iter(other), fillvalue=object())
+            return all(x == y for x, y in z)
+        return NotImplemented
 
     def __len__(self):
         if self._len is None:

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -497,7 +497,7 @@ class BaseXCom(Base, LoggingMixin):
         elif dag_ids is not None:
             query = query.filter(cls.dag_id == dag_ids)
 
-        if isinstance(map_indexes, range) and map_indexes.step == 1:
+        if isinstance(map_indexes, range) and abs(map_indexes.step) == 1:
             query = query.filter(cls.map_index >= map_indexes.start, cls.map_index < map_indexes.stop)
         elif is_container(map_indexes):
             query = query.filter(cls.map_index.in_(map_indexes))

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -496,7 +496,9 @@ class BaseXCom(Base, LoggingMixin):
         elif dag_ids is not None:
             query = query.filter(cls.dag_id == dag_ids)
 
-        if is_container(map_indexes):
+        if isinstance(map_indexes, range) and map_indexes.step == 1:
+            query = query.filter(cls.map_index >= map_indexes.start, cls.map_index < map_indexes.stop)
+        elif is_container(map_indexes):
             query = query.filter(cls.map_index.in_(map_indexes))
         elif map_indexes is not None:
             query = query.filter(cls.map_index == map_indexes)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -47,26 +47,22 @@ from airflow.exceptions import (
     UnmappableXComTypePushed,
     XComForMappingNotPushed,
 )
-from airflow.models import (
-    DAG,
-    Connection,
-    DagBag,
-    DagRun,
-    Pool,
-    RenderedTaskInstanceFields,
-    TaskInstance as TI,
-    TaskReschedule,
-    Variable,
-    XCom,
-)
+from airflow.models.connection import Connection
+from airflow.models.dag import DAG
+from airflow.models.dagbag import DagBag
+from airflow.models.dagrun import DagRun
 from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent, DatasetModel
 from airflow.models.expandinput import EXPAND_INPUT_EMPTY, NotFullyPopulated
 from airflow.models.param import process_params
+from airflow.models.pool import Pool
+from airflow.models.renderedtifields import RenderedTaskInstanceFields
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskfail import TaskFail
-from airflow.models.taskinstance import TaskInstance
+from airflow.models.taskinstance import TaskInstance, TaskInstance as TI
 from airflow.models.taskmap import TaskMap
-from airflow.models.xcom import XCOM_RETURN_KEY
+from airflow.models.taskreschedule import TaskReschedule
+from airflow.models.variable import Variable
+from airflow.models.xcom import XCOM_RETURN_KEY, LazyXComAccess, XCom
 from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
@@ -3522,9 +3518,8 @@ def test_ti_xcom_pull_on_mapped_operator_return_lazy_iterable(mock_deserialize_v
 
     # Simply pulling the joined XCom value should not deserialize.
     joined = ti_2.xcom_pull("task_1", session=session)
+    assert isinstance(joined, LazyXComAccess)
     assert mock_deserialize_value.call_count == 0
-
-    assert repr(joined) == "LazyXComAccess(dag_id='test_xcom', run_id='test', task_id='task_1')"
 
     # Only when we go through the iterable does deserialization happen.
     it = iter(joined)


### PR DESCRIPTION
Three optimizations here:

1. If the provided `map_indexes` value is a `range` object with `step=1`, we can optimize the query to use `>=` and `<` instead of `IN`.
2. Instead of eagerly pulling values from database and sort in Python, we can use `CASE` to make the database perform the sorting instead.
3. If `map_indexes` is a range, the above sorting can be further optimized into a simple column ordering and take advantage of the index.

I’m pretty sure the first and third are harmless. Less sure about the second; while this likely requires a full scan, it is needed anyway at the Python side when the values are returned, so it’s probably never (much) worse?

Also a small portion of #27678.