### PR TITLE
Allow hyphens in pod id used by k8s executor

### DIFF
--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -43,7 +43,7 @@ def create_pod_id(dag_id: str | None = None, task_id: str | None = None) -> str:
         if name:
             name += "-"
         name += task_id
-    return slugify(name, lowercase=True).strip("-.")[:253]
+    return slugify(name, lowercase=True)[:253].strip("-.")
 
 
 def annotations_to_key(annotations: dict[str, str]) -> TaskInstanceKey:

--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import logging
-import re
 
 import pendulum
 from slugify import slugify
@@ -25,46 +24,6 @@ from slugify import slugify
 from airflow.models.taskinstance import TaskInstanceKey
 
 log = logging.getLogger(__name__)
-
-
-def _strip_unsafe_kubernetes_special_chars(string: str) -> str:
-    """
-    Kubernetes only supports lowercase alphanumeric characters, "-" and "." in
-    the pod name.
-    However, there are special rules about how "-" and "." can be used so let's
-    only keep
-    alphanumeric chars  see here for detail:
-    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
-
-    :param string: The requested Pod name
-    :return: Pod name stripped of any unsafe characters
-    """
-    return slugify(string, separator="", lowercase=True)
-
-
-def _make_pod_name_safe(val: str) -> str:
-    """
-    Given a value, convert it to a pod name.
-    Adds a 0 if start or end char is invalid.
-    Replaces any other invalid char with `-`.
-
-    :param val: non-empty string, presumed to be a task id
-    :return valid kubernetes object name.
-    """
-    if not val:
-        raise ValueError("_task_id_to_pod_name requires non-empty string.")
-    val = val.lower()
-    if not re.match(r"[a-z0-9]", val[0]):
-        val = f"0{val}"
-    if not re.match(r"[a-z0-9]", val[-1]):
-        val = f"{val}0"
-    val = re.sub(r"[^a-z0-9\-.]", "-", val)
-    if len(val) > 253:
-        raise ValueError(
-            f"Pod name {val} is longer than 253 characters. "
-            "See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/."
-        )
-    return val
 
 
 def create_pod_id(dag_id: str | None = None, task_id: str | None = None) -> str:
@@ -79,12 +38,12 @@ def create_pod_id(dag_id: str | None = None, task_id: str | None = None) -> str:
     """
     name = ""
     if dag_id:
-        name += dag_id.strip("-.")
+        name += dag_id
     if task_id:
         if name:
             name += "-"
-        name += task_id.strip("-.")
-    return _make_pod_name_safe(name).strip("-.")
+        name += task_id
+    return slugify(name, lowercase=True).strip("-.")[:253]
 
 
 def annotations_to_key(annotations: dict[str, str]) -> TaskInstanceKey:

--- a/tests/kubernetes/test_kubernetes_helper_functions.py
+++ b/tests/kubernetes/test_kubernetes_helper_functions.py
@@ -74,7 +74,7 @@ def test_create_pod_id_dag_only(val, expected):
         ("90AçLbˆˆç˙ßß˜˜˙c*a", "90AçLbˆˆç˙ßß˜˜˙c*a", "90aclb-c-ssss-c-a-90aclb-c-ssss-c-a"),  # ugly
     ],
 )
-def test_create_pod_id_dag_only(dag_id, task_id, expected):
+def test_create_pod_id_dag_and_task(dag_id, task_id, expected):
     actual = create_pod_id(dag_id=dag_id, task_id=task_id)
     assert actual == expected
     assert re.match(pod_name_regex, actual)

--- a/tests/kubernetes/test_kubernetes_helper_functions.py
+++ b/tests/kubernetes/test_kubernetes_helper_functions.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from airflow.kubernetes.kubernetes_helper_functions import create_pod_id
+
+pod_name_regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+
+
+@pytest.mark.parametrize(
+    "val, expected",
+    [
+        ("task-id", "task-id"),  # no problem
+        ("task_id", "task-id"),  # underscores
+        ("task.id", "task.id"),  # dots ok
+        (".task.id", "task.id"),  # leading dot invalid
+        ("**task.id", "0--task.id"),  # leading dot invalid
+        ("-90Abc*&", "90abc--0"),  # invalid ends
+        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90a-lb---------c-a"),  # weird unicode
+    ],
+)
+def test_create_pod_id_task_only(val, expected):
+    assert create_pod_id(task_id=val) == expected
+    assert re.match(pod_name_regex, expected)
+
+
+@pytest.mark.parametrize(
+    "dag_id, task_id, expected",
+    [
+        ("dag-id", "task-id", "dag-id-task-id"),  # no problem
+        ("dag_id", "task_id", "dag-id-task-id"),  # underscores
+        ("dag.id", "task.id", "dag.id-task.id"),  # dots ok
+        (".dag.id", ".task.id", "dag.id-task.id"),  # leading dot invalid
+        ("**dag.id", "**task.id", "0--dag.id---task.id"),  # leading dot invalid
+        ("-90Abc*&", "-90Abc*&", "90abc---90abc--0"),  # invalid ends
+        ("90AçLbˆˆç˙ßß˜˜˙c*a", "90AçLbˆˆç˙ßß˜˜˙c*a", "90a-lb---------c-a-90a-lb---------c-a"),  # ugly
+    ],
+)
+def test_create_pod_id_dag_only(dag_id, task_id, expected):
+    assert create_pod_id(dag_id=dag_id, task_id=task_id) == expected
+    assert re.match(pod_name_regex, expected)
+
+
+def test_task_id_to_pod_name_long():
+    with pytest.raises(ValueError, match="longer than 253"):
+        create_pod_id("0" * 254)


### PR DESCRIPTION
Makes things more readable.  E.g. my-dag-my-task instead of mydagmytask.
