### PR TITLE
Fix a deprecation warning related to airflow.utils.helpers.chain

### DIFF
--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -978,7 +978,7 @@ def test_task_fail_duration(app, admin_client, dag_maker, session):
 
 def test_graph_view_doesnt_fail_on_recursion_error(app, dag_maker, admin_client):
     """Test that the graph view doesn't fail on a recursion error."""
-    from airflow.utils.helpers import chain
+    from airflow.models.baseoperator import chain
 
     with dag_maker("test_fails_with_recursion") as dag:
 


### PR DESCRIPTION
One of warnings from `tests/www/views/test_views_tasks.py::test_graph_view_doesnt_fail_on_recursion_error` is fixed.

**Warning Log**
```
tests/www/views/test_views_tasks.py::test_graph_view_doesnt_fail_on_recursion_error
  /opt/airflow/tests/www/views/test_views_tasks.py:992: RemovedInAirflow3Warning: This function is deprecated. Please use `airflow.models.baseoperator.chain`.
    chain(*tasks)
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
