### PR TITLE
Updates health check endpoint to include `triggerer` status

### DIFF
--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -41,7 +41,6 @@ def get_health() -> APIResponse:
                 scheduler_status = HEALTHY
     except Exception:
         metadatabase_status = UNHEALTHY
- 
     try:
         triggerer_job = TriggererJob.most_recent_job()
 

--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -16,8 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-from typing import Optional
-
 from airflow.api_connexion.schemas.health_schema import health_schema
 from airflow.api_connexion.types import APIResponse
 from airflow.jobs.scheduler_job import SchedulerJob
@@ -33,7 +31,7 @@ def get_health() -> APIResponse:
     latest_scheduler_heartbeat = None
     latest_triggerer_heartbeat = None
     scheduler_status = UNHEALTHY
-    triggerer_status: Optional[str] = UNHEALTHY
+    triggerer_status: str | None = UNHEALTHY
     try:
         scheduler_job = SchedulerJob.most_recent_job()
 

--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from airflow.api_connexion.schemas.health_schema import health_schema
 from airflow.api_connexion.types import APIResponse
 from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.jobs.triggerer_job import TriggererJob
 
 HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"
@@ -28,7 +29,9 @@ def get_health() -> APIResponse:
     """Return the health of the airflow scheduler and metadatabase."""
     metadatabase_status = HEALTHY
     latest_scheduler_heartbeat = None
+    latest_triggerer_heartbeat = None
     scheduler_status = UNHEALTHY
+    triggerer_status = None
     try:
         scheduler_job = SchedulerJob.most_recent_job()
 
@@ -38,12 +41,28 @@ def get_health() -> APIResponse:
                 scheduler_status = HEALTHY
     except Exception:
         metadatabase_status = UNHEALTHY
+ 
+    try:
+        triggerer_job = TriggererJob.most_recent_job()
+
+        if triggerer_job:
+            latest_triggerer_heartbeat = triggerer_job.latest_heartbeat.isoformat()
+            if triggerer_job.is_alive():
+                triggerer_status = HEALTHY
+            else:
+                triggerer_status = UNHEALTHY
+    except Exception:
+        metadatabase_status = UNHEALTHY
 
     payload = {
         "metadatabase": {"status": metadatabase_status},
         "scheduler": {
             "status": scheduler_status,
             "latest_scheduler_heartbeat": latest_scheduler_heartbeat,
+        },
+        "triggerer": {
+            "status": triggerer_status,
+            "latest_triggerer_heartbeat": latest_triggerer_heartbeat,
         },
     }
 

--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -16,6 +16,8 @@
 # under the License.
 from __future__ import annotations
 
+from typing import Optional
+
 from airflow.api_connexion.schemas.health_schema import health_schema
 from airflow.api_connexion.types import APIResponse
 from airflow.jobs.scheduler_job import SchedulerJob
@@ -31,7 +33,7 @@ def get_health() -> APIResponse:
     latest_scheduler_heartbeat = None
     latest_triggerer_heartbeat = None
     scheduler_status = UNHEALTHY
-    triggerer_status = UNHEALTHY
+    triggerer_status: Optional[str] = UNHEALTHY
     try:
         scheduler_job = SchedulerJob.most_recent_job()
 

--- a/airflow/api_connexion/endpoints/health_endpoint.py
+++ b/airflow/api_connexion/endpoints/health_endpoint.py
@@ -31,7 +31,7 @@ def get_health() -> APIResponse:
     latest_scheduler_heartbeat = None
     latest_triggerer_heartbeat = None
     scheduler_status = UNHEALTHY
-    triggerer_status = None
+    triggerer_status = UNHEALTHY
     try:
         scheduler_job = SchedulerJob.most_recent_job()
 
@@ -48,8 +48,8 @@ def get_health() -> APIResponse:
             latest_triggerer_heartbeat = triggerer_job.latest_heartbeat.isoformat()
             if triggerer_job.is_alive():
                 triggerer_status = HEALTHY
-            else:
-                triggerer_status = UNHEALTHY
+        else:
+            triggerer_status = None
     except Exception:
         metadatabase_status = UNHEALTHY
 

--- a/airflow/api_connexion/schemas/health_schema.py
+++ b/airflow/api_connexion/schemas/health_schema.py
@@ -30,9 +30,15 @@ class MetaDatabaseInfoSchema(BaseInfoSchema):
 
 
 class SchedulerInfoSchema(BaseInfoSchema):
-    """Schema for Metadatabase info."""
+    """Schema for Scheduler info."""
 
     latest_scheduler_heartbeat = fields.String(dump_only=True)
+
+
+class TriggererInfoSchema(BaseInfoSchema):
+    """Schema for Triggerer info."""
+
+    latest_triggerer_heartbeat = fields.String(dump_only=True)
 
 
 class HealthInfoSchema(Schema):
@@ -40,6 +46,7 @@ class HealthInfoSchema(Schema):
 
     metadatabase = fields.Nested(MetaDatabaseInfoSchema)
     scheduler = fields.Nested(SchedulerInfoSchema)
+    triggerer = fields.Nested(TriggererInfoSchema)
 
 
 health_schema = HealthInfoSchema()

--- a/docs/apache-airflow/logging-monitoring/check-health.rst
+++ b/docs/apache-airflow/logging-monitoring/check-health.rst
@@ -47,6 +47,10 @@ To check the health status of your Airflow instance, you can simply access the e
     "scheduler":{
       "status":"healthy",
       "latest_scheduler_heartbeat":"2018-12-26 17:15:11+00:00"
+    },
+    "triggerer":{
+      "status":"healthy",
+      "latest_triggerer_heartbeat":"2018-12-26 17:16:12+00:00"
     }
   }
 
@@ -62,6 +66,10 @@ To check the health status of your Airflow instance, you can simply access the e
       ``[scheduler]`` section in ``airflow.cfg``
     * If you run more than one scheduler, only the state of one scheduler will be reported, i.e. only one working scheduler is enough
       for the scheduler state to be considered healthy
+
+  * The status of the ``triggerer`` behaves exactly like that of the ``scheduler`` as described above.
+    Note that the ``status`` and ``latest_triggerer_heartbeat`` fields in the health check response will be null for
+    deployments that do not include a ``triggerer`` component.
 
 Please keep in mind that the HTTP response code of ``/health`` endpoint **should not** be used to determine the health
 status of the application. The return code is only indicative of the state of the rest call (200 for success).


### PR DESCRIPTION

This PR updates the `health` endpoint to include the `triggerer`s status in its response. The `status` and `latest_triggerer_heartbeat` sections will be null for deployments that do not include a triggerer component.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
