### PR TITLE
Remove XCom API endpoint full deserialization option

### DIFF
--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -88,14 +88,10 @@ def get_xcom_entry(
     task_id: str,
     dag_run_id: str,
     xcom_key: str,
-    deserialize: bool = False,
     session: Session = NEW_SESSION,
 ) -> APIResponse:
     """Get an XCom entry"""
-    if deserialize:
-        query = session.query(XCom, XCom.value)
-    else:
-        query = session.query(XCom)
+    query = session.query(XCom)
 
     query = query.filter(XCom.dag_id == dag_id, XCom.task_id == task_id, XCom.key == xcom_key)
     query = query.join(DR, and_(XCom.dag_id == DR.dag_id, XCom.run_id == DR.run_id))
@@ -104,12 +100,5 @@ def get_xcom_entry(
     item = query.one_or_none()
     if item is None:
         raise NotFound("XCom entry not found")
-
-    if deserialize:
-        xcom, value = item
-        stub = copy.copy(xcom)
-        stub.value = value
-        stub.value = XCom.deserialize_value(stub)
-        item = stub
 
     return xcom_schema.dump(item)

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1588,23 +1588,6 @@ paths:
       x-openapi-router-controller: airflow.api_connexion.endpoints.xcom_endpoint
       operationId: get_xcom_entry
       tags: [XCom]
-      parameters:
-        - in: query
-          name: deserialize
-          schema:
-            type: boolean
-            default: false
-          required: false
-          description: |
-            Whether to deserialize an XCom value when using a custom XCom backend.
-
-            The XCom API endpoint calls `orm_deserialize_value` by default since an XCom may contain value
-            that is potentially expensive to deserialize in the web server. Setting this to true overrides
-            the consideration, and calls `deserialize_value` instead.
-
-            This parameter is not meaningful when using the default XCom backend.
-
-            *New in version 2.4.0*
       responses:
         '200':
           description: Success.

--- a/airflow/www/static/js/types/api-generated.ts
+++ b/airflow/www/static/js/types/api-generated.ts
@@ -3711,20 +3711,6 @@ export interface operations {
         /** The XCom key. */
         xcom_key: components["parameters"]["XComKey"];
       };
-      query: {
-        /**
-         * Whether to deserialize an XCom value when using a custom XCom backend.
-         *
-         * The XCom API endpoint calls `orm_deserialize_value` by default since an XCom may contain value
-         * that is potentially expensive to deserialize in the web server. Setting this to true overrides
-         * the consideration, and calls `deserialize_value` instead.
-         *
-         * This parameter is not meaningful when using the default XCom backend.
-         *
-         * *New in version 2.4.0*
-         */
-        deserialize?: boolean;
-      };
     };
     responses: {
       /** Success. */
@@ -4543,7 +4529,7 @@ export type GetVariableVariables = CamelCasedPropertiesDeep<operations['get_vari
 export type DeleteVariableVariables = CamelCasedPropertiesDeep<operations['delete_variable']['parameters']['path']>;
 export type PatchVariableVariables = CamelCasedPropertiesDeep<operations['patch_variable']['parameters']['path'] & operations['patch_variable']['parameters']['query'] & operations['patch_variable']['requestBody']['content']['application/json']>;
 export type GetXcomEntriesVariables = CamelCasedPropertiesDeep<operations['get_xcom_entries']['parameters']['path'] & operations['get_xcom_entries']['parameters']['query']>;
-export type GetXcomEntryVariables = CamelCasedPropertiesDeep<operations['get_xcom_entry']['parameters']['path'] & operations['get_xcom_entry']['parameters']['query']>;
+export type GetXcomEntryVariables = CamelCasedPropertiesDeep<operations['get_xcom_entry']['parameters']['path']>;
 export type GetExtraLinksVariables = CamelCasedPropertiesDeep<operations['get_extra_links']['parameters']['path']>;
 export type GetLogVariables = CamelCasedPropertiesDeep<operations['get_log']['parameters']['path'] & operations['get_log']['parameters']['query']>;
 export type GetDagDetailsVariables = CamelCasedPropertiesDeep<operations['get_dag_details']['parameters']['path']>;

--- a/newsfragments/27740.significant.rst
+++ b/newsfragments/27740.significant.rst
@@ -1,0 +1,6 @@
+XCom API endpoint no longer supports ``deserialize`` option
+
+For security reasons the XCom API no longer supports the ``deserialize`` option
+to deserialize arbitrary XCom values in the webserver. Custom XCom backend can
+implement their own ``orm_deserialize_value`` if required. However it is strongly
+suggested to deserialize on the client side.

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -185,8 +185,6 @@ class TestGetXComEntry(TestXComEndpoint):
     @pytest.mark.parametrize(
         "query, expected_value",
         [
-            pytest.param("?deserialize=true", "real deserialized TEST_VALUE", id="true"),
-            pytest.param("?deserialize=false", "orm deserialized TEST_VALUE", id="false"),
             pytest.param("", "orm deserialized TEST_VALUE", id="default"),
         ],
     )


### PR DESCRIPTION
It is possible to fully deserialize XCom values in the webserver by specifying a `deserialize` parameter. This creates a potential security issue as deserialization instantiates arbitrary objects.

Custom XCom backends should implement `orm_deserialize_value` themselves if they want to retain the behavior. However, it is strongly suggested to deserialize on the client side for the above mentioned reasons.

See also: #26343

cc @uranusjr @ashb @herunyu 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
