### PR TITLE
Replace `unittests` in providers-apache tests by pure `pytest`

### DIFF
--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -51,8 +50,8 @@ EXPECTED_ADDITIONAL_OPTIONS = {
 TEST_IMPERSONATION_ACCOUNT = "test@impersonation.com"
 
 
-class TestBeamRunPythonPipelineOperator(unittest.TestCase):
-    def setUp(self):
+class TestBeamRunPythonPipelineOperator:
+    def setup_method(self):
         self.operator = BeamRunPythonPipelineOperator(
             task_id=TASK_ID,
             py_file=PY_FILE,
@@ -63,13 +62,13 @@ class TestBeamRunPythonPipelineOperator(unittest.TestCase):
 
     def test_init(self):
         """Test BeamRunPythonPipelineOperator instance is properly initialized."""
-        self.assertEqual(self.operator.task_id, TASK_ID)
-        self.assertEqual(self.operator.py_file, PY_FILE)
-        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
-        self.assertEqual(self.operator.py_options, PY_OPTIONS)
-        self.assertEqual(self.operator.py_interpreter, PY_INTERPRETER)
-        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_PYTHON)
-        self.assertEqual(self.operator.pipeline_options, EXPECTED_ADDITIONAL_OPTIONS)
+        assert self.operator.task_id == TASK_ID
+        assert self.operator.py_file == PY_FILE
+        assert self.operator.runner == DEFAULT_RUNNER
+        assert self.operator.py_options == PY_OPTIONS
+        assert self.operator.py_interpreter == PY_INTERPRETER
+        assert self.operator.default_pipeline_options == DEFAULT_OPTIONS_PYTHON
+        assert self.operator.pipeline_options == EXPECTED_ADDITIONAL_OPTIONS
 
     @mock.patch("airflow.providers.apache.beam.operators.beam.BeamHook")
     @mock.patch("airflow.providers.apache.beam.operators.beam.GCSHook")
@@ -180,8 +179,8 @@ class TestBeamRunPythonPipelineOperator(unittest.TestCase):
         dataflow_cancel_job.assert_not_called()
 
 
-class TestBeamRunJavaPipelineOperator(unittest.TestCase):
-    def setUp(self):
+class TestBeamRunJavaPipelineOperator:
+    def setup_method(self):
         self.operator = BeamRunJavaPipelineOperator(
             task_id=TASK_ID,
             jar=JAR_FILE,
@@ -192,12 +191,12 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
 
     def test_init(self):
         """Test BeamRunJavaPipelineOperator instance is properly initialized."""
-        self.assertEqual(self.operator.task_id, TASK_ID)
-        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
-        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_JAVA)
-        self.assertEqual(self.operator.job_class, JOB_CLASS)
-        self.assertEqual(self.operator.jar, JAR_FILE)
-        self.assertEqual(self.operator.pipeline_options, ADDITIONAL_OPTIONS)
+        assert self.operator.task_id == TASK_ID
+        assert self.operator.runner == DEFAULT_RUNNER
+        assert self.operator.default_pipeline_options == DEFAULT_OPTIONS_JAVA
+        assert self.operator.job_class == JOB_CLASS
+        assert self.operator.jar == JAR_FILE
+        assert self.operator.pipeline_options == ADDITIONAL_OPTIONS
 
     @mock.patch("airflow.providers.apache.beam.operators.beam.BeamHook")
     @mock.patch("airflow.providers.apache.beam.operators.beam.GCSHook")
@@ -299,8 +298,8 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
         dataflow_cancel_job.assert_not_called()
 
 
-class TestBeamRunGoPipelineOperator(unittest.TestCase):
-    def setUp(self):
+class TestBeamRunGoPipelineOperator:
+    def setup_method(self):
         self.operator = BeamRunGoPipelineOperator(
             task_id=TASK_ID,
             go_file=GO_FILE,
@@ -310,11 +309,11 @@ class TestBeamRunGoPipelineOperator(unittest.TestCase):
 
     def test_init(self):
         """Test BeamRunGoPipelineOperator instance is properly initialized."""
-        self.assertEqual(self.operator.task_id, TASK_ID)
-        self.assertEqual(self.operator.go_file, GO_FILE)
-        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
-        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_PYTHON)
-        self.assertEqual(self.operator.pipeline_options, EXPECTED_ADDITIONAL_OPTIONS)
+        assert self.operator.task_id == TASK_ID
+        assert self.operator.go_file == GO_FILE
+        assert self.operator.runner == DEFAULT_RUNNER
+        assert self.operator.default_pipeline_options == DEFAULT_OPTIONS_PYTHON
+        assert self.operator.pipeline_options == EXPECTED_ADDITIONAL_OPTIONS
 
     @mock.patch(
         "tempfile.TemporaryDirectory",

--- a/tests/providers/apache/cassandra/hooks/test_cassandra.py
+++ b/tests/providers/apache/cassandra/hooks/test_cassandra.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -35,14 +34,14 @@ from airflow.utils import db
 
 
 @pytest.mark.integration("cassandra")
-class TestCassandraHook(unittest.TestCase):
-    def setUp(self):
+class TestCassandraHook:
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="cassandra_test",
                 conn_type="cassandra",
                 host="host-1,host-2",
-                port="9042",
+                port=9042,
                 schema="test_keyspace",
                 extra='{"load_balancing_policy":"TokenAwarePolicy","protocol_version":4}',
             )
@@ -52,7 +51,7 @@ class TestCassandraHook(unittest.TestCase):
                 conn_id="cassandra_default_with_schema",
                 conn_type="cassandra",
                 host="cassandra",
-                port="9042",
+                port=9042,
                 schema="s",
             )
         )

--- a/tests/providers/apache/cassandra/sensors/test_record.py
+++ b/tests/providers/apache/cassandra/sensors/test_record.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from airflow.providers.apache.cassandra.sensors.record import CassandraRecordSensor
@@ -27,7 +26,7 @@ TEST_CASSANDRA_TABLE = "t"
 TEST_CASSANDRA_KEY = {"foo": "bar"}
 
 
-class TestCassandraRecordSensor(unittest.TestCase):
+class TestCassandraRecordSensor:
     @patch("airflow.providers.apache.cassandra.sensors.record.CassandraHook")
     def test_poke(self, mock_hook):
         sensor = CassandraRecordSensor(

--- a/tests/providers/apache/cassandra/sensors/test_table.py
+++ b/tests/providers/apache/cassandra/sensors/test_table.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from airflow.providers.apache.cassandra.sensors.table import CassandraTableSensor
@@ -27,7 +26,7 @@ TEST_CASSANDRA_TABLE = "t"
 TEST_CASSANDRA_TABLE_WITH_KEYSPACE = "keyspacename.tablename"
 
 
-class TestCassandraTableSensor(unittest.TestCase):
+class TestCassandraTableSensor:
     @patch("airflow.providers.apache.cassandra.sensors.table.CassandraHook")
     def test_poke(self, mock_hook):
         sensor = CassandraTableSensor(

--- a/tests/providers/apache/drill/hooks/test_drill.py
+++ b/tests/providers/apache/drill/hooks/test_drill.py
@@ -17,14 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock
 
 from airflow.providers.apache.drill.hooks.drill import DrillHook
 
 
-class TestDrillHook(unittest.TestCase):
-    def setUp(self):
+class TestDrillHook:
+    def setup_method(self):
         self.cur = MagicMock(rowcount=0)
         self.conn = conn = MagicMock()
         self.conn.login = "drill_user"

--- a/tests/providers/apache/drill/operators/test_drill.py
+++ b/tests/providers/apache/drill/operators/test_drill.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import pytest
 
 from airflow.models.dag import DAG
@@ -32,13 +30,13 @@ TEST_DAG_ID = "unit_test_dag"
 
 
 @pytest.mark.backend("drill")
-class TestDrillOperator(unittest.TestCase):
-    def setUp(self):
+class TestDrillOperator:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         dag = DAG(TEST_DAG_ID, default_args=args)
         self.dag = dag
 
-    def tearDown(self):
+    def teardown_method(self):
         tables_to_drop = ["dfs.tmp.test_airflow"]
         from airflow.providers.apache.drill.hooks.drill import DrillHook
 

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -17,20 +17,19 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-import requests_mock
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook, DruidHook
 
 
-class TestDruidHook(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
+class TestDruidHook:
+    def setup_method(self):
+        import requests_mock
+
         session = requests.Session()
         adapter = requests_mock.Adapter()
         session.mount("mock", adapter)
@@ -41,13 +40,12 @@ class TestDruidHook(unittest.TestCase):
 
         self.db_hook = TestDRuidhook()
 
-    @requests_mock.mock()
-    def test_submit_gone_wrong(self, m):
-        task_post = m.post(
+    def test_submit_gone_wrong(self, requests_mock):
+        task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
         )
-        status_check = m.get(
+        status_check = requests_mock.get(
             "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
             text='{"status":{"status": "FAILED"}}',
         )
@@ -59,13 +57,12 @@ class TestDruidHook(unittest.TestCase):
         assert task_post.called_once
         assert status_check.called_once
 
-    @requests_mock.mock()
-    def test_submit_ok(self, m):
-        task_post = m.post(
+    def test_submit_ok(self, requests_mock):
+        task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
         )
-        status_check = m.get(
+        status_check = requests_mock.get(
             "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
             text='{"status":{"status": "SUCCESS"}}',
         )
@@ -76,13 +73,12 @@ class TestDruidHook(unittest.TestCase):
         assert task_post.called_once
         assert status_check.called_once
 
-    @requests_mock.mock()
-    def test_submit_correct_json_body(self, m):
-        task_post = m.post(
+    def test_submit_correct_json_body(self, requests_mock):
+        task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
         )
-        status_check = m.get(
+        status_check = requests_mock.get(
             "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
             text='{"status":{"status": "SUCCESS"}}',
         )
@@ -100,13 +96,12 @@ class TestDruidHook(unittest.TestCase):
             req_body = task_post.request_history[0].json()
             assert req_body["task"] == "9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"
 
-    @requests_mock.mock()
-    def test_submit_unknown_response(self, m):
-        task_post = m.post(
+    def test_submit_unknown_response(self, requests_mock):
+        task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
         )
-        status_check = m.get(
+        status_check = requests_mock.get(
             "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
             text='{"status":{"status": "UNKNOWN"}}',
         )
@@ -118,19 +113,18 @@ class TestDruidHook(unittest.TestCase):
         assert task_post.called_once
         assert status_check.called_once
 
-    @requests_mock.mock()
-    def test_submit_timeout(self, m):
+    def test_submit_timeout(self, requests_mock):
         self.db_hook.timeout = 1
         self.db_hook.max_ingestion_time = 5
-        task_post = m.post(
+        task_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
         )
-        status_check = m.get(
+        status_check = requests_mock.get(
             "http://druid-overlord:8081/druid/indexer/v1/task/9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/status",
             text='{"status":{"status": "RUNNING"}}',
         )
-        shutdown_post = m.post(
+        shutdown_post = requests_mock.post(
             "http://druid-overlord:8081/druid/indexer/v1/task/"
             "9f8a7359-77d4-4612-b0cd-cc2f6a3c28de/shutdown",
             text='{"task":"9f8a7359-77d4-4612-b0cd-cc2f6a3c28de"}',
@@ -189,9 +183,8 @@ class TestDruidHook(unittest.TestCase):
         assert self.db_hook.get_auth() is None
 
 
-class TestDruidDbApiHook(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
+class TestDruidDbApiHook:
+    def setup_method(self):
         self.cur = MagicMock(rowcount=0)
         self.conn = conn = MagicMock()
         self.conn.host = "host"

--- a/tests/providers/apache/druid/transfers/test_hive_to_druid.py
+++ b/tests/providers/apache/druid/transfers/test_hive_to_druid.py
@@ -17,16 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import requests
-import requests_mock
 
 from airflow.models.dag import DAG
 from airflow.providers.apache.druid.transfers.hive_to_druid import HiveToDruidOperator
 
 
-class TestDruidHook(unittest.TestCase):
+class TestDruidHook:
 
     # To debug the large json diff
     maxDiff = None
@@ -57,8 +54,8 @@ class TestDruidHook(unittest.TestCase):
 
     index_spec_config = {"static_path": "/apps/db/warehouse/hive/", "columns": ["country", "segment"]}
 
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
+        import requests_mock
 
         args = {"owner": "airflow", "start_date": "2017-01-01"}
         self.dag = DAG("hive_to_druid", default_args=args)

--- a/tests/providers/apache/hdfs/hooks/test_hdfs.py
+++ b/tests/providers/apache/hdfs/hooks/test_hdfs.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 import pytest
@@ -26,13 +25,10 @@ import pytest
 from airflow.models import Connection
 from airflow.providers.apache.hdfs.hooks.hdfs import HDFSHook
 
-try:
-    import snakebite
-except ImportError:
-    pytestmark = pytest.mark.skip("Skipping test because HDFSHook is not installed")
+snakebite = pytest.importorskip("snakebite")
 
 
-class TestHDFSHook(unittest.TestCase):
+class TestHDFSHook:
     @mock.patch.dict(
         "os.environ",
         {

--- a/tests/providers/apache/hdfs/sensors/test_hdfs.py
+++ b/tests/providers/apache/hdfs/sensors/test_hdfs.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 import re
-import unittest
 from datetime import timedelta
 
 import pytest
@@ -33,8 +32,8 @@ DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = "unit_test_dag"
 
 
-class TestHdfsSensor(unittest.TestCase):
-    def setUp(self):
+class TestHdfsSensor:
+    def setup_method(self):
         self.hook = FakeHDFSHook
 
     def test_legacy_file_exist(self):
@@ -97,11 +96,15 @@ class TestHdfsSensor(unittest.TestCase):
             task.execute(None)
 
 
-class TestHdfsSensorFolder(unittest.TestCase):
-    def setUp(self):
+class TestHdfsSensorFolder:
+    def setup_method(self, method):
         self.hook = FakeHDFSHook
-        self.log = logging.getLogger()
-        self.log.setLevel(logging.DEBUG)
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+        logger.debug("#" * 10)
+        logger.debug("Running test case: %s.%s", self.__class__.__name__, method.__name__)
+        logger.debug("#" * 10)
 
     def test_should_be_empty_directory(self):
         """
@@ -109,9 +112,6 @@ class TestHdfsSensorFolder(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         task = HdfsFolderSensor(
             task_id="Should_be_empty_directory",
             filepath="/datadirectory/empty_directory",
@@ -134,9 +134,6 @@ class TestHdfsSensorFolder(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         task = HdfsFolderSensor(
             task_id="Should_be_empty_directory_fail",
             filepath="/datadirectory/not_empty_directory",
@@ -158,9 +155,6 @@ class TestHdfsSensorFolder(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         task = HdfsFolderSensor(
             task_id="Should_be_non_empty_directory",
             filepath="/datadirectory/not_empty_directory",
@@ -182,9 +176,6 @@ class TestHdfsSensorFolder(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         task = HdfsFolderSensor(
             task_id="Should_be_empty_directory_fail",
             filepath="/datadirectory/empty_directory",
@@ -200,11 +191,15 @@ class TestHdfsSensorFolder(unittest.TestCase):
             task.execute(None)
 
 
-class TestHdfsSensorRegex(unittest.TestCase):
-    def setUp(self):
+class TestHdfsSensorRegex:
+    def setup_method(self, method):
         self.hook = FakeHDFSHook
-        self.log = logging.getLogger()
-        self.log.setLevel(logging.DEBUG)
+
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+        logger.debug("#" * 10)
+        logger.debug("Running test case: %s.%s", self.__class__.__name__, method.__name__)
+        logger.debug("#" * 10)
 
     def test_should_match_regex(self):
         """
@@ -212,9 +207,6 @@ class TestHdfsSensorRegex(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         compiled_regex = re.compile("test[1-2]file")
         task = HdfsRegexSensor(
             task_id="Should_match_the_regex",
@@ -238,9 +230,6 @@ class TestHdfsSensorRegex(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         compiled_regex = re.compile("^IDoNotExist")
         task = HdfsRegexSensor(
             task_id="Should_not_match_the_regex",
@@ -263,9 +252,6 @@ class TestHdfsSensorRegex(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         compiled_regex = re.compile("test[1-2]file")
         task = HdfsRegexSensor(
             task_id="Should_match_the_regex_and_filesize",
@@ -292,9 +278,6 @@ class TestHdfsSensorRegex(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         compiled_regex = re.compile("test[1-2]file")
         task = HdfsRegexSensor(
             task_id="Should_match_the_regex_but_filesize",
@@ -318,9 +301,6 @@ class TestHdfsSensorRegex(unittest.TestCase):
         :return:
         """
         # Given
-        self.log.debug("#" * 10)
-        self.log.debug("Running %s", self._testMethodName)
-        self.log.debug("#" * 10)
         compiled_regex = re.compile(r"copying_file_\d+.txt")
         task = HdfsRegexSensor(
             task_id="Should_match_the_regex_but_filesize",

--- a/tests/providers/apache/hdfs/sensors/test_web_hdfs.py
+++ b/tests/providers/apache/hdfs/sensors/test_web_hdfs.py
@@ -20,13 +20,12 @@ from __future__ import annotations
 from unittest import mock
 
 from airflow.providers.apache.hdfs.sensors.web_hdfs import WebHdfsSensor
-from tests.providers.apache.hive import TestHiveEnvironment
 
 TEST_HDFS_CONN = "webhdfs_default"
 TEST_HDFS_PATH = "hdfs://user/hive/warehouse/airflow.db/static_babynames"
 
 
-class TestWebHdfsSensor(TestHiveEnvironment):
+class TestWebHdfsSensor:
     @mock.patch("airflow.providers.apache.hdfs.hooks.webhdfs.WebHDFSHook")
     def test_poke(self, mock_hook):
         sensor = WebHdfsSensor(

--- a/tests/providers/apache/hive/__init__.py
+++ b/tests/providers/apache/hive/__init__.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest import TestCase
 from unittest.mock import MagicMock
 
 from airflow.models.dag import DAG
@@ -30,8 +29,8 @@ DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 
 
-class TestHiveEnvironment(TestCase):
-    def setUp(self):
+class TestHiveEnvironment:
+    def setup_method(self, method):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         dag = DAG("test_dag_id", default_args=args)
         self.dag = dag

--- a/tests/providers/apache/hive/operators/test_hive.py
+++ b/tests/providers/apache/hive/operators/test_hive.py
@@ -18,8 +18,9 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from airflow.configuration import conf
 from airflow.models import DagRun, TaskInstance
@@ -95,7 +96,9 @@ class HiveOperatorTest(TestHiveEnvironment):
         )
 
 
-@unittest.skipIf("AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
+@pytest.mark.skipif(
+    "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
+)
 class TestHivePresto(TestHiveEnvironment):
     @mock.patch("tempfile.tempdir", "/tmp/")
     @mock.patch("tempfile._RandomNameSequence.__next__")

--- a/tests/providers/apache/hive/operators/test_hive_stats.py
+++ b/tests/providers/apache/hive/operators/test_hive_stats.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import os
 import re
-import unittest
 from collections import OrderedDict
 from unittest.mock import MagicMock, patch
 
@@ -62,7 +61,7 @@ class MockPrestoHook(PrestoHook):
 
 
 class TestHiveStatsCollectionOperator(TestHiveEnvironment):
-    def setUp(self):
+    def setup_method(self, method):
         self.kwargs = dict(
             table="table",
             partition=dict(col="col", value="value"),
@@ -71,7 +70,7 @@ class TestHiveStatsCollectionOperator(TestHiveEnvironment):
             mysql_conn_id="mysql_conn_id",
             task_id="test_hive_stats_collection_operator",
         )
-        super().setUp()
+        super().setup_method(method)
 
     def test_get_default_exprs(self):
         col = "col"
@@ -305,8 +304,8 @@ class TestHiveStatsCollectionOperator(TestHiveEnvironment):
             """
         mock_mysql_hook.return_value.run.assert_called_once_with(sql)
 
-    @unittest.skipIf(
-        "AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"
+    @pytest.mark.skipif(
+        "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
     )
     @patch(
         "airflow.providers.apache.hive.operators.hive_stats.HiveMetastoreHook",

--- a/tests/providers/apache/hive/sensors/test_hdfs.py
+++ b/tests/providers/apache/hive/sensors/test_hdfs.py
@@ -18,13 +18,16 @@
 from __future__ import annotations
 
 import os
-import unittest
+
+import pytest
 
 from airflow.providers.apache.hdfs.sensors.hdfs import HdfsSensor
 from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
 
 
-@unittest.skipIf("AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
+@pytest.mark.skipif(
+    "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
+)
 class TestHdfsSensor(TestHiveEnvironment):
     def test_hdfs_sensor(self):
         op = HdfsSensor(

--- a/tests/providers/apache/hive/sensors/test_hive_partition.py
+++ b/tests/providers/apache/hive/sensors/test_hive_partition.py
@@ -18,14 +18,17 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest.mock import patch
+
+import pytest
 
 from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSensor
 from tests.providers.apache.hive import DEFAULT_DATE, MockHiveMetastoreHook, TestHiveEnvironment
 
 
-@unittest.skipIf("AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
+@pytest.mark.skipif(
+    "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
+)
 @patch(
     "airflow.providers.apache.hive.sensors.hive_partition.HiveMetastoreHook",
     side_effect=MockHiveMetastoreHook,

--- a/tests/providers/apache/hive/sensors/test_metastore_partition.py
+++ b/tests/providers/apache/hive/sensors/test_metastore_partition.py
@@ -18,14 +18,17 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest import mock
+
+import pytest
 
 from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
 from tests.providers.apache.hive import DEFAULT_DATE, DEFAULT_DATE_DS, MockDBConnection, TestHiveEnvironment
 
 
-@unittest.skipIf("AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
+@pytest.mark.skipif(
+    "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
+)
 class TestHivePartitionSensor(TestHiveEnvironment):
     def test_hive_metastore_sql_sensor(self):
         op = MetastorePartitionSensor(

--- a/tests/providers/apache/hive/sensors/test_named_hive_partition.py
+++ b/tests/providers/apache/hive/sensors/test_named_hive_partition.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from datetime import timedelta
 from unittest import mock
 
@@ -35,8 +34,8 @@ DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 
 
-class TestNamedHivePartitionSensor(unittest.TestCase):
-    def setUp(self):
+class TestNamedHivePartitionSensor:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", default_args=args)
         self.next_day = (DEFAULT_DATE + timedelta(days=1)).isoformat()[:10]
@@ -114,7 +113,9 @@ class TestNamedHivePartitionSensor(unittest.TestCase):
         )
 
 
-@unittest.skipIf("AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
+@pytest.mark.skipif(
+    "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
+)
 class TestPartitions(TestHiveEnvironment):
     def test_succeeds_on_one_partition(self):
         mock_hive_metastore_hook = MockHiveMetastoreHook()

--- a/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_mysql.py
@@ -19,8 +19,9 @@ from __future__ import annotations
 
 import os
 import re
-import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from airflow.providers.apache.hive.transfers.hive_to_mysql import HiveToMySqlOperator
 from airflow.utils import timezone
@@ -31,7 +32,7 @@ DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 
 
 class TestHiveToMySqlTransfer(TestHiveEnvironment):
-    def setUp(self):
+    def setup_method(self, method):
         self.kwargs = dict(
             sql="sql",
             mysql_table="table",
@@ -39,7 +40,7 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
             mysql_conn_id="mysql_default",
             task_id="test_hive_to_mysql",
         )
-        super().setUp()
+        super().setup_method(method)
 
     @patch("airflow.providers.apache.hive.transfers.hive_to_mysql.MySqlHook")
     @patch("airflow.providers.apache.hive.transfers.hive_to_mysql.HiveServer2Hook")
@@ -116,8 +117,8 @@ class TestHiveToMySqlTransfer(TestHiveEnvironment):
 
         mock_hive_hook.get_records.assert_called_once_with(self.kwargs["sql"], parameters=hive_conf)
 
-    @unittest.skipIf(
-        "AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"
+    @pytest.mark.skipif(
+        "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
     )
     def test_hive_to_mysql(self):
         test_hive_results = "test_hive_results"

--- a/tests/providers/apache/hive/transfers/test_hive_to_samba.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_samba.py
@@ -18,8 +18,9 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+import pytest
 
 from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
 from airflow.providers.samba.hooks.samba import SambaHook
@@ -44,7 +45,7 @@ class MockSambaHook(SambaHook):
 
 
 class TestHive2SambaOperator(TestHiveEnvironment):
-    def setUp(self):
+    def setup_method(self, method):
         self.kwargs = dict(
             hql="hql",
             destination_filepath="destination_filepath",
@@ -52,7 +53,7 @@ class TestHive2SambaOperator(TestHiveEnvironment):
             hiveserver2_conn_id="hiveserver2_default",
             task_id="test_hive_to_samba_operator",
         )
-        super().setUp()
+        super().setup_method(method)
 
     @patch("airflow.providers.apache.hive.transfers.hive_to_samba.SambaHook")
     @patch("airflow.providers.apache.hive.transfers.hive_to_samba.HiveServer2Hook")
@@ -75,8 +76,8 @@ class TestHive2SambaOperator(TestHiveEnvironment):
             self.kwargs["destination_filepath"], mock_tmp_file.name
         )
 
-    @unittest.skipIf(
-        "AIRFLOW_RUNALL_TESTS" not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"
+    @pytest.mark.skipif(
+        "AIRFLOW_RUNALL_TESTS" not in os.environ, reason="Skipped because AIRFLOW_RUNALL_TESTS is not set"
     )
     @patch("tempfile.tempdir", "/tmp/")
     @patch("tempfile._RandomNameSequence.__next__")

--- a/tests/providers/apache/hive/transfers/test_mssql_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_mssql_to_hive.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from collections import OrderedDict
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -26,8 +25,8 @@ import pymssql
 from airflow.providers.apache.hive.transfers.mssql_to_hive import MsSqlToHiveOperator
 
 
-class TestMsSqlToHiveTransfer(unittest.TestCase):
-    def setUp(self):
+class TestMsSqlToHiveTransfer:
+    def setup_method(self):
         self.kwargs = dict(sql="sql", hive_table="table", task_id="test_mssql_to_hive", dag=None)
 
     def test_type_map_binary(self):

--- a/tests/providers/apache/hive/transfers/test_vertica_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_vertica_to_hive.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 from unittest import mock
 
 from airflow.models.dag import DAG
@@ -40,8 +39,8 @@ def mock_get_conn():
     return conn_mock
 
 
-class TestVerticaToHiveTransfer(unittest.TestCase):
-    def setUp(self):
+class TestVerticaToHiveTransfer:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/apache/kylin/hooks/test_kylin.py
+++ b/tests/providers/apache/kylin/hooks/test_kylin.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,8 +26,8 @@ from airflow.exceptions import AirflowException
 from airflow.providers.apache.kylin.hooks.kylin import KylinHook
 
 
-class TestKylinHook(unittest.TestCase):
-    def setUp(self) -> None:
+class TestKylinHook:
+    def setup_method(self) -> None:
         self.hook = KylinHook(kylin_conn_id="kylin_default", project="learn_kylin")
 
     @patch("kylinpy.Kylin.get_job")

--- a/tests/providers/apache/kylin/operators/test_kylin_cube.py
+++ b/tests/providers/apache/kylin/operators/test_kylin_cube.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -32,7 +31,7 @@ from airflow.utils import timezone
 DEFAULT_DATE = timezone.datetime(2020, 1, 1)
 
 
-class TestKylinCubeOperator(unittest.TestCase):
+class TestKylinCubeOperator:
     _config = {
         "kylin_conn_id": "kylin_default",
         "project": "learn_kylin",
@@ -59,7 +58,7 @@ class TestKylinCubeOperator(unittest.TestCase):
 
     build_response = {"uuid": "c143e0e4-ac5f-434d-acf3-46b0d15e3dc6"}
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/apache/pig/hooks/test_pig.py
+++ b/tests/providers/apache/pig/hooks/test_pig.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -25,10 +24,8 @@ import pytest
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
 
 
-class TestPigCliHook(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
+class TestPigCliHook:
+    def setup_method(self):
         self.extra_dejson = mock.MagicMock()
         self.extra_dejson.get.return_value = None
         self.conn = mock.MagicMock()

--- a/tests/providers/apache/pig/operators/test_pig.py
+++ b/tests/providers/apache/pig/operators/test_pig.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.apache.pig.hooks.pig import PigCliHook
@@ -27,7 +26,7 @@ TEST_CONTEXT_ID = "test_context_id"
 PIG = "ls /;"
 
 
-class TestPigOperator(unittest.TestCase):
+class TestPigOperator:
     def test_prepare_template(self):
         pig = "sh echo $DATE;"
         task_id = TEST_TASK_ID

--- a/tests/providers/apache/pinot/hooks/test_pinot.py
+++ b/tests/providers/apache/pinot/hooks/test_pinot.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import io
 import os
 import subprocess
-import unittest
 from unittest import mock
 
 import pytest
@@ -29,9 +28,8 @@ from airflow.exceptions import AirflowException
 from airflow.providers.apache.pinot.hooks.pinot import PinotAdminHook, PinotDbApiHook
 
 
-class TestPinotAdminHook(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
+class TestPinotAdminHook:
+    def setup_method(self):
         self.conn = conn = mock.MagicMock()
         self.conn.host = "host"
         self.conn.port = "1000"
@@ -213,9 +211,8 @@ class TestPinotAdminHookCreation:
         PinotAdminHook(cmd_path="pinot-admin.sh")
 
 
-class TestPinotDbApiHook(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
+class TestPinotDbApiHook:
+    def setup_method(self):
         self.conn = conn = mock.MagicMock()
         self.conn.host = "host"
         self.conn.port = "1000"
@@ -276,8 +273,8 @@ class TestPinotDbApiHook(unittest.TestCase):
             assert item[0] == df.values.tolist()[i][0]
 
 
-class TestPinotDbApiHookIntegration(unittest.TestCase):
-    @pytest.mark.integration("pinot")
+@pytest.mark.integration("pinot")
+class TestPinotDbApiHookIntegration:
     @mock.patch.dict("os.environ", AIRFLOW_CONN_PINOT_BROKER_DEFAULT="pinot://pinot:8000/")
     def test_should_return_records(self):
         hook = PinotDbApiHook()

--- a/tests/providers/apache/spark/hooks/test_spark_jdbc.py
+++ b/tests/providers/apache/spark/hooks/test_spark_jdbc.py
@@ -17,14 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 from airflow.models import Connection
 from airflow.providers.apache.spark.hooks.spark_jdbc import SparkJDBCHook
 from airflow.utils import db
 
 
-class TestSparkJDBCHook(unittest.TestCase):
+class TestSparkJDBCHook:
 
     _config = {
         "cmd_type": "spark_to_jdbc",
@@ -63,7 +61,7 @@ class TestSparkJDBCHook(unittest.TestCase):
         "comments VARCHAR(1024)",
     }
 
-    def setUp(self):
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="spark-default",

--- a/tests/providers/apache/spark/hooks/test_spark_sql.py
+++ b/tests/providers/apache/spark/hooks/test_spark_sql.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import io
-import unittest
 from itertools import dropwhile
 from unittest.mock import call, patch
 
@@ -38,7 +37,7 @@ def get_after(sentinel, iterable):
     return next(truncated)
 
 
-class TestSparkSqlHook(unittest.TestCase):
+class TestSparkSqlHook:
     _config = {
         "conn_id": "spark_default",
         "executor_cores": 4,
@@ -52,12 +51,12 @@ class TestSparkSqlHook(unittest.TestCase):
     }
 
     @classmethod
-    def setUpClass(cls) -> None:
+    def setup_class(cls) -> None:
         clear_db_connections(add_default_connections_back=False)
         db.merge_conn(Connection(conn_id="spark_default", conn_type="spark", host="yarn://yarn-master"))
 
     @classmethod
-    def tearDownClass(cls) -> None:
+    def teardown_class(cls) -> None:
         clear_db_connections(add_default_connections_back=True)
 
     def test_build_command(self):

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -19,11 +19,9 @@ from __future__ import annotations
 
 import io
 import os
-import unittest
 from unittest.mock import call, patch
 
 import pytest
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -31,7 +29,7 @@ from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
 from airflow.utils import db
 
 
-class TestSparkSubmitHook(unittest.TestCase):
+class TestSparkSubmitHook:
 
     _spark_job_file = "test_application.py"
     _config = {
@@ -75,7 +73,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                 return_dict[arg] = list_cmd[pos + 1]
         return return_dict
 
-    def setUp(self):
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="spark_yarn_cluster",
@@ -795,8 +793,9 @@ class TestSparkSubmitHook(unittest.TestCase):
             "spark-pi-edf2ace37be7353a958b38733a12f8e6-driver", "mynamespace", **kwargs
         )
 
-    @parameterized.expand(
-        (
+    @pytest.mark.parametrize(
+        "command, expected",
+        [
             (
                 ("spark-submit", "foo", "--bar", "baz", "--password='secret'", "--foo", "bar"),
                 "spark-submit foo --bar baz --password='******' --foo bar",
@@ -829,7 +828,7 @@ class TestSparkSubmitHook(unittest.TestCase):
                 ("spark-submit",),
                 "spark-submit",
             ),
-        )
+        ],
     )
     def test_masks_passwords(self, command: str, expected: str) -> None:
         # Given

--- a/tests/providers/apache/spark/operators/test_spark_jdbc.py
+++ b/tests/providers/apache/spark/operators/test_spark_jdbc.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 from airflow.models.dag import DAG
 from airflow.providers.apache.spark.operators.spark_jdbc import SparkJDBCOperator
 from airflow.utils import timezone
@@ -26,7 +24,7 @@ from airflow.utils import timezone
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 
-class TestSparkJDBCOperator(unittest.TestCase):
+class TestSparkJDBCOperator:
     _config = {
         "spark_app_name": "{{ task_instance.task_id }}",
         "spark_conf": {"parquet.compression": "SNAPPY"},
@@ -57,7 +55,7 @@ class TestSparkJDBCOperator(unittest.TestCase):
         "comments VARCHAR(1024)",
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/apache/spark/operators/test_spark_sql.py
+++ b/tests/providers/apache/spark/operators/test_spark_sql.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 
 from airflow.models.dag import DAG
 from airflow.providers.apache.spark.operators.spark_sql import SparkSqlOperator
@@ -26,7 +25,7 @@ from airflow.providers.apache.spark.operators.spark_sql import SparkSqlOperator
 DEFAULT_DATE = datetime.datetime(2017, 1, 1)
 
 
-class TestSparkSqlOperator(unittest.TestCase):
+class TestSparkSqlOperator:
     _config = {
         "sql": "SELECT 22",
         "conn_id": "spark_special_conn_id",
@@ -42,7 +41,7 @@ class TestSparkSqlOperator(unittest.TestCase):
         "yarn_queue": "special-queue",
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import timedelta
 
 from airflow.models import DagRun, TaskInstance
@@ -28,7 +27,7 @@ from airflow.utils import timezone
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
 
-class TestSparkSubmitOperator(unittest.TestCase):
+class TestSparkSubmitOperator:
 
     _config = {
         "conf": {"parquet.compression": "SNAPPY"},
@@ -67,7 +66,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         ],
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         self.dag = DAG("test_dag_id", default_args=args)
 

--- a/tests/providers/apache/sqoop/hooks/test_sqoop.py
+++ b/tests/providers/apache/sqoop/hooks/test_sqoop.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import collections
 import json
-import unittest
 from io import StringIO
 from unittest import mock
 from unittest.mock import call, patch
@@ -32,7 +31,7 @@ from airflow.providers.apache.sqoop.hooks.sqoop import SqoopHook
 from airflow.utils import db
 
 
-class TestSqoopHook(unittest.TestCase):
+class TestSqoopHook:
     _config = {
         "conn_id": "sqoop_test",
         "num_mappers": 22,
@@ -82,7 +81,7 @@ class TestSqoopHook(unittest.TestCase):
         "archives": "/path/to/archives",
     }
 
-    def setUp(self):
+    def setup_method(self):
         db.merge_conn(
             Connection(
                 conn_id="sqoop_test",

--- a/tests/providers/apache/sqoop/operators/test_sqoop.py
+++ b/tests/providers/apache/sqoop/operators/test_sqoop.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import datetime
-import unittest
 
 import pytest
 
@@ -27,7 +26,7 @@ from airflow.models.dag import DAG
 from airflow.providers.apache.sqoop.operators.sqoop import SqoopOperator
 
 
-class TestSqoopOperator(unittest.TestCase):
+class TestSqoopOperator:
     _config = {
         "conn_id": "sqoop_default",
         "cmd_type": "export",
@@ -62,7 +61,7 @@ class TestSqoopOperator(unittest.TestCase):
         "schema": "myschema",
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
 


### PR DESCRIPTION
Migrate all Apache providers tests to `pytest`.

All changes are more or less straightforward:
- Get rid of `unittests.TestCase` class and **TestCase.assert*** methods
- Replace decorator `parameterized.expand` by `pytest.mark.parametrize`. I
- replace `requests_mock.mock` decorator by `requests_mock` fixture
- Convert `TestCase.subTest` to parametrize tests  
- Convert classes **setUp*** and **tearDown*** to [appropriate pytest methods](https://docs.pytest.org/en/6.2.x/xunit_setup.html#classic-xunit-style-setup)

_See additional findings in comments_