### PR TITLE
Make MappedTaskGroup depend on its expand inputs

### DIFF
--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -229,7 +229,7 @@ class AbstractOperator(LoggingMixin, DAGNode):
             return set()
         return [dag.task_dict[task_id] for task_id in self.get_flat_relative_ids(upstream)]
 
-    def _iter_all_mapped_downstreams(self) -> Iterator[MappedOperator]:
+    def _iter_all_mapped_downstreams(self) -> Iterator[MappedOperator | MappedTaskGroup]:
         """Return mapped nodes that are direct dependencies of the current task.
 
         For now, this walks the entire DAG to find mapped nodes that has this
@@ -264,12 +264,12 @@ class AbstractOperator(LoggingMixin, DAGNode):
         for key, child in _walk_group(dag.task_group):
             if key == self.node_id:
                 continue
-            if not isinstance(child, MappedOperator):
+            if not isinstance(child, (MappedOperator, MappedTaskGroup)):
                 continue
             if self.node_id in child.upstream_task_ids:
                 yield child
 
-    def iter_mapped_dependants(self) -> Iterator[MappedOperator]:
+    def iter_mapped_dependants(self) -> Iterator[MappedOperator | MappedTaskGroup]:
         """Return mapped nodes that depend on the current task the expansion.
 
         For now, this walks the entire DAG to find mapped nodes that has this

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -97,7 +97,7 @@ from airflow.templates import SandboxedEnvironment
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import REQUEUEABLE_DEPS, RUNNING_DEPS
 from airflow.timetables.base import DataInterval
-from airflow.typing_compat import Literal
+from airflow.typing_compat import Literal, TypeGuard
 from airflow.utils import timezone
 from airflow.utils.context import ConnectionAccessor, Context, VariableAccessor, context_merge
 from airflow.utils.email import send_email
@@ -277,6 +277,19 @@ def clear_task_instances(
                 dr.last_scheduling_decision = None
                 dr.start_date = None
     session.flush()
+
+
+def _is_mappable_value(value: Any) -> TypeGuard[Collection]:
+    """Whether a value can be used for task mapping.
+
+    We only allow collections with guaranteed ordering, but exclude character
+    sequences since that's usually not what users would expect to be mappable.
+    """
+    if not isinstance(value, (collections.abc.Sequence, dict)):
+        return False
+    if isinstance(value, (bytearray, bytes, str)):
+        return False
+    return True
 
 
 class TaskInstanceKey(NamedTuple):
@@ -2226,18 +2239,14 @@ class TaskInstance(Base, LoggingMixin):
             return
         # TODO: We don't push TaskMap for mapped task instances because it's not
         # currently possible for a downstream to depend on one individual mapped
-        # task instance. This will change when we implement task group mapping,
-        # and we'll need to further analyze the mapped task case.
+        # task instance. This will change when we implement task mapping inside
+        # a mapped task group, and we'll need to further analyze the case.
         if task.is_mapped:
             return
         if value is None:
             raise XComForMappingNotPushed()
-        if not isinstance(value, (collections.abc.Sequence, dict)):
+        if not _is_mappable_value(value):
             raise UnmappableXComTypePushed(value)
-        if isinstance(value, (bytes, str)):
-            raise UnmappableXComTypePushed(value)
-        if TYPE_CHECKING:  # The isinstance() checks above guard this.
-            assert isinstance(value, collections.abc.Collection)
         task_map = TaskMap.from_task_instance_xcom(self, value)
         max_map_length = conf.getint("core", "max_map_length", fallback=1024)
         if task_map.length > max_map_length:


### PR DESCRIPTION
This allows the scheduler to correctly identify the dependencies, run things in the right order, and write TaskMap metadata as needed.

This also helped catch a bug in BackfillJob where children of a mapped task group is not correctly identified and expanded.

Fix #27878.

Reproduction:

```python
from datetime import datetime

from airflow import DAG
from airflow.decorators import task, task_group
from airflow.operators.empty import EmptyOperator

with DAG(
    dag_id="taskmap_taskgroup",
    tags=["AIP_42"],
    start_date=datetime(1970, 1, 1),
    schedule=None,
) as dag:

    @task
    def onetwothree():
        return [1, 2, 3]

    @task
    def hello_there(arg):
        print(arg)

    @task_group
    def tg(x):
        hello_there(x)

    increment_and_verify.expand(x=onetwothree()) >> EmptyOperator(task_id="done")
```

when executed, `tg` is currently unable to correctly identify `onetwothree` as an upstream, and `hellow_there` fails to expand with error

```
Cannot expand <Task(_PythonDecoratedOperator): tg.hello_there> for run my_custom_run; missing upstream values: ['x']
```

since the task group cannot “provide” it the value.