### PR TITLE
Fixing the behaviours of SQL Hooks and Operators finally

### DIFF
--- a/airflow/providers/common/sql/CHANGELOG.rst
+++ b/airflow/providers/common/sql/CHANGELOG.rst
@@ -32,7 +32,9 @@ This release fixes a few errors that were introduced in common.sql operator whil
 * ``_process_output`` method in ``SQLExecuteQueryOperator`` has now consistent semantics and typing, it
   can also modify the returned (and stored in XCom) values in the operators that derive from the
   ``SQLExecuteQueryOperator``).
-* last description of the cursor whether to return scalar values are now stored in DBApiHook
+* descriptions of all returned results are stored as descriptions property in the DBApiHook
+* last description of the cursor whether to return single query results values are now exposed in
+  DBApiHook via last_description property.
 
 Lack of consistency in the operator caused ``1.3.0`` to be yanked - the ``1.3.0`` should not be used - if
 you have ``1.3.0`` installed, upgrade to ``1.3.1``.

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -24,7 +24,7 @@ import pandas as pd
 import pyexasol
 from pyexasol import ExaConnection
 
-from airflow.providers.common.sql.hooks.sql import DbApiHook
+from airflow.providers.common.sql.hooks.sql import DbApiHook, return_single_query_results
 
 
 class ExasolHook(DbApiHook):
@@ -157,7 +157,6 @@ class ExasolHook(DbApiHook):
         :param return_last: Whether to return result for only last statement or for all after split
         :return: return only result of the LAST SQL expression if handler was provided.
         """
-        self.scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 sql = self.split_sql_string(sql)
@@ -187,7 +186,7 @@ class ExasolHook(DbApiHook):
 
         if handler is None:
             return None
-        elif self.scalar_return_last:
+        elif return_single_query_results(sql, return_last, split_statements):
             return results[-1]
         else:
             return results

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -32,7 +32,7 @@ from snowflake.sqlalchemy import URL
 from sqlalchemy import create_engine
 
 from airflow import AirflowException
-from airflow.providers.common.sql.hooks.sql import DbApiHook
+from airflow.providers.common.sql.hooks.sql import DbApiHook, return_single_query_results
 from airflow.utils.strings import to_boolean
 
 
@@ -350,7 +350,6 @@ class SnowflakeHook(DbApiHook):
         """
         self.query_ids = []
 
-        self.scalar_return_last = isinstance(sql, str) and return_last
         if isinstance(sql, str):
             if split_statements:
                 split_statements_tuple = util_text.split_statements(StringIO(sql))
@@ -387,7 +386,7 @@ class SnowflakeHook(DbApiHook):
 
         if handler is None:
             return None
-        elif self.scalar_return_last:
+        elif return_single_query_results(sql, return_last, split_statements):
             return results[-1]
         else:
             return results

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -88,6 +88,8 @@ class TestSQLExecuteQueryOperator:
             autocommit=False,
             parameters=None,
             split_statements=False,
+            handler=None,
+            return_last=True,
         )
 
 

--- a/tests/providers/common/sql/operators/test_sql_execute.py
+++ b/tests/providers/common/sql/operators/test_sql_execute.py
@@ -1,0 +1,276 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any, NamedTuple, Sequence
+from unittest.mock import MagicMock
+
+import pytest
+
+from airflow.providers.common.sql.hooks.sql import fetch_all_handler
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+DATE = "2017-04-20"
+TASK_ID = "sql-operator"
+
+
+class Row(NamedTuple):
+    id: str
+    value: str
+
+
+class Row2(NamedTuple):
+    id2: str
+    value2: str
+
+
+@pytest.mark.parametrize(
+    "sql, return_last, split_statement, hook_results, hook_descriptions, expected_results",
+    [
+        pytest.param(
+            "select * from dummy",
+            True,
+            True,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            id="Scalar: Single SQL statement, return_last, split statement",
+        ),
+        pytest.param(
+            "select * from dummy;select * from dummy2",
+            True,
+            True,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            id="Scalar: Multiple SQL statements, return_last, split statement",
+        ),
+        pytest.param(
+            "select * from dummy",
+            False,
+            False,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            id="Scalar: Single SQL statements, no return_last (doesn't matter), no split statement",
+        ),
+        pytest.param(
+            "select * from dummy",
+            True,
+            False,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            id="Scalar: Single SQL statements, return_last (doesn't matter), no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy"],
+            False,
+            False,
+            [[Row(id=1, value="value1"), Row(id=2, value="value2")]],
+            [[("id",), ("value",)]],
+            [[Row(id=1, value="value1"), Row(id=2, value="value2")]],
+            id="Non-Scalar: Single SQL statements in list, no return_last, no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy", "select * from dummy2"],
+            False,
+            False,
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            [[("id",), ("value",)], [("id2",), ("value2",)]],
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            id="Non-Scalar: Multiple SQL statements in list, no return_last (no matter), no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy", "select * from dummy2"],
+            True,
+            False,
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            [[("id",), ("value",)], [("id2",), ("value2",)]],
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            id="Non-Scalar: Multiple SQL statements in list, return_last (no matter), no split statement",
+        ),
+    ],
+)
+def test_exec_success(sql, return_last, split_statement, hook_results, hook_descriptions, expected_results):
+    """
+    Test the execute function in case where SQL query was successful.
+    """
+
+    class SQLExecuteQueryOperatorForTest(SQLExecuteQueryOperator):
+        _mock_db_api_hook = MagicMock()
+
+        def get_db_hook(self):
+            return self._mock_db_api_hook
+
+    op = SQLExecuteQueryOperatorForTest(
+        task_id=TASK_ID,
+        sql=sql,
+        do_xcom_push=True,
+        return_last=return_last,
+        split_statements=split_statement,
+    )
+
+    op._mock_db_api_hook.run.return_value = hook_results
+    op._mock_db_api_hook.descriptions = hook_descriptions
+
+    execute_results = op.execute(None)
+
+    assert execute_results == expected_results
+    op._mock_db_api_hook.run.assert_called_once_with(
+        sql=sql,
+        parameters=None,
+        handler=fetch_all_handler,
+        autocommit=False,
+        return_last=return_last,
+        split_statements=split_statement,
+    )
+
+
+@pytest.mark.parametrize(
+    "sql, return_last, split_statement, hook_results, hook_descriptions, expected_results",
+    [
+        pytest.param(
+            "select * from dummy",
+            True,
+            True,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+            id="Scalar: Single SQL statement, return_last, split statement",
+        ),
+        pytest.param(
+            "select * from dummy;select * from dummy2",
+            True,
+            True,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+            id="Scalar: Multiple SQL statements, return_last, split statement",
+        ),
+        pytest.param(
+            "select * from dummy",
+            False,
+            False,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+            id="Scalar: Single SQL statements, no return_last (doesn't matter), no split statement",
+        ),
+        pytest.param(
+            "select * from dummy",
+            True,
+            False,
+            [Row(id=1, value="value1"), Row(id=2, value="value2")],
+            [[("id",), ("value",)]],
+            ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+            id="Scalar: Single SQL statements, return_last (doesn't matter), no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy"],
+            False,
+            False,
+            [[Row(id=1, value="value1"), Row(id=2, value="value2")]],
+            [[("id",), ("value",)]],
+            [([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")])],
+            id="Non-Scalar: Single SQL statements in list, no return_last, no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy", "select * from dummy2"],
+            False,
+            False,
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            [[("id",), ("value",)], [("id2",), ("value2",)]],
+            [
+                ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+                ([("id2",), ("value2",)], [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")]),
+            ],
+            id="Non-Scalar: Multiple SQL statements in list, no return_last (no matter), no split statement",
+        ),
+        pytest.param(
+            ["select * from dummy", "select * from dummy2"],
+            True,
+            False,
+            [
+                [Row(id=1, value="value1"), Row(id=2, value="value2")],
+                [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")],
+            ],
+            [[("id",), ("value",)], [("id2",), ("value2",)]],
+            [
+                ([("id",), ("value",)], [Row(id=1, value="value1"), Row(id=2, value="value2")]),
+                ([("id2",), ("value2",)], [Row2(id2=1, value2="value1"), Row2(id2=2, value2="value2")]),
+            ],
+            id="Non-Scalar: Multiple SQL statements in list, return_last (no matter), no split statement",
+        ),
+    ],
+)
+def test_exec_success_with_process_output(
+    sql, return_last, split_statement, hook_results, hook_descriptions, expected_results
+):
+    """
+    Test the execute function in case where SQL query was successful.
+    """
+
+    class SQLExecuteQueryOperatorForTestWithProcessOutput(SQLExecuteQueryOperator):
+        _mock_db_api_hook = MagicMock()
+
+        def get_db_hook(self):
+            return self._mock_db_api_hook
+
+        def _process_output(
+            self, results: list[Any], descriptions: list[Sequence[Sequence] | None]
+        ) -> list[Any]:
+            return list(zip(descriptions, results))
+
+    op = SQLExecuteQueryOperatorForTestWithProcessOutput(
+        task_id=TASK_ID,
+        sql=sql,
+        do_xcom_push=True,
+        return_last=return_last,
+        split_statements=split_statement,
+    )
+
+    op._mock_db_api_hook.run.return_value = hook_results
+    op._mock_db_api_hook.descriptions = hook_descriptions
+
+    execute_results = op.execute(None)
+
+    assert execute_results == expected_results
+    op._mock_db_api_hook.run.assert_called_once_with(
+        sql=sql,
+        parameters=None,
+        handler=fetch_all_handler,
+        autocommit=False,
+        return_last=return_last,
+        split_statements=split_statement,
+    )

--- a/tests/providers/databricks/operators/test_databricks_copy.py
+++ b/tests/providers/databricks/operators/test_databricks_copy.py
@@ -1,0 +1,230 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from airflow import AirflowException
+from airflow.providers.databricks.operators.databricks_sql import DatabricksCopyIntoOperator
+
+DATE = "2017-04-20"
+TASK_ID = "databricks-sql-operator"
+DEFAULT_CONN_ID = "databricks_default"
+COPY_FILE_LOCATION = "s3://my-bucket/jsonData"
+
+
+def test_copy_with_files():
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        files=["file1", "file2", "file3"],
+        format_options={"dateFormat": "yyyy-MM-dd"},
+        task_id=TASK_ID,
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM '{COPY_FILE_LOCATION}'
+FILEFORMAT = JSON
+FILES = ('file1','file2','file3')
+FORMAT_OPTIONS ('dateFormat' = 'yyyy-MM-dd')
+""".strip()
+    )
+
+
+def test_copy_with_expression():
+    expression = "col1, col2"
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="CSV",
+        table_name="test",
+        task_id=TASK_ID,
+        pattern="folder1/file_[a-g].csv",
+        expression_list=expression,
+        format_options={"header": "true"},
+        force_copy=True,
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM (SELECT {expression} FROM '{COPY_FILE_LOCATION}')
+FILEFORMAT = CSV
+PATTERN = 'folder1/file_[a-g].csv'
+FORMAT_OPTIONS ('header' = 'true')
+COPY_OPTIONS ('force' = 'true')
+""".strip()
+    )
+
+
+def test_copy_with_credential():
+    expression = "col1, col2"
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="CSV",
+        table_name="test",
+        task_id=TASK_ID,
+        expression_list=expression,
+        credential={"AZURE_SAS_TOKEN": "abc"},
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM (SELECT {expression} FROM '{COPY_FILE_LOCATION}' WITH (CREDENTIAL (AZURE_SAS_TOKEN = 'abc') ))
+FILEFORMAT = CSV
+""".strip()
+    )
+
+
+def test_copy_with_target_credential():
+    expression = "col1, col2"
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="CSV",
+        table_name="test",
+        task_id=TASK_ID,
+        expression_list=expression,
+        storage_credential="abc",
+        credential={"AZURE_SAS_TOKEN": "abc"},
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test WITH (CREDENTIAL abc)
+FROM (SELECT {expression} FROM '{COPY_FILE_LOCATION}' WITH (CREDENTIAL (AZURE_SAS_TOKEN = 'abc') ))
+FILEFORMAT = CSV
+""".strip()
+    )
+
+
+def test_copy_with_encryption():
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="CSV",
+        table_name="test",
+        task_id=TASK_ID,
+        encryption={"TYPE": "AWS_SSE_C", "MASTER_KEY": "abc"},
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM '{COPY_FILE_LOCATION}' WITH ( ENCRYPTION (TYPE = 'AWS_SSE_C', MASTER_KEY = 'abc'))
+FILEFORMAT = CSV
+""".strip()
+    )
+
+
+def test_copy_with_encryption_and_credential():
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="CSV",
+        table_name="test",
+        task_id=TASK_ID,
+        encryption={"TYPE": "AWS_SSE_C", "MASTER_KEY": "abc"},
+        credential={"AZURE_SAS_TOKEN": "abc"},
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM '{COPY_FILE_LOCATION}' WITH (CREDENTIAL (AZURE_SAS_TOKEN = 'abc') """
+        """ENCRYPTION (TYPE = 'AWS_SSE_C', MASTER_KEY = 'abc'))
+FILEFORMAT = CSV
+""".strip()
+    )
+
+
+def test_copy_with_validate_all():
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        task_id=TASK_ID,
+        validate=True,
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM '{COPY_FILE_LOCATION}'
+FILEFORMAT = JSON
+VALIDATE ALL
+""".strip()
+    )
+
+
+def test_copy_with_validate_N_rows():
+    op = DatabricksCopyIntoOperator(
+        file_location=COPY_FILE_LOCATION,
+        file_format="JSON",
+        table_name="test",
+        task_id=TASK_ID,
+        validate=10,
+    )
+    assert (
+        op._create_sql_query()
+        == f"""COPY INTO test
+FROM '{COPY_FILE_LOCATION}'
+FILEFORMAT = JSON
+VALIDATE 10 ROWS
+""".strip()
+    )
+
+
+def test_incorrect_params_files_patterns():
+    exception_message = "Only one of 'pattern' or 'files' should be specified"
+    with pytest.raises(AirflowException, match=exception_message):
+        DatabricksCopyIntoOperator(
+            task_id=TASK_ID,
+            file_location=COPY_FILE_LOCATION,
+            file_format="JSON",
+            table_name="test",
+            files=["file1", "file2", "file3"],
+            pattern="abc",
+        )
+
+
+def test_incorrect_params_emtpy_table():
+    exception_message = "table_name shouldn't be empty"
+    with pytest.raises(AirflowException, match=exception_message):
+        DatabricksCopyIntoOperator(
+            task_id=TASK_ID,
+            file_location=COPY_FILE_LOCATION,
+            file_format="JSON",
+            table_name="",
+        )
+
+
+def test_incorrect_params_emtpy_location():
+    exception_message = "file_location shouldn't be empty"
+    with pytest.raises(AirflowException, match=exception_message):
+        DatabricksCopyIntoOperator(
+            task_id=TASK_ID,
+            file_location="",
+            file_format="JSON",
+            table_name="abc",
+        )
+
+
+def test_incorrect_params_wrong_format():
+    file_format = "JSONL"
+    exception_message = f"file_format '{file_format}' isn't supported"
+    with pytest.raises(AirflowException, match=exception_message):
+        DatabricksCopyIntoOperator(
+            task_id=TASK_ID,
+            file_location=COPY_FILE_LOCATION,
+            file_format=file_format,
+            table_name="abc",
+        )

--- a/tests/providers/jdbc/operators/test_jdbc.py
+++ b/tests/providers/jdbc/operators/test_jdbc.py
@@ -50,5 +50,7 @@ class TestJdbcOperator:
             sql=jdbc_operator.sql,
             autocommit=jdbc_operator.autocommit,
             parameters=jdbc_operator.parameters,
+            handler=None,
+            return_last=True,
             split_statements=False,
         )


### PR DESCRIPTION
This is the more bold fix to common.sql and related providers. It implements more comprehensive tests and describes the intended behaviours in much more explicit way, also it simplifies the notion of "scalar" behaviour by introducing a new method to check on when scalar return is expected.

Comprehensive suite of tests have been added (the original tests were converted to Pytest test and parameterized was used to test all the combinations of parameters and returned values.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
