### PR TITLE
Gracefully handle whole config sections being renamed

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -233,7 +233,7 @@ class AirflowConfigParser(ConfigParser):
     }
 
     # A mapping of new section -> (old section, since_version).
-    deprecated_sections: dict[str, tuple[str, str]] = {"kubernetes_executor": ("kubernetes", "2.4.2")}
+    deprecated_sections: dict[str, tuple[str, str]] = {"kubernetes_executor": ("kubernetes", "2.5.0")}
 
     # Now build the inverse so we can go from old_section/old_key to new_section/new_key
     # if someone tries to retrieve it based on old_section/old_key

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -595,8 +595,8 @@ class AirflowConfigParser(ConfigParser):
         # For when we rename whole sections
         if section in self.deprecated_sections:
             warnings.warn(
-                f"The config section [{section}] has been renamed to {self.deprecated_sections[section][0]}."
-                " Please update your config.",
+                f"The config section [{section}] has been renamed to "
+                f"[{self.deprecated_sections[section][0]}]. Please update your config.",
                 FutureWarning,
                 stacklevel=2,
             )

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -615,8 +615,6 @@ class AirflowConfigParser(ConfigParser):
                     stacklevel=2,
                 )
                 issue_warning = False
-            # deprecated_section, deprecated_key = section, key
-            # section, key = (new_section, new_key)
         else:
             deprecated_section, deprecated_key, _ = self.deprecated_options.get(
                 (section, key), (None, None, None)

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -56,11 +56,8 @@ HOME_DIR = os.path.expanduser("~")
 
 @pytest.fixture(scope="module")
 def restore_env():
-    current = os.environ.copy()
-
-    yield
-
-    os.environ = current
+    with mock.patch.dict("os.environ"):
+        yield
 
 
 @unittest.mock.patch.dict(
@@ -838,6 +835,7 @@ key7 =
         assert test_conf.gettimedelta("default", "key7") is None
 
 
+@pytest.mark.usefixtures("restore_env")
 class TestDeprecatedConf:
     @conf_vars(
         {
@@ -1048,10 +1046,6 @@ sql_alchemy_conn=sqlite://test
             test_conf = AirflowConfigParser(
                 default_config=textwrap.dedent(
                     """
-                    [core]
-                    executor=SequentialExecutor
-                    [api]
-                    auth_backends=foo
                     [new_section]
                     val=new
                     """

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -54,7 +54,7 @@ from tests.utils.test_config import (
 HOME_DIR = os.path.expanduser("~")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def restore_env():
     with mock.patch.dict("os.environ"):
         yield
@@ -69,7 +69,6 @@ def restore_env():
         "AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD": 'echo -n "NOT OK"',
     },
 )
-@pytest.mark.usefixtures("restore_env")
 class TestConf:
     def test_airflow_home_default(self):
         with unittest.mock.patch.dict("os.environ"):
@@ -835,7 +834,6 @@ key7 =
         assert test_conf.gettimedelta("default", "key7") is None
 
 
-@pytest.mark.usefixtures("restore_env")
 class TestDeprecatedConf:
     @conf_vars(
         {

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1036,6 +1036,8 @@ sql_alchemy_conn=sqlite://test
                     """
                     [core]
                     executor=SequentialExecutor
+                    [api]
+                    auth_backends=foo
                     [new_section]
                     val=new
                     """
@@ -1057,9 +1059,16 @@ sql_alchemy_conn=sqlite://test
             monkeypatch.setenv(*environ)
 
         test_conf = make_config()
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(
+            DeprecationWarning,
+            match=r"section/key \[old_section/val\] has been deprecated, you should use "
+            r"\[new_section/val\] instead",
+        ):
             assert test_conf.get("new_section", "val") == expected
-        with pytest.warns(FutureWarning):
+        with pytest.warns(
+            FutureWarning,
+            match=r"The config section \[old_section\] has been renamed to \[new_section\]",
+        ):
             assert test_conf.get("old_section", "val") == expected
 
     def test_deprecated_funcs(self):

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -54,6 +54,15 @@ from tests.utils.test_config import (
 HOME_DIR = os.path.expanduser("~")
 
 
+@pytest.fixture(scope="module")
+def restore_env():
+    current = os.environ.copy()
+
+    yield
+
+    os.environ = current
+
+
 @unittest.mock.patch.dict(
     "os.environ",
     {
@@ -63,6 +72,7 @@ HOME_DIR = os.path.expanduser("~")
         "AIRFLOW__TESTCMDENV__NOTACOMMAND_CMD": 'echo -n "NOT OK"',
     },
 )
+@pytest.mark.usefixtures("restore_env")
 class TestConf:
     def test_airflow_home_default(self):
         with unittest.mock.patch.dict("os.environ"):


### PR DESCRIPTION
We renamed the whole kubernetes section to kubernetes_executor, but if you tried to get the _old_ value it would cause an exception.

This has been a problem for basically ever, but we've never noticed before because we upgrade the access in core at the same time, but in the case of kubernetes_executor/namespace it is "possible" (and maybe even reasonable) to access that config setting in a DAG.

Without this change we will break some DAGs on upgrade, which we should avoid.

Closes #27999
