### PR TITLE
Make updating breeze deps via breeze easier

### DIFF
--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -57,11 +57,17 @@ def in_self_upgrade() -> bool:
 
 
 def in_help() -> bool:
-    return "--help" in sys.argv
+    return "--help" in sys.argv or "-h" in sys.argv
 
 
 def skip_upgrade_check():
-    return in_self_upgrade() or in_autocomplete() or in_help() or hasattr(sys, "_called_from_test")
+    return (
+        in_self_upgrade()
+        or in_autocomplete()
+        or in_help()
+        or hasattr(sys, "_called_from_test")
+        or os.environ.get("SKIP_UPGRADE_CHECK")
+    )
 
 
 def skip_group_output():

--- a/dev/breeze/src/airflow_breeze/utils/reinstall.py
+++ b/dev/breeze/src/airflow_breeze/utils/reinstall.py
@@ -37,7 +37,10 @@ def reinstall_breeze(breeze_sources: Path, re_run: bool = True):
     get_console().print(f"\n[info]Reinstalling Breeze from {breeze_sources}\n")
     subprocess.check_call(["pipx", "install", "-e", str(breeze_sources), "--force"])
     if re_run:
-        os.execl(sys.executable, "breeze", *sys.argv)
+        # Make sure we don't loop forever if the metadata hash hasn't been updated yet (else it is tricky to
+        # run pre-commit checks via breeze!)
+        os.environ["SKIP_UPGRADE_CHECK"] = "1"
+        os.execl(sys.executable, sys.executable, *sys.argv)
     get_console().print(f"\n[info]Breeze has been reinstalled from {breeze_sources}. Exiting now.[/]\n\n")
     sys.exit(0)
 


### PR DESCRIPTION
In trying to update the deps of breeze, I made a change to `setup.cfg`
and then ran `breeze static-checks update-breeze-readme-config-hash`
and ran in to two problems that this fixes

1. It prevents a self-update loop, where the change to `setup.cfg` was
   detected, but the hash in the README hasn't been updated, so it just
   came around again and just tried to reinstall again and again and
   again.

2. This correctly sets/maintains `argv[0]` for the re-exec'd process
   (which is what `sys.executable` gets set to) so that when we do
   `assert_pre_commit_installed` and try to find the pre-commit version,
   we don't invoke breeze again by mistake!