### PR TITLE
Improve "sensor timeout" messaging

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -205,10 +205,15 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
             if run_duration() > self.timeout:
                 # If sensor is in soft fail mode but times out raise AirflowSkipException.
+                message = (
+                    f"Sensor has timed out; run duration of {run_duration()} seconds exceeds "
+                    f"the specified timeout of {self.timeout}."
+                )
+
                 if self.soft_fail:
-                    raise AirflowSkipException(f"Snap. Time is OUT. DAG id: {log_dag_id}")
+                    raise AirflowSkipException(message)
                 else:
-                    raise AirflowSensorTimeout(f"Snap. Time is OUT. DAG id: {log_dag_id}")
+                    raise AirflowSensorTimeout(message)
             if self.reschedule:
                 next_poke_interval = self._get_next_poke_interval(started_at, run_duration, try_number)
                 reschedule_date = timezone.utcnow() + timedelta(seconds=next_poke_interval)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -161,7 +161,7 @@ class TestExternalTaskSensor(unittest.TestCase):
     def test_external_task_group_not_exists_without_check_existence(self):
         self.add_time_sensor()
         self.add_dummy_task_group()
-        with pytest.raises(AirflowException, match=f"Snap. Time is OUT. DAG id: {TEST_DAG_ID}"):
+        with pytest.raises(AirflowException, match="Sensor has timed out"):
             op = ExternalTaskSensor(
                 task_id="test_external_task_sensor_check",
                 external_dag_id=TEST_DAG_ID,

--- a/tests/sensors/test_timeout_sensor.py
+++ b/tests/sensors/test_timeout_sensor.py
@@ -55,9 +55,9 @@ class TimeoutTestSensor(BaseSensorOperator):
                 started_at -= time_jump
             if (timezone.utcnow() - started_at).total_seconds() > self.timeout:
                 if self.soft_fail:
-                    raise AirflowSkipException("Snap. Time is OUT.")
+                    raise AirflowSkipException("timeout")
                 else:
-                    raise AirflowSensorTimeout("Snap. Time is OUT.")
+                    raise AirflowSensorTimeout("timeout")
             time.sleep(self.poke_interval)
         self.log.info("Success criteria met. Exiting.")
 


### PR DESCRIPTION
It's been around a long, long time, but that doesn't make it any less confusing.  I think it's time to do away with the "SNAP. Time is OUT" message, and replace it with something less cute / more clear / direct.
