### PR TITLE
Simplify dataset subgraph logic

### DIFF
--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -119,6 +119,7 @@ with DAG(
     schedule=[
         Dataset("s3://unrelated/dataset3.txt"),
         Dataset("s3://unrelated/dataset_other_unknown.txt"),
+        Dataset("s3://unrelated/dataset4.txt"),
     ],
     tags=["dataset-scheduled"],
 ) as dag6:

--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -119,7 +119,6 @@ with DAG(
     schedule=[
         Dataset("s3://unrelated/dataset3.txt"),
         Dataset("s3://unrelated/dataset_other_unknown.txt"),
-        Dataset("s3://unrelated/dataset4.txt"),
     ],
     tags=["dataset-scheduled"],
 ) as dag6:


### PR DESCRIPTION
To calculate all the independent graphs in the datasets view, we start with a graph for each edge with no upstreams and then merge them once we find a common edge. This wasn't merging nodes correctly, sometimes the same node was added over and over for every edge it had. I found a patch for the fix, but then realized that the logic was quite brittle and decided to refactor.
We only need the edges to figure out the graph, so we just recursively iterate over those. Using `.reduce` and `.map` instead of weird `indicesToRemove` objects. Once all the edges are placed, we add the nodes.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
