### PR TITLE
Use asserts instead of exceptions for executor not started

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -33,8 +33,6 @@ from airflow.utils.state import State
 
 PARALLELISM: int = conf.getint("core", "PARALLELISM")
 
-NOT_STARTED_MESSAGE = "The executor should be started first!"
-
 QUEUEING_ATTEMPTS = 5
 
 # Command to execute - list of strings

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -25,14 +25,14 @@ DaskExecutor
 from __future__ import annotations
 
 import subprocess
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from distributed import Client, Future, as_completed
 from distributed.security import Security
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException
-from airflow.executors.base_executor import NOT_STARTED_MESSAGE, BaseExecutor, CommandType
+from airflow.executors.base_executor import BaseExecutor, CommandType
 from airflow.models.taskinstance import TaskInstanceKey
 
 # queue="default" is a special case since this is the base config default queue name,
@@ -78,13 +78,13 @@ class DaskExecutor(BaseExecutor):
         queue: str | None = None,
         executor_config: Any | None = None,
     ) -> None:
+        if TYPE_CHECKING:
+            assert self.client
 
         self.validate_airflow_tasks_run_command(command)
 
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)
-
-        assert self.client, NOT_STARTED_MESSAGE
 
         resources = None
         if queue not in _UNDEFINED_QUEUES:
@@ -101,7 +101,9 @@ class DaskExecutor(BaseExecutor):
         self.futures[future] = key  # type: ignore
 
     def _process_future(self, future: Future) -> None:
-        assert self.futures, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.futures
+
         if future.done():
             key = self.futures[future]
             if future.exception():
@@ -115,19 +117,25 @@ class DaskExecutor(BaseExecutor):
             self.futures.pop(future)
 
     def sync(self) -> None:
-        assert self.futures, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.futures
+
         # make a copy so futures can be popped during iteration
         for future in self.futures.copy():
             self._process_future(future)
 
     def end(self) -> None:
-        assert self.client, NOT_STARTED_MESSAGE
-        assert self.futures, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.client
+            assert self.futures
+
         self.client.cancel(list(self.futures.keys()))
         for future in as_completed(self.futures.copy()):
             self._process_future(future)
 
     def terminate(self):
-        assert self.futures, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.futures
+
         self.client.cancel(self.futures.keys())
         self.end()

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -115,22 +115,19 @@ class DaskExecutor(BaseExecutor):
             self.futures.pop(future)
 
     def sync(self) -> None:
-        if self.futures is None:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.futures, NOT_STARTED_MESSAGE
         # make a copy so futures can be popped during iteration
         for future in self.futures.copy():
             self._process_future(future)
 
     def end(self) -> None:
         assert self.client, NOT_STARTED_MESSAGE
-        if self.futures is None:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.futures, NOT_STARTED_MESSAGE
         self.client.cancel(list(self.futures.keys()))
         for future in as_completed(self.futures.copy()):
             self._process_future(future)
 
     def terminate(self):
-        if self.futures is None:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.futures, NOT_STARTED_MESSAGE
         self.client.cancel(self.futures.keys())
         self.end()

--- a/airflow/executors/dask_executor.py
+++ b/airflow/executors/dask_executor.py
@@ -84,8 +84,7 @@ class DaskExecutor(BaseExecutor):
         def airflow_run():
             return subprocess.check_call(command, close_fds=True)
 
-        if not self.client:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.client, NOT_STARTED_MESSAGE
 
         resources = None
         if queue not in _UNDEFINED_QUEUES:
@@ -102,8 +101,7 @@ class DaskExecutor(BaseExecutor):
         self.futures[future] = key  # type: ignore
 
     def _process_future(self, future: Future) -> None:
-        if not self.futures:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.futures, NOT_STARTED_MESSAGE
         if future.done():
             key = self.futures[future]
             if future.exception():
@@ -124,8 +122,7 @@ class DaskExecutor(BaseExecutor):
             self._process_future(future)
 
     def end(self) -> None:
-        if not self.client:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.client, NOT_STARTED_MESSAGE
         if self.futures is None:
             raise AirflowException(NOT_STARTED_MESSAGE)
         self.client.cancel(list(self.futures.keys()))

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -30,7 +30,7 @@ import multiprocessing
 import time
 from datetime import timedelta
 from queue import Empty, Queue
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
 
 from kubernetes import client, watch
 from kubernetes.client import Configuration, models as k8s
@@ -38,7 +38,7 @@ from kubernetes.client.rest import ApiException
 from urllib3.exceptions import ReadTimeoutError
 
 from airflow.exceptions import AirflowException, PodMutationHookException, PodReconciliationError
-from airflow.executors.base_executor import NOT_STARTED_MESSAGE, BaseExecutor, CommandType
+from airflow.executors.base_executor import BaseExecutor, CommandType
 from airflow.kubernetes import pod_generator
 from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.kube_config import KubeConfig
@@ -96,8 +96,10 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
 
     def run(self) -> None:
         """Performs watching"""
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+
         kube_client: client.CoreV1Api = get_kube_client()
-        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
         while True:
             try:
                 self.resource_version = self._run(
@@ -462,9 +464,10 @@ class KubernetesExecutor(BaseExecutor):
         is around, and if not, and there's no matching entry in our own
         task_queue, marks it for re-execution.
         """
-        self.log.debug("Clearing tasks that have not been launched")
-        assert self.kube_client, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.kube_client
 
+        self.log.debug("Clearing tasks that have not been launched")
         query = session.query(TaskInstance).filter(
             TaskInstance.state == State.QUEUED, TaskInstance.queued_by_job_id == self.job_id
         )
@@ -553,6 +556,9 @@ class KubernetesExecutor(BaseExecutor):
         executor_config: Any | None = None,
     ) -> None:
         """Executes task asynchronously"""
+        if TYPE_CHECKING:
+            assert self.task_queue
+
         if self.log.isEnabledFor(logging.DEBUG):
             self.log.debug("Add task %s with command %s, executor_config %s", key, command, executor_config)
         else:
@@ -569,7 +575,6 @@ class KubernetesExecutor(BaseExecutor):
             pod_template_file = executor_config.get("pod_template_file", None)
         else:
             pod_template_file = None
-        assert self.task_queue, NOT_STARTED_MESSAGE
         self.event_buffer[key] = (State.QUEUED, self.scheduler_job_id)
         self.task_queue.put((key, command, kube_executor_config, pod_template_file))
         # We keep a temporary local record that we've handled this so we don't
@@ -578,16 +583,18 @@ class KubernetesExecutor(BaseExecutor):
 
     def sync(self) -> None:
         """Synchronize task state."""
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+            assert self.kube_scheduler
+            assert self.kube_config
+            assert self.result_queue
+            assert self.task_queue
+            assert self.event_scheduler
+
         if self.running:
             self.log.debug("self.running: %s", self.running)
         if self.queued_tasks:
             self.log.debug("self.queued: %s", self.queued_tasks)
-        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
-        assert self.kube_scheduler, NOT_STARTED_MESSAGE
-        assert self.kube_config, NOT_STARTED_MESSAGE
-        assert self.result_queue, NOT_STARTED_MESSAGE
-        assert self.task_queue, NOT_STARTED_MESSAGE
-        assert self.event_scheduler, NOT_STARTED_MESSAGE
         self.kube_scheduler.sync()
 
         last_resource_version = None
@@ -662,7 +669,9 @@ class KubernetesExecutor(BaseExecutor):
 
     def _check_worker_pods_pending_timeout(self):
         """Check if any pending worker pods have timed out"""
-        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+
         timeout = self.kube_config.worker_pods_pending_timeout
         self.log.debug("Looking for pending worker pods older than %d seconds", timeout)
 
@@ -696,9 +705,11 @@ class KubernetesExecutor(BaseExecutor):
                 self.kube_scheduler.delete_pod(pod.metadata.name, pod.metadata.namespace)
 
     def _change_state(self, key: TaskInstanceKey, state: str | None, pod_id: str, namespace: str) -> None:
+        if TYPE_CHECKING:
+            assert self.kube_scheduler
+
         if state != State.RUNNING:
             if self.kube_config.delete_worker_pods:
-                assert self.kube_scheduler, NOT_STARTED_MESSAGE
                 if state != State.FAILED or self.kube_config.delete_worker_pods_on_failure:
                     self.kube_scheduler.delete_pod(pod_id, namespace)
                     self.log.info("Deleted pod: %s in namespace %s", str(key), str(namespace))
@@ -733,7 +744,9 @@ class KubernetesExecutor(BaseExecutor):
         :param pod: V1Pod spec that we will patch with new label
         :param pod_ids: pod_ids we expect to patch.
         """
-        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+
         self.log.info("attempting to adopt pod %s", pod.metadata.name)
         pod.metadata.labels["airflow-worker"] = pod_generator.make_safe_label_value(self.scheduler_job_id)
         pod_id = annotations_to_key(pod.metadata.annotations)
@@ -759,7 +772,9 @@ class KubernetesExecutor(BaseExecutor):
 
         :param kube_client: kubernetes client for speaking to kube API
         """
-        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.scheduler_job_id
+
         new_worker_id_label = pod_generator.make_safe_label_value(self.scheduler_job_id)
         kwargs = {
             "field_selector": "status.phase=Succeeded",
@@ -779,7 +794,9 @@ class KubernetesExecutor(BaseExecutor):
                 self.log.info("Failed to adopt pod %s. Reason: %s", pod.metadata.name, e)
 
     def _flush_task_queue(self) -> None:
-        assert self.task_queue, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.task_queue
+
         self.log.debug("Executor shutting down, task_queue approximate size=%d", self.task_queue.qsize())
         while True:
             try:
@@ -791,7 +808,9 @@ class KubernetesExecutor(BaseExecutor):
                 break
 
     def _flush_result_queue(self) -> None:
-        assert self.result_queue, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.result_queue
+
         self.log.debug("Executor shutting down, result_queue approximate size=%d", self.result_queue.qsize())
         while True:
             try:
@@ -818,9 +837,11 @@ class KubernetesExecutor(BaseExecutor):
 
     def end(self) -> None:
         """Called when the executor shuts down"""
-        assert self.task_queue, NOT_STARTED_MESSAGE
-        assert self.result_queue, NOT_STARTED_MESSAGE
-        assert self.kube_scheduler, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.task_queue
+            assert self.result_queue
+            assert self.kube_scheduler
+
         self.log.info("Shutting down Kubernetes executor")
         self.log.debug("Flushing task_queue...")
         self._flush_task_queue()

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -97,8 +97,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
     def run(self) -> None:
         """Performs watching"""
         kube_client: client.CoreV1Api = get_kube_client()
-        if not self.scheduler_job_id:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
         while True:
             try:
                 self.resource_version = self._run(
@@ -464,8 +463,7 @@ class KubernetesExecutor(BaseExecutor):
         task_queue, marks it for re-execution.
         """
         self.log.debug("Clearing tasks that have not been launched")
-        if not self.kube_client:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.kube_client, NOT_STARTED_MESSAGE
 
         query = session.query(TaskInstance).filter(
             TaskInstance.state == State.QUEUED, TaskInstance.queued_by_job_id == self.job_id
@@ -571,8 +569,7 @@ class KubernetesExecutor(BaseExecutor):
             pod_template_file = executor_config.get("pod_template_file", None)
         else:
             pod_template_file = None
-        if not self.task_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.task_queue, NOT_STARTED_MESSAGE
         self.event_buffer[key] = (State.QUEUED, self.scheduler_job_id)
         self.task_queue.put((key, command, kube_executor_config, pod_template_file))
         # We keep a temporary local record that we've handled this so we don't
@@ -585,18 +582,12 @@ class KubernetesExecutor(BaseExecutor):
             self.log.debug("self.running: %s", self.running)
         if self.queued_tasks:
             self.log.debug("self.queued: %s", self.queued_tasks)
-        if not self.scheduler_job_id:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.kube_scheduler:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.kube_config:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.result_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.task_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.event_scheduler:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
+        assert self.kube_scheduler, NOT_STARTED_MESSAGE
+        assert self.kube_config, NOT_STARTED_MESSAGE
+        assert self.result_queue, NOT_STARTED_MESSAGE
+        assert self.task_queue, NOT_STARTED_MESSAGE
+        assert self.event_scheduler, NOT_STARTED_MESSAGE
         self.kube_scheduler.sync()
 
         last_resource_version = None
@@ -671,8 +662,7 @@ class KubernetesExecutor(BaseExecutor):
 
     def _check_worker_pods_pending_timeout(self):
         """Check if any pending worker pods have timed out"""
-        if not self.scheduler_job_id:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
         timeout = self.kube_config.worker_pods_pending_timeout
         self.log.debug("Looking for pending worker pods older than %d seconds", timeout)
 
@@ -708,8 +698,7 @@ class KubernetesExecutor(BaseExecutor):
     def _change_state(self, key: TaskInstanceKey, state: str | None, pod_id: str, namespace: str) -> None:
         if state != State.RUNNING:
             if self.kube_config.delete_worker_pods:
-                if not self.kube_scheduler:
-                    raise AirflowException(NOT_STARTED_MESSAGE)
+                assert self.kube_scheduler, NOT_STARTED_MESSAGE
                 if state != State.FAILED or self.kube_config.delete_worker_pods_on_failure:
                     self.kube_scheduler.delete_pod(pod_id, namespace)
                     self.log.info("Deleted pod: %s in namespace %s", str(key), str(namespace))
@@ -744,8 +733,7 @@ class KubernetesExecutor(BaseExecutor):
         :param pod: V1Pod spec that we will patch with new label
         :param pod_ids: pod_ids we expect to patch.
         """
-        if not self.scheduler_job_id:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
         self.log.info("attempting to adopt pod %s", pod.metadata.name)
         pod.metadata.labels["airflow-worker"] = pod_generator.make_safe_label_value(self.scheduler_job_id)
         pod_id = annotations_to_key(pod.metadata.annotations)
@@ -771,8 +759,7 @@ class KubernetesExecutor(BaseExecutor):
 
         :param kube_client: kubernetes client for speaking to kube API
         """
-        if not self.scheduler_job_id:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.scheduler_job_id, NOT_STARTED_MESSAGE
         new_worker_id_label = pod_generator.make_safe_label_value(self.scheduler_job_id)
         kwargs = {
             "field_selector": "status.phase=Succeeded",
@@ -792,8 +779,7 @@ class KubernetesExecutor(BaseExecutor):
                 self.log.info("Failed to adopt pod %s. Reason: %s", pod.metadata.name, e)
 
     def _flush_task_queue(self) -> None:
-        if not self.task_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.task_queue, NOT_STARTED_MESSAGE
         self.log.debug("Executor shutting down, task_queue approximate size=%d", self.task_queue.qsize())
         while True:
             try:
@@ -805,8 +791,7 @@ class KubernetesExecutor(BaseExecutor):
                 break
 
     def _flush_result_queue(self) -> None:
-        if not self.result_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.result_queue, NOT_STARTED_MESSAGE
         self.log.debug("Executor shutting down, result_queue approximate size=%d", self.result_queue.qsize())
         while True:
             try:
@@ -833,12 +818,9 @@ class KubernetesExecutor(BaseExecutor):
 
     def end(self) -> None:
         """Called when the executor shuts down"""
-        if not self.task_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.result_queue:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.kube_scheduler:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.task_queue, NOT_STARTED_MESSAGE
+        assert self.result_queue, NOT_STARTED_MESSAGE
+        assert self.kube_scheduler, NOT_STARTED_MESSAGE
         self.log.info("Shutting down Kubernetes executor")
         self.log.debug("Flushing task_queue...")
         self._flush_task_queue()

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -245,8 +245,7 @@ class LocalExecutor(BaseExecutor):
             :param queue: Name of the queue
             :param executor_config: configuration for the executor
             """
-            if not self.executor.result_queue:
-                raise AirflowException(NOT_STARTED_MESSAGE)
+            assert self.executor.result_queue, NOT_STARTED_MESSAGE
             local_worker = LocalWorker(self.executor.result_queue, key=key, command=command)
             self.executor.workers_used += 1
             self.executor.workers_active += 1
@@ -284,11 +283,9 @@ class LocalExecutor(BaseExecutor):
 
         def start(self) -> None:
             """Starts limited parallelism implementation."""
-            if not self.executor.manager:
-                raise AirflowException(NOT_STARTED_MESSAGE)
+            assert self.executor.manager, NOT_STARTED_MESSAGE
             self.queue = self.executor.manager.Queue()
-            if not self.executor.result_queue:
-                raise AirflowException(NOT_STARTED_MESSAGE)
+            assert self.executor.result_queue, NOT_STARTED_MESSAGE
             self.executor.workers = [
                 QueuedLocalWorker(self.queue, self.executor.result_queue)
                 for _ in range(self.executor.parallelism)
@@ -314,8 +311,7 @@ class LocalExecutor(BaseExecutor):
             :param queue: name of the queue
             :param executor_config: configuration for the executor
             """
-            if not self.queue:
-                raise AirflowException(NOT_STARTED_MESSAGE)
+            assert self.queue, NOT_STARTED_MESSAGE
             self.queue.put((key, command))
 
         def sync(self):
@@ -365,8 +361,7 @@ class LocalExecutor(BaseExecutor):
         executor_config: Any | None = None,
     ) -> None:
         """Execute asynchronously."""
-        if not self.impl:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.impl, NOT_STARTED_MESSAGE
 
         self.validate_airflow_tasks_run_command(command)
 
@@ -374,8 +369,7 @@ class LocalExecutor(BaseExecutor):
 
     def sync(self) -> None:
         """Sync will get called periodically by the heartbeat method."""
-        if not self.impl:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.impl, NOT_STARTED_MESSAGE
         self.impl.sync()
 
     def end(self) -> None:
@@ -383,10 +377,8 @@ class LocalExecutor(BaseExecutor):
         Ends the executor.
         :return:
         """
-        if not self.impl:
-            raise AirflowException(NOT_STARTED_MESSAGE)
-        if not self.manager:
-            raise AirflowException(NOT_STARTED_MESSAGE)
+        assert self.impl, NOT_STARTED_MESSAGE
+        assert self.manager, NOT_STARTED_MESSAGE
         self.log.info(
             "Shutting down LocalExecutor"
             "; waiting for running tasks to finish.  Signal again if you don't want to wait."

--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -31,13 +31,13 @@ from abc import abstractmethod
 from multiprocessing import Manager, Process
 from multiprocessing.managers import SyncManager
 from queue import Empty, Queue
-from typing import Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple
 
 from setproctitle import getproctitle, setproctitle
 
 from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.executors.base_executor import NOT_STARTED_MESSAGE, PARALLELISM, BaseExecutor, CommandType
+from airflow.executors.base_executor import PARALLELISM, BaseExecutor, CommandType
 from airflow.models.taskinstance import TaskInstanceKey, TaskInstanceStateType
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
@@ -245,7 +245,9 @@ class LocalExecutor(BaseExecutor):
             :param queue: Name of the queue
             :param executor_config: configuration for the executor
             """
-            assert self.executor.result_queue, NOT_STARTED_MESSAGE
+            if TYPE_CHECKING:
+                assert self.executor.result_queue
+
             local_worker = LocalWorker(self.executor.result_queue, key=key, command=command)
             self.executor.workers_used += 1
             self.executor.workers_active += 1
@@ -283,9 +285,11 @@ class LocalExecutor(BaseExecutor):
 
         def start(self) -> None:
             """Starts limited parallelism implementation."""
-            assert self.executor.manager, NOT_STARTED_MESSAGE
+            if TYPE_CHECKING:
+                assert self.executor.manager
+                assert self.executor.result_queue
+
             self.queue = self.executor.manager.Queue()
-            assert self.executor.result_queue, NOT_STARTED_MESSAGE
             self.executor.workers = [
                 QueuedLocalWorker(self.queue, self.executor.result_queue)
                 for _ in range(self.executor.parallelism)
@@ -311,7 +315,9 @@ class LocalExecutor(BaseExecutor):
             :param queue: name of the queue
             :param executor_config: configuration for the executor
             """
-            assert self.queue, NOT_STARTED_MESSAGE
+            if TYPE_CHECKING:
+                assert self.queue
+
             self.queue.put((key, command))
 
         def sync(self):
@@ -361,7 +367,8 @@ class LocalExecutor(BaseExecutor):
         executor_config: Any | None = None,
     ) -> None:
         """Execute asynchronously."""
-        assert self.impl, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.impl
 
         self.validate_airflow_tasks_run_command(command)
 
@@ -369,7 +376,9 @@ class LocalExecutor(BaseExecutor):
 
     def sync(self) -> None:
         """Sync will get called periodically by the heartbeat method."""
-        assert self.impl, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.impl
+
         self.impl.sync()
 
     def end(self) -> None:
@@ -377,8 +386,10 @@ class LocalExecutor(BaseExecutor):
         Ends the executor.
         :return:
         """
-        assert self.impl, NOT_STARTED_MESSAGE
-        assert self.manager, NOT_STARTED_MESSAGE
+        if TYPE_CHECKING:
+            assert self.impl
+            assert self.manager
+
         self.log.info(
             "Shutting down LocalExecutor"
             "; waiting for running tasks to finish.  Signal again if you don't want to wait."


### PR DESCRIPTION
It's a little cleaner, and I'm pretty sure the actual practical import here is just getting mypy to cooperate, so I think the intention is clearer this way too.

## question

do we really need the "not started" message? it's ugly...