### PR TITLE
Order TIs by map_index

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -312,7 +312,7 @@ class SchedulerJob(BaseJob):
                 .filter(not_(DM.is_paused))
                 .filter(TI.state == TaskInstanceState.SCHEDULED)
                 .options(selectinload("dag_model"))
-                .order_by(-TI.priority_weight, DR.execution_date)
+                .order_by(-TI.priority_weight, DR.execution_date, TI.map_index)
             )
 
             if starved_pools:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Sort TIs by the `map_index` field when selecting them for queueing. Currently TIs are only ordered by `priority_weight` and `execution_date`. This does not fix any bug, but makes it more understandable and "cleaner" in the UI.

Without this, every now and then the TIs get executed from the middle - probably something to do with database internals.
![2022-11-24_15-47](https://user-images.githubusercontent.com/3342974/203914401-97c9be97-43ab-432f-bd8f-b858ad09c058.png)



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
