### PR TITLE
POC / WIP testing out using logfmt for more structured logging

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -378,7 +378,7 @@ def task_run(args, dag=None):
 
     hostname = get_hostname()
 
-    log.info("Running %s on host %s", ti, hostname)
+    log.info({"event": "running task", "task_instance": ti, "hostname": hostname})
 
     if args.interactive:
         _run_task_by_selected_method(args, dag, ti)

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -72,16 +72,14 @@ DEFAULT_LOGGING_CONFIG: dict[str, Any] = {
     "disable_existing_loggers": False,
     "formatters": {
         "airflow": {
-            "format": LOG_FORMAT,
-            "class": LOG_FORMATTER_CLASS,
-        },
-        "airflow_coloured": {
-            "format": COLORED_LOG_FORMAT if COLORED_LOG else LOG_FORMAT,
-            "class": COLORED_FORMATTER_CLASS if COLORED_LOG else LOG_FORMATTER_CLASS,
+            "()": LOG_FORMATTER_CLASS,
+            "keys": ["at", "when"],
+            "mapping": {"at": "levelname", "when": "asctime"},
         },
         "source_processor": {
-            "format": DAG_PROCESSOR_LOG_FORMAT,
-            "class": LOG_FORMATTER_CLASS,
+            "()": LOG_FORMATTER_CLASS,
+            "keys": ["at", "when"],
+            "mapping": {"at": "levelname", "when": "asctime"},
         },
     },
     "filters": {
@@ -142,6 +140,13 @@ DEFAULT_LOGGING_CONFIG: dict[str, Any] = {
         "filters": ["mask_secrets"],
     },
 }
+if COLORED_LOG:
+    DEFAULT_LOGGING_CONFIG["formatters"]["airflow_coloured"] = {
+        "format": COLORED_LOG_FORMAT if COLORED_LOG else LOG_FORMAT,
+        "class": COLORED_FORMATTER_CLASS if COLORED_LOG else LOG_FORMATTER_CLASS,
+    }
+else:
+    DEFAULT_LOGGING_CONFIG["formatters"]["airflow_coloured"] = DEFAULT_LOGGING_CONFIG["formatters"]["airflow"]
 
 EXTRA_LOGGER_NAMES: str | None = conf.get("logging", "EXTRA_LOGGER_NAMES", fallback=None)
 if EXTRA_LOGGER_NAMES:

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -60,7 +60,7 @@ class SubprocessHook(BaseHook):
         :return: :class:`namedtuple` containing ``exit_code`` and ``output``, the last line from stderr
             or stdout
         """
-        self.log.info("Tmp dir root location: \n %s", gettempdir())
+        self.log.info({"temp dir root": gettempdir()})
         with contextlib.ExitStack() as stack:
             if cwd is None:
                 cwd = stack.enter_context(TemporaryDirectory(prefix="airflowtmp"))
@@ -72,7 +72,7 @@ class SubprocessHook(BaseHook):
                         signal.signal(getattr(signal, sig), signal.SIG_DFL)
                 os.setsid()
 
-            self.log.info("Running command: %s", command)
+            self.log.info({"running command": command})
 
             self.sub_process = Popen(
                 command,
@@ -83,18 +83,17 @@ class SubprocessHook(BaseHook):
                 preexec_fn=pre_exec,
             )
 
-            self.log.info("Output:")
             line = ""
             if self.sub_process is None:
                 raise RuntimeError("The subprocess should be created here and is None!")
             if self.sub_process.stdout is not None:
                 for raw_line in iter(self.sub_process.stdout.readline, b""):
                     line = raw_line.decode(output_encoding, errors="backslashreplace").rstrip()
-                    self.log.info("%s", line)
+                    self.log.info({"process output": line})
 
             self.sub_process.wait()
 
-            self.log.info("Command exited with return code %s", self.sub_process.returncode)
+            self.log.info({"event": "command exited", "return code": self.sub_process.returncode})
             return_code: int = self.sub_process.returncode
 
         return SubprocessResult(exit_code=return_code, output=line)

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -156,7 +156,7 @@ class LocalTaskJob(BaseJob):
         """
         # Without setting this, heartbeat may get us
         self.terminating = True
-        self.log.info("Task exited with return code %s", return_code)
+        self.log.info({"event": "task exited", "return_code": return_code})
 
         if not self.task_instance.test_mode:
             if conf.getboolean("scheduler", "schedule_after_task_execution", fallback=True):

--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -67,7 +67,7 @@ def configure_logging():
 
         # Try to init logging
         dictConfig(logging_config)
-    except (ValueError, KeyError) as e:
+    except (RuntimeError) as e:
         log.error("Unable to load the config, contains a configuration error.")
         # When there is an error in the config, escalate the exception
         # otherwise Airflow would silently fall back on the default config

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -126,8 +126,7 @@ class BaseTaskRunner(LoggingMixin):
         run_with = run_with or []
         full_cmd = run_with + self._command
 
-        self.log.info("Running on host: %s", get_hostname())
-        self.log.info("Running: %s", full_cmd)
+        self.log.info({"event": "running task", "hostname": get_hostname(), "command": full_cmd})
         with _airflow_parsing_context_manager(
             dag_id=self._task_instance.dag_id,
             task_id=self._task_instance.task_id,

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -79,8 +79,14 @@ class StandardTaskRunner(BaseTaskRunner):
             # We prefer the job_id passed on the command-line because at this time, the
             # task instance may not have been updated.
             job_id = getattr(args, "job_id", self._task_instance.job_id)
-            self.log.info("Running: %s", self._command)
-            self.log.info("Job %s: Subtask %s", job_id, self._task_instance.task_id)
+            self.log.info(
+                {
+                    "event": "running task",
+                    "command": self._command,
+                    "job": job_id,
+                    "subtask": self._task_instance.task_id,
+                }
+            )
 
             proc_title = "airflow task runner: {0.dag_id} {0.task_id} {0.execution_date_or_run_id}"
             if job_id is not None:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -350,3 +350,8 @@ class FileTaskHandler(logging.Handler):
                 logging.warning("OSError while change ownership of the log file")
 
         return full_path
+
+
+import structlog
+
+structlog.getLogger()

--- a/airflow/utils/log/timezone_aware.py
+++ b/airflow/utils/log/timezone_aware.py
@@ -19,9 +19,13 @@ from __future__ import annotations
 import logging
 
 import pendulum
+from logfmter import Logfmter
+from logfmter.formatter import RESERVED
+
+EXCLUDED = {*RESERVED, "__SecretsMasker_filtered"}
 
 
-class TimezoneAware(logging.Formatter):
+class TimezoneAware(Logfmter):
     """
     Override `default_time_format`, `default_msec_format` and `formatTime` to specify utc offset.
     utc offset is the matter, without it, time conversion could be wrong.
@@ -49,3 +53,10 @@ class TimezoneAware(logging.Formatter):
         if self.default_tz_format:
             s += dt.strftime(self.default_tz_format)
         return s
+
+    @classmethod
+    def get_extra(cls, record: logging.LogRecord) -> dict:
+        """Return a dictionary of logger extra parameters by filtering any reserved keys."""
+        return {
+            cls.normalize_key(key): value for key, value in record.__dict__.items() if key not in EXCLUDED
+        }


### PR DESCRIPTION
Just starting the exploration process.  I think structured logging could unlock a _lot_ of value.  CC @ashb @potiuk @jedcunningham @uranusjr 

Here I'm solely changing the formatter class.

It's possible we could use more elaborate solution like https://structlog.org/

There's also the question of whether to use logfmt key-value style or json.

Sample after checking out this PR.

I explored a few different things...

First, this is what happens to task logs when we just enable the logfmt formatter and don't otherwise change the code:

```
at=INFO when=2022-11-18T15:09:52.696-0800 msg="Dependencies all met for <TaskInstance: example_bash_operator.also_run_this abc123-3 [queued]>"
at=INFO when=2022-11-18T15:09:52.714-0800 msg="Dependencies all met for <TaskInstance: example_bash_operator.also_run_this abc123-3 [queued]>"
at=INFO when=2022-11-18T15:09:52.715-0800 msg=\n--------------------------------------------------------------------------------
at=INFO when=2022-11-18T15:09:52.715-0800 msg="Starting attempt 1 of 1"
at=INFO when=2022-11-18T15:09:52.716-0800 msg=\n--------------------------------------------------------------------------------
at=INFO when=2022-11-18T15:09:52.741-0800 msg="Executing <Task(BashOperator): also_run_this> on 2022-11-18 23:06:50+00:00"
at=INFO when=2022-11-18T15:09:52.745-0800 msg="Started process 90021 to run task"
at=INFO when=2022-11-18T15:09:52.752-0800 msg="Running: ['airflow', 'tasks', 'run', 'example_bash_operator', 'also_run_this', 'abc123-3', '--job-id', '38', '--raw', '--subdir', '/Users/dstandish/code/airflow/airflow/example_dags/example_bash_operator.py', '--cfg-path', '/var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T/tmp24s66bc9']"
at=INFO when=2022-11-18T15:09:52.755-0800 msg="Job 38: Subtask also_run_this"
at=INFO when=2022-11-18T15:09:52.857-0800 msg="Running <TaskInstance: example_bash_operator.also_run_this abc123-3 [running]> on host Daniels-MacBook-Pro-2.local"
at=INFO when=2022-11-18T15:09:52.955-0800 msg="Exporting the following env vars:\nAIRFLOW_CTX_DAG_OWNER=airflow\nAIRFLOW_CTX_DAG_ID=example_bash_operator\nAIRFLOW_CTX_TASK_ID=also_run_this\nAIRFLOW_CTX_EXECUTION_DATE=2022-11-18T23:06:50+00:00\nAIRFLOW_CTX_TRY_NUMBER=1\nAIRFLOW_CTX_DAG_RUN_ID=abc123-3"
at=INFO when=2022-11-18T15:09:52.957-0800 msg="Tmp dir root location: \n /var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T"
at=INFO when=2022-11-18T15:09:52.958-0800 msg="Running command: ['/usr/local/bin/bash', '-c', 'echo \"ti_key=example_bash_operator__also_run_this__20221118\"']"
at=INFO when=2022-11-18T15:09:52.966-0800 msg=Output:
at=INFO when=2022-11-18T15:09:52.974-0800 msg="ti_key=example_bash_operator__also_run_this__20221118"
at=INFO when=2022-11-18T15:09:52.975-0800 msg="Command exited with return code 0"
at=INFO when=2022-11-18T15:09:53.014-0800 msg="Marking task as SUCCESS. dag_id=example_bash_operator, task_id=also_run_this, execution_date=20221118T230650, start_date=20221118T230952, end_date=20221118T230953"
at=INFO when=2022-11-18T15:09:53.044-0800 msg="Task exited with return code 0"
at=INFO when=2022-11-18T15:09:53.073-0800 msg="0 downstream tasks scheduled from follow-on schedule check"
```

But we can improve this a little bit by changing the log calls to be a little more structured.  See commit #2 to see what changed.  Here's the resulting output.

```
at=INFO when=2022-11-18T16:17:27.726-0800 event="dependencies all met" task="<TaskInstance: example_bash_operator.also_run_this abc123-5 [queued]>"
at=INFO when=2022-11-18T16:17:27.748-0800 event="dependencies all met" task="<TaskInstance: example_bash_operator.also_run_this abc123-5 [queued]>"
at=INFO when=2022-11-18T16:17:27.749-0800 event="starting attempt" try_number=1 max_tries=1
at=INFO when=2022-11-18T16:17:27.775-0800 event="proceeding with task execution" task="<Task(BashOperator): also_run_this>" execution_date="2022-11-19 00:16:56+00:00"
at=INFO when=2022-11-18T16:17:27.779-0800 msg="Started process 97845 to run task"
at=INFO when=2022-11-18T16:17:27.786-0800 event="running task" command="['airflow', 'tasks', 'run', 'example_bash_operator', 'also_run_this', 'abc123-5', '--job-id', '56', '--raw', '--subdir', '/Users/dstandish/code/airflow/airflow/example_dags/example_bash_operator.py', '--cfg-path', '/var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T/tmplustcnhv']" job=56 subtask=also_run_this
at=INFO when=2022-11-18T16:17:27.900-0800 event="running task" task_instance="<TaskInstance: example_bash_operator.also_run_this abc123-5 [running]>" hostname=Daniels-MacBook-Pro-2.local
at=INFO when=2022-11-18T16:17:27.999-0800 exporting_env_vars="{'AIRFLOW_CTX_DAG_OWNER': 'airflow', 'AIRFLOW_CTX_DAG_ID': 'example_bash_operator', 'AIRFLOW_CTX_TASK_ID': 'also_run_this', 'AIRFLOW_CTX_EXECUTION_DATE': '2022-11-19T00:16:56+00:00', 'AIRFLOW_CTX_TRY_NUMBER': '1', 'AIRFLOW_CTX_DAG_RUN_ID': 'abc123-5'}"
at=INFO when=2022-11-18T16:17:28.001-0800 temp_dir_root=/var/folders/7_/1xx0hqcs3txd7kqt0ngfdjth0000gn/T
at=INFO when=2022-11-18T16:17:28.003-0800 running_command="['/usr/local/bin/bash', '-c', 'echo \"ti_key=example_bash_operator__also_run_this__20221119\"']"
at=INFO when=2022-11-18T16:17:28.019-0800 process_output="ti_key=example_bash_operator__also_run_this__20221119"
at=INFO when=2022-11-18T16:17:28.021-0800 event="command exited" return_code=0
at=INFO when=2022-11-18T16:17:28.067-0800 state=SUCCESS execution_date=20221119T001656 start_date=20221119T001727 end_date=20221119T001728 dag_id=example_bash_operator task_id=also_run_this
at=INFO when=2022-11-18T16:17:28.120-0800 event="task exited" return_code=0
at=INFO when=2022-11-18T16:17:28.149-0800 event="follow-on schedule check" downstream_tasks_scheduled=0
```

Notice that things like try_number and return_code and such are represented as key-value pairs instead of english.  I think this is as-or-more readable.

Note also that we can split things out like "event" which could be short description of what happened, then additional details are presented in key-values.