### PR TITLE
Prevent double loading of providers from local paths

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -504,7 +504,14 @@ class ProvidersManager(LoggingMixin):
             log.info("You have no providers installed.")
             return
         try:
+            seen = set()
             for path in airflow.providers.__path__:  # type: ignore[attr-defined]
+                # The same path can appear in the __path__ twice, under non-normalized paths (ie.
+                # /path/to/repo/airflow/providers and /path/to/repo/./airflow/providers)
+                path = os.path.realpath(path)
+                if path in seen:
+                    continue
+                seen.add(path)
                 self._add_provider_info_from_local_source_files_on_path(path)
         except Exception as e:
             log.warning("Error when loading 'provider.yaml' files from airflow sources: %s", e)


### PR DESCRIPTION
I noticed a case where the same local providers were loaded more than
once, and it turned out to be caused by having `.` in the python search
path.

The fix for this is to canonicalize the path before looking for
providers in it, and not searching in a path more than once.

This also caused a number of warnings of "provider already loaded" to appear.

(All of thise only affects people running from a checkout of Airflow)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
