### PR TITLE
Experiment: Run static checks and postgres tests before all else

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -221,7 +221,7 @@ jobs:
       Build PROD images
       ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: ${{ needs.build-info.outputs.runs-on }}
-    needs: [build-info, build-ci-images]
+    needs: [build-info, build-ci-images, tests-postgres]
     if: |
       needs.build-info.outputs.image-build == 'true' &&
       github.event.pull_request.head.repo.full_name != 'apache/airflow'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     needs:
       - build-info
+      - tests-postgres
     strategy:
       fail-fast: false
       matrix:
@@ -304,6 +305,7 @@ jobs:
     needs:
       - build-info
       - push-early-buildx-cache-to-github-registry
+      - tests-postgres
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       UPGRADE_TO_NEWER_DEPENDENCIES: false
@@ -402,7 +404,7 @@ jobs:
     timeout-minutes: 10
     name: Breeze unit tests
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info]
+    needs: [build-info, tests-postgres]
     steps:
       - name: Cleanup repo
         run: docker run -v "${GITHUB_WORKSPACE}:/workspace" -u 0:0 bash -c "rm -rf /workspace/*"
@@ -422,7 +424,7 @@ jobs:
     timeout-minutes: 10
     name: React WWW tests
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info]
+    needs: [build-info, tests-postgres]
     if: needs.build-info.outputs.run-www-tests == 'true'
     steps:
       - name: Cleanup repo
@@ -450,7 +452,7 @@ jobs:
     timeout-minutes: 10
     name: "Test OpenAPI client generation"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info]
+    needs: [build-info, tests-postgres]
     if: needs.build-info.outputs.needs-api-codegen == 'true'
     steps:
       - name: Cleanup repo
@@ -467,7 +469,7 @@ jobs:
     timeout-minutes: 60
     name: "Test examples of production image building"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info]
+    needs: [build-info, tests-postgres]
     if: needs.build-info.outputs.image-build == 'true'
     steps:
       - name: Cleanup repo
@@ -492,7 +494,7 @@ jobs:
     timeout-minutes: 5
     name: "Test git clone on Windows"
     runs-on: windows-latest
-    needs: [build-info]
+    needs: [build-info, tests-postgres]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v3
@@ -627,7 +629,7 @@ jobs:
     timeout-minutes: 45
     name: "Build docs"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     if: needs.build-info.outputs.docs-build == 'true'
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
@@ -675,7 +677,7 @@ jobs:
     timeout-minutes: 80
     name: "Provider packages ${{matrix.package-format}}"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     strategy:
       matrix:
         package-format: ["sdist", "wheel"]
@@ -741,7 +743,7 @@ jobs:
     timeout-minutes: 80
     name: "Python unit tests for Helm chart"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       TEST_TYPES: "Helm"
@@ -817,7 +819,7 @@ jobs:
     name: >
       MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     strategy:
       matrix:
         python-version: "${{fromJson(needs.build-info.outputs.python-versions)}}"
@@ -858,7 +860,7 @@ jobs:
     name: >
       MSSQL${{matrix.mssql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     strategy:
       matrix:
         python-version: "${{fromJson(needs.build-info.outputs.python-versions)}}"
@@ -900,7 +902,7 @@ jobs:
     name: >
       Sqlite Py${{matrix.python-version}}: ${{needs.build-info.outputs.test-types}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.python-versions) }}
@@ -940,7 +942,7 @@ jobs:
     name: "Quarantined tests"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
     continue-on-error: true
-    needs: [build-info, wait-for-ci-images]
+    needs: [build-info, wait-for-ci-images, tests-postgres]
     env:
       RUNS_ON: "${{needs.build-info.outputs.runs-on}}"
       TEST_TYPES: "Quarantined"
@@ -1041,7 +1043,7 @@ jobs:
     timeout-minutes: 60
     name: "Test docker-compose quick start"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-prod-images]
+    needs: [build-info, wait-for-prod-images, tests-postgres]
     if: needs.build-info.outputs.image-build == 'true'
     env:
       PYTHON_MAJOR_MINOR_VERSION: "${{needs.build-info.outputs.default-python-version}}"
@@ -1068,7 +1070,7 @@ jobs:
     timeout-minutes: 240
     name: "Helm: ${{matrix.executor}} - ${{needs.build-info.outputs.kubernetes-versions-list-as-string}}"
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, wait-for-prod-images]
+    needs: [build-info, wait-for-prod-images, tests-postgres]
     strategy:
       matrix:
         executor: [KubernetesExecutor, CeleryExecutor, LocalExecutor]
@@ -1210,6 +1212,7 @@ jobs:
       - build-info
       - constraints
       - docs
+      - tests-postgres
     if: needs.build-info.outputs.canary-run == 'true'
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
       ${{needs.build-info.outputs.build-job-description}} PROD images
       ${{needs.build-info.outputs.all-python-versions-list-as-string}}
     runs-on: "${{needs.build-info.outputs.runs-on}}"
-    needs: [build-info, build-ci-images]
+    needs: [build-info, build-ci-images, tests-postgres]
     env:
       DEFAULT_BRANCH: ${{ needs.build-info.outputs.default-branch }}
       DEFAULT_CONSTRAINTS_BRANCH: ${{ needs.build-info.outputs.default-constraints-branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,8 +780,8 @@ jobs:
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
-        python-version: "${{fromJson(needs.build-info.outputs.python-versions)}}"
-        postgres-version: "${{fromJson(needs.build-info.outputs.postgres-versions)}}"
+        python-version: "3.7"
+        postgres-version: "11"
         exclude: "${{fromJson(needs.build-info.outputs.postgres-exclude)}}"
       fail-fast: false
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,8 +780,8 @@ jobs:
     needs: [build-info, wait-for-ci-images]
     strategy:
       matrix:
-        python-version: "3.7"
-        postgres-version: "11"
+        python-version: ["3.7"]
+        postgres-version: ["11"]
         exclude: "${{fromJson(needs.build-info.outputs.postgres-exclude)}}"
       fail-fast: false
     env:

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -166,6 +166,7 @@ class TestDagRunEndpoint:
 
 class TestDeleteDagRun(TestDagRunEndpoint):
     def test_should_respond_204(self, session):
+        assert False
         session.add_all(self._create_test_dag_run())
         session.commit()
         response = self.client.delete(


### PR DESCRIPTION
This ~should~ may (?) allow for faster failure / iteration time on non-hosted runners.
