### PR TITLE
Improve TriggerRuleDep typing and readability

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -18,20 +18,51 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator, NamedTuple
 
 from sqlalchemy import func
 
 from airflow.ti_deps.dep_context import DepContext
-from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.session import NEW_SESSION, provide_session
-from airflow.utils.state import State
+from airflow.ti_deps.deps.base_ti_dep import BaseTIDep, TIDepStatus
+from airflow.utils.state import TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule as TR
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
     from airflow.models.taskinstance import TaskInstance
+
+
+class _UpstreamTIStates(NamedTuple):
+    """States of the upstream tis for a specific ti.
+
+    This is used to determine whether the specific ti can run in this iteration.
+    """
+
+    success: int
+    skipped: int
+    failed: int
+    upstream_failed: int
+    removed: int
+    done: int
+
+    @classmethod
+    def calculate(cls, ti: TaskInstance, finished_tis: list[TaskInstance]) -> _UpstreamTIStates:
+        """Calculate states for a task instance.
+
+        :param ti: the ti that we want to calculate deps for
+        :param finished_tis: all the finished tasks of the dag_run
+        """
+        task = ti.task
+        counter = Counter(ti.state for ti in finished_tis if ti.task_id in task.upstream_task_ids)
+        return _UpstreamTIStates(
+            counter.get(TaskInstanceState.SUCCESS, 0),
+            counter.get(TaskInstanceState.SKIPPED, 0),
+            counter.get(TaskInstanceState.FAILED, 0),
+            counter.get(TaskInstanceState.UPSTREAM_FAILED, 0),
+            counter.get(TaskInstanceState.REMOVED, 0),
+            sum(counter.values()),
+        )
 
 
 class TriggerRuleDep(BaseTIDep):
@@ -44,27 +75,12 @@ class TriggerRuleDep(BaseTIDep):
     IGNORABLE = True
     IS_TASK_DEP = True
 
-    @staticmethod
-    def _get_states_count_upstream_ti(task, finished_tis):
-        """
-        This function returns the states of the upstream tis for a specific ti in order to determine
-        whether this ti can run in this iteration
-
-        :param ti: the ti that we want to calculate deps for
-        :param finished_tis: all the finished tasks of the dag_run
-        """
-        counter = Counter(ti.state for ti in finished_tis if ti.task_id in task.upstream_task_ids)
-        return (
-            counter.get(State.SUCCESS, 0),
-            counter.get(State.SKIPPED, 0),
-            counter.get(State.FAILED, 0),
-            counter.get(State.UPSTREAM_FAILED, 0),
-            counter.get(State.REMOVED, 0),
-            sum(counter.values()),
-        )
-
-    @provide_session
-    def _get_dep_statuses(self, ti, session, dep_context: DepContext):
+    def _get_dep_statuses(
+        self,
+        ti: TaskInstance,
+        session: Session,
+        dep_context: DepContext,
+    ) -> Iterator[TIDepStatus]:
         # Checking that all upstream dependencies have succeeded
         if not ti.task.upstream_list:
             yield self._passing_status(reason="The task instance did not have any upstream tasks.")
@@ -73,23 +89,8 @@ class TriggerRuleDep(BaseTIDep):
         if ti.task.trigger_rule == TR.ALWAYS:
             yield self._passing_status(reason="The task had a always trigger rule set.")
             return
-        # see if the task name is in the task upstream for our task
-        successes, skipped, failed, upstream_failed, removed, done = self._get_states_count_upstream_ti(
-            task=ti.task, finished_tis=dep_context.ensure_finished_tis(ti.get_dagrun(session), session)
-        )
 
-        yield from self._evaluate_trigger_rule(
-            ti=ti,
-            successes=successes,
-            skipped=skipped,
-            failed=failed,
-            upstream_failed=upstream_failed,
-            removed=removed,
-            done=done,
-            flag_upstream_failed=dep_context.flag_upstream_failed,
-            dep_context=dep_context,
-            session=session,
-        )
+        yield from self._evaluate_trigger_rule(ti=ti, dep_context=dep_context, session=session)
 
     @staticmethod
     def _count_upstreams(ti: TaskInstance, *, session: Session):
@@ -116,99 +117,83 @@ class TriggerRuleDep(BaseTIDep):
         )
         return len(upstream_task_ids) + mapped_tis_addition
 
-    @provide_session
     def _evaluate_trigger_rule(
         self,
         ti: TaskInstance,
-        successes,
-        skipped,
-        failed,
-        upstream_failed,
-        removed,
-        done,
-        flag_upstream_failed,
         dep_context: DepContext,
-        session: Session = NEW_SESSION,
-    ):
-        """
-        Yields a dependency status that indicate whether the given task instance's trigger
-        rule was met.
+        session: Session,
+    ) -> Iterator[TIDepStatus]:
+        """Evaluate whether ``ti``'s trigger rule was met.
 
-        :param ti: the task instance to evaluate the trigger rule of
-        :param successes: Number of successful upstream tasks
-        :param skipped: Number of skipped upstream tasks
-        :param failed: Number of failed upstream tasks
-        :param upstream_failed: Number of upstream_failed upstream tasks
-        :param done: Number of completed upstream tasks
-        :param flag_upstream_failed: This is a hack to generate
-            the upstream_failed state creation while checking to see
-            whether the task instance is runnable. It was the shortest
-            path to add the feature
-        :param session: database session
+        :param ti: Task instance to evaluate the trigger rule of.
+        :param dep_context: The current dependency context.
+        :param session: Database session.
         """
+        finished_tis = dep_context.ensure_finished_tis(ti.get_dagrun(session), session)
+        upstream_states = _UpstreamTIStates.calculate(ti, finished_tis)
+
+        success = upstream_states.success
+        skipped = upstream_states.skipped
+        failed = upstream_states.failed
+        upstream_failed = upstream_states.upstream_failed
+        removed = upstream_states.removed
+        done = upstream_states.done
+
         task = ti.task
-        upstream = self._count_upstreams(ti, session=session)
         trigger_rule = task.trigger_rule
+        upstream = self._count_upstreams(ti, session=session)
         upstream_done = done >= upstream
-        upstream_tasks_state = {
-            "total": upstream,
-            "successes": successes,
-            "skipped": skipped,
-            "failed": failed,
-            "removed": removed,
-            "upstream_failed": upstream_failed,
-            "done": done,
-        }
-        changed: bool = False
-        if flag_upstream_failed:
+
+        changed = False
+        if dep_context.flag_upstream_failed:
             if trigger_rule == TR.ALL_SUCCESS:
                 if upstream_failed or failed:
-                    changed = ti.set_state(State.UPSTREAM_FAILED, session)
+                    changed = ti.set_state(TaskInstanceState.UPSTREAM_FAILED, session)
                 elif skipped:
-                    changed = ti.set_state(State.SKIPPED, session)
-                elif removed and successes and ti.map_index > -1:
-                    if ti.map_index >= successes:
-                        changed = ti.set_state(State.REMOVED, session)
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
+                elif removed and success and ti.map_index > -1:
+                    if ti.map_index >= success:
+                        changed = ti.set_state(TaskInstanceState.REMOVED, session)
             elif trigger_rule == TR.ALL_FAILED:
-                if successes or skipped:
-                    changed = ti.set_state(State.SKIPPED, session)
+                if success or skipped:
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
             elif trigger_rule == TR.ONE_SUCCESS:
                 if upstream_done and done == skipped:
                     # if upstream is done and all are skipped mark as skipped
-                    changed = ti.set_state(State.SKIPPED, session)
-                elif upstream_done and successes <= 0:
-                    # if upstream is done and there are no successes mark as upstream failed
-                    changed = ti.set_state(State.UPSTREAM_FAILED, session)
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
+                elif upstream_done and success <= 0:
+                    # if upstream is done and there are no success mark as upstream failed
+                    changed = ti.set_state(TaskInstanceState.UPSTREAM_FAILED, session)
             elif trigger_rule == TR.ONE_FAILED:
                 if upstream_done and not (failed or upstream_failed):
-                    changed = ti.set_state(State.SKIPPED, session)
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
             elif trigger_rule == TR.ONE_DONE:
-                if upstream_done and not (failed or successes):
-                    changed = ti.set_state(State.SKIPPED, session)
+                if upstream_done and not (failed or success):
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
             elif trigger_rule == TR.NONE_FAILED:
                 if upstream_failed or failed:
-                    changed = ti.set_state(State.UPSTREAM_FAILED, session)
+                    changed = ti.set_state(TaskInstanceState.UPSTREAM_FAILED, session)
             elif trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS:
                 if upstream_failed or failed:
-                    changed = ti.set_state(State.UPSTREAM_FAILED, session)
+                    changed = ti.set_state(TaskInstanceState.UPSTREAM_FAILED, session)
                 elif skipped == upstream:
-                    changed = ti.set_state(State.SKIPPED, session)
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
             elif trigger_rule == TR.NONE_SKIPPED:
                 if skipped:
-                    changed = ti.set_state(State.SKIPPED, session)
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
             elif trigger_rule == TR.ALL_SKIPPED:
-                if successes or failed:
-                    changed = ti.set_state(State.SKIPPED, session)
+                if success or failed:
+                    changed = ti.set_state(TaskInstanceState.SKIPPED, session)
 
         if changed:
             dep_context.have_changed_ti_states = True
 
         if trigger_rule == TR.ONE_SUCCESS:
-            if successes <= 0:
+            if success <= 0:
                 yield self._failing_status(
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires one upstream task success, "
-                        f"but none were found. upstream_tasks_state={upstream_tasks_state}, "
+                        f"but none were found. upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
@@ -217,22 +202,22 @@ class TriggerRuleDep(BaseTIDep):
                 yield self._failing_status(
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires one upstream task failure, "
-                        f"but none were found. upstream_tasks_state={upstream_tasks_state}, "
+                        f"but none were found. upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
         elif trigger_rule == TR.ONE_DONE:
-            if successes + failed <= 0:
+            if success + failed <= 0:
                 yield self._failing_status(
                     reason=(
                         f"Task's trigger rule '{trigger_rule}'"
                         "requires at least one upstream task failure or success"
-                        f"but none were failed or success. upstream_tasks_state={upstream_tasks_state}, "
+                        f"but none were failed or success. upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
         elif trigger_rule == TR.ALL_SUCCESS:
-            num_failures = upstream - successes
+            num_failures = upstream - success
             if ti.map_index > -1:
                 num_failures -= removed
             if num_failures > 0:
@@ -240,20 +225,20 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
                         f"succeeded, but found {num_failures} non-success(es). "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
         elif trigger_rule == TR.ALL_FAILED:
-            num_successes = upstream - failed - upstream_failed
+            num_success = upstream - failed - upstream_failed
             if ti.map_index > -1:
-                num_successes -= removed
-            if num_successes > 0:
+                num_success -= removed
+            if num_success > 0:
                 yield self._failing_status(
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have failed, "
-                        f"but found {num_successes} non-failure(s). "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"but found {num_success} non-failure(s). "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
@@ -263,12 +248,12 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
                         f"completed, but found {upstream_done} task(s) that were not done. "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
         elif trigger_rule == TR.NONE_FAILED:
-            num_failures = upstream - successes - skipped
+            num_failures = upstream - success - skipped
             if ti.map_index > -1:
                 num_failures -= removed
             if num_failures > 0:
@@ -276,12 +261,12 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
                         f"succeeded or been skipped, but found {num_failures} non-success(es). "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
         elif trigger_rule == TR.NONE_FAILED_MIN_ONE_SUCCESS:
-            num_failures = upstream - successes - skipped
+            num_failures = upstream - success - skipped
             if ti.map_index > -1:
                 num_failures -= removed
             if num_failures > 0:
@@ -289,7 +274,7 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have "
                         f"succeeded or been skipped, but found {num_failures} non-success(es). "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
@@ -299,7 +284,7 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to not have been "
                         f"skipped, but found {skipped} task(s) skipped. "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )
@@ -310,7 +295,7 @@ class TriggerRuleDep(BaseTIDep):
                     reason=(
                         f"Task's trigger rule '{trigger_rule}' requires all upstream tasks to have been "
                         f"skipped, but found {num_non_skipped} task(s) in non skipped state. "
-                        f"upstream_tasks_state={upstream_tasks_state}, "
+                        f"upstream_states={upstream_states}, "
                         f"upstream_task_ids={task.upstream_task_ids}"
                     )
                 )

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -56,12 +56,12 @@ class _UpstreamTIStates(NamedTuple):
         task = ti.task
         counter = Counter(ti.state for ti in finished_tis if ti.task_id in task.upstream_task_ids)
         return _UpstreamTIStates(
-            counter.get(TaskInstanceState.SUCCESS, 0),
-            counter.get(TaskInstanceState.SKIPPED, 0),
-            counter.get(TaskInstanceState.FAILED, 0),
-            counter.get(TaskInstanceState.UPSTREAM_FAILED, 0),
-            counter.get(TaskInstanceState.REMOVED, 0),
-            sum(counter.values()),
+            success=counter.get(TaskInstanceState.SUCCESS, 0),
+            skipped=counter.get(TaskInstanceState.SKIPPED, 0),
+            failed=counter.get(TaskInstanceState.FAILED, 0),
+            upstream_failed=counter.get(TaskInstanceState.UPSTREAM_FAILED, 0),
+            removed=counter.get(TaskInstanceState.REMOVED, 0),
+            done=sum(counter.values()),
         )
 
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -74,7 +74,7 @@ from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.ti_deps.dependencies_states import RUNNABLE_STATES
 from airflow.ti_deps.deps.base_ti_dep import TIDepStatus
-from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
+from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
 from airflow.utils import timezone
 from airflow.utils.db import merge_conn
 from airflow.utils.session import create_session, provide_session
@@ -1064,69 +1064,66 @@ class TestTaskInstance:
     # Numeric fields are in order:
     #   successes, skipped, failed, upstream_failed, done, removed
     @pytest.mark.parametrize(
-        "trigger_rule,successes,skipped,failed,upstream_failed,done,removed,"
-        "flag_upstream_failed,expect_state,expect_completed",
+        "trigger_rule, upstream_states, flag_upstream_failed, expect_state, expect_completed",
         [
             #
             # Tests for all_success
             #
-            ["all_success", 5, 0, 0, 0, 0, 0, True, None, True],
-            ["all_success", 2, 0, 0, 0, 0, 0, True, None, False],
-            ["all_success", 2, 0, 1, 0, 0, 0, True, State.UPSTREAM_FAILED, False],
-            ["all_success", 2, 1, 0, 0, 0, 0, True, State.SKIPPED, False],
+            ["all_success", _UpstreamTIStates(5, 0, 0, 0, 0, 0), True, None, True],
+            ["all_success", _UpstreamTIStates(2, 0, 0, 0, 0, 0), True, None, False],
+            ["all_success", _UpstreamTIStates(2, 0, 1, 0, 0, 0), True, State.UPSTREAM_FAILED, False],
+            ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 0), True, State.SKIPPED, False],
             #
             # Tests for one_success
             #
-            ["one_success", 5, 0, 0, 0, 5, 0, True, None, True],
-            ["one_success", 2, 0, 0, 0, 2, 0, True, None, True],
-            ["one_success", 2, 0, 1, 0, 3, 0, True, None, True],
-            ["one_success", 2, 1, 0, 0, 3, 0, True, None, True],
-            ["one_success", 0, 5, 0, 0, 5, 0, True, State.SKIPPED, False],
-            ["one_success", 0, 4, 1, 0, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 3, 1, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 4, 0, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 5, 0, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 4, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 0, 5, 5, 0, True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, True],
+            ["one_success", _UpstreamTIStates(0, 5, 0, 0, 0, 5), True, State.SKIPPED, False],
+            ["one_success", _UpstreamTIStates(0, 4, 1, 0, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 3, 1, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 4, 0, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 5, 0, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 4, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 0, 5, 0, 5), True, State.UPSTREAM_FAILED, False],
             #
             # Tests for all_failed
             #
-            ["all_failed", 5, 0, 0, 0, 5, 0, True, State.SKIPPED, False],
-            ["all_failed", 0, 0, 5, 0, 5, 0, True, None, True],
-            ["all_failed", 2, 0, 0, 0, 2, 0, True, State.SKIPPED, False],
-            ["all_failed", 2, 0, 1, 0, 3, 0, True, State.SKIPPED, False],
-            ["all_failed", 2, 1, 0, 0, 3, 0, True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(0, 0, 5, 0, 0, 5), True, None, True],
+            ["all_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, State.SKIPPED, False],
             #
             # Tests for one_failed
             #
-            ["one_failed", 5, 0, 0, 0, 0, 0, True, None, False],
-            ["one_failed", 2, 0, 0, 0, 0, 0, True, None, False],
-            ["one_failed", 2, 0, 1, 0, 0, 0, True, None, True],
-            ["one_failed", 2, 1, 0, 0, 3, 0, True, None, False],
-            ["one_failed", 2, 3, 0, 0, 5, 0, True, State.SKIPPED, False],
+            ["one_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 0), True, None, True],
+            ["one_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 3, 0, 0, 0, 5), True, State.SKIPPED, False],
             #
             # Tests for done
             #
-            ["all_done", 5, 0, 0, 0, 5, 0, True, None, True],
-            ["all_done", 2, 0, 0, 0, 2, 0, True, None, False],
-            ["all_done", 2, 0, 1, 0, 3, 0, True, None, False],
-            ["all_done", 2, 1, 0, 0, 3, 0, True, None, False],
+            ["all_done", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, None, True],
+            ["all_done", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, None, False],
+            ["all_done", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, None, False],
+            ["all_done", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, False],
         ],
     )
     def test_check_task_dependencies(
         self,
+        monkeypatch,
+        dag_maker,
         trigger_rule: str,
-        successes: int,
-        skipped: int,
-        failed: int,
-        removed: int,
-        upstream_failed: int,
-        done: int,
+        upstream_states: _UpstreamTIStates,
         flag_upstream_failed: bool,
         expect_state: State,
         expect_completed: bool,
-        dag_maker,
     ):
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
+
         with dag_maker() as dag:
             downstream = EmptyOperator(task_id="downstream", trigger_rule=trigger_rule)
             for i in range(5):
@@ -1137,16 +1134,11 @@ class TestTaskInstance:
 
         ti = dag_maker.create_dagrun(execution_date=run_date).get_task_instance(downstream.task_id)
         ti.task = downstream
+
         dep_results = TriggerRuleDep()._evaluate_trigger_rule(
             ti=ti,
-            successes=successes,
-            skipped=skipped,
-            failed=failed,
-            removed=removed,
-            upstream_failed=upstream_failed,
-            done=done,
-            dep_context=DepContext(),
-            flag_upstream_failed=flag_upstream_failed,
+            dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+            session=dag_maker.session,
         )
         completed = all(dep.passed for dep in dep_results)
 
@@ -1158,72 +1150,68 @@ class TestTaskInstance:
     # Numeric fields are in order:
     #   successes, skipped, failed, upstream_failed, done,removed
     @pytest.mark.parametrize(
-        "trigger_rule,successes,skipped,failed,upstream_failed,done,removed,"
-        "flag_upstream_failed,expect_state,expect_completed",
+        "trigger_rule, upstream_states, flag_upstream_failed, expect_state, expect_completed",
         [
             #
             # Tests for all_success
             #
-            ["all_success", 5, 0, 0, 0, 0, 0, True, None, True],
-            ["all_success", 2, 0, 0, 0, 0, 0, True, None, False],
-            ["all_success", 2, 0, 1, 0, 0, 0, True, State.UPSTREAM_FAILED, False],
-            ["all_success", 2, 1, 0, 0, 0, 0, True, State.SKIPPED, False],
-            ["all_success", 3, 0, 0, 0, 0, 2, True, State.REMOVED, True],  # ti.map_index >=successes
+            ["all_success", _UpstreamTIStates(5, 0, 0, 0, 0, 0), True, None, True],
+            ["all_success", _UpstreamTIStates(2, 0, 0, 0, 0, 0), True, None, False],
+            ["all_success", _UpstreamTIStates(2, 0, 1, 0, 0, 0), True, State.UPSTREAM_FAILED, False],
+            ["all_success", _UpstreamTIStates(2, 1, 0, 0, 0, 0), True, State.SKIPPED, False],
+            # ti.map_index >= success
+            ["all_success", _UpstreamTIStates(3, 0, 0, 0, 2, 0), True, State.REMOVED, True],
             #
             # Tests for one_success
             #
-            ["one_success", 5, 0, 0, 0, 5, 0, True, None, True],
-            ["one_success", 2, 0, 0, 0, 2, 0, True, None, True],
-            ["one_success", 2, 0, 1, 0, 3, 0, True, None, True],
-            ["one_success", 2, 1, 0, 0, 3, 0, True, None, True],
-            ["one_success", 0, 5, 0, 0, 5, 0, True, State.SKIPPED, False],
-            ["one_success", 0, 4, 1, 0, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 3, 1, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 4, 0, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 5, 0, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 4, 1, 5, 0, True, State.UPSTREAM_FAILED, False],
-            ["one_success", 0, 0, 0, 5, 5, 0, True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, None, True],
+            ["one_success", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, True],
+            ["one_success", _UpstreamTIStates(0, 5, 0, 0, 0, 5), True, State.SKIPPED, False],
+            ["one_success", _UpstreamTIStates(0, 4, 1, 0, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 3, 1, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 4, 0, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 5, 0, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 4, 1, 0, 5), True, State.UPSTREAM_FAILED, False],
+            ["one_success", _UpstreamTIStates(0, 0, 0, 5, 0, 5), True, State.UPSTREAM_FAILED, False],
             #
             # Tests for all_failed
             #
-            ["all_failed", 5, 0, 0, 0, 5, 0, True, State.SKIPPED, False],
-            ["all_failed", 0, 0, 5, 0, 5, 0, True, None, True],
-            ["all_failed", 2, 0, 0, 0, 2, 0, True, State.SKIPPED, False],
-            ["all_failed", 2, 0, 1, 0, 3, 0, True, State.SKIPPED, False],
-            ["all_failed", 2, 1, 0, 0, 3, 0, True, State.SKIPPED, False],
-            ["all_failed", 2, 1, 0, 0, 4, 1, True, State.SKIPPED, False],  # One removed
+            ["all_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(0, 0, 5, 0, 0, 5), True, None, True],
+            ["all_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, State.SKIPPED, False],
+            ["all_failed", _UpstreamTIStates(2, 1, 0, 0, 1, 4), True, State.SKIPPED, False],  # One removed
             #
             # Tests for one_failed
             #
-            ["one_failed", 5, 0, 0, 0, 0, 0, True, None, False],
-            ["one_failed", 2, 0, 0, 0, 0, 0, True, None, False],
-            ["one_failed", 2, 0, 1, 0, 0, 0, True, None, True],
-            ["one_failed", 2, 1, 0, 0, 3, 0, True, None, False],
-            ["one_failed", 2, 3, 0, 0, 5, 0, True, State.SKIPPED, False],
-            ["one_failed", 2, 2, 0, 0, 5, 1, True, State.SKIPPED, False],  # One removed
+            ["one_failed", _UpstreamTIStates(5, 0, 0, 0, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 0, 0, 0, 0), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 0, 1, 0, 0, 0), True, None, True],
+            ["one_failed", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, False],
+            ["one_failed", _UpstreamTIStates(2, 3, 0, 0, 0, 5), True, State.SKIPPED, False],
+            ["one_failed", _UpstreamTIStates(2, 2, 0, 0, 1, 5), True, State.SKIPPED, False],  # One removed
             #
             # Tests for done
             #
-            ["all_done", 5, 0, 0, 0, 5, 0, True, None, True],
-            ["all_done", 2, 0, 0, 0, 2, 0, True, None, False],
-            ["all_done", 2, 0, 1, 0, 3, 0, True, None, False],
-            ["all_done", 2, 1, 0, 0, 3, 0, True, None, False],
+            ["all_done", _UpstreamTIStates(5, 0, 0, 0, 0, 5), True, None, True],
+            ["all_done", _UpstreamTIStates(2, 0, 0, 0, 0, 2), True, None, False],
+            ["all_done", _UpstreamTIStates(2, 0, 1, 0, 0, 3), True, None, False],
+            ["all_done", _UpstreamTIStates(2, 1, 0, 0, 0, 3), True, None, False],
         ],
     )
     def test_check_task_dependencies_for_mapped(
         self,
+        monkeypatch,
+        dag_maker,
+        session,
         trigger_rule: str,
-        successes: int,
-        skipped: int,
-        failed: int,
-        removed: int,
-        upstream_failed: int,
-        done: int,
+        upstream_states: _UpstreamTIStates,
         flag_upstream_failed: bool,
         expect_state: State,
         expect_completed: bool,
-        dag_maker,
-        session,
     ):
         from airflow.decorators import task
 
@@ -1235,12 +1223,13 @@ class TestTaskInstance:
         def do_something_else(i):
             return 1
 
-        with dag_maker(dag_id="test_dag"):
+        with dag_maker(dag_id="test_dag", session=session):
             nums = do_something.expand(i=[i + 1 for i in range(5)])
             do_something_else.expand(i=nums)
 
         dr = dag_maker.create_dagrun()
 
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
         ti = dr.get_task_instance("do_something_else", session=session)
         ti.map_index = 0
         for map_index in range(1, 5):
@@ -1253,14 +1242,8 @@ class TestTaskInstance:
         ti.task = downstream
         dep_results = TriggerRuleDep()._evaluate_trigger_rule(
             ti=ti,
-            successes=successes,
-            skipped=skipped,
-            failed=failed,
-            removed=removed,
-            upstream_failed=upstream_failed,
-            done=done,
-            dep_context=DepContext(),
-            flag_upstream_failed=flag_upstream_failed,
+            dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+            session=session,
         )
         completed = all(dep.passed for dep in dep_results)
 

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -18,37 +18,54 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import Mock
+from unittest import mock
 
 import pytest
 
-from airflow import settings
-from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.operators.empty import EmptyOperator
 from airflow.ti_deps.dep_context import DepContext
-from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
-from airflow.utils import timezone
-from airflow.utils.session import create_session
-from airflow.utils.state import State, TaskInstanceState
+from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep, _UpstreamTIStates
+from airflow.utils.state import DagRunState, TaskInstanceState
 from airflow.utils.trigger_rule import TriggerRule
-from tests.models import DEFAULT_DATE
-from tests.test_utils.db import clear_db_runs
 
 
 @pytest.fixture
-def get_task_instance(session, dag_maker):
-    def _get_task_instance(trigger_rule=TriggerRule.ALL_SUCCESS, state=None, upstream_task_ids=None):
+def get_task_instance(monkeypatch, session, dag_maker):
+    def _get_task_instance(
+        trigger_rule: TriggerRule = TriggerRule.ALL_SUCCESS,
+        *,
+        success: int | list[str] = 0,
+        skipped: int | list[str] = 0,
+        failed: int | list[str] = 0,
+        upstream_failed: int | list[str] = 0,
+        removed: int | list[str] = 0,
+        done: int = 0,
+    ):
         with dag_maker(session=session):
             task = BaseOperator(
-                task_id="test_task", trigger_rule=trigger_rule, start_date=datetime(2015, 1, 1)
+                task_id="test_task",
+                trigger_rule=trigger_rule,
+                start_date=datetime(2015, 1, 1),
             )
-            if upstream_task_ids:
-                [EmptyOperator(task_id=task_id) for task_id in upstream_task_ids] >> task
+            for upstreams in (success, skipped, failed, upstream_failed, removed, done):
+                if not isinstance(upstreams, int):
+                    [EmptyOperator(task_id=task_id) for task_id in upstreams] >> task
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.task = task
+
+        fake_upstream_states = _UpstreamTIStates(
+            success=(success if isinstance(success, int) else len(success)),
+            skipped=(skipped if isinstance(skipped, int) else len(skipped)),
+            failed=(failed if isinstance(failed, int) else len(failed)),
+            upstream_failed=(upstream_failed if isinstance(upstream_failed, int) else len(upstream_failed)),
+            removed=(removed if isinstance(removed, int) else len(removed)),
+            done=done,
+        )
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: fake_upstream_states)
+
         return ti
 
     return _get_task_instance
@@ -56,7 +73,7 @@ def get_task_instance(session, dag_maker):
 
 @pytest.fixture
 def get_mapped_task_dagrun(session, dag_maker):
-    def _get_dagrun(trigger_rule=TriggerRule.ALL_SUCCESS, state=State.SUCCESS):
+    def _get_dagrun(trigger_rule=TriggerRule.ALL_SUCCESS, state=TaskInstanceState.SUCCESS):
         from airflow.decorators import task
 
         @task
@@ -99,33 +116,34 @@ class TestTriggerRuleDep:
         """
         If the TI has no upstream TIs then there is nothing to check and the dep is passed
         """
-        ti = get_task_instance(TriggerRule.ALL_DONE, State.UP_FOR_RETRY)
+        ti = get_task_instance(TriggerRule.ALL_DONE)
         assert TriggerRuleDep().is_met(ti=ti)
 
     def test_always_tr(self, get_task_instance):
         """
         The always trigger rule should always pass this dep
         """
-        ti = get_task_instance(TriggerRule.ALWAYS, State.UP_FOR_RETRY)
+        ti = get_task_instance(TriggerRule.ALWAYS)
         assert TriggerRuleDep().is_met(ti=ti)
 
     def test_one_success_tr_success(self, get_task_instance):
         """
         One-success trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ONE_SUCCESS, State.UP_FOR_RETRY)
+        ti = get_task_instance(
+            TriggerRule.ONE_SUCCESS,
+            success=1,
+            skipped=2,
+            failed=3,
+            removed=0,
+            upstream_failed=2,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=2,
-                failed=2,
-                removed=0,
-                upstream_failed=2,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -134,19 +152,20 @@ class TestTriggerRuleDep:
         """
         One-success trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ONE_SUCCESS)
+        ti = get_task_instance(
+            TriggerRule.ONE_SUCCESS,
+            success=0,
+            skipped=2,
+            failed=2,
+            removed=0,
+            upstream_failed=2,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=2,
-                failed=2,
-                removed=0,
-                upstream_failed=2,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -156,19 +175,20 @@ class TestTriggerRuleDep:
         """
         One-failure trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ONE_FAILED)
+        ti = get_task_instance(
+            TriggerRule.ONE_FAILED,
+            success=2,
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=2,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -178,35 +198,42 @@ class TestTriggerRuleDep:
         """
         One-failure trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ONE_FAILED)
+        ti = get_task_instance(
+            TriggerRule.ONE_FAILED,
+            success=0,
+            skipped=2,
+            failed=2,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=2,
-                failed=2,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
 
+    def test_one_failure_tr_success_no_failed(self, get_task_instance):
+        """
+        One-failure trigger rule success
+        """
+        ti = get_task_instance(
+            TriggerRule.ONE_FAILED,
+            success=0,
+            skipped=2,
+            failed=0,
+            removed=0,
+            upstream_failed=2,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=2,
-                failed=0,
-                removed=0,
-                upstream_failed=2,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -215,35 +242,42 @@ class TestTriggerRuleDep:
         """
         One-done trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ONE_DONE)
+        ti = get_task_instance(
+            TriggerRule.ONE_DONE,
+            success=2,
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=2,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
 
+    def test_one_done_tr_success_with_failed(self, get_task_instance):
+        """
+        One-done trigger rule success
+        """
+        ti = get_task_instance(
+            TriggerRule.ONE_DONE,
+            success=0,
+            skipped=0,
+            failed=2,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=0,
-                failed=2,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -252,19 +286,20 @@ class TestTriggerRuleDep:
         """
         One-done trigger rule skip
         """
-        ti = get_task_instance(TriggerRule.ONE_DONE)
+        ti = get_task_instance(
+            TriggerRule.ONE_DONE,
+            success=0,
+            skipped=2,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=2,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -274,19 +309,20 @@ class TestTriggerRuleDep:
         """
         One-done trigger rule upstream_failed
         """
-        ti = get_task_instance(TriggerRule.ONE_DONE)
+        ti = get_task_instance(
+            TriggerRule.ONE_DONE,
+            success=0,
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=2,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=2,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -296,19 +332,20 @@ class TestTriggerRuleDep:
         """
         All-success trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ALL_SUCCESS, upstream_task_ids=["FakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_SUCCESS,
+            success=["FakeTaskID"],
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=1,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=1,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -317,132 +354,95 @@ class TestTriggerRuleDep:
         """
         All-success trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ALL_SUCCESS, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_SUCCESS,
+            success=["FakeTaskID"],
+            skipped=0,
+            failed=["OtherFakeTaskID"],
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=0,
-                failed=1,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_all_success_tr_skip(self, get_task_instance):
+    @pytest.mark.parametrize(
+        "flag_upstream_failed, expected_ti_state",
+        [(True, TaskInstanceState.SKIPPED), (False, None)],
+    )
+    def test_all_success_tr_skip(self, get_task_instance, flag_upstream_failed, expected_ti_state):
         """
         All-success trigger rule fails when some upstream tasks are skipped.
         """
-        ti = get_task_instance(TriggerRule.ALL_SUCCESS, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_SUCCESS,
+            success=["FakeTaskID"],
+            skipped=["OtherFakeTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=1,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
+        assert ti.state == expected_ti_state
 
-    def test_all_success_tr_skip_flag_upstream(self, get_task_instance):
-        """
-        All-success trigger rule fails when some upstream tasks are skipped. The state of the ti
-        should be set to SKIPPED when flag_upstream_failed is True.
-        """
-        ti = get_task_instance(TriggerRule.ALL_SUCCESS, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
-        dep_statuses = tuple(
-            TriggerRuleDep()._evaluate_trigger_rule(
-                ti=ti,
-                successes=1,
-                skipped=1,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=True,
-                dep_context=DepContext(),
-                session=Mock(),
-            )
-        )
-        assert len(dep_statuses) == 1
-        assert not dep_statuses[0].passed
-        assert ti.state == State.SKIPPED
-
-    def test_none_failed_tr_success(self, get_task_instance):
+    @pytest.mark.parametrize("flag_upstream_failed", [True, False])
+    def test_none_failed_tr_success(self, get_task_instance, flag_upstream_failed):
         """
         All success including skip trigger rule success
         """
-        ti = get_task_instance(TriggerRule.NONE_FAILED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.NONE_FAILED,
+            success=["FakeTaskID"],
+            skipped=["OtherFakeTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=1,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
-
-    def test_none_failed_tr_skipped(self, get_task_instance):
-        """
-        All success including all upstream skips trigger rule success
-        """
-        ti = get_task_instance(TriggerRule.NONE_FAILED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
-        dep_statuses = tuple(
-            TriggerRuleDep()._evaluate_trigger_rule(
-                ti=ti,
-                successes=0,
-                skipped=2,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=True,
-                dep_context=DepContext(),
-                session=Mock(),
-            )
-        )
-        assert len(dep_statuses) == 0
-        assert ti.state == State.NONE
+        assert ti.state is None
 
     def test_none_failed_tr_failure(self, get_task_instance):
         """
         All success including skip trigger rule failure
         """
         ti = get_task_instance(
-            TriggerRule.NONE_FAILED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID", "FailedFakeTaskID"]
+            TriggerRule.NONE_FAILED,
+            success=["FakeTaskID"],
+            skipped=["OtherFakeTaskID"],
+            failed=["FailedFakeTaskID"],
+            removed=0,
+            upstream_failed=0,
+            done=3,
         )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=1,
-                failed=1,
-                removed=0,
-                upstream_failed=0,
-                done=3,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -453,20 +453,19 @@ class TestTriggerRuleDep:
         All success including skip trigger rule success
         """
         ti = get_task_instance(
-            TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"]
+            TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
+            success=["FakeTaskID"],
+            skipped=["OtherFakeTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
         )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=1,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -476,24 +475,23 @@ class TestTriggerRuleDep:
         All success including all upstream skips trigger rule success
         """
         ti = get_task_instance(
-            TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"]
+            TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
+            success=0,
+            skipped=["FakeTaskID", "OtherFakeTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
         )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=2,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=True,
-                dep_context=DepContext(),
-                session=Mock(),
+                dep_context=DepContext(flag_upstream_failed=True),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
-        assert ti.state == State.SKIPPED
+        assert ti.state == TaskInstanceState.SKIPPED
 
     def test_none_failed_min_one_success_tr_failure(self, session, get_task_instance):
         """
@@ -501,20 +499,18 @@ class TestTriggerRuleDep:
         """
         ti = get_task_instance(
             TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
-            upstream_task_ids=["FakeTaskID", "OtherFakeTaskID", "FailedFakeTaskID"],
+            success=["FakeTaskID"],
+            skipped=["OtherFakeTaskID"],
+            failed=["FailedFakeTaskID"],
+            removed=0,
+            upstream_failed=0,
+            done=3,
         )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=1,
-                failed=1,
-                removed=0,
-                upstream_failed=0,
-                done=3,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -524,19 +520,20 @@ class TestTriggerRuleDep:
         """
         All-failed trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ALL_FAILED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_FAILED,
+            success=0,
+            skipped=0,
+            failed=["FakeTaskID", "OtherFakeTaskID"],
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=0,
-                failed=2,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -545,19 +542,20 @@ class TestTriggerRuleDep:
         """
         All-failed trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ALL_FAILED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_FAILED,
+            success=["FakeTaskID", "OtherFakeTaskID"],
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=2,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
@@ -567,19 +565,20 @@ class TestTriggerRuleDep:
         """
         All-done trigger rule success
         """
-        ti = get_task_instance(TriggerRule.ALL_DONE, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_DONE,
+            success=["FakeTaskID", "OtherFakeTaskID"],
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=2,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=2,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 0
@@ -588,271 +587,207 @@ class TestTriggerRuleDep:
         """
         All-skipped trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ALL_SKIPPED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_SKIPPED,
+            success=["FakeTaskID"],
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=1,
+        )
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=1,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_all_skipped_tr_success(self, get_task_instance):
+    @pytest.mark.parametrize("flag_upstream_failed", [True, False])
+    def test_all_skipped_tr_success(self, get_task_instance, flag_upstream_failed):
         """
         All-skipped trigger rule success
         """
         ti = get_task_instance(
-            TriggerRule.ALL_SKIPPED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID", "FailedFakeTaskID"]
+            TriggerRule.ALL_SKIPPED,
+            success=0,
+            skipped=["FakeTaskID", "OtherFakeTaskID", "FailedFakeTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=3,
         )
-        with create_session() as session:
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=0,
-                    skipped=3,
-                    failed=0,
-                    removed=0,
-                    upstream_failed=0,
-                    done=3,
-                    flag_upstream_failed=False,
-                    dep_context=DepContext(),
-                    session=session,
-                )
+        dep_statuses = tuple(
+            TriggerRuleDep()._evaluate_trigger_rule(
+                ti=ti,
+                dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+                session=mock.Mock(),
             )
-            assert len(dep_statuses) == 0
-
-            # with `flag_upstream_failed` set to True
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=0,
-                    skipped=3,
-                    failed=0,
-                    removed=0,
-                    upstream_failed=0,
-                    done=3,
-                    flag_upstream_failed=True,
-                    dep_context=DepContext(),
-                    session=session,
-                )
-            )
-            assert len(dep_statuses) == 0
+        )
+        assert len(dep_statuses) == 0
 
     def test_all_done_tr_failure(self, get_task_instance):
         """
         All-done trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.ALL_DONE, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID"])
+        ti = get_task_instance(
+            TriggerRule.ALL_DONE,
+            success=["FakeTaskID"],
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=1,
+        )
+        EmptyOperator(task_id="OtherFakeTeakID", dag=ti.task.dag) >> ti.task  # An unfinished upstream.
+
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=1,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_none_skipped_tr_success(self, get_task_instance):
+    @pytest.mark.parametrize("flag_upstream_failed", [True, False])
+    def test_none_skipped_tr_success(self, get_task_instance, flag_upstream_failed):
         """
         None-skipped trigger rule success
         """
         ti = get_task_instance(
-            TriggerRule.NONE_SKIPPED, upstream_task_ids=["FakeTaskID", "OtherFakeTaskID", "FailedFakeTaskID"]
+            TriggerRule.NONE_SKIPPED,
+            success=["FakeTaskID", "OtherFakeTaskID"],
+            skipped=0,
+            failed=["FailedFakeTaskID"],
+            removed=0,
+            upstream_failed=0,
+            done=3,
         )
-        with create_session() as session:
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=2,
-                    skipped=0,
-                    failed=1,
-                    removed=0,
-                    upstream_failed=0,
-                    done=3,
-                    flag_upstream_failed=False,
-                    dep_context=DepContext(),
-                    session=session,
-                )
+        dep_statuses = tuple(
+            TriggerRuleDep()._evaluate_trigger_rule(
+                ti=ti,
+                dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+                session=mock.Mock(),
             )
-            assert len(dep_statuses) == 0
+        )
+        assert len(dep_statuses) == 0
 
-            # with `flag_upstream_failed` set to True
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=0,
-                    skipped=0,
-                    failed=3,
-                    removed=0,
-                    upstream_failed=0,
-                    done=3,
-                    flag_upstream_failed=True,
-                    dep_context=DepContext(),
-                    session=session,
-                )
-            )
-            assert len(dep_statuses) == 0
-
-    def test_none_skipped_tr_failure(self, get_task_instance):
+    @pytest.mark.parametrize("flag_upstream_failed", [True, False])
+    def test_none_skipped_tr_failure(self, get_task_instance, flag_upstream_failed):
         """
         None-skipped trigger rule failure
         """
-        ti = get_task_instance(TriggerRule.NONE_SKIPPED, upstream_task_ids=["FakeTaskID", "SkippedTaskID"])
-
-        with create_session() as session:
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=1,
-                    skipped=1,
-                    failed=0,
-                    removed=0,
-                    upstream_failed=0,
-                    done=2,
-                    flag_upstream_failed=False,
-                    dep_context=DepContext(),
-                    session=session,
-                )
+        ti = get_task_instance(
+            TriggerRule.NONE_SKIPPED,
+            success=["FakeTaskID"],
+            skipped=["SkippedTaskID"],
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=2,
+        )
+        dep_statuses = tuple(
+            TriggerRuleDep()._evaluate_trigger_rule(
+                ti=ti,
+                dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
+                session=mock.Mock(),
             )
-            assert len(dep_statuses) == 1
-            assert not dep_statuses[0].passed
+        )
+        assert len(dep_statuses) == 1
+        assert not dep_statuses[0].passed
 
-            # with `flag_upstream_failed` set to True
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=1,
-                    skipped=1,
-                    failed=0,
-                    removed=0,
-                    upstream_failed=0,
-                    done=2,
-                    flag_upstream_failed=True,
-                    dep_context=DepContext(),
-                    session=session,
-                )
-            )
-            assert len(dep_statuses) == 1
-            assert not dep_statuses[0].passed
+    def test_none_skipped_tr_failure_empty(self, get_task_instance):
+        """
+        None-skipped trigger rule fails until all upstream tasks have completed execution
+        """
+        ti = get_task_instance(
+            TriggerRule.NONE_SKIPPED,
+            success=0,
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=0,
+        )
+        EmptyOperator(task_id="FakeTeakID", dag=ti.task.dag) >> ti.task  # An unfinished upstream.
 
-            # Fail until all upstream tasks have completed execution
-            dep_statuses = tuple(
-                TriggerRuleDep()._evaluate_trigger_rule(
-                    ti=ti,
-                    successes=0,
-                    skipped=0,
-                    failed=0,
-                    removed=0,
-                    upstream_failed=0,
-                    done=0,
-                    flag_upstream_failed=False,
-                    dep_context=DepContext(),
-                    session=session,
-                )
+        dep_statuses = tuple(
+            TriggerRuleDep()._evaluate_trigger_rule(
+                ti=ti,
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
-            assert len(dep_statuses) == 1
-            assert not dep_statuses[0].passed
+        )
+        assert len(dep_statuses) == 1
+        assert not dep_statuses[0].passed
 
     def test_unknown_tr(self, get_task_instance):
         """
         Unknown trigger rules should cause this dep to fail
         """
-        ti = get_task_instance()
+        ti = get_task_instance(
+            TriggerRule.DUMMY,
+            success=1,
+            skipped=0,
+            failed=0,
+            removed=0,
+            upstream_failed=0,
+            done=1,
+        )
         ti.task.trigger_rule = "Unknown Trigger Rule"
+
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=1,
-                skipped=0,
-                failed=0,
-                removed=0,
-                upstream_failed=0,
-                done=1,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session="Fake Session",
+                dep_context=DepContext(flag_upstream_failed=False),
+                session=mock.Mock(),
             )
         )
-
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_get_states_count_upstream_ti(self):
+    def test_UpstreamTIStates(self, session, dag_maker):
         """
-        this test tests the helper function '_get_states_count_upstream_ti' as a unit and inside update_state
+        this test tests the helper class '_UpstreamTIStates' as a unit and inside update_state
         """
-        from airflow.ti_deps.dep_context import DepContext
+        with dag_maker(session=session):
+            op1 = EmptyOperator(task_id="op1")
+            op2 = EmptyOperator(task_id="op2")
+            op3 = EmptyOperator(task_id="op3")
+            op4 = EmptyOperator(task_id="op4")
+            op5 = EmptyOperator(task_id="op5", trigger_rule=TriggerRule.ONE_FAILED)
 
-        get_states_count_upstream_ti = TriggerRuleDep._get_states_count_upstream_ti
-        session = settings.Session()
-        now = timezone.utcnow()
-        dag = DAG("test_dagrun_with_pre_tis", start_date=DEFAULT_DATE, default_args={"owner": "owner1"})
+            op1 >> (op2, op3) >> op4
+            (op2, op3, op4) >> op5
 
-        with dag:
-            op1 = EmptyOperator(task_id="A")
-            op2 = EmptyOperator(task_id="B")
-            op3 = EmptyOperator(task_id="C")
-            op4 = EmptyOperator(task_id="D")
-            op5 = EmptyOperator(task_id="E", trigger_rule=TriggerRule.ONE_FAILED)
+        dr = dag_maker.create_dagrun()
+        tis = {ti.task_id: ti for ti in dr.task_instances}
 
-            op1.set_downstream([op2, op3])  # op1 >> op2, op3
-            op4.set_upstream([op3, op2])  # op3, op2 >> op4
-            op5.set_upstream([op2, op3, op4])  # (op2, op3, op4) >> op5
-
-        clear_db_runs()
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_id="test_dagrun_with_pre_tis", state=State.RUNNING, execution_date=now, start_date=now
-        )
-
-        ti_op1 = dr.get_task_instance(op1.task_id, session)
-        ti_op2 = dr.get_task_instance(op2.task_id, session)
-        ti_op3 = dr.get_task_instance(op3.task_id, session)
-        ti_op4 = dr.get_task_instance(op4.task_id, session)
-        ti_op5 = dr.get_task_instance(op5.task_id, session)
-        ti_op1.task = op1
-        ti_op2.task = op2
-        ti_op3.task = op3
-        ti_op4.task = op4
-        ti_op5.task = op5
-
-        ti_op1.set_state(state=State.SUCCESS, session=session)
-        ti_op2.set_state(state=State.FAILED, session=session)
-        ti_op3.set_state(state=State.SUCCESS, session=session)
-        ti_op4.set_state(state=State.SUCCESS, session=session)
-        ti_op5.set_state(state=State.SUCCESS, session=session)
-
-        session.commit()
+        tis["op1"].state = TaskInstanceState.SUCCESS
+        tis["op2"].state = TaskInstanceState.FAILED
+        tis["op3"].state = TaskInstanceState.SUCCESS
+        tis["op4"].state = TaskInstanceState.SUCCESS
+        tis["op5"].state = TaskInstanceState.SUCCESS
 
         # check handling with cases that tasks are triggered from backfill with no finished tasks
-        finished_tis = DepContext().ensure_finished_tis(ti_op2.dag_run, session)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op2) == (1, 0, 0, 0, 0, 1)
-        finished_tis = dr.get_task_instances(state=State.finished, session=session)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op4) == (1, 0, 1, 0, 0, 2)
-        assert get_states_count_upstream_ti(finished_tis=finished_tis, task=op5) == (2, 0, 1, 0, 0, 3)
+        finished_tis = tis.values()
+        assert _UpstreamTIStates.calculate(ti=tis["op2"], finished_tis=finished_tis) == (1, 0, 0, 0, 0, 1)
+        assert _UpstreamTIStates.calculate(ti=tis["op4"], finished_tis=finished_tis) == (1, 0, 1, 0, 0, 2)
+        assert _UpstreamTIStates.calculate(ti=tis["op5"], finished_tis=finished_tis) == (2, 0, 1, 0, 0, 3)
 
-        dr.update_state()
-        assert State.SUCCESS == dr.state
+        dr.update_state(session=session)
+        assert dr.state == DagRunState.SUCCESS
 
     def test_mapped_task_upstream_removed_with_all_success_trigger_rules(
-        self, session, get_mapped_task_dagrun
+        self,
+        monkeypatch,
+        session,
+        get_mapped_task_dagrun,
     ):
         """
         Test ALL_SUCCESS trigger rule with mapped task upstream removed
@@ -863,106 +798,97 @@ class TestTriggerRuleDep:
         ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)
         ti.task = task
 
+        upstream_states = _UpstreamTIStates(
+            success=3,
+            skipped=0,
+            failed=0,
+            removed=2,
+            upstream_failed=0,
+            done=5,
+        )
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
+
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=3,
-                skipped=0,
-                failed=0,
-                removed=2,
-                upstream_failed=0,
-                done=5,
-                flag_upstream_failed=True,  # marks the task as removed if upstream is removed
-                dep_context=DepContext(),
+                # Marks the task as removed if upstream is removed.
+                dep_context=DepContext(flag_upstream_failed=True),
                 session=session,
             )
         )
-
         assert len(dep_statuses) == 0
         assert ti.state == TaskInstanceState.REMOVED
 
     def test_mapped_task_upstream_removed_with_all_failed_trigger_rules(
-        self, session, get_mapped_task_dagrun
+        self,
+        monkeypatch,
+        session,
+        get_mapped_task_dagrun,
     ):
         """
         Test ALL_FAILED trigger rule with mapped task upstream removed
         """
 
-        dr, task = get_mapped_task_dagrun(trigger_rule=TriggerRule.ALL_FAILED, state=State.FAILED)
+        dr, task = get_mapped_task_dagrun(trigger_rule=TriggerRule.ALL_FAILED, state=TaskInstanceState.FAILED)
 
         # ti with removed upstream ti
         ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)
         ti.task = task
 
+        upstream_states = _UpstreamTIStates(
+            success=0,
+            skipped=0,
+            failed=3,
+            removed=2,
+            upstream_failed=0,
+            done=5,
+        )
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
+
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=0,
-                skipped=0,
-                failed=3,
-                removed=2,
-                upstream_failed=0,
-                done=5,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
+                dep_context=DepContext(flag_upstream_failed=False),
                 session=session,
             )
         )
 
         assert len(dep_statuses) == 0
 
+    @pytest.mark.parametrize(
+        "trigger_rule",
+        [TriggerRule.NONE_FAILED, TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS],
+    )
     def test_mapped_task_upstream_removed_with_none_failed_trigger_rules(
-        self, session, get_mapped_task_dagrun
+        self,
+        monkeypatch,
+        session,
+        get_mapped_task_dagrun,
+        trigger_rule,
     ):
         """
         Test NONE_FAILED trigger rule with mapped task upstream removed
         """
-        dr, task = get_mapped_task_dagrun(trigger_rule=TriggerRule.NONE_FAILED)
+        dr, task = get_mapped_task_dagrun(trigger_rule=trigger_rule)
 
         # ti with removed upstream ti
         ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)
         ti.task = task
 
-        dep_statuses = tuple(
-            TriggerRuleDep()._evaluate_trigger_rule(
-                ti=ti,
-                successes=3,
-                skipped=0,
-                failed=0,
-                removed=2,
-                upstream_failed=0,
-                done=5,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
-                session=session,
-            )
+        upstream_states = _UpstreamTIStates(
+            success=3,
+            skipped=0,
+            failed=0,
+            removed=2,
+            upstream_failed=0,
+            done=5,
         )
-
-        assert len(dep_statuses) == 0
-
-    def test_mapped_task_upstream_removed_with_none_failed_min_one_success_trigger_rules(
-        self, session, get_mapped_task_dagrun
-    ):
-        """
-        Test NONE_FAILED_MIN_ONE_SUCCESS trigger rule with mapped task upstream removed
-        """
-        dr, task = get_mapped_task_dagrun(trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS)
-
-        # ti with removed upstream ti
-        ti = dr.get_task_instance(task_id="do_something_else", map_index=3, session=session)
-        ti.task = task
+        monkeypatch.setattr(_UpstreamTIStates, "calculate", lambda *_: upstream_states)
 
         dep_statuses = tuple(
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
-                successes=3,
-                skipped=0,
-                failed=0,
-                removed=2,
-                upstream_failed=0,
-                done=5,
-                flag_upstream_failed=False,
-                dep_context=DepContext(),
+                dep_context=DepContext(flag_upstream_failed=False),
                 session=session,
             )
         )


### PR DESCRIPTION
To implement depth-first execution, a task instance must be able to depend on only selective upstream _task instances_, not the entire upstream _task_. So TriggerRuleDep’s helper functions are all changed to take `ti` to make this easier. I also took the chance to add type annotations to all the functions (including those from BaseTIDep).