### PR TITLE
Fix old-style typing in Base Sensor

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -103,7 +103,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
     """
 
     ui_color: str = "#e6f1f2"
-    valid_modes = ["poke", "reschedule"]  # type: Iterable[str]
+    valid_modes: Iterable[str] = ["poke", "reschedule"]
 
     # Adds one additional dependency for all sensor operators that checks if a
     # sensor task instance can be rescheduled.


### PR DESCRIPTION
The new autoflake removes unused Iterable from sensor - because it is used via old-style typing. Subsequently MyPy complains that Iterable is not imported.

This PR converts typing to new-style to fix it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
