### PR TITLE
fix(sec): upgrade jinja2 to 2.11.3

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0
 cached_property;python_version<"3.8"
-jinja2>=2.10
+jinja2>=2.11.3
 keyring==10.1
 PyGithub
 jsonpath_ng


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in jinja2 2.10
- [CVE-2019-10906](https://www.oscs1024.com/hd/CVE-2019-10906)


### What did I do？
Upgrade jinja2 from 2.10 to 2.11.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS