### PR TITLE
Patch "checked" when pod not successful

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -491,7 +491,7 @@ class KubernetesPodOperator(BaseOperator):
                 f"remote_pod: {remote_pod}"
             )
         else:
-            self.process_pod_deletion(remote_pod)
+            self.process_pod_deletion(remote_pod, reraise=False)
 
     def process_pod_deletion(self, pod: k8s.V1Pod, *, reraise=True):
         with _optionally_suppress(reraise=reraise):

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -518,7 +518,7 @@ class KubernetesPodOperator(BaseOperator):
             return re.sub(r"[^a-z0-9-]+", "-", name.lower())
         return None
 
-    def patch_already_checked(self, pod: k8s.V1Pod, *, reraise=False):
+    def patch_already_checked(self, pod: k8s.V1Pod, *, reraise=True):
         """Add an "already checked" annotation to ensure we don't reattach on retries"""
         with _optionally_suppress(reraise=reraise):
             pod.metadata.labels[self.POD_CHECKED_KEY] = "True"

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -21,7 +21,7 @@ import json
 import logging
 import re
 import warnings
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from typing import TYPE_CHECKING, Any, Sequence
 
 from kubernetes.client import CoreV1Api, models as k8s
@@ -420,8 +420,7 @@ class KubernetesPodOperator(BaseOperator):
             self.pod_manager.await_pod_start(pod=pod, startup_timeout=self.startup_timeout_seconds)
         except PodLaunchFailedException:
             if self.log_events_on_failure:
-                for event in self.pod_manager.read_pod_events(pod).items:
-                    self.log.error("Pod Event: %s - %s", event.reason, event.message)
+                self._read_pod_log_events(pod, reraise=True)
             raise
 
     def extract_xcom(self, pod: k8s.V1Pod):
@@ -472,34 +471,36 @@ class KubernetesPodOperator(BaseOperator):
         if self.do_xcom_push:
             return result
 
+    def _read_pod_log_events(self, pod, *, reraise=True):
+        """Will fetch and emit events from pod"""
+        with _optionally_suppress(reraise=reraise):
+            for event in self.pod_manager.read_pod_events(pod).items:
+                self.log.error("Pod Event: %s - %s", event.reason, event.message)
+
     def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod):
         pod_phase = remote_pod.status.phase if hasattr(remote_pod, "status") else None
-        if not self.is_delete_operator_pod:
-            with _suppress(Exception):
-                self.patch_already_checked(remote_pod)
+        if pod_phase != PodPhase.SUCCEEDED or not self.is_delete_operator_pod:
+            self.patch_already_checked(remote_pod, reraise=False)
         if pod_phase != PodPhase.SUCCEEDED:
             if self.log_events_on_failure:
-                with _suppress(Exception):
-                    for event in self.pod_manager.read_pod_events(pod).items:
-                        self.log.error("Pod Event: %s - %s", event.reason, event.message)
-            with _suppress(Exception):
-                self.process_pod_deletion(remote_pod)
+                self._read_pod_log_events(pod, reraise=False)
+            self.process_pod_deletion(remote_pod, reraise=False)
             error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)
-            error_message = "\n" + error_message if error_message else ""
             raise AirflowException(
-                f"Pod {pod and pod.metadata.name} returned a failure:{error_message}\n{remote_pod}"
+                f"Pod {pod and pod.metadata.name} returned a failure:{error_message}\n"
+                f"remote_pod: {remote_pod}"
             )
         else:
-            with _suppress(Exception):
-                self.process_pod_deletion(remote_pod)
+            self.process_pod_deletion(remote_pod)
 
-    def process_pod_deletion(self, pod: k8s.V1Pod):
-        if pod is not None:
-            if self.is_delete_operator_pod:
-                self.log.info("Deleting pod: %s", pod.metadata.name)
-                self.pod_manager.delete_pod(pod)
-            else:
-                self.log.info("skipping deleting pod: %s", pod.metadata.name)
+    def process_pod_deletion(self, pod: k8s.V1Pod, *, reraise=True):
+        with _optionally_suppress(reraise=reraise):
+            if pod is not None:
+                if self.is_delete_operator_pod:
+                    self.log.info("Deleting pod: %s", pod.metadata.name)
+                    self.pod_manager.delete_pod(pod)
+                else:
+                    self.log.info("skipping deleting pod: %s", pod.metadata.name)
 
     def _build_find_pod_label_selector(self, context: Context | None = None, *, exclude_checked=True) -> str:
         labels = self._get_ti_pod_labels(context, include_try_number=False)
@@ -517,11 +518,12 @@ class KubernetesPodOperator(BaseOperator):
             return re.sub(r"[^a-z0-9-]+", "-", name.lower())
         return None
 
-    def patch_already_checked(self, pod: k8s.V1Pod):
+    def patch_already_checked(self, pod: k8s.V1Pod, *, reraise=False):
         """Add an "already checked" annotation to ensure we don't reattach on retries"""
-        pod.metadata.labels[self.POD_CHECKED_KEY] = "True"
-        body = PodGenerator.serialize_pod(pod)
-        self.client.patch_namespaced_pod(pod.metadata.name, pod.metadata.namespace, body)
+        with _optionally_suppress(reraise=reraise):
+            pod.metadata.labels[self.POD_CHECKED_KEY] = "True"
+            body = PodGenerator.serialize_pod(pod)
+            self.client.patch_namespaced_pod(pod.metadata.name, pod.metadata.namespace, body)
 
     def on_kill(self) -> None:
         if self.pod:
@@ -650,6 +652,8 @@ class _suppress(AbstractContextManager):
 
     The caught exception is also stored on the context manager instance under
     attribute ``exception``.
+
+    :meta private:
     """
 
     def __init__(self, *exceptions):
@@ -666,3 +670,12 @@ class _suppress(AbstractContextManager):
             logger = logging.getLogger(__name__)
             logger.exception(excinst)
         return caught_error
+
+
+def _optionally_suppress(*, reraise=False):
+    """
+    Returns context manager that will swallow and log all exceptions.
+
+    We can disable suppression behavior by supplying reraise=True.
+    """
+    return _suppress(Exception) if reraise is False else nullcontext()

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -487,7 +487,7 @@ class KubernetesPodOperator(BaseOperator):
             self.process_pod_deletion(remote_pod, reraise=False)
             error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)
             raise AirflowException(
-                f"Pod {pod and pod.metadata.name} returned a failure:{error_message}\n"
+                f"Pod {pod and pod.metadata.name} returned a failure:\n{error_message}\n"
                 f"remote_pod: {remote_pod}"
             )
         else:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -658,8 +658,9 @@ class _optionally_suppress(AbstractContextManager):
     """
 
     def __init__(self, *exceptions, reraise=False):
-        self.reraise = reraise
         self._exceptions = exceptions or (Exception,)
+        self.reraise = reraise
+        self.exception = None
 
     def __enter__(self):
         return self

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -649,23 +649,24 @@ class _optionally_suppress(AbstractContextManager):
     """
     Returns context manager that will swallow and log exceptions.
 
-    By default swallows descendents of Exception, but you can provide other classes through ``*args``.
+    By default swallows descendents of Exception, but you can provide other classes through
+    the vararg ``exceptions``.
 
     Suppression behavior can be disabled with reraise=True.
 
     :meta private:
     """
 
-    def __init__(self, *args, reraise=False):
+    def __init__(self, *exceptions, reraise=False):
         self.reraise = reraise
-        self._exception = args or (Exception,)
+        self._exceptions = exceptions or (Exception,)
 
     def __enter__(self):
         return self
 
     def __exit__(self, exctype, excinst, exctb):
         error = exctype is not None
-        matching_error = error and issubclass(exctype, self._exception)
+        matching_error = error and issubclass(exctype, self._exceptions)
         if error and not matching_error:
             return False
         elif matching_error and self.reraise:

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -21,7 +21,7 @@ import json
 import math
 import time
 import warnings
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterable, cast
@@ -85,12 +85,13 @@ def container_is_running(pod: V1Pod, container_name: str) -> bool:
 
 
 def get_container_termination_message(pod: V1Pod, container_name: str):
-    try:
+    with suppress(AttributeError, TypeError):
         container_statuses = pod.status.container_statuses
         container_status = next((x for x in container_statuses if x.name == container_name), None)
-        return container_status.state.terminated.message if container_status else None
-    except (AttributeError, TypeError):
-        return None
+        message = container_status.state.terminated.message if container_status else None
+        if message:
+            message += "\n"
+        return message
 
 
 @dataclass

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -88,10 +88,7 @@ def get_container_termination_message(pod: V1Pod, container_name: str):
     with suppress(AttributeError, TypeError):
         container_statuses = pod.status.container_statuses
         container_status = next((x for x in container_statuses if x.name == container_name), None)
-        message = container_status.state.terminated.message if container_status else None
-        if message:
-            message += "\n"
-        return message
+        return container_status.state.terminated.message if container_status else None
 
 
 @dataclass

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -938,7 +938,6 @@ class TestKubernetesPodOperator:
         """If we aren't deleting pods and have an exception, mark it so we don't reattach to it"""
         k = KubernetesPodOperator(
             task_id="task",
-            is_delete_operator_pod=False,
         )
         self.await_pod_mock.side_effect = AirflowException("oops")
         context = create_context(k)


### PR DESCRIPTION
In KPO, if pod gets stuck in terminating status, then we might keep reattaching to it.

the key change is the the addition of "or pod not successful" to the conditions for patching the pod as "checked"

We patch not just if "is delete" but also any time tha pod phase is not successful.

this is to ensure that if the pod takes a long time to get removed (or if it simply failed to start in the first place) that we make sure we don't reattach to it on the retry.

everything else is drive by refactor / cleanup