### PR TITLE
Amazon Provider Package user agent

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -411,7 +411,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         self.resource_type = resource_type
 
         self._region_name = region_name
-        self._config = config or botocore.config.Config()
+        self._config = config
         self._verify = verify
 
     @classmethod
@@ -527,9 +527,9 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
         return self.conn_config.region_name
 
     @property
-    def config(self) -> Config | None:
+    def config(self) -> Config:
         """Configuration for botocore client read-only property."""
-        return self.conn_config.botocore_config
+        return self.conn_config.botocore_config or botocore.config.Config()
 
     @property
     def verify(self) -> bool | str | None:

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -475,7 +475,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
             return str(uuid.uuid5(uuid.NAMESPACE_OID, dag_id))
         except Exception:
             # Under no condition should an error here ever cause an issue for the user.
-            return "00000000-0000-5000-0000-000000000000"
+            return "00000000-0000-0000-0000-000000000000"
 
     @staticmethod
     def _get_airflow_version() -> str:

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -51,8 +51,8 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
-from airflow.utils.helpers import exactly_one
 from airflow.providers_manager import ProvidersManager
+from airflow.utils.helpers import exactly_one
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 


### PR DESCRIPTION
Adding a couple of fields to the boto3 user agent will allow the AWS team to better understand which services and operators to focus improvements on in the future.  This is similar to the user agent fields added by [Databricks](https://github.com/apache/airflow/blob/main/airflow/providers/databricks/hooks/databricks_base.py#L141), [Google](https://github.com/apache/airflow/blob/main/airflow/providers/google/common/hooks/base_google.py#L322), [Yandex](https://github.com/apache/airflow/blob/main/airflow/providers/yandex/hooks/yandex.py#L93), and others.