### PR TITLE
Fix UnboundLocalError in breeze

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -155,6 +155,8 @@ def check_for_python_emulation():
 def check_for_rosetta_environment():
     if sys.platform != "darwin":
         return
+
+    from inputimeout import TimeoutOccurred, inputimeout
     try:
         runs_in_rosetta = subprocess.check_output(
             ["sysctl", "-n", "sysctl.proc_translated"],
@@ -181,7 +183,6 @@ def check_for_rosetta_environment():
                 "If you have mixed Intel/ARM binaries installed you should likely nuke and "
                 "reinstall your development environment (including brew and Python) from scratch!\n\n"
             )
-            from inputimeout import TimeoutOccurred, inputimeout
 
             user_status = inputimeout(
                 prompt="Are you REALLY sure you want to continue? (answer with y otherwise we exit in 20s)\n",

--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -157,6 +157,7 @@ def check_for_rosetta_environment():
         return
 
     from inputimeout import TimeoutOccurred, inputimeout
+
     try:
         runs_in_rosetta = subprocess.check_output(
             ["sysctl", "-n", "sysctl.proc_translated"],


### PR DESCRIPTION
I got the following error after installing breeze: 
`UnboundLocalError: local variable 'TimeoutOccurred' referenced before assignment` 

It seems that changing the import place fixes the issue.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
