### PR TITLE
Simplify notes accordion test

### DIFF
--- a/airflow/www/static/js/dag/details/NotesAccordion.test.tsx
+++ b/airflow/www/static/js/dag/details/NotesAccordion.test.tsx
@@ -52,11 +52,6 @@ describe('Test DagRun / Task Instance Notes', () => {
     );
 
     await waitFor(() => expect(getByText('Add Note')).toBeVisible());
-
-    const accordion = getByText('DAG Run Notes:');
-
-    fireEvent.click(accordion);
-    await waitFor(() => expect(getByText('Add Note')).not.toBeVisible());
   });
 
   test('With initial value, accordion is open. And update button changed', () => {


### PR DESCRIPTION
We were testing a 3rd party accordion component that had a long animation. This is a lot heavier than we need it to be. (2s is wayyy too long)
<img width="630" alt="Screen Shot 2022-11-17 at 5 45 10 PM" src="https://user-images.githubusercontent.com/4600967/202576152-d41164b8-1523-42ee-b3dc-1c74c7f7fa11.png">

Instead, we should just test that the 'Add Note' button renders and not that the accordion opens/closes.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
