### PR TITLE
Sync context.py with context.pyi

### DIFF
--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -53,6 +53,7 @@ KNOWN_CONTEXT_KEYS = {
     "ds",
     "ds_nodash",
     "execution_date",
+    "expanded_ti_count",
     "exception",
     "inlets",
     "logical_date",


### PR DESCRIPTION

A new field (`expanded_ti_count`) was added to `context.pyi` [here](https://github.com/apache/airflow/pull/27680) but `context.py` was not updated. This caused the pre-commit tests to fail for another branch I was working on since the Context object no longer matched:
![Screenshot from 2022-11-17 23-12-15](https://user-images.githubusercontent.com/65743084/202642980-b3875eb9-4aef-434e-a1cf-0adee86717b1.png)

After testing this change in the same branch, pre-commits passed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
