### PR TITLE
fix sagemaker system test to run on Apple Silicon

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -170,7 +170,7 @@ def _build_and_upload_docker_image(preprocess_script, repository_uri):
 
         docker_build_and_push_commands = f"""
             cp /root/.aws/credentials /tmp/credentials &&
-            docker build -f {dockerfile.name} -t {repository_uri} /tmp &&
+            docker build --platform=linux/amd64 -f {dockerfile.name} -t {repository_uri} /tmp &&
             rm /tmp/credentials &&
             aws ecr get-login-password --region {ecr_region} |
             docker login --username {username} --password {password} {repository_uri} &&


### PR DESCRIPTION
this test was failing when launched from an M1 mac because the docker image was built for the local CPU type (arm64) and then uploaded to an amd64 linux, which didn't work.
`--platform` is a flag for buildx, but breeze has it replacing the default `docker build`, so this works alright.

tested on an M1 macbook pro and on an EC2 ubuntu instance.