### PR TITLE
Chart: add airflow_local_settings to all airflow containers

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -67,16 +67,7 @@ spec:
       volumeMounts:
         - mountPath: {{ template "airflow_logs" . }}
           name: logs
-        - name: config
-          mountPath: {{ template "airflow_config_path" . }}
-          subPath: airflow.cfg
-          readOnly: true
-{{- if .Values.airflowLocalSettings }}
-        - name: config
-          mountPath: {{ template "airflow_local_setting_path" . }}
-          subPath: airflow_local_settings.py
-          readOnly: true
-{{- end }}
+{{- include "airflow_config_mount" . | nindent 8 }}
 {{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
         {{- include "airflow_dags_mount" . | nindent 8 }}
 {{- end }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -451,6 +451,19 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{ (printf "%s-airflow-config" .Release.Name) }}
 {{- end }}
 
+{{ define "airflow_config_mount" -}}
+- name: config
+  mountPath: {{ template "airflow_config_path" . }}
+  subPath: airflow.cfg
+  readOnly: true
+  {{- if .Values.airflowLocalSettings }}
+- name: config
+  mountPath: {{ template "airflow_local_setting_path" . }}
+  subPath: airflow_local_settings.py
+  readOnly: true
+  {{- end }}
+{{- end -}}
+
 {{/*
 Create the name of the webserver service account to use
 */}}

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -101,10 +101,7 @@ spec:
               {{- include "standard_airflow_environment" . | indent 12 }}
               {{- include "container_extra_envs" (list . .Values.cleanup.env) | indent 12 }}
               volumeMounts:
-                - name: config
-                  mountPath: {{ template "airflow_config_path" . }}
-                  subPath: airflow.cfg
-                  readOnly: true
+{{- include "airflow_config_mount" . | nindent 16 }}
               resources:
 {{ toYaml .Values.cleanup.resources | indent 16 }}
           volumes:

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -116,10 +116,7 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
           args:
           {{- include "wait-for-migrations-command" . | nindent 10 }}
           envFrom:
@@ -155,16 +152,7 @@ spec:
             {{- end }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
-            {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
+{{- include "airflow_config_mount" . | nindent 12 }}
             {{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
             {{- include "airflow_dags_mount" . | nindent 12 }}
             {{- end }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -96,10 +96,7 @@ spec:
           resources:
 {{ toYaml .Values.flower.resources | indent 12 }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.flower.extraVolumeMounts }}
             {{ toYaml .Values.flower.extraVolumeMounts | nindent 12 }}
             {{- end }}

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -105,10 +105,7 @@ spec:
           resources:
 {{ toYaml .Values.createUserJob.resources | indent 12 }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.createUserJob.extraVolumeMounts }}
 {{ toYaml .Values.createUserJob.extraVolumeMounts | nindent 12 }}
 {{- end }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -106,10 +106,7 @@ spec:
           resources:
 {{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.migrateDatabaseJob.extraVolumeMounts }}
 {{ toYaml .Values.migrateDatabaseJob.extraVolumeMounts | nindent 12 }}
 {{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -136,10 +136,7 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.scheduler.extraVolumeMounts }}
 {{ toYaml .Values.scheduler.extraVolumeMounts | indent 12 }}
 {{- end }}
@@ -206,16 +203,7 @@ spec:
             {{- end }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
-            {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if and $localOrDagProcessorDisabled (or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled) }}
 {{- include "airflow_dags_mount" . | nindent 12 }}
 {{- end }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -116,10 +116,7 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.triggerer.extraVolumeMounts }}
             {{ toYaml .Values.triggerer.extraVolumeMounts | nindent 12 }}
             {{- end }}
@@ -158,16 +155,7 @@ spec:
             {{- end }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
-            {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
+{{- include "airflow_config_mount" . | nindent 12 }}
             {{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
             {{- include "airflow_dags_mount" . | nindent 12 }}
             {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -128,10 +128,7 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.webserver.extraVolumeMounts }}
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
 {{- end }}
@@ -171,20 +168,11 @@ spec:
               subPath: pod_template_file.yaml
               readOnly: true
 {{- end }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.webserver.webserverConfig }}
             - name: webserver-config
               mountPath: {{ template "airflow_webserver_config_path" . }}
               subPath: webserver_config.py
-              readOnly: true
-{{- end }}
-{{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
               readOnly: true
 {{- end }}
 {{- if and (semverCompare "<2.0.0" .Values.airflowVersion) (or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled) }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -146,10 +146,7 @@ spec:
           image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           volumeMounts:
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 12 }}
 {{- end }}
@@ -206,10 +203,7 @@ spec:
 {{- end }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
             {{- if .Values.workers.kerberosSidecar.enabled }}
             - name: config
               mountPath: {{ .Values.kerberos.configPath | quote }}
@@ -217,12 +211,6 @@ spec:
               readOnly: true
             - name: kerberos-ccache
               mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
-              readOnly: true
-            {{- end }}
-            {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
               readOnly: true
             {{- end }}
             {{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
@@ -280,20 +268,11 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
-            - name: config
-              mountPath: {{ template "airflow_config_path" . }}
-              subPath: airflow.cfg
-              readOnly: true
+{{- include "airflow_config_mount" . | nindent 12 }}
             - name: config
               mountPath: {{ .Values.kerberos.configPath | quote }}
               subPath: krb5.conf
               readOnly: true
-            {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template "airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
             - name: kerberos-keytab
               subPath: "kerberos.keytab"
               mountPath: {{ .Values.kerberos.keytabPath | quote }}

--- a/tests/charts/test_cleanup_pods.py
+++ b/tests/charts/test_cleanup_pods.py
@@ -239,6 +239,42 @@ class TestCleanupPods:
         assert 2 == jmespath.search("spec.failedJobsHistoryLimit", docs[0])
         assert 4 == jmespath.search("spec.successfulJobsHistoryLimit", docs[0])
 
+    def test_no_airflow_local_settings(self):
+        docs = render_chart(
+            values={
+                "cleanup": {
+                    "enabled": True,
+                    "failedJobsHistoryLimit": 2,
+                    "successfulJobsHistoryLimit": 4,
+                },
+                "airflowLocalSettings": None,
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+        volume_mounts = jmespath.search(
+            "spec.jobTemplate.spec.template.spec.containers[0].volumeMounts", docs[0]
+        )
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={
+                "cleanup": {
+                    "enabled": True,
+                    "failedJobsHistoryLimit": 2,
+                    "successfulJobsHistoryLimit": 4,
+                },
+                "airflowLocalSettings": "# Well hello!",
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+        assert {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        } in jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].volumeMounts", docs[0])
+
 
 class TestCleanupServiceAccount:
     def test_should_add_component_specific_labels(self):

--- a/tests/charts/test_cleanup_pods.py
+++ b/tests/charts/test_cleanup_pods.py
@@ -242,11 +242,7 @@ class TestCleanupPods:
     def test_no_airflow_local_settings(self):
         docs = render_chart(
             values={
-                "cleanup": {
-                    "enabled": True,
-                    "failedJobsHistoryLimit": 2,
-                    "successfulJobsHistoryLimit": 4,
-                },
+                "cleanup": {"enabled": True},
                 "airflowLocalSettings": None,
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
@@ -259,11 +255,7 @@ class TestCleanupPods:
     def test_airflow_local_settings(self):
         docs = render_chart(
             values={
-                "cleanup": {
-                    "enabled": True,
-                    "failedJobsHistoryLimit": 2,
-                    "successfulJobsHistoryLimit": 4,
-                },
+                "cleanup": {"enabled": True},
                 "airflowLocalSettings": "# Well hello!",
             },
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],

--- a/tests/charts/test_dag_processor.py
+++ b/tests/charts/test_dag_processor.py
@@ -497,3 +497,27 @@ class TestDagProcessor:
         assert "git-sync-init" not in [
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]
+
+    def test_no_airflow_local_settings(self):
+        docs = render_chart(
+            values={"dagProcessor": {"enabled": True}, "airflowLocalSettings": None},
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+        volume_mounts_init = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts_init)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"dagProcessor": {"enabled": True}, "airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/dag-processor/dag-processor-deployment.yaml"],
+        )
+        volume_mount = {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        }
+        assert volume_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])

--- a/tests/charts/test_migrate_database_job.py
+++ b/tests/charts/test_migrate_database_job.py
@@ -262,3 +262,22 @@ class TestMigrateDatabaseJob:
 
         assert ["release-name"] == jmespath.search("spec.template.spec.containers[0].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[0].args", docs[0])
+
+    def test_no_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": None}, show_only=["templates/jobs/migrate-database-job.yaml"]
+        )
+        volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/jobs/migrate-database-job.yaml"],
+        )
+        assert {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])

--- a/tests/charts/test_scheduler.py
+++ b/tests/charts/test_scheduler.py
@@ -394,18 +394,22 @@ class TestScheduler:
         )
         volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
         assert "airflow_local_settings.py" not in str(volume_mounts)
+        volume_mounts_init = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts_init)
 
     def test_airflow_local_settings(self):
         docs = render_chart(
             values={"airflowLocalSettings": "# Well hello!"},
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
-        assert {
+        volume_mount = {
             "name": "config",
             "mountPath": "/opt/airflow/config/airflow_local_settings.py",
             "subPath": "airflow_local_settings.py",
             "readOnly": True,
-        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        }
+        assert volume_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])
 
     @pytest.mark.parametrize(
         "executor, persistence, update_strategy, expected_update_strategy",

--- a/tests/charts/test_triggerer.py
+++ b/tests/charts/test_triggerer.py
@@ -470,6 +470,29 @@ class TestTriggerer:
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]
 
+    def test_no_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": None}, show_only=["templates/triggerer/triggerer-deployment.yaml"]
+        )
+        volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+        volume_mounts_init = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts_init)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+        volume_mount = {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        }
+        assert volume_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])
+
 
 class TestTriggererServiceAccount:
     def test_should_add_component_specific_labels(self):

--- a/tests/charts/test_webserver.py
+++ b/tests/charts/test_webserver.py
@@ -519,18 +519,22 @@ class TestWebserverDeployment:
         )
         volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
         assert "airflow_local_settings.py" not in str(volume_mounts)
+        volume_mounts_init = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts_init)
 
     def test_airflow_local_settings(self):
         docs = render_chart(
             values={"airflowLocalSettings": "# Well hello!"},
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
-        assert {
+        volume_mount = {
             "name": "config",
             "mountPath": "/opt/airflow/config/airflow_local_settings.py",
             "subPath": "airflow_local_settings.py",
             "readOnly": True,
-        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        }
+        assert volume_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])
 
     def test_default_command_and_args(self):
         docs = render_chart(show_only=["templates/webserver/webserver-deployment.yaml"])

--- a/tests/charts/test_worker.py
+++ b/tests/charts/test_worker.py
@@ -451,18 +451,22 @@ class TestWorker:
         )
         volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
         assert "airflow_local_settings.py" not in str(volume_mounts)
+        volume_mounts_init = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts_init)
 
     def test_airflow_local_settings(self):
         docs = render_chart(
             values={"airflowLocalSettings": "# Well hello!"},
             show_only=["templates/workers/worker-deployment.yaml"],
         )
-        assert {
+        volume_mount = {
             "name": "config",
             "mountPath": "/opt/airflow/config/airflow_local_settings.py",
             "subPath": "airflow_local_settings.py",
             "readOnly": True,
-        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        }
+        assert volume_mount in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert volume_mount in jmespath.search("spec.template.spec.initContainers[0].volumeMounts", docs[0])
 
     def test_airflow_local_settings_kerberos_sidecar(self):
         docs = render_chart(


### PR DESCRIPTION
This PR adds `airflow_local_settings` volume mount to all containers in the chart that use `airflow` command. This allows to reference `airflow_local_settings` file in all airflow containers.

closes: #25637, closes #27498

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
