### PR TITLE
Enhance chart to allow over-riding command-line args to statsd exporter

### DIFF
--- a/chart/templates/statsd/statsd-deployment.yaml
+++ b/chart/templates/statsd/statsd-deployment.yaml
@@ -87,8 +87,9 @@ spec:
         - name: statsd
           image: {{ template "statsd_image" . }}
           imagePullPolicy: {{ .Values.images.statsd.pullPolicy }}
-          args:
-            - "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+          {{- if .Values.statsd.args }}
+          args: {{ tpl (toYaml .Values.statsd.args) . | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.statsd.resources | indent 12 }}
           ports:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4167,6 +4167,17 @@
                     "additionalProperties": {
                         "type": "string"
                     }
+                },
+                "args": {
+                    "description": "Args to use when running statsd-exporter (templated).",
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [ "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml" ]
                 }
             }
         },

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -4177,7 +4177,9 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": [ "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml" ]
+                    "default": [
+                        "--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+                    ]
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1331,6 +1331,9 @@ statsd:
   # Max number of old replicasets to retain
   revisionHistoryLimit: ~
 
+  # Arguments for StatsD exporter command.
+  args: ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
+
   # Create ServiceAccount
   serviceAccount:
     # Specifies whether a ServiceAccount should be created

--- a/tests/charts/test_statsd.py
+++ b/tests/charts/test_statsd.py
@@ -222,4 +222,4 @@ class TestStatsd:
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 
-        assert needle in jmespath.search("spec.template.spec.containers[0].args", docs[0])
+        assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == args

--- a/tests/charts/test_statsd.py
+++ b/tests/charts/test_statsd.py
@@ -41,6 +41,9 @@ class TestStatsd:
             "subPath": "mappings.yml",
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
+        default_args = ["--statsd.mapping-config=/etc/statsd-exporter/mappings.yml"]
+        assert default_args == jmespath.search("spec.template.spec.containers[0].args", docs[0])
+
     def test_should_add_volume_and_volume_mount_when_exist_extra_mappings(self):
         extra_mapping = {
             "match": "airflow.pool.queued_slots.*",
@@ -210,3 +213,13 @@ class TestStatsd:
 
         assert 1 == len(mappings_yml_obj["mappings"])
         assert "airflow_pool_queued_slots" == mappings_yml_obj["mappings"][0]["name"]
+
+    def test_statsd_args_can_be_overridden(self):
+        needle = "--some-arg=foo"
+        args = [ needle ]
+        docs = render_chart(
+            values={"statsd": {"enabled": True, "args": args }},
+            show_only=["templates/statsd/statsd-deployment.yaml"],
+        )
+
+        assert needle in jmespath.search("spec.template.spec.containers[0].args", docs[0])

--- a/tests/charts/test_statsd.py
+++ b/tests/charts/test_statsd.py
@@ -216,9 +216,9 @@ class TestStatsd:
 
     def test_statsd_args_can_be_overridden(self):
         needle = "--some-arg=foo"
-        args = [ needle ]
+        args = [needle]
         docs = render_chart(
-            values={"statsd": {"enabled": True, "args": args }},
+            values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],
         )
 

--- a/tests/charts/test_statsd.py
+++ b/tests/charts/test_statsd.py
@@ -215,8 +215,7 @@ class TestStatsd:
         assert "airflow_pool_queued_slots" == mappings_yml_obj["mappings"][0]["name"]
 
     def test_statsd_args_can_be_overridden(self):
-        needle = "--some-arg=foo"
-        args = [needle]
+        args = ["--some-arg=foo"]
         docs = render_chart(
             values={"statsd": {"enabled": True, "args": args}},
             show_only=["templates/statsd/statsd-deployment.yaml"],


### PR DESCRIPTION
Add a new configurable option (statsd.args) to the helm chart to allow args on the statsd-exporter container to be over-ridden in the same manner as the args on other containers.
