### PR TITLE
tests: always cleanup registered test listeners

### DIFF
--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -65,6 +65,7 @@ class AirflowTestOnLoadExceptionPlugin(AirflowPlugin):
 
 @pytest.fixture(autouse=True, scope="module")
 def clean_plugins():
+    get_listener_manager().clear()
     yield
     get_listener_manager().clear()
 

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -72,6 +72,7 @@ class TestStandardTaskRunner:
         (as the test environment does not have enough context for the normal
         way to run) and ensures they reset back to normal on the way out.
         """
+        get_listener_manager().clear()
         clear_db_runs()
         dictConfig(LOGGING_CONFIG)
         yield
@@ -79,6 +80,7 @@ class TestStandardTaskRunner:
         airflow_logger.handlers = []
         clear_db_runs()
         dictConfig(DEFAULT_LOGGING_CONFIG)
+        get_listener_manager().clear()
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()


### PR DESCRIPTION
Listeners get registered in tests, that run in various order. 

Every place that registers listeners should clean up, defensively before and after using registering new managers.

Signed-off-by: Maciej Obuchowski <obuchowski.maciej@gmail.com>
