### PR TITLE
Fix deserializing Params where the default is an array

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -560,14 +560,19 @@ class BaseSerialization:
         class_: type[Param] = import_string(class_name)
         attrs = ("default", "description", "schema")
         kwargs = {}
+
+        def is_serialized(val):
+            if isinstance(val, dict):
+                return Encoding.TYPE in val
+            if isinstance(val, list):
+                return all(isinstance(item, dict) and Encoding.TYPE in item for item in val)
+            return False
+
         for attr in attrs:
             if attr not in param_dict:
                 continue
             val = param_dict[attr]
-            is_serialized = (isinstance(val, dict) and Encoding.TYPE in val) or (
-                isinstance(val, list) and all(Encoding.TYPE in param for param in val)
-            )
-            if is_serialized:
+            if is_serialized(val):
                 deserialized_val = cls.deserialize(param_dict[attr])
                 kwargs[attr] = deserialized_val
             else:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -836,6 +836,7 @@ class TestStringifiedDAGs:
             Param("my value", description="hello", schema={"type": "string"}),
             Param("my value", description="hello"),
             Param(None, description=None),
+            Param([True], type="array", items={"type": "boolean"}),
         ],
     )
     def test_full_param_roundtrip(self, param):


### PR DESCRIPTION
In a previous change (#27482) we deserialized Param values inside a list, but the tests didn't previously cover an array of plain values (`[True]` for instance)

This caused the webserver to 500 (bad, but only affected a single DAG) but it _also_ caused the scheduler to crash when it tried to process this DAG (bad-bordering on terrible! Nothing should ever bring down the whole scheduler)

Discovered by @jyotsa09

Closes #27942