### PR TITLE
Make sure we can get out of a faulty scheduler state

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -484,7 +484,6 @@ class AbstractOperator(LoggingMixin, DAGNode):
                 # are not done yet, so the task can't fail yet.
                 if not self.dag or not self.dag.partial:
                     unmapped_ti.state = TaskInstanceState.UPSTREAM_FAILED
-                indexes_to_map: Iterable[int] = ()
             elif total_length < 1:
                 # If the upstream maps this to a zero-length value, simply mark
                 # the unmapped task instance as SKIPPED (if needed).
@@ -494,18 +493,15 @@ class AbstractOperator(LoggingMixin, DAGNode):
                     total_length,
                 )
                 unmapped_ti.state = TaskInstanceState.SKIPPED
-                indexes_to_map = ()
             else:
-                # Otherwise convert this into the first mapped index, and create
-                # TaskInstance for other indexes.
-                unmapped_ti.map_index = 0
-                self.log.debug("Updated in place to become %s", unmapped_ti)
-                all_expanded_tis.append(unmapped_ti)
-                indexes_to_map = range(1, total_length)
-            state = unmapped_ti.state
-        elif not total_length:
+                # Delete the original task so we can create new ones
+                self.log.debug("Deleting the original task instance: %s", unmapped_ti)
+                state = unmapped_ti.state
+                session.delete(unmapped_ti)
+
+        if total_length is None or total_length < 1:
             # Nothing to fixup.
-            indexes_to_map = ()
+            indexes_to_map: Iterable[int] = ()
         else:
             # Only create "missing" ones.
             current_max_mapping = (

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -769,7 +769,8 @@ class DagRun(Base, LoggingMixin):
             """Try to expand the ti, if needed.
 
             If the ti needs expansion, newly created task instances are
-            returned. The original ti is modified in-place and assigned the
+            returned as well as the original ti.
+            The original ti is also modified in-place and assigned the
             ``map_index`` of 0.
 
             If the ti does not need expansion, either because the task is not

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -782,8 +782,7 @@ class DagRun(Base, LoggingMixin):
             except NotMapped:  # Not a mapped task, nothing needed.
                 return None
             if expanded_tis:
-                assert expanded_tis[0] is ti
-                return expanded_tis[1:]
+                return expanded_tis
             return ()
 
         # Check dependencies.
@@ -799,12 +798,13 @@ class DagRun(Base, LoggingMixin):
             # in the scheduler to ensure that the mapped task is correctly
             # expanded before executed. Also see _revise_map_indexes_if_mapped
             # docstring for additional information.
+            new_tis = None
             if schedulable.map_index < 0:
                 new_tis = _expand_mapped_task_if_needed(schedulable)
                 if new_tis is not None:
                     additional_tis.extend(new_tis)
                     expansion_happened = True
-            if schedulable.state in SCHEDULEABLE_STATES:
+            if new_tis is None and schedulable.state in SCHEDULEABLE_STATES:
                 ready_tis.extend(self._revise_map_indexes_if_mapped(schedulable.task, session=session))
                 ready_tis.append(schedulable)
 


### PR DESCRIPTION
This PR fixed the case where we have a faulty state in the database. The state that is fixed is that both the unmapped task instance and mapped task instances exist at the same time.

So we have instances with map_index [-1, 0, 1].
The -1 task instances should be removed in this case.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:



How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: https://github.com/apache/airflow/discussions/26959

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
