### PR TITLE
Change log level to DEBUG when secret not found for google secret manager

### DIFF
--- a/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
+++ b/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
@@ -75,7 +75,7 @@ class _SecretManagerClient(LoggingMixin):
             value = response.payload.data.decode("UTF-8")
             return value
         except NotFound:
-            self.log.error("Google Cloud API Call Error (NotFound): Secret ID %s not found.", secret_id)
+            self.log.info("Google Cloud API Call Error (NotFound): Secret ID %s not found.", secret_id)
             return None
         except PermissionDenied:
             self.log.error(

--- a/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
+++ b/airflow/providers/google/cloud/_internal_client/secret_manager_client.py
@@ -75,7 +75,7 @@ class _SecretManagerClient(LoggingMixin):
             value = response.payload.data.decode("UTF-8")
             return value
         except NotFound:
-            self.log.info("Google Cloud API Call Error (NotFound): Secret ID %s not found.", secret_id)
+            self.log.debug("Google Cloud API Call Error (NotFound): Secret ID %s not found.", secret_id)
             return None
         except PermissionDenied:
             self.log.error(

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -127,7 +127,7 @@ class TestCloudSecretManagerBackend(TestCase):
 
         secrets_manager_backend = CloudSecretManagerBackend(connections_prefix=CONNECTIONS_PREFIX)
         secret_id = secrets_manager_backend.build_path(CONNECTIONS_PREFIX, CONN_ID, SEP)
-        with self.assertLogs(secrets_manager_backend.client.log, level="ERROR") as log_output:
+        with self.assertLogs(secrets_manager_backend.client.log, level="INFO") as log_output:
             assert secrets_manager_backend.get_conn_uri(conn_id=CONN_ID) is None
             assert secrets_manager_backend.get_connection(conn_id=CONN_ID) is None
             assert re.search(
@@ -202,7 +202,7 @@ class TestCloudSecretManagerBackend(TestCase):
 
         secrets_manager_backend = CloudSecretManagerBackend(variables_prefix=VARIABLES_PREFIX)
         secret_id = secrets_manager_backend.build_path(VARIABLES_PREFIX, VAR_KEY, SEP)
-        with self.assertLogs(secrets_manager_backend.client.log, level="ERROR") as log_output:
+        with self.assertLogs(secrets_manager_backend.client.log, level="INFO") as log_output:
             assert secrets_manager_backend.get_variable(VAR_KEY) is None
             assert re.search(
                 f"Google Cloud API Call Error \\(NotFound\\): Secret ID {secret_id} not found",

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -127,7 +127,7 @@ class TestCloudSecretManagerBackend(TestCase):
 
         secrets_manager_backend = CloudSecretManagerBackend(connections_prefix=CONNECTIONS_PREFIX)
         secret_id = secrets_manager_backend.build_path(CONNECTIONS_PREFIX, CONN_ID, SEP)
-        with self.assertLogs(secrets_manager_backend.client.log, level="INFO") as log_output:
+        with self.assertLogs(secrets_manager_backend.client.log, level="DEBUG") as log_output:
             assert secrets_manager_backend.get_conn_uri(conn_id=CONN_ID) is None
             assert secrets_manager_backend.get_connection(conn_id=CONN_ID) is None
             assert re.search(
@@ -202,7 +202,7 @@ class TestCloudSecretManagerBackend(TestCase):
 
         secrets_manager_backend = CloudSecretManagerBackend(variables_prefix=VARIABLES_PREFIX)
         secret_id = secrets_manager_backend.build_path(VARIABLES_PREFIX, VAR_KEY, SEP)
-        with self.assertLogs(secrets_manager_backend.client.log, level="INFO") as log_output:
+        with self.assertLogs(secrets_manager_backend.client.log, level="DEBUG") as log_output:
             assert secrets_manager_backend.get_variable(VAR_KEY) is None
             assert re.search(
                 f"Google Cloud API Call Error \\(NotFound\\): Secret ID {secret_id} not found",


### PR DESCRIPTION
In the Airflow we serching first the connections & variables from alternative secrets backend and then in the databse, so we can have the situation when part of variables/connection we have in database and part of them in the secret backend. In this case we generating a lot of error logs that they are not errors, even if the variable/connection doesn't exist, I think, `info` level is enough.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
