### PR TITLE
task command: lifecycle notification about starting and finishing

### DIFF
--- a/tests/listeners/file_write_listener.py
+++ b/tests/listeners/file_write_listener.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import logging
+
+from airflow.cli.commands.task_command import TaskCommandMarker
+from airflow.listeners import hookimpl
+
+log = logging.getLogger(__name__)
+
+
+class FileWriteListener:
+    def __init__(self, path):
+        self.path = path
+
+    def write(self, line: str):
+        with open(self.path, "a") as f:
+            f.write(line + "\n")
+
+    @hookimpl
+    def on_starting(self, component):
+        if isinstance(component, TaskCommandMarker):
+            self.write("on_starting")
+
+    @hookimpl
+    def before_stopping(self, component):
+        if isinstance(component, TaskCommandMarker):
+            self.write("before_stopping")


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/27113 we expanded listener API with lifecycle methods - `on_starting` and `before_finish`. Those allow plugin authors set up and teardown their plugin if needed.  

This PR adds the lifecycle method to `task command`, as listener methods are called in this process: `on_task_instance_success` and `on_task_instance_failure`, so it would be useful to set up plugin process properly in this context too. 

Previously, this PR was adding this to `StandardTaskRunner`, but it needed to be done in `task command` as previous version would not cover `exec path`.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
