### PR TITLE
Replace `unittests` in amazon provider tests by pure `pytest`

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_athena.py
+++ b/tests/providers/amazon/aws/hooks/test_athena.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.athena import AthenaHook
@@ -48,8 +47,8 @@ MOCK_QUERY_EXECUTION_OUTPUT = {
 }
 
 
-class TestAthenaHook(unittest.TestCase):
-    def setUp(self):
+class TestAthenaHook:
+    def setup_method(self):
         self.athena = AthenaHook(sleep_time=0)
 
     def test_init(self):
@@ -175,7 +174,3 @@ class TestAthenaHook(unittest.TestCase):
         mock_conn.return_value.get_query_execution.return_value = MOCK_QUERY_EXECUTION_OUTPUT
         result = self.athena.get_output_location(query_execution_id=MOCK_DATA["query_execution_id"])
         assert result == "s3://test_bucket/test.csv"
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import json
 import os
-import unittest
 from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 from unittest import mock
@@ -606,7 +605,7 @@ class TestAwsBaseHook:
     def test_connection_region_name(
         self, conn_type, connection_uri, region_name, env_region, expected_region_name
     ):
-        with unittest.mock.patch.dict(
+        with mock.patch.dict(
             "os.environ", AIRFLOW_CONN_TEST_CONN=connection_uri, AWS_DEFAULT_REGION=env_region
         ):
             if conn_type == "client":
@@ -629,10 +628,7 @@ class TestAwsBaseHook:
         ],
     )
     def test_connection_aws_partition(self, conn_type, connection_uri, expected_partition):
-        with unittest.mock.patch.dict(
-            "os.environ",
-            AIRFLOW_CONN_TEST_CONN=connection_uri,
-        ):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=connection_uri):
             if conn_type == "client":
                 hook = AwsBaseHook(aws_conn_id="test_conn", client_type="dynamodb")
             elif conn_type == "resource":
@@ -772,7 +768,7 @@ class TestAwsBaseHook:
             extra={"verify": conn_verify} if conn_verify is not None else {},
         )
 
-        with unittest.mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=mock_conn.get_uri()):
+        with mock.patch.dict("os.environ", AIRFLOW_CONN_TEST_CONN=mock_conn.get_uri()):
             hook = AwsBaseHook(aws_conn_id="test_conn", verify=verify)
             expected = verify if verify is not None else conn_verify
             assert hook.verify == expected

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -30,7 +30,6 @@ derived from the moto test suite for testing the Batch client.
 from __future__ import annotations
 
 import inspect
-import unittest
 from typing import NamedTuple
 from unittest import mock
 
@@ -317,12 +316,12 @@ def test_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_definiti
     assert job_status == "SUCCEEDED"
 
 
-class TestBatchWaiters(unittest.TestCase):
+class TestBatchWaiters:
     @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
     @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
     @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsBaseHook.get_client_type")
-    def setUp(self, get_client_type_mock):
+    def setup_method(self, method, get_client_type_mock):
         self.job_id = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
         self.region_name = AWS_REGION
 

--- a/tests/providers/amazon/aws/hooks/test_datasync.py
+++ b/tests/providers/amazon/aws/hooks/test_datasync.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import boto3
@@ -29,7 +28,7 @@ from airflow.providers.amazon.aws.hooks.datasync import DataSyncHook
 
 
 @mock_datasync
-class TestDataSyncHook(unittest.TestCase):
+class TestDataSyncHook:
     def test_get_conn(self):
         hook = DataSyncHook(aws_conn_id="aws_default")
         assert hook.get_conn() is not None
@@ -50,21 +49,21 @@ class TestDataSyncHook(unittest.TestCase):
 
 @mock_datasync
 @mock.patch.object(DataSyncHook, "get_conn")
-class TestDataSyncHookMocked(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.source_server_hostname = "host"
-        self.source_subdirectory = "somewhere"
-        self.destination_bucket_name = "my_bucket"
-        self.destination_bucket_dir = "dir"
+class TestDataSyncHookMocked:
+    @staticmethod
+    def setup_class(cls):
+        cls.source_server_hostname = "host"
+        cls.source_subdirectory = "somewhere"
+        cls.destination_bucket_name = "my_bucket"
+        cls.destination_bucket_dir = "dir"
 
-        self.client = None
-        self.hook = None
-        self.source_location_arn = None
-        self.destination_location_arn = None
-        self.task_arn = None
+        cls.client = None
+        cls.hook = None
+        cls.source_location_arn = None
+        cls.destination_location_arn = None
+        cls.task_arn = None
 
-    def setUp(self):
+    def setup_method(self, method):
         self.client = boto3.client("datasync", region_name="us-east-1")
         self.hook = DataSyncHook(aws_conn_id="aws_default", wait_interval_seconds=0)
 
@@ -86,7 +85,7 @@ class TestDataSyncHookMocked(unittest.TestCase):
             DestinationLocationArn=self.destination_location_arn,
         )["TaskArn"]
 
-    def tearDown(self):
+    def teardown_method(self, method):
         # Delete all tasks:
         tasks = self.client.list_tasks()
         for task in tasks["Tasks"]:

--- a/tests/providers/amazon/aws/hooks/test_dms_task.py
+++ b/tests/providers/amazon/aws/hooks/test_dms_task.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from typing import Any
 from unittest import mock
 
@@ -68,8 +67,8 @@ MOCK_STOP_RESPONSE: dict[str, Any] = {"ReplicationTask": {**MOCK_TASK_RESPONSE_D
 MOCK_DELETE_RESPONSE: dict[str, Any] = {"ReplicationTask": {**MOCK_TASK_RESPONSE_DATA, "Status": "deleting"}}
 
 
-class TestDmsHook(unittest.TestCase):
-    def setUp(self):
+class TestDmsHook:
+    def setup_method(self):
         self.dms = DmsHook()
 
     def test_init(self):

--- a/tests/providers/amazon/aws/hooks/test_dynamodb.py
+++ b/tests/providers/amazon/aws/hooks/test_dynamodb.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 import uuid
 
 from moto import mock_dynamodb
@@ -25,7 +24,7 @@ from moto import mock_dynamodb
 from airflow.providers.amazon.aws.hooks.dynamodb import DynamoDBHook
 
 
-class TestDynamoDBHook(unittest.TestCase):
+class TestDynamoDBHook:
     @mock_dynamodb
     def test_get_conn_returns_a_boto3_connection(self):
         hook = DynamoDBHook(aws_conn_id="aws_default")
@@ -39,7 +38,7 @@ class TestDynamoDBHook(unittest.TestCase):
         )
 
         # this table needs to be created in production
-        table = hook.get_conn().create_table(
+        hook.get_conn().create_table(
             TableName="test_airflow",
             KeySchema=[
                 {"AttributeName": "id", "KeyType": "HASH"},

--- a/tests/providers/amazon/aws/hooks/test_ecs.py
+++ b/tests/providers/amazon/aws/hooks/test_ecs.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import timedelta
 from unittest import mock
 
@@ -56,38 +55,34 @@ class TestEksHooks:
         assert EcsHook().get_task_state(cluster="cluster_name", task="task_name") == "ACTIVE"
 
 
-class TestShouldRetry(unittest.TestCase):
+class TestShouldRetry:
     def test_return_true_on_valid_reason(self):
-        self.assertTrue(should_retry(EcsOperatorError([{"reason": "RESOURCE:MEMORY"}], "Foo")))
+        assert should_retry(EcsOperatorError([{"reason": "RESOURCE:MEMORY"}], "Foo"))
 
     def test_return_false_on_invalid_reason(self):
-        self.assertFalse(should_retry(EcsOperatorError([{"reason": "CLUSTER_NOT_FOUND"}], "Foo")))
+        assert not should_retry(EcsOperatorError([{"reason": "CLUSTER_NOT_FOUND"}], "Foo"))
 
 
-class TestShouldRetryEni(unittest.TestCase):
+class TestShouldRetryEni:
     def test_return_true_on_valid_reason(self):
-        self.assertTrue(
-            should_retry_eni(
-                EcsTaskFailToStart(
-                    "The task failed to start due to: "
-                    "Timeout waiting for network interface provisioning to complete."
-                )
+        assert should_retry_eni(
+            EcsTaskFailToStart(
+                "The task failed to start due to: "
+                "Timeout waiting for network interface provisioning to complete."
             )
         )
 
     def test_return_false_on_invalid_reason(self):
-        self.assertFalse(
-            should_retry_eni(
-                EcsTaskFailToStart(
-                    "The task failed to start due to: "
-                    "CannotPullContainerError: "
-                    "ref pull has been retried 5 time(s): failed to resolve reference"
-                )
+        assert not should_retry_eni(
+            EcsTaskFailToStart(
+                "The task failed to start due to: "
+                "CannotPullContainerError: "
+                "ref pull has been retried 5 time(s): failed to resolve reference"
             )
         )
 
 
-class TestEcsTaskLogFetcher(unittest.TestCase):
+class TestEcsTaskLogFetcher:
     @mock.patch("logging.Logger")
     def set_up_log_fetcher(self, logger_mock):
         self.logger_mock = logger_mock
@@ -99,7 +94,7 @@ class TestEcsTaskLogFetcher(unittest.TestCase):
             logger=logger_mock,
         )
 
-    def setUp(self):
+    def setup_method(self):
         self.set_up_log_fetcher()
 
     @mock.patch(

--- a/tests/providers/amazon/aws/hooks/test_elasticache_replication_group.py
+++ b/tests/providers/amazon/aws/hooks/test_elasticache_replication_group.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase
 from unittest.mock import Mock
 
 import pytest
@@ -26,7 +25,7 @@ from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.elasticache_replication_group import ElastiCacheReplicationGroupHook
 
 
-class TestElastiCacheReplicationGroupHook(TestCase):
+class TestElastiCacheReplicationGroupHook:
     REPLICATION_GROUP_ID = "test-elasticache-replication-group-hook"
 
     REPLICATION_GROUP_CONFIG = {
@@ -44,7 +43,7 @@ class TestElastiCacheReplicationGroupHook(TestCase):
         {"creating", "available", "modifying", "deleting", "create - failed", "snapshotting"}
     )
 
-    def setUp(self):
+    def setup_method(self):
         self.hook = ElastiCacheReplicationGroupHook()
         # noinspection PyPropertyAccess
         self.hook.conn = Mock()

--- a/tests/providers/amazon/aws/hooks/test_emr_containers.py
+++ b/tests/providers/amazon/aws/hooks/test_emr_containers.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
@@ -47,8 +46,8 @@ JOB2_RUN_DESCRIPTION = {
 }
 
 
-class TestEmrContainerHook(unittest.TestCase):
-    def setUp(self):
+class TestEmrContainerHook:
+    def setup_method(self):
         self.emr_containers = EmrContainerHook(virtual_cluster_id="vc1234")
 
     def test_init(self):
@@ -110,7 +109,9 @@ class TestEmrContainerHook(unittest.TestCase):
         mock_session.return_value = emr_session_mock
         emr_client_mock.describe_job_run.return_value = JOB2_RUN_DESCRIPTION
 
-        query_status = self.emr_containers.poll_query_status(job_id="job123456", max_polling_attempts=2)
+        query_status = self.emr_containers.poll_query_status(
+            job_id="job123456", max_polling_attempts=2, poll_interval=2
+        )
         # should poll until max_tries is reached since query is in non-terminal state
         assert emr_client_mock.describe_job_run.call_count == 2
         assert query_status == "RUNNING"

--- a/tests/providers/amazon/aws/hooks/test_glacier.py
+++ b/tests/providers/amazon/aws/hooks/test_glacier.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
+import logging
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.glacier import GlacierHook
@@ -30,8 +30,8 @@ RESPONSE_BODY = {"body": "data"}
 JOB_STATUS = {"Action": "", "StatusCode": "Succeeded"}
 
 
-class TestAmazonGlacierHook(unittest.TestCase):
-    def setUp(self):
+class TestAmazonGlacierHook:
+    def setup_method(self):
         with mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.__init__", return_value=None):
             self.hook = GlacierHook(aws_conn_id="aws_default")
 
@@ -47,25 +47,20 @@ class TestAmazonGlacierHook(unittest.TestCase):
         assert job_id == result
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
-    def test_retrieve_inventory_should_log_mgs(self, mock_conn):
+    def test_retrieve_inventory_should_log_mgs(self, mock_conn, caplog):
         # given
         job_id = {"jobId": "1234abcd"}
         # when
-        with self.assertLogs() as log:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=self.hook.log.name):
             mock_conn.return_value.initiate_job.return_value = job_id
             self.hook.retrieve_inventory(VAULT_NAME)
-            # then
-            self.assertEqual(
-                log.output,
-                [
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Retrieving inventory for vault: {VAULT_NAME}",
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Initiated inventory-retrieval job for: {VAULT_NAME}",
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Retrieval Job ID: {job_id.get('jobId')}",
-                ],
-            )
+        # then
+        assert caplog.messages == [
+            f"Retrieving inventory for vault: {VAULT_NAME}",
+            f"Initiated inventory-retrieval job for: {VAULT_NAME}",
+            f"Retrieval Job ID: {job_id.get('jobId')}",
+        ]
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
     def test_retrieve_inventory_results_should_return_response(self, mock_conn):
@@ -77,19 +72,14 @@ class TestAmazonGlacierHook(unittest.TestCase):
         assert response == RESPONSE_BODY
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
-    def test_retrieve_inventory_results_should_log_mgs(self, mock_conn):
+    def test_retrieve_inventory_results_should_log_mgs(self, mock_conn, caplog):
         # when
-        with self.assertLogs() as log:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=self.hook.log.name):
             mock_conn.return_value.get_job_output.return_value = REQUEST_RESULT
             self.hook.retrieve_inventory_results(VAULT_NAME, JOB_ID)
-            # then
-            self.assertEqual(
-                log.output,
-                [
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Retrieving the job results for vault: {VAULT_NAME}...",
-                ],
-            )
+        # then
+        assert caplog.messages == [f"Retrieving the job results for vault: {VAULT_NAME}..."]
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
     def test_describe_job_should_return_status_succeeded(self, mock_conn):
@@ -101,18 +91,14 @@ class TestAmazonGlacierHook(unittest.TestCase):
         assert response == JOB_STATUS
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
-    def test_describe_job_should_log_mgs(self, mock_conn):
+    def test_describe_job_should_log_mgs(self, mock_conn, caplog):
         # when
-        with self.assertLogs() as log:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=self.hook.log.name):
             mock_conn.return_value.describe_job.return_value = JOB_STATUS
             self.hook.describe_job(VAULT_NAME, JOB_ID)
-            # then
-            self.assertEqual(
-                log.output,
-                [
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Retrieving status for vault: {VAULT_NAME} and job {JOB_ID}",
-                    "INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:"
-                    f"Job status: {JOB_STATUS.get('Action')}, code status: {JOB_STATUS.get('StatusCode')}",
-                ],
-            )
+        # then
+        assert caplog.messages == [
+            f"Retrieving status for vault: {VAULT_NAME} and job {JOB_ID}",
+            f"Job status: {JOB_STATUS.get('Action')}, code status: {JOB_STATUS.get('StatusCode')}",
+        ]

--- a/tests/providers/amazon/aws/hooks/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_crawler.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from copy import deepcopy
 from unittest import mock
 
@@ -83,18 +82,17 @@ mock_config = {
 }
 
 
-class TestGlueCrawlerHook(unittest.TestCase):
-    @classmethod
-    def setUp(cls):
-        cls.hook = GlueCrawlerHook(aws_conn_id="aws_default")
+class TestGlueCrawlerHook:
+    def setup_method(self):
+        self.hook = GlueCrawlerHook(aws_conn_id="aws_default")
 
     def test_init(self):
-        self.assertEqual(self.hook.aws_conn_id, "aws_default")
+        assert self.hook.aws_conn_id == "aws_default"
 
     @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_has_crawler(self, mock_get_conn):
         response = self.hook.has_crawler(mock_crawler_name)
-        self.assertEqual(response, True)
+        assert response
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
     @mock.patch.object(GlueCrawlerHook, "get_conn")
@@ -105,7 +103,7 @@ class TestGlueCrawlerHook(unittest.TestCase):
         mock_get_conn.return_value.exceptions.EntityNotFoundException = MockException
         mock_get_conn.return_value.get_crawler.side_effect = MockException("AAA")
         response = self.hook.has_crawler(mock_crawler_name)
-        self.assertEqual(response, False)
+        assert not response
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
     @mock.patch.object(GlueCrawlerHook, "get_conn")
@@ -115,7 +113,7 @@ class TestGlueCrawlerHook(unittest.TestCase):
         mock_config_two = deepcopy(mock_config)
         mock_config_two["Role"] = "test-2-role"
         response = self.hook.update_crawler(**mock_config_two)
-        self.assertEqual(response, True)
+        assert response
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
         mock_get_conn.return_value.update_crawler.assert_called_once_with(**mock_config_two)
 
@@ -123,21 +121,21 @@ class TestGlueCrawlerHook(unittest.TestCase):
     def test_update_crawler_not_needed(self, mock_get_conn):
         mock_get_conn.return_value.get_crawler.return_value = {"Crawler": mock_config}
         response = self.hook.update_crawler(**mock_config)
-        self.assertEqual(response, False)
+        assert not response
         mock_get_conn.return_value.get_crawler.assert_called_once_with(Name=mock_crawler_name)
 
     @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_create_crawler(self, mock_get_conn):
         mock_get_conn.return_value.create_crawler.return_value = {"Crawler": {"Name": mock_crawler_name}}
         glue_crawler = self.hook.create_crawler(**mock_config)
-        self.assertIn("Crawler", glue_crawler)
-        self.assertIn("Name", glue_crawler["Crawler"])
-        self.assertEqual(glue_crawler["Crawler"]["Name"], mock_crawler_name)
+        assert "Crawler" in glue_crawler
+        assert "Name" in glue_crawler["Crawler"]
+        assert glue_crawler["Crawler"]["Name"] == mock_crawler_name
 
     @mock.patch.object(GlueCrawlerHook, "get_conn")
     def test_start_crawler(self, mock_get_conn):
         result = self.hook.start_crawler(mock_crawler_name)
-        self.assertEqual(result, mock_get_conn.return_value.start_crawler.return_value)
+        assert result == mock_get_conn.return_value.start_crawler.return_value
 
         mock_get_conn.return_value.start_crawler.assert_called_once_with(Name=mock_crawler_name)
 
@@ -159,7 +157,7 @@ class TestGlueCrawlerHook(unittest.TestCase):
             ]
         }
         result = self.hook.wait_for_crawler_completion(mock_crawler_name)
-        self.assertEqual(result, "MOCK_STATUS")
+        assert result == "MOCK_STATUS"
         mock_get_conn.assert_has_calls(
             [
                 mock.call(),
@@ -195,7 +193,7 @@ class TestGlueCrawlerHook(unittest.TestCase):
             },
         ]
         result = self.hook.wait_for_crawler_completion(mock_crawler_name)
-        self.assertEqual(result, "MOCK_STATUS")
+        assert result == "MOCK_STATUS"
         mock_get_conn.assert_has_calls(
             [
                 mock.call(),
@@ -208,7 +206,3 @@ class TestGlueCrawlerHook(unittest.TestCase):
                 mock.call(mock_crawler_name),
             ]
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/providers/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_sql.py
@@ -17,19 +17,16 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 
 
-class TestRedshiftSQLHookConn(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-
+class TestRedshiftSQLHookConn:
+    def setup_method(self):
         self.connection = Connection(
             conn_type="redshift", login="login", password="password", host="host", port=5439, schema="dev"
         )
@@ -71,7 +68,8 @@ class TestRedshiftSQLHookConn(unittest.TestCase):
             iam=True,
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "conn_params, conn_extra, expected_call_args",
         [
             ({}, {}, {}),
             ({"login": "test"}, {}, {"user": "test"}),
@@ -81,7 +79,7 @@ class TestRedshiftSQLHookConn(unittest.TestCase):
         ],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
-    def test_get_conn_overrides_correctly(self, conn_params, conn_extra, expected_call_args, mock_connect):
+    def test_get_conn_overrides_correctly(self, mock_connect, conn_params, conn_extra, expected_call_args):
         with mock.patch(
             "airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.conn",
             Connection(conn_type="redshift", extra=conn_extra, **conn_params),

--- a/tests/providers/amazon/aws/operators/test_athena.py
+++ b/tests/providers/amazon/aws/operators/test_athena.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -44,8 +43,8 @@ query_context = {"Database": MOCK_DATA["database"]}
 result_configuration = {"OutputLocation": MOCK_DATA["outputLocation"]}
 
 
-class TestAthenaOperator(unittest.TestCase):
-    def setUp(self):
+class TestAthenaOperator:
+    def setup_method(self):
         args = {
             "owner": "airflow",
             "start_date": DEFAULT_DATE,

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -40,7 +39,7 @@ RESPONSE_WITHOUT_FAILURES = {
 }
 
 
-class TestBatchOperator(unittest.TestCase):
+class TestBatchOperator:
 
     MAX_RETRIES = 2
     STATUS_RETRIES = 3
@@ -49,7 +48,7 @@ class TestBatchOperator(unittest.TestCase):
     @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
     @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsBaseHook.get_client_type")
-    def setUp(self, get_client_type_mock):
+    def setup_method(self, method, get_client_type_mock):
         self.get_client_type_mock = get_client_type_mock
         self.batch = BatchOperator(
             task_id="task",
@@ -188,7 +187,7 @@ class TestBatchOperator(unittest.TestCase):
         self.client_mock.terminate_job.assert_called_once_with(jobId=JOB_ID, reason="Task killed by the user")
 
 
-class TestBatchCreateComputeEnvironmentOperator(unittest.TestCase):
+class TestBatchCreateComputeEnvironmentOperator:
     @mock.patch.object(BatchClientHook, "client")
     def test_execute(self, mock_conn):
         environment_name = "environment_name"

--- a/tests/providers/amazon/aws/operators/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/operators/test_cloud_formation.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 from airflow.models.dag import DAG
@@ -30,8 +29,8 @@ from airflow.utils import timezone
 DEFAULT_DATE = timezone.datetime(2019, 1, 1)
 
 
-class TestCloudFormationCreateStackOperator(unittest.TestCase):
-    def setUp(self):
+class TestCloudFormationCreateStackOperator:
+    def setup_method(self):
         self.args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         # Mock out the cloudformation_client (moto fails with an exception).
@@ -64,8 +63,8 @@ class TestCloudFormationCreateStackOperator(unittest.TestCase):
         )
 
 
-class TestCloudFormationDeleteStackOperator(unittest.TestCase):
-    def setUp(self):
+class TestCloudFormationDeleteStackOperator:
+    def setup_method(self):
         self.args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         # Mock out the cloudformation_client (moto fails with an exception).

--- a/tests/providers/amazon/aws/operators/test_datasync.py
+++ b/tests/providers/amazon/aws/operators/test_datasync.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import boto3
@@ -69,26 +68,21 @@ MOCK_DATA = {
 
 @mock_datasync
 @mock.patch.object(DataSyncHook, "get_conn")
-class DataSyncTestCaseBase(unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.datasync = None
+class DataSyncTestCaseBase:
+    datasync = None
 
     # Runs once for each test
-    def setUp(self):
+    def setup_method(self, method):
         args = {
             "owner": "airflow",
             "start_date": DEFAULT_DATE,
         }
-
         self.dag = DAG(
             TEST_DAG_ID + "test_schedule_dag_once",
             default_args=args,
             schedule="@once",
         )
-
         self.client = boto3.client("datasync", region_name="us-east-1")
-
         self.source_location_arn = self.client.create_location_smb(
             **MOCK_DATA["create_source_location_kwargs"]
         )["LocationArn"]
@@ -100,7 +94,7 @@ class DataSyncTestCaseBase(unittest.TestCase):
             DestinationLocationArn=self.destination_location_arn,
         )["TaskArn"]
 
-    def tearDown(self):
+    def teardown_method(self, method):
         # Delete all tasks:
         tasks = self.client.list_tasks()
         for task in tasks["Tasks"]:
@@ -519,10 +513,6 @@ class TestDataSyncOperatorGetTasks(DataSyncTestCaseBase):
 @mock_datasync
 @mock.patch.object(DataSyncHook, "get_conn")
 class TestDataSyncOperatorUpdate(DataSyncTestCaseBase):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.datasync = None
-
     def set_up_operator(
         self, task_id="test_datasync_update_task_operator", task_arn="self", update_task_kwargs="default"
     ):

--- a/tests/providers/amazon/aws/operators/test_dms_create_task.py
+++ b/tests/providers/amazon/aws/operators/test_dms_create_task.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.dms import DmsHook
@@ -45,7 +44,7 @@ TASK_DATA = {
 }
 
 
-class TestDmsCreateTaskOperator(unittest.TestCase):
+class TestDmsCreateTaskOperator:
     def test_init(self):
         create_operator = DmsCreateTaskOperator(task_id="create_task", **TASK_DATA)
 

--- a/tests/providers/amazon/aws/operators/test_dms_delete_task.py
+++ b/tests/providers/amazon/aws/operators/test_dms_delete_task.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.dms import DmsHook
@@ -33,7 +32,7 @@ TASK_DATA = {
 }
 
 
-class TestDmsDeleteTaskOperator(unittest.TestCase):
+class TestDmsDeleteTaskOperator:
     def test_init(self):
         dms_operator = DmsDeleteTaskOperator(task_id="delete_task", replication_task_arn=TASK_ARN)
 

--- a/tests/providers/amazon/aws/operators/test_dms_describe_tasks.py
+++ b/tests/providers/amazon/aws/operators/test_dms_describe_tasks.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 from airflow.models import DAG, DagRun, TaskInstance
@@ -52,8 +51,8 @@ MOCK_RESPONSE = [
 ]
 
 
-class TestDmsDescribeTasksOperator(unittest.TestCase):
-    def setUp(self):
+class TestDmsDescribeTasksOperator:
+    def setup_method(self):
         args = {
             "owner": "airflow",
             "start_date": DEFAULT_DATE,

--- a/tests/providers/amazon/aws/operators/test_dms_start_task.py
+++ b/tests/providers/amazon/aws/operators/test_dms_start_task.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.dms import DmsHook
@@ -33,7 +32,7 @@ TASK_DATA = {
 }
 
 
-class TestDmsStartTaskOperator(unittest.TestCase):
+class TestDmsStartTaskOperator:
     def test_init(self):
         dms_operator = DmsStartTaskOperator(task_id="start_task", replication_task_arn=TASK_ARN)
 

--- a/tests/providers/amazon/aws/operators/test_dms_stop_task.py
+++ b/tests/providers/amazon/aws/operators/test_dms_stop_task.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.dms import DmsHook
@@ -33,7 +32,7 @@ TASK_DATA = {
 }
 
 
-class TestDmsStopTaskOperator(unittest.TestCase):
+class TestDmsStopTaskOperator:
     def test_init(self):
         dms_operator = DmsStopTaskOperator(task_id="stop_task", replication_task_arn=TASK_ARN)
 

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -39,7 +39,7 @@ GENERATED_UUID = "800647a9-adda-4237-94e6-f542c85fa55b"
 
 class TestEmrContainerOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook")
-    def setup_method(self, emr_hook_mock):
+    def setup_method(self, method, emr_hook_mock):
         conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock
@@ -143,7 +143,7 @@ class TestEmrContainerOperator:
 
 class TestEmrEksCreateClusterOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook")
-    def setup_method(self, emr_hook_mock):
+    def setup_method(self, method, emr_hook_mock):
         conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -38,9 +37,9 @@ CREATE_EMR_ON_EKS_CLUSTER_RETURN = {"ResponseMetadata": {"HTTPStatusCode": 200},
 GENERATED_UUID = "800647a9-adda-4237-94e6-f542c85fa55b"
 
 
-class TestEmrContainerOperator(unittest.TestCase):
+class TestEmrContainerOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook")
-    def setUp(self, emr_hook_mock):
+    def setup_method(self, emr_hook_mock):
         conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock
@@ -142,9 +141,9 @@ class TestEmrContainerOperator(unittest.TestCase):
             assert "Max tries of poll status exceeded" in str(ctx.value)
 
 
-class TestEmrEksCreateClusterOperator(unittest.TestCase):
+class TestEmrEksCreateClusterOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.emr.EmrContainerHook")
-    def setUp(self, emr_hook_mock):
+    def setup_method(self, emr_hook_mock):
         conf.load_test_config()
 
         self.emr_hook_mock = emr_hook_mock

--- a/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_create_job_flow.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -42,7 +41,7 @@ TEMPLATE_SEARCHPATH = os.path.join(
 )
 
 
-class TestEmrCreateJobFlowOperator(unittest.TestCase):
+class TestEmrCreateJobFlowOperator:
     # When
     _config = {
         "Name": "test_job_flow",
@@ -59,7 +58,7 @@ class TestEmrCreateJobFlowOperator(unittest.TestCase):
         ],
     }
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         # Mock out the emr_client (moto has incorrect response)

--- a/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
+++ b/tests/providers/amazon/aws/operators/test_emr_modify_cluster.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,8 +33,8 @@ MODIFY_CLUSTER_SUCCESS_RETURN = {"ResponseMetadata": {"HTTPStatusCode": 200}, "S
 MODIFY_CLUSTER_ERROR_RETURN = {"ResponseMetadata": {"HTTPStatusCode": 400}}
 
 
-class TestEmrModifyClusterOperator(unittest.TestCase):
-    def setUp(self):
+class TestEmrModifyClusterOperator:
+    def setup_method(self):
         self.args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         # Mock out the emr_client (moto has incorrect response)

--- a/tests/providers/amazon/aws/operators/test_emr_terminate_job_flow.py
+++ b/tests/providers/amazon/aws/operators/test_emr_terminate_job_flow.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 from airflow.providers.amazon.aws.operators.emr import EmrTerminateJobFlowOperator
@@ -25,8 +24,8 @@ from airflow.providers.amazon.aws.operators.emr import EmrTerminateJobFlowOperat
 TERMINATE_SUCCESS_RETURN = {"ResponseMetadata": {"HTTPStatusCode": 200}}
 
 
-class TestEmrTerminateJobFlowOperator(unittest.TestCase):
-    def setUp(self):
+class TestEmrTerminateJobFlowOperator:
+    def setup_method(self):
         # Mock out the emr_client (moto has incorrect response)
         mock_emr_client = MagicMock()
         mock_emr_client.terminate_job_flows.return_value = TERMINATE_SUCCESS_RETURN

--- a/tests/providers/amazon/aws/operators/test_glacier.py
+++ b/tests/providers/amazon/aws/operators/test_glacier.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.operators.glacier import (
     GlacierCreateJobOperator,
@@ -34,7 +34,7 @@ TASK_ID = "glacier_job"
 VAULT_NAME = "airflow"
 
 
-class TestGlacierCreateJobOperator(TestCase):
+class TestGlacierCreateJobOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.glacier.GlacierHook")
     def test_execute(self, hook_mock):
         op = GlacierCreateJobOperator(aws_conn_id=AWS_CONN_ID, vault_name=VAULT_NAME, task_id=TASK_ID)
@@ -43,7 +43,7 @@ class TestGlacierCreateJobOperator(TestCase):
         hook_mock.return_value.retrieve_inventory.assert_called_once_with(vault_name=VAULT_NAME)
 
 
-class TestGlacierUploadArchiveOperator(TestCase):
+class TestGlacierUploadArchiveOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.glacier.GlacierHook.get_conn")
     def test_execute(self, hook_mock):
         op = GlacierUploadArchiveOperator(

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -16,10 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.configuration import conf
 from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
@@ -27,18 +26,19 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.operators.glue import GlueJobOperator
 
 
-class TestGlueJobOperator(unittest.TestCase):
+class TestGlueJobOperator:
     @mock.patch("airflow.providers.amazon.aws.hooks.glue.GlueJobHook")
-    def setUp(self, glue_hook_mock):
+    def setup_method(self, method, glue_hook_mock):
         conf.load_test_config()
 
         self.glue_hook_mock = glue_hook_mock
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "script_location",
         [
-            "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
-            "/glue-examples/glue-scripts/sample_aws_glue_job.py",
-        ]
+            pytest.param("s3://glue-examples/glue-scripts/sample_aws_glue_job.py", id="s3 URI"),
+            pytest.param("/glue-examples/glue-scripts/sample_aws_glue_job.py", id="path without schema"),
+        ],
     )
     @mock.patch.object(GlueJobHook, "print_job_logs")
     @mock.patch.object(GlueJobHook, "get_job_state")
@@ -47,12 +47,12 @@ class TestGlueJobOperator(unittest.TestCase):
     @mock.patch.object(S3Hook, "load_file")
     def test_execute_without_failure(
         self,
-        script_location,
         mock_load_file,
         mock_get_conn,
         mock_initialize_job,
         mock_get_job_state,
         mock_print_job_logs,
+        script_location,
     ):
         glue = GlueJobOperator(
             task_id="test_glue_operator",

--- a/tests/providers/amazon/aws/operators/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/operators/test_glue_crawler.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.operators.glue_crawler import GlueCrawlerOperator
@@ -81,8 +80,8 @@ mock_config = {
 }
 
 
-class TestGlueCrawlerOperator(unittest.TestCase):
-    def setUp(self):
+class TestGlueCrawlerOperator:
+    def setup_method(self):
         self.glue = GlueCrawlerOperator(task_id="test_glue_crawler_operator", config=mock_config)
 
     @mock.patch("airflow.providers.amazon.aws.operators.glue_crawler.GlueCrawlerHook")

--- a/tests/providers/amazon/aws/operators/test_lambda.py
+++ b/tests/providers/amazon/aws/operators/test_lambda.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import io
 import json
-import unittest
 import zipfile
 
 import pytest
@@ -33,7 +32,7 @@ from airflow.providers.amazon.aws.operators.lambda_function import AwsLambdaInvo
 @mock_lambda
 @mock_sts
 @mock_iam
-class TestAwsLambdaInvokeFunctionOperator(unittest.TestCase):
+class TestAwsLambdaInvokeFunctionOperator:
     def test_init(self):
         lambda_operator = AwsLambdaInvokeFunctionOperator(
             task_id="test",

--- a/tests/providers/amazon/aws/operators/test_quicksight.py
+++ b/tests/providers/amazon/aws/operators/test_quicksight.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.quicksight import QuickSightHook
@@ -37,8 +36,8 @@ MOCK_RESPONSE = {
 }
 
 
-class TestQuickSightCreateIngestionOperator(unittest.TestCase):
-    def setUp(self):
+class TestQuickSightCreateIngestionOperator:
+    def setup_method(self):
         self.quicksight = QuickSightCreateIngestionOperator(
             task_id="test_quicksight_operator",
             data_set_id=DATA_SET_ID,

--- a/tests/providers/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_sql.py
@@ -16,31 +16,33 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 from airflow.providers.common.sql.hooks.sql import fetch_all_handler
 
 
-class TestRedshiftSQLOperator(unittest.TestCase):
-    @parameterized.expand([(True, ("a", "b")), (False, ("c", "d"))])
+class TestRedshiftSQLOperator:
+    @pytest.mark.parametrize(
+        "autocommit", [pytest.param(True, id="autocommit-on"), pytest.param(True, id="autocommit-off")]
+    )
     @mock.patch("airflow.providers.amazon.aws.operators.redshift_sql.RedshiftSQLOperator.get_db_hook")
-    def test_redshift_operator(self, test_autocommit, test_parameters, mock_get_hook):
+    def test_redshift_operator(self, mock_get_hook, autocommit):
         hook = MagicMock()
         mock_run = hook.run
         mock_get_hook.return_value = hook
+        test_parameters = ("a", "b")
         sql = MagicMock()
         operator = RedshiftSQLOperator(
-            task_id="test", sql=sql, autocommit=test_autocommit, parameters=test_parameters
+            task_id="test", sql=sql, autocommit=autocommit, parameters=test_parameters
         )
         operator.execute(None)
         mock_run.assert_called_once_with(
             sql=sql,
-            autocommit=test_autocommit,
+            autocommit=autocommit,
             parameters=test_parameters,
             handler=fetch_all_handler,
             return_last=True,

--- a/tests/providers/amazon/aws/operators/test_s3_bucket.py
+++ b/tests/providers/amazon/aws/operators/test_s3_bucket.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest import mock
 
 from moto import mock_s3
@@ -30,8 +29,8 @@ BUCKET_NAME = os.environ.get("BUCKET_NAME", "test-airflow-bucket")
 TASK_ID = os.environ.get("TASK_ID", "test-s3-operator")
 
 
-class TestS3CreateBucketOperator(unittest.TestCase):
-    def setUp(self):
+class TestS3CreateBucketOperator:
+    def setup_method(self):
         self.create_bucket_operator = S3CreateBucketOperator(
             task_id=TASK_ID,
             bucket_name=BUCKET_NAME,
@@ -58,8 +57,8 @@ class TestS3CreateBucketOperator(unittest.TestCase):
         mock_create_bucket.assert_called_once_with(bucket_name=BUCKET_NAME, region_name=None)
 
 
-class TestS3DeleteBucketOperator(unittest.TestCase):
-    def setUp(self):
+class TestS3DeleteBucketOperator:
+    def setup_method(self):
         self.delete_bucket_operator = S3DeleteBucketOperator(
             task_id=TASK_ID,
             bucket_name=BUCKET_NAME,

--- a/tests/providers/amazon/aws/operators/test_s3_bucket_tagging.py
+++ b/tests/providers/amazon/aws/operators/test_s3_bucket_tagging.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import os
-import unittest
 from unittest import mock
 
 from moto import mock_s3
@@ -35,14 +34,14 @@ TAG_SET = [{"Key": "Color", "Value": "Green"}]
 TASK_ID = os.environ.get("TASK_ID", "test-s3-operator")
 
 
-class TestS3GetBucketTaggingOperator(unittest.TestCase):
-    def setUp(self):
+@mock_s3
+class TestS3GetBucketTaggingOperator:
+    def setup_method(self, method):
         self.get_bucket_tagging_operator = S3GetBucketTaggingOperator(
             task_id=TASK_ID,
             bucket_name=BUCKET_NAME,
         )
 
-    @mock_s3
     @mock.patch.object(S3Hook, "get_bucket_tagging")
     @mock.patch.object(S3Hook, "check_for_bucket")
     def test_execute_if_bucket_exist(self, mock_check_for_bucket, get_bucket_tagging):
@@ -52,7 +51,6 @@ class TestS3GetBucketTaggingOperator(unittest.TestCase):
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         get_bucket_tagging.assert_called_once_with(BUCKET_NAME)
 
-    @mock_s3
     @mock.patch.object(S3Hook, "get_bucket_tagging")
     @mock.patch.object(S3Hook, "check_for_bucket")
     def test_execute_if_not_bucket_exist(self, mock_check_for_bucket, get_bucket_tagging):
@@ -63,15 +61,15 @@ class TestS3GetBucketTaggingOperator(unittest.TestCase):
         get_bucket_tagging.assert_not_called()
 
 
-class TestS3PutBucketTaggingOperator(unittest.TestCase):
-    def setUp(self):
+@mock_s3
+class TestS3PutBucketTaggingOperator:
+    def setup_method(self, method):
         self.put_bucket_tagging_operator = S3PutBucketTaggingOperator(
             task_id=TASK_ID,
             tag_set=TAG_SET,
             bucket_name=BUCKET_NAME,
         )
 
-    @mock_s3
     @mock.patch.object(S3Hook, "put_bucket_tagging")
     @mock.patch.object(S3Hook, "check_for_bucket")
     def test_execute_if_bucket_exist(self, mock_check_for_bucket, put_bucket_tagging):
@@ -94,14 +92,14 @@ class TestS3PutBucketTaggingOperator(unittest.TestCase):
         put_bucket_tagging.assert_not_called()
 
 
-class TestS3DeleteBucketTaggingOperator(unittest.TestCase):
-    def setUp(self):
+@mock_s3
+class TestS3DeleteBucketTaggingOperator:
+    def setup_method(self, method):
         self.delete_bucket_tagging_operator = S3DeleteBucketTaggingOperator(
             task_id=TASK_ID,
             bucket_name=BUCKET_NAME,
         )
 
-    @mock_s3
     @mock.patch.object(S3Hook, "delete_bucket_tagging")
     @mock.patch.object(S3Hook, "check_for_bucket")
     def test_execute_if_bucket_exist(self, mock_check_for_bucket, delete_bucket_tagging):
@@ -111,7 +109,6 @@ class TestS3DeleteBucketTaggingOperator(unittest.TestCase):
         mock_check_for_bucket.assert_called_once_with(BUCKET_NAME)
         delete_bucket_tagging.assert_called_once_with(BUCKET_NAME)
 
-    @mock_s3
     @mock.patch.object(S3Hook, "delete_bucket_tagging")
     @mock.patch.object(S3Hook, "check_for_bucket")
     def test_execute_if_not_bucket_exist(self, mock_check_for_bucket, delete_bucket_tagging):

--- a/tests/providers/amazon/aws/operators/test_s3_list.py
+++ b/tests/providers/amazon/aws/operators/test_s3_list.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.operators.s3 import S3ListOperator
@@ -29,7 +28,7 @@ PREFIX = "TEST"
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
 
 
-class TestS3ListOperator(unittest.TestCase):
+class TestS3ListOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
     def test_execute(self, mock_hook):
 

--- a/tests/providers/amazon/aws/operators/test_s3_list_prefixes.py
+++ b/tests/providers/amazon/aws/operators/test_s3_list_prefixes.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.operators.s3 import S3ListPrefixesOperator
@@ -29,7 +28,7 @@ PREFIX = "test/"
 MOCK_SUBFOLDERS = ["test/"]
 
 
-class TestS3ListOperator(unittest.TestCase):
+class TestS3ListOperator:
     @mock.patch("airflow.providers.amazon.aws.operators.s3.S3Hook")
     def test_execute(self, mock_hook):
 

--- a/tests/providers/amazon/aws/operators/test_s3_object.py
+++ b/tests/providers/amazon/aws/operators/test_s3_object.py
@@ -18,10 +18,10 @@
 from __future__ import annotations
 
 import io
-import unittest
 from unittest import mock
 
 import boto3
+import pytest
 from moto import mock_s3
 
 from airflow import AirflowException
@@ -37,14 +37,14 @@ S3_KEY = "test-airflow-key"
 TASK_ID = "test-s3-operator"
 
 
-class TestS3CopyObjectOperator(unittest.TestCase):
-    def setUp(self):
+@mock_s3
+class TestS3CopyObjectOperator:
+    def setup_method(self, method):
         self.source_bucket = "bucket1"
         self.source_key = "path1/data.txt"
         self.dest_bucket = "bucket2"
         self.dest_key = "path2/data_copy.txt"
 
-    @mock_s3
     def test_s3_copy_object_arg_combination_1(self):
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.source_bucket)
@@ -69,7 +69,6 @@ class TestS3CopyObjectOperator(unittest.TestCase):
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_dest_bucket["Contents"][0]["Key"] == self.dest_key
 
-    @mock_s3
     def test_s3_copy_object_arg_combination_2(self):
         conn = boto3.client("s3")
         conn.create_bucket(Bucket=self.source_bucket)
@@ -95,8 +94,8 @@ class TestS3CopyObjectOperator(unittest.TestCase):
         assert objects_in_dest_bucket["Contents"][0]["Key"] == self.dest_key
 
 
-class TestS3DeleteObjectsOperator(unittest.TestCase):
-    @mock_s3
+@mock_s3
+class TestS3DeleteObjectsOperator:
     def test_s3_delete_single_object(self):
         bucket = "testbucket"
         key = "path/data.txt"
@@ -116,7 +115,6 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # There should be no object found in the bucket created earlier
         assert "Contents" not in conn.list_objects(Bucket=bucket, Prefix=key)
 
-    @mock_s3
     def test_s3_delete_multiple_objects(self):
         bucket = "testbucket"
         key_pattern = "path/data"
@@ -139,7 +137,6 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # There should be no object found in the bucket created earlier
         assert "Contents" not in conn.list_objects(Bucket=bucket, Prefix=key_pattern)
 
-    @mock_s3
     def test_s3_delete_prefix(self):
         bucket = "testbucket"
         key_pattern = "path/data"
@@ -162,7 +159,6 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # There should be no object found in the bucket created earlier
         assert "Contents" not in conn.list_objects(Bucket=bucket, Prefix=key_pattern)
 
-    @mock_s3
     def test_s3_delete_empty_list(self):
         bucket = "testbucket"
         key_of_test = "path/data.txt"
@@ -185,7 +181,6 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_dest_bucket["Contents"][0]["Key"] == key_of_test
 
-    @mock_s3
     def test_s3_delete_empty_string(self):
         bucket = "testbucket"
         key_of_test = "path/data.txt"
@@ -208,36 +203,32 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_dest_bucket["Contents"][0]["Key"] == key_of_test
 
-    @mock_s3
-    def test_assert_s3_both_keys_and_prifix_given(self):
-        bucket = "testbucket"
-        keys = "path/data.txt"
-        key_pattern = "path/data"
-
-        conn = boto3.client("s3")
-        conn.create_bucket(Bucket=bucket)
-        conn.upload_fileobj(Bucket=bucket, Key=keys, Fileobj=io.BytesIO(b"input"))
-
-        # The object should be detected before the DELETE action is tested
-        objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=keys)
-        assert len(objects_in_dest_bucket["Contents"]) == 1
-        assert objects_in_dest_bucket["Contents"][0]["Key"] == keys
-        with self.assertRaises(AirflowException):
-            op = S3DeleteObjectsOperator(
-                task_id="test_assert_s3_both_keys_and_prifix_given",
-                bucket=bucket,
+    @pytest.mark.parametrize(
+        "keys, prefix",
+        [
+            pytest.param("path/data.txt", "path/data", id="single-key-and-prefix"),
+            pytest.param(["path/data.txt"], "path/data", id="multiple-keys-and-prefix"),
+            pytest.param(None, None, id="both-none"),
+        ],
+    )
+    def test_validate_keys_and_prefix_in_constructor(self, keys, prefix):
+        with pytest.raises(AirflowException, match=r"Either keys or prefix should be set\."):
+            S3DeleteObjectsOperator(
+                task_id="test_validate_keys_and_prefix_in_constructor",
+                bucket="foo-bar-bucket",
                 keys=keys,
-                prefix=key_pattern,
+                prefix=prefix,
             )
-            op.execute(None)
 
-        # The object found in the bucket created earlier should still be there
-        assert len(objects_in_dest_bucket["Contents"]) == 1
-        # the object found should be consistent with dest_key specified earlier
-        assert objects_in_dest_bucket["Contents"][0]["Key"] == keys
-
-    @mock_s3
-    def test_assert_s3_no_keys_or_prifix_given(self):
+    @pytest.mark.parametrize(
+        "keys, prefix",
+        [
+            pytest.param("path/data.txt", "path/data", id="single-key-and-prefix"),
+            pytest.param(["path/data.txt"], "path/data", id="multiple-keys-and-prefix"),
+            pytest.param(None, None, id="both-none"),
+        ],
+    )
+    def test_validate_keys_and_prefix_in_execute(self, keys, prefix):
         bucket = "testbucket"
         key_of_test = "path/data.txt"
 
@@ -245,20 +236,31 @@ class TestS3DeleteObjectsOperator(unittest.TestCase):
         conn.create_bucket(Bucket=bucket)
         conn.upload_fileobj(Bucket=bucket, Key=key_of_test, Fileobj=io.BytesIO(b"input"))
 
+        # Set valid values for constructor, and change them later for emulate rendering template
+        op = S3DeleteObjectsOperator(
+            task_id="test_validate_keys_and_prefix_in_execute",
+            bucket=bucket,
+            keys="keys-exists",
+            prefix=None,
+        )
+        op.keys = keys
+        op.prefix = prefix
+
         # The object should be detected before the DELETE action is tested
         objects_in_dest_bucket = conn.list_objects(Bucket=bucket, Prefix=key_of_test)
         assert len(objects_in_dest_bucket["Contents"]) == 1
         assert objects_in_dest_bucket["Contents"][0]["Key"] == key_of_test
-        with self.assertRaises(AirflowException):
-            op = S3DeleteObjectsOperator(task_id="test_assert_s3_no_keys_or_prifix_given", bucket=bucket)
+
+        with pytest.raises(AirflowException, match=r"Either keys or prefix should be set\."):
             op.execute(None)
+
         # The object found in the bucket created earlier should still be there
         assert len(objects_in_dest_bucket["Contents"]) == 1
         # the object found should be consistent with dest_key specified earlier
         assert objects_in_dest_bucket["Contents"][0]["Key"] == key_of_test
 
 
-class TestS3CreateObjectOperator(unittest.TestCase):
+class TestS3CreateObjectOperator:
     @mock.patch.object(S3Hook, "load_string")
     def test_execute_if_data_is_string(self, mock_load_string):
         data = "data"

--- a/tests/providers/amazon/aws/operators/test_sagemaker_base.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_base.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from typing import Any
 
 from airflow.providers.amazon.aws.operators.sagemaker import SageMakerBaseOperator
@@ -27,8 +26,8 @@ PARSED_CONFIG: dict = {"key1": 1, "key2": {"key3": 3, "key4": 4}, "key5": [{"key
 EXPECTED_INTEGER_FIELDS: list[list[Any]] = []
 
 
-class TestSageMakerBaseOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerBaseOperator:
+    def setup_method(self):
         self.sagemaker = SageMakerBaseOperator(task_id="test_sagemaker_operator", config=CONFIG)
         self.sagemaker.aws_conn_id = "aws_default"
 

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -55,8 +54,8 @@ CONFIG: dict = {
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [["EndpointConfig", "ProductionVariants", "InitialInstanceCount"]]
 
 
-class TestSageMakerEndpointOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerEndpointOperator:
+    def setup_method(self):
         self.sagemaker = SageMakerEndpointOperator(
             task_id="test_sagemaker_operator",
             config=CONFIG,

--- a/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_endpoint_config.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -42,8 +41,8 @@ CREATE_ENDPOINT_CONFIG_PARAMS: dict = {
 EXPECTED_INTEGER_FIELDS: list[list[str]] = [["ProductionVariants", "InitialInstanceCount"]]
 
 
-class TestSageMakerEndpointConfigOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerEndpointConfigOperator:
+    def setup_method(self):
         self.sagemaker = SageMakerEndpointConfigOperator(
             task_id="test_sagemaker_operator",
             config=CREATE_ENDPOINT_CONFIG_PARAMS,

--- a/tests/providers/amazon/aws/operators/test_sagemaker_model.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_model.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -41,8 +40,8 @@ CREATE_MODEL_PARAMS: dict = {
 EXPECTED_INTEGER_FIELDS: list[list[str]] = []
 
 
-class TestSageMakerModelOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerModelOperator:
+    def setup_method(self):
         self.sagemaker = SageMakerModelOperator(task_id="test_sagemaker_operator", config=CREATE_MODEL_PARAMS)
 
     @mock.patch.object(SageMakerHook, "describe_model", return_value="")
@@ -60,7 +59,7 @@ class TestSageMakerModelOperator(unittest.TestCase):
             self.sagemaker.execute(None)
 
 
-class TestSageMakerDeleteModelOperator(unittest.TestCase):
+class TestSageMakerDeleteModelOperator:
     @mock.patch.object(SageMakerHook, "delete_model")
     def test_execute(self, delete_model):
         op = SageMakerDeleteModelOperator(

--- a/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_processing.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -87,8 +86,8 @@ EXPECTED_INTEGER_FIELDS: list[list[str]] = [
 EXPECTED_STOPPING_CONDITION_INTEGER_FIELDS: list[list[str]] = [["StoppingCondition", "MaxRuntimeInSeconds"]]
 
 
-class TestSageMakerProcessingOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerProcessingOperator:
+    def setup_method(self):
         self.processing_config_kwargs = dict(
             task_id="test_sagemaker_operator", wait_for_completion=False, check_interval=5
         )
@@ -185,7 +184,7 @@ class TestSageMakerProcessingOperator(unittest.TestCase):
         with pytest.raises(AirflowException):
             sagemaker.execute(None)
 
-    @unittest.skip("Currently, the auto-increment jobname functionality is not missing.")
+    @pytest.mark.skip(reason="Currently, the auto-increment jobname functionality is not missing.")
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "count_processing_jobs_by_name", return_value=1)
     @mock.patch.object(

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
+import copy
 from unittest import mock
 
 import pytest
@@ -57,11 +57,12 @@ CREATE_TRAINING_PARAMS = {
 }
 
 
-class TestSageMakerTrainingOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerTrainingOperator:
+    def setup_method(self):
+        self.create_training_params = copy.deepcopy(CREATE_TRAINING_PARAMS)
         self.sagemaker = SageMakerTrainingOperator(
             task_id="test_sagemaker_operator",
-            config=CREATE_TRAINING_PARAMS,
+            config=self.create_training_params,
             wait_for_completion=False,
             check_interval=5,
         )
@@ -92,7 +93,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         self.sagemaker.execute(None)
         self.sagemaker._check_if_job_exists.assert_called_once()
         mock_training.assert_called_once_with(
-            CREATE_TRAINING_PARAMS,
+            self.create_training_params,
             wait_for_completion=False,
             print_log=True,
             check_interval=5,
@@ -112,7 +113,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         self.sagemaker.execute(None)
         self.sagemaker._check_if_job_exists.assert_not_called()
         mock_training.assert_called_once_with(
-            CREATE_TRAINING_PARAMS,
+            self.create_training_params,
             wait_for_completion=False,
             print_log=True,
             check_interval=5,
@@ -137,7 +138,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         mock_list_training_jobs.return_value = [{"TrainingJobName": "job_name"}]
         self.sagemaker._check_if_job_exists()
 
-        expected_config = CREATE_TRAINING_PARAMS.copy()
+        expected_config = self.create_training_params
         # Expect to see TrainingJobName suffixed with "-2" because we return one existing job
         expected_config["TrainingJobName"] = "job_name-2"
         assert self.sagemaker.config == expected_config

--- a/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_tuning.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -73,8 +72,8 @@ CREATE_TUNING_PARAMS: dict = {
 }
 
 
-class TestSageMakerTuningOperator(unittest.TestCase):
-    def setUp(self):
+class TestSageMakerTuningOperator:
+    def setup_method(self):
         self.sagemaker = SageMakerTuningOperator(
             task_id="test_sagemaker_operator",
             config=CREATE_TUNING_PARAMS,

--- a/tests/providers/amazon/aws/operators/test_sns.py
+++ b/tests/providers/amazon/aws/operators/test_sns.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.operators.sns import SnsPublishOperator
@@ -30,7 +29,7 @@ SUBJECT = "Subject to send"
 MESSAGE_ATTRIBUTES = {"test-attribute": "Attribute to send"}
 
 
-class TestSnsPublishOperator(unittest.TestCase):
+class TestSnsPublishOperator:
     def test_init(self):
         # Given / When
         operator = SnsPublishOperator(

--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock
 
 import pytest
@@ -38,8 +37,8 @@ FIFO_QUEUE_NAME = "test-queue.fifo"
 FIFO_QUEUE_URL = f"https://{FIFO_QUEUE_NAME}"
 
 
-class TestSqsPublishOperator(unittest.TestCase):
-    def setUp(self):
+class TestSqsPublishOperator:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         self.dag = DAG("test_dag_id", default_args=args)

--- a/tests/providers/amazon/aws/operators/test_step_function.py
+++ b/tests/providers/amazon/aws/operators/test_step_function.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -37,10 +36,10 @@ NAME = "NAME"
 INPUT = "{}"
 
 
-class TestStepFunctionGetExecutionOutputOperator(unittest.TestCase):
+class TestStepFunctionGetExecutionOutputOperator:
     TASK_ID = "step_function_get_execution_output"
 
-    def setUp(self):
+    def setup_method(self):
         self.mock_context = MagicMock()
 
     def test_init(self):
@@ -80,10 +79,10 @@ class TestStepFunctionGetExecutionOutputOperator(unittest.TestCase):
         assert {} == result
 
 
-class TestStepFunctionStartExecutionOperator(unittest.TestCase):
+class TestStepFunctionStartExecutionOperator:
     TASK_ID = "step_function_start_execution_task"
 
-    def setUp(self):
+    def setup_method(self):
         self.mock_context = MagicMock()
 
     def test_init(self):

--- a/tests/providers/amazon/aws/sensors/test_athena.py
+++ b/tests/providers/amazon/aws/sensors/test_athena.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -27,8 +26,8 @@ from airflow.providers.amazon.aws.hooks.athena import AthenaHook
 from airflow.providers.amazon.aws.sensors.athena import AthenaSensor
 
 
-class TestAthenaSensor(unittest.TestCase):
-    def setUp(self):
+class TestAthenaSensor:
+    def setup_method(self):
         self.sensor = AthenaSensor(
             task_id="test_athena_sensor",
             query_execution_id="abc",
@@ -37,26 +36,18 @@ class TestAthenaSensor(unittest.TestCase):
             aws_conn_id="aws_default",
         )
 
-    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=("SUCCEEDED",))
-    def test_poke_success(self, mock_poll_query_status):
-        assert self.sensor.poke({})
+    @pytest.mark.parametrize("poll_query_status", ["SUCCEEDED"])
+    def test_poke_true_on_status(self, poll_query_status):
+        with mock.patch.object(AthenaHook, "poll_query_status", side_effect=[poll_query_status]):
+            assert self.sensor.poke({})
 
-    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=("RUNNING",))
-    def test_poke_running(self, mock_poll_query_status):
-        assert not self.sensor.poke({})
+    @pytest.mark.parametrize("poll_query_status", ["RUNNING", "QUEUED"])
+    def test_poke_false_on_status(self, poll_query_status):
+        with mock.patch.object(AthenaHook, "poll_query_status", side_effect=[poll_query_status]):
+            assert not self.sensor.poke({})
 
-    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=("QUEUED",))
-    def test_poke_queued(self, mock_poll_query_status):
-        assert not self.sensor.poke({})
-
-    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=("FAILED",))
-    def test_poke_failed(self, mock_poll_query_status):
-        with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
-        assert "Athena sensor failed" in str(ctx.value)
-
-    @mock.patch.object(AthenaHook, "poll_query_status", side_effect=("CANCELLED",))
-    def test_poke_cancelled(self, mock_poll_query_status):
-        with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke({})
-        assert "Athena sensor failed" in str(ctx.value)
+    @pytest.mark.parametrize("poll_query_status", ["FAILED", "CANCELLED"])
+    def test_poke_raise_on_status(self, poll_query_status):
+        with mock.patch.object(AthenaHook, "poll_query_status", side_effect=[poll_query_status]):
+            with pytest.raises(AirflowException, match=r"Athena sensor failed"):
+                self.sensor.poke({})

--- a/tests/providers/amazon/aws/sensors/test_emr_base.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_base.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import pytest
 
 from airflow.exceptions import AirflowException
@@ -60,7 +58,7 @@ class EmrBaseSensorSubclass(EmrBaseSensor):
         return None
 
 
-class TestEmrBaseSensor(unittest.TestCase):
+class TestEmrBaseSensor:
     def test_poke_returns_true_when_state_is_in_target_states(self):
         operator = EmrBaseSensorSubclass(
             task_id="test_task",

--- a/tests/providers/amazon/aws/sensors/test_emr_containers.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_containers.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -27,8 +26,8 @@ from airflow.providers.amazon.aws.hooks.emr import EmrContainerHook
 from airflow.providers.amazon.aws.sensors.emr import EmrContainerSensor
 
 
-class TestEmrContainerSensor(unittest.TestCase):
-    def setUp(self):
+class TestEmrContainerSensor:
+    def setup_method(self):
         self.sensor = EmrContainerSensor(
             task_id="test_emrcontainer_sensor",
             virtual_cluster_id="vzwemreks",
@@ -41,36 +40,18 @@ class TestEmrContainerSensor(unittest.TestCase):
         # avoids an Airflow warning about connection cannot be found.
         self.sensor.hook.get_connection = lambda _: None
 
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("PENDING",))
-    def test_poke_pending(self, mock_check_query_status):
-        assert not self.sensor.poke(None)
+    @pytest.mark.parametrize("query_status", ["COMPLETED"])
+    def test_poke_true_on_query_status(self, query_status):
+        with mock.patch.object(EmrContainerHook, "check_query_status", side_effect=[query_status]):
+            assert self.sensor.poke({})
 
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("SUBMITTED",))
-    def test_poke_submitted(self, mock_check_query_status):
-        assert not self.sensor.poke(None)
+    @pytest.mark.parametrize("query_status", ["PENDING", "SUBMITTED", "RUNNING"])
+    def test_poke_false_on_query_status(self, query_status):
+        with mock.patch.object(EmrContainerHook, "check_query_status", side_effect=[query_status]):
+            assert not self.sensor.poke({})
 
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("RUNNING",))
-    def test_poke_running(self, mock_check_query_status):
-        assert not self.sensor.poke(None)
-
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("COMPLETED",))
-    def test_poke_completed(self, mock_check_query_status):
-        assert self.sensor.poke(None)
-
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("FAILED",))
-    def test_poke_failed(self, mock_check_query_status):
-        with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke(None)
-        assert "EMR Containers sensor failed" in str(ctx.value)
-
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("CANCELLED",))
-    def test_poke_cancelled(self, mock_check_query_status):
-        with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke(None)
-        assert "EMR Containers sensor failed" in str(ctx.value)
-
-    @mock.patch.object(EmrContainerHook, "check_query_status", side_effect=("CANCEL_PENDING",))
-    def test_poke_cancel_pending(self, mock_check_query_status):
-        with pytest.raises(AirflowException) as ctx:
-            self.sensor.poke(None)
-        assert "EMR Containers sensor failed" in str(ctx.value)
+    @pytest.mark.parametrize("query_status", ["FAILED", "CANCELLED", "CANCEL_PENDING"])
+    def test_poke_raise_on_query_status(self, query_status):
+        with mock.patch.object(EmrContainerHook, "check_query_status", side_effect=[query_status]):
+            with pytest.raises(AirflowException, match=r"EMR Containers sensor failed"):
+                assert not self.sensor.poke({})

--- a/tests/providers/amazon/aws/sensors/test_emr_job_flow.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_job_flow.py
@@ -18,8 +18,7 @@
 from __future__ import annotations
 
 import datetime
-import unittest
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import pytest
 from dateutil.tz import tzlocal
@@ -188,16 +187,16 @@ DESCRIBE_CLUSTER_TERMINATED_WITH_ERRORS_RETURN = {
 }
 
 
-class TestEmrJobFlowSensor(unittest.TestCase):
-    def setUp(self):
+class TestEmrJobFlowSensor:
+    def setup_method(self):
         # Mock out the emr_client (moto has incorrect response)
-        self.mock_emr_client = MagicMock()
+        self.mock_emr_client = mock.MagicMock()
 
-        mock_emr_session = MagicMock()
+        mock_emr_session = mock.MagicMock()
         mock_emr_session.client.return_value = self.mock_emr_client
 
         # Mock out the emr_client creator
-        self.boto3_session_mock = MagicMock(return_value=mock_emr_session)
+        self.boto3_session_mock = mock.MagicMock(return_value=mock_emr_session)
 
     def test_execute_calls_with_the_job_flow_id_until_it_reaches_a_target_state(self):
         self.mock_emr_client.describe_cluster.side_effect = [
@@ -205,7 +204,7 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             DESCRIBE_CLUSTER_RUNNING_RETURN,
             DESCRIBE_CLUSTER_TERMINATED_RETURN,
         ]
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             operator = EmrJobFlowSensor(
                 task_id="test_task", poke_interval=0, job_flow_id="j-8989898989", aws_conn_id="aws_default"
             )
@@ -216,7 +215,7 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             assert self.mock_emr_client.describe_cluster.call_count == 3
 
             # make sure it was called with the job_flow_id
-            calls = [unittest.mock.call(ClusterId="j-8989898989")]
+            calls = [mock.call(ClusterId="j-8989898989")]
             self.mock_emr_client.describe_cluster.assert_has_calls(calls)
 
     def test_execute_calls_with_the_job_flow_id_until_it_reaches_failed_state_with_exception(self):
@@ -224,7 +223,7 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             DESCRIBE_CLUSTER_RUNNING_RETURN,
             DESCRIBE_CLUSTER_TERMINATED_WITH_ERRORS_RETURN,
         ]
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             operator = EmrJobFlowSensor(
                 task_id="test_task", poke_interval=0, job_flow_id="j-8989898989", aws_conn_id="aws_default"
             )
@@ -247,7 +246,7 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             DESCRIBE_CLUSTER_TERMINATED_RETURN,  # will not be used
             DESCRIBE_CLUSTER_TERMINATED_WITH_ERRORS_RETURN,  # will not be used
         ]
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             operator = EmrJobFlowSensor(
                 task_id="test_task",
                 poke_interval=0,
@@ -262,5 +261,5 @@ class TestEmrJobFlowSensor(unittest.TestCase):
             assert self.mock_emr_client.describe_cluster.call_count == 3
 
             # make sure it was called with the job_flow_id
-            calls = [unittest.mock.call(ClusterId="j-8989898989")]
+            calls = [mock.call(ClusterId="j-8989898989")]
             self.mock_emr_client.describe_cluster.assert_has_calls(calls)

--- a/tests/providers/amazon/aws/sensors/test_emr_step.py
+++ b/tests/providers/amazon/aws/sensors/test_emr_step.py
@@ -17,9 +17,8 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest import mock
 
 import pytest
 from dateutil.tz import tzlocal
@@ -142,9 +141,9 @@ DESCRIBE_JOB_STEP_COMPLETED_RETURN = {
 }
 
 
-class TestEmrStepSensor(unittest.TestCase):
-    def setUp(self):
-        self.emr_client_mock = MagicMock()
+class TestEmrStepSensor:
+    def setup_method(self):
+        self.emr_client_mock = mock.MagicMock()
         self.sensor = EmrStepSensor(
             task_id="test_task",
             poke_interval=0,
@@ -153,11 +152,11 @@ class TestEmrStepSensor(unittest.TestCase):
             aws_conn_id="aws_default",
         )
 
-        mock_emr_session = MagicMock()
+        mock_emr_session = mock.MagicMock()
         mock_emr_session.client.return_value = self.emr_client_mock
 
         # Mock out the emr_client creator
-        self.boto3_session_mock = MagicMock(return_value=mock_emr_session)
+        self.boto3_session_mock = mock.MagicMock(return_value=mock_emr_session)
 
     def test_step_completed(self):
         self.emr_client_mock.describe_step.side_effect = [
@@ -165,13 +164,13 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_COMPLETED_RETURN,
         ]
 
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             self.sensor.execute(None)
 
             assert self.emr_client_mock.describe_step.call_count == 2
             calls = [
-                unittest.mock.call(ClusterId="j-8989898989", StepId="s-VK57YR1Z9Z5N"),
-                unittest.mock.call(ClusterId="j-8989898989", StepId="s-VK57YR1Z9Z5N"),
+                mock.call(ClusterId="j-8989898989", StepId="s-VK57YR1Z9Z5N"),
+                mock.call(ClusterId="j-8989898989", StepId="s-VK57YR1Z9Z5N"),
             ]
             self.emr_client_mock.describe_step.assert_has_calls(calls)
 
@@ -181,7 +180,7 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_CANCELLED_RETURN,
         ]
 
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             with pytest.raises(AirflowException):
                 self.sensor.execute(None)
 
@@ -191,7 +190,7 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_FAILED_RETURN,
         ]
 
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             with pytest.raises(AirflowException):
                 self.sensor.execute(None)
 
@@ -201,6 +200,6 @@ class TestEmrStepSensor(unittest.TestCase):
             DESCRIBE_JOB_STEP_INTERRUPTED_RETURN,
         ]
 
-        with patch("boto3.session.Session", self.boto3_session_mock):
+        with mock.patch("boto3.session.Session", self.boto3_session_mock):
             with pytest.raises(AirflowException):
                 self.sensor.execute(None)

--- a/tests/providers/amazon/aws/sensors/test_glacier.py
+++ b/tests/providers/amazon/aws/sensors/test_glacier.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -29,8 +28,8 @@ SUCCEEDED = "Succeeded"
 IN_PROGRESS = "InProgress"
 
 
-class TestAmazonGlacierSensor(unittest.TestCase):
-    def setUp(self):
+class TestAmazonGlacierSensor:
+    def setup_method(self):
         self.op = GlacierJobOperationSensor(
             task_id="test_athena_sensor",
             aws_conn_id="aws_default",
@@ -63,7 +62,7 @@ class TestAmazonGlacierSensor(unittest.TestCase):
         assert "Sensor failed" in str(ctx.value)
 
 
-class TestSensorJobDescription(unittest.TestCase):
+class TestSensorJobDescription:
     def test_job_status_success(self):
         assert JobStatus.SUCCEEDED.value == SUCCEEDED
 

--- a/tests/providers/amazon/aws/sensors/test_glue.py
+++ b/tests/providers/amazon/aws/sensors/test_glue.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import ANY
 
@@ -28,8 +27,8 @@ from airflow.providers.amazon.aws.hooks.glue import GlueJobHook
 from airflow.providers.amazon.aws.sensors.glue import GlueJobSensor
 
 
-class TestGlueJobSensor(unittest.TestCase):
-    def setUp(self):
+class TestGlueJobSensor:
+    def setup_method(self):
         conf.load_test_config()
 
     @mock.patch.object(GlueJobHook, "print_job_logs")
@@ -142,7 +141,3 @@ class TestGlueJobSensor(unittest.TestCase):
                 filter_pattern="?ERROR ?Exception",
                 next_token=ANY,
             )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/providers/amazon/aws/sensors/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/sensors/test_glue_crawler.py
@@ -16,15 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.hooks.glue_crawler import GlueCrawlerHook
 from airflow.providers.amazon.aws.sensors.glue_crawler import GlueCrawlerSensor
 
 
-class TestGlueCrawlerSensor(unittest.TestCase):
-    def setUp(self):
+class TestGlueCrawlerSensor:
+    def setup_method(self):
         self.sensor = GlueCrawlerSensor(
             task_id="test_glue_crawler_sensor",
             crawler_name="aws_test_glue_crawler",
@@ -36,21 +35,17 @@ class TestGlueCrawlerSensor(unittest.TestCase):
     @mock.patch.object(GlueCrawlerHook, "get_crawler")
     def test_poke_success(self, mock_get_crawler):
         mock_get_crawler.return_value["LastCrawl"]["Status"] = "SUCCEEDED"
-        self.assertFalse(self.sensor.poke({}))
+        assert not self.sensor.poke({})
         mock_get_crawler.assert_called_once_with("aws_test_glue_crawler")
 
     @mock.patch.object(GlueCrawlerHook, "get_crawler")
     def test_poke_failed(self, mock_get_crawler):
         mock_get_crawler.return_value["LastCrawl"]["Status"] = "FAILED"
-        self.assertFalse(self.sensor.poke({}))
+        assert not self.sensor.poke({})
         mock_get_crawler.assert_called_once_with("aws_test_glue_crawler")
 
     @mock.patch.object(GlueCrawlerHook, "get_crawler")
     def test_poke_cancelled(self, mock_get_crawler):
         mock_get_crawler.return_value["LastCrawl"]["Status"] = "CANCELLED"
-        self.assertFalse(self.sensor.poke({}))
+        assert not self.sensor.poke({})
         mock_get_crawler.assert_called_once_with("aws_test_glue_crawler")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -17,11 +17,9 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
@@ -30,7 +28,7 @@ from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
 from airflow.utils import timezone
 
 
-class TestS3KeySensor(unittest.TestCase):
+class TestS3KeySensor:
     def test_bucket_name_none_and_bucket_key_as_relative_path(self):
         """
         Test if exception is raised when bucket_name is None
@@ -81,14 +79,15 @@ class TestS3KeySensor(unittest.TestCase):
         with pytest.raises(TypeError):
             op.poke(None)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "key, bucket, parsed_key, parsed_bucket",
         [
-            ["s3://bucket/key", None, "key", "bucket"],
-            ["key", "bucket", "key", "bucket"],
-        ]
+            pytest.param("s3://bucket/key", None, "key", "bucket", id="key as s3url"),
+            pytest.param("key", "bucket", "key", "bucket", id="separate bucket and key"),
+        ],
     )
     @mock.patch("airflow.providers.amazon.aws.sensors.s3.S3Hook.head_object")
-    def test_parse_bucket_key(self, key, bucket, parsed_key, parsed_bucket, mock_head_object):
+    def test_parse_bucket_key(self, mock_head_object, key, bucket, parsed_key, parsed_bucket):
         mock_head_object.return_value = None
 
         op = S3KeySensor(

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_base.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_base.py
@@ -17,15 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import pytest
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.sensors.sagemaker import SageMakerBaseSensor
 
 
-class TestSagemakerBaseSensor(unittest.TestCase):
+class TestSagemakerBaseSensor:
     def test_execute(self):
         class SageMakerBaseSensorSubclass(SageMakerBaseSensor):
             def non_terminal_states(self):

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_endpoint.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -55,7 +54,7 @@ DESCRIBE_ENDPOINT_UPDATING_RESPONSE = {
 }
 
 
-class TestSageMakerEndpointSensor(unittest.TestCase):
+class TestSageMakerEndpointSensor:
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "describe_endpoint")
     def test_sensor_with_failure(self, mock_describe, mock_get_conn):

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_training.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from datetime import datetime
 from unittest import mock
 
@@ -48,7 +47,7 @@ DESCRIBE_TRAINING_STOPPING_RESPONSE = dict(DESCRIBE_TRAINING_COMPLETED_RESPONSE)
 DESCRIBE_TRAINING_STOPPING_RESPONSE.update({"TrainingJobStatus": "Stopping"})
 
 
-class TestSageMakerTrainingSensor(unittest.TestCase):
+class TestSageMakerTrainingSensor:
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "__init__")
     @mock.patch.object(SageMakerHook, "describe_training_job")

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_transform.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -53,7 +52,7 @@ DESCRIBE_TRANSFORM_STOPPING_RESPONSE = {
 }
 
 
-class TestSageMakerTransformSensor(unittest.TestCase):
+class TestSageMakerTransformSensor:
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "describe_transform_job")
     def test_sensor_with_failure(self, mock_describe_job, mock_client):

--- a/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
+++ b/tests/providers/amazon/aws/sensors/test_sagemaker_tuning.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -56,7 +55,7 @@ DESCRIBE_TUNING_STOPPING_RESPONSE = {
 }
 
 
-class TestSageMakerTuningSensor(unittest.TestCase):
+class TestSageMakerTuningSensor:
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "describe_tuning_job")
     def test_sensor_with_failure(self, mock_describe_job, mock_client):

--- a/tests/providers/amazon/aws/sensors/test_sqs.py
+++ b/tests/providers/amazon/aws/sensors/test_sqs.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 import pytest
@@ -36,8 +35,8 @@ QUEUE_NAME = "test-queue"
 QUEUE_URL = f"https://{QUEUE_NAME}"
 
 
-class TestSqsSensor(unittest.TestCase):
-    def setUp(self):
+class TestSqsSensor:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         self.dag = DAG("test_dag_id", default_args=args)
@@ -161,11 +160,11 @@ class TestSqsSensor(unittest.TestCase):
         self.sqs_hook.create_queue(QUEUE_NAME)
         matching = [{"id": 11, "body": "a matching message"}]
         non_matching = [{"id": 12, "body": "a non-matching message"}]
-        all = matching + non_matching
+        all_options = matching + non_matching
 
         def mock_receive_message(**kwargs):
             messages = []
-            for message in all:
+            for message in all_options:
                 messages.append(
                     {
                         "MessageId": message["id"],
@@ -207,11 +206,11 @@ class TestSqsSensor(unittest.TestCase):
             {"id": 14, "key": {"nope": [5, 6]}},
             {"id": 15, "key": {"nope": [7, 8]}},
         ]
-        all = matching + non_matching
+        all_options = matching + non_matching
 
         def mock_receive_message(**kwargs):
             messages = []
-            for message in all:
+            for message in all_options:
                 messages.append(
                     {
                         "MessageId": message["id"],
@@ -254,11 +253,11 @@ class TestSqsSensor(unittest.TestCase):
             {"id": 22, "key": {"nope": [5, 6]}},
             {"id": 23, "key": {"nope": [7, 8]}},
         ]
-        all = matching + non_matching
+        all_options = matching + non_matching
 
         def mock_receive_message(**kwargs):
             messages = []
-            for message in all:
+            for message in all_options:
                 messages.append(
                     {
                         "MessageId": message["id"],

--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -18,14 +18,13 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest.mock import MagicMock, patch
 
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator
 
 
-class DynamodbToS3Test(unittest.TestCase):
-    def setUp(self):
+class TestDynamodbToS3:
+    def setup_method(self):
         self.output_queue = []
 
     def mock_upload_file(self, Filename, Bucket, Key):

--- a/tests/providers/amazon/aws/transfers/test_ftp_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_ftp_to_s3.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.transfers.ftp_to_s3 import FTPToS3Operator
@@ -32,9 +31,10 @@ S3_KEY_MULTIPLE = "test/"
 FTP_PATH_MULTIPLE = "/tmp/"
 
 
-class TestFTPToS3Operator(unittest.TestCase):
+class TestFTPToS3Operator:
+    @staticmethod
     def assert_execute(
-        self, mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file, ftp_file, s3_file
+        mock_local_tmp_file, mock_s3_hook_load_file, mock_ftp_hook_retrieve_file, ftp_file, s3_file
     ):
 
         mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value

--- a/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
+++ b/tests/providers/amazon/aws/transfers/test_glacier_to_gcs.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.amazon.aws.transfers.glacier_to_gcs import GlacierToGCSOperator
 
@@ -31,7 +31,7 @@ TASK_ID = "glacier_job"
 VAULT_NAME = "airflow"
 
 
-class TestGlacierToGCSOperator(TestCase):
+class TestGlacierToGCSOperator:
     @mock.patch("airflow.providers.amazon.aws.transfers.glacier_to_gcs.GlacierHook")
     @mock.patch("airflow.providers.amazon.aws.transfers.glacier_to_gcs.GCSHook")
     @mock.patch("airflow.providers.amazon.aws.transfers.glacier_to_gcs.tempfile")

--- a/tests/providers/amazon/aws/transfers/test_google_api_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_google_api_to_s3.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import Mock, patch
 
 import pytest
@@ -29,8 +28,8 @@ from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS
 from airflow.utils import db
 
 
-class TestGoogleApiToS3(unittest.TestCase):
-    def setUp(self):
+class TestGoogleApiToS3:
+    def setup_method(self):
         conf.load_test_config()
 
         db.merge_conn(

--- a/tests/providers/amazon/aws/transfers/test_hive_to_dynamodb.py
+++ b/tests/providers/amazon/aws/transfers/test_hive_to_dynamodb.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import datetime
 import json
-import unittest
 from unittest import mock
 
 import pandas as pd
@@ -34,8 +33,8 @@ DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
 
 
-class TestHiveToDynamoDBOperator(unittest.TestCase):
-    def setUp(self):
+class TestHiveToDynamoDBOperator:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         dag = DAG("test_dag_id", default_args=args)
         self.dag = dag

--- a/tests/providers/amazon/aws/transfers/test_imap_attachment_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_imap_attachment_to_s3.py
@@ -17,14 +17,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from airflow.providers.amazon.aws.transfers.imap_attachment_to_s3 import ImapAttachmentToS3Operator
 
 
-class TestImapAttachmentToS3Operator(unittest.TestCase):
-    def setUp(self):
+class TestImapAttachmentToS3Operator:
+    def setup_method(self):
         self.kwargs = dict(
             imap_attachment_name="test_file",
             s3_bucket="test_bucket",

--- a/tests/providers/amazon/aws/transfers/test_local_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_local_to_s3.py
@@ -19,20 +19,20 @@ from __future__ import annotations
 
 import datetime
 import os
-import unittest
 
 import boto3
+import pytest
 from moto import mock_s3
 
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.transfers.local_to_s3 import LocalFilesystemToS3Operator
 
 
-class TestFileToS3Operator(unittest.TestCase):
+class TestFileToS3Operator:
 
     _config = {"verify": False, "replace": False, "encrypt": False, "gzip": False}
 
-    def setUp(self):
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": datetime.datetime(2017, 1, 1)}
         self.dag = DAG("test_dag_id", default_args=args)
         self.dest_key = "test/test1.csv"
@@ -41,7 +41,7 @@ class TestFileToS3Operator(unittest.TestCase):
         with open(self.testfile1, "wb") as f:
             f.write(b"x" * 393216)
 
-    def tearDown(self):
+    def teardown_method(self):
         os.remove(self.testfile1)
 
     def test_init(self):
@@ -70,7 +70,7 @@ class TestFileToS3Operator(unittest.TestCase):
             dest_bucket=self.dest_bucket,
             **self._config,
         )
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError, match=r"dest_key should be a relative path from root level"):
             operator.execute(None)
 
     @mock_s3

--- a/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.models import DAG, DagRun, TaskInstance
@@ -40,8 +39,8 @@ MOCK_MONGO_RETURN = [
 ]
 
 
-class TestMongoToS3Operator(unittest.TestCase):
-    def setUp(self):
+class TestMongoToS3Operator:
+    def setup_method(self):
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
 
         self.dag = DAG("test_dag_id", default_args=args)

--- a/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
@@ -17,37 +17,36 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
+import pytest
 from boto3.session import Session
-from parameterized import parameterized
 
 from airflow.models.connection import Connection
 from airflow.providers.amazon.aws.transfers.redshift_to_s3 import RedshiftToS3Operator
 from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
+TABLE_AS_FILE_NAME_TEST_CASES = [
+    pytest.param(True, "key/table_", id="table as filename True"),
+    pytest.param(False, "key", id="table as filename False"),
+]
 
-class TestRedshiftToS3Transfer(unittest.TestCase):
-    @parameterized.expand(
-        [
-            [True, "key/table_"],
-            [False, "key"],
-        ]
-    )
+
+class TestRedshiftToS3Transfer:
+    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", TABLE_AS_FILE_NAME_TEST_CASES)
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
     def test_table_unloading(
         self,
-        table_as_file_name,
-        expected_s3_key,
         mock_run,
         mock_session,
         mock_connection,
         mock_hook,
+        table_as_file_name,
+        expected_s3_key,
     ):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -92,26 +91,21 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert access_key in unload_query
         assert secret_key in unload_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], unload_query)
 
-    @parameterized.expand(
-        [
-            [True, "key/table_"],
-            [False, "key"],
-        ]
-    )
+    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", TABLE_AS_FILE_NAME_TEST_CASES)
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
     def test_execute_sts_token(
         self,
-        table_as_file_name,
-        expected_s3_key,
         mock_run,
         mock_session,
         mock_connection,
         mock_hook,
+        table_as_file_name,
+        expected_s3_key,
     ):
         access_key = "ASIA_aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -158,15 +152,16 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
         assert access_key in unload_query
         assert secret_key in unload_query
         assert token in unload_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], unload_query)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "table, table_as_file_name, expected_s3_key",
         [
-            ["table", True, "key/table_"],
-            ["table", False, "key"],
-            [None, False, "key"],
-            [None, True, "key"],
-        ]
+            ("table", True, "key/table_"),
+            ("table", False, "key"),
+            (None, False, "key"),
+            (None, True, "key"),
+        ],
     )
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -174,13 +169,13 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
     def test_custom_select_query_unloading(
         self,
-        table,
-        table_as_file_name,
-        expected_s3_key,
         mock_run,
         mock_session,
         mock_connection,
         mock_hook,
+        table,
+        table_as_file_name,
+        expected_s3_key,
     ):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -223,26 +218,21 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert access_key in unload_query
         assert secret_key in unload_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], unload_query)
 
-    @parameterized.expand(
-        [
-            [True, "key/table_"],
-            [False, "key"],
-        ]
-    )
+    @pytest.mark.parametrize("table_as_file_name, expected_s3_key", TABLE_AS_FILE_NAME_TEST_CASES)
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
     @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.RedshiftSQLHook.run")
     def test_table_unloading_role_arn(
         self,
-        table_as_file_name,
-        expected_s3_key,
         mock_run,
         mock_session,
         mock_connection,
         mock_hook,
+        table_as_file_name,
+        expected_s3_key,
     ):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -287,7 +277,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
 
         assert mock_run.call_count == 1
         assert extra["role_arn"] in unload_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], unload_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], unload_query)
 
     def test_template_fields_overrides(self):
         assert RedshiftToS3Operator.template_fields == (

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.amazon.aws.transfers.s3_to_ftp import S3ToFTPOperator
@@ -30,7 +29,7 @@ AWS_CONN_ID = "aws_default"
 FTP_CONN_ID = "ftp_default"
 
 
-class TestS3ToFTPOperator(unittest.TestCase):
+class TestS3ToFTPOperator:
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.store_file")
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_key")
     @mock.patch("airflow.providers.amazon.aws.transfers.s3_to_ftp.NamedTemporaryFile")

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -29,7 +28,7 @@ from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOp
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 
-class TestS3ToRedshiftTransfer(unittest.TestCase):
+class TestS3ToRedshiftTransfer:
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
@@ -73,7 +72,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], copy_query)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -120,7 +119,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], copy_query)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -170,7 +169,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, "\n".join(mock_run.call_args[0][0]), transaction)
+        assert_equal_ignore_multiple_spaces(None, "\n".join(mock_run.call_args[0][0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -225,7 +224,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     INSERT INTO {schema}.{table} SELECT * FROM #{table};
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, "\n".join(mock_run.call_args[0][0]), transaction)
+        assert_equal_ignore_multiple_spaces(None, "\n".join(mock_run.call_args[0][0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -274,7 +273,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
         assert secret_key in copy_statement
         assert token in copy_statement
         assert mock_run.call_count == 1
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_statement)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], copy_statement)
 
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
@@ -322,7 +321,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
 
         assert extra["role_arn"] in copy_statement
         assert mock_run.call_count == 1
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_statement)
+        assert_equal_ignore_multiple_spaces(None, mock_run.call_args[0][0], copy_statement)
 
     def test_template_fields_overrides(self):
         assert S3ToRedshiftOperator.template_fields == (

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -17,8 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import boto3
 from moto import mock_s3
 
@@ -42,9 +40,9 @@ TEST_DAG_ID = "unit_tests_s3_to_sftp"
 DEFAULT_DATE = datetime(2018, 1, 1)
 
 
-class TestS3ToSFTPOperator(unittest.TestCase):
-    @mock_s3
-    def setUp(self):
+@mock_s3
+class TestS3ToSFTPOperator:
+    def setup_method(self, method):
         from airflow.providers.amazon.aws.hooks.s3 import S3Hook
         from airflow.providers.ssh.hooks.ssh import SSHHook
 
@@ -68,7 +66,6 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         self.sftp_path = SFTP_PATH
         self.s3_key = S3_KEY
 
-    @mock_s3
     @conf_vars({("core", "enable_xcom_pickling"): "True"})
     def test_s3_to_sftp_operation(self):
         # Setting
@@ -124,7 +121,7 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         conn.delete_bucket(Bucket=self.s3_bucket)
         assert not self.s3_hook.check_for_bucket(self.s3_bucket)
 
-    def delete_remote_resource(self):
+    def teardown_method(self, method):
         # check the remote file content
         remove_file_task = SSHOperator(
             task_id="test_rm_file",
@@ -135,6 +132,3 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         )
         assert remove_file_task is not None
         remove_file_task.execute(None)
-
-    def tearDown(self):
-        self.delete_remote_resource()

--- a/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from collections import OrderedDict
 from unittest import mock
 
@@ -55,7 +54,7 @@ REPLACE = ENCRYPT = GZIP = False
 ACL_POLICY = None
 
 
-class TestSalesforceToGcsOperator(unittest.TestCase):
+class TestSalesforceToGcsOperator:
     @mock.patch.object(S3Hook, "load_file")
     @mock.patch.object(SalesforceHook, "write_object_to_file")
     @mock.patch.object(SalesforceHook, "make_query")

--- a/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
@@ -17,11 +17,9 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
-
 import boto3
+import pytest
 from moto import mock_s3
-from parameterized import parameterized
 
 from airflow.models import DAG
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -44,9 +42,9 @@ TEST_DAG_ID = "unit_tests_sftp_tos3_op"
 DEFAULT_DATE = datetime(2018, 1, 1)
 
 
-class TestSFTPToS3Operator(unittest.TestCase):
-    @mock_s3
-    def setUp(self):
+@mock_s3
+class TestSFTPToS3Operator:
+    def setup_method(self, method):
         hook = SSHHook(ssh_conn_id="ssh_default")
 
         s3_hook = S3Hook("aws_default")
@@ -68,15 +66,9 @@ class TestSFTPToS3Operator(unittest.TestCase):
         self.sftp_path = SFTP_PATH
         self.s3_key = S3_KEY
 
-    @parameterized.expand(
-        [
-            (True,),
-            (False,),
-        ]
-    )
-    @mock_s3
+    @pytest.mark.parametrize("use_temp_file", [True, False])
     @conf_vars({("core", "enable_xcom_pickling"): "True"})
-    def test_sftp_to_s3_operation(self, use_temp_file=True):
+    def test_sftp_to_s3_operation(self, use_temp_file):
         # Setting
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "

--- a/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sql_to_s3.py
@@ -17,19 +17,17 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
 import pandas as pd
 import pytest
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.transfers.sql_to_s3 import SqlToS3Operator
 
 
-class TestSqlToS3Operator(unittest.TestCase):
+class TestSqlToS3Operator:
     @mock.patch("airflow.providers.amazon.aws.transfers.sql_to_s3.NamedTemporaryFile")
     @mock.patch("airflow.providers.amazon.aws.transfers.sql_to_s3.S3Hook")
     def test_execute_csv(self, mock_s3_hook, temp_mock):
@@ -146,13 +144,14 @@ class TestSqlToS3Operator(unittest.TestCase):
                 replace=True,
             )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "params",
         [
-            ("with-csv", {"file_format": "csv", "null_string_result": None}),
-            ("with-parquet", {"file_format": "parquet", "null_string_result": "None"}),
-        ]
+            pytest.param({"file_format": "csv", "null_string_result": None}, id="with-csv"),
+            pytest.param({"file_format": "parquet", "null_string_result": "None"}, id="with-parquet"),
+        ],
     )
-    def test_fix_dtypes(self, _, params):
+    def test_fix_dtypes(self, params):
         op = SqlToS3Operator(
             query="query",
             s3_bucket="s3_bucket",

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -17,14 +17,14 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 
 from airflow.providers.amazon.aws.utils.emailer import send_email
 
 
-class TestSendEmailSes(TestCase):
+class TestSendEmailSes:
     @mock.patch("airflow.providers.amazon.aws.utils.emailer.SesHook")
     def test_send_ses_email(self, mock_hook):
         send_email(

--- a/tests/providers/amazon/aws/utils/test_redshift.py
+++ b/tests/providers/amazon/aws/utils/test_redshift.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from boto3.session import Session
@@ -25,7 +24,7 @@ from boto3.session import Session
 from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
 
 
-class TestS3ToRedshiftTransfer(unittest.TestCase):
+class TestS3ToRedshiftTransfer:
     @mock.patch("boto3.session.Session")
     def test_build_credentials_block(self, mock_session):
         access_key = "aws_access_key_id"

--- a/tests/providers/amazon/aws/utils/test_utils.py
+++ b/tests/providers/amazon/aws/utils/test_utils.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest import TestCase
 
 import pytz
 
@@ -33,7 +32,7 @@ DT = datetime(2000, 1, 1, tzinfo=pytz.UTC)
 EPOCH = 946_684_800
 
 
-class TestUtils(TestCase):
+class TestUtils:
     def test_trim_none_values(self):
         input_object = {
             "test": "test",


### PR DESCRIPTION
Migrate Amazon provider's tests to `pytest`.

All changes are more or less straightforward:
- Get rid of `unittests.TestCase` class and **TestCase.assert*** methods
- Replace decorator `parameterized.expand` by `pytest.mark.parametrize`. I
- replace `requests_mock.mock` decorator by `requests_mock` fixture
- Convert `TestCase.subTest` to parametrize tests  
- Convert classes **setUp*** and **tearDown*** to [appropriate pytest methods](https://docs.pytest.org/en/6.2.x/xunit_setup.html#classic-xunit-style-setup)

_See additional findings, info about significant changes and potential follow up in comments_