### PR TITLE
Fix suffix for pre-release cross-dependent packages

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -330,7 +330,7 @@ def get_install_requirements(provider_package_id: str, version_suffix: str) -> s
             # including all development releases. When you specify dependency as >= X.Y.Z, and you
             # have packages X.Y.Zdev0 or X.Y.Zrc1 in a local file, such package is not considered
             # as fulfilling the requirement even if `--pre` switch is used.
-            return install_clause + ".*"
+            return install_clause + ".dev0"
         return install_clause
 
     install_requires = [


### PR DESCRIPTION
We used .* as suffix for dependent pre-release packages but it turned out to be misunderstanding of the dependencies and PEP440.

According to PEP440 the dev/a/b/c(rc) versions are strictly ordered and ">=X.Y.Z.dev0" is equivalent of "depends on any pre-release package of X.Y.Z and all packages that follow".

Result of discusion in https://github.com/python-poetry/poetry/issues/7047

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
