### PR TITLE
Revert "Display parameter values from serialized dag in trigger dag view. (#27482)

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -564,9 +564,7 @@ class BaseSerialization:
             if attr not in param_dict:
                 continue
             val = param_dict[attr]
-            is_serialized = (isinstance(val, dict) and Encoding.TYPE in val) or (
-                isinstance(val, list) and all(Encoding.TYPE in param for param in val)
-            )
+            is_serialized = isinstance(val, dict) and '__type' in val
             if is_serialized:
                 deserialized_val = cls.deserialize(param_dict[attr])
                 kwargs[attr] = deserialized_val

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -564,7 +564,7 @@ class BaseSerialization:
             if attr not in param_dict:
                 continue
             val = param_dict[attr]
-            is_serialized = isinstance(val, dict) and '__type' in val
+            is_serialized = isinstance(val, dict) and "__type" in val
             if is_serialized:
                 deserialized_val = cls.deserialize(param_dict[attr])
                 kwargs[attr] = deserialized_val

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -23,8 +23,6 @@ import json
 import pytest
 
 from airflow.models import DagBag, DagRun
-from airflow.models.param import Param
-from airflow.operators.empty import EmptyOperator
 from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session
@@ -198,40 +196,6 @@ def test_trigger_dag_params_conf(admin_client, request_conf, expected_conf):
     check_content_in_response(
         f'<textarea class="form-control" name="conf" id="json">{expected_dag_conf}</textarea>',
         resp,
-    )
-
-
-def test_trigger_dag_params_render(admin_client, dag_maker, session, app, monkeypatch):
-    """
-    Test that textarea in Trigger DAG UI is pre-populated
-    with param value set in DAG.
-    """
-    account = {"name": "account_name_1", "country": "usa"}
-    expected_conf = {"accounts": [account]}
-    expected_dag_conf = json.dumps(expected_conf, indent=4).replace('"', "&#34;")
-    DAG_ID = "params_dag"
-    param = Param(
-        [account],
-        schema={
-            "type": "array",
-            "minItems": 1,
-            "items": {
-                "type": "object",
-                "default": account,
-                "properties": {"name": {"type": "string"}, "country": {"type": "string"}},
-                "required": ["name", "country"],
-            },
-        },
-    )
-    with monkeypatch.context() as m:
-        with dag_maker(dag_id=DAG_ID, serialized=True, session=session, params={"accounts": param}):
-            EmptyOperator(task_id="task1")
-
-        m.setattr(app, "dag_bag", dag_maker.dagbag)
-        resp = admin_client.get(f"trigger?dag_id={DAG_ID}")
-
-    check_content_in_response(
-        f'<textarea class="form-control" name="conf" id="json">{expected_dag_conf}</textarea>', resp
     )
 
 


### PR DESCRIPTION

This reverts commit 9409293514cef574179a5320ed3ed50881064423.

@tirkarthi we can't view grid view of a dag if the Param type is boolean

```python
int1 = randint(20, 200)
bool1 = []
bools = bool1.append(True) if int1 % 2 == 0 else bool1.append(False)

@task
def fail_if_invalid(val):
        print(val)
        assert type(val[0]) == bool


@dag(
    start_date=datetime(1970, 1, 1),
    schedule_interval=timedelta(days=365 * 30),
    params={"val": Param(False, type="boolean")},
    doc_md=docs,
    tags=["core", "taskflow-api", "dag-params"],
)
def bool_taskflow_test(bool_val):

    # val is a DagParam object
    # print(val)  # <airflow.models.param.DagParam object at 0x103360b50>

    # the task dereferences it
    fail_if_invalid(bool_val)


the_dag = bool_taskflow_test(bool1)
```