### PR TITLE
Fix wrapping of run() method result of exasol and snoflake DB hooks

### DIFF
--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -159,19 +159,21 @@ class ExasolHook(DbApiHook):
         """
         if isinstance(sql, str):
             if split_statements:
-                sql = self.split_sql_string(sql)
+                sql_list: Iterable[str] = self.split_sql_string(sql)
             else:
-                sql = [self.strip_sql_string(sql)]
+                sql_list = [self.strip_sql_string(sql)]
+        else:
+            sql_list = sql
 
-        if sql:
-            self.log.debug("Executing following statements against Exasol DB: %s", list(sql))
+        if sql_list:
+            self.log.debug("Executing following statements against Exasol DB: %s", list(sql_list))
         else:
             raise ValueError("List of SQL statements is empty")
 
         with closing(self.get_conn()) as conn:
             self.set_autocommit(conn, autocommit)
             results = []
-            for sql_statement in sql:
+            for sql_statement in sql_list:
                 with closing(conn.execute(sql_statement, parameters)) as cur:
                     self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
                     if handler is not None:


### PR DESCRIPTION
The change #27912 fixed and unified behaviour of DBApiHooks across the board, but it missed two places where sql was mis-used and overridden in exasol and snowflake hooks.

The check for "sql" type did not use the original sql parameter value but the one that was overridden later in the run method implementation.

The fix is the same as applied in Databricks Hook and DBAPI generic run methods - using consistent typing and separate variable to convert the sql string into sql list.

Related: https://github.com/astronomer/astro-sdk/pull/1324

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
