### PR TITLE
Add documentation for task group mapping

### DIFF
--- a/docs/apache-airflow/concepts/dynamic-task-mapping.rst
+++ b/docs/apache-airflow/concepts/dynamic-task-mapping.rst
@@ -333,6 +333,10 @@ In the above example, task ``convert_to_yaml`` is expanded into two task instanc
 
     Use Airflow's DAG-building constructs, such as ``@task.branch``, to achieve the intended effect instead.
 
+.. note:: Task-mapping in a mapped task group is not permitted
+
+    It is not currently permitted to do task mapping nested inside a mapped task group. While the technical aspect of this feature is not particularly difficult, we have decided to intentionally omit this feature since it adds considerable UI complexities, and may not be necessary for general use cases. This restriction may be revisited in the future depending on user feedback.
+
 Depth-first execution
 ---------------------
 


### PR DESCRIPTION
I also took the chance to reorganise existing task mapping documentation a _little_ bit to make the document flows better (for me).

Note that this is intended to be in Airflow 2.6, _not 2.5_.