### PR TITLE
Don't log CLI actions if db not initialized

### DIFF
--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -97,6 +97,8 @@ def default_action_log(sub_command, user, task_id, dag_id, execution_date, host_
     :param **_: other keyword arguments that is not being used by this function
     :return: None
     """
+    from sqlalchemy.exc import OperationalError, ProgrammingError
+
     from airflow.models.log import Log
     from airflow.utils import timezone
     from airflow.utils.session import create_session
@@ -121,8 +123,17 @@ def default_action_log(sub_command, user, task_id, dag_id, execution_date, host_
                     }
                 ],
             )
-    except Exception as error:
-        logging.warning("Failed to log action with %s", error)
+    except (OperationalError, ProgrammingError) as e:
+        expected = [
+            '"log" does not exist',  # postgres
+            "no such table",  # sqlite
+            "log' doesn't exist",  # mysql
+            "Invalid object name 'log'",  # mssql
+        ]
+        if getattr(e, "args", None) and not any(x in e.args[0] for x in expected):
+            logging.warning("Failed to log action %s", e)
+    except Exception as e:
+        logging.error("Failed to log action %s", e)
 
 
 __pre_exec_callbacks: list[Callable] = []

--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -130,7 +130,8 @@ def default_action_log(sub_command, user, task_id, dag_id, execution_date, host_
             "log' doesn't exist",  # mysql
             "Invalid object name 'log'",  # mssql
         ]
-        if e.args and not any(x in e.args[0] for x in expected):
+        error_is_ok = e.args and any(x in e.args[0] for x in expected)
+        if not error_is_ok:
             logging.warning("Failed to log action %s", e)
     except Exception as e:
         logging.warning("Failed to log action %s", e)

--- a/airflow/utils/cli_action_loggers.py
+++ b/airflow/utils/cli_action_loggers.py
@@ -130,10 +130,10 @@ def default_action_log(sub_command, user, task_id, dag_id, execution_date, host_
             "log' doesn't exist",  # mysql
             "Invalid object name 'log'",  # mssql
         ]
-        if getattr(e, "args", None) and not any(x in e.args[0] for x in expected):
+        if e.args and not any(x in e.args[0] for x in expected):
             logging.warning("Failed to log action %s", e)
     except Exception as e:
-        logging.error("Failed to log action %s", e)
+        logging.warning("Failed to log action %s", e)
 
 
 __pre_exec_callbacks: list[Callable] = []


### PR DESCRIPTION
This gets rid of a potentially confusing error message.

Before:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/15932138/203466778-de475387-9caa-4ca9-a56e-a3809593fab6.png">
After:
<img width="426" alt="image" src="https://user-images.githubusercontent.com/15932138/203466794-8450909a-9693-4caf-989b-6a54d1b024fb.png">
