### PR TITLE
Fix GCP Memorystore system tests

### DIFF
--- a/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
+++ b/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
@@ -42,7 +42,7 @@ PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "google_project_id")
 
 DAG_ID = "cloud_memorystore_memcached"
 
-MEMORYSTORE_MEMCACHED_INSTANCE_NAME = f"{ENV_ID}-memcached-1"
+MEMORYSTORE_MEMCACHED_INSTANCE_NAME = f"memcached-{ENV_ID}-1"
 LOCATION = "europe-north1"
 
 # [START howto_operator_memcached_instance]

--- a/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
+++ b/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
@@ -54,9 +54,9 @@ DAG_ID = "cloud_memorystore_redis"
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 LOCATION = "europe-north1"
-MEMORYSTORE_REDIS_INSTANCE_NAME = f"{ENV_ID}-redis-1"
-MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"{ENV_ID}-redis-2"
-MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"{ENV_ID}-redis-3"
+MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID.lower()}-1"
+MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"redis-{ENV_ID.lower()}-2"
+MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"redis-{ENV_ID.lower()}-3"
 
 EXPORT_GCS_URL = f"gs://{BUCKET_NAME}/my-export.rdb"
 


### PR DESCRIPTION
The instance names should not start with numbers or special characters and the name should be lowercase. Moved ENV_ID to end of the name

