### PR TITLE
Add Zendesk connection type

### DIFF
--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -47,3 +47,7 @@ hooks:
   - integration-name: Zendesk
     python-modules:
       - airflow.providers.zendesk.hooks.zendesk
+      
+connection-types:
+  - hook-class-name: airflow.providers.zendesk.hooks.zendesk.ZendeskHook
+    connection-type: zendesk

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -47,6 +47,7 @@ hooks:
   - integration-name: Zendesk
     python-modules:
       - airflow.providers.zendesk.hooks.zendesk
+
 connection-types:
   - hook-class-name: airflow.providers.zendesk.hooks.zendesk.ZendeskHook
     connection-type: zendesk

--- a/airflow/providers/zendesk/provider.yaml
+++ b/airflow/providers/zendesk/provider.yaml
@@ -47,7 +47,6 @@ hooks:
   - integration-name: Zendesk
     python-modules:
       - airflow.providers.zendesk.hooks.zendesk
-      
 connection-types:
   - hook-class-name: airflow.providers.zendesk.hooks.zendesk.ZendeskHook
     connection-type: zendesk


### PR DESCRIPTION
Zendesk connection doesn't show up in the Airflow UI (with provider `apache-airflow-providers-zendesk` installed).

![image](https://user-images.githubusercontent.com/97064715/204519526-5834a39f-d4ac-41ff-9cbb-59ce6dbade8c.png)

