### PR TITLE
Unify "full tests needed" and "run everything" in CI

### DIFF
--- a/dev/breeze/SELECTIVE_CHECKS.md
+++ b/dev/breeze/SELECTIVE_CHECKS.md
@@ -32,8 +32,8 @@ contributors in case of simpler changes.
 
 We have the following Groups of files for CI that determine which tests are run:
 
-* `Environment files` - if any of those changes, that forces 'run everything' mode, because changes there might
-  simply change the whole environment of what is going on in CI (Container image, dependencies)
+* `Environment files` - if any of those changes, that forces 'full tests needed' mode, because changes
+  there might simply change the whole environment of what is going on in CI (Container image, dependencies)
 * `Python and Javascript production files` - this area is useful in CodeQL Security scanning - if any of
   the python or javascript files for airflow "production" changed, this means that the security scans should run
 * `API tests and codegen files` - those are OpenAPI definition files that impact Open API specification and
@@ -74,13 +74,12 @@ usage in one big test run, but also not to increase the number of jobs per each 
 
 The logic implements the following rules:
 
-* `Full tests` mode is enabled when the event is PUSH, or SCHEDULE or when "full tests needed" label is set.
-  That enables all matrix combinations of variables, and all possible tests
+* `Full tests mode` is enabled when the event is PUSH, or SCHEDULE or we miss commit info or any of the
+  important environment files (setup.py, setup.cfg, provider.yaml, Dockerfile, build scripts) changed or
+  when `full tests needed` label is set.  That enables all matrix combinations of variables (representative)
+  and all possible test type. No further checks are performed.
 * Python, Kubernetes, Backend, Kind, Helm versions are limited to "defaults" only unless `Full tests` mode
   is enabled.
-* If "Commit" to work on cannot be determined, or `Full Test` mode is enabled or some of the important
-  environment files (setup.py, setup.cfg, Dockerfile, build scripts) changed - all unit tests are
-  executed - this is `run everything` mode. No further checks are performed.
 * `Python scans`, `Javascript scans`, `API tests/codegen`, `UI`, `WWW`, `Kubernetes` tests and `DOC builds`
   are enabled if any of the relevant files have been changed.
 * `Helm` tests are run only if relevant files have been changed and if current branch is `main`.

--- a/dev/breeze/src/airflow_breeze/utils/selective_checks.py
+++ b/dev/breeze/src/airflow_breeze/utils/selective_checks.py
@@ -292,8 +292,14 @@ class SelectiveChecks:
 
     @cached_property
     def full_tests_needed(self) -> bool:
+        if not self._commit_ref:
+            get_console().print("[warning]Running everything as commit is missing[/]")
+            return True
         if self._github_event in [GithubEvents.PUSH, GithubEvents.SCHEDULE, GithubEvents.WORKFLOW_DISPATCH]:
             get_console().print(f"[warning]Full tests needed because event is {self._github_event}[/]")
+            return True
+        if len(self._matching_files(FileGroupForCi.ENVIRONMENT_FILES, CI_FILE_GROUP_MATCHES)) > 0:
+            get_console().print("[warning]Running everything because env files changed[/]")
             return True
         if FULL_TESTS_NEEDED_LABEL in self._pr_labels:
             get_console().print(
@@ -307,7 +313,7 @@ class SelectiveChecks:
     def python_versions(self) -> list[str]:
         return (
             CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
-            if self._run_everything or self.full_tests_needed
+            if self.full_tests_needed
             else [DEFAULT_PYTHON_MAJOR_MINOR_VERSION]
         )
 
@@ -319,7 +325,7 @@ class SelectiveChecks:
     def all_python_versions(self) -> list[str]:
         return (
             ALL_PYTHON_MAJOR_MINOR_VERSIONS
-            if self._run_everything or self.full_tests_needed
+            if self.full_tests_needed
             else [DEFAULT_PYTHON_MAJOR_MINOR_VERSION]
         )
 
@@ -432,21 +438,8 @@ class SelectiveChecks:
             get_console().print(f"[warning]{match_group} did not match any file.[/]")
         return matched_files
 
-    @cached_property
-    def _run_everything(self) -> bool:
-        if not self._commit_ref:
-            get_console().print("[warning]Running everything as commit is missing[/]")
-            return True
-        if self.full_tests_needed:
-            get_console().print("[warning]Running everything as full tests are needed[/]")
-            return True
-        if len(self._matching_files(FileGroupForCi.ENVIRONMENT_FILES, CI_FILE_GROUP_MATCHES)) > 0:
-            get_console().print("[warning]Running everything because env files changed[/]")
-            return True
-        return False
-
     def _should_be_run(self, source_area: FileGroupForCi) -> bool:
-        if self._run_everything:
+        if self.full_tests_needed:
             get_console().print(f"[warning]{source_area} enabled because we are running everything[/]")
             return True
         matched_files = self._matching_files(source_area, CI_FILE_GROUP_MATCHES)
@@ -557,7 +550,7 @@ class SelectiveChecks:
     def test_types(self) -> str:
         if not self.run_tests:
             return ""
-        if self._run_everything:
+        if self.full_tests_needed:
             current_test_types = set(all_selective_test_types())
         else:
             current_test_types = set(self._get_test_types_to_run())


### PR DESCRIPTION
After recent changes in https://github.com/apache/airflow/pull/27754 where representative tests now are run even in "full tests needed", run_everything became practically equivalent to full tests needed.

This change removes "run_everything" mode and replaces it with "full tests needed" - either automatically detected by set of changes or type of PR or manually set by PR label.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
