### PR TITLE
Bump common.sql provider to 1.3.1

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -48,7 +48,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - boto3>=1.24.0
   # watchtower 3 has been released end Jan and introduced breaking change across the board that might
   # change logging behaviour:

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -35,7 +35,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - sqlalchemy-drill>=1.1.0
 
 integrations:

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -42,7 +42,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pydruid>=0.4.1
 
 integrations:

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -44,7 +44,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - hmsclient>=0.1.0
   - pandas>=0.17.1
   - pyhive[hive]>=0.6.0

--- a/airflow/providers/apache/pinot/provider.yaml
+++ b/airflow/providers/apache/pinot/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pinotdb>0.4.7
 
 integrations:

--- a/airflow/providers/common/sql/CHANGELOG.rst
+++ b/airflow/providers/common/sql/CHANGELOG.rst
@@ -24,6 +24,26 @@
 Changelog
 ---------
 
+1.3.1
+.....
+
+This release fixes a few errors that were introduced in common.sql operator while refactoring common parts:
+
+* ``_process_output`` method in ``SQLExecuteQueryOperator`` has now consistent semantics and typing, it
+  can also modify the returned (and stored in XCom) values in the operators that derive from the
+  ``SQLExecuteQueryOperator``).
+* last description of the cursor whether to return scalar values are now stored in DBApiHook
+
+Lack of consistency in the operator caused ``1.3.0`` to be yanked - the ``1.3.0`` should not be used - if
+you have ``1.3.0`` installed, upgrade to ``1.3.1``.
+
+Bug Fixes
+~~~~~~~~~
+
+* ``Restore removed (but used) methods in common.sql (#27843)``
+* ``Fix errors in Databricks SQL operator introduced when refactoring (#27854)``
+
+
 1.3.0
 .....
 

--- a/airflow/providers/common/sql/provider.yaml
+++ b/airflow/providers/common/sql/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Common SQL Provider <https://en.wikipedia.org/wiki/SQL>`__
 
 versions:
+  - 1.3.1
   - 1.3.0
   - 1.2.0
   - 1.1.0

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -42,7 +42,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - requests>=2.27,<3
   - databricks-sql-connector>=2.0.0, <3.0.0
   - aiohttp>=3.6.3, <4

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -44,7 +44,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - elasticsearch>7
   - elasticsearch-dbapi
   - elasticsearch-dsl>=5.0.0

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pyexasol>=0.5.1
   - pandas>=0.17.1
 

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -56,7 +56,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   # Google has very clear rules on what dependencies should be used. All the limits below
   # follow strict guidelines of Google Libraries as quoted here:
   # While this issue is open, dependents of google-api-core, google-cloud-core. and google-auth

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -38,7 +38,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - jaydebeapi>=1.1.1
 
 integrations:

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pymssql>=2.1.5; platform_machine != "aarch64"
 
 integrations:

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -41,7 +41,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - mysql-connector-python>=8.0.11; platform_machine != "aarch64"
   - mysqlclient>=1.3.6; platform_machine != "aarch64"
 

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -37,7 +37,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pyodbc
 
 integrations:

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -41,7 +41,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - oracledb>=1.0.0
 
 integrations:

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -43,7 +43,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - psycopg2>=2.8.0
 
 integrations:

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -40,7 +40,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - presto-python-client>=0.8.2
   - pandas>=0.17.1
 

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - qds-sdk>=1.10.4
 
 integrations:

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -39,7 +39,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - slack_sdk>=3.0.0
 
 integrations:

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -47,7 +47,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - snowflake-connector-python>=2.4.1
   - snowflake-sqlalchemy>=1.1.0
 

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -38,7 +38,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
 
 integrations:
   - integration-name: SQLite

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -40,7 +40,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - pandas>=0.17.1
   - trino>=0.318.0
 

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -38,7 +38,7 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - apache-airflow-providers-common-sql>=1.3.0
+  - apache-airflow-providers-common-sql>=1.3.1
   - vertica-python>=0.5.1
 
 integrations:

--- a/docs/apache-airflow-providers-common-sql/commits.rst
+++ b/docs/apache-airflow-providers-common-sql/commits.rst
@@ -28,14 +28,27 @@ For high-level changelog, see :doc:`package information including changelog <ind
 
 
 
+1.4.0
+.....
+
+Latest change: 2022-11-24
+
+=================================================================================================  ===========  ==============================================================================
+Commit                                                                                             Committed    Subject
+=================================================================================================  ===========  ==============================================================================
+`ea306c9462 <https://github.com/apache/airflow/commit/ea306c9462615d6b215d43f7f17d68f4c62951b1>`_  2022-11-24   ``Fix errors in Databricks SQL operator introduced when refactoring (#27854)``
+`dbb4b59dcb <https://github.com/apache/airflow/commit/dbb4b59dcbc8b57243d1588d45a4d2717c3e7758>`_  2022-11-23   ``Restore removed (but used) methods in common.sql (#27843)``
+=================================================================================================  ===========  ==============================================================================
+
 1.3.0
 .....
 
-Latest change: 2022-11-14
+Latest change: 2022-11-15
 
 =================================================================================================  ===========  ====================================================================================
 Commit                                                                                             Committed    Subject
 =================================================================================================  ===========  ====================================================================================
+`12c3c39d1a <https://github.com/apache/airflow/commit/12c3c39d1a816c99c626fe4c650e88cf7b1cc1bc>`_  2022-11-15   ``pRepare docs for November 2022 wave of Providers (#27613)``
 `3ae98b824d <https://github.com/apache/airflow/commit/3ae98b824db437b2db928a73ac8b50c0a2f80124>`_  2022-11-14   ``Use unused SQLCheckOperator.parameters in SQLCheckOperator.execute. (#27599)``
 `5c37b503f1 <https://github.com/apache/airflow/commit/5c37b503f118b8ad2585dff9949dd8fdb96689ed>`_  2022-10-31   ``Use DbApiHook.run for DbApiHook.get_records and DbApiHook.get_first (#26944)``
 `9ab1a6a3e7 <https://github.com/apache/airflow/commit/9ab1a6a3e70b32a3cddddf0adede5d2f3f7e29ea>`_  2022-10-27   ``Update old style typing (#26872)``

--- a/docs/apache-airflow-providers-common-sql/index.rst
+++ b/docs/apache-airflow-providers-common-sql/index.rst
@@ -64,7 +64,7 @@ Package apache-airflow-providers-common-sql
 `Common SQL Provider <https://en.wikipedia.org/wiki/SQL>`__
 
 
-Release: 1.3.0
+Release: 1.4.0
 
 Provider package
 ----------------

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -17,7 +17,7 @@
   },
   "amazon": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "boto3>=1.24.0",
       "jsonpath_ng>=1.5.3",
@@ -60,7 +60,7 @@
   },
   "apache.drill": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "sqlalchemy-drill>=1.1.0"
     ],
@@ -70,7 +70,7 @@
   },
   "apache.druid": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pydruid>=0.4.1"
     ],
@@ -89,7 +89,7 @@
   },
   "apache.hive": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "hmsclient>=0.1.0",
       "pandas>=0.17.1",
@@ -131,7 +131,7 @@
   },
   "apache.pinot": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pinotdb>0.4.7"
     ],
@@ -205,7 +205,7 @@
   "databricks": {
     "deps": [
       "aiohttp>=3.6.3, <4",
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "databricks-sql-connector>=2.0.0, <3.0.0",
       "requests>=2.27,<3"
@@ -258,7 +258,7 @@
   },
   "elasticsearch": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "elasticsearch-dbapi",
       "elasticsearch-dsl>=5.0.0",
@@ -270,7 +270,7 @@
   },
   "exasol": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pandas>=0.17.1",
       "pyexasol>=0.5.1"
@@ -300,7 +300,7 @@
   "google": {
     "deps": [
       "PyOpenSSL",
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "asgiref>=3.5.2",
       "gcloud-aio-bigquery>=6.1.2",
@@ -411,7 +411,7 @@
   },
   "jdbc": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "jaydebeapi>=1.1.1"
     ],
@@ -454,7 +454,7 @@
   },
   "microsoft.mssql": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pymssql>=2.1.5; platform_machine != \"aarch64\""
     ],
@@ -485,7 +485,7 @@
   },
   "mysql": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "mysql-connector-python>=8.0.11; platform_machine != \"aarch64\"",
       "mysqlclient>=1.3.6; platform_machine != \"aarch64\""
@@ -507,7 +507,7 @@
   },
   "odbc": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pyodbc"
     ],
@@ -530,7 +530,7 @@
   },
   "oracle": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "oracledb>=1.0.0"
     ],
@@ -562,7 +562,7 @@
   },
   "postgres": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "psycopg2>=2.8.0"
     ],
@@ -573,7 +573,7 @@
   },
   "presto": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pandas>=0.17.1",
       "presto-python-client>=0.8.2"
@@ -585,7 +585,7 @@
   },
   "qubole": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "qds-sdk>=1.10.4"
     ],
@@ -647,7 +647,7 @@
   },
   "slack": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "slack_sdk>=3.0.0"
     ],
@@ -657,7 +657,7 @@
   },
   "snowflake": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "snowflake-connector-python>=2.4.1",
       "snowflake-sqlalchemy>=1.1.0"
@@ -669,7 +669,7 @@
   },
   "sqlite": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0"
+      "apache-airflow-providers-common-sql>=1.3.1"
     ],
     "cross-providers-deps": [
       "common.sql"
@@ -705,7 +705,7 @@
   },
   "trino": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "pandas>=0.17.1",
       "trino>=0.318.0"
@@ -717,7 +717,7 @@
   },
   "vertica": {
     "deps": [
-      "apache-airflow-providers-common-sql>=1.3.0",
+      "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
       "vertica-python>=0.5.1"
     ],


### PR DESCRIPTION
The common.sql provider should be bumped to 1.3.1 in order to handle some of the problems found in 1.3.0 - mainly about consistency of common SQLExecuteQueryOperator that is used in multiple providers.

We are going to yank 1.3.0 - this PR also bumps min dependency for all providers that use common.sql to make sure we can release them in sync with the common.sql provider.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
