### PR TITLE
Fix Cloud Build trigger name and teardown method

### DIFF
--- a/tests/system/providers/google/cloud/cloud_build/example_cloud_build_trigger.py
+++ b/tests/system/providers/google/cloud/cloud_build/example_cloud_build_trigger.py
@@ -37,6 +37,7 @@ from airflow.providers.google.cloud.operators.cloud_build import (
     CloudBuildRunBuildTriggerOperator,
     CloudBuildUpdateBuildTriggerOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
@@ -45,9 +46,11 @@ DAG_ID = "example_gcp_cloud_build_trigger"
 
 GCP_SOURCE_REPOSITORY_NAME = "test-cloud-build-repo"
 
+TRIGGER_NAME = f"cloud-build-trigger-{ENV_ID}"
+
 # [START howto_operator_gcp_create_build_trigger_body]
 create_build_trigger_body = {
-    "name": f"test-cloud-build-trigger-{ENV_ID}",
+    "name": TRIGGER_NAME,
     "trigger_template": {
         "project_id": PROJECT_ID,
         "repo_name": GCP_SOURCE_REPOSITORY_NAME,
@@ -126,6 +129,7 @@ with models.DAG(
         trigger_id=build_trigger_id,
     )
     # [END howto_operator_delete_build_trigger]
+    delete_build_trigger.trigger_rule = TriggerRule.ALL_DONE
 
     # [START howto_operator_list_build_triggers]
     list_build_triggers = CloudBuildListBuildTriggersOperator(


### PR DESCRIPTION
Our internal CI can produce longer ENV_ID - which would make the trigger name too long. Removed "test" from the name to shorten the trigger name.

Also added a missing teardown method for the trigger.