### PR TITLE
Fix instance name construction in GCP cloud memory sytem test

### DIFF
--- a/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
+++ b/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
@@ -54,9 +54,9 @@ DAG_ID = "cloud_memorystore_redis"
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 LOCATION = "europe-north1"
-MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID.lower()}-1"
-MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"redis-{ENV_ID.lower()}-2"
-MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"redis-{ENV_ID.lower()}-3"
+MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID}-1".lower()
+MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"redis-{ENV_ID}-2".lower()
+MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"redis-{ENV_ID}-3".lower()
 
 EXPORT_GCS_URL = f"gs://{BUCKET_NAME}/my-export.rdb"
 


### PR DESCRIPTION
Seems. like `SYSTEM_TESTS_ENV_ID` not set during `always` unittests in main

```
FAILED tests/always/test_example_dags.py::test_should_be_importable[tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py]

ERROR    airflow.models.dagbag.DagBag:dagbag.py:343 Failed to import: /opt/airflow/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/dagbag.py", line 339, in parse
    loader.exec_module(new_module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/opt/airflow/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py", line 57, in <module>
    MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID.lower()}-1"
AttributeError: 'NoneType' object has no attribute 'lower'
```