### PR TITLE
add hostname argument to DockerOperator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -136,6 +136,7 @@ class DockerOperator(BaseOperator):
         greater than 0. If omitted uses system default.
     :param tty: Allocate pseudo-TTY to the container
         This needs to be set see logs of the Docker container.
+    :param hostname: Optional hostname for the container.
     :param privileged: Give extended privileges to this container.
     :param cap_add: Include container capabilities
     :param retrieve_output: Should this docker image consistently attempt to pull from and output
@@ -194,6 +195,7 @@ class DockerOperator(BaseOperator):
         auto_remove: str = "never",
         shm_size: int | None = None,
         tty: bool = False,
+        hostname: str | None = None,
         privileged: bool = False,
         cap_add: Iterable[str] | None = None,
         extra_hosts: dict[str, str] | None = None,
@@ -251,6 +253,7 @@ class DockerOperator(BaseOperator):
         self.docker_conn_id = docker_conn_id
         self.shm_size = shm_size
         self.tty = tty
+        self.hostname = hostname
         self.privileged = privileged
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
@@ -342,6 +345,7 @@ class DockerOperator(BaseOperator):
             entrypoint=self.format_command(self.entrypoint),
             working_dir=self.working_dir,
             tty=self.tty,
+            hostname=self.hostname,
         )
         logstream = self.cli.attach(container=self.container["Id"], stdout=True, stderr=True, stream=True)
         try:

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -135,6 +135,7 @@ class TestDockerOperator(unittest.TestCase):
             entrypoint=["sh", "-c"],
             working_dir="/container/path",
             tty=True,
+            hostname="test.contrainer.host",
         )
         self.client_mock.create_host_config.assert_called_once_with(
             mounts=[
@@ -191,6 +192,7 @@ class TestDockerOperator(unittest.TestCase):
             shm_size=1000,
             host_tmp_dir="/host/airflow",
             container_name="test_container",
+            hostname="test.contrainer.host",
             tty=True,
         )
         operator.execute(None)
@@ -209,6 +211,7 @@ class TestDockerOperator(unittest.TestCase):
             entrypoint=["sh", "-c"],
             working_dir="/container/path",
             tty=True,
+            hostname="test.contrainer.host",
         )
         self.client_mock.create_host_config.assert_called_once_with(
             mounts=[
@@ -298,6 +301,7 @@ class TestDockerOperator(unittest.TestCase):
                     entrypoint=["sh", "-c"],
                     working_dir="/container/path",
                     tty=True,
+                    hostname=None,
                 ),
                 call(
                     command="env",
@@ -309,6 +313,7 @@ class TestDockerOperator(unittest.TestCase):
                     entrypoint=["sh", "-c"],
                     working_dir="/container/path",
                     tty=True,
+                    hostname=None,
                 ),
             ]
         )
@@ -407,6 +412,7 @@ class TestDockerOperator(unittest.TestCase):
             entrypoint=["sh", "-c"],
             working_dir="/container/path",
             tty=True,
+            hostname=None,
         )
         stringio_mock.assert_called_once_with("UNIT=FILE\nPRIVATE=FILE\nVAR=VALUE")
         self.dotenv_mock.assert_called_once_with(stream="UNIT=FILE\nPRIVATE=FILE\nVAR=VALUE")

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -108,6 +108,7 @@ class TestDockerOperator(unittest.TestCase):
             host_tmp_dir="/host/airflow",
             container_name="test_container",
             tty=True,
+            hostname="test.contrainer.host",
             device_requests=[DeviceRequest(count=-1, capabilities=[["gpu"]])],
             log_opts_max_file="5",
             log_opts_max_size="10m",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

DockerOperator could easily support `hostname` argument to pass in [docker-py](https://docker-py.readthedocs.io/en/stable/api.html) `APIClient.create_container()`. This could be useful in multiple cases, which we had run in. 
