### PR TITLE
Remove auto unroll for dict values from taskflow

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -286,21 +286,12 @@ class _TaskDecorator(ExpandableFactory, Generic[FParams, FReturn, OperatorSubcla
 
     function: Callable[FParams, FReturn] = attr.ib(validator=attr.validators.is_callable())
     operator_class: type[OperatorSubclass]
-    multiple_outputs: bool = attr.ib()
+    multiple_outputs: bool = attr.ib(default=False)
     kwargs: dict[str, Any] = attr.ib(factory=dict)
 
     decorator_name: str = attr.ib(repr=False, default="task")
 
     _airflow_is_task_decorator: ClassVar[bool] = True
-
-    @multiple_outputs.default
-    def _infer_multiple_outputs(self):
-        try:
-            return_type = typing_extensions.get_type_hints(self.function).get("return", Any)
-        except TypeError:  # Can't evaluate return type.
-            return False
-        ttype = getattr(return_type, "__origin__", return_type)
-        return ttype == dict or ttype == Dict
 
     def __attrs_post_init__(self):
         if "self" in self.function_signature.parameters:

--- a/docs/apache-airflow/tutorial/taskflow.rst
+++ b/docs/apache-airflow/tutorial/taskflow.rst
@@ -377,19 +377,21 @@ section "Having sensors return XOM values" of :doc:`apache-airflow-providers:how
 
 Multiple outputs inference
 --------------------------
-Tasks can also infer multiple outputs by using dict Python typing.
+In case a task has multiple return values, Airflow can unroll these in separate values if using
+Python dict typing. The values then become available as separate arguments to downstream tasks.
 
 .. code-block:: python
 
-   @task
+   @task(multiple_outputs=True)
    def identity_dict(x: int, y: int) -> dict[str, int]:
        return {"x": x, "y": y}
 
 By using the typing ``Dict`` for the function return type, the ``multiple_outputs`` parameter
 is automatically set to true.
 
-Note, If you manually set the ``multiple_outputs`` parameter the inference is disabled and
-the parameter value is used.
+Note, before Airflow 2.5, Airflow would automatically unroll ``dict`` return values and you would need to set
+``multiple_outputs=False` explicitly. This was deemed confusing and now always defaults to ``False``.
+
 
 Adding dependencies between decorated and traditional tasks
 -----------------------------------------------------------

--- a/newsfragments/27819.significant.rst
+++ b/newsfragments/27819.significant.rst
@@ -1,0 +1,2 @@
+Airflow no longer automatically unrolls dict values into separate arguments requiring an explicit
+``multiple_outputs=True`` if unrolling is required.

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -94,19 +94,14 @@ class TestAirflowTaskDecorator:
             "Dict[str, int]",
         ],
     )
-    def test_infer_multiple_outputs_using_dict_typing(self, resolve, annotation):
-        @task_decorator
-        def identity_dict(x: int, y: int) -> resolve(annotation):
-            return {"x": x, "y": y}
+    def test_infer_multiple_outputs_using_dict_typing_raises(self, resolve, annotation):
+        with pytest.raises(AttributeError) as e:
 
-        assert identity_dict(5, 5).operator.multiple_outputs is True
+            @task_decorator()
+            def identity_dict(x: int, y: int) -> resolve(annotation):
+                return {"x": x, "y": y}
 
-        # Check invoking ``@task_decorator.__call__()`` yields the correct inference.
-        @task_decorator()
-        def identity_dict_with_decorator_call(x: int, y: int) -> resolve(annotation):
-            return {"x": x, "y": y}
-
-        assert identity_dict_with_decorator_call(5, 5).operator.multiple_outputs is True
+        assert "not implicitly unroll" in str(e.value)
 
     def test_infer_multiple_outputs_using_other_typing(self):
         @task_decorator


### PR DESCRIPTION
dict return values from functions were automatically unrolled in separate values. This meant that the default of `multiple_outputs` was changing based on the return type of the function.

This is confusing as it requires the user to be aware of this and rather un-pythonic (explicit over implicit) and makes conversion from plain python functions to Airflow tasks harder as unit tests would suddenly fail.

Closes: #27819

@uranusjr 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
