### PR TITLE
Simplify FAB table resetting

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -69,6 +69,7 @@ def import_all_models():
     import airflow.models.dataset
     import airflow.models.serialized_dag
     import airflow.models.tasklog
+    import airflow.www.fab_security.sqla.models
 
 
 def __getattr__(name):

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1600,7 +1600,6 @@ def resetdb(session: Session = NEW_SESSION, skip_init: bool = False):
 
     with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         drop_airflow_models(connection)
-        drop_flask_models(connection)
         drop_airflow_moved_tables(session)
 
     if not skip_init:
@@ -1707,18 +1706,6 @@ def drop_airflow_moved_tables(session):
     for tbl in to_delete:
         tbl.drop(settings.engine, checkfirst=False)
         Base.metadata.remove(tbl)
-
-
-def drop_flask_models(connection):
-    """
-    Drops all Flask models.
-
-    :param connection: SQLAlchemy Connection
-    :return: None
-    """
-    from airflow.www.fab_security.sqla.models import Base
-
-    Base.metadata.drop_all(connection)
 
 
 @provide_session

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -214,7 +214,6 @@ class TestDb:
     @pytest.mark.parametrize("skip_init", [False, True])
     @mock.patch("airflow.utils.db.create_global_lock", new=MagicMock)
     @mock.patch("airflow.utils.db.drop_airflow_models")
-    @mock.patch("airflow.utils.db.drop_flask_models")
     @mock.patch("airflow.utils.db.drop_airflow_moved_tables")
     @mock.patch("airflow.utils.db.initdb")
     @mock.patch("airflow.settings.engine.connect")
@@ -223,14 +222,12 @@ class TestDb:
         mock_connect,
         mock_init,
         mock_drop_moved,
-        mock_drop_flask,
         mock_drop_airflow,
         skip_init,
     ):
         session_mock = MagicMock()
         resetdb(session_mock, skip_init=skip_init)
         mock_drop_airflow.assert_called_once_with(mock_connect.return_value)
-        mock_drop_flask.assert_called_once_with(mock_connect.return_value)
         mock_drop_moved.assert_called_once_with(session_mock)
         if skip_init:
             mock_init.assert_not_called()


### PR DESCRIPTION
We can simplify how we reset FAB tables now that everything is an "Airflow" table.