### PR TITLE
fix: dag_id and task_id non ascii char

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -51,6 +51,8 @@ import pendulum
 from dateutil.relativedelta import relativedelta
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
+import text_unidecode
+
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, RemovedInAirflow3Warning, TaskDeferred
@@ -84,7 +86,7 @@ from airflow.ti_deps.deps.trigger_rule_dep import TriggerRuleDep
 from airflow.triggers.base import BaseTrigger
 from airflow.utils import timezone
 from airflow.utils.context import Context
-from airflow.utils.helpers import validate_key
+from airflow.utils.helpers import is_ascii, replace_invalid_ascii_char, validate_key
 from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.trigger_rule import TriggerRule
@@ -767,6 +769,12 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                 category=RemovedInAirflow3Warning,
                 stacklevel=3,
             )
+
+        if not is_ascii(task_id):
+            # # using text_unidecode to make non-ascii characters ascii equivalent
+            unicoded_string = text_unidecode.unidecode(task_id).replace(" ", "-")
+            task_id = replace_invalid_ascii_char(unicoded_string)
+
         validate_key(task_id)
 
         dag = dag or DagContext.get_current_dag()

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -51,6 +51,7 @@ from urllib.parse import urlsplit
 
 import jinja2
 import pendulum
+import text_unidecode
 from dateutil.relativedelta import relativedelta
 from pendulum.tz.timezone import Timezone
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, and_, case, func, not_, or_
@@ -91,7 +92,7 @@ from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.file import correct_maybe_zipped
-from airflow.utils.helpers import at_most_one, exactly_one, validate_key
+from airflow.utils.helpers import is_ascii, replace_invalid_ascii_char, at_most_one, exactly_one, validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import Interval, UtcDateTime, skip_locked, tuple_in_condition, with_row_locks
@@ -438,6 +439,11 @@ class DAG(LoggingMixin):
                 RemovedInAirflow3Warning,
                 stacklevel=2,
             )
+
+        if not is_ascii(dag_id):
+            # using text_unidecode to make non-ascii characters ascii equivalent
+            unicoded_string = text_unidecode.unidecode(dag_id).replace(" ", "-")
+            dag_id = replace_invalid_ascii_char(unicoded_string)
 
         validate_key(dag_id)
 

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -381,3 +381,23 @@ def prevent_duplicates(kwargs1: dict[str, Any], kwargs2: Mapping[str, Any], *, f
         raise TypeError(f"{fail_reason} argument: {duplicated_keys.pop()}")
     duplicated_keys_display = ", ".join(sorted(duplicated_keys))
     raise TypeError(f"{fail_reason} arguments: {duplicated_keys_display}")
+
+def is_ascii(s):
+    """Check if a string is ascii"""
+    return all(ord(c) < 128 for c in s)
+
+
+def replace_invalid_ascii_char(value, delimiter="."):
+    """
+    Substitute unacceptable characters for acceptable equivalent
+        Args:
+        value: str
+        delimiter: str e.g ('.', '-')
+    """
+    str = value
+
+    for char in str:
+        if not KEY_REGEX.match(char):
+            str = str.replace(char, delimiter)
+
+    return str


### PR DESCRIPTION
continuation of Melodi's PR #19257 

'Used Python Slugify library to convert non-ascii characters to ascii characters that can be interpreted by Airflow

This allows the usage of non-ascii characters for both dag_id and task_id

closes: https://github.com/apache/airflow/issues/18010
related: https://github.com/apache/airflow/issues/8634

^ Add meaningful description above

Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines) for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).'