### PR TITLE
Add documentation for [core] mp_start_method config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -99,6 +99,15 @@
       type: string
       example: ~
       default: "16"
+    - name: mp_start_method
+      description: |
+        The name of the method used in order to start Python processes via the multiprocessing module.
+        This corresponds directly with the options available in the `Python multiprocessing docs <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method>`__.
+        Must be one of the values returned by `multiprocessing.get_all_start_methods() <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods>`__.
+      version_added: "2.0.0"
+      type: string
+      default: ~
+      example: "fork"
     - name: load_examples
       description: |
         Whether to load the DAG examples that ship with Airflow. It's good to

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -102,8 +102,10 @@
     - name: mp_start_method
       description: |
         The name of the method used in order to start Python processes via the multiprocessing module.
-        This corresponds directly with the options available in the `Python multiprocessing docs <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method>`__.
-        Must be one of the values returned by `multiprocessing.get_all_start_methods() <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods>`__.
+        This corresponds directly with the options available in the Python docs:
+        https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method.
+        Must be one of the values returned by:
+        https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods.
       version_added: "2.0.0"
       type: string
       default: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -75,6 +75,14 @@ dags_are_paused_at_creation = True
 # which is defaulted as ``max_active_runs_per_dag``.
 max_active_runs_per_dag = 16
 
+# The name of the method used in order to start Python processes via the multiprocessing module.
+# This corresponds directly with the options available in the Python docs:
+# https://docs.python.org/3/library/multiprocessing.html#multiprocessing.set_start_method.
+# Must be one of the values returned by:
+# https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods.
+# Example: mp_start_method = fork
+# mp_start_method =
+
 # Whether to load the DAG examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to ``False`` in a production
 # environment


### PR DESCRIPTION
This was added back just before 2.0.0, but was just missing from docs

