### PR TITLE
Allow depth-first execution

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -131,6 +131,7 @@ if TYPE_CHECKING:
     from airflow.models.dagrun import DagRun
     from airflow.models.dataset import DatasetEvent
     from airflow.models.operator import Operator
+    from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
 
 @contextlib.contextmanager
@@ -2572,6 +2573,103 @@ class TaskInstance(Base, LoggingMixin):
                 exc_info=True,
             )
             session.rollback()
+
+    def get_relevant_upstream_map_indexes(
+        self,
+        upstream: Operator,
+        ti_count: int | None,
+        *,
+        session: Session,
+    ) -> int | range | None:
+        """Infer the map indexes of an upstream "relevant" to this ti.
+
+        The bulk of the logic mainly exists to solve the problem described by
+        the following example, where 'val' must resolve to different values,
+        depending on where the reference is being used::
+
+            @task
+            def this_task(v):  # This is self.task.
+                return v * 2
+
+            @task_group
+            def tg1(inp):
+                val = upstream(inp)  # This is the upstream task.
+                this_task(val)  # When inp is 1, val here should resolve to 2.
+                return val
+
+            # This val is the same object returned by tg1.
+            val = tg1.expand(inp=[1, 2, 3])
+
+            @task_group
+            def tg2(inp):
+                another_task(inp, val)  # val here should resolve to [2, 4, 6].
+
+            tg2.expand(inp=["a", "b"])
+
+        The surrounding mapped task groups of ``upstream`` and ``self.task`` are
+        inspected to find a common "ancestor". If such an ancestor is found,
+        we need to return specific map indexes to pull a partial value from
+        upstream XCom.
+
+        :param upstream: The referenced upstream task.
+        :param ti_count: The total count of task instance this task was expanded
+            by the scheduler, i.e. ``expanded_ti_count`` in the template context.
+        :return: Specific map index or map indexes to pull, or ``None`` if we
+            want to "whole" return value (i.e. no mapped task groups involved).
+        """
+        # Find the innermost common mapped task group between the current task
+        # If the current task and the referenced task does not have a common
+        # mapped task group, the two are in different task mapping contexts
+        # (like another_task above), and we should use the "whole" value.
+        common_ancestor = _find_common_ancestor_mapped_group(self.task, upstream)
+        if common_ancestor is None:
+            return None
+
+        # This value should never be None since we already know the current task
+        # is in a mapped task group, and should have been expanded. The check
+        # exists mainly to satisfy Mypy.
+        if ti_count is None:
+            return None
+
+        # At this point we know the two tasks share a mapped task group, and we
+        # should use a "partial" value. Let's break down the mapped ti count
+        # between the ancestor and further expansion happened inside it.
+        ancestor_ti_count = common_ancestor.get_mapped_ti_count(self.run_id, session=session)
+        ancestor_map_index = self.map_index * ancestor_ti_count // ti_count
+
+        # If the task is NOT further expanded inside the common ancestor, we
+        # only want to reference one single ti. We must walk the actual DAG,
+        # and "ti_count == ancestor_ti_count" does not work, since the further
+        # expansion may be of length 1.
+        if not _is_further_mapped_inside(upstream, common_ancestor):
+            return ancestor_map_index
+
+        # Otherwise we need a partial aggregation for values from selected task
+        # instances in the ancestor's expansion context.
+        further_count = ti_count // ancestor_ti_count
+        map_index_start = ancestor_map_index * further_count
+        return range(map_index_start, map_index_start + further_count)
+
+
+def _find_common_ancestor_mapped_group(node1: Operator, node2: Operator) -> MappedTaskGroup | None:
+    """Given two operators, find their innermost common mapped task group."""
+    if node1.dag is None or node2.dag is None or node1.dag_id != node2.dag_id:
+        return None
+    parent_group_ids = {g.group_id for g in node1.iter_mapped_task_groups()}
+    common_groups = (g for g in node2.iter_mapped_task_groups() if g.group_id in parent_group_ids)
+    return next(common_groups, None)
+
+
+def _is_further_mapped_inside(operator: Operator, container: TaskGroup) -> bool:
+    """Whether given operator is *further* mapped inside a task group."""
+    if operator.is_mapped:
+        return True
+    task_group = operator.task_group
+    while task_group is not None and task_group.group_id != container.group_id:
+        if isinstance(task_group, MappedTaskGroup):
+            return True
+        task_group = task_group.parent_group
+    return False
 
 
 # State of the task instance.

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -497,7 +497,7 @@ class BaseXCom(Base, LoggingMixin):
         elif dag_ids is not None:
             query = query.filter(cls.dag_id == dag_ids)
 
-        if isinstance(map_indexes, range) and abs(map_indexes.step) == 1:
+        if isinstance(map_indexes, range) and map_indexes.step == 1:
             query = query.filter(cls.map_index >= map_indexes.start, cls.map_index < map_indexes.stop)
         elif is_container(map_indexes):
             query = query.filter(cls.map_index.in_(map_indexes))

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -37,34 +37,11 @@ from airflow.utils.types import NOTSET, ArgNotSet
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
     from airflow.models.operator import Operator
-    from airflow.models.taskinstance import TaskInstance
-    from airflow.utils.task_group import MappedTaskGroup, TaskGroup
 
 # Callable objects contained by MapXComArg. We only accept callables from
 # the user, but deserialize them into strings in a serialized XComArg for
 # safety (those callables are arbitrary user code).
 MapCallables = Sequence[Union[Callable[[Any], Any], str]]
-
-
-def _find_common_ancestor_mapped_group(node1: Operator, node2: Operator) -> MappedTaskGroup | None:
-    """Given two operators, find their innermost common mapped task group."""
-    if node1.dag is None or node2.dag is None or node1.dag_id != node2.dag_id:
-        return None
-    parent_group_ids = {g.group_id for g in node1.iter_mapped_task_groups()}
-    common_groups = (g for g in node2.iter_mapped_task_groups() if g.group_id in parent_group_ids)
-    return next(common_groups, None)
-
-
-def _is_further_mapped_inside(operator: Operator, container: TaskGroup) -> bool:
-    """Whether given operator is *further* mapped inside a task group."""
-    if operator.is_mapped:
-        return True
-    task_group = operator.task_group
-    while task_group is not None and task_group.group_id != container.group_id:
-        if isinstance(task_group, MappedTaskGroup):
-            return True
-        task_group = task_group.parent_group
-    return False
 
 
 class XComArg(ResolveMixin, DependencyMixin):
@@ -341,90 +318,18 @@ class PlainXComArg(XComArg):
             )
         return query.scalar()
 
-    def _get_map_indexes_to_pull(
-        self,
-        ti: TaskInstance,
-        ti_count: int | None,
-        *,
-        session: Session,
-    ) -> int | range | None:
-        """Infer the correct ``map_indexes`` to ``xcom_pull`` for resolution.
-
-        The bulk of the logic mainly exists to solve the problem described by
-        the following example, where 'val' must resolve to different values,
-        depending on where the reference is being used::
-
-            @task
-            def this_task(v):  # This task is ti.task.
-                return v * 2
-
-            @task_group
-            def tg1(inp):
-                val = referenced_task(inp)  # This task is self.operator.
-                this_task(val)  # When inp is 1, val here should resolve to 2.
-                return val
-
-            # This val is the same object returned by tg1.
-            val = tg1.expand(inp=[1, 2, 3])
-
-            @task_group
-            def tg2(inp):
-                another_task(inp, val)  # val here should resolve to [2, 4, 6].
-
-            tg2.expand(inp=["a", "b"])
-
-        The surrounding mapped task groups of ``self.operator`` and ``ti.task``
-        are inspected to find a common "ancestor". If such an ancestor is found,
-        we need to return specific map indexes to pull a partial value from
-        upstream XCom.
-
-        :param ti: The currently executing task instance, i.e. ``ti`` in the
-            template context.
-        :param ti_count: The total count of task instance this task was expanded
-            by the scheduler, i.e. ``expanded_ti_count`` in the template context.
-        :return: Specific map index or map indexes to pull, or ``None`` if we
-            want to "whole" return value (i.e. no mapped task groups involved).
-        """
-        # Find the innermost common mapped task group between the current task
-        # If the current task and the referenced task does not have a common
-        # mapped task group, the two are in different task mapping contexts
-        # (like another_task above), and we should use the "whole" value.
-        common_ancestor = _find_common_ancestor_mapped_group(ti.task, self.operator)
-        if common_ancestor is None:
-            return None
-
-        # This value should never be None since we already know the current task
-        # is in a mapped task group, and should have been expanded. The check
-        # exists mainly to satisfy Mypy.
-        if ti_count is None:
-            return None
-
-        # At this point we know the two tasks share a mapped task group, and we
-        # should use a "partial" value. Let's break down the mapped ti count
-        # between the ancestor and further expansion happened inside it.
-        ancestor_ti_count = common_ancestor.get_mapped_ti_count(ti.run_id, session=session)
-        ancestor_map_index = ti.map_index * ancestor_ti_count // ti_count
-
-        # If the task is NOT further expanded inside the common ancestor, we
-        # only want to reference one single ti. We must walk the actual DAG,
-        # and "ti_count == ancestor_ti_count" does not work, since the further
-        # expansion may be of length 1.
-        if not _is_further_mapped_inside(self.operator, common_ancestor):
-            return ancestor_map_index
-
-        # Otherwise we need a partial aggregation for values from selected task
-        # instances in the ancestor's expansion context.
-        further_count = ti_count // ancestor_ti_count
-        map_index_start = ancestor_map_index * further_count
-        return range(map_index_start, map_index_start + further_count)
-
     @provide_session
     def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
         ti = context["ti"]
         task_id = self.operator.task_id
+        map_indexes = ti.get_relevant_upstream_map_indexes(
+            self.operator,
+            context["expanded_ti_count"],
+            session=session,
+        )
         result = ti.xcom_pull(
             task_ids=task_id,
-            map_indexes=self._get_map_indexes_to_pull(ti, context["expanded_ti_count"], session=session),
+            map_indexes=map_indexes,
             key=self.key,
             default=NOTSET,
             session=session,

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -17,10 +17,11 @@
 # under the License.
 from __future__ import annotations
 
-from collections import Counter
+import collections
+import functools
 from typing import TYPE_CHECKING, Iterator, NamedTuple
 
-from sqlalchemy import func
+from sqlalchemy import and_, func, or_
 
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep, TIDepStatus
@@ -29,6 +30,7 @@ from airflow.utils.trigger_rule import TriggerRule as TR
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+    from sqlalchemy.sql.expression import ColumnOperators
 
     from airflow.models.taskinstance import TaskInstance
 
@@ -53,7 +55,7 @@ class _UpstreamTIStates(NamedTuple):
         :param ti: the ti that we want to calculate deps for
         :param finished_tis: all the finished tasks of the dag_run
         """
-        counter = Counter(ti.state for ti in finished_upstreams)
+        counter = collections.Counter(ti.state for ti in finished_upstreams)
         return _UpstreamTIStates(
             success=counter.get(TaskInstanceState.SUCCESS, 0),
             skipped=counter.get(TaskInstanceState.SKIPPED, 0),
@@ -80,44 +82,18 @@ class TriggerRuleDep(BaseTIDep):
         session: Session,
         dep_context: DepContext,
     ) -> Iterator[TIDepStatus]:
-        # Checking that all upstream dependencies have succeeded
-        if not ti.task.upstream_list:
+        # Checking that all upstream dependencies have succeeded.
+        if not ti.task.upstream_task_ids:
             yield self._passing_status(reason="The task instance did not have any upstream tasks.")
             return
-
         if ti.task.trigger_rule == TR.ALWAYS:
             yield self._passing_status(reason="The task had a always trigger rule set.")
             return
-
         yield from self._evaluate_trigger_rule(ti=ti, dep_context=dep_context, session=session)
-
-    @staticmethod
-    def _count_upstreams(ti: TaskInstance, *, session: Session) -> int:
-        from airflow.models.taskinstance import TaskInstance
-
-        # Optimization: Don't need to hit the database if no upstreams are mapped.
-        upstream_task_ids = ti.task.upstream_task_ids
-        if ti.task.dag and not any(ti.task.dag.get_task(tid).is_mapped for tid in upstream_task_ids):
-            return len(upstream_task_ids)
-
-        # We don't naively count task instances because it is not guaranteed
-        # that all upstreams have been created in the database at this point.
-        # Instead, we look for already-expanded tasks, and add them to the raw
-        # task count without considering mapping.
-        mapped_tis_addition = (
-            session.query(func.count())
-            .filter(
-                TaskInstance.dag_id == ti.dag_id,
-                TaskInstance.run_id == ti.run_id,
-                TaskInstance.task_id.in_(upstream_task_ids),
-                TaskInstance.map_index > 0,
-            )
-            .scalar()
-        )
-        return len(upstream_task_ids) + mapped_tis_addition
 
     def _evaluate_trigger_rule(
         self,
+        *,
         ti: TaskInstance,
         dep_context: DepContext,
         session: Session,
@@ -128,14 +104,65 @@ class TriggerRuleDep(BaseTIDep):
         :param dep_context: The current dependency context.
         :param session: Database session.
         """
+        from airflow.models.taskinstance import TaskInstance
+
         task = ti.task
+        upstream_tasks = {t.task_id: t for t in task.upstream_list}
         trigger_rule = task.trigger_rule
 
-        upstream_states = _UpstreamTIStates.calculate(
+        @functools.lru_cache()
+        def _get_expanded_ti_count() -> int:
+            """Get how many tis the current task is supposed to be expanded into.
+
+            This extra closure allows us to query the database only when needed,
+            and at most once.
+            """
+            return task.get_mapped_ti_count(ti.run_id, session=session)
+
+        @functools.lru_cache()
+        def _get_relevant_upstream_map_indexes(upstream_id: str) -> int | range | None:
+            """Get the given task's map indexes relevant to the current ti.
+
+            This extra closure allows us to query the database only when needed,
+            and at most once for each task (instead of once for each expanded
+            task instance of the same task).
+            """
+            return ti.get_relevant_upstream_map_indexes(
+                upstream_tasks[upstream_id],
+                _get_expanded_ti_count(),
+                session=session,
+            )
+
+        def _is_relevant_upstream(upstream: TaskInstance) -> bool:
+            """Whether a task instance is a "relevant upstream" of the current task."""
+            # Not actually an upstream task.
+            if upstream.task_id not in task.upstream_task_ids:
+                return False
+            # The current task is not in a mapped task group. All tis from an
+            # upstream task are relevant.
+            if task.get_closest_mapped_task_group() is None:
+                return True
+            # The upstream ti is not expanded. The upstream may be mapped or
+            # not, but the ti is relevant either way.
+            if upstream.map_index < 0:
+                return True
+            # Now we need to perform fine-grained check on whether this specific
+            # upstream ti's map index is relevant.
+            relevant = _get_relevant_upstream_map_indexes(upstream.task_id)
+            if relevant is None:
+                return True
+            if relevant == upstream.map_index:
+                return True
+            if isinstance(relevant, range) and upstream.map_index in relevant:
+                return True
+            return False
+
+        finished_upstream_tis = (
             finished_ti
             for finished_ti in dep_context.ensure_finished_tis(ti.get_dagrun(session), session)
-            if finished_ti.task_id in task.upstream_task_ids
+            if _is_relevant_upstream(finished_ti)
         )
+        upstream_states = _UpstreamTIStates.calculate(finished_upstream_tis)
 
         success = upstream_states.success
         skipped = upstream_states.skipped
@@ -144,7 +171,46 @@ class TriggerRuleDep(BaseTIDep):
         removed = upstream_states.removed
         done = upstream_states.done
 
-        upstream = self._count_upstreams(ti, session=session)
+        def _iter_upstream_conditions() -> Iterator[ColumnOperators]:
+            # Optimization: If the current task is not in a mapped task group,
+            # it depends on all upstream task instances.
+            if task.get_closest_mapped_task_group() is None:
+                yield TaskInstance.task_id.in_(upstream_tasks)
+                return
+            # Otherwise we need to figure out which map indexes are depended on
+            # for each upstream by the current task instance.
+            for upstream_id in upstream_tasks:
+                map_indexes = _get_relevant_upstream_map_indexes(upstream_id)
+                if map_indexes is None:  # All tis of this upstream are dependencies.
+                    yield (TaskInstance.task_id == upstream_id)
+                    continue
+                # At this point we know we want to depend on only selected tis
+                # of this upstream task. Since the upstream may not have been
+                # expanded at this point, we also depend on the non-expanded ti
+                # to ensure at least one ti is included for the task.
+                yield and_(TaskInstance.task_id == upstream_id, TaskInstance.map_index < 0)
+                if isinstance(map_indexes, int):
+                    yield and_(TaskInstance.task_id == upstream_id, TaskInstance.map_index == map_indexes)
+                elif isinstance(map_indexes, range) and map_indexes.step == 1:
+                    yield and_(
+                        TaskInstance.task_id == upstream_id,
+                        TaskInstance.map_index >= map_indexes.start,
+                        TaskInstance.map_index < map_indexes.stop,
+                    )
+                else:
+                    yield and_(TaskInstance.task_id == upstream_id, TaskInstance.map_index.in_(map_indexes))
+
+        # Optimization: Don't need to hit the database if all upstreams are
+        # "simple" tasks (no task or task group mapping involved).
+        if not any(t.is_mapped or t.get_closest_mapped_task_group() for t in upstream_tasks.values()):
+            upstream = len(upstream_tasks)
+        else:
+            upstream = (
+                session.query(func.count())
+                .filter(TaskInstance.dag_id == ti.dag_id, TaskInstance.run_id == ti.run_id)
+                .filter(or_(*_iter_upstream_conditions()))
+                .scalar()
+            )
         upstream_done = done >= upstream
 
         changed = False

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest import mock
+from typing import Iterator
 
 import pytest
 
@@ -126,7 +126,7 @@ class TestTriggerRuleDep:
         ti = get_task_instance(TriggerRule.ALWAYS)
         assert TriggerRuleDep().is_met(ti=ti)
 
-    def test_one_success_tr_success(self, get_task_instance):
+    def test_one_success_tr_success(self, session, get_task_instance):
         """
         One-success trigger rule success
         """
@@ -143,12 +143,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_one_success_tr_failure(self, get_task_instance):
+    def test_one_success_tr_failure(self, session, get_task_instance):
         """
         One-success trigger rule failure
         """
@@ -165,13 +165,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_one_failure_tr_failure(self, get_task_instance):
+    def test_one_failure_tr_failure(self, session, get_task_instance):
         """
         One-failure trigger rule failure
         """
@@ -188,13 +188,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_one_failure_tr_success(self, get_task_instance):
+    def test_one_failure_tr_success(self, session, get_task_instance):
         """
         One-failure trigger rule success
         """
@@ -211,12 +211,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_one_failure_tr_success_no_failed(self, get_task_instance):
+    def test_one_failure_tr_success_no_failed(self, session, get_task_instance):
         """
         One-failure trigger rule success
         """
@@ -233,12 +233,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_one_done_tr_success(self, get_task_instance):
+    def test_one_done_tr_success(self, session, get_task_instance):
         """
         One-done trigger rule success
         """
@@ -255,12 +255,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_one_done_tr_success_with_failed(self, get_task_instance):
+    def test_one_done_tr_success_with_failed(self, session, get_task_instance):
         """
         One-done trigger rule success
         """
@@ -277,12 +277,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_one_done_tr_skip(self, get_task_instance):
+    def test_one_done_tr_skip(self, session, get_task_instance):
         """
         One-done trigger rule skip
         """
@@ -299,13 +299,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_one_done_tr_upstream_failed(self, get_task_instance):
+    def test_one_done_tr_upstream_failed(self, session, get_task_instance):
         """
         One-done trigger rule upstream_failed
         """
@@ -322,13 +322,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_all_success_tr_success(self, get_task_instance):
+    def test_all_success_tr_success(self, session, get_task_instance):
         """
         All-success trigger rule success
         """
@@ -345,12 +345,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_all_success_tr_failure(self, get_task_instance):
+    def test_all_success_tr_failure(self, session, get_task_instance):
         """
         All-success trigger rule failure
         """
@@ -367,7 +367,7 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
@@ -377,7 +377,7 @@ class TestTriggerRuleDep:
         "flag_upstream_failed, expected_ti_state",
         [(True, TaskInstanceState.SKIPPED), (False, None)],
     )
-    def test_all_success_tr_skip(self, get_task_instance, flag_upstream_failed, expected_ti_state):
+    def test_all_success_tr_skip(self, session, get_task_instance, flag_upstream_failed, expected_ti_state):
         """
         All-success trigger rule fails when some upstream tasks are skipped.
         """
@@ -394,7 +394,7 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
@@ -402,7 +402,7 @@ class TestTriggerRuleDep:
         assert ti.state == expected_ti_state
 
     @pytest.mark.parametrize("flag_upstream_failed", [True, False])
-    def test_none_failed_tr_success(self, get_task_instance, flag_upstream_failed):
+    def test_none_failed_tr_success(self, session, get_task_instance, flag_upstream_failed):
         """
         All success including skip trigger rule success
         """
@@ -419,13 +419,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
         assert ti.state is None
 
-    def test_none_failed_tr_failure(self, get_task_instance):
+    def test_none_failed_tr_failure(self, session, get_task_instance):
         """
         All success including skip trigger rule failure
         """
@@ -442,13 +442,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_none_failed_min_one_success_tr_success(self, get_task_instance):
+    def test_none_failed_min_one_success_tr_success(self, session, get_task_instance):
         """
         All success including skip trigger rule success
         """
@@ -465,12 +465,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_none_failed_min_one_success_tr_skipped(self, get_task_instance):
+    def test_none_failed_min_one_success_tr_skipped(self, session, get_task_instance):
         """
         All success including all upstream skips trigger rule success
         """
@@ -487,7 +487,7 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=True),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
@@ -510,13 +510,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_all_failed_tr_success(self, get_task_instance):
+    def test_all_failed_tr_success(self, session, get_task_instance):
         """
         All-failed trigger rule success
         """
@@ -533,12 +533,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_all_failed_tr_failure(self, get_task_instance):
+    def test_all_failed_tr_failure(self, session, get_task_instance):
         """
         All-failed trigger rule failure
         """
@@ -555,13 +555,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_all_done_tr_success(self, get_task_instance):
+    def test_all_done_tr_success(self, session, get_task_instance):
         """
         All-done trigger rule success
         """
@@ -578,12 +578,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_all_skipped_tr_failure(self, get_task_instance):
+    def test_all_skipped_tr_failure(self, session, get_task_instance):
         """
         All-skipped trigger rule failure
         """
@@ -600,14 +600,14 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
     @pytest.mark.parametrize("flag_upstream_failed", [True, False])
-    def test_all_skipped_tr_success(self, get_task_instance, flag_upstream_failed):
+    def test_all_skipped_tr_success(self, session, get_task_instance, flag_upstream_failed):
         """
         All-skipped trigger rule success
         """
@@ -624,12 +624,12 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
-    def test_all_done_tr_failure(self, get_task_instance):
+    def test_all_done_tr_failure(self, session, get_task_instance):
         """
         All-done trigger rule failure
         """
@@ -648,14 +648,14 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
     @pytest.mark.parametrize("flag_upstream_failed", [True, False])
-    def test_none_skipped_tr_success(self, get_task_instance, flag_upstream_failed):
+    def test_none_skipped_tr_success(self, session, get_task_instance, flag_upstream_failed):
         """
         None-skipped trigger rule success
         """
@@ -672,13 +672,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 0
 
     @pytest.mark.parametrize("flag_upstream_failed", [True, False])
-    def test_none_skipped_tr_failure(self, get_task_instance, flag_upstream_failed):
+    def test_none_skipped_tr_failure(self, session, get_task_instance, flag_upstream_failed):
         """
         None-skipped trigger rule failure
         """
@@ -695,13 +695,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=flag_upstream_failed),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_none_skipped_tr_failure_empty(self, get_task_instance):
+    def test_none_skipped_tr_failure_empty(self, session, get_task_instance):
         """
         None-skipped trigger rule fails until all upstream tasks have completed execution
         """
@@ -720,13 +720,13 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
         assert not dep_statuses[0].passed
 
-    def test_unknown_tr(self, get_task_instance):
+    def test_unknown_tr(self, session, get_task_instance):
         """
         Unknown trigger rules should cause this dep to fail
         """
@@ -745,7 +745,7 @@ class TestTriggerRuleDep:
             TriggerRuleDep()._evaluate_trigger_rule(
                 ti=ti,
                 dep_context=DepContext(flag_upstream_failed=False),
-                session=mock.Mock(),
+                session=session,
             )
         )
         assert len(dep_statuses) == 1
@@ -774,11 +774,13 @@ class TestTriggerRuleDep:
         tis["op4"].state = TaskInstanceState.SUCCESS
         tis["op5"].state = TaskInstanceState.SUCCESS
 
+        def _get_finished_tis(task_id: str) -> Iterator[TaskInstance]:
+            return (ti for ti in tis.values() if ti.task_id in tis[task_id].task.upstream_task_ids)
+
         # check handling with cases that tasks are triggered from backfill with no finished tasks
-        finished_tis = tis.values()
-        assert _UpstreamTIStates.calculate(ti=tis["op2"], finished_tis=finished_tis) == (1, 0, 0, 0, 0, 1)
-        assert _UpstreamTIStates.calculate(ti=tis["op4"], finished_tis=finished_tis) == (1, 0, 1, 0, 0, 2)
-        assert _UpstreamTIStates.calculate(ti=tis["op5"], finished_tis=finished_tis) == (2, 0, 1, 0, 0, 3)
+        assert _UpstreamTIStates.calculate(_get_finished_tis("op2")) == (1, 0, 0, 0, 0, 1)
+        assert _UpstreamTIStates.calculate(_get_finished_tis("op4")) == (1, 0, 1, 0, 0, 2)
+        assert _UpstreamTIStates.calculate(_get_finished_tis("op5")) == (2, 0, 1, 0, 0, 3)
 
         dr.update_state(session=session)
         assert dr.state == DagRunState.SUCCESS


### PR DESCRIPTION
The main thing is to make TriggerRuleDep to only count upstream task instances with "relevant" map indexes, instead all of them. If a downstream task instance is considered to only need cetain tis of an upstream task (instead of all of them), the dependency analyzer will
mark the downstream as ready to execute when those selected tis are finished, instead of needing to wait for all tis of that upstream task, effectively enabling depth-first execution.

Most of the "relevant map indexes" logic is already in place when we implemented XComArg resolution, so we just need to reuse that.

~~Tests will come later.~~ Added!