### PR TITLE
Set limits for XCOM pod

### DIFF
--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import tempfile
 import warnings
 from typing import TYPE_CHECKING, Any, Generator
@@ -100,6 +101,9 @@ class KubernetesHook(BaseHook):
             "disable_tcp_keepalive": BooleanField(lazy_gettext("Disable TCP keepalive")),
             "xcom_sidecar_container_image": StringField(
                 lazy_gettext("XCom sidecar image"), widget=BS3TextFieldWidget()
+            ),
+            "xcom_sidecar_container_resources": StringField(
+                lazy_gettext("XCom sidecar resources (JSON format)"), widget=BS3TextFieldWidget()
             ),
         }
 
@@ -365,6 +369,13 @@ class KubernetesHook(BaseHook):
     def get_xcom_sidecar_container_image(self):
         """Returns the xcom sidecar image that defined in the connection"""
         return self._get_field("xcom_sidecar_container_image")
+
+    def get_xcom_sidecar_container_resources(self):
+        """Returns the xcom sidecar resources that defined in the connection"""
+        field = self._get_field("xcom_sidecar_container_resources")
+        if not field:
+            return None
+        return json.loads(field)
 
     def get_pod_log_stream(
         self,

--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -810,7 +810,9 @@ class KubernetesPodOperator(BaseOperator):
         if self.do_xcom_push:
             self.log.debug("Adding xcom sidecar to task %s", self.task_id)
             pod = xcom_sidecar.add_xcom_sidecar(
-                pod, sidecar_container_image=self.hook.get_xcom_sidecar_container_image()
+                pod,
+                sidecar_container_image=self.hook.get_xcom_sidecar_container_image(),
+                sidecar_container_resources=self.hook.get_xcom_sidecar_container_resources(),
             )
 
         labels = self._get_ti_pod_labels(context)

--- a/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
+++ b/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
@@ -42,12 +42,18 @@ class PodDefaults:
         resources=k8s.V1ResourceRequirements(
             requests={
                 "cpu": "1m",
-            }
+                "memory": "10Mi",
+            },
         ),
     )
 
 
-def add_xcom_sidecar(pod: k8s.V1Pod, *, sidecar_container_image=None) -> k8s.V1Pod:
+def add_xcom_sidecar(
+    pod: k8s.V1Pod,
+    *,
+    sidecar_container_image: str | None = None,
+    sidecar_container_resources: k8s.V1ResourceRequirements | dict | None = None,
+) -> k8s.V1Pod:
     """Adds sidecar"""
     pod_cp = copy.deepcopy(pod)
     pod_cp.spec.volumes = pod.spec.volumes or []
@@ -56,6 +62,8 @@ def add_xcom_sidecar(pod: k8s.V1Pod, *, sidecar_container_image=None) -> k8s.V1P
     pod_cp.spec.containers[0].volume_mounts.insert(0, PodDefaults.VOLUME_MOUNT)
     sidecar = copy.deepcopy(PodDefaults.SIDECAR_CONTAINER)
     sidecar.image = sidecar_container_image or PodDefaults.SIDECAR_CONTAINER.image
+    if sidecar_container_resources:
+        sidecar.resources = sidecar_container_resources
     pod_cp.spec.containers.append(sidecar)
 
     return pod_cp

--- a/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/decorators/test_kubernetes.py
@@ -128,6 +128,10 @@ def test_kubernetes_with_input_output(
     (ti,) = dr.task_instances
 
     mock_hook.return_value.get_xcom_sidecar_container_image.return_value = XCOM_IMAGE
+    mock_hook.return_value.get_xcom_sidecar_container_resources.return_value = {
+        "requests": {"cpu": "1m", "memory": "10Mi"},
+        "limits": {"cpu": "1m", "memory": "50Mi"},
+    }
 
     dag.get_task("my_task_id").execute(context=ti.get_template_context(session=session))
 
@@ -139,6 +143,7 @@ def test_kubernetes_with_input_output(
     )
     assert mock_create_pod.call_count == 1
     assert mock_hook.return_value.get_xcom_sidecar_container_image.call_count == 1
+    assert mock_hook.return_value.get_xcom_sidecar_container_resources.call_count == 1
 
     containers = mock_create_pod.call_args[1]["pod"].spec.containers
 

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
@@ -76,6 +76,18 @@ class TestKubernetesHook:
             ("disable_tcp_keepalive_empty", {"disable_tcp_keepalive": ""}),
             ("sidecar_container_image", {"xcom_sidecar_container_image": "private.repo.com/alpine:3.16"}),
             ("sidecar_container_image_empty", {"xcom_sidecar_container_image": ""}),
+            (
+                "sidecar_container_resources",
+                {
+                    "xcom_sidecar_container_resources": json.dumps(
+                        {
+                            "requests": {"cpu": "1m", "memory": "10Mi"},
+                            "limits": {"cpu": "1m", "memory": "50Mi"},
+                        }
+                    ),
+                },
+            ),
+            ("sidecar_container_resources_empty", {"xcom_sidecar_container_resources": ""}),
         ]:
             db.merge_conn(Connection(conn_type="kubernetes", conn_id=conn_id, extra=json.dumps(extra)))
 
@@ -340,6 +352,27 @@ class TestKubernetesHook:
     def test_get_xcom_sidecar_container_image(self, conn_id, expected):
         hook = KubernetesHook(conn_id=conn_id)
         assert hook.get_xcom_sidecar_container_image() == expected
+
+    @pytest.mark.parametrize(
+        "conn_id, expected",
+        (
+            pytest.param(
+                "sidecar_container_resources",
+                {
+                    "requests": {"cpu": "1m", "memory": "10Mi"},
+                    "limits": {
+                        "cpu": "1m",
+                        "memory": "50Mi",
+                    },
+                },
+                id="sidecar-with-resources",
+            ),
+            pytest.param("sidecar_container_resources_empty", None, id="sidecar-without-resources"),
+        ),
+    )
+    def test_get_xcom_sidecar_container_resources(self, conn_id, expected):
+        hook = KubernetesHook(conn_id=conn_id)
+        assert hook.get_xcom_sidecar_container_resources() == expected
 
     @patch("kubernetes.config.kube_config.KubeConfigLoader")
     @patch("kubernetes.config.kube_config.KubeConfigMerger")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

My k8s namespace has specified `ResourceQuota`, and thus every container should be created with both `requests` and `limits` resources set.

I've tried to run simple dag like this:
```python
import datetime

from airflow import DAG
from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator

from kubernetes.client import models as k8s

with DAG(
    dag_id="example_k8s_operator",
    schedule=None,
    start_date=datetime.datetime(2021, 1, 1),
    catchup=False,
    tags=["example"],
) as dag:

    task = KubernetesPodOperator(
        namespace="onetl-demo-user-namespace",
        name="hello-dry-run",
        image="debian",
        cmds=["bash", "-cx"],
        arguments=["echo", "10"],
        labels={"foo": "bar"},
        task_id="dry_run_demo",
        container_resources=k8s.V1ResourceRequirements(
            requests={"memory": "250M", "cpu": "100m"},
            limits={"memory": "250M", "cpu": "100m"},
        ),
        do_xcom_push=True,
    )
```

but got an exception:
```
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/providers/cncf/kubernetes/utils/pod_manager.py", line 135, in run_pod_async
    body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/api/core_v1_api.py", line 7356, in create_namespaced_pod
    return self.create_namespaced_pod_with_http_info(namespace, body, **kwargs)  # noqa: E501
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/api/core_v1_api.py", line 7469, in create_namespaced_pod_with_http_info
    collection_formats=collection_formats)
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/api_client.py", line 353, in call_api
    _preload_content, _request_timeout, _host)
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/api_client.py", line 184, in __call_api
    _request_timeout=_request_timeout)
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/api_client.py", line 397, in request
    body=body)
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/rest.py", line 281, in POST
    body=body)
  File "/home/airflow/.local/lib/python3.7/site-packages/kubernetes/client/rest.py", line 234, in request
    raise ApiException(http_resp=r)
kubernetes.client.exceptions.ApiException: (403)
Reason: Forbidden

HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \"hello-dry-run-8863acf43ec04fa0b293f81ca981d701\" is forbidden: failed quota: portalquota: must specify limits.cpu,limits.memory","reason":"Forbidden","details":{"name":"hello-dry-run-8863acf43ec04fa0b293f81ca981d701","kind":"pods"},"code":403}
```

Full pod spec from logs:
```json
{
  "apiVersion": "v1",
  "kind": "Pod",
  "metadata": {
    "annotations": {},
    "labels": {
      "foo": "bar",
      "dag_id": "example_k8s_operator",
      "task_id": "dry_run_demo",
      "run_id": "manual__2022-12-05T151152.3955870000-b2ac559bc",
      "kubernetes_pod_operator": "True",
      "try_number": "1",
      "airflow_version": "2.4.1",
      "airflow_kpo_in_cluster": "True"
    },
    "name": "hello-dry-run-8863acf43ec04fa0b293f81ca981d701",
    "namespace": "onetl-demo-user-namespace"
  },
  "spec": {
    "affinity": {},
    "containers": [
      {
        "args": [
          "echo",
          "10"
        ],
        "command": [
          "bash",
          "-cx"
        ],
        "env": [],
        "envFrom": [],
        "image": "debian",
        "name": "base",
        "ports": [],
        "resources": {
          "limits": {
            "memory": "250M",
            "cpu": "100m"
          },
          "requests": {
            "memory": "250M",
            "cpu": "100m"
          }
        },
        "volumeMounts": [
          {
            "mountPath": "/airflow/xcom",
            "name": "xcom"
          }
        ]
      },
      {
        "command": [
          "sh",
          "-c",
          "trap \"exit 0\" INT; while true; do sleep 1; done;"
        ],
        "image": "alpine",
        "name": "airflow-xcom-sidecar",
        "resources": {
          "requests": {
            "cpu": "1m"
          }
        },
        "volumeMounts": [
          {
            "mountPath": "/airflow/xcom",
            "name": "xcom"
          }
        ]
      }
    ],
    "hostNetwork": false,
    "imagePullSecrets": [],
    "initContainers": [],
    "nodeSelector": {},
    "restartPolicy": "Never",
    "securityContext": {},
    "tolerations": [],
    "volumes": [
      {
        "emptyDir": {},
        "name": "xcom"
      }
    ]
  }
}
```

Container with pod command has the same resources I've set using `KubernetesPodOperator.container_resources`, but sidecar container with XCOM fetcher is created without limits, causing this exception. As a result I cannot get XCOM of any task created using this operator.

Here I've set limits as `1m` for cpu and `10m` for memory. IMHO, `sleep 1` command does not need more resources, even `10m` maybe too much.

I haven't add any options to change these values (like in #26766), it seems that currently there is no way to change command executed by this container.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
