### PR TITLE
Replace helm chart icon

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -26,7 +26,7 @@ description: The official Helm chart to deploy Apache Airflow, a platform to
 home: https://airflow.apache.org/
 sources:
   - https://github.com/apache/airflow
-icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
+icon: https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/logos/airflow_64x64_emoji_transparent.png
 keywords:
   - apache
   - airflow

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -26,7 +26,7 @@ description: The official Helm chart to deploy Apache Airflow, a platform to
 home: https://airflow.apache.org/
 sources:
   - https://github.com/apache/airflow
-icon: https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/logos/airflow_64x64_emoji_transparent.png
+icon: https://airflow.apache.org/images/airflow_dark_bg.png
 keywords:
   - apache
   - airflow


### PR DESCRIPTION
The current helm chart icon defined in Chart.yaml can't be found. I replaced it with another icon.
komodorio/helm-dashboard#90