### PR TITLE
Add allow list for imports during deserialization

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -212,7 +212,7 @@
       see_also: "https://docs.python.org/3/library/pickle.html#comparison-with-json"
     - name: allowed_deserialization_classes
       description: |
-        What classes can be imported during deserialization. This is a multiline value.
+        What classes can be imported during deserialization. This is a multi line value.
         The individual items will be parsed as regexp. Python built-in classes (like dict)
         are always allowed
       version_added: 2.5.0

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -210,6 +210,15 @@
       example: ~
       default: "False"
       see_also: "https://docs.python.org/3/library/pickle.html#comparison-with-json"
+    - name: allowed_deserialization_classes
+      description: |
+        What classes can be imported during deserialization. This is a multiline value.
+        The individual items will be parsed as regexp. Python built-in classes (like dict)
+        are always allowed
+      version_added: 2.5.0
+      type: string
+      default: 'airflow\..*'
+      example: ~
     - name: killed_task_cleanup_time
       description: |
         When a task is killed forcefully, this is the amount of time in seconds that

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -127,6 +127,11 @@ unit_test_mode = False
 # RCE exploits).
 enable_xcom_pickling = False
 
+# What classes can be imported during deserialization. This is a multiline value.
+# The individual items will be parsed as regexp. Python built-in classes (like dict)
+# are always allowed
+allowed_deserialization_classes = airflow\..*
+
 # When a task is killed forcefully, this is the amount of time in seconds that
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
 killed_task_cleanup_time = 60

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -127,7 +127,7 @@ unit_test_mode = False
 # RCE exploits).
 enable_xcom_pickling = False
 
-# What classes can be imported during deserialization. This is a multiline value.
+# What classes can be imported during deserialization. This is a multi line value.
 # The individual items will be parsed as regexp. Python built-in classes (like dict)
 # are always allowed
 allowed_deserialization_classes = airflow\..*

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -35,6 +35,8 @@ plugins_folder = {TEST_PLUGINS_FOLDER}
 dags_are_paused_at_creation = False
 fernet_key = {FERNET_KEY}
 killed_task_cleanup_time = 5
+allowed_deserialization_classes = airflow\..*
+                                  tests\..*
 
 [database]
 sql_alchemy_conn = sqlite:///{AIRFLOW_HOME}/unittests.db


### PR DESCRIPTION
During deserialization Airflow can instantiate arbitrary objects for which it imports modules. This can be dangerous as it could lead to unwanted effects. With this change administrators can now limit what objects can be deserialized. It defaults to Airflow's own only.

cc @ashb @kaxil @BasPH 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
