### PR TITLE
Add CI step to run prepare provider documentation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -699,6 +699,9 @@ jobs:
         uses: ./.github/actions/prepare_breeze_and_image
       - name: "Cleanup dist files"
         run: rm -fv ./dist/*
+      - name: "Prepare provider documentation"
+        run: breeze release-management prepare-provider-documentation
+        if: matrix.package-format == 'wheel'
       - name: "Prepare provider packages: ${{matrix.package-format}}"
         run: breeze release-management prepare-provider-packages --version-suffix-for-pypi dev0
       - name: "Prepare airflow package: ${{matrix.package-format}}"


### PR DESCRIPTION
Adds CI step that was likely missing during refactoring when we run prepare-provider-documentation step to test that it is still working.

We are running pretty much all our `breeze` commnd in CI even those that we are using for manual release management, just to make sure they are still working and that none of the refactorings break it. This is very reassuring that whenever you attempt to do the release, most likely the tools that we use for that are still working.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
