### PR TITLE
Replace `unittests` in providers-microsoft tests by pure `pytest` [Wave-4]

### DIFF
--- a/tests/providers/microsoft/azure/hooks/test_adx.py
+++ b/tests/providers/microsoft/azure/hooks/test_adx.py
@@ -37,7 +37,7 @@ ADX_TEST_CONN_ID = "adx_test_connection_id"
 
 
 class TestAzureDataExplorerHook:
-    def teardown(self):
+    def teardown_method(self):
         with create_session() as session:
             session.query(Connection).filter(Connection.conn_id == ADX_TEST_CONN_ID).delete()
 

--- a/tests/providers/microsoft/azure/hooks/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_batch.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -29,9 +28,9 @@ from airflow.providers.microsoft.azure.hooks.batch import AzureBatchHook
 from airflow.utils import db
 
 
-class TestAzureBatchHook(unittest.TestCase):
+class TestAzureBatchHook:
     # set up the test environment
-    def setUp(self):
+    def setup_method(self):
         # set up the test variable
         self.test_vm_conn_id = "test_azure_batch_vm"
         self.test_cloud_conn_id = "test_azure_batch_cloud"

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_instance.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest.mock import patch
 
 from azure.mgmt.containerinstance.models import (
@@ -34,8 +33,8 @@ from airflow.providers.microsoft.azure.hooks.container_instance import AzureCont
 from airflow.utils import db
 
 
-class TestAzureContainerInstanceHook(unittest.TestCase):
-    def setUp(self):
+class TestAzureContainerInstanceHook:
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="azure_container_instance_test",

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_registry.py
@@ -17,14 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_registry import AzureContainerRegistryHook
 from airflow.utils import db
 
 
-class TestAzureContainerRegistryHook(unittest.TestCase):
+class TestAzureContainerRegistryHook:
     def test_get_conn(self):
         db.merge_conn(
             Connection(

--- a/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_container_volume.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.container_volume import AzureContainerVolumeHook
@@ -26,7 +25,7 @@ from airflow.utils import db
 from tests.test_utils.providers import get_provider_min_airflow_version
 
 
-class TestAzureContainerVolumeHook(unittest.TestCase):
+class TestAzureContainerVolumeHook:
     def test_get_file_volume(self):
         db.merge_conn(
             Connection(

--- a/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_cosmos.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import logging
-import unittest
 import uuid
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -34,10 +33,10 @@ from airflow.utils import db
 from tests.test_utils.providers import get_provider_min_airflow_version
 
 
-class TestAzureCosmosDbHook(unittest.TestCase):
+class TestAzureCosmosDbHook:
 
     # Set up an environment to test with
-    def setUp(self):
+    def setup_method(self):
         # set up some test variables
         self.test_end_point = "https://test_endpoint:443"
         self.test_master_key = "magic_test_key"

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 from airflow.models import Connection
@@ -27,8 +26,8 @@ from airflow.utils import db
 from tests.test_utils.providers import get_provider_min_airflow_version
 
 
-class TestAzureDataLakeHook(unittest.TestCase):
-    def setUp(self):
+class TestAzureDataLakeHook:
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="adl_test_key",

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -41,7 +41,7 @@ from tests.test_utils.providers import get_provider_min_airflow_version, object_
 
 
 class TestAzureFileshareHook:
-    def setup(self):
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="azure_fileshare_test_key",

--- a/tests/providers/microsoft/azure/hooks/test_base_azure.py
+++ b/tests/providers/microsoft/azure/hooks/test_base_azure.py
@@ -16,14 +16,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import Mock, patch
 
 from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.base_azure import AzureBaseHook
 
 
-class TestBaseAzureHook(unittest.TestCase):
+class TestBaseAzureHook:
     @patch("airflow.providers.microsoft.azure.hooks.base_azure.get_client_from_auth_file")
     @patch(
         "airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook.get_connection",

--- a/tests/providers/microsoft/azure/hooks/test_wasb.py
+++ b/tests/providers/microsoft/azure/hooks/test_wasb.py
@@ -39,7 +39,7 @@ ACCESS_KEY_STRING = "AccountName=name;skdkskd"
 
 
 class TestWasbHook:
-    def setup(self):
+    def setup_method(self):
         db.merge_conn(Connection(conn_id="wasb_test_key", conn_type="wasb", login="login", password="key"))
         self.connection_type = "wasb"
         self.connection_string_id = "azure_test_connection_string"

--- a/tests/providers/microsoft/azure/operators/test_adls_delete.py
+++ b/tests/providers/microsoft/azure/operators/test_adls_delete.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.microsoft.azure.operators.adls import ADLSDeleteOperator
@@ -26,7 +25,7 @@ TASK_ID = "test-adls-list-operator"
 TEST_PATH = "test"
 
 
-class TestAzureDataLakeStorageDeleteOperator(unittest.TestCase):
+class TestAzureDataLakeStorageDeleteOperator:
     @mock.patch("airflow.providers.microsoft.azure.operators.adls.AzureDataLakeHook")
     def test_execute(self, mock_hook):
 

--- a/tests/providers/microsoft/azure/operators/test_adls_list.py
+++ b/tests/providers/microsoft/azure/operators/test_adls_list.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.microsoft.azure.operators.adls import ADLSListOperator
@@ -33,7 +32,7 @@ MOCK_FILES = [
 ]
 
 
-class TestAzureDataLakeStorageListOperator(unittest.TestCase):
+class TestAzureDataLakeStorageListOperator:
     @mock.patch("airflow.providers.microsoft.azure.operators.adls.AzureDataLakeHook")
     def test_execute(self, mock_hook):
         mock_hook.return_value.list.return_value = MOCK_FILES

--- a/tests/providers/microsoft/azure/operators/test_adx.py
+++ b/tests/providers/microsoft/azure/operators/test_adx.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from azure.kusto.data._models import KustoResultTable
@@ -60,8 +59,8 @@ class MockResponse:
     primary_results = [MOCK_RESULT]
 
 
-class TestAzureDataExplorerQueryOperator(unittest.TestCase):
-    def setUp(self):
+class TestAzureDataExplorerQueryOperator:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE, "provide_context": True}
 
         self.dag = DAG(TEST_DAG_ID + "test_schedule_dag_once", default_args=args, schedule="@once")

--- a/tests/providers/microsoft/azure/operators/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_batch.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 import pytest
@@ -41,11 +40,11 @@ FORMULA = """$curTime = time();
              $TargetDedicated = $isWorkingWeekdayHour ? 20:10;"""
 
 
-class TestAzureBatchOperator(unittest.TestCase):
+class TestAzureBatchOperator:
     # set up the test environment
     @mock.patch("airflow.providers.microsoft.azure.hooks.batch.AzureBatchHook")
     @mock.patch("airflow.providers.microsoft.azure.hooks.batch.BatchServiceClient")
-    def setUp(self, mock_batch, mock_hook):
+    def setup_method(self, method, mock_batch, mock_hook):
         # set up the test variable
         self.test_vm_conn_id = "test_azure_batch_vm2"
         self.test_cloud_conn_id = "test_azure_batch_cloud2"

--- a/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from collections import namedtuple
 from unittest import mock
 from unittest.mock import MagicMock
@@ -64,7 +63,7 @@ def make_mock_cg_with_missing_events(container_state):
     return container_g
 
 
-class TestACIOperator(unittest.TestCase):
+class TestACIOperator:
     @mock.patch("airflow.providers.microsoft.azure.operators.container_instances.AzureContainerInstanceHook")
     def test_execute(self, aci_mock):
         expected_c_state = ContainerState(state="Terminated", exit_code=0, detail_status="test")

--- a/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_cosmos.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 import uuid
 from unittest import mock
 
@@ -27,10 +26,10 @@ from airflow.providers.microsoft.azure.operators.cosmos import AzureCosmosInsert
 from airflow.utils import db
 
 
-class TestAzureCosmosDbHook(unittest.TestCase):
+class TestAzureCosmosDbHook:
 
     # Set up an environment to test with
-    def setUp(self):
+    def setup_method(self):
         # set up some test variables
         self.test_end_point = "https://test_endpoint:443"
         self.test_master_key = "magic_test_key"

--- a/tests/providers/microsoft/azure/operators/test_azure_synapse.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_synapse.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -39,8 +38,8 @@ CONN_EXTRAS = {
 JOB_RUN_RESPONSE = {"id": 123}
 
 
-class TestAzureSynapseRunSparkBatchOperator(unittest.TestCase):
-    def setUp(self):
+class TestAzureSynapseRunSparkBatchOperator:
+    def setup_method(self):
         self.mock_ti = MagicMock()
         self.mock_context = {"ti": self.mock_ti}
         self.config = {

--- a/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
+++ b/tests/providers/microsoft/azure/operators/test_wasb_delete_blob.py
@@ -18,21 +18,20 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.operators.wasb_delete_blob import WasbDeleteBlobOperator
 
 
-class TestWasbDeleteBlobOperator(unittest.TestCase):
+class TestWasbDeleteBlobOperator:
 
     _config = {
         "container_name": "container",
         "blob_name": "blob",
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/microsoft/azure/sensors/test_azure_cosmos.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_cosmos.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.microsoft.azure.sensors.cosmos import AzureCosmosDocumentSensor
@@ -26,7 +25,7 @@ COLLECTION_NAME = "test-db-collection-name"
 DOCUMENT_ID = "test-document-id"
 
 
-class TestAzureCosmosSensor(unittest.TestCase):
+class TestAzureCosmosSensor:
     @mock.patch("airflow.providers.microsoft.azure.sensors.cosmos.AzureCosmosDBHook")
     def test_should_call_hook_with_args(self, mock_hook):
         mock_instance = mock_hook.return_value

--- a/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/sensors/test_azure_data_factory.py
@@ -16,11 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 import pytest
-from parameterized import parameterized
 
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
@@ -30,8 +28,8 @@ from airflow.providers.microsoft.azure.hooks.data_factory import (
 from airflow.providers.microsoft.azure.sensors.data_factory import AzureDataFactoryPipelineRunStatusSensor
 
 
-class TestPipelineRunStatusSensor(unittest.TestCase):
-    def setUp(self):
+class TestPipelineRunStatusSensor:
+    def setup_method(self):
         self.config = {
             "azure_data_factory_conn_id": "azure_data_factory_test",
             "run_id": "run_id",
@@ -50,7 +48,8 @@ class TestPipelineRunStatusSensor(unittest.TestCase):
         assert self.sensor.timeout == self.config["timeout"]
         assert self.sensor.poke_interval == self.config["poke_interval"]
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "pipeline_run_status, expected_status",
         [
             (AzureDataFactoryPipelineRunStatus.SUCCEEDED, True),
             (AzureDataFactoryPipelineRunStatus.FAILED, "exception"),
@@ -58,10 +57,10 @@ class TestPipelineRunStatusSensor(unittest.TestCase):
             (AzureDataFactoryPipelineRunStatus.CANCELING, False),
             (AzureDataFactoryPipelineRunStatus.QUEUED, False),
             (AzureDataFactoryPipelineRunStatus.IN_PROGRESS, False),
-        ]
+        ],
     )
     @patch.object(AzureDataFactoryHook, "get_pipeline_run")
-    def test_poke(self, pipeline_run_status, expected_status, mock_pipeline_run):
+    def test_poke(self, mock_pipeline_run, pipeline_run_status, expected_status):
         mock_pipeline_run.return_value.status = pipeline_run_status
 
         if expected_status != "exception":

--- a/tests/providers/microsoft/azure/sensors/test_wasb.py
+++ b/tests/providers/microsoft/azure/sensors/test_wasb.py
@@ -18,14 +18,13 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 from unittest import mock
 
 from airflow.models.dag import DAG
 from airflow.providers.microsoft.azure.sensors.wasb import WasbBlobSensor, WasbPrefixSensor
 
 
-class TestWasbBlobSensor(unittest.TestCase):
+class TestWasbBlobSensor:
     _config = {
         "container_name": "container",
         "blob_name": "blob",
@@ -33,7 +32,7 @@ class TestWasbBlobSensor(unittest.TestCase):
         "timeout": 100,
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 
@@ -60,7 +59,7 @@ class TestWasbBlobSensor(unittest.TestCase):
         mock_instance.check_for_blob.assert_called_once_with("container", "blob", timeout=2)
 
 
-class TestWasbPrefixSensor(unittest.TestCase):
+class TestWasbPrefixSensor:
     _config = {
         "container_name": "container",
         "prefix": "prefix",
@@ -68,7 +67,7 @@ class TestWasbPrefixSensor(unittest.TestCase):
         "timeout": 100,
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
+++ b/tests/providers/microsoft/azure/transfers/test_azure_blob_to_gcs.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.microsoft.azure.transfers.azure_blob_to_gcs import AzureBlobStorageToGCSOperator
@@ -35,7 +34,7 @@ IMPERSONATION_CHAIN = None
 TASK_ID = "transfer_file"
 
 
-class TestAzureBlobStorageToGCSTransferOperator(unittest.TestCase):
+class TestAzureBlobStorageToGCSTransferOperator:
     def test_init(self):
         operator = AzureBlobStorageToGCSOperator(
             wasb_conn_id=WASB_CONN_ID,

--- a/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -31,7 +30,7 @@ BAD_LOCAL_PATH = "test/**"
 REMOTE_PATH = "TEST-DIR"
 
 
-class TestADLSUploadOperator(unittest.TestCase):
+class TestADLSUploadOperator:
     @mock.patch("airflow.providers.microsoft.azure.transfers.local_to_adls.AzureDataLakeHook")
     def test_execute_success(self, mock_hook):
         operator = LocalFilesystemToADLSOperator(

--- a/tests/providers/microsoft/azure/transfers/test_local_to_wasb.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_wasb.py
@@ -36,7 +36,7 @@ class TestLocalFilesystemToWasbOperator:
         "retries": 3,
     }
 
-    def setup(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/microsoft/azure/transfers/test_oracle_to_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/transfers/test_oracle_to_azure_data_lake.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from tempfile import TemporaryDirectory
 from unittest import mock
 from unittest.mock import MagicMock
@@ -30,7 +29,7 @@ from airflow.providers.microsoft.azure.transfers.oracle_to_azure_data_lake impor
 )
 
 
-class TestOracleToAzureDataLakeTransfer(unittest.TestCase):
+class TestOracleToAzureDataLakeTransfer:
 
     mock_module_path = "airflow.providers.microsoft.azure.transfers.oracle_to_azure_data_lake"
 

--- a/tests/providers/microsoft/mssql/hooks/test_mssql.py
+++ b/tests/providers/microsoft/mssql/hooks/test_mssql.py
@@ -17,11 +17,10 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from urllib.parse import quote_plus
 
-from parameterized import parameterized
+import pytest
 
 from airflow.models import Connection
 from airflow.providers.microsoft.mssql.hooks.mssql import MsSqlHook
@@ -52,7 +51,7 @@ PYMSSQL_CONN_ALT_2 = Connection(
 )
 
 
-class TestMsSqlHook(unittest.TestCase):
+class TestMsSqlHook:
     @mock.patch("airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook.get_conn")
     @mock.patch("airflow.providers.common.sql.hooks.sql.DbApiHook.get_connection")
     def test_get_conn_should_return_connection(self, get_connection, mssql_get_conn):
@@ -92,7 +91,8 @@ class TestMsSqlHook(unittest.TestCase):
         mssql_get_conn.assert_called_once()
         assert hook.get_autocommit(conn) == "autocommit_state"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "conn, exp_uri",
         [
             (
                 PYMSSQL_CONN,
@@ -130,7 +130,7 @@ class TestMsSqlHook(unittest.TestCase):
         ],
     )
     @mock.patch("airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook.get_connection")
-    def test_get_uri_driver_rewrite(self, conn, exp_uri, get_connection):
+    def test_get_uri_driver_rewrite(self, get_connection, conn, exp_uri):
         get_connection.return_value = conn
 
         hook = MsSqlHook()

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -18,10 +18,9 @@
 from __future__ import annotations
 
 from logging import DEBUG, ERROR, INFO, WARNING
-from unittest import TestCase
 from unittest.mock import MagicMock, Mock, call, patch
 
-from parameterized import parameterized
+import pytest
 from pypsrp.host import PSHost
 from pypsrp.messages import MessageType
 from pypsrp.powershell import PSInvocationState
@@ -111,7 +110,7 @@ def mock_powershell_factory():
 @patch(f"{PsrpHook.__module__}.WSMan")
 @patch(f"{PsrpHook.__module__}.PowerShell", new_callable=mock_powershell_factory)
 @patch(f"{PsrpHook.__module__}.RunspacePool")
-class TestPsrpHook(TestCase):
+class TestPsrpHook:
     def test_get_conn(self, runspace_pool, powershell, ws_man):
         hook = PsrpHook(CONNECTION_ID)
         assert hook.get_conn() is runspace_pool.return_value
@@ -128,7 +127,9 @@ class TestPsrpHook(TestCase):
         with raises(AirflowException, match="Unexpected extra configuration keys: foo"):
             hook.get_conn()
 
-    @parameterized.expand([(None,), (ERROR,)])
+    @pytest.mark.parametrize(
+        "logging_level", [pytest.param(None, id="none"), pytest.param(ERROR, id="ERROR")]
+    )
     def test_invoke(self, runspace_pool, powershell, ws_man, logging_level):
         runspace_options = {"connection_name": "foo"}
         wsman_options = {"encryption": "auto"}

--- a/tests/providers/microsoft/winrm/hooks/test_winrm.py
+++ b/tests/providers/microsoft/winrm/hooks/test_winrm.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 import pytest
@@ -27,7 +26,7 @@ from airflow.models import Connection
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 
 
-class TestWinRMHook(unittest.TestCase):
+class TestWinRMHook:
     @patch("airflow.providers.microsoft.winrm.hooks.winrm.Protocol")
     def test_get_conn_exists(self, mock_protocol):
         winrm_hook = WinRMHook()

--- a/tests/providers/microsoft/winrm/operators/test_winrm.py
+++ b/tests/providers/microsoft/winrm/operators/test_winrm.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -26,7 +25,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
 
 
-class TestWinRMOperator(unittest.TestCase):
+class TestWinRMOperator:
     def test_no_winrm_hook_no_ssh_conn_id(self):
         op = WinRMOperator(task_id="test_task_id", winrm_hook=None, ssh_conn_id=None)
         exception_msg = "Cannot operate without winrm_hook or ssh_conn_id."


### PR DESCRIPTION
Migrate all Microsoft's providers tests to `pytest`.

Follow-up:  #27696
