### PR TITLE
Remove get_db_hook method

### DIFF
--- a/airflow/providers/google/suite/transfers/sql_to_sheets.py
+++ b/airflow/providers/google/suite/transfers/sql_to_sheets.py
@@ -102,8 +102,7 @@ class SQLToGoogleSheetsOperator(BaseSQLOperator):
             yield item_list
 
     def _get_data(self):
-        hook = self.get_db_hook()
-        with closing(hook.get_conn()) as conn, closing(conn.cursor()) as cur:
+        with closing(self.db_hook.get_conn()) as conn, closing(conn.cursor()) as cur:
             self.log.info("Executing query")
             cur.execute(self.sql, self.parameters or ())
 

--- a/airflow/providers/trino/operators/trino.py
+++ b/airflow/providers/trino/operators/trino.py
@@ -60,11 +60,11 @@ class TrinoOperator(SQLExecuteQueryOperator):
         )
 
     def on_kill(self) -> None:
-        if self._hook is not None and isinstance(self._hook, TrinoHook):
-            query_id = "'" + self._hook.query_id + "'"
+        if self.db_hook is not None and isinstance(self.db_hook, TrinoHook):
+            query_id = "'" + self.db_hook.query_id + "'"
             try:
-                self.log.info("Stopping query run with queryId - %s", self._hook.query_id)
-                self._hook.run(
+                self.log.info("Stopping query run with queryId - %s", self.db_hook.query_id)
+                self.db_hook.run(
                     sql=f"CALL system.runtime.kill_query(query_id => {query_id},message => 'Job "
                     f"killed by "
                     f"user');",

--- a/tests/providers/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_sql.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import unittest
 from unittest import mock
-from unittest.mock import MagicMock
 
 from parameterized import parameterized
 
@@ -28,18 +27,14 @@ from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 
 class TestRedshiftSQLOperator(unittest.TestCase):
     @parameterized.expand([(True, ("a", "b")), (False, ("c", "d"))])
-    @mock.patch("airflow.providers.amazon.aws.operators.redshift_sql.RedshiftSQLOperator.get_db_hook")
-    def test_redshift_operator(self, test_autocommit, test_parameters, mock_get_hook):
-        hook = MagicMock()
-        mock_run = hook.run
-        mock_get_hook.return_value = hook
-        sql = MagicMock()
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_redshift_operator(self, test_autocommit, test_parameters, mock_hook):
         operator = RedshiftSQLOperator(
-            task_id="test", sql=sql, autocommit=test_autocommit, parameters=test_parameters
+            task_id="test", sql="SELECT 1", autocommit=test_autocommit, parameters=test_parameters
         )
         operator.execute(None)
-        mock_run.assert_called_once_with(
-            sql=sql,
+        mock_hook.run.assert_called_once_with(
+            sql="SELECT 1",
             autocommit=test_autocommit,
             parameters=test_parameters,
             handler=fetch_all_handler,

--- a/tests/providers/exasol/operators/test_exasol.py
+++ b/tests/providers/exasol/operators/test_exasol.py
@@ -24,11 +24,11 @@ from airflow.providers.exasol.operators.exasol import ExasolOperator
 
 
 class TestExasol:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_overwrite_autocommit(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_overwrite_autocommit(self, mock_hook):
         operator = ExasolOperator(task_id="TEST", sql="SELECT 1", autocommit=True)
         operator.execute({})
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql="SELECT 1",
             autocommit=True,
             parameters=None,
@@ -37,11 +37,11 @@ class TestExasol:
             split_statements=False,
         )
 
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_pass_parameters(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_pass_parameters(self, mock_hook):
         operator = ExasolOperator(task_id="TEST", sql="SELECT {value!s}", parameters={"value": 1})
         operator.execute({})
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql="SELECT {value!s}",
             autocommit=False,
             parameters={"value": 1},

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -789,16 +789,16 @@ class TestBigQueryGetDatasetTablesOperator(unittest.TestCase):
     ],
 )
 class TestBigQueryCheckOperators:
-    @mock.patch("airflow.providers.google.cloud.operators.bigquery._BigQueryDbHookMixin.get_db_hook")
-    def test_get_db_hook(
+    @mock.patch("airflow.providers.google.cloud.operators.bigquery._BigQueryDbHookMixin.db_hook")
+    def test_db_hook(
         self,
-        mock_get_db_hook,
+        mock_db_hook,
         operator_class,
         kwargs,
     ):
         operator = operator_class(task_id=TASK_ID, gcp_conn_id="google_cloud_default", **kwargs)
-        operator.get_db_hook()
-        mock_get_db_hook.assert_called_once()
+        operator.db_hook
+        mock_db_hook.assert_called_once()
 
 
 class TestBigQueryUpsertTableOperator(unittest.TestCase):

--- a/tests/providers/jdbc/operators/test_jdbc.py
+++ b/tests/providers/jdbc/operators/test_jdbc.py
@@ -27,12 +27,12 @@ class TestJdbcOperator:
     def setup_method(self):
         self.kwargs = dict(sql="sql", task_id="test_jdbc_operator", dag=None)
 
-    @patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute_do_push(self, mock_get_db_hook):
+    @patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_execute_do_push(self, mock_hook):
         jdbc_operator = JdbcOperator(**self.kwargs, do_xcom_push=True)
         jdbc_operator.execute(context={})
 
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql=jdbc_operator.sql,
             autocommit=jdbc_operator.autocommit,
             handler=fetch_all_handler,
@@ -41,12 +41,12 @@ class TestJdbcOperator:
             split_statements=False,
         )
 
-    @patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute_dont_push(self, mock_get_db_hook):
+    @patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_execute_dont_push(self, mock_hook):
         jdbc_operator = JdbcOperator(**self.kwargs, do_xcom_push=False)
         jdbc_operator.execute(context={})
 
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql=jdbc_operator.sql,
             autocommit=jdbc_operator.autocommit,
             parameters=jdbc_operator.parameters,

--- a/tests/providers/microsoft/mssql/operators/test_mssql.py
+++ b/tests/providers/microsoft/mssql/operators/test_mssql.py
@@ -26,8 +26,8 @@ from airflow.providers.microsoft.mssql.operators.mssql import MsSqlOperator
 
 
 class TestMsSqlOperator:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_get_hook_from_conn(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_get_hook_from_conn(self, mock_db_hook):
         """
         :class:`~.MsSqlOperator` should use the hook returned by :meth:`airflow.models.Connection.get_hook`
         if one is returned.
@@ -38,20 +38,20 @@ class TestMsSqlOperator:
         call of ``get_hook`` on the object returned from :meth:`~.BaseHook.get_connection`.
         """
         mock_hook = MagicMock()
-        mock_get_db_hook.return_value = mock_hook
+        mock_db_hook.return_value = mock_hook
 
         op = MsSqlOperator(task_id="test", sql="")
-        assert op.get_db_hook() == mock_hook
+        assert op.db_hook() == mock_hook
 
     @mock.patch(
-        "airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook", autospec=MsSqlHook
+        "airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook", autospec=MsSqlHook
     )
-    def test_get_hook_default(self, mock_get_db_hook):
+    def test_get_hook_default(self, mock_db_hook):
         """
         If :meth:`airflow.models.Connection.get_hook` does not return a hook (e.g. because of an invalid
         conn type), then :class:`~.MsSqlHook` should be used.
         """
-        mock_get_db_hook.return_value.side_effect = Mock(side_effect=AirflowException())
+        mock_db_hook.return_value.side_effect = Mock(side_effect=AirflowException())
 
         op = MsSqlOperator(task_id="test", sql="")
-        assert op.get_db_hook().__class__.__name__ == "MsSqlHook"
+        assert op.db_hook.__class__.__name__ == "MsSqlHook"

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -26,8 +26,8 @@ from airflow.providers.oracle.operators.oracle import OracleOperator, OracleStor
 
 
 class TestOracleOperator:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_execute(self, mock_hook):
         sql = "SELECT * FROM test_table"
         oracle_conn_id = "oracle_default"
         parameters = {"parameter": "value"}
@@ -44,7 +44,7 @@ class TestOracleOperator:
                 task_id=task_id,
             )
         operator.execute(context=context)
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql=sql,
             autocommit=autocommit,
             parameters=parameters,

--- a/tests/providers/qubole/operators/test_qubole_check.py
+++ b/tests/providers/qubole/operators/test_qubole_check.py
@@ -64,7 +64,7 @@ class TestQuboleCheckMixin:
         hook = operator.get_hook()
         assert hook.context == context
 
-    @mock.patch.object(_QuboleCheckOperatorMixin, "get_db_hook")
+    @mock.patch.object(_QuboleCheckOperatorMixin, "db_hook")
     @mock.patch.object(_QuboleCheckOperatorMixin, "get_hook")
     def test_get_db_hook(
         self, mock_get_hook, mock_get_db_hook, operator_class, kwargs, parent_check_operator

--- a/tests/providers/snowflake/operators/test_snowflake.py
+++ b/tests/providers/snowflake/operators/test_snowflake.py
@@ -42,8 +42,8 @@ class TestSnowflakeOperator:
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
 
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_snowflake_operator(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperatordb_hook")
+    def test_snowflake_operator(self, mock_hook):
         sql = """
         CREATE TABLE IF NOT EXISTS test_airflow (
             dummy VARCHAR(50)
@@ -63,13 +63,13 @@ class TestSnowflakeOperator:
     ],
 )
 class TestSnowflakeCheckOperators:
-    @mock.patch("airflow.providers.common.sql.operators.sql.BaseSQLOperator.get_db_hook")
-    def test_get_db_hook(
+    @mock.patch("airflow.providers.common.sql.operators.sql.BaseSQLOperator.db_hook")
+    def test_db_hook(
         self,
-        mock_get_db_hook,
+        mock_db_hook,
         operator_class,
         kwargs,
     ):
         operator = operator_class(task_id="snowflake_check", snowflake_conn_id="snowflake_default", **kwargs)
-        operator.get_db_hook()
-        mock_get_db_hook.assert_called_once()
+        operator.db_hook()
+        mock_db_hook.assert_called_once()

--- a/tests/providers/trino/operators/test_trino.py
+++ b/tests/providers/trino/operators/test_trino.py
@@ -28,8 +28,8 @@ TASK_ID = "test_trino_task"
 
 
 class TestTrinoOperator:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_execute(self, mock_hook):
         """Asserts that the run method is called when a TrinoOperator task is executed"""
 
         with pytest.warns(DeprecationWarning, match="This class is deprecated.*"):
@@ -41,7 +41,7 @@ class TestTrinoOperator:
             )
         op.execute(None)
 
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql="SELECT 1;",
             autocommit=False,
             handler=list,

--- a/tests/providers/vertica/operators/test_vertica.py
+++ b/tests/providers/vertica/operators/test_vertica.py
@@ -24,12 +24,12 @@ from airflow.providers.vertica.operators.vertica import VerticaOperator
 
 
 class TestVerticaOperator:
-    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
-    def test_execute(self, mock_get_db_hook):
+    @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.db_hook")
+    def test_execute(self, mock_hook):
         sql = "select a, b, c"
         op = VerticaOperator(task_id="test_task_id", sql=sql)
         op.execute(None)
-        mock_get_db_hook.return_value.run.assert_called_once_with(
+        mock_hook.run.assert_called_once_with(
             sql=sql,
             autocommit=False,
             handler=fetch_all_handler,


### PR DESCRIPTION
Method `get_db_hook` was used only in DatabricksSqlOperator.
These changes might make code cleaner
