### PR TITLE
Update RdsHook docstrings to match code

### DIFF
--- a/airflow/providers/amazon/aws/hooks/rds.py
+++ b/airflow/providers/amazon/aws/hooks/rds.py
@@ -229,7 +229,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB instance.
 
-        :param snapshot_id: The ID of the target DB instance.
+        :param db_instance_id: The ID of the target DB instance.
         :return: Returns the status of the DB instance as a string (eg. "available")
         :rtype: str
         :raises AirflowNotFoundException: If the DB instance does not exist.
@@ -278,7 +278,7 @@ class RdsHook(AwsGenericHook["RDSClient"]):
         """
         Get the current state of a DB cluster.
 
-        :param snapshot_id: The ID of the target DB cluster.
+        :param db_cluster_id: The ID of the target DB cluster.
         :return: Returns the status of the DB cluster as a string (eg. "available")
         :rtype: str
         :raises AirflowNotFoundException: If the DB cluster does not exist.


### PR DESCRIPTION
### Summary

I noticed 2 places in the `RdsHook` documentation where docstring argument names don't match the code. This PR fixes those docstrings.

_Example: The correct argument name is db_instance_id, but docstring says snapshot_id._

<img width="610" alt="Screen Shot 2022-12-05 at 14 33 36" src="https://user-images.githubusercontent.com/11639738/205557081-e5507296-958b-4e42-8c84-8bb05a84fcbc.png">