### PR TITLE
Allow longer pod names for k8s executor / KPO

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -231,7 +231,7 @@ class KubernetesPodOperator(BaseOperator):
         namespace: str | None = None,
         image: str | None = None,
         name: str | None = None,
-        random_name_suffix: bool | None = True,
+        random_name_suffix: bool = True,
         cmds: list[str] | None = None,
         arguments: list[str] | None = None,
         ports: list[k8s.V1ContainerPort] | None = None,

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 import json
 import logging
 import re
+import secrets
+import string
 import warnings
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, Sequence
 
 from kubernetes.client import CoreV1Api, models as k8s
+from slugify import slugify
 
 from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException
@@ -61,30 +64,62 @@ if TYPE_CHECKING:
 
     from airflow.utils.context import Context
 
+alphanum_lower = string.ascii_lowercase + string.digits
 
-def _task_id_to_pod_name(val: str) -> str:
-    """
-    Given a task_id, convert it to a pod name.
-    Adds a 0 if start or end char is invalid.
-    Replaces any other invalid char with `-`.
 
-    :param val: non-empty string, presumed to be a task id
-    :return valid kubernetes object name.
+def _rand_str(num):
+    """Generate random lowercase alphanumeric string of length num.
+
+    TODO: when min airflow version >= 2.5, delete this function and import from kubernetes_helper_functions.
+
+    :meta private:
     """
-    if not val:
-        raise ValueError("_task_id_to_pod_name requires non-empty string.")
-    val = val.lower()
-    if not re.match(r"[a-z0-9]", val[0]):
-        val = f"0{val}"
-    if not re.match(r"[a-z0-9]", val[-1]):
-        val = f"{val}0"
-    val = re.sub(r"[^a-z0-9\-.]", "-", val)
-    if len(val) > 253:
-        raise ValueError(
-            f"Pod name {val} is longer than 253 characters. "
-            "See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/."
-        )
-    return val
+    return "".join(secrets.choice(alphanum_lower) for _ in range(num))
+
+
+def _add_pod_suffix(*, pod_name, rand_len=8, max_len=253):
+    """Add random string to pod name while staying under max len
+
+    TODO: when min airflow version >= 2.5, delete this function and import from kubernetes_helper_functions.
+
+    :meta private:
+    """
+    suffix = "-" + _rand_str(rand_len)
+    return pod_name[: max_len - len(suffix)].strip("-.") + suffix
+
+
+def _create_pod_id(
+    dag_id: str | None = None,
+    task_id: str | None = None,
+    *,
+    max_length: int = 80,
+    unique: bool = True,
+) -> str:
+    """
+    Generates unique pod ID given a dag_id and / or task_id.
+
+    TODO: when min airflow version >= 2.5, delete this function and import from kubernetes_helper_functions.
+
+    :param dag_id: DAG ID
+    :param task_id: Task ID
+    :param max_length: max number of characters
+    :param unique: whether a random string suffix should be added
+    :return: A valid identifier for a kubernetes pod name
+    """
+    if not (dag_id or task_id):
+        raise ValueError("Must supply either dag_id or task_id.")
+    name = ""
+    if dag_id:
+        name += dag_id
+    if task_id:
+        if name:
+            name += "-"
+        name += task_id
+    base_name = slugify(name, lowercase=True)[:max_length].strip(".-")
+    if unique:
+        return _add_pod_suffix(pod_name=base_name, max_len=max_length)
+    else:
+        return base_name
 
 
 class PodReattachFailure(AirflowException):
@@ -598,10 +633,10 @@ class KubernetesPodOperator(BaseOperator):
         pod = PodGenerator.reconcile_pods(pod_template, pod)
 
         if not pod.metadata.name:
-            pod.metadata.name = _task_id_to_pod_name(self.task_id)
-
-        if self.random_name_suffix:
-            pod.metadata.name = PodGenerator.make_unique_pod_id(pod.metadata.name)
+            pod.metadata.name = _create_pod_id(task_id=self.task_id, unique=self.random_name_suffix)
+        elif self.random_name_suffix:
+            # user has supplied pod name, we're just adding suffix
+            pod.metadata.name = _add_pod_suffix(pod_name=pod.metadata.name)
 
         if not pod.metadata.namespace:
             # todo: replace with call to `hook.get_namespace` in 6.0, when it doesn't default to `default`.

--- a/tests/kubernetes/models/test_secret.py
+++ b/tests/kubernetes/models/test_secret.py
@@ -63,11 +63,14 @@ class TestSecret:
         )
 
     @mock.patch("uuid.uuid4")
-    def test_attach_to_pod(self, mock_uuid):
+    @mock.patch("airflow.kubernetes.pod_generator.rand_str")
+    def test_attach_to_pod(self, mock_rand_str, mock_uuid):
         static_uuid = uuid.UUID("cf4a56d2-8101-4217-b027-2af6216feb48")
         mock_uuid.return_value = static_uuid
+        rand_str = "abcd1234"
+        mock_rand_str.return_value = rand_str
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base.yaml"
-        pod = PodGenerator(pod_template_file=path).gen_pod()
+        pod = PodGenerator(pod_template_file=path).ud_pod
         secrets = [
             # This should be a secretRef
             Secret("env", None, "secret_a"),
@@ -84,7 +87,7 @@ class TestSecret:
             "kind": "Pod",
             "metadata": {
                 "labels": {"app": "myapp"},
-                "name": "myapp-pod-cf4a56d281014217b0272af6216feb48",
+                "name": f"myapp-pod-{rand_str}",
                 "namespace": "default",
             },
             "spec": {

--- a/tests/kubernetes/models/test_secret.py
+++ b/tests/kubernetes/models/test_secret.py
@@ -111,7 +111,6 @@ class TestSecret:
                         "ports": [{"containerPort": 1234, "name": "foo"}],
                         "resources": {"limits": {"memory": "200Mi"}, "requests": {"memory": "100Mi"}},
                         "volumeMounts": [
-                            {"mountPath": "/airflow/xcom", "name": "xcom"},
                             {
                                 "mountPath": "/etc/foo",
                                 "name": "secretvol" + str(static_uuid),
@@ -119,19 +118,11 @@ class TestSecret:
                             },
                         ],
                     },
-                    {
-                        "command": ["sh", "-c", 'trap "exit 0" INT; while true; do sleep 30; done;'],
-                        "image": "alpine",
-                        "name": "airflow-xcom-sidecar",
-                        "resources": {"requests": {"cpu": "1m"}},
-                        "volumeMounts": [{"mountPath": "/airflow/xcom", "name": "xcom"}],
-                    },
                 ],
                 "hostNetwork": True,
                 "imagePullSecrets": [{"name": "pull_secret_a"}, {"name": "pull_secret_b"}],
                 "securityContext": {"fsGroup": 2000, "runAsUser": 1000},
                 "volumes": [
-                    {"emptyDir": {}, "name": "xcom"},
                     {"name": "secretvol" + str(static_uuid), "secret": {"secretName": "secret_b"}},
                 ],
             },

--- a/tests/kubernetes/models/test_secret.py
+++ b/tests/kubernetes/models/test_secret.py
@@ -87,7 +87,7 @@ class TestSecret:
             "kind": "Pod",
             "metadata": {
                 "labels": {"app": "myapp"},
-                "name": f"myapp-pod-{rand_str}",
+                "name": "myapp-pod",
                 "namespace": "default",
             },
             "spec": {

--- a/tests/kubernetes/test_kubernetes_helper_functions.py
+++ b/tests/kubernetes/test_kubernetes_helper_functions.py
@@ -20,67 +20,97 @@ from __future__ import annotations
 import re
 
 import pytest
+from pytest import param
 
 from airflow.kubernetes.kubernetes_helper_functions import create_pod_id
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import _create_pod_id
 
 pod_name_regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 
 
+# todo: when cncf provider min airflow version >= 2.5 remove this parameterization
+# we added this function to provider temporarily until min airflow version catches up
+# meanwhile, we use this one test to test both core and provider
 @pytest.mark.parametrize(
-    "val, expected",
-    [
-        ("task-id", "task-id"),  # no problem
-        ("task_id", "task-id"),  # underscores
-        ("---task.id---", "task-id"),  # dots
-        (".task.id", "task-id"),  # leading dot invalid
-        ("**task.id", "task-id"),  # leading dot invalid
-        ("-90Abc*&", "90abc"),  # invalid ends
-        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a"),  # weird unicode
-    ],
+    "create_pod_id", [param(_create_pod_id, id="provider"), param(create_pod_id, id="core")]
 )
-def test_create_pod_id_task_only(val, expected):
-    actual = create_pod_id(task_id=val)
-    assert actual == expected
-    assert re.match(pod_name_regex, actual)
+class TestCreatePodId:
+    @pytest.mark.parametrize(
+        "val, expected",
+        [
+            ("task-id", "task-id"),  # no problem
+            ("task_id", "task-id"),  # underscores
+            ("---task.id---", "task-id"),  # dots
+            (".task.id", "task-id"),  # leading dot invalid
+            ("**task.id", "task-id"),  # leading dot invalid
+            ("-90Abc*&", "90abc"),  # invalid ends
+            ("90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a"),  # weird unicode
+        ],
+    )
+    def test_create_pod_id_task_only(self, val, expected, create_pod_id):
+        actual = create_pod_id(task_id=val, unique=False)
+        assert actual == expected
+        assert re.match(pod_name_regex, actual)
 
+    @pytest.mark.parametrize(
+        "val, expected",
+        [
+            ("dag-id", "dag-id"),  # no problem
+            ("dag_id", "dag-id"),  # underscores
+            ("---dag.id---", "dag-id"),  # dots
+            (".dag.id", "dag-id"),  # leading dot invalid
+            ("**dag.id", "dag-id"),  # leading dot invalid
+            ("-90Abc*&", "90abc"),  # invalid ends
+            ("90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a"),  # weird unicode
+        ],
+    )
+    def test_create_pod_id_dag_only(self, val, expected, create_pod_id):
+        actual = create_pod_id(dag_id=val, unique=False)
+        assert actual == expected
+        assert re.match(pod_name_regex, actual)
 
-@pytest.mark.parametrize(
-    "val, expected",
-    [
-        ("dag-id", "dag-id"),  # no problem
-        ("dag_id", "dag-id"),  # underscores
-        ("---dag.id---", "dag-id"),  # dots
-        (".dag.id", "dag-id"),  # leading dot invalid
-        ("**dag.id", "dag-id"),  # leading dot invalid
-        ("-90Abc*&", "90abc"),  # invalid ends
-        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a"),  # weird unicode
-    ],
-)
-def test_create_pod_id_dag_only(val, expected):
-    actual = create_pod_id(dag_id=val)
-    assert actual == expected
-    assert re.match(pod_name_regex, actual)
+    @pytest.mark.parametrize(
+        "dag_id, task_id, expected",
+        [
+            ("dag-id", "task-id", "dag-id-task-id"),  # no problem
+            ("dag_id", "task_id", "dag-id-task-id"),  # underscores
+            ("dag.id", "task.id", "dag-id-task-id"),  # dots
+            (".dag.id", ".---task.id", "dag-id-task-id"),  # leading dot invalid
+            ("**dag.id", "**task.id", "dag-id-task-id"),  # leading dot invalid
+            ("-90Abc*&", "-90Abc*&", "90abc-90abc"),  # invalid ends
+            ("90AçLbˆˆç˙ßß˜˜˙c*a", "90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a-90aclb-c-ssss-c-a"),  # ugly
+        ],
+    )
+    def test_create_pod_id_dag_and_task(self, dag_id, task_id, expected, create_pod_id):
+        actual = create_pod_id(dag_id=dag_id, task_id=task_id, unique=False)
+        assert actual == expected
+        assert re.match(pod_name_regex, actual)
 
+    def test_create_pod_id_dag_too_long_with_suffix(self, create_pod_id):
+        actual = create_pod_id("0" * 254)
+        assert re.match(r"0{71}-[a-z0-9]{8}", actual)
+        assert re.match(pod_name_regex, actual)
 
-@pytest.mark.parametrize(
-    "dag_id, task_id, expected",
-    [
-        ("dag-id", "task-id", "dag-id-task-id"),  # no problem
-        ("dag_id", "task_id", "dag-id-task-id"),  # underscores
-        ("dag.id", "task.id", "dag-id-task-id"),  # dots
-        (".dag.id", ".---task.id", "dag-id-task-id"),  # leading dot invalid
-        ("**dag.id", "**task.id", "dag-id-task-id"),  # leading dot invalid
-        ("-90Abc*&", "-90Abc*&", "90abc-90abc"),  # invalid ends
-        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a-90aclb-c-ssss-c-a"),  # ugly
-    ],
-)
-def test_create_pod_id_dag_and_task(dag_id, task_id, expected):
-    actual = create_pod_id(dag_id=dag_id, task_id=task_id)
-    assert actual == expected
-    assert re.match(pod_name_regex, actual)
+    def test_create_pod_id_dag_too_long_non_unique(self, create_pod_id):
+        actual = create_pod_id("0" * 254, unique=False)
+        assert re.match(r"0{80}", actual)
+        assert re.match(pod_name_regex, actual)
 
-
-def test_create_pod_id_dag_too_long():
-    actual = create_pod_id("0" * 254)
-    assert actual == "0" * 253
-    assert re.match(pod_name_regex, actual)
+    @pytest.mark.parametrize("unique", [True, False])
+    @pytest.mark.parametrize("length", [25, 100, 200, 300])
+    def test_create_pod_id(self, create_pod_id, length, unique):
+        """Test behavior of max_length and unique."""
+        dag_id = "dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-dag-"
+        task_id = "task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-task-"
+        actual = create_pod_id(
+            dag_id=dag_id,
+            task_id=task_id,
+            max_length=length,
+            unique=unique,
+        )
+        base = f"{dag_id}{task_id}".strip("-")
+        if unique:
+            assert actual[:-9] == base[: length - 9].strip("-")
+            assert re.match(r"-[a-z0-9]{8}", actual[-9:])
+        else:
+            assert actual == base[:length]

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -161,6 +161,10 @@ class TestPodGenerator:
 
     @mock.patch("airflow.kubernetes.kubernetes_helper_functions.rand_str")
     def test_gen_pod_extract_xcom(self, mock_rand_str):
+        """
+        Method gen_pod is used nowhere in codebase and is deprecated.
+        This test is only retained for backcompat.
+        """
         mock_rand_str.return_value = self.rand_str
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -19,14 +19,13 @@ from __future__ import annotations
 import os
 import re
 import sys
-import uuid
 from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
 from dateutil import parser
 from kubernetes.client import ApiClient, models as k8s
-from parameterized import parameterized
+from pytest import param
 
 from airflow import __version__
 from airflow.exceptions import AirflowConfigException, PodReconciliationError
@@ -42,7 +41,7 @@ from airflow.kubernetes.secret import Secret
 
 class TestPodGenerator:
     def setup_method(self):
-        self.static_uuid = uuid.UUID("cf4a56d2-8101-4217-b027-2af6216feb48")
+        self.rand_str = "abcd1234"
         self.deserialize_result = {
             "apiVersion": "v1",
             "kind": "Pod",
@@ -92,7 +91,7 @@ class TestPodGenerator:
         }
         self.metadata = {
             "labels": self.labels,
-            "name": "pod_id-" + self.static_uuid.hex,
+            "name": "pod_id-" + self.rand_str,
             "namespace": "namespace",
             "annotations": self.annotations,
         }
@@ -112,7 +111,7 @@ class TestPodGenerator:
             kind="Pod",
             metadata=k8s.V1ObjectMeta(
                 namespace="default",
-                name="myapp-pod-" + self.static_uuid.hex,
+                name="myapp-pod-" + self.rand_str,
                 labels={"app": "myapp"},
             ),
             spec=k8s.V1PodSpec(
@@ -160,14 +159,13 @@ class TestPodGenerator:
             ),
         )
 
-    @mock.patch("uuid.uuid4")
-    def test_gen_pod_extract_xcom(self, mock_uuid):
-        mock_uuid.return_value = self.static_uuid
+    @mock.patch("airflow.kubernetes.kubernetes_helper_functions.rand_str")
+    def test_gen_pod_extract_xcom(self, mock_rand_str):
+        mock_rand_str.return_value = self.rand_str
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
 
         pod_generator = PodGenerator(pod_template_file=path, extract_xcom=True)
         result = pod_generator.gen_pod()
-        result_dict = self.k8s_client.sanitize_for_serialization(result)
         container_two = {
             "name": "airflow-xcom-sidecar",
             "image": "alpine",
@@ -189,7 +187,6 @@ class TestPodGenerator:
         )
         result_dict = self.k8s_client.sanitize_for_serialization(result)
         expected_dict = self.k8s_client.sanitize_for_serialization(self.expected)
-
         assert result_dict == expected_dict
 
     def test_from_obj(self):
@@ -322,18 +319,11 @@ class TestPodGenerator:
             },
         } == result
 
-    @mock.patch("uuid.uuid4")
-    def test_reconcile_pods_empty_mutator_pod(self, mock_uuid):
-        mock_uuid.return_value = self.static_uuid
+    def test_reconcile_pods_empty_mutator_pod(self):
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
-
         pod_generator = PodGenerator(pod_template_file=path, extract_xcom=True)
-        base_pod = pod_generator.gen_pod()
+        base_pod = pod_generator.ud_pod
         mutator_pod = None
-        name = "name1-" + self.static_uuid.hex
-
-        base_pod.metadata.name = name
-
         result = PodGenerator.reconcile_pods(base_pod, mutator_pod)
         assert base_pod == result
 
@@ -341,12 +331,12 @@ class TestPodGenerator:
         result = PodGenerator.reconcile_pods(base_pod, mutator_pod)
         assert base_pod == result
 
-    @mock.patch("uuid.uuid4")
-    def test_reconcile_pods(self, mock_uuid):
-        mock_uuid.return_value = self.static_uuid
+    @mock.patch("airflow.kubernetes.kubernetes_helper_functions.rand_str")
+    def test_reconcile_pods(self, mock_rand_str):
+        mock_rand_str.return_value = self.rand_str
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
 
-        base_pod = PodGenerator(pod_template_file=path, extract_xcom=False).gen_pod()
+        base_pod = PodGenerator(pod_template_file=path, extract_xcom=False).ud_pod
 
         mutator_pod = k8s.V1Pod(
             metadata=k8s.V1ObjectMeta(
@@ -400,15 +390,13 @@ class TestPodGenerator:
     @pytest.mark.parametrize(
         "config_image, expected_image",
         [
-            pytest.param("my_image:my_tag", "my_image:my_tag", id="image_in_cfg"),
-            pytest.param(None, "busybox", id="no_image_in_cfg"),
+            param("my_image:my_tag", "my_image:my_tag", id="image_in_cfg"),
+            param(None, "busybox", id="no_image_in_cfg"),
         ],
     )
-    @mock.patch("uuid.uuid4")
-    def test_construct_pod(self, mock_uuid, config_image, expected_image):
+    def test_construct_pod(self, config_image, expected_image):
         template_file = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
         worker_config = PodGenerator.deserialize_model_file(template_file)
-        mock_uuid.return_value = self.static_uuid
         executor_config = k8s.V1Pod(
             spec=k8s.V1PodSpec(
                 containers=[
@@ -436,7 +424,7 @@ class TestPodGenerator:
         expected.metadata.labels = self.labels
         expected.metadata.labels["app"] = "myapp"
         expected.metadata.annotations = self.annotations
-        expected.metadata.name = "pod_id-" + self.static_uuid.hex
+        expected.metadata.name = "pod_id"
         expected.metadata.namespace = "test_namespace"
         expected.spec.containers[0].args = ["command"]
         expected.spec.containers[0].image = expected_image
@@ -452,12 +440,9 @@ class TestPodGenerator:
 
         assert expected_dict == result_dict
 
-    @mock.patch("uuid.uuid4")
-    def test_construct_pod_mapped_task(self, mock_uuid):
+    def test_construct_pod_mapped_task(self):
         template_file = sys.path[0] + "/tests/kubernetes/pod_generator_base.yaml"
         worker_config = PodGenerator.deserialize_model_file(template_file)
-        mock_uuid.return_value = self.static_uuid
-
         result = PodGenerator.construct_pod(
             dag_id=self.dag_id,
             task_id=self.task_id,
@@ -478,7 +463,7 @@ class TestPodGenerator:
         expected.metadata.labels["map_index"] = "0"
         expected.metadata.annotations = self.annotations
         expected.metadata.annotations["map_index"] = "0"
-        expected.metadata.name = "pod_id-" + self.static_uuid.hex
+        expected.metadata.name = "pod_id"
         expected.metadata.namespace = "test_namespace"
         expected.spec.containers[0].args = ["command"]
         del expected.spec.containers[0].env_from[1:]
@@ -489,11 +474,9 @@ class TestPodGenerator:
 
         assert expected_dict == result_dict
 
-    @mock.patch("uuid.uuid4")
-    def test_construct_pod_empty_executor_config(self, mock_uuid):
+    def test_construct_pod_empty_executor_config(self):
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
         worker_config = PodGenerator.deserialize_model_file(path)
-        mock_uuid.return_value = self.static_uuid
         executor_config = None
 
         result = PodGenerator.construct_pod(
@@ -515,23 +498,23 @@ class TestPodGenerator:
         worker_config.metadata.annotations = self.annotations
         worker_config.metadata.labels = self.labels
         worker_config.metadata.labels["app"] = "myapp"
-        worker_config.metadata.name = "pod_id-" + self.static_uuid.hex
+        worker_config.metadata.name = "pod_id"
         worker_config.metadata.namespace = "namespace"
         worker_config.spec.containers[0].env.append(
             k8s.V1EnvVar(name="AIRFLOW_IS_K8S_EXECUTOR_POD", value="True")
         )
         worker_config_result = self.k8s_client.sanitize_for_serialization(worker_config)
-        assert worker_config_result == sanitized_result
+        assert sanitized_result == worker_config_result
 
-    @mock.patch("uuid.uuid4")
-    def test_construct_pod_attribute_error(self, mock_uuid):
+    @mock.patch("airflow.kubernetes.kubernetes_helper_functions.rand_str")
+    def test_construct_pod_attribute_error(self, mock_rand_str):
         """
         After upgrading k8s library we might get attribute error.
         In this case it should raise PodReconciliationError
         """
         path = sys.path[0] + "/tests/kubernetes/pod_generator_base_with_secrets.yaml"
         worker_config = PodGenerator.deserialize_model_file(path)
-        mock_uuid.return_value = self.static_uuid
+        mock_rand_str.return_value = self.rand_str
         executor_config = MagicMock()
         executor_config.side_effect = AttributeError("error")
 
@@ -550,9 +533,9 @@ class TestPodGenerator:
                 scheduler_job_id="uuid",
             )
 
-    @mock.patch("uuid.uuid4")
-    def test_ensure_max_label_length(self, mock_uuid):
-        mock_uuid.return_value = self.static_uuid
+    @mock.patch("airflow.kubernetes.kubernetes_helper_functions.rand_str")
+    def test_ensure_max_identifier_length(self, mock_rand_str):
+        mock_rand_str.return_value = self.rand_str
         path = os.path.join(os.path.dirname(__file__), "pod_generator_base_with_secrets.yaml")
         worker_config = PodGenerator.deserialize_model_file(path)
 
@@ -570,7 +553,7 @@ class TestPodGenerator:
             base_worker_pod=worker_config,
         )
 
-        assert result.metadata.name == "a" * 30 + "-" + self.static_uuid.hex
+        assert result.metadata.name == "a" * 244 + "-" + self.rand_str
         for _, v in result.metadata.labels.items():
             assert len(v) <= 63
 
@@ -727,30 +710,33 @@ class TestPodGenerator:
         assert len(caplog.records) == 1
         assert "does not exist" in caplog.text
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "input",
         (
-            ("max_label_length", "a" * 63),
-            ("max_subdomain_length", "a" * 253),
-            (
-                "tiny",
-                "aaa",
-            ),
-        )
+            param("a" * 70, id="max_label_length"),
+            param("a" * 253, id="max_subdomain_length"),
+            param("a" * 95, id="close to max"),
+            param("aaa", id="tiny"),
+        ),
     )
-    def test_pod_name_confirm_to_max_length(self, _, pod_id):
-        name = PodGenerator.make_unique_pod_id(pod_id)
-        assert len(name) <= 253
-        parts = name.split("-")
+    def test_pod_name_confirm_to_max_length(self, input):
+        actual = PodGenerator.make_unique_pod_id(input)
+        assert len(actual) <= 100
+        actual_base, actual_suffix = actual.rsplit("-", maxsplit=1)
+        # we limit pod id length to 100
+        # random suffix is 8 chars plus the '-' separator
+        # so actual pod id base should first 91 chars of requested pod id
+        assert actual_base == input[:91]
+        # suffix should always be 8, the random alphanum
+        assert re.match(r"^[a-z0-9]{8}$", actual_suffix)
 
-        # 63 is the MAX_LABEL_LEN in pod_generator.py
-        # 33 is the length of uuid4 + 1 for the separating '-' (32 + 1)
-        # 30 is the max length of the prefix
-        # so 30 = 63 - (32 + 1)
-        assert len(parts[0]) <= 30
-        assert len(parts[1]) == 32
-
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "pod_id, expected_starts_with",
         (
+            (
+                "somewhat-long-pod-name-maybe-longer-than-previously-supported-with-hyphen-",
+                "somewhat-long-pod-name-maybe-longer-than-previously-supported-with-hyphen",
+            ),
             ("pod-name-with-hyphen-", "pod-name-with-hyphen"),
             ("pod-name-with-double-hyphen--", "pod-name-with-double-hyphen"),
             ("pod0-name", "pod0-name"),
@@ -758,17 +744,22 @@ class TestPodGenerator:
             ("pod-name-with-dot.", "pod-name-with-dot"),
             ("pod-name-with-double-dot..", "pod-name-with-double-dot"),
             ("pod-name-with-hyphen-dot-.", "pod-name-with-hyphen-dot"),
-        )
+        ),
     )
     def test_pod_name_is_valid(self, pod_id, expected_starts_with):
-        name = PodGenerator.make_unique_pod_id(pod_id)
-
+        """
+        `make_unique_pod_id` doesn't actually guarantee that the regex passes for any input.
+        But I guess this test verifies that an otherwise valid pod_id doesn't get _screwed up_.
+        """
+        actual = PodGenerator.make_unique_pod_id(pod_id)
+        assert len(actual) <= 253
+        assert actual == actual.lower(), "not lowercase"
+        # verify using official k8s regex
         regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-        assert (
-            len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
-        ), "pod_id is invalid - fails allowed regex check"
-
-        assert name.rsplit("-", 1)[0] == expected_starts_with
+        assert re.match(regex, actual), "pod_id is invalid - fails allowed regex check"
+        assert actual.rsplit("-", 1)[0] == expected_starts_with
+        # verify ends with 8 char lowercase alphanum string
+        assert re.match(rf"^{expected_starts_with}-[a-z0-9]{{8}}$", actual), "doesn't match expected pattern"
 
     def test_validate_pod_generator(self):
         with pytest.raises(AirflowConfigException):

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -1011,8 +1011,7 @@ class TestKubernetesPodOperator:
         pod = k.build_pod_request_obj({})
         assert (
             re.match(
-                r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-z0-9]{8}",
+                r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-z0-9]{8}",
                 pod.metadata.name,
             )
             is not None

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -33,7 +33,6 @@ from airflow.models.xcom import XCom
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
     KubernetesPodOperator,
     _optionally_suppress,
-    _task_id_to_pod_name,
 )
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -992,7 +991,7 @@ class TestKubernetesPodOperator:
             random_name_suffix=False,
         )
         pod = k.build_pod_request_obj({})
-        assert pod.metadata.name == "0.hi.--09hi"
+        assert pod.metadata.name == "hi-09hi"
 
     def test_task_id_as_name_with_suffix(self):
         k = KubernetesPodOperator(
@@ -1000,9 +999,9 @@ class TestKubernetesPodOperator:
             random_name_suffix=True,
         )
         pod = k.build_pod_request_obj({})
-        expected = "0.hi.--09hi"
-        assert pod.metadata.name.startswith(expected)
-        assert re.match(rf"{expected}-[a-z0-9-]+", pod.metadata.name) is not None
+        expected = "hi-09hi"
+        assert pod.metadata.name[: len(expected)] == expected
+        assert re.match(rf"{expected}-[a-z0-9]{{8}}", pod.metadata.name) is not None
 
     def test_task_id_as_name_with_suffix_very_long(self):
         k = KubernetesPodOperator(
@@ -1010,7 +1009,14 @@ class TestKubernetesPodOperator:
             random_name_suffix=True,
         )
         pod = k.build_pod_request_obj({})
-        assert re.match(r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-z0-9-]+", pod.metadata.name) is not None
+        assert (
+            re.match(
+                r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                r"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-[a-z0-9]{8}",
+                pod.metadata.name,
+            )
+            is not None
+        )
 
     def test_task_id_as_name_dag_id_is_ignored(self):
         dag = DAG(dag_id="this_is_a_dag_name", start_date=pendulum.now())
@@ -1078,23 +1084,3 @@ class TestSuppress:
         with _optionally_suppress():
             print("hi")
         assert caplog.text == ""
-
-
-@pytest.mark.parametrize(
-    "val, expected",
-    [
-        ("task-id", "task-id"),  # no problem
-        ("task_id", "task-id"),  # underscores
-        ("task.id", "task.id"),  # dots ok
-        (".task.id", "0.task.id"),  # leading dot invalid
-        ("-90Abc*&", "0-90abc--0"),  # invalid ends
-        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90a-lb---------c-a"),  # weird unicode
-    ],
-)
-def test_task_id_to_pod_name(val, expected):
-    assert _task_id_to_pod_name(val) == expected
-
-
-def test_task_id_to_pod_name_long():
-    with pytest.raises(ValueError, match="longer than 253"):
-        _task_id_to_pod_name("0" * 254)


### PR DESCRIPTION
Previously this limited pod length to 63 but that's the limit for label values not pod ids.

Meanwhile, a UUID was previously used which occupies 32 characters, much more space than necessary.  This left you with a short and not very readable pod name.

Here we update the logic to use a suffix of 8 random alphanum chars, and set a longer max length of 80 characters.

One qualification on that.  We set a max length of 80 when _we_ control the pod name -- e.g. when using kube executor or KPO when pod name not supplied.  Since we're generating it, 80 is a reasonable max.  But, with KPO, when pod_id, and user asks for random suffix, we set max length to 253, to give user most control.

Along the way, we consolidate the name building logic into one function.  Previously, one function would create the "pod_id" and then, only later in the process would a random suffix be added.  Here, all of that is done in create_pod_id, and its behavior is controllable with params.  cc @o-nikolas 


Why 80 characters: that's about as much as can reasonably fit on a normal-sized terminal.  Any more doesn't help with readability.

Why 8 character suffix: 8 random characters is more than enough. Probably fewer would be fine too.

Finally, a note.... I copied the core code to provider and we must keep it there until min airflow version catches up.  And instead of duplicating test code, i parameterized the core test to also handle provider.

---


Now, an example.

Calling with 

```
PodGenerator.make_unique_pod_id("this-is-my-semi-long-but-not-too-long-pod-id")
```

We would previously get this:

```
this-is-my-semi-long-but-not-t-c27ae4725b2049d6bf953e9f1f3d14c1
```

And now we'd get this:
```
this-is-my-semi-long-but-not-too-long-pod-id-l4hiiqxh
```
