### PR TITLE
Restore removed (but used) methods in common.sql

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -71,14 +71,13 @@ def _get_failed_checks(checks, col=None):
     ]
 
 
-def parse_boolean(val: str) -> str | bool:
-    """
-    IMPORTANT!!! Keep it for compatibility with released 8.4.0 version of google provider.
+parse_boolean = _parse_boolean
+"""
+IMPORTANT!!! Keep it for compatibility with released 8.4.0 version of google provider.
 
-    Unfortunately the provider used _get_failed_checks and parse_boolean as imports and we should
-    keep those methods to avoid 8.4.0 version from failing.
-    """
-    return _parse_boolean(val)
+Unfortunately the provider used _get_failed_checks and parse_boolean as imports and we should
+keep those methods to avoid 8.4.0 version from failing.
+"""
 
 
 _PROVIDERS_MATCHER = re.compile(r"airflow\.providers\.(.*)\.hooks.*")

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -51,6 +51,36 @@ def _parse_boolean(val: str) -> str | bool:
     raise ValueError(f"{val!r} is not a boolean-like string value")
 
 
+def _get_failed_checks(checks, col=None):
+    """
+    IMPORTANT!!! Keep it for compatibility with released 8.4.0 version of google provider.
+
+    Unfortunately the provider used _get_failed_checks and parse_boolean as imports and we should
+    keep those methods to avoid 8.4.0 version from failing.
+    """
+    if col:
+        return [
+            f"Column: {col}\nCheck: {check},\nCheck Values: {check_values}\n"
+            for check, check_values in checks.items()
+            if not check_values["success"]
+        ]
+    return [
+        f"\tCheck: {check},\n\tCheck Values: {check_values}\n"
+        for check, check_values in checks.items()
+        if not check_values["success"]
+    ]
+
+
+def parse_boolean(val: str) -> str | bool:
+    """
+    IMPORTANT!!! Keep it for compatibility with released 8.4.0 version of google provider.
+
+    Unfortunately the provider used _get_failed_checks and parse_boolean as imports and we should
+    keep those methods to avoid 8.4.0 version from failing.
+    """
+    return _parse_boolean(val)
+
+
 _PROVIDERS_MATCHER = re.compile(r"airflow\.providers\.(.*)\.hooks.*")
 
 _MIN_SUPPORTED_PROVIDERS_VERSION = {


### PR DESCRIPTION
Unfortunately two of the methods that have been removed in #26761 have been used in Google Provider 8.4.0

Those methods should be restored and 1.3.0 version of the common.sql has to be yanked to get rid of the problem when Bigquery is broken by common.sql

Fixes: #27838

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
