### PR TITLE
[misc] Replace XOR `^` conditions by `exactly_one` helper in providers

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -47,6 +47,7 @@ from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
 from airflow.providers.amazon.aws.utils.connection_wrapper import AwsConnectionWrapper
+from airflow.utils.helpers import exactly_one
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 
@@ -493,7 +494,7 @@ class AwsGenericHook(BaseHook, Generic[BaseAwsConnection]):
 
         :return: boto3.client or boto3.resource
         """
-        if not ((not self.client_type) ^ (not self.resource_type)):
+        if not exactly_one(self.client_type, self.resource_type):
             raise ValueError(
                 f"Either client_type={self.client_type!r} or "
                 f"resource_type={self.resource_type!r} must be provided, not both."

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -26,6 +26,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook, EmrHook, EmrServerlessHook
 from airflow.providers.amazon.aws.links.emr import EmrClusterLink
+from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -71,7 +72,7 @@ class EmrAddStepsOperator(BaseOperator):
         wait_for_completion: bool = False,
         **kwargs,
     ):
-        if not (job_flow_id is None) ^ (job_flow_name is None):
+        if not exactly_one(job_flow_id is None, job_flow_name is None):
             raise AirflowException("Exactly one of job_flow_id or job_flow_name must be specified.")
         super().__init__(**kwargs)
         cluster_states = cluster_states or []

--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Sequence
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -463,11 +464,11 @@ class S3DeleteObjectsOperator(BaseOperator):
         self.aws_conn_id = aws_conn_id
         self.verify = verify
 
-        if not bool(keys is None) ^ bool(prefix is None):
+        if not exactly_one(prefix is None, keys is None):
             raise AirflowException("Either keys or prefix should be set.")
 
     def execute(self, context: Context):
-        if not bool(self.keys is None) ^ bool(self.prefix is None):
+        if not exactly_one(self.keys is None, self.prefix is None):
             raise AirflowException("Either keys or prefix should be set.")
 
         if isinstance(self.keys, (list, str)) and not bool(self.keys):

--- a/airflow/providers/google/cloud/operators/cloud_build.py
+++ b/airflow/providers/google/cloud/operators/cloud_build.py
@@ -38,6 +38,7 @@ from airflow.providers.google.cloud.links.cloud_build import (
     CloudBuildTriggersListLink,
 )
 from airflow.utils import yaml
+from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
@@ -917,7 +918,7 @@ class BuildProcessor:
         self.build = deepcopy(build)
 
     def _verify_source(self) -> None:
-        if not (("storage_source" in self.build["source"]) ^ ("repo_source" in self.build["source"])):
+        if not exactly_one("storage_source" in self.build["source"], "repo_source" in self.build["source"]):
             raise AirflowException(
                 "The source could not be determined. Please choose one data source from: "
                 "storage_source and repo_source."

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -30,6 +30,7 @@ from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowException, AirflowNotFoundException
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.utils import ConnectionExtraConfig
+from airflow.utils.helpers import exactly_one
 from airflow.utils.log.secrets_masker import mask_secret
 
 if TYPE_CHECKING:
@@ -268,7 +269,7 @@ class SlackHook(BaseHook):
             - `Slack API files.upload method <https://api.slack.com/methods/files.upload>`_
             - `File types <https://api.slack.com/types/file#file_types>`_
         """
-        if not ((not file) ^ (not content)):
+        if not exactly_one(file, content):
             raise ValueError("Either `file` or `content` must be provided, not both.")
         elif file:
             file = Path(file)

--- a/tests/providers/amazon/aws/operators/test_emr_add_steps.py
+++ b/tests/providers/amazon/aws/operators/test_emr_add_steps.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import os
-import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, call, patch
 
@@ -41,7 +40,7 @@ TEMPLATE_SEARCHPATH = os.path.join(
 )
 
 
-class TestEmrAddStepsOperator(unittest.TestCase):
+class TestEmrAddStepsOperator:
     # When
     _config = [
         {
@@ -54,7 +53,7 @@ class TestEmrAddStepsOperator(unittest.TestCase):
         }
     ]
 
-    def setUp(self):
+    def setup_method(self):
         self.args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         # Mock out the emr_client (moto has incorrect response)
@@ -78,6 +77,22 @@ class TestEmrAddStepsOperator(unittest.TestCase):
     def test_init(self):
         assert self.operator.job_flow_id == "j-8989898989"
         assert self.operator.aws_conn_id == "aws_default"
+
+    @pytest.mark.parametrize(
+        "job_flow_id, job_flow_name",
+        [
+            pytest.param("j-8989898989", "test_cluster", id="both-specified"),
+            pytest.param(None, None, id="both-none"),
+        ],
+    )
+    def test_validate_mutually_exclusive_args(self, job_flow_id, job_flow_name):
+        error_message = r"Exactly one of job_flow_id or job_flow_name must be specified\."
+        with pytest.raises(AirflowException, match=error_message):
+            EmrAddStepsOperator(
+                task_id="test_validate_mutually_exclusive_args",
+                job_flow_id=job_flow_id,
+                job_flow_name=job_flow_name,
+            )
 
     def test_render_template(self):
         dag_run = DagRun(dag_id=self.operator.dag.dag_id, execution_date=DEFAULT_DATE, run_id="test")

--- a/tests/providers/google/cloud/operators/test_cloud_build.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build.py
@@ -252,8 +252,12 @@ class TestCloudBuildOperator(TestCase):
 
 class TestBuildProcessor(TestCase):
     def test_verify_source(self):
-        with pytest.raises(AirflowException, match="The source could not be determined."):
+        error_message = r"The source could not be determined."
+        with pytest.raises(AirflowException, match=error_message):
             BuildProcessor(build={"source": {"storage_source": {}, "repo_source": {}}}).process_body()
+
+        with pytest.raises(AirflowException, match=error_message):
+            BuildProcessor(build={"source": {}}).process_body()
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Follow-up: https://github.com/apache/airflow/pull/27775#discussion_r1028460927

This PR potentially add more code readability. `exactly_one` helper exists in Airflow 2.3 so it should be safe to use it in providers packages.

I also added additional tests fro conditions which not tested before
