### PR TITLE
Google secret backend impersonalization feature

### DIFF
--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -76,6 +76,8 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
     :param gcp_scopes: Comma-separated string containing OAuth2 scopes
     :param project_id: Project ID to read the secrets from. If not passed, the project ID from credentials
         will be used.
+    :param impersonation_chain: the service account to impersonate or a chained list leading to this
+    account
     :param sep: Separator used to concatenate connections_prefix and conn_id. Default: "-"
     """
 


### PR DESCRIPTION
This feature enables to use _impersonation_chain_ in kwargs in env variables setting Google secret manager backend.
Example of the use of new feature:
 ```
AIRFLOW__SECRETS__BACKEND=airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
AIRFLOW__SECRETS__BACKEND_KWARGS='{"impersonation_chain":"service_account@project_id.iam.gserviceaccount.com","project_id":"project_id","connections_prefix": "airflow-connections", "variables_prefix": "airflow-variables"}'
```

Why this change is needed? 
Our Airflow deployment service account and team developers accounts share one main team serviceaccount via serviceAccountTokenCreator permission. This team serviceaccount has accesses to particular services like BQ, GCS, Google secrets. While BQ and GCS operators has impersonalisation_chain arg, google secret manager backend doesnt support this feautre. Using this new feature all approaches are aligned and it is possible to follow this good pattern.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
