### PR TITLE
Add Export Format to Template Fields in BigQueryToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_gcs.py
@@ -86,6 +86,7 @@ class BigQueryToGCSOperator(BaseOperator):
     template_fields: Sequence[str] = (
         "source_project_dataset_table",
         "destination_cloud_storage_uris",
+        "export_format",
         "labels",
         "impersonation_chain",
     )


### PR DESCRIPTION
closes: #27909 

There might be an use case where the export_format can be based on some dynamic values. So, adding export_format will help developers in future.
P.S: In our usecase, we do derive its value as a macro method