### PR TITLE
Replace `unittests` in google provider tests by pure `pytest` (Part 1)

### DIFF
--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -21,7 +21,6 @@ from unittest import mock
 import pytest
 from flask_login import current_user
 from google.auth.exceptions import GoogleAuthError
-from parameterized import parameterized
 
 from airflow.www.app import create_app
 from tests.test_utils.config import conf_vars
@@ -79,9 +78,9 @@ class TestGoogleOpenID:
         assert 200 == response.status_code
         assert "Default pool" in str(response.json)
 
-    @parameterized.expand([("bearer",), ("JWT_TOKEN",), ("bearer ",)])
+    @pytest.mark.parametrize("auth_header", ["bearer", "JWT_TOKEN", "bearer "])
     @mock.patch("google.oauth2.id_token.verify_token")
-    def test_malformed_headers(self, auth_header, mock_verify_token):
+    def test_malformed_headers(self, mock_verify_token, auth_header):
         mock_verify_token.return_value = {
             "iss": "accounts.google.com",
             "email_verified": True,

--- a/tests/providers/google/common/hooks/test_discovery_api.py
+++ b/tests/providers/google/common/hooks/test_discovery_api.py
@@ -17,18 +17,17 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import call, patch
 
 from airflow import models
-from airflow.configuration import load_test_config
+from airflow.configuration import conf
 from airflow.providers.google.common.hooks.discovery_api import GoogleDiscoveryApiHook
 from airflow.utils import db
 
 
-class TestGoogleDiscoveryApiHook(unittest.TestCase):
-    def setUp(self):
-        load_test_config()
+class TestGoogleDiscoveryApiHook:
+    def setup_method(self):
+        conf.load_test_config()
 
         db.merge_conn(
             models.Connection(

--- a/tests/providers/google/common/utils/test_id_token_credentials.py
+++ b/tests/providers/google/common/utils/test_id_token_credentials.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import unittest
 from unittest import mock
 
 import pytest
@@ -32,7 +31,7 @@ from airflow.providers.google.common.utils.id_token_credentials import (
 )
 
 
-class TestIDTokenCredentialsAdapter(unittest.TestCase):
+class TestIDTokenCredentialsAdapter:
     def test_should_use_id_token_from_parent_credentials(self):
         parent_credentials = mock.MagicMock()
         type(parent_credentials).id_token = mock.PropertyMock(side_effect=["ID_TOKEN1", "ID_TOKEN2"])
@@ -46,7 +45,7 @@ class TestIDTokenCredentialsAdapter(unittest.TestCase):
         assert creds.token == "ID_TOKEN2"
 
 
-class TestGetDefaultIdTokenCredentials(unittest.TestCase):
+class TestGetDefaultIdTokenCredentials:
     @mock.patch.dict("os.environ")
     @mock.patch(
         "google.auth._cloud_sdk.get_application_default_credentials_path",

--- a/tests/providers/google/firebase/hooks/test_firestore.py
+++ b/tests/providers/google/firebase/hooks/test_firestore.py
@@ -19,7 +19,6 @@ Tests for Google Cloud Firestore
 """
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -47,10 +46,10 @@ TEST_ERROR_OPERATION = {"done": True, "response": "response", "error": "error"}
 TEST_PROJECT_ID = "firestore--project-id"
 
 
-class TestCloudFirestoreHookWithPassedProjectId(unittest.TestCase):
+class TestCloudFirestoreHookWithPassedProjectId:
     hook: CloudFirestoreHook | None = None
 
-    def setUp(self):
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -126,10 +125,10 @@ class TestCloudFirestoreHookWithPassedProjectId(unittest.TestCase):
             self.hook.export_documents(body=EXPORT_DOCUMENT_BODY, project_id=TEST_PROJECT_ID)
 
 
-class TestCloudFirestoreHookWithDefaultProjectIdFromConnection(unittest.TestCase):
+class TestCloudFirestoreHookWithDefaultProjectIdFromConnection:
     hook: CloudFirestoreHook | None = None
 
-    def setUp(self):
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -220,10 +219,10 @@ class TestCloudFirestoreHookWithDefaultProjectIdFromConnection(unittest.TestCase
             self.hook.export_documents(body=EXPORT_DOCUMENT_BODY)
 
 
-class TestCloudFirestoreHookWithoutProjectId(unittest.TestCase):
+class TestCloudFirestoreHookWithoutProjectId:
     hook: CloudFirestoreHook | None = None
 
-    def setUp(self):
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/firebase/operators/test_firestore.py
+++ b/tests/providers/google/firebase/operators/test_firestore.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.firebase.operators.firestore import CloudFirestoreExportDatabaseOperator
@@ -30,7 +29,7 @@ EXPORT_DOCUMENT_BODY = {
 }
 
 
-class TestCloudFirestoreExportDatabaseOperator(unittest.TestCase):
+class TestCloudFirestoreExportDatabaseOperator:
     @mock.patch("airflow.providers.google.firebase.operators.firestore.CloudFirestoreHook")
     def test_execute(self, mock_firestore_hook):
         op = CloudFirestoreExportDatabaseOperator(

--- a/tests/providers/google/leveldb/hooks/test_leveldb.py
+++ b/tests/providers/google/leveldb/hooks/test_leveldb.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -25,7 +24,7 @@ import pytest
 from airflow.providers.google.leveldb.hooks.leveldb import LevelDBHook, LevelDBHookException
 
 
-class TestLevelDBHook(unittest.TestCase):
+class TestLevelDBHook:
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
     def test_get_conn_db_is_not_none(self):
         """Test get_conn method of hook"""

--- a/tests/providers/google/leveldb/operators/test_leveldb.py
+++ b/tests/providers/google/leveldb/operators/test_leveldb.py
@@ -33,14 +33,13 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.leveldb.hooks.leveldb import LevelDBHook
 from airflow.providers.google.leveldb.operators.leveldb import LevelDBOperator
 
 
-class TestLevelDBOperator(unittest.TestCase):
+class TestLevelDBOperator:
     @mock.patch.dict("os.environ", AIRFLOW_CONN_LEVELDB_DEFAULT="test")
     @mock.patch.object(LevelDBHook, "run")
     def test_execute(self, mock_run):

--- a/tests/providers/google/marketing_platform/hooks/test_analytics.py
+++ b/tests/providers/google/marketing_platform/hooks/test_analytics.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.marketing_platform.hooks.analytics import GoogleAnalyticsHook
@@ -33,8 +32,8 @@ DELEGATE_TO = "TEST_DELEGATE_TO"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestGoogleAnalyticsHook(unittest.TestCase):
-    def setUp(self):
+class TestGoogleAnalyticsHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/marketing_platform/hooks/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/hooks/test_campaign_manager.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.hooks.campaign_manager import GoogleCampaignManagerHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
@@ -32,8 +32,8 @@ ENCRYPTION_ENTITY_TYPE = "encryption_entity_type"
 ENCRYPTION_ENTITY_ID = 1234567
 
 
-class TestGoogleCampaignManagerHook(TestCase):
-    def setUp(self):
+class TestGoogleCampaignManagerHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/marketing_platform/hooks/test_display_video.py
+++ b/tests/providers/google/marketing_platform/hooks/test_display_video.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.hooks.display_video import GoogleDisplayVideo360Hook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
@@ -26,8 +26,8 @@ API_VERSION = "v1"
 GCP_CONN_ID = "google_cloud_default"
 
 
-class TestGoogleDisplayVideo360Hook(TestCase):
-    def setUp(self):
+class TestGoogleDisplayVideo360Hook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/marketing_platform/hooks/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/hooks/test_search_ads.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.hooks.search_ads import GoogleSearchAdsHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
@@ -26,8 +26,8 @@ API_VERSION = "v2"
 GCP_CONN_ID = "google_cloud_default"
 
 
-class TestSearchAdsHook(TestCase):
-    def setUp(self):
+class TestSearchAdsHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.marketing_platform.hooks.search_ads.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/marketing_platform/operators/test_analytics.py
+++ b/tests/providers/google/marketing_platform/operators/test_analytics.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from tempfile import NamedTemporaryFile
 from unittest import mock
 
@@ -40,7 +39,7 @@ BUCKET = "gs://bucket"
 BUCKET_OBJECT_NAME = "file.csv"
 
 
-class TestGoogleAnalyticsListAccountsOperator(unittest.TestCase):
+class TestGoogleAnalyticsListAccountsOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.GoogleAnalyticsHook")
     def test_execute(self, hook_mock):
         op = GoogleAnalyticsListAccountsOperator(
@@ -54,7 +53,7 @@ class TestGoogleAnalyticsListAccountsOperator(unittest.TestCase):
         hook_mock.return_value.list_accounts.assert_called_once()
 
 
-class TestGoogleAnalyticsRetrieveAdsLinksListOperator(unittest.TestCase):
+class TestGoogleAnalyticsRetrieveAdsLinksListOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.GoogleAnalyticsHook")
     def test_execute(self, hook_mock):
         op = GoogleAnalyticsRetrieveAdsLinksListOperator(
@@ -78,7 +77,7 @@ class TestGoogleAnalyticsRetrieveAdsLinksListOperator(unittest.TestCase):
         )
 
 
-class TestGoogleAnalyticsGetAdsLinkOperator(unittest.TestCase):
+class TestGoogleAnalyticsGetAdsLinkOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.GoogleAnalyticsHook")
     def test_execute(self, hook_mock):
         op = GoogleAnalyticsGetAdsLinkOperator(
@@ -105,7 +104,7 @@ class TestGoogleAnalyticsGetAdsLinkOperator(unittest.TestCase):
         )
 
 
-class TestGoogleAnalyticsDataImportUploadOperator(unittest.TestCase):
+class TestGoogleAnalyticsDataImportUploadOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.GoogleAnalyticsHook")
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.GCSHook")
     @mock.patch("airflow.providers.google.marketing_platform.operators.analytics.NamedTemporaryFile")

--- a/tests/providers/google/marketing_platform/operators/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/operators/test_campaign_manager.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import json
 from tempfile import NamedTemporaryFile
-from unittest import TestCase, mock
+from unittest import mock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.models import DAG, TaskInstance as TI
 from airflow.providers.google.marketing_platform.operators.campaign_manager import (
@@ -62,7 +62,7 @@ REPORT_NAME = "test_report.csv"
 TEMP_FILE_NAME = "test"
 
 
-class TestGoogleCampaignManagerDeleteReportOperator(TestCase):
+class TestGoogleCampaignManagerDeleteReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.campaign_manager.GoogleCampaignManagerHook"
     )
@@ -86,12 +86,12 @@ class TestGoogleCampaignManagerDeleteReportOperator(TestCase):
         )
 
 
-class TestGoogleCampaignManagerDownloadReportOperator(TestCase):
-    def setUp(self):
+class TestGoogleCampaignManagerDownloadReportOperator:
+    def setup_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
-    def tearDown(self):
+    def teardown_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
@@ -153,7 +153,10 @@ class TestGoogleCampaignManagerDownloadReportOperator(TestCase):
         )
         xcom_mock.assert_called_once_with(None, key="report_name", value=REPORT_NAME + ".gz")
 
-    @parameterized.expand([BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"])
+    @pytest.mark.parametrize(
+        "test_bucket_name",
+        [BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"],
+    )
     @mock.patch("airflow.providers.google.marketing_platform.operators.campaign_manager.http")
     @mock.patch("airflow.providers.google.marketing_platform.operators.campaign_manager.tempfile")
     @mock.patch(
@@ -162,11 +165,11 @@ class TestGoogleCampaignManagerDownloadReportOperator(TestCase):
     @mock.patch("airflow.providers.google.marketing_platform.operators.campaign_manager.GCSHook")
     def test_set_bucket_name(
         self,
-        test_bucket_name,
         gcs_hook_mock,
         hook_mock,
         tempfile_mock,
         http_mock,
+        test_bucket_name,
     ):
         http_mock.MediaIoBaseDownload.return_value.next_chunk.return_value = (
             None,
@@ -211,7 +214,7 @@ class TestGoogleCampaignManagerDownloadReportOperator(TestCase):
         )
 
 
-class TestGoogleCampaignManagerInsertReportOperator(TestCase):
+class TestGoogleCampaignManagerInsertReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.campaign_manager.GoogleCampaignManagerHook"
     )
@@ -258,7 +261,7 @@ class TestGoogleCampaignManagerInsertReportOperator(TestCase):
         assert op.report == report
 
 
-class TestGoogleCampaignManagerRunReportOperator(TestCase):
+class TestGoogleCampaignManagerRunReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.campaign_manager.GoogleCampaignManagerHook"
     )
@@ -292,7 +295,7 @@ class TestGoogleCampaignManagerRunReportOperator(TestCase):
         xcom_mock.assert_called_once_with(None, key="file_id", value=FILE_ID)
 
 
-class TestGoogleCampaignManagerBatchInsertConversionsOperator(TestCase):
+class TestGoogleCampaignManagerBatchInsertConversionsOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.campaign_manager.GoogleCampaignManagerHook"
     )
@@ -317,7 +320,7 @@ class TestGoogleCampaignManagerBatchInsertConversionsOperator(TestCase):
         )
 
 
-class TestGoogleCampaignManagerBatchUpdateConversionOperator(TestCase):
+class TestGoogleCampaignManagerBatchUpdateConversionOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.campaign_manager.GoogleCampaignManagerHook"
     )

--- a/tests/providers/google/marketing_platform/operators/test_display_video.py
+++ b/tests/providers/google/marketing_platform/operators/test_display_video.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import json
 from tempfile import NamedTemporaryFile
-from unittest import TestCase, mock
+from unittest import mock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.models import DAG, TaskInstance as TI
 from airflow.providers.google.marketing_platform.operators.display_video import (
@@ -50,7 +50,7 @@ QUERY_ID = FILENAME = "test"
 OBJECT_NAME = "object_name"
 
 
-class TestGoogleDisplayVideo360CreateReportOperator(TestCase):
+class TestGoogleDisplayVideo360CreateReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators."
         "display_video.GoogleDisplayVideo360CreateReportOperator.xcom_push"
@@ -88,7 +88,7 @@ class TestGoogleDisplayVideo360CreateReportOperator(TestCase):
         assert op.body == body
 
 
-class TestGoogleDisplayVideo360DeleteReportOperator(TestCase):
+class TestGoogleDisplayVideo360DeleteReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
     )
@@ -106,12 +106,12 @@ class TestGoogleDisplayVideo360DeleteReportOperator(TestCase):
         hook_mock.return_value.delete_query.assert_called_once_with(query_id=QUERY_ID)
 
 
-class TestGoogleDisplayVideo360DownloadReportOperator(TestCase):
-    def setUp(self):
+class TestGoogleDisplayVideo360DownloadReportOperator:
+    def setup_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
-    def tearDown(self):
+    def teardown_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
@@ -172,7 +172,10 @@ class TestGoogleDisplayVideo360DownloadReportOperator(TestCase):
         )
         mock_xcom.assert_called_once_with(None, key="report_name", value=REPORT_NAME + ".gz")
 
-    @parameterized.expand([BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"])
+    @pytest.mark.parametrize(
+        "test_bucket_name",
+        [BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"],
+    )
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.shutil")
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.urllib.request")
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.tempfile")
@@ -182,12 +185,12 @@ class TestGoogleDisplayVideo360DownloadReportOperator(TestCase):
     )
     def test_set_bucket_name(
         self,
-        test_bucket_name,
         mock_hook,
         mock_gcs_hook,
         mock_temp,
         mock_request,
         mock_shutil,
+        test_bucket_name,
     ):
         mock_temp.NamedTemporaryFile.return_value.__enter__.return_value.name = FILENAME
         mock_hook.return_value.get_query.return_value = {
@@ -232,7 +235,7 @@ class TestGoogleDisplayVideo360DownloadReportOperator(TestCase):
         )
 
 
-class TestGoogleDisplayVideo360RunReportOperator(TestCase):
+class TestGoogleDisplayVideo360RunReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
     )
@@ -254,7 +257,7 @@ class TestGoogleDisplayVideo360RunReportOperator(TestCase):
         hook_mock.return_value.run_query.assert_called_once_with(query_id=REPORT_ID, params=parameters)
 
 
-class TestGoogleDisplayVideo360DownloadLineItemsOperator(TestCase):
+class TestGoogleDisplayVideo360DownloadLineItemsOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
     )
@@ -306,7 +309,7 @@ class TestGoogleDisplayVideo360DownloadLineItemsOperator(TestCase):
         hook_mock.return_value.download_line_items.assert_called_once_with(request_body=request_body)
 
 
-class TestGoogleDisplayVideo360UploadLineItemsOperator(TestCase):
+class TestGoogleDisplayVideo360UploadLineItemsOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.display_video.tempfile")
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
@@ -347,7 +350,7 @@ class TestGoogleDisplayVideo360UploadLineItemsOperator(TestCase):
         hook_mock.return_value.upload_line_items.assert_called_once_with(line_items=line_items)
 
 
-class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
+class TestGoogleDisplayVideo360SDFtoGCSOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators.display_video.GoogleDisplayVideo360Hook"
     )
@@ -416,7 +419,7 @@ class TestGoogleDisplayVideo360SDFtoGCSOperator(TestCase):
         )
 
 
-class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator(TestCase):
+class TestGoogleDisplayVideo360CreateSDFDownloadTaskOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.operators."
         "display_video.GoogleDisplayVideo360CreateSDFDownloadTaskOperator.xcom_push"

--- a/tests/providers/google/marketing_platform/operators/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/operators/test_search_ads.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 
 import json
 from tempfile import NamedTemporaryFile
-from unittest import TestCase, mock
+from unittest import mock
 
-from parameterized import parameterized
+import pytest
 
 from airflow.models import DAG, TaskInstance as TI
 from airflow.providers.google.marketing_platform.operators.search_ads import (
@@ -42,7 +42,7 @@ REPORT_NAME = "test_report.csv"
 FILE_NAME = "test"
 
 
-class TestGoogleSearchAdsInsertReportOperator(TestCase):
+class TestGoogleSearchAdsInsertReportOperator:
     @mock.patch("airflow.providers.google.marketing_platform.operators.search_ads.GoogleSearchAdsHook")
     @mock.patch("airflow.providers.google.marketing_platform.operators.search_ads.BaseOperator")
     @mock.patch(
@@ -77,12 +77,12 @@ class TestGoogleSearchAdsInsertReportOperator(TestCase):
         assert op.report == report
 
 
-class TestGoogleSearchAdsDownloadReportOperator(TestCase):
-    def setUp(self):
+class TestGoogleSearchAdsDownloadReportOperator:
+    def setup_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
-    def tearDown(self):
+    def teardown_method(self):
         with create_session() as session:
             session.query(TI).delete()
 
@@ -125,11 +125,14 @@ class TestGoogleSearchAdsDownloadReportOperator(TestCase):
         )
         xcom_mock.assert_called_once_with(None, key="file_name", value=FILE_NAME + ".csv.gz")
 
-    @parameterized.expand([BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"])
+    @pytest.mark.parametrize(
+        "test_bucket_name",
+        [BUCKET_NAME, f"gs://{BUCKET_NAME}", "XComArg", "{{ ti.xcom_pull(task_ids='f') }}"],
+    )
     @mock.patch("airflow.providers.google.marketing_platform.operators.search_ads.NamedTemporaryFile")
     @mock.patch("airflow.providers.google.marketing_platform.operators.search_ads.GCSHook")
     @mock.patch("airflow.providers.google.marketing_platform.operators.search_ads.GoogleSearchAdsHook")
-    def test_set_bucket_name(self, test_bucket_name, hook_mock, gcs_hook_mock, tempfile_mock):
+    def test_set_bucket_name(self, hook_mock, gcs_hook_mock, tempfile_mock, test_bucket_name):
         temp_file_name = "TEMP"
         data = b"data"
 

--- a/tests/providers/google/marketing_platform/sensors/test_campaign_manager.py
+++ b/tests/providers/google/marketing_platform/sensors/test_campaign_manager.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.sensors.campaign_manager import (
     GoogleCampaignManagerReportSensor,
@@ -27,7 +27,7 @@ API_VERSION = "api_version"
 GCP_CONN_ID = "google_cloud_default"
 
 
-class TestGoogleCampaignManagerDeleteReportOperator(TestCase):
+class TestGoogleCampaignManagerDeleteReportOperator:
     @mock.patch(
         "airflow.providers.google.marketing_platform.sensors.campaign_manager.GoogleCampaignManagerHook"
     )

--- a/tests/providers/google/marketing_platform/sensors/test_display_video.py
+++ b/tests/providers/google/marketing_platform/sensors/test_display_video.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.sensors.display_video import (
     GoogleDisplayVideo360GetSDFDownloadOperationSensor,
@@ -28,7 +28,7 @@ API_VERSION = "api_version"
 GCP_CONN_ID = "google_cloud_default"
 
 
-class TestGoogleDisplayVideo360ReportSensor(TestCase):
+class TestGoogleDisplayVideo360ReportSensor:
     @mock.patch("airflow.providers.google.marketing_platform.sensors.display_video.GoogleDisplayVideo360Hook")
     @mock.patch("airflow.providers.google.marketing_platform.sensors.display_video.BaseSensorOperator")
     def test_poke(self, mock_base_op, hook_mock):
@@ -46,7 +46,7 @@ class TestGoogleDisplayVideo360ReportSensor(TestCase):
         hook_mock.return_value.get_query.assert_called_once_with(query_id=report_id)
 
 
-class TestGoogleDisplayVideo360Sensor(TestCase):
+class TestGoogleDisplayVideo360Sensor:
     @mock.patch("airflow.providers.google.marketing_platform.sensors.display_video.GoogleDisplayVideo360Hook")
     @mock.patch("airflow.providers.google.marketing_platform.sensors.display_video.BaseSensorOperator")
     def test_poke(self, mock_base_op, hook_mock):

--- a/tests/providers/google/marketing_platform/sensors/test_search_ads.py
+++ b/tests/providers/google/marketing_platform/sensors/test_search_ads.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.marketing_platform.sensors.search_ads import GoogleSearchAdsReportSensor
 
@@ -25,7 +25,7 @@ API_VERSION = "api_version"
 GCP_CONN_ID = "google_cloud_default"
 
 
-class TestSearchAdsReportSensor(TestCase):
+class TestSearchAdsReportSensor:
     @mock.patch("airflow.providers.google.marketing_platform.sensors.search_ads.GoogleSearchAdsHook")
     @mock.patch("airflow.providers.google.marketing_platform.sensors.search_ads.BaseSensorOperator")
     def test_poke(self, mock_base_op, hook_mock):

--- a/tests/providers/google/suite/hooks/test_calendar.py
+++ b/tests/providers/google/suite/hooks/test_calendar.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 Unit Tests for the Google Calendar Hook
 """
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.suite.hooks.calendar import GoogleCalendarHook
@@ -46,8 +45,8 @@ NUM_RETRIES = 5
 API_RESPONSE = {"test": "response"}
 
 
-class TestGoogleCalendarHook(unittest.TestCase):
-    def setUp(self):
+class TestGoogleCalendarHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -60,7 +59,7 @@ class TestGoogleCalendarHook(unittest.TestCase):
         execute_method = get_method.return_value.execute
         execute_method.return_value = {"kind": "calendar#events", "nextPageToken": None, "items": [EVENT]}
         result = self.hook.get_events(calendar_id=CALENDAR_ID)
-        self.assertEqual(result, [EVENT])
+        assert result == [EVENT]
         execute_method.assert_called_once_with(num_retries=NUM_RETRIES)
         get_method.assert_called_once_with(
             calendarId=CALENDAR_ID,

--- a/tests/providers/google/suite/hooks/test_drive.py
+++ b/tests/providers/google/suite/hooks/test_drive.py
@@ -17,22 +17,21 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.suite.hooks.drive import GoogleDriveHook
 from tests.providers.google.cloud.utils.base_gcp_mock import GCP_CONNECTION_WITH_PROJECT_ID
 
 
-class TestGoogleDriveHook(unittest.TestCase):
-    def setUp(self):
+class TestGoogleDriveHook:
+    def setup_method(self):
         self.patcher_get_connection = mock.patch(
             "airflow.hooks.base.BaseHook.get_connection", return_value=GCP_CONNECTION_WITH_PROJECT_ID
         )
         self.patcher_get_connection.start()
         self.gdrive_hook = GoogleDriveHook(gcp_conn_id="test")
 
-    def tearDown(self) -> None:
+    def teardown_method(self) -> None:
         self.patcher_get_connection.stop()
 
     @mock.patch(
@@ -171,7 +170,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         mock_method.assert_called_once_with(
             folder_id=folder_id, file_name=file_name, drive_id=drive_id, include_trashed=True
         )
-        self.assertEqual(True, result_value)
+        assert result_value
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_file_id")
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
@@ -218,7 +217,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         ]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)
-        self.assertEqual({"id": "ID_1", "mime_type": "text/plain"}, result_value)
+        assert result_value == {"id": "ID_1", "mime_type": "text/plain"}
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
     def test_get_file_id_when_multiple_files_exists(self, mock_get_conn):
@@ -231,7 +230,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         ]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)
-        self.assertEqual({"id": "ID_1", "mime_type": "text/plain"}, result_value)
+        assert result_value == {"id": "ID_1", "mime_type": "text/plain"}
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")
     def test_get_file_id_when_no_file_exists(self, mock_get_conn):
@@ -242,7 +241,7 @@ class TestGoogleDriveHook(unittest.TestCase):
         mock_get_conn.return_value.files.return_value.list.return_value.execute.side_effect = [{"files": []}]
 
         result_value = self.gdrive_hook.get_file_id(folder_id, file_name, drive_id)
-        self.assertEqual({}, result_value)
+        assert result_value == {}
 
     @mock.patch("airflow.providers.google.suite.hooks.drive.MediaFileUpload")
     @mock.patch("airflow.providers.google.suite.hooks.drive.GoogleDriveHook.get_conn")

--- a/tests/providers/google/suite/hooks/test_sheets.py
+++ b/tests/providers/google/suite/hooks/test_sheets.py
@@ -20,7 +20,6 @@ Unit Tests for the GSheets Hook
 """
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -45,8 +44,8 @@ NUM_RETRIES = 5
 API_RESPONSE = {"test": "response"}
 
 
-class TestGSheetsHook(unittest.TestCase):
-    def setUp(self):
+class TestGSheetsHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/suite/sensors/test_drive.py
+++ b/tests/providers/google/suite/sensors/test_drive.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 import os
-from unittest import TestCase, mock
+from unittest import mock
 
 from airflow.providers.google.suite.sensors.drive import GoogleDriveFileExistenceSensor
 
@@ -30,7 +30,7 @@ TEST_DELEGATE_TO = "TEST_DELEGATE_TO"
 TEST_IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestGoogleDriveFileSensor(TestCase):
+class TestGoogleDriveFileSensor:
     @mock.patch("airflow.providers.google.suite.sensors.drive.GoogleDriveHook")
     def test_should_pass_argument_to_hook(self, mock_hook):
         task = GoogleDriveFileExistenceSensor(
@@ -46,8 +46,8 @@ class TestGoogleDriveFileSensor(TestCase):
         mock_hook.return_value.exists.return_value = True
 
         result = task.poke(mock.MagicMock())
+        assert result
 
-        self.assertEqual(True, result)
         mock_hook.assert_called_once_with(
             delegate_to=TEST_DELEGATE_TO,
             gcp_conn_id=TEST_GCP_CONN_ID,

--- a/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
+++ b/tests/providers/google/suite/transfers/test_gcs_to_gdrive.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -29,7 +28,7 @@ MODULE = "airflow.providers.google.suite.transfers.gcs_to_gdrive"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestGcsToGDriveOperator(unittest.TestCase):
+class TestGcsToGDriveOperator:
     @mock.patch(MODULE + ".GCSHook")
     @mock.patch(MODULE + ".GoogleDriveHook")
     @mock.patch(MODULE + ".tempfile.NamedTemporaryFile")

--- a/tests/providers/google/suite/transfers/test_sql_to_sheets.py
+++ b/tests/providers/google/suite/transfers/test_sql_to_sheets.py
@@ -16,18 +16,17 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import Mock, patch
 
 from airflow.providers.google.suite.transfers.sql_to_sheets import SQLToGoogleSheetsOperator
 
 
-class TestSQLToGoogleSheets(unittest.TestCase):
+class TestSQLToGoogleSheets:
     """
     Test class for SQLToGoogleSheetsOperator
     """
 
-    def setUp(self):
+    def setup_method(self):
         """
         setup
         """

--- a/tests/providers/google/test_go_module.py
+++ b/tests/providers/google/test_go_module.py
@@ -17,13 +17,12 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.go_module_utils import init_module, install_dependencies
 
 
-class TestGoModule(unittest.TestCase):
+class TestGoModule:
     @mock.patch("airflow.providers.google.go_module_utils.execute_in_subprocess")
     def test_should_init_go_module(self, mock_execute_in_subprocess):
         init_module(go_module_name="example.com/main", go_module_path="/home/example/go")


### PR DESCRIPTION
Migrate part of Google provider's tests (exclude `tests/providers/google/cloud`) to `pytest`.

All changes are more or less straightforward:
- Get rid of `unittests.TestCase` class and **TestCase.assert*** methods
- Replace decorator `parameterized.expand` by `pytest.mark.parametrize`.
- Convert classes **setUp*** and **tearDown*** to [appropriate pytest methods](https://docs.pytest.org/en/6.2.x/xunit_setup.html#classic-xunit-style-setup)