### PR TITLE
Fix errors in Databricks SQL operator introduced when refactoring

### DIFF
--- a/airflow/providers/databricks/hooks/databricks_sql.py
+++ b/airflow/providers/databricks/hooks/databricks_sql.py
@@ -147,7 +147,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         handler: Callable | None = None,
         split_statements: bool = True,
         return_last: bool = True,
-    ) -> tuple[str, Any] | list[tuple[str, Any]] | None:
+    ) -> Any | list[Any] | None:
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -163,7 +163,7 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
         :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
-        scalar_return_last = isinstance(sql, str) and return_last
+        self.scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -186,14 +186,14 @@ class DatabricksSqlHook(BaseDatabricksHook, DbApiHook):
 
                     if handler is not None:
                         result = handler(cur)
-                        schema = cur.description
-                        results.append((schema, result))
+                        results.append(result)
+                    self.last_description = cur.description
 
             self._sql_conn = None
 
         if handler is None:
             return None
-        elif scalar_return_last:
+        elif self.scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/databricks/operators/databricks_sql.py
+++ b/airflow/providers/databricks/operators/databricks_sql.py
@@ -120,12 +120,21 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
         }
         return DatabricksSqlHook(self.databricks_conn_id, **hook_params)
 
-    def _process_output(self, schema, results):
+    def _process_output(
+        self, results: Any | list[Any], description: Sequence[Sequence] | None, scalar_results: bool
+    ) -> Any:
         if not self._output_path:
-            return
+            return description, results
         if not self._output_format:
             raise AirflowException("Output format should be specified!")
-        field_names = [field[0] for field in schema]
+        if description is None:
+            self.log.warning("Description of the cursor is missing. Will not process the output")
+            return description, results
+        field_names = [field[0] for field in description]
+        if scalar_results:
+            list_results: list[Any] = [results]
+        else:
+            list_results = results
         if self._output_format.lower() == "csv":
             with open(self._output_path, "w", newline="") as file:
                 if self._csv_params:
@@ -138,18 +147,19 @@ class DatabricksSqlOperator(SQLExecuteQueryOperator):
                 writer = csv.DictWriter(file, fieldnames=field_names, **csv_params)
                 if write_header:
                     writer.writeheader()
-                for row in results:
+                for row in list_results:
                     writer.writerow(row.asDict())
         elif self._output_format.lower() == "json":
             with open(self._output_path, "w") as file:
-                file.write(json.dumps([row.asDict() for row in results]))
+                file.write(json.dumps([row.asDict() for row in list_results]))
         elif self._output_format.lower() == "jsonl":
             with open(self._output_path, "w") as file:
-                for row in results:
+                for row in list_results:
                     file.write(json.dumps(row.asDict()))
                     file.write("\n")
         else:
             raise AirflowException(f"Unsupported output format: '{self._output_format}'")
+        return description, results
 
 
 COPY_INTO_APPROVED_FORMATS = ["CSV", "JSON", "AVRO", "ORC", "PARQUET", "TEXT", "BINARYFILE"]

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -157,7 +157,7 @@ class ExasolHook(DbApiHook):
         :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
-        scalar_return_last = isinstance(sql, str) and return_last
+        self.scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -187,7 +187,7 @@ class ExasolHook(DbApiHook):
 
         if handler is None:
             return None
-        elif scalar_return_last:
+        elif self.scalar_return_last:
             return results[-1]
         else:
             return results

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -350,7 +350,7 @@ class SnowflakeHook(DbApiHook):
         """
         self.query_ids = []
 
-        scalar_return_last = isinstance(sql, str) and return_last
+        self.scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 split_statements_tuple = util_text.split_statements(StringIO(sql))
@@ -387,7 +387,7 @@ class SnowflakeHook(DbApiHook):
 
         if handler is None:
             return None
-        elif scalar_return_last:
+        elif self.scalar_return_last:
             return results[-1]
         else:
             return results

--- a/tests/providers/databricks/hooks/test_databricks_sql.py
+++ b/tests/providers/databricks/hooks/test_databricks_sql.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
+#
 from __future__ import annotations
 
 import unittest
@@ -70,17 +71,17 @@ class TestDatabricksSqlHookQueryByName(unittest.TestCase):
         type(mock_requests.get.return_value).status_code = status_code_mock
 
         test_fields = ["id", "value"]
-        test_schema = [(field,) for field in test_fields]
+        test_description = [(field,) for field in test_fields]
 
         conn = mock_conn.return_value
-        cur = mock.MagicMock(rowcount=0, description=test_schema)
+        cur = mock.MagicMock(rowcount=0, description=test_description)
         cur.fetchall.return_value = []
         conn.cursor.return_value = cur
 
         query = "select * from test.test;"
-        schema, results = self.hook.run(sql=query, handler=fetch_all_handler)
+        results = self.hook.run(sql=query, handler=fetch_all_handler)
 
-        assert schema == test_schema
+        assert self.hook.last_description == test_description
         assert results == []
 
         cur.execute.assert_has_calls([mock.call(q) for q in [query]])

--- a/tests/providers/databricks/operators/test_databricks_sql.py
+++ b/tests/providers/databricks/operators/test_databricks_sql.py
@@ -47,13 +47,15 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         sql = "select * from dummy"
         op = DatabricksSqlOperator(task_id=TASK_ID, sql=sql, do_xcom_push=True)
         db_mock = db_mock_class.return_value
-        mock_schema = [("id",), ("value",)]
+        mock_description = [("id",), ("value",)]
         mock_results = [Row(id=1, value="value1")]
-        db_mock.run.return_value = [(mock_schema, mock_results)]
+        db_mock.run.return_value = mock_results
+        db_mock.last_description = mock_description
+        db_mock.scalar_return_last = False
 
-        results = op.execute(None)
+        execute_results = op.execute(None)
 
-        assert results[0][1] == mock_results
+        assert execute_results == (mock_description, mock_results)
         db_mock_class.assert_called_once_with(
             DEFAULT_CONN_ID,
             http_path=None,
@@ -82,9 +84,11 @@ class TestDatabricksSqlOperator(unittest.TestCase):
         tempfile_path = tempfile.mkstemp()[1]
         op = DatabricksSqlOperator(task_id=TASK_ID, sql=sql, output_path=tempfile_path)
         db_mock = db_mock_class.return_value
-        mock_schema = [("id",), ("value",)]
+        mock_description = [("id",), ("value",)]
         mock_results = [Row(id=1, value="value1")]
-        db_mock.run.return_value = [(mock_schema, mock_results)]
+        db_mock.run.return_value = mock_results
+        db_mock.last_description = mock_description
+        db_mock.scalar_return_last = False
 
         try:
             op.execute(None)


### PR DESCRIPTION
When SQLExecuteQueryOperator has been introduced in https://github.com/apache/airflow/pull/25717, it
introduced some errors in the Databricks SQL operator:

* The schema (description) parameter has been passed as _process_output
  parameter from Hook's output
* The run() method of DatabricksHook was not conforming to other
  run methods of the Hook - it was returning Tuple of the
  result/description
* The _process_output type was not specified - if scalar was used
  it returned different output than without it and it was not
  specified in the DBApiHook.

This PR fixes it by:

* the Databricks Hook is now conformant to the other DBAPIHooks in
  terms of value returned by Hook (backwards incompatible so we
  need to bump major version of the provider)
* the DBApiHook now has "last_description" field which on one hand
  makes it stateless, on the other, the state reflects the
  description of the last run method and is not a problem to keep.
  This implies 1.4 version of common-sql provider as this is a new
  feature for the provider
* the DBApiHook now has "scalar_return_last" field that indicates
  if scalar output was specified.
* Python dbapi's "description" is properly named now - previously it was
  "schema" which clashed with the "schema" name passed to hook
  initialisation - the actual database schema

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
