### PR TITLE
Fix flaky backfill test

### DIFF
--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -636,9 +636,10 @@ class TestBackfillJob:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=2),
         )
-        job.run()
-        error_log_records = [record for record in caplog.records if record.levelname == "ERROR"]
-        assert "Backfill cannot be created for DagRun" in error_log_records[0].msg
+        with caplog.at_level(logging.ERROR, logger="airflow.jobs.backfill_job.BackfillJob"):
+            caplog.clear()
+            job.run()
+            assert "Backfill cannot be created for DagRun" in caplog.messages[0]
 
         ti = TI(
             task=dag.get_task("test_backfill_skip_active_scheduled_dagrun-1"), execution_date=DEFAULT_DATE


### PR DESCRIPTION
The test falls sometimes when initial setup of the tests causes recoverable failure - making "first" test contain different error followed by an expected one.

The fix is to look for the message in all error logs registered

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
