### PR TITLE
Align TaskGroup semantics to AbstractOperator

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -18,9 +18,7 @@
 from __future__ import annotations
 
 import datetime
-import functools
 import inspect
-import operator
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection, Iterable, Iterator, Sequence
 
 from airflow.compat.functools import cache, cached_property
@@ -284,12 +282,21 @@ class AbstractOperator(LoggingMixin, DAGNode):
         )
 
     def iter_mapped_task_groups(self) -> Iterator[MappedTaskGroup]:
-        """Return mapped task groups this task belongs to."""
+        """Return mapped task groups this task belongs to.
+
+        Groups are returned from the closest to the outmost.
+
+        :meta private:
+        """
         parent = self.task_group
         while parent is not None:
             if isinstance(parent, MappedTaskGroup):
                 yield parent
             parent = parent.task_group
+
+    def get_closest_mapped_task_group(self) -> MappedTaskGroup | None:
+        """:meta private:"""
+        return next(self.iter_mapped_task_groups(), None)
 
     def unmap(self, resolve: None | dict[str, Any] | tuple[Context, Session]) -> BaseOperator:
         """Get the "normal" operator from current abstract operator.
@@ -397,11 +404,10 @@ class AbstractOperator(LoggingMixin, DAGNode):
             mapped task groups.
         :return: Total number of mapped TIs this task should have.
         """
-        mapped_task_groups = list(self.iter_mapped_task_groups())
-        if not mapped_task_groups:
+        group = self.get_closest_mapped_task_group()
+        if group is None:
             raise NotMapped
-        counts = (g.get_parse_time_mapped_ti_count() for g in mapped_task_groups)
-        return functools.reduce(operator.mul, counts)
+        return group.get_parse_time_mapped_ti_count()
 
     def get_mapped_ti_count(self, run_id: str, *, session: Session) -> int:
         """Number of mapped TaskInstances that can be created at run time.
@@ -416,11 +422,10 @@ class AbstractOperator(LoggingMixin, DAGNode):
             mapped task groups.
         :return: Total number of mapped TIs this task should have.
         """
-        mapped_task_groups = list(self.iter_mapped_task_groups())
-        if not mapped_task_groups:
+        group = self.get_closest_mapped_task_group()
+        if group is None:
             raise NotMapped
-        counts = (g.get_mapped_ti_count(run_id, session=session) for g in mapped_task_groups)
-        return functools.reduce(operator.mul, counts)
+        return group.get_mapped_ti_count(run_id, session=session)
 
     def render_template_fields(
         self,

--- a/airflow/models/expandinput.py
+++ b/airflow/models/expandinput.py
@@ -57,9 +57,9 @@ class MappedArgument(ResolveMixin):
     _key: str
 
     def get_task_map_length(self, run_id: str, *, session: Session) -> int | None:
-        # TODO (AIP-42): Implement run-time task map length inspection.
-        # This simply marks the value as un-expandable at parse-time.
-        return None
+        # TODO (AIP-42): Implement run-time task map length inspection. This is
+        # needed when we implement task mapping inside a mapped task group.
+        raise NotImplementedError()
 
     @provide_session
     def resolve(self, context: Context, *, session: Session = NEW_SESSION) -> Any:

--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -309,7 +309,7 @@ class MappedOperator(AbstractOperator):
     def __attrs_post_init__(self):
         from airflow.models.xcom_arg import XComArg
 
-        if next(self.iter_mapped_task_groups(), None) is not None:
+        if self.get_closest_mapped_task_group() is not None:
             raise NotImplementedError("operator expansion in an expanded task group is not yet supported")
 
         if self.task_group:

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -22,9 +22,11 @@ together when the DAG is displayed graphically.
 from __future__ import annotations
 
 import copy
+import functools
+import operator
 import re
 import weakref
-from typing import TYPE_CHECKING, Any, Generator, Sequence
+from typing import TYPE_CHECKING, Any, Generator, Iterator, Sequence
 
 from airflow.compat.functools import cache
 from airflow.exceptions import (
@@ -457,6 +459,20 @@ class TaskGroup(DAGNode):
 
         return graph_sorted
 
+    def iter_mapped_task_groups(self) -> Iterator[MappedTaskGroup]:
+        """Return mapped task groups in the hierarchy.
+
+        Groups are returned from the closest to the outmost. If *self* is a
+        mapped task group, it is returned first.
+
+        :meta private:
+        """
+        group: TaskGroup | None = self
+        while group is not None:
+            if isinstance(group, MappedTaskGroup):
+                yield group
+            group = group.task_group
+
 
 class MappedTaskGroup(TaskGroup):
     """A mapped task group.
@@ -477,15 +493,20 @@ class MappedTaskGroup(TaskGroup):
         """Number of instances a task in this group should be mapped to, when a DAG run is created.
 
         This only considers literal mapped arguments, and would return *None*
-        when any non-literal values are used for mapping. This also does not
-        account for nested mapped groups; only the number expanded due to this
-        specific group is returned, regardless of whether any of its parent
-        groups are mapped.
+        when any non-literal values are used for mapping.
+
+        If this group is inside mapped task groups, all the nested counts are
+        multiplied and accounted.
+
+        :meta private:
 
         :raise NotFullyPopulated: If any non-literal mapped arguments are encountered.
         :return: The total number of mapped instances each task should have.
         """
-        return self._expand_input.get_parse_time_mapped_ti_count()
+        return functools.reduce(
+            operator.mul,
+            (g._expand_input.get_parse_time_mapped_ti_count() for g in self.iter_mapped_task_groups()),
+        )
 
     def get_mapped_ti_count(self, run_id: str, *, session: Session) -> int:
         """Number of instances a task in this group should be mapped to at run time.
@@ -495,10 +516,19 @@ class MappedTaskGroup(TaskGroup):
         return value should be identical to ``parse_time_mapped_ti_count`` if
         all mapped arguments are literal.
 
+        If this group is inside mapped task groups, all the nested counts are
+        multiplied and accounted.
+
+        :meta private:
+
         :raise NotFullyPopulated: If upstream tasks are not all complete yet.
         :return: Total number of mapped TIs this task should have.
         """
-        return self._expand_input.get_total_map_length(run_id, session=session)
+        groups = self.iter_mapped_task_groups()
+        return functools.reduce(
+            operator.mul,
+            (g._expand_input.get_total_map_length(run_id, session=session) for g in groups),
+        )
 
 
 class TaskGroupContext:


### PR DESCRIPTION
This adds `iter_mapped_task_groups()` to TaskGroup, and also modifies `get_parse_time_mapped_ti_count()` and `get_mapped_ti_count()` so their behaviours match functions of the same names on AbstractOperator.

A shorthand function `get_closest_mapped_task_group()` is also added to AbstractOperator since this logic is needed quite often.

A part of #27678.