### PR TITLE
Resolve false warning about calling conf.get on moved item

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -1267,7 +1267,14 @@ class AirflowConfigParser(ConfigParser):
         include_secret: bool,
     ):
         sect = config_sources.setdefault(section, OrderedDict())
-        for (k, val) in config.items(section=section, raw=raw):
+        with warnings.catch_warnings():
+            # calling `items` on config has the effect of calling `get` on each item
+            # if we call `get` on a moved item, we will falsely get a warning
+            # letting us know to update our code
+            # so we suppress such warnings here
+            warnings.simplefilter("ignore", category=FutureWarning)
+            items = config.items(section=section, raw=raw)
+        for (k, val) in items:
             deprecated_section, deprecated_key, _ = deprecated_options.get((section, k), (None, None, None))
             if deprecated_section and deprecated_key:
                 if source_name == "default":

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -1369,3 +1369,13 @@ sql_alchemy_conn=sqlite://test
                 conf.read_dict(dictionary=cfg_dict)
                 os.environ.clear()
                 assert conf.get("database", "sql_alchemy_conn") == f"sqlite:///{HOME_DIR}/airflow/airflow.db"
+
+    def test_should_not_falsely_emit_future_warning(self):
+        from airflow.configuration import AirflowConfigParser
+
+        test_conf = AirflowConfigParser()
+        test_conf.read_dict({"scheduler": {"deactivate_stale_dags_interval": 60}})
+
+        with warnings.catch_warnings(record=True) as captured:
+            test_conf.as_dict()
+        assert captured == []


### PR DESCRIPTION
Calling `items` on config has the effect of calling `get` on each item. If we call `get` on a moved item, we will falsely get a warning letting us know to update our code so we suppress such warnings when iterating the config.
