### PR TITLE
logging poke info when external dag is not none and task_id and task_ids are none

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -140,20 +140,29 @@ class ExternalTaskSensor(BaseSensorOperator):
                 f"`{self.allowed_states}` and failed states `{self.failed_states}`"
             )
 
-        if external_task_id is not None and external_task_ids is not None:
+        if external_task_id and external_task_ids:
             raise ValueError(
                 "Only one of `external_task_id` or `external_task_ids` may "
-                "be provided to ExternalTaskSensor; not both."
+                "be provided to ExternalTaskSensor; "
+                "Use external_task_id or external_task_ids or external_task_group_id."
+            )
+
+        if external_task_group_id and external_task_id:
+            raise ValueError(
+                "Only one of `external_task_group_id` or `external_task_id` may "
+                "be provided to ExternalTaskSensor; "
+                "Use external_task_id or external_task_ids or external_task_group_id."
+            )
+
+        if external_task_group_id and external_task_ids:
+            raise ValueError(
+                "Only one of `external_task_group_id` or `external_task_ids` may "
+                "be provided to ExternalTaskSensor; "
+                "Use external_task_id or external_task_ids or external_task_group_id."
             )
 
         if external_task_id is not None:
             external_task_ids = [external_task_id]
-
-        if external_task_group_id and external_task_ids:
-            raise ValueError(
-                "Values for `external_task_group_id` and `external_task_id` or `external_task_ids` "
-                "can't be set at the same time"
-            )
 
         if external_task_ids or external_task_group_id:
             if not total_states <= set(State.task_states):

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -140,21 +140,21 @@ class ExternalTaskSensor(BaseSensorOperator):
                 f"`{self.allowed_states}` and failed states `{self.failed_states}`"
             )
 
-        if external_task_id and external_task_ids:
+        if external_task_id is not None and external_task_ids is not None:
             raise ValueError(
                 "Only one of `external_task_id` or `external_task_ids` may "
                 "be provided to ExternalTaskSensor; "
                 "Use external_task_id or external_task_ids or external_task_group_id."
             )
 
-        if external_task_group_id and external_task_id:
+        if external_task_group_id is not None and external_task_id is not None:
             raise ValueError(
                 "Only one of `external_task_group_id` or `external_task_id` may "
                 "be provided to ExternalTaskSensor; "
                 "Use external_task_id or external_task_ids or external_task_group_id."
             )
 
-        if external_task_group_id and external_task_ids:
+        if external_task_group_id is not None and external_task_ids is not None:
             raise ValueError(
                 "Only one of `external_task_group_id` or `external_task_ids` may "
                 "be provided to ExternalTaskSensor; "

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -201,6 +201,14 @@ class ExternalTaskSensor(BaseSensorOperator):
         dttm_filter = self._get_dttm_filter(context)
         serialized_dttm_filter = ",".join(dt.isoformat() for dt in dttm_filter)
 
+        if self.external_task_ids:
+            self.log.info(
+                "Poking for tasks %s in dag %s on %s ... ",
+                self.external_task_ids,
+                self.external_dag_id,
+                serialized_dttm_filter,
+            )
+
         if self.external_task_group_id:
             self.log.info(
                 "Poking for task_group '%s' in dag '%s' on %s ... ",
@@ -208,10 +216,10 @@ class ExternalTaskSensor(BaseSensorOperator):
                 self.external_dag_id,
                 serialized_dttm_filter,
             )
-        else:
+
+        if self.external_dag_id and not self.external_task_group_id and not self.external_task_ids:
             self.log.info(
-                "Poking for tasks %s in dag %s on %s ... ",
-                self.external_task_ids,
+                "Poking for dag '%s' on %s ... ",
                 self.external_dag_id,
                 serialized_dttm_filter,
             )

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -144,21 +144,21 @@ class ExternalTaskSensor(BaseSensorOperator):
             raise ValueError(
                 "Only one of `external_task_id` or `external_task_ids` may "
                 "be provided to ExternalTaskSensor; "
-                "Use external_task_id or external_task_ids or external_task_group_id."
+                "use external_task_id or external_task_ids or external_task_group_id."
             )
 
         if external_task_group_id is not None and external_task_id is not None:
             raise ValueError(
                 "Only one of `external_task_group_id` or `external_task_id` may "
                 "be provided to ExternalTaskSensor; "
-                "Use external_task_id or external_task_ids or external_task_group_id."
+                "use external_task_id or external_task_ids or external_task_group_id."
             )
 
         if external_task_group_id is not None and external_task_ids is not None:
             raise ValueError(
                 "Only one of `external_task_group_id` or `external_task_ids` may "
                 "be provided to ExternalTaskSensor; "
-                "Use external_task_id or external_task_ids or external_task_group_id."
+                "use external_task_id or external_task_ids or external_task_group_id."
             )
 
         if external_task_id is not None:
@@ -228,7 +228,7 @@ class ExternalTaskSensor(BaseSensorOperator):
 
         if self.external_dag_id and not self.external_task_group_id and not self.external_task_ids:
             self.log.info(
-                "Poking for dag '%s' on %s ... ",
+                "Poking for DAG '%s' on %s ... ",
                 self.external_dag_id,
                 serialized_dttm_filter,
             )

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -201,18 +201,17 @@ class ExternalTaskSensor(BaseSensorOperator):
         dttm_filter = self._get_dttm_filter(context)
         serialized_dttm_filter = ",".join(dt.isoformat() for dt in dttm_filter)
 
-        if self.external_task_ids:
-            self.log.info(
-                "Poking for tasks %s in dag %s on %s ... ",
-                self.external_task_ids,
-                self.external_dag_id,
-                serialized_dttm_filter,
-            )
-
         if self.external_task_group_id:
             self.log.info(
                 "Poking for task_group '%s' in dag '%s' on %s ... ",
                 self.external_task_group_id,
+                self.external_dag_id,
+                serialized_dttm_filter,
+            )
+        else:
+            self.log.info(
+                "Poking for tasks %s in dag %s on %s ... ",
+                self.external_task_ids,
                 self.external_dag_id,
                 serialized_dttm_filter,
             )

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -359,14 +359,13 @@ class TestExternalTaskSensor:
         op = ExternalTaskSensor(
             task_id="test_external_dag_sensor_check",
             external_dag_id="other_dag",
-            external_task_ids=None,
             dag=self.dag,
         )
         with self.assertLogs(op.log, level=logging.INFO) as cm:
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
             assert (
-                f"INFO:airflow.task.operators:Poking for tasks None "
-                f"in dag other_dag on {DEFAULT_DATE.isoformat()} ... " in cm.output
+                f"INFO:airflow.task.operators:Poking for "
+                f"dag 'other_dag' on {DEFAULT_DATE.isoformat()} ... " in cm.output
             )
 
     def test_external_dag_sensor_soft_fail_as_skipped(self):

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -392,10 +392,8 @@ class TestExternalTaskSensor:
             external_dag_id="other_dag",
             dag=self.dag,
         )
-        with caplog.at_level(logging.INFO, logger=op.log.name):
-            caplog.clear()
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-            assert (f"Poking for DAG 'other_dag' on {DEFAULT_DATE.isoformat()} ... ") in caplog.messages
+        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        assert (f"Poking for DAG 'other_dag' on {DEFAULT_DATE.isoformat()} ... ") in caplog.messages
 
     def test_external_dag_sensor_soft_fail_as_skipped(self):
         other_dag = DAG("other_dag", default_args=self.args, end_date=DEFAULT_DATE, schedule="@once")

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -156,7 +156,7 @@ class TestExternalTaskSensor:
         assert (
             str(ctx.value) == "Only one of `external_task_id` or `external_task_ids` may "
             "be provided to ExternalTaskSensor; "
-            "Use external_task_id or external_task_ids or external_task_group_id."
+            "use external_task_id or external_task_ids or external_task_group_id."
         )
 
     def test_raise_with_external_task_sensor_task_group_and_task_id(self):
@@ -171,7 +171,7 @@ class TestExternalTaskSensor:
         assert (
             str(ctx.value) == "Only one of `external_task_group_id` or `external_task_id` may "
             "be provided to ExternalTaskSensor; "
-            "Use external_task_id or external_task_ids or external_task_group_id."
+            "use external_task_id or external_task_ids or external_task_group_id."
         )
 
     def test_raise_with_external_task_sensor_task_group_and_task_ids(self):
@@ -186,7 +186,7 @@ class TestExternalTaskSensor:
         assert (
             str(ctx.value) == "Only one of `external_task_group_id` or `external_task_ids` may "
             "be provided to ExternalTaskSensor; "
-            "Use external_task_id or external_task_ids or external_task_group_id."
+            "use external_task_id or external_task_ids or external_task_group_id."
         )
 
     # by default i.e. check_existence=False, if task_group doesn't exist, the sensor will run till timeout,
@@ -395,7 +395,7 @@ class TestExternalTaskSensor:
         with caplog.at_level(logging.INFO, logger=op.log.name):
             caplog.clear()
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-            assert (f"Poking for dag 'other_dag' on {DEFAULT_DATE.isoformat()} ... ") in caplog.messages
+            assert (f"Poking for DAG 'other_dag' on {DEFAULT_DATE.isoformat()} ... ") in caplog.messages
 
     def test_external_dag_sensor_soft_fail_as_skipped(self):
         other_dag = DAG("other_dag", default_args=self.args, end_date=DEFAULT_DATE, schedule="@once")

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -144,18 +144,49 @@ class TestExternalTaskSensor:
         )
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    def test_raise_with_external_task_sensor_task_id_and_task_ids(self):
+        with pytest.raises(ValueError) as ctx:
+            ExternalTaskSensor(
+                task_id="test_external_task_sensor_task_id_with_task_ids_failed_status",
+                external_dag_id=TEST_DAG_ID,
+                external_task_id=TEST_TASK_ID,
+                external_task_ids=TEST_TASK_ID,
+                dag=self.dag,
+            )
+        assert (
+            str(ctx.value) == "Only one of `external_task_id` or `external_task_ids` may "
+            "be provided to ExternalTaskSensor; "
+            "Use external_task_id or external_task_ids or external_task_group_id."
+        )
+
     def test_raise_with_external_task_sensor_task_group_and_task_id(self):
         with pytest.raises(ValueError) as ctx:
             ExternalTaskSensor(
                 task_id="test_external_task_sensor_task_group_with_task_id_failed_status",
+                external_dag_id=TEST_DAG_ID,
+                external_task_id=TEST_TASK_ID,
+                external_task_group_id=TEST_TASK_GROUP_ID,
+                dag=self.dag,
+            )
+        assert (
+            str(ctx.value) == "Only one of `external_task_group_id` or `external_task_id` may "
+            "be provided to ExternalTaskSensor; "
+            "Use external_task_id or external_task_ids or external_task_group_id."
+        )
+
+    def test_raise_with_external_task_sensor_task_group_and_task_ids(self):
+        with pytest.raises(ValueError) as ctx:
+            ExternalTaskSensor(
+                task_id="test_external_task_sensor_task_group_with_task_ids_failed_status",
                 external_dag_id=TEST_DAG_ID,
                 external_task_ids=TEST_TASK_ID,
                 external_task_group_id=TEST_TASK_GROUP_ID,
                 dag=self.dag,
             )
         assert (
-            str(ctx.value) == "Values for `external_task_group_id` and `external_task_id` or "
-            "`external_task_ids` can't be set at the same time"
+            str(ctx.value) == "Only one of `external_task_group_id` or `external_task_ids` may "
+            "be provided to ExternalTaskSensor; "
+            "Use external_task_id or external_task_ids or external_task_group_id."
         )
 
     # by default i.e. check_existence=False, if task_group doesn't exist, the sensor will run till timeout,


### PR DESCRIPTION
When using ExternalTaskSensor to check for an external_dag_id and external_task_ids=None, we are missing the logging info.
This PR is to fix the missing logging info for "Poking for tasks None in dag ......."
