### PR TITLE
Add better diagnostics in case of outdated images for pre-commits

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_flake8.py
+++ b/scripts/ci/pre_commit/pre_commit_flake8.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
 
     sys.path.insert(0, str(AIRFLOW_SOURCES / "dev" / "breeze" / "src"))
     from airflow_breeze.global_constants import MOUNT_SELECTED
+    from airflow_breeze.utils.console import get_console
     from airflow_breeze.utils.docker_command_utils import get_extra_docker_flags
     from airflow_breeze.utils.run_utils import get_ci_image_for_pre_commits, run_command
 
@@ -63,4 +64,9 @@ if __name__ == "__main__":
         ],
         check=False,
     )
+    if cmd_result.returncode != 0:
+        get_console().print(
+            "[warning]If you see strange stacktraces above, "
+            "run `breeze ci-image build --python 3.7` and try again."
+        )
     sys.exit(cmd_result.returncode)

--- a/scripts/ci/pre_commit/pre_commit_migration_reference.py
+++ b/scripts/ci/pre_commit/pre_commit_migration_reference.py
@@ -34,6 +34,7 @@ os.environ["SKIP_GROUP_OUTPUT"] = "true"
 if __name__ == "__main__":
     sys.path.insert(0, str(AIRFLOW_SOURCES / "dev" / "breeze" / "src"))
     from airflow_breeze.global_constants import MOUNT_SELECTED
+    from airflow_breeze.utils.console import get_console
     from airflow_breeze.utils.docker_command_utils import get_extra_docker_flags
     from airflow_breeze.utils.run_utils import get_ci_image_for_pre_commits, run_command
 
@@ -54,4 +55,9 @@ if __name__ == "__main__":
         ],
         check=False,
     )
+    if cmd_result.returncode != 0:
+        get_console().print(
+            "[warning]If you see strange stacktraces above, "
+            "run `breeze ci-image build --python 3.7` and try again."
+        )
     sys.exit(cmd_result.returncode)

--- a/scripts/ci/pre_commit/pre_commit_mypy.py
+++ b/scripts/ci/pre_commit/pre_commit_mypy.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
 
     sys.path.insert(0, str(AIRFLOW_SOURCES / "dev" / "breeze" / "src"))
     from airflow_breeze.global_constants import MOUNT_SELECTED
+    from airflow_breeze.utils.console import get_console
     from airflow_breeze.utils.docker_command_utils import get_extra_docker_flags
     from airflow_breeze.utils.path_utils import create_mypy_volume_if_needed
     from airflow_breeze.utils.run_utils import get_ci_image_for_pre_commits, run_command
@@ -66,4 +67,9 @@ if __name__ == "__main__":
         ],
         check=False,
     )
+    if cmd_result.returncode != 0:
+        get_console().print(
+            "[warning]If you see strange stacktraces above, "
+            "run `breeze ci-image build --python 3.7` and try again."
+        )
     sys.exit(cmd_result.returncode)

--- a/scripts/ci/pre_commit/pre_commit_update_er_diagram.py
+++ b/scripts/ci/pre_commit/pre_commit_update_er_diagram.py
@@ -34,6 +34,7 @@ os.environ["SKIP_GROUP_OUTPUT"] = "true"
 if __name__ == "__main__":
     sys.path.insert(0, str(AIRFLOW_SOURCES / "dev" / "breeze" / "src"))
     from airflow_breeze.global_constants import MOUNT_SELECTED
+    from airflow_breeze.utils.console import get_console
     from airflow_breeze.utils.docker_command_utils import (
         get_extra_docker_flags,
         update_expected_environment_variables,
@@ -62,4 +63,10 @@ if __name__ == "__main__":
         env=env,
         check=False,
     )
+    if cmd_result.returncode != 0:
+        get_console().print(
+            "[warning]If you see strange stacktraces above, "
+            "run `breeze ci-image build --python 3.7` and try again."
+        )
+
     sys.exit(cmd_result.returncode)


### PR DESCRIPTION
When you have out-dated Python 3.7 image, some of the pre-commits
might fail when using it and produce strange stacktraces which
are difficult to understand the root cause of.

We do not want to check if the image is fresh in those cases - that
will often lead to unnecessary time needed for rebuilding image just
to get the pre-commit runs, instead we explicitly suggest the user
what can be done in case they are lost.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
