### PR TITLE
Add a missing space in a print of initialize_virtualenv.py

### DIFF
--- a/scripts/tools/initialize_virtualenv.py
+++ b/scripts/tools/initialize_virtualenv.py
@@ -157,7 +157,7 @@ def main():
             print('export CPPFLAGS="-I/usr/local/opt/openssl/include"')
         else:
             print(
-                "sudo apt install build-essential python3-dev libsqlite3-dev openssl"
+                "sudo apt install build-essential python3-dev libsqlite3-dev openssl "
                 "sqlite default-libmysqlclient-dev libmysqlclient-dev postgresql"
             )
         sys.exit(4)


### PR DESCRIPTION
related: [#22971](https://github.com/apache/airflow/pull/22971)

---


There's a double-lined print of a `sudo apt` command, where space is missing at the end of the first line. After copying and pasting the command, it causes a concatenation of two different packages without a space - thus, an error while running the command. This PR fixes it.