### PR TITLE
dagrun, next_dagruns_to_examine, add MySQL index hint

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -292,6 +292,7 @@ class DagRun(Base, LoggingMixin):
         # TODO: Bake this query, it is run _A lot_
         query = (
             session.query(cls)
+            .with_hint(cls, 'USE INDEX (idx_dag_run_running_dags)', dialect_name='mysql')
             .filter(cls.state == state, cls.run_type != DagRunType.BACKFILL_JOB)
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .filter(DagModel.is_paused == false(), DagModel.is_active == true())

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -292,7 +292,7 @@ class DagRun(Base, LoggingMixin):
         # TODO: Bake this query, it is run _A lot_
         query = (
             session.query(cls)
-            .with_hint(cls, 'USE INDEX (idx_dag_run_running_dags)', dialect_name='mysql')
+            .with_hint(cls, "USE INDEX (idx_dag_run_running_dags)", dialect_name="mysql")
             .filter(cls.state == state, cls.run_type != DagRunType.BACKFILL_JOB)
             .join(DagModel, DagModel.dag_id == cls.dag_id)
             .filter(DagModel.is_paused == false(), DagModel.is_active == true())


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Similar to https://github.com/apache/airflow/pull/25673, we are seeing MySQL is not using the index on dag_run state and completing a full-table scan on the dag_run table when finding `RUNNING` dag_runs in the `_do_scheduling` method in the scheduler loop
https://github.com/apache/airflow/blob/9c00985849f6fd4708b3ac21afa25525bec37cdc//airflow/jobs/scheduler_job.py#L946
https://github.com/apache/airflow/blob/9c00985849f6fd4708b3ac21afa25525bec37cdc/airflow/models/dagrun.py#L293-L298
MySQL index hint resolved this issue for us, so this PR adds an index hint on the above query.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
