### PR TITLE
Allow SSL mode in MySQL provider

### DIFF
--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -127,6 +127,8 @@ class MySqlHook(DbApiHook):
             if isinstance(dejson_ssl, str):
                 dejson_ssl = json.loads(dejson_ssl)
             conn_config["ssl"] = dejson_ssl
+        if conn.extra_dejson.get("ssl_mode", False):
+            conn_config["ssl_mode"] = conn.extra_dejson["ssl_mode"]
         if conn.extra_dejson.get("unix_socket"):
             conn_config["unix_socket"] = conn.extra_dejson["unix_socket"]
         if local_infile:
@@ -144,6 +146,11 @@ class MySqlHook(DbApiHook):
 
         if conn.extra_dejson.get("allow_local_infile", False):
             conn_config["allow_local_infile"] = True
+        # Adding 'ssl_mode' key to keep it consistent with mysql_client
+        if conn.extra_dejson.get("ssl_mode", False):
+            conn_config["ssl-mode"] = conn.extra_dejson["ssl_mode"]
+        if conn.extra_dejson.get("ssl_ca", False):
+            conn_config["ssl-ca"] = conn.extra_dejson["ssl_ca"]
 
         return conn_config
 

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -146,11 +146,10 @@ class MySqlHook(DbApiHook):
 
         if conn.extra_dejson.get("allow_local_infile", False):
             conn_config["allow_local_infile"] = True
-        # Adding 'ssl_mode' key to keep it consistent with mysql_client
-        if conn.extra_dejson.get("ssl_mode", False):
-            conn_config["ssl-mode"] = conn.extra_dejson["ssl_mode"]
-        if conn.extra_dejson.get("ssl_ca", False):
-            conn_config["ssl-ca"] = conn.extra_dejson["ssl_ca"]
+        # Ref: https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html
+        for key, value in conn.extra_dejson.items():
+            if key.startswith("ssl_"):
+                conn_config[key] = value
 
         return conn_config
 

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -228,13 +228,13 @@ class TestMySqlHookConnMySqlConnectorPython(unittest.TestCase):
     @mock.patch("mysql.connector.connect")
     def test_get_ssl_mode(self, mock_connect):
         extra_dict = self.connection.extra_dejson
-        extra_dict.update(ssl_mode="DISABLED")
+        extra_dict.update(ssl_disabled=True)
         self.connection.extra = json.dumps(extra_dict)
         self.db_hook.get_conn()
         assert mock_connect.call_count == 1
         args, kwargs = mock_connect.call_args
         assert args == ()
-        assert kwargs["ssl-mode"] == "DISABLED"
+        assert kwargs["ssl_disabled"] == 1
 
 
 class MockMySQLConnectorConnection:

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -154,6 +154,15 @@ class TestMySqlHookConn(unittest.TestCase):
         assert kwargs["ssl"] == SSL_DICT
 
     @mock.patch("MySQLdb.connect")
+    def test_get_ssl_mode(self, mock_connect):
+        self.connection.extra = json.dumps({"ssl_mode": "DISABLED"})
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        assert args == ()
+        assert kwargs["ssl_mode"] == "DISABLED"
+
+    @mock.patch("MySQLdb.connect")
     @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type")
     def test_get_conn_rds_iam(self, mock_client, mock_connect):
         self.connection.extra = '{"iam":true}'
@@ -215,6 +224,17 @@ class TestMySqlHookConnMySqlConnectorPython(unittest.TestCase):
         args, kwargs = mock_connect.call_args
         assert args == ()
         assert kwargs["allow_local_infile"] == 1
+
+    @mock.patch("mysql.connector.connect")
+    def test_get_ssl_mode(self, mock_connect):
+        extra_dict = self.connection.extra_dejson
+        extra_dict.update(ssl_mode="DISABLED")
+        self.connection.extra = json.dumps(extra_dict)
+        self.db_hook.get_conn()
+        assert mock_connect.call_count == 1
+        args, kwargs = mock_connect.call_args
+        assert args == ()
+        assert kwargs["ssl-mode"] == "DISABLED"
 
 
 class MockMySQLConnectorConnection:


### PR DESCRIPTION
We need to allow SSL mode to be passed in the connection arguments for MySQL provider. More Information can be found on this - https://github.com/apache/airflow/issues/24675