### PR TITLE
Add retry to the scheduler loop to protect against DB hiccups

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -880,7 +880,7 @@ class SchedulerJob(BaseJob):
                     # is finished to avoid concurrent access to the DB.
                     self.log.debug("Waiting for processors to finish since we're using sqlite")
                     self.processor_agent.wait_until_finished()
-                max_retry_count = conf.getint('scheduler', 'scheduler_loop_max_retries', fallback=5)
+                max_retry_count = conf.getint('database', 'max_db_retries', fallback=3)
                 for retry_count in range(1, max_retry_count):
                     start_time = time.time()
                     try:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -892,10 +892,8 @@ class SchedulerJob(BaseJob):
                                 session.expunge_all()
                                 num_finished_events = self._process_executor_events(session=session)
                         except OperationalError as e:
-                            end_time = time.time()
-                            self.log.error("got a MySql exception (retry:" + str(
-                                attempt.retry_state.attempt_number) + ", total time in seconds: " + str(
-                                end_time - start_time) + "), details: " + str(e))
+                            total_time = time.time() - start_time
+                            self.log.error("got a DB exception (retry:%d, total time in seconds: %d), details: %s", attempt.retry_state.attempt_number, total_time, e)
                             raise
                 
                 if self.processor_agent:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from __future__ import annotations
-
+#
+import datetime
 import itertools
 import logging
 import multiprocessing
@@ -26,69 +26,48 @@ import sys
 import time
 import warnings
 from collections import defaultdict
-from datetime import datetime, timedelta
-from pathlib import Path
-from typing import TYPE_CHECKING, Collection, DefaultDict, Iterator
+from datetime import timedelta
+from typing import Collection, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 
-from sqlalchemy import and_, func, not_, or_, text
+from sqlalchemy import and_, func, not_, or_, tuple_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import load_only, selectinload
 from sqlalchemy.orm.session import Session, make_transient
-from sqlalchemy.sql import expression
 
-from airflow import settings
-from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackRequest, TaskCallbackRequest
-from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
+from airflow import models, settings
 from airflow.configuration import conf
-from airflow.exceptions import RemovedInAirflow3Warning
+from airflow.dag_processing.manager import DagFileProcessorAgent
 from airflow.executors.executor_loader import UNPICKLEABLE_EXECUTORS
 from airflow.jobs.base_job import BaseJob
-from airflow.models.dag import DAG, DagModel
+from airflow.models import DAG
+from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
-from airflow.models.dataset import (
-    DagScheduleDatasetReference,
-    DatasetDagRunQueue,
-    DatasetEvent,
-    DatasetModel,
-    TaskOutletDatasetReference,
-)
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
-from airflow.timetables.simple import DatasetTriggeredTimetable
 from airflow.utils import timezone
+from airflow.utils.callback_requests import DagCallbackRequest, TaskCallbackRequest
+from airflow.utils.docs import get_docs_url
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
-from airflow.utils.session import NEW_SESSION, create_session, provide_session
-from airflow.utils.sqlalchemy import (
-    CommitProhibitorGuard,
-    is_lock_not_available_error,
-    prohibit_commit,
-    skip_locked,
-    tuple_in_condition,
-    with_row_locks,
-)
+from airflow.utils.session import create_session, provide_session
+from airflow.utils.sqlalchemy import is_lock_not_available_error, prohibit_commit, skip_locked, with_row_locks
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
-if TYPE_CHECKING:
-    from types import FrameType
-
-    from airflow.dag_processing.manager import DagFileProcessorAgent
-
-TI = TaskInstance
-DR = DagRun
-DM = DagModel
+TI = models.TaskInstance
+DR = models.DagRun
+DM = models.DagModel
 
 
-def _is_parent_process() -> bool:
+def _is_parent_process():
     """
     Returns True if the current process is the parent process. False if the current process is a child
     process started by multiprocessing.
     """
-    return multiprocessing.current_process().name == "MainProcess"
+    return multiprocessing.current_process().name == 'MainProcess'
 
 
 class SchedulerJob(BaseJob):
@@ -101,30 +80,36 @@ class SchedulerJob(BaseJob):
 
     :param subdir: directory containing Python files with Airflow DAG
         definitions, or a specific path to a file
+    :type subdir: str
     :param num_runs: The number of times to run the scheduling loop. If you
         have a large number of DAG files this could complete before each file
         has been parsed. -1 for unlimited times.
+    :type num_runs: int
     :param num_times_parse_dags: The number of times to try to parse each DAG file.
         -1 for unlimited times.
+    :type num_times_parse_dags: int
     :param scheduler_idle_sleep_time: The number of seconds to wait between
         polls of running processors
+    :type scheduler_idle_sleep_time: int
     :param do_pickle: once a DAG object is obtained by executing the Python
         file, whether to serialize the DAG object to the DB
+    :type do_pickle: bool
     :param log: override the default Logger
+    :type log: logging.Logger
     """
 
-    __mapper_args__ = {"polymorphic_identity": "SchedulerJob"}
-    heartrate: int = conf.getint("scheduler", "SCHEDULER_HEARTBEAT_SEC")
+    __mapper_args__ = {'polymorphic_identity': 'SchedulerJob'}
+    heartrate: int = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
 
     def __init__(
         self,
         subdir: str = settings.DAGS_FOLDER,
-        num_runs: int = conf.getint("scheduler", "num_runs"),
+        num_runs: int = conf.getint('scheduler', 'num_runs'),
         num_times_parse_dags: int = -1,
-        scheduler_idle_sleep_time: float = conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
+        scheduler_idle_sleep_time: float = conf.getfloat('scheduler', 'scheduler_idle_sleep_time'),
         do_pickle: bool = False,
-        log: logging.Logger | None = None,
-        processor_poll_interval: float | None = None,
+        log: logging.Logger = None,
+        processor_poll_interval: Optional[float] = None,
         *args,
         **kwargs,
     ):
@@ -140,15 +125,12 @@ class SchedulerJob(BaseJob):
             warnings.warn(
                 "The 'processor_poll_interval' parameter is deprecated. "
                 "Please use 'scheduler_idle_sleep_time'.",
-                RemovedInAirflow3Warning,
+                DeprecationWarning,
                 stacklevel=2,
             )
             scheduler_idle_sleep_time = processor_poll_interval
         self._scheduler_idle_sleep_time = scheduler_idle_sleep_time
-        # How many seconds do we wait for tasks to heartbeat before mark them as zombies.
-        self._zombie_threshold_secs = conf.getint("scheduler", "scheduler_zombie_task_threshold")
-        self._standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
-        self._dag_stale_not_seen_duration = conf.getint("scheduler", "dag_stale_not_seen_duration")
+
         self.do_pickle = do_pickle
         super().__init__(*args, **kwargs)
 
@@ -156,13 +138,24 @@ class SchedulerJob(BaseJob):
             self._log = log
 
         # Check what SQL backend we use
-        sql_conn: str = conf.get_mandatory_value("database", "sql_alchemy_conn").lower()
-        self.using_sqlite = sql_conn.startswith("sqlite")
-        # Dag Processor agent - not used in Dag Processor standalone mode.
-        self.processor_agent: DagFileProcessorAgent | None = None
+        sql_conn: str = conf.get('core', 'sql_alchemy_conn').lower()
+        self.using_sqlite = sql_conn.startswith('sqlite')
+        self.using_mysql = sql_conn.startswith('mysql')
+        self.max_tis_per_query: int = conf.getint('scheduler', 'max_tis_per_query')
+        self.processor_agent: Optional[DagFileProcessorAgent] = None
 
         self.dagbag = DagBag(dag_folder=self.subdir, read_dags_from_db=True, load_op_links=False)
-        self._paused_dag_without_running_dagruns: set = set()
+
+        if conf.getboolean('smart_sensor', 'use_smart_sensor'):
+            compatible_sensors = set(
+                map(lambda l: l.strip(), conf.get('smart_sensor', 'sensors_enabled').split(','))
+            )
+            docs_url = get_docs_url('concepts/smart-sensors.html#migrating-to-deferrable-operators')
+            warnings.warn(
+                f'Smart sensors are deprecated, yet can be used for {compatible_sensors} sensors.'
+                f' Please use Deferrable Operators instead. See {docs_url} for more info.',
+                DeprecationWarning,
+            )
 
     def register_signals(self) -> None:
         """Register signals that stop child processes"""
@@ -170,7 +163,7 @@ class SchedulerJob(BaseJob):
         signal.signal(signal.SIGTERM, self._exit_gracefully)
         signal.signal(signal.SIGUSR2, self._debug_dump)
 
-    def _exit_gracefully(self, signum: int, frame: FrameType | None) -> None:
+    def _exit_gracefully(self, signum, frame) -> None:
         """Helper method to clean up processor_agent to avoid leaving orphan processes."""
         if not _is_parent_process():
             # Only the parent process should perform the cleanup.
@@ -181,7 +174,7 @@ class SchedulerJob(BaseJob):
             self.processor_agent.end()
         sys.exit(os.EX_OK)
 
-    def _debug_dump(self, signum: int, frame: FrameType | None) -> None:
+    def _debug_dump(self, signum, frame):
         if not _is_parent_process():
             # Only the parent process should perform the debug dump.
             return
@@ -196,7 +189,7 @@ class SchedulerJob(BaseJob):
         self.executor.debug_dump()
         self.log.info("-" * 80)
 
-    def is_alive(self, grace_multiplier: float | None = None) -> bool:
+    def is_alive(self, grace_multiplier: Optional[float] = None) -> bool:
         """
         Is this SchedulerJob alive?
 
@@ -206,74 +199,62 @@ class SchedulerJob(BaseJob):
 
         ``grace_multiplier`` is accepted for compatibility with the parent class.
 
+        :rtype: boolean
         """
         if grace_multiplier is not None:
             # Accept the same behaviour as superclass
             return super().is_alive(grace_multiplier=grace_multiplier)
-        scheduler_health_check_threshold: int = conf.getint("scheduler", "scheduler_health_check_threshold")
+        scheduler_health_check_threshold: int = conf.getint('scheduler', 'scheduler_health_check_threshold')
         return (
             self.state == State.RUNNING
             and (timezone.utcnow() - self.latest_heartbeat).total_seconds() < scheduler_health_check_threshold
         )
 
+    @provide_session
     def __get_concurrency_maps(
-        self, states: list[TaskInstanceState], session: Session
-    ) -> tuple[DefaultDict[str, int], DefaultDict[tuple[str, str], int]]:
+        self, states: List[TaskInstanceState], session: Session = None
+    ) -> Tuple[DefaultDict[str, int], DefaultDict[Tuple[str, str], int]]:
         """
         Get the concurrency maps.
 
         :param states: List of states to query for
+        :type states: list[airflow.utils.state.State]
         :return: A map from (dag_id, task_id) to # of task instances and
          a map from (dag_id, task_id) to # of task instances in the given state list
+        :rtype: tuple[dict[str, int], dict[tuple[str, str], int]]
         """
-        ti_concurrency_query: list[tuple[str, str, int]] = (
-            session.query(TI.task_id, TI.dag_id, func.count("*"))
+        ti_concurrency_query: List[Tuple[str, str, int]] = (
+            session.query(TI.task_id, TI.dag_id, func.count('*'))
             .filter(TI.state.in_(states))
             .group_by(TI.task_id, TI.dag_id)
         ).all()
         dag_map: DefaultDict[str, int] = defaultdict(int)
-        task_map: DefaultDict[tuple[str, str], int] = defaultdict(int)
+        task_map: DefaultDict[Tuple[str, str], int] = defaultdict(int)
         for result in ti_concurrency_query:
             task_id, dag_id, count = result
             dag_map[dag_id] += count
             task_map[(dag_id, task_id)] = count
         return dag_map, task_map
 
-    def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
+    @provide_session
+    def _executable_task_instances_to_queued(self, max_tis: int, session: Session = None) -> List[TI]:
         """
         Finds TIs that are ready for execution with respect to pool limits,
         dag max_active_tasks, executor state, and priority.
 
         :param max_tis: Maximum number of TIs to queue in this loop.
+        :type max_tis: int
         :return: list[airflow.models.TaskInstance]
         """
-        from airflow.models.pool import Pool
-        from airflow.utils.db import DBLocks
-
-        executable_tis: list[TI] = []
-
-        if session.get_bind().dialect.name == "postgresql":
-            # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
-            # timeout", try to take out a transactional advisory lock (unlocks automatically on
-            # COMMIT/ROLLBACK)
-            lock_acquired = session.execute(
-                text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
-                    id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
-                )
-            ).scalar()
-            if not lock_acquired:
-                # Throw an error like the one that would happen with NOWAIT
-                raise OperationalError(
-                    "Failed to acquire advisory lock", params=None, orig=RuntimeError("55P03")
-                )
+        executable_tis: List[TI] = []
 
         # Get the pool settings. We get a lock on the pool rows, treating this as a "critical section"
         # Throws an exception if lock cannot be obtained, rather than blocking
-        pools = Pool.slots_stats(lock_rows=True, session=session)
+        pools = models.Pool.slots_stats(lock_rows=True, session=session)
 
         # If the pools are full, there is no point doing anything!
         # If _somehow_ the pool is overfull, don't let the limit go negative - it breaks SQL
-        pool_slots_free = sum(max(0, pool["open"]) for pool in pools.values())
+        pool_slots_free = max(0, sum(pool['open'] for pool in pools.values()))
 
         if pool_slots_free == 0:
             self.log.debug("All pools are full!")
@@ -281,11 +262,11 @@ class SchedulerJob(BaseJob):
 
         max_tis = min(max_tis, pool_slots_free)
 
-        starved_pools = {pool_name for pool_name, stats in pools.items() if stats["open"] <= 0}
+        starved_pools = {pool_name for pool_name, stats in pools.items() if stats['open'] <= 0}
 
         # dag_id to # of running tasks and (dag_id, task_id) to # of running tasks.
         dag_active_tasks_map: DefaultDict[str, int]
-        task_concurrency_map: DefaultDict[tuple[str, str], int]
+        task_concurrency_map: DefaultDict[Tuple[str, str], int]
         dag_active_tasks_map, task_concurrency_map = self.__get_concurrency_maps(
             states=list(EXECUTION_STATES), session=session
         )
@@ -295,8 +276,8 @@ class SchedulerJob(BaseJob):
         num_starving_tasks_total = 0
 
         # dag and task ids that can't be queued because of concurrency limits
-        starved_dags: set[str] = set()
-        starved_tasks: set[tuple[str, str]] = set()
+        starved_dags: Set[str] = set()
+        starved_tasks: Set[Tuple[str, str]] = set()
 
         pool_num_starving_tasks: DefaultDict[str, int] = defaultdict(int)
 
@@ -311,14 +292,21 @@ class SchedulerJob(BaseJob):
             # and the dag is not paused
             query = (
                 session.query(TI)
-                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+                ##################################################
+                # This patch was added - https://github.com/apache/airflow/issues/25627
+                # In the Scheduler, we are coming across instances where MySQL is inefficiently optimizing the
+                # critical section task queuing query. When a large number of task instances are scheduled,
+                # MySQL failing to use the ti_state index to filter the task_instance table,
+                # resulting in a full table scan (about 7.3 million rows).
+                .with_hint(TI, 'USE INDEX (ti_state)', dialect_name='mysql')
+                ##################################################
                 .join(TI.dag_run)
                 .filter(DR.run_type != DagRunType.BACKFILL_JOB, DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)
                 .filter(not_(DM.is_paused))
                 .filter(TI.state == TaskInstanceState.SCHEDULED)
-                .options(selectinload("dag_model"))
-                .order_by(-TI.priority_weight, DR.execution_date, TI.map_index)
+                .options(selectinload('dag_model'))
+                .order_by(-TI.priority_weight, DR.execution_date)
             )
 
             if starved_pools:
@@ -328,26 +316,27 @@ class SchedulerJob(BaseJob):
                 query = query.filter(not_(TI.dag_id.in_(starved_dags)))
 
             if starved_tasks:
-                task_filter = tuple_in_condition((TaskInstance.dag_id, TaskInstance.task_id), starved_tasks)
+                if settings.engine.dialect.name == 'mssql':
+                    task_filter = or_(
+                        and_(
+                            TaskInstance.dag_id == dag_id,
+                            TaskInstance.task_id == task_id,
+                        )
+                        for (dag_id, task_id) in starved_tasks
+                    )
+                else:
+                    task_filter = tuple_(TaskInstance.dag_id, TaskInstance.task_id).in_(starved_tasks)
+
                 query = query.filter(not_(task_filter))
 
             query = query.limit(max_tis)
 
-            timer = Stats.timer("scheduler.critical_section_query_duration")
-            timer.start()
-
-            try:
-                task_instances_to_examine: list[TI] = with_row_locks(
-                    query,
-                    of=TI,
-                    session=session,
-                    **skip_locked(session=session),
-                ).all()
-                timer.stop(send=True)
-            except OperationalError as e:
-                timer.stop(send=False)
-                raise e
-
+            task_instances_to_examine: List[TI] = with_row_locks(
+                query,
+                of=TI,
+                session=session,
+                **skip_locked(session=session),
+            ).all()
             # TODO[HA]: This was wrong before anyway, as it only looked at a sub-set of dags, not everything.
             # Stats.gauge('scheduler.tasks.pending', len(task_instances_to_examine))
 
@@ -361,126 +350,141 @@ class SchedulerJob(BaseJob):
                 "%s tasks up for execution:\n\t%s", len(task_instances_to_examine), task_instance_str
             )
 
+            pool_to_task_instances: DefaultDict[str, List[TI]] = defaultdict(list)
             for task_instance in task_instances_to_examine:
-                pool_name = task_instance.pool
+                pool_to_task_instances[task_instance.pool].append(task_instance)
 
-                pool_stats = pools.get(pool_name)
-                if not pool_stats:
-                    self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool_name)
+            # Go through each pool, and queue up a task for execution if there are
+            # any open slots in the pool.
+
+            for pool, task_instances in pool_to_task_instances.items():
+                pool_name = pool
+                if pool not in pools:
+                    self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool)
                     starved_pools.add(pool_name)
                     continue
 
-                # Make sure to emit metrics if pool has no starving tasks
-                pool_num_starving_tasks.setdefault(pool_name, 0)
+                pool_total = pools[pool]["total"]
+                open_slots = pools[pool]["open"]
 
-                pool_total = pool_stats["total"]
-                open_slots = pool_stats["open"]
-
-                if open_slots <= 0:
-                    self.log.info(
-                        "Not scheduling since there are %s open slots in pool %s", open_slots, pool_name
-                    )
-                    # Can't schedule any more since there are no more open slots.
-                    pool_num_starving_tasks[pool_name] += 1
-                    num_starving_tasks_total += 1
-                    starved_pools.add(pool_name)
-                    continue
-
-                if task_instance.pool_slots > pool_total:
-                    self.log.warning(
-                        "Not executing %s. Requested pool slots (%s) are greater than "
-                        "total pool slots: '%s' for pool: %s.",
-                        task_instance,
-                        task_instance.pool_slots,
-                        pool_total,
-                        pool_name,
-                    )
-
-                    pool_num_starving_tasks[pool_name] += 1
-                    num_starving_tasks_total += 1
-                    starved_tasks.add((task_instance.dag_id, task_instance.task_id))
-                    continue
-
-                if task_instance.pool_slots > open_slots:
-                    self.log.info(
-                        "Not executing %s since it requires %s slots "
-                        "but there are %s open slots in the pool %s.",
-                        task_instance,
-                        task_instance.pool_slots,
-                        open_slots,
-                        pool_name,
-                    )
-                    pool_num_starving_tasks[pool_name] += 1
-                    num_starving_tasks_total += 1
-                    starved_tasks.add((task_instance.dag_id, task_instance.task_id))
-                    # Though we can execute tasks with lower priority if there's enough room
-                    continue
-
-                # Check to make sure that the task max_active_tasks of the DAG hasn't been
-                # reached.
-                dag_id = task_instance.dag_id
-
-                current_active_tasks_per_dag = dag_active_tasks_map[dag_id]
-                max_active_tasks_per_dag_limit = task_instance.dag_model.max_active_tasks
+                num_ready = len(task_instances)
                 self.log.info(
-                    "DAG %s has %s/%s running and queued tasks",
-                    dag_id,
-                    current_active_tasks_per_dag,
-                    max_active_tasks_per_dag_limit,
+                    "Figuring out tasks to run in Pool(name=%s) with %s open slots "
+                    "and %s task instances ready to be queued",
+                    pool,
+                    open_slots,
+                    num_ready,
                 )
-                if current_active_tasks_per_dag >= max_active_tasks_per_dag_limit:
-                    self.log.info(
-                        "Not executing %s since the number of tasks running or queued "
-                        "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
-                        task_instance,
-                        dag_id,
-                        max_active_tasks_per_dag_limit,
-                    )
-                    starved_dags.add(dag_id)
-                    continue
 
-                if task_instance.dag_model.has_task_concurrency_limits:
-                    # Many dags don't have a task_concurrency, so where we can avoid loading the full
-                    # serialized DAG the better.
-                    serialized_dag = self.dagbag.get_dag(dag_id, session=session)
-                    # If the dag is missing, fail the task and continue to the next task.
-                    if not serialized_dag:
-                        self.log.error(
-                            "DAG '%s' for task instance %s not found in serialized_dag table",
-                            dag_id,
-                            task_instance,
+                priority_sorted_task_instances = sorted(
+                    task_instances, key=lambda ti: (-ti.priority_weight, ti.execution_date)
+                )
+
+                for current_index, task_instance in enumerate(priority_sorted_task_instances):
+                    if open_slots <= 0:
+                        self.log.info(
+                            "Not scheduling since there are %s open slots in pool %s", open_slots, pool
                         )
-                        session.query(TI).filter(
-                            TI.dag_id == dag_id, TI.state == TaskInstanceState.SCHEDULED
-                        ).update({TI.state: TaskInstanceState.FAILED}, synchronize_session="fetch")
+                        # Can't schedule any more since there are no more open slots.
+                        num_unhandled = len(priority_sorted_task_instances) - current_index
+                        pool_num_starving_tasks[pool_name] += num_unhandled
+                        num_starving_tasks_total += num_unhandled
+                        starved_pools.add(pool_name)
+                        break
+
+                    if task_instance.pool_slots > pool_total:
+                        self.log.warning(
+                            "Not executing %s. Requested pool slots (%s) are greater than "
+                            "total pool slots: '%s' for pool: %s.",
+                            task_instance,
+                            task_instance.pool_slots,
+                            pool_total,
+                            pool,
+                        )
+
+                        starved_tasks.add((task_instance.dag_id, task_instance.task_id))
                         continue
 
-                    task_concurrency_limit: int | None = None
-                    if serialized_dag.has_task(task_instance.task_id):
-                        task_concurrency_limit = serialized_dag.get_task(
-                            task_instance.task_id
-                        ).max_active_tis_per_dag
+                    if task_instance.pool_slots > open_slots:
+                        self.log.info(
+                            "Not executing %s since it requires %s slots "
+                            "but there are %s open slots in the pool %s.",
+                            task_instance,
+                            task_instance.pool_slots,
+                            open_slots,
+                            pool,
+                        )
+                        pool_num_starving_tasks[pool_name] += 1
+                        num_starving_tasks_total += 1
+                        starved_tasks.add((task_instance.dag_id, task_instance.task_id))
+                        # Though we can execute tasks with lower priority if there's enough room
+                        continue
 
-                    if task_concurrency_limit is not None:
-                        current_task_concurrency = task_concurrency_map[
-                            (task_instance.dag_id, task_instance.task_id)
-                        ]
+                    # Check to make sure that the task max_active_tasks of the DAG hasn't been
+                    # reached.
+                    dag_id = task_instance.dag_id
 
-                        if current_task_concurrency >= task_concurrency_limit:
-                            self.log.info(
-                                "Not executing %s since the task concurrency for"
-                                " this task has been reached.",
+                    current_active_tasks_per_dag = dag_active_tasks_map[dag_id]
+                    max_active_tasks_per_dag_limit = task_instance.dag_model.max_active_tasks
+                    self.log.info(
+                        "DAG %s has %s/%s running and queued tasks",
+                        dag_id,
+                        current_active_tasks_per_dag,
+                        max_active_tasks_per_dag_limit,
+                    )
+                    if current_active_tasks_per_dag >= max_active_tasks_per_dag_limit:
+                        self.log.info(
+                            "Not executing %s since the number of tasks running or queued "
+                            "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
+                            task_instance,
+                            dag_id,
+                            max_active_tasks_per_dag_limit,
+                        )
+                        starved_dags.add(dag_id)
+                        continue
+
+                    if task_instance.dag_model.has_task_concurrency_limits:
+                        # Many dags don't have a task_concurrency, so where we can avoid loading the full
+                        # serialized DAG the better.
+                        serialized_dag = self.dagbag.get_dag(dag_id, session=session)
+                        # If the dag is missing, fail the task and continue to the next task.
+                        if not serialized_dag:
+                            self.log.error(
+                                "DAG '%s' for task instance %s not found in serialized_dag table",
+                                dag_id,
                                 task_instance,
                             )
-                            starved_tasks.add((task_instance.dag_id, task_instance.task_id))
+                            session.query(TI).filter(TI.dag_id == dag_id, TI.state == State.SCHEDULED).update(
+                                {TI.state: State.FAILED}, synchronize_session='fetch'
+                            )
                             continue
 
-                executable_tis.append(task_instance)
-                open_slots -= task_instance.pool_slots
-                dag_active_tasks_map[dag_id] += 1
-                task_concurrency_map[(task_instance.dag_id, task_instance.task_id)] += 1
+                        task_concurrency_limit: Optional[int] = None
+                        if serialized_dag.has_task(task_instance.task_id):
+                            task_concurrency_limit = serialized_dag.get_task(
+                                task_instance.task_id
+                            ).max_active_tis_per_dag
 
-                pool_stats["open"] = open_slots
+                        if task_concurrency_limit is not None:
+                            current_task_concurrency = task_concurrency_map[
+                                (task_instance.dag_id, task_instance.task_id)
+                            ]
+
+                            if current_task_concurrency >= task_concurrency_limit:
+                                self.log.info(
+                                    "Not executing %s since the task concurrency for"
+                                    " this task has been reached.",
+                                    task_instance,
+                                )
+                                starved_tasks.add((task_instance.dag_id, task_instance.task_id))
+                                continue
+
+                    executable_tis.append(task_instance)
+                    open_slots -= task_instance.pool_slots
+                    dag_active_tasks_map[dag_id] += 1
+                    task_concurrency_map[(task_instance.dag_id, task_instance.task_id)] += 1
+
+                pools[pool]["open"] = open_slots
 
             is_done = executable_tis or len(task_instances_to_examine) < max_tis
             # Check this to avoid accidental infinite loops
@@ -500,11 +504,11 @@ class SchedulerJob(BaseJob):
             )
 
         for pool_name, num_starving_tasks in pool_num_starving_tasks.items():
-            Stats.gauge(f"pool.starving_tasks.{pool_name}", num_starving_tasks)
+            Stats.gauge(f'pool.starving_tasks.{pool_name}', num_starving_tasks)
 
-        Stats.gauge("scheduler.tasks.starving", num_starving_tasks_total)
-        Stats.gauge("scheduler.tasks.running", num_tasks_in_executor)
-        Stats.gauge("scheduler.tasks.executable", len(executable_tis))
+        Stats.gauge('scheduler.tasks.starving', num_starving_tasks_total)
+        Stats.gauge('scheduler.tasks.running', num_tasks_in_executor)
+        Stats.gauge('scheduler.tasks.executable', len(executable_tis))
 
         if len(executable_tis) > 0:
             task_instance_str = "\n\t".join(repr(x) for x in executable_tis)
@@ -515,11 +519,7 @@ class SchedulerJob(BaseJob):
             session.query(TI).filter(filter_for_tis).update(
                 # TODO[ha]: should we use func.now()? How does that work with DB timezone
                 # on mysql when it's not UTC?
-                {
-                    TI.state: TaskInstanceState.QUEUED,
-                    TI.queued_dttm: timezone.utcnow(),
-                    TI.queued_by_job_id: self.id,
-                },
+                {TI.state: State.QUEUED, TI.queued_dttm: timezone.utcnow(), TI.queued_by_job_id: self.id},
                 synchronize_session=False,
             )
 
@@ -527,13 +527,18 @@ class SchedulerJob(BaseJob):
             make_transient(ti)
         return executable_tis
 
-    def _enqueue_task_instances_with_queued_state(self, task_instances: list[TI], session: Session) -> None:
+    @provide_session
+    def _enqueue_task_instances_with_queued_state(
+        self, task_instances: List[TI], session: Session = None
+    ) -> None:
         """
         Takes task_instances, which should have been set to queued, and enqueues them
         with the executor.
 
         :param task_instances: TaskInstances to enqueue
+        :type task_instances: list[TaskInstance]
         :param session: The session object
+        :type session: Session
         """
         # actually enqueue them
         for ti in task_instances:
@@ -556,9 +561,9 @@ class SchedulerJob(BaseJob):
                 queue=queue,
             )
 
-    def _critical_section_enqueue_task_instances(self, session: Session) -> int:
+    def _critical_section_execute_task_instances(self, session: Session) -> int:
         """
-        Enqueues TaskInstances for execution.
+        Attempts to execute TaskInstances that should be executed by the scheduler.
 
         There are three steps:
         1. Pick TIs by priority with the constraint that they are in the expected states
@@ -573,6 +578,7 @@ class SchedulerJob(BaseJob):
         MariaDB or MySQL 5.x) the other schedulers will wait for the lock before continuing.
 
         :param session:
+        :type session: sqlalchemy.orm.Session
         :return: Number of task instance with state changed.
         """
         if self.max_tis_per_query == 0:
@@ -584,13 +590,14 @@ class SchedulerJob(BaseJob):
         self._enqueue_task_instances_with_queued_state(queued_tis, session=session)
         return len(queued_tis)
 
-    def _process_executor_events(self, session: Session) -> int:
+    @provide_session
+    def _process_executor_events(self, session: Session = None) -> int:
         """Respond to executor events."""
-        if not self._standalone_dag_processor and not self.processor_agent:
+        if not self.processor_agent:
             raise ValueError("Processor agent is not started.")
-        ti_primary_key_to_try_number_map: dict[tuple[str, str, str, int], int] = {}
+        ti_primary_key_to_try_number_map: Dict[Tuple[str, str, datetime.datetime], int] = {}
         event_buffer = self.executor.get_event_buffer()
-        tis_with_right_state: list[TaskInstanceKey] = []
+        tis_with_right_state: List[TaskInstanceKey] = []
 
         # Report execution
         for ti_key, value in event_buffer.items():
@@ -607,7 +614,7 @@ class SchedulerJob(BaseJob):
                 state,
                 ti_key.try_number,
             )
-            if state in (TaskInstanceState.FAILED, TaskInstanceState.SUCCESS, TaskInstanceState.QUEUED):
+            if state in (State.FAILED, State.SUCCESS, State.QUEUED):
                 tis_with_right_state.append(ti_key)
 
         # Return if no finished tasks
@@ -616,7 +623,7 @@ class SchedulerJob(BaseJob):
 
         # Check state of finished tasks
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
-        query = session.query(TI).filter(filter_for_tis).options(selectinload("dag_model"))
+        query = session.query(TI).filter(filter_for_tis).options(selectinload('dag_model'))
         # row lock this entire set of taskinstances to make sure the scheduler doesn't fail when we have
         # multi-schedulers
         tis: Iterator[TI] = with_row_locks(
@@ -630,24 +637,23 @@ class SchedulerJob(BaseJob):
             buffer_key = ti.key.with_try_number(try_number)
             state, info = event_buffer.pop(buffer_key)
 
-            if state == TaskInstanceState.QUEUED:
+            # TODO: should we fail RUNNING as well, as we do in Backfills?
+            if state == State.QUEUED:
                 ti.external_executor_id = info
                 self.log.info("Setting external_id for %s to %s", ti, info)
                 continue
 
             msg = (
-                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, map_index=%s, "
+                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
                 "run_start_date=%s, run_end_date=%s, "
                 "run_duration=%s, state=%s, executor_state=%s, try_number=%s, max_tries=%s, job_id=%s, "
-                "pool=%s, queue=%s, priority_weight=%d, operator=%s, queued_dttm=%s, "
-                "queued_by_job_id=%s, pid=%s"
+                "pool=%s, queue=%s, priority_weight=%d, operator=%s"
             )
             self.log.info(
                 msg,
                 ti.dag_id,
                 ti.task_id,
                 ti.run_id,
-                ti.map_index,
                 ti.start_date,
                 ti.end_date,
                 ti.duration,
@@ -660,26 +666,10 @@ class SchedulerJob(BaseJob):
                 ti.queue,
                 ti.priority_weight,
                 ti.operator,
-                ti.queued_dttm,
-                ti.queued_by_job_id,
-                ti.pid,
             )
 
-            # There are two scenarios why the same TI with the same try_number is queued
-            # after executor is finished with it:
-            # 1) the TI was killed externally and it had no time to mark itself failed
-            # - in this case we should mark it as failed here.
-            # 2) the TI has been requeued after getting deferred - in this case either our executor has it
-            # or the TI is queued by another job. Either ways we should not fail it.
-
-            # All of this could also happen if the state is "running",
-            # but that is handled by the zombie detection.
-
-            ti_queued = ti.try_number == buffer_key.try_number and ti.state == TaskInstanceState.QUEUED
-            ti_requeued = ti.queued_by_job_id != self.id or self.executor.has_task(ti)
-
-            if ti_queued and not ti_requeued:
-                Stats.incr("scheduler.tasks.killed_externally")
+            if ti.try_number == buffer_key.try_number and ti.state == State.QUEUED:
+                Stats.incr('scheduler.tasks.killed_externally')
                 msg = (
                     "Executor reports task instance %s finished (%s) although the "
                     "task says its %s. (Info: %s) Was the task killed externally?"
@@ -698,19 +688,16 @@ class SchedulerJob(BaseJob):
                 if task.on_retry_callback or task.on_failure_callback:
                     request = TaskCallbackRequest(
                         full_filepath=ti.dag_model.fileloc,
-                        simple_task_instance=SimpleTaskInstance.from_ti(ti),
+                        simple_task_instance=SimpleTaskInstance(ti),
                         msg=msg % (ti, state, ti.state, info),
-                        processor_subdir=ti.dag_model.processor_subdir,
                     )
-                    self.executor.send_callback(request)
+                    self.processor_agent.send_callback_to_execute(request)
                 else:
                     ti.handle_failure(error=msg % (ti, state, ti.state, info), session=session)
 
         return len(event_buffer)
 
     def _execute(self) -> None:
-        from airflow.dag_processing.manager import DagFileProcessorAgent
-
         self.log.info("Starting the scheduler")
 
         # DAGs can be pickled for easier remote execution by some executors
@@ -722,54 +709,40 @@ class SchedulerJob(BaseJob):
         # so the scheduler job and DAG parser don't access the DB at the same time.
         async_mode = not self.using_sqlite
 
-        processor_timeout_seconds: int = conf.getint("core", "dag_file_processor_timeout")
+        processor_timeout_seconds: int = conf.getint('core', 'dag_file_processor_timeout')
         processor_timeout = timedelta(seconds=processor_timeout_seconds)
-        if not self._standalone_dag_processor:
-            self.processor_agent = DagFileProcessorAgent(
-                dag_directory=Path(self.subdir),
-                max_runs=self.num_times_parse_dags,
-                processor_timeout=processor_timeout,
-                dag_ids=[],
-                pickle_dags=pickle_dags,
-                async_mode=async_mode,
-            )
+        self.processor_agent = DagFileProcessorAgent(
+            dag_directory=self.subdir,
+            max_runs=self.num_times_parse_dags,
+            processor_timeout=processor_timeout,
+            dag_ids=[],
+            pickle_dags=pickle_dags,
+            async_mode=async_mode,
+        )
 
         try:
             self.executor.job_id = self.id
-            if self.processor_agent:
-                self.log.debug("Using PipeCallbackSink as callback sink.")
-                self.executor.callback_sink = PipeCallbackSink(
-                    get_sink_pipe=self.processor_agent.get_callbacks_pipe
-                )
-            else:
-                from airflow.callbacks.database_callback_sink import DatabaseCallbackSink
-
-                self.log.debug("Using DatabaseCallbackSink as callback sink.")
-                self.executor.callback_sink = DatabaseCallbackSink()
-
             self.executor.start()
 
             self.register_signals()
 
-            if self.processor_agent:
-                self.processor_agent.start()
+            self.processor_agent.start()
 
             execute_start_time = timezone.utcnow()
 
             self._run_scheduler_loop()
 
-            if self.processor_agent:
-                # Stop any processors
-                self.processor_agent.terminate()
+            # Stop any processors
+            self.processor_agent.terminate()
 
-                # Verify that all files were processed, and if so, deactivate DAGs that
-                # haven't been touched by the scheduler as they likely have been
-                # deleted.
-                if self.processor_agent.all_files_processed:
-                    self.log.info(
-                        "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
-                    )
-                    DAG.deactivate_stale_dags(execute_start_time)
+            # Verify that all files were processed, and if so, deactivate DAGs that
+            # haven't been touched by the scheduler as they likely have been
+            # deleted.
+            if self.processor_agent.all_files_processed:
+                self.log.info(
+                    "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
+                )
+                models.DAG.deactivate_stale_dags(execute_start_time)
 
             settings.Session.remove()  # type: ignore
         except Exception:
@@ -780,39 +753,11 @@ class SchedulerJob(BaseJob):
                 self.executor.end()
             except Exception:
                 self.log.exception("Exception when executing Executor.end")
-            if self.processor_agent:
-                try:
-                    self.processor_agent.end()
-                except Exception:
-                    self.log.exception("Exception when executing DagFileProcessorAgent.end")
+            try:
+                self.processor_agent.end()
+            except Exception:
+                self.log.exception("Exception when executing DagFileProcessorAgent.end")
             self.log.info("Exited execute loop")
-
-    @provide_session
-    def _update_dag_run_state_for_paused_dags(self, session: Session = NEW_SESSION) -> None:
-        try:
-            paused_runs = (
-                session.query(DagRun)
-                .join(DagRun.dag_model)
-                .join(TaskInstance)
-                .filter(
-                    DagModel.is_paused == expression.true(),
-                    DagRun.state == DagRunState.RUNNING,
-                    DagRun.run_type != DagRunType.BACKFILL_JOB,
-                )
-                .having(DagRun.last_scheduling_decision <= func.max(TaskInstance.updated_at))
-                .group_by(DagRun)
-            )
-            for dag_run in paused_runs:
-                dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
-                if dag is None:
-                    continue
-
-                dag_run.dag = dag
-                _, callback_to_run = dag_run.update_state(execute_callbacks=False, session=session)
-                if callback_to_run:
-                    self._send_dag_callbacks_to_processor(dag, callback_to_run)
-        except Exception as e:  # should not fail the scheduler
-            self.log.exception("Failed to update dag run state for paused dags due to %s", str(e))
 
     def _run_scheduler_loop(self) -> None:
         """
@@ -829,10 +774,11 @@ class SchedulerJob(BaseJob):
 
         .. image:: ../docs/apache-airflow/img/scheduler_loop.jpg
 
+        :rtype: None
         """
-        if not self.processor_agent and not self._standalone_dag_processor:
+        if not self.processor_agent:
             raise ValueError("Processor agent is not started.")
-        is_unit_test: bool = conf.getboolean("core", "unit_test_mode")
+        is_unit_test: bool = conf.getboolean('core', 'unit_test_mode')
 
         timers = EventScheduler()
 
@@ -840,64 +786,47 @@ class SchedulerJob(BaseJob):
         self.adopt_or_reset_orphaned_tasks()
 
         timers.call_regular_interval(
-            conf.getfloat("scheduler", "orphaned_tasks_check_interval", fallback=300.0),
+            conf.getfloat('scheduler', 'orphaned_tasks_check_interval', fallback=300.0),
             self.adopt_or_reset_orphaned_tasks,
         )
 
         timers.call_regular_interval(
-            conf.getfloat("scheduler", "trigger_timeout_check_interval", fallback=15.0),
+            conf.getfloat('scheduler', 'trigger_timeout_check_interval', fallback=15.0),
             self.check_trigger_timeouts,
         )
 
         timers.call_regular_interval(
-            conf.getfloat("scheduler", "pool_metrics_interval", fallback=5.0),
+            conf.getfloat('scheduler', 'pool_metrics_interval', fallback=5.0),
             self._emit_pool_metrics,
         )
 
-        timers.call_regular_interval(
-            conf.getfloat("scheduler", "zombie_detection_interval", fallback=10.0),
-            self._find_zombies,
-        )
-        timers.call_regular_interval(60.0, self._update_dag_run_state_for_paused_dags)
-
-        timers.call_regular_interval(
-            conf.getfloat("scheduler", "parsing_cleanup_interval"),
-            self._orphan_unreferenced_datasets,
-        )
-
-        if self._standalone_dag_processor:
-            timers.call_regular_interval(
-                conf.getfloat("scheduler", "parsing_cleanup_interval"),
-                self._cleanup_stale_dags,
-            )
-
         for loop_count in itertools.count(start=1):
-            with Stats.timer("scheduler.scheduler_loop_duration") as timer:
+            with Stats.timer() as timer:
 
-                if self.using_sqlite and self.processor_agent:
+                if self.using_sqlite:
                     self.processor_agent.run_single_parsing_loop()
                     # For the sqlite case w/ 1 thread, wait until the processor
                     # is finished to avoid concurrent access to the DB.
                     self.log.debug("Waiting for processors to finish since we're using sqlite")
                     self.processor_agent.wait_until_finished()
-                max_retry_count = conf.getint('database', 'max_db_retries', fallback=3)
-                for retry_count in range(1, max_retry_count):
-                    start_time = time.time()
-                    try:
-                        with create_session() as session:
-                            num_queued_tis = self._do_scheduling(session)
-
-                            self.executor.heartbeat()
-                            session.expunge_all()
-                            num_finished_events = self._process_executor_events(session=session)
-                            break
-                    except OperationalError as e:
-                        end_time = time.time()
-                        Stats.incr("scheduler.scheduler_loop_failures")
-                        self.log.error("got a MySql exception (retry:" + str(retry_count) + ", total time in seconds: " + str(end_time - start_time) + "), details: " + str(e))
-                if self.processor_agent:
-                    self.processor_agent.heartbeat()
-
+                
+                for attempt in run_with_db_retries():
+                    with attempt:
+                        start_time = time.time()
+                        try:
+                            with create_session() as session:
+                                num_queued_tis = self._do_scheduling(session)
+    
+                                self.executor.heartbeat()
+                                session.expunge_all()
+                                num_finished_events = self._process_executor_events(session=session)
+                                break
+                        except OperationalError as e:
+                            end_time = time.time()
+                            self.log.error("got a MySql exception (retry:" + str(attempt.retry_state.attempt_number) + ", total time in seconds: " + str(end_time - start_time) + "), details: " + str(e))
+                            raise
+                self.processor_agent.heartbeat()
+                
                 # Heartbeat the scheduler periodically
                 self.heartbeat(only_if_necessary=True)
 
@@ -911,7 +840,7 @@ class SchedulerJob(BaseJob):
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
                 # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
                 # usage when "idle"
-                time.sleep(min(self._scheduler_idle_sleep_time, next_event if next_event else 0))
+                time.sleep(min(self._scheduler_idle_sleep_time, next_event))
 
             if loop_count >= self.num_runs > 0:
                 self.log.info(
@@ -920,7 +849,7 @@ class SchedulerJob(BaseJob):
                     loop_count,
                 )
                 break
-            if self.processor_agent and self.processor_agent.done:
+            if self.processor_agent.done:
                 self.log.info(
                     "Exiting scheduler loop as requested DAG parse count (%d) has been reached after %d"
                     " scheduler loops",
@@ -929,7 +858,7 @@ class SchedulerJob(BaseJob):
                 )
                 break
 
-    def _do_scheduling(self, session: Session) -> int:
+    def _do_scheduling(self, session) -> int:
         """
         This function is where the main scheduling decisions take places. It:
 
@@ -946,7 +875,7 @@ class SchedulerJob(BaseJob):
 
           By "next oldest", we mean hasn't been examined/scheduled in the most time.
 
-          We don't select all dagruns at once, because the rows are selected with row locks, meaning
+          The reason we don't select all dagruns at once because the rows are selected with row locks, meaning
           that only one scheduler can "process them", even it is waiting behind other dags. Increasing this
           limit will allow more throughput for smaller DAGs but will likely slow down throughput for larger
           (>500 tasks.) DAGs
@@ -954,66 +883,70 @@ class SchedulerJob(BaseJob):
         - Then, via a Critical Section (locking the rows of the Pool model) we queue tasks, and then send them
           to the executor.
 
-          See docs of _critical_section_enqueue_task_instances for more.
+          See docs of _critical_section_execute_task_instances for more.
 
         :return: Number of TIs enqueued in this iteration
+        :rtype: int
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
+
             if settings.USE_JOB_SCHEDULE:
                 self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
             guard.commit()
-            dag_runs = self._get_next_dagruns_to_examine(DagRunState.RUNNING, session)
+            dag_runs = self._get_next_dagruns_to_examine(State.RUNNING, session)
             # Bulk fetch the currently active dag runs for the dags we are
             # examining, rather than making one query per DagRun
 
-            callback_tuples = self._schedule_all_dag_runs(guard, dag_runs, session)
+            callback_tuples = []
+            for dag_run in dag_runs:
+                callback_to_run = self._schedule_dag_run(dag_run, session)
+                callback_tuples.append((dag_run, callback_to_run))
 
-        # Send the callbacks after we commit to ensure the context is up to date when it gets run
-        for dag_run, callback_to_run in callback_tuples:
-            dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
-            if not dag:
-                self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
-                continue
-            # Sending callbacks there as in standalone_dag_processor they are adding to the database,
-            # so it must be done outside of prohibit_commit.
-            self._send_dag_callbacks_to_processor(dag, callback_to_run)
+            guard.commit()
 
-        with prohibit_commit(session) as guard:
+            # Send the callbacks after we commit to ensure the context is up to date when it gets run
+            for dag_run, callback_to_run in callback_tuples:
+                dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
+                if not dag:
+                    self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
+                    continue
+
+                self._send_dag_callbacks_to_processor(dag, callback_to_run)
+
             # Without this, the session has an invalid view of the DB
             session.expunge_all()
             # END: schedule TIs
 
-            if self.executor.slots_available <= 0:
-                # We know we can't do anything here, so don't even try!
-                self.log.debug("Executor full, skipping critical section")
-                num_queued_tis = 0
-            else:
-                try:
-                    timer = Stats.timer("scheduler.critical_section_duration")
-                    timer.start()
+            try:
+                if self.executor.slots_available <= 0:
+                    # We know we can't do anything here, so don't even try!
+                    self.log.debug("Executor full, skipping critical section")
+                    return 0
 
-                    # Find anything TIs in state SCHEDULED, try to QUEUE it (send it to the executor)
-                    num_queued_tis = self._critical_section_enqueue_task_instances(session=session)
+                timer = Stats.timer('scheduler.critical_section_duration')
+                timer.start()
 
-                    # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
-                    # metric, way down
-                    timer.stop(send=True)
-                except OperationalError as e:
-                    timer.stop(send=False)
+                # Find anything TIs in state SCHEDULED, try to QUEUE it (send it to the executor)
+                num_queued_tis = self._critical_section_execute_task_instances(session=session)
 
-                    if is_lock_not_available_error(error=e):
-                        self.log.debug("Critical section lock held by another Scheduler")
-                        Stats.incr("scheduler.critical_section_busy")
-                        session.rollback()
-                        return 0
-                    raise
+                # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
+                # metric, way down
+                timer.stop(send=True)
+            except OperationalError as e:
+                timer.stop(send=False)
+
+                if is_lock_not_available_error(error=e):
+                    self.log.debug("Critical section lock held by another Scheduler")
+                    Stats.incr('scheduler.critical_section_busy')
+                    session.rollback()
+                    return 0
+                raise
 
             guard.commit()
-
-        return num_queued_tis
+            return num_queued_tis
 
     @retry_db_transaction
     def _get_next_dagruns_to_examine(self, state: DagRunState, session: Session):
@@ -1021,19 +954,10 @@ class SchedulerJob(BaseJob):
         return DagRun.next_dagruns_to_examine(state, session)
 
     @retry_db_transaction
-    def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
+    def _create_dagruns_for_dags(self, guard, session):
         """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError"""
-        query, dataset_triggered_dag_info = DagModel.dags_needing_dagruns(session)
-        all_dags_needing_dag_runs = set(query.all())
-        dataset_triggered_dags = [
-            dag for dag in all_dags_needing_dag_runs if dag.dag_id in dataset_triggered_dag_info
-        ]
-        non_dataset_dags = all_dags_needing_dag_runs.difference(dataset_triggered_dags)
-        self._create_dag_runs(non_dataset_dags, session)
-        if dataset_triggered_dags:
-            self._create_dag_runs_dataset_triggered(
-                dataset_triggered_dags, dataset_triggered_dag_info, session
-            )
+        query = DagModel.dags_needing_dagruns(session)
+        self._create_dag_runs(query.all(), session)
 
         # commit the session - Release the write lock on DagModel table.
         guard.commit()
@@ -1048,15 +972,24 @@ class SchedulerJob(BaseJob):
         # as DagModel.dag_id and DagModel.next_dagrun
         # This list is used to verify if the DagRun already exist so that we don't attempt to create
         # duplicate dag runs
-        existing_dagruns = (
-            session.query(DagRun.dag_id, DagRun.execution_date)
-            .filter(
-                tuple_in_condition(
-                    (DagRun.dag_id, DagRun.execution_date),
-                    ((dm.dag_id, dm.next_dagrun) for dm in dag_models),
-                ),
+
+        if session.bind.dialect.name == 'mssql':
+            existing_dagruns_filter = or_(
+                *(
+                    and_(
+                        DagRun.dag_id == dm.dag_id,
+                        DagRun.execution_date == dm.next_dagrun,
+                    )
+                    for dm in dag_models
+                )
             )
-            .all()
+        else:
+            existing_dagruns_filter = tuple_(DagRun.dag_id, DagRun.execution_date).in_(
+                [(dm.dag_id, dm.next_dagrun) for dm in dag_models]
+            )
+
+        existing_dagruns = (
+            session.query(DagRun.dag_id, DagRun.execution_date).filter(existing_dagruns_filter).all()
         )
 
         active_runs_of_dags = defaultdict(
@@ -1086,7 +1019,7 @@ class SchedulerJob(BaseJob):
                 dag.create_dagrun(
                     run_type=DagRunType.SCHEDULED,
                     execution_date=dag_model.next_dagrun,
-                    state=DagRunState.QUEUED,
+                    state=State.QUEUED,
                     data_interval=data_interval,
                     external_trigger=False,
                     session=session,
@@ -1099,107 +1032,7 @@ class SchedulerJob(BaseJob):
         # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
         # memory for larger dags? or expunge_all()
 
-    def _create_dag_runs_dataset_triggered(
-        self,
-        dag_models: Collection[DagModel],
-        dataset_triggered_dag_info: dict[str, tuple[datetime, datetime]],
-        session: Session,
-    ) -> None:
-        """For DAGs that are triggered by datasets, create dag runs."""
-        # Bulk Fetch DagRuns with dag_id and execution_date same
-        # as DagModel.dag_id and DagModel.next_dagrun
-        # This list is used to verify if the DagRun already exist so that we don't attempt to create
-        # duplicate dag runs
-        exec_dates = {
-            dag_id: timezone.coerce_datetime(last_time)
-            for dag_id, (_, last_time) in dataset_triggered_dag_info.items()
-        }
-        existing_dagruns: set[tuple[str, timezone.DateTime]] = set(
-            session.query(DagRun.dag_id, DagRun.execution_date).filter(
-                tuple_in_condition((DagRun.dag_id, DagRun.execution_date), exec_dates.items())
-            )
-        )
-
-        for dag_model in dag_models:
-            dag = self.dagbag.get_dag(dag_model.dag_id, session=session)
-            if not dag:
-                self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
-                continue
-
-            if not isinstance(dag.timetable, DatasetTriggeredTimetable):
-                self.log.error(
-                    "DAG '%s' was dataset-scheduled, but didn't have a DatasetTriggeredTimetable!",
-                    dag_model.dag_id,
-                )
-                continue
-
-            dag_hash = self.dagbag.dags_hash.get(dag.dag_id)
-
-            # Explicitly check if the DagRun already exists. This is an edge case
-            # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
-            # are not updated.
-            # We opted to check DagRun existence instead
-            # of catching an Integrity error and rolling back the session i.e
-            # we need to set dag.next_dagrun_info if the Dag Run already exists or if we
-            # create a new one. This is so that in the next Scheduling loop we try to create new runs
-            # instead of falling in a loop of Integrity Error.
-            exec_date = exec_dates[dag.dag_id]
-            if (dag.dag_id, exec_date) not in existing_dagruns:
-
-                previous_dag_run = (
-                    session.query(DagRun)
-                    .filter(
-                        DagRun.dag_id == dag.dag_id,
-                        DagRun.execution_date < exec_date,
-                        DagRun.run_type == DagRunType.DATASET_TRIGGERED,
-                    )
-                    .order_by(DagRun.execution_date.desc())
-                    .first()
-                )
-                dataset_event_filters = [
-                    DagScheduleDatasetReference.dag_id == dag.dag_id,
-                    DatasetEvent.timestamp <= exec_date,
-                ]
-                if previous_dag_run:
-                    dataset_event_filters.append(DatasetEvent.timestamp > previous_dag_run.execution_date)
-
-                dataset_events = (
-                    session.query(DatasetEvent)
-                    .join(
-                        DagScheduleDatasetReference,
-                        DatasetEvent.dataset_id == DagScheduleDatasetReference.dataset_id,
-                    )
-                    .join(DatasetEvent.source_dag_run)
-                    .filter(*dataset_event_filters)
-                    .all()
-                )
-
-                data_interval = dag.timetable.data_interval_for_events(exec_date, dataset_events)
-                run_id = dag.timetable.generate_run_id(
-                    run_type=DagRunType.DATASET_TRIGGERED,
-                    logical_date=exec_date,
-                    data_interval=data_interval,
-                    session=session,
-                    events=dataset_events,
-                )
-
-                dag_run = dag.create_dagrun(
-                    run_id=run_id,
-                    run_type=DagRunType.DATASET_TRIGGERED,
-                    execution_date=exec_date,
-                    data_interval=data_interval,
-                    state=DagRunState.QUEUED,
-                    external_trigger=False,
-                    session=session,
-                    dag_hash=dag_hash,
-                    creating_job_id=self.id,
-                )
-                dag_run.consumed_dataset_events.extend(dataset_events)
-                session.query(DatasetDagRunQueue).filter(
-                    DatasetDagRunQueue.target_dag_id == dag_run.dag_id
-                ).delete()
-
-    def _should_update_dag_next_dagruns(self, dag, dag_model: DagModel, total_active_runs: int) -> bool:
+    def _should_update_dag_next_dagruns(self, dag, dag_model: DagModel, total_active_runs) -> bool:
         """Check if the dag's next_dagruns_create_after should be updated."""
         if total_active_runs >= dag.max_active_runs:
             self.log.info(
@@ -1212,9 +1045,12 @@ class SchedulerJob(BaseJob):
             return False
         return True
 
-    def _start_queued_dagruns(self, session: Session) -> None:
+    def _start_queued_dagruns(
+        self,
+        session: Session,
+    ) -> int:
         """Find DagRuns in queued state and decide moving them to running state"""
-        dag_runs = self._get_next_dagruns_to_examine(DagRunState.QUEUED, session)
+        dag_runs = self._get_next_dagruns_to_examine(State.QUEUED, session)
 
         active_runs_of_dags = defaultdict(
             int,
@@ -1222,7 +1058,7 @@ class SchedulerJob(BaseJob):
         )
 
         def _update_state(dag: DAG, dag_run: DagRun):
-            dag_run.state = DagRunState.RUNNING
+            dag_run.state = State.RUNNING
             dag_run.start_date = timezone.utcnow()
             if dag.timetable.periodic:
                 # TODO: Logically, this should be DagRunInfo.run_after, but the
@@ -1232,9 +1068,10 @@ class SchedulerJob(BaseJob):
                 # always happening immediately after the data interval.
                 expected_start_date = dag.get_run_data_interval(dag_run).end
                 schedule_delay = dag_run.start_date - expected_start_date
-                Stats.timing(f"dagrun.schedule_delay.{dag.dag_id}", schedule_delay)
+                Stats.timing(f'dagrun.schedule_delay.{dag.dag_id}', schedule_delay)
 
         for dag_run in dag_runs:
+
             dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
             if not dag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
@@ -1251,38 +1088,23 @@ class SchedulerJob(BaseJob):
             else:
                 active_runs_of_dags[dag_run.dag_id] += 1
                 _update_state(dag, dag_run)
-                dag_run.notify_dagrun_state_changed()
-
-    @retry_db_transaction
-    def _schedule_all_dag_runs(self, guard, dag_runs, session):
-        """Makes scheduling decisions for all `dag_runs`"""
-        callback_tuples = []
-        for dag_run in dag_runs:
-            callback_to_run = self._schedule_dag_run(dag_run, session)
-            callback_tuples.append((dag_run, callback_to_run))
-
-        guard.commit()
-
-        return callback_tuples
 
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
         session: Session,
-    ) -> DagCallbackRequest | None:
+    ) -> Optional[DagCallbackRequest]:
         """
         Make scheduling decisions about an individual dag run
 
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
-        callback: DagCallbackRequest | None = None
-
         dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
 
         if not dag:
             self.log.error("Couldn't find dag %s in DagBag/DB!", dag_run.dag_id)
-            return callback
+            return 0
         dag_model = DM.get_dagmodel(dag.dag_id, session)
 
         if (
@@ -1290,7 +1112,7 @@ class SchedulerJob(BaseJob):
             and dag.dagrun_timeout
             and dag_run.start_date < timezone.utcnow() - dag.dagrun_timeout
         ):
-            dag_run.set_state(DagRunState.FAILED)
+            dag_run.set_state(State.FAILED)
             unfinished_task_instances = (
                 session.query(TI)
                 .filter(TI.dag_id == dag_run.dag_id)
@@ -1298,7 +1120,7 @@ class SchedulerJob(BaseJob):
                 .filter(TI.state.in_(State.unfinished))
             )
             for task_instance in unfinished_task_instances:
-                task_instance.state = TaskInstanceState.SKIPPED
+                task_instance.state = State.SKIPPED
                 session.merge(task_instance)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
@@ -1312,20 +1134,19 @@ class SchedulerJob(BaseJob):
                 dag_id=dag.dag_id,
                 run_id=dag_run.run_id,
                 is_failure_callback=True,
-                processor_subdir=dag_model.processor_subdir,
-                msg="timed_out",
+                msg='timed_out',
             )
 
-            dag_run.notify_dagrun_state_changed()
-            return callback_to_execute
+            # Send SLA & DAG Success/Failure Callbacks to be executed
+            self._send_dag_callbacks_to_processor(dag, callback_to_execute)
+
+            return 0
 
         if dag_run.execution_date > timezone.utcnow() and not dag.allow_future_exec_dates:
             self.log.error("Execution date is in future: %s", dag_run.execution_date)
-            return callback
+            return 0
 
-        if not self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session):
-            self.log.warning("The DAG disappeared before verifying integrity: %s. Skipping.", dag_run.dag_id)
-            return callback
+        self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
         if dag_run.state in State.finished:
@@ -1333,6 +1154,7 @@ class SchedulerJob(BaseJob):
             # Work out if we should allow creating a new DagRun now?
             if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
+
         # This will do one query per dag run. We "could" build up a complex
         # query to update all the TIs across all the execution dates and dag
         # IDs in a single query, but it turns out that can be _very very slow_
@@ -1341,80 +1163,69 @@ class SchedulerJob(BaseJob):
 
         return callback_to_run
 
-    def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session: Session) -> bool:
-        """
-        Only run DagRun.verify integrity if Serialized DAG has changed since it is slow.
-
-        Return True if we determine that DAG still exists.
-        """
+    @provide_session
+    def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session=None):
+        """Only run DagRun.verify integrity if Serialized DAG has changed since it is slow"""
         latest_version = SerializedDagModel.get_latest_version_hash(dag_run.dag_id, session=session)
         if dag_run.dag_hash == latest_version:
             self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
-            return True
+            return
 
         dag_run.dag_hash = latest_version
 
         # Refresh the DAG
         dag_run.dag = self.dagbag.get_dag(dag_id=dag_run.dag_id, session=session)
-        if not dag_run.dag:
-            return False
 
         # Verify integrity also takes care of session.flush
         dag_run.verify_integrity(session=session)
-        return True
 
-    def _send_dag_callbacks_to_processor(self, dag: DAG, callback: DagCallbackRequest | None = None) -> None:
+    def _send_dag_callbacks_to_processor(self, dag: DAG, callback: Optional[DagCallbackRequest] = None):
+        if not self.processor_agent:
+            raise ValueError("Processor agent is not started.")
+
         self._send_sla_callbacks_to_processor(dag)
         if callback:
-            self.executor.send_callback(callback)
-        else:
-            self.log.debug("callback is empty")
+            self.processor_agent.send_callback_to_execute(callback)
 
-    def _send_sla_callbacks_to_processor(self, dag: DAG) -> None:
+    def _send_sla_callbacks_to_processor(self, dag: DAG):
         """Sends SLA Callbacks to DagFileProcessor if tasks have SLAs set and check_slas=True"""
         if not settings.CHECK_SLAS:
             return
 
-        if not any(isinstance(task.sla, timedelta) for task in dag.tasks):
+        if not any(isinstance(ti.sla, timedelta) for ti in dag.tasks):
             self.log.debug("Skipping SLA check for %s because no tasks in DAG have SLAs", dag)
             return
 
-        if not dag.timetable.periodic:
-            self.log.debug("Skipping SLA check for %s because DAG is not scheduled", dag)
-            return
+        if not self.processor_agent:
+            raise ValueError("Processor agent is not started.")
 
-        dag_model = DagModel.get_dagmodel(dag.dag_id)
-        request = SlaCallbackRequest(
-            full_filepath=dag.fileloc,
-            dag_id=dag.dag_id,
-            processor_subdir=dag_model.processor_subdir,
+        self.processor_agent.send_sla_callback_request_to_execute(
+            full_filepath=dag.fileloc, dag_id=dag.dag_id
         )
-        self.executor.send_callback(request)
 
     @provide_session
-    def _emit_pool_metrics(self, session: Session = NEW_SESSION) -> None:
-        from airflow.models.pool import Pool
-
-        pools = Pool.slots_stats(session=session)
+    def _emit_pool_metrics(self, session: Session = None) -> None:
+        pools = models.Pool.slots_stats(session=session)
         for pool_name, slot_stats in pools.items():
-            Stats.gauge(f"pool.open_slots.{pool_name}", slot_stats["open"])
-            Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
-            Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
+            Stats.gauge(f'pool.open_slots.{pool_name}', slot_stats["open"])
+            Stats.gauge(f'pool.queued_slots.{pool_name}', slot_stats[State.QUEUED])  # type: ignore
+            Stats.gauge(f'pool.running_slots.{pool_name}', slot_stats[State.RUNNING])  # type: ignore
 
     @provide_session
-    def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
-        Stats.incr("scheduler_heartbeat", 1, 1)
+    def heartbeat_callback(self, session: Session = None) -> None:
+        Stats.incr('scheduler_heartbeat', 1, 1)
 
     @provide_session
-    def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:
+    def adopt_or_reset_orphaned_tasks(self, session: Session = None):
         """
         Reset any TaskInstance still in QUEUED or SCHEDULED states that were
         enqueued by a SchedulerJob that is no longer running.
 
         :return: the number of TIs reset
+        :rtype: int
         """
         self.log.info("Resetting orphaned tasks for active dag runs")
-        timeout = conf.getint("scheduler", "scheduler_health_check_threshold")
+        timeout = conf.getint('scheduler', 'scheduler_health_check_threshold')
 
         for attempt in run_with_db_retries(logger=self.log):
             with attempt:
@@ -1437,9 +1248,9 @@ class SchedulerJob(BaseJob):
 
                     if num_failed:
                         self.log.info("Marked %d SchedulerJob instances as failed", num_failed)
-                        Stats.incr(self.__class__.__name__.lower() + "_end", num_failed)
+                        Stats.incr(self.__class__.__name__.lower() + '_end', num_failed)
 
-                    resettable_states = [TaskInstanceState.QUEUED, TaskInstanceState.RUNNING]
+                    resettable_states = [State.QUEUED, State.RUNNING]
                     query = (
                         session.query(TI)
                         .filter(TI.state.in_(resettable_states))
@@ -1472,11 +1283,11 @@ class SchedulerJob(BaseJob):
                     for ti in set(tis_to_reset_or_adopt) - set(to_reset):
                         ti.queued_by_job_id = self.id
 
-                    Stats.incr("scheduler.orphaned_tasks.cleared", len(to_reset))
-                    Stats.incr("scheduler.orphaned_tasks.adopted", len(tis_to_reset_or_adopt) - len(to_reset))
+                    Stats.incr('scheduler.orphaned_tasks.cleared', len(to_reset))
+                    Stats.incr('scheduler.orphaned_tasks.adopted', len(tis_to_reset_or_adopt) - len(to_reset))
 
                     if to_reset:
-                        task_instance_str = "\n\t".join(reset_tis_message)
+                        task_instance_str = '\n\t'.join(reset_tis_message)
                         self.log.info(
                             "Reset the following %s orphaned TaskInstances:\n\t%s",
                             len(to_reset),
@@ -1493,22 +1304,19 @@ class SchedulerJob(BaseJob):
         return len(to_reset)
 
     @provide_session
-    def check_trigger_timeouts(self, session: Session = NEW_SESSION) -> None:
+    def check_trigger_timeouts(self, session: Session = None):
         """
         Looks at all tasks that are in the "deferred" state and whose trigger
         or execution timeout has passed, so they can be marked as failed.
         """
         num_timed_out_tasks = (
             session.query(TaskInstance)
-            .filter(
-                TaskInstance.state == TaskInstanceState.DEFERRED,
-                TaskInstance.trigger_timeout < timezone.utcnow(),
-            )
+            .filter(TaskInstance.state == State.DEFERRED, TaskInstance.trigger_timeout < timezone.utcnow())
             .update(
                 # We have to schedule these to fail themselves so it doesn't
                 # happen inside the scheduler.
                 {
-                    "state": TaskInstanceState.SCHEDULED,
+                    "state": State.SCHEDULED,
                     "next_method": "__fail__",
                     "next_kwargs": {"error": "Trigger/execution timeout"},
                     "trigger_id": None,
@@ -1517,118 +1325,3 @@ class SchedulerJob(BaseJob):
         )
         if num_timed_out_tasks:
             self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
-
-    @provide_session
-    def _find_zombies(self, session: Session) -> None:
-        """
-        Find zombie task instances, which are tasks haven't heartbeated for too long
-        or have a no-longer-running LocalTaskJob, and create a TaskCallbackRequest
-        to be handled by the DAG processor.
-        """
-        from airflow.jobs.local_task_job import LocalTaskJob
-
-        self.log.debug("Finding 'running' jobs without a recent heartbeat")
-        limit_dttm = timezone.utcnow() - timedelta(seconds=self._zombie_threshold_secs)
-
-        zombies = (
-            session.query(TaskInstance, DagModel.fileloc)
-            .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
-            .join(LocalTaskJob, TaskInstance.job_id == LocalTaskJob.id)
-            .join(DagModel, TaskInstance.dag_id == DagModel.dag_id)
-            .filter(TaskInstance.state == TaskInstanceState.RUNNING)
-            .filter(
-                or_(
-                    LocalTaskJob.state != State.RUNNING,
-                    LocalTaskJob.latest_heartbeat < limit_dttm,
-                )
-            )
-            .filter(TaskInstance.queued_by_job_id == self.id)
-            .all()
-        )
-
-        if zombies:
-            self.log.warning("Failing (%s) jobs without heartbeat after %s", len(zombies), limit_dttm)
-
-        for ti, file_loc in zombies:
-            zombie_message_details = self._generate_zombie_message_details(ti)
-            request = TaskCallbackRequest(
-                full_filepath=file_loc,
-                processor_subdir=ti.dag_model.processor_subdir,
-                simple_task_instance=SimpleTaskInstance.from_ti(ti),
-                msg=str(zombie_message_details),
-            )
-            self.log.error("Detected zombie job: %s", request)
-            self.executor.send_callback(request)
-            Stats.incr("zombies_killed")
-
-    @staticmethod
-    def _generate_zombie_message_details(ti: TaskInstance):
-        zombie_message_details = {
-            "DAG Id": ti.dag_id,
-            "Task Id": ti.task_id,
-            "Run Id": ti.run_id,
-        }
-
-        if ti.map_index != -1:
-            zombie_message_details["Map Index"] = ti.map_index
-        if ti.hostname:
-            zombie_message_details["Hostname"] = ti.hostname
-        if ti.external_executor_id:
-            zombie_message_details["External Executor Id"] = ti.external_executor_id
-
-        return zombie_message_details
-
-    @provide_session
-    def _cleanup_stale_dags(self, session: Session = NEW_SESSION) -> None:
-        """
-        Find all dags that were not updated by Dag Processor recently and mark them as inactive.
-
-        In case one of DagProcessors is stopped (in case there are multiple of them
-        for different dag folders), it's dags are never marked as inactive.
-        Also remove dags from SerializedDag table.
-        Executed on schedule only if [scheduler]standalone_dag_processor is True.
-        """
-        self.log.debug("Checking dags not parsed within last %s seconds.", self._dag_stale_not_seen_duration)
-        limit_lpt = timezone.utcnow() - timedelta(seconds=self._dag_stale_not_seen_duration)
-        stale_dags = (
-            session.query(DagModel).filter(DagModel.is_active, DagModel.last_parsed_time < limit_lpt).all()
-        )
-        if not stale_dags:
-            self.log.debug("Not stale dags found.")
-            return
-
-        self.log.info("Found (%d) stales dags not parsed after %s.", len(stale_dags), limit_lpt)
-        for dag in stale_dags:
-            dag.is_active = False
-            SerializedDagModel.remove_dag(dag_id=dag.dag_id, session=session)
-        session.flush()
-
-    @provide_session
-    def _orphan_unreferenced_datasets(self, session: Session = NEW_SESSION) -> None:
-        """
-        Detects datasets that are no longer referenced in any DAG schedule parameters or task outlets and
-        sets the dataset is_orphaned flag to True
-        """
-        orphaned_dataset_query = (
-            session.query(DatasetModel)
-            .join(
-                DagScheduleDatasetReference,
-                isouter=True,
-            )
-            .join(
-                TaskOutletDatasetReference,
-                isouter=True,
-            )
-            # MSSQL doesn't like it when we select a column that we haven't grouped by. All other DBs let us
-            # group by id and select all columns.
-            .group_by(DatasetModel if session.get_bind().dialect.name == "mssql" else DatasetModel.id)
-            .having(
-                and_(
-                    func.count(DagScheduleDatasetReference.dag_id) == 0,
-                    func.count(TaskOutletDatasetReference.dag_id) == 0,
-                )
-            )
-        )
-        for dataset in orphaned_dataset_query:
-            self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
-            dataset.is_orphaned = expression.true()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-import datetime
+from __future__ import annotations
+
 import itertools
 import logging
 import multiprocessing
@@ -26,90 +26,108 @@ import sys
 import time
 import warnings
 from collections import defaultdict
-from datetime import timedelta
-from typing import Collection, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Collection, DefaultDict, Iterator
 
-from sqlalchemy import and_, func, not_, or_, tuple_
+from sqlalchemy import and_, func, not_, or_, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import load_only, selectinload
 from sqlalchemy.orm.session import Session, make_transient
+from sqlalchemy.sql import expression
 
-from airflow import models, settings
+from airflow import settings
+from airflow.callbacks.callback_requests import DagCallbackRequest, SlaCallbackRequest, TaskCallbackRequest
+from airflow.callbacks.pipe_callback_sink import PipeCallbackSink
 from airflow.configuration import conf
-from airflow.dag_processing.manager import DagFileProcessorAgent
+from airflow.exceptions import RemovedInAirflow3Warning
 from airflow.executors.executor_loader import UNPICKLEABLE_EXECUTORS
 from airflow.jobs.base_job import BaseJob
-from airflow.models import DAG
-from airflow.models.dag import DagModel
+from airflow.models.dag import DAG, DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
+from airflow.models.dataset import (
+    DagScheduleDatasetReference,
+    DatasetDagRunQueue,
+    DatasetEvent,
+    DatasetModel,
+    TaskOutletDatasetReference,
+)
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
+from airflow.timetables.simple import DatasetTriggeredTimetable
 from airflow.utils import timezone
-from airflow.utils.callback_requests import DagCallbackRequest, TaskCallbackRequest
-from airflow.utils.docs import get_docs_url
 from airflow.utils.event_scheduler import EventScheduler
 from airflow.utils.retries import MAX_DB_RETRIES, retry_db_transaction, run_with_db_retries
-from airflow.utils.session import create_session, provide_session
-from airflow.utils.sqlalchemy import is_lock_not_available_error, prohibit_commit, skip_locked, with_row_locks
+from airflow.utils.session import NEW_SESSION, create_session, provide_session
+from airflow.utils.sqlalchemy import (
+    CommitProhibitorGuard,
+    is_lock_not_available_error,
+    prohibit_commit,
+    skip_locked,
+    tuple_in_condition,
+    with_row_locks,
+)
 from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.types import DagRunType
 
-TI = models.TaskInstance
-DR = models.DagRun
-DM = models.DagModel
+if TYPE_CHECKING:
+    from types import FrameType
+
+    from airflow.dag_processing.manager import DagFileProcessorAgent
+
+TI = TaskInstance
+DR = DagRun
+DM = DagModel
 
 
-def _is_parent_process():
+def _is_parent_process() -> bool:
     """
-    Returns True if the current process is the parent process. False if the current process is a child
-    process started by multiprocessing.
+    Whether this is a parent process.
+
+    Return True if the current process is the parent process.
+    False if the current process is a child process started by multiprocessing.
     """
-    return multiprocessing.current_process().name == 'MainProcess'
+    return multiprocessing.current_process().name == "MainProcess"
 
 
 class SchedulerJob(BaseJob):
     """
-    This SchedulerJob runs for a specific time interval and schedules the jobs
-    that are ready to run. It figures out the latest runs for each
-    task and sees if the dependencies for the next schedules are met.
+    SchedulerJob runs for a specific time interval and schedules jobs that are ready to run.
+
+    It figures out the latest runs for each task and sees if the dependencies
+    for the next schedules are met.
     If so, it creates appropriate TaskInstances and sends run commands to the
     executor. It does this for each task in each DAG and repeats.
 
     :param subdir: directory containing Python files with Airflow DAG
         definitions, or a specific path to a file
-    :type subdir: str
     :param num_runs: The number of times to run the scheduling loop. If you
         have a large number of DAG files this could complete before each file
         has been parsed. -1 for unlimited times.
-    :type num_runs: int
     :param num_times_parse_dags: The number of times to try to parse each DAG file.
         -1 for unlimited times.
-    :type num_times_parse_dags: int
     :param scheduler_idle_sleep_time: The number of seconds to wait between
         polls of running processors
-    :type scheduler_idle_sleep_time: int
     :param do_pickle: once a DAG object is obtained by executing the Python
         file, whether to serialize the DAG object to the DB
-    :type do_pickle: bool
     :param log: override the default Logger
-    :type log: logging.Logger
     """
 
-    __mapper_args__ = {'polymorphic_identity': 'SchedulerJob'}
-    heartrate: int = conf.getint('scheduler', 'SCHEDULER_HEARTBEAT_SEC')
+    __mapper_args__ = {"polymorphic_identity": "SchedulerJob"}
+    heartrate: int = conf.getint("scheduler", "SCHEDULER_HEARTBEAT_SEC")
 
     def __init__(
         self,
         subdir: str = settings.DAGS_FOLDER,
-        num_runs: int = conf.getint('scheduler', 'num_runs'),
+        num_runs: int = conf.getint("scheduler", "num_runs"),
         num_times_parse_dags: int = -1,
-        scheduler_idle_sleep_time: float = conf.getfloat('scheduler', 'scheduler_idle_sleep_time'),
+        scheduler_idle_sleep_time: float = conf.getfloat("scheduler", "scheduler_idle_sleep_time"),
         do_pickle: bool = False,
-        log: logging.Logger = None,
-        processor_poll_interval: Optional[float] = None,
+        log: logging.Logger | None = None,
+        processor_poll_interval: float | None = None,
         *args,
         **kwargs,
     ):
@@ -125,12 +143,15 @@ class SchedulerJob(BaseJob):
             warnings.warn(
                 "The 'processor_poll_interval' parameter is deprecated. "
                 "Please use 'scheduler_idle_sleep_time'.",
-                DeprecationWarning,
+                RemovedInAirflow3Warning,
                 stacklevel=2,
             )
             scheduler_idle_sleep_time = processor_poll_interval
         self._scheduler_idle_sleep_time = scheduler_idle_sleep_time
-
+        # How many seconds do we wait for tasks to heartbeat before mark them as zombies.
+        self._zombie_threshold_secs = conf.getint("scheduler", "scheduler_zombie_task_threshold")
+        self._standalone_dag_processor = conf.getboolean("scheduler", "standalone_dag_processor")
+        self._dag_stale_not_seen_duration = conf.getint("scheduler", "dag_stale_not_seen_duration")
         self.do_pickle = do_pickle
         super().__init__(*args, **kwargs)
 
@@ -138,32 +159,21 @@ class SchedulerJob(BaseJob):
             self._log = log
 
         # Check what SQL backend we use
-        sql_conn: str = conf.get('core', 'sql_alchemy_conn').lower()
-        self.using_sqlite = sql_conn.startswith('sqlite')
-        self.using_mysql = sql_conn.startswith('mysql')
-        self.max_tis_per_query: int = conf.getint('scheduler', 'max_tis_per_query')
-        self.processor_agent: Optional[DagFileProcessorAgent] = None
+        sql_conn: str = conf.get_mandatory_value("database", "sql_alchemy_conn").lower()
+        self.using_sqlite = sql_conn.startswith("sqlite")
+        # Dag Processor agent - not used in Dag Processor standalone mode.
+        self.processor_agent: DagFileProcessorAgent | None = None
 
         self.dagbag = DagBag(dag_folder=self.subdir, read_dags_from_db=True, load_op_links=False)
-
-        if conf.getboolean('smart_sensor', 'use_smart_sensor'):
-            compatible_sensors = set(
-                map(lambda l: l.strip(), conf.get('smart_sensor', 'sensors_enabled').split(','))
-            )
-            docs_url = get_docs_url('concepts/smart-sensors.html#migrating-to-deferrable-operators')
-            warnings.warn(
-                f'Smart sensors are deprecated, yet can be used for {compatible_sensors} sensors.'
-                f' Please use Deferrable Operators instead. See {docs_url} for more info.',
-                DeprecationWarning,
-            )
+        self._paused_dag_without_running_dagruns: set = set()
 
     def register_signals(self) -> None:
-        """Register signals that stop child processes"""
+        """Register signals that stop child processes."""
         signal.signal(signal.SIGINT, self._exit_gracefully)
         signal.signal(signal.SIGTERM, self._exit_gracefully)
         signal.signal(signal.SIGUSR2, self._debug_dump)
 
-    def _exit_gracefully(self, signum, frame) -> None:
+    def _exit_gracefully(self, signum: int, frame: FrameType | None) -> None:
         """Helper method to clean up processor_agent to avoid leaving orphan processes."""
         if not _is_parent_process():
             # Only the parent process should perform the cleanup.
@@ -174,7 +184,7 @@ class SchedulerJob(BaseJob):
             self.processor_agent.end()
         sys.exit(os.EX_OK)
 
-    def _debug_dump(self, signum, frame):
+    def _debug_dump(self, signum: int, frame: FrameType | None) -> None:
         if not _is_parent_process():
             # Only the parent process should perform the debug dump.
             return
@@ -189,9 +199,9 @@ class SchedulerJob(BaseJob):
         self.executor.debug_dump()
         self.log.info("-" * 80)
 
-    def is_alive(self, grace_multiplier: Optional[float] = None) -> bool:
+    def is_alive(self, grace_multiplier: float | None = None) -> bool:
         """
-        Is this SchedulerJob alive?
+        Whether the SchedulerJob is alive.
 
         We define alive as in a state of running and a heartbeat within the
         threshold defined in the ``scheduler_health_check_threshold`` config
@@ -199,62 +209,79 @@ class SchedulerJob(BaseJob):
 
         ``grace_multiplier`` is accepted for compatibility with the parent class.
 
-        :rtype: boolean
         """
         if grace_multiplier is not None:
             # Accept the same behaviour as superclass
             return super().is_alive(grace_multiplier=grace_multiplier)
-        scheduler_health_check_threshold: int = conf.getint('scheduler', 'scheduler_health_check_threshold')
+        scheduler_health_check_threshold: int = conf.getint("scheduler", "scheduler_health_check_threshold")
         return (
             self.state == State.RUNNING
             and (timezone.utcnow() - self.latest_heartbeat).total_seconds() < scheduler_health_check_threshold
         )
 
-    @provide_session
     def __get_concurrency_maps(
-        self, states: List[TaskInstanceState], session: Session = None
-    ) -> Tuple[DefaultDict[str, int], DefaultDict[Tuple[str, str], int]]:
+        self, states: list[TaskInstanceState], session: Session
+    ) -> tuple[DefaultDict[str, int], DefaultDict[tuple[str, str], int]]:
         """
         Get the concurrency maps.
 
         :param states: List of states to query for
-        :type states: list[airflow.utils.state.State]
         :return: A map from (dag_id, task_id) to # of task instances and
          a map from (dag_id, task_id) to # of task instances in the given state list
-        :rtype: tuple[dict[str, int], dict[tuple[str, str], int]]
         """
-        ti_concurrency_query: List[Tuple[str, str, int]] = (
-            session.query(TI.task_id, TI.dag_id, func.count('*'))
+        ti_concurrency_query: list[tuple[str, str, int]] = (
+            session.query(TI.task_id, TI.dag_id, func.count("*"))
             .filter(TI.state.in_(states))
             .group_by(TI.task_id, TI.dag_id)
         ).all()
         dag_map: DefaultDict[str, int] = defaultdict(int)
-        task_map: DefaultDict[Tuple[str, str], int] = defaultdict(int)
+        task_map: DefaultDict[tuple[str, str], int] = defaultdict(int)
         for result in ti_concurrency_query:
             task_id, dag_id, count = result
             dag_map[dag_id] += count
             task_map[(dag_id, task_id)] = count
         return dag_map, task_map
 
-    @provide_session
-    def _executable_task_instances_to_queued(self, max_tis: int, session: Session = None) -> List[TI]:
+    def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
-        Finds TIs that are ready for execution with respect to pool limits,
-        dag max_active_tasks, executor state, and priority.
+        Find TIs that are ready for execution based on conditions.
+
+        Conditions include:
+        - pool limits
+        - DAG max_active_tasks
+        - executor state
+        - priority
 
         :param max_tis: Maximum number of TIs to queue in this loop.
-        :type max_tis: int
         :return: list[airflow.models.TaskInstance]
         """
-        executable_tis: List[TI] = []
+        from airflow.models.pool import Pool
+        from airflow.utils.db import DBLocks
+
+        executable_tis: list[TI] = []
+
+        if session.get_bind().dialect.name == "postgresql":
+            # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
+            # timeout", try to take out a transactional advisory lock (unlocks automatically on
+            # COMMIT/ROLLBACK)
+            lock_acquired = session.execute(
+                text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
+                    id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
+                )
+            ).scalar()
+            if not lock_acquired:
+                # Throw an error like the one that would happen with NOWAIT
+                raise OperationalError(
+                    "Failed to acquire advisory lock", params=None, orig=RuntimeError("55P03")
+                )
 
         # Get the pool settings. We get a lock on the pool rows, treating this as a "critical section"
         # Throws an exception if lock cannot be obtained, rather than blocking
-        pools = models.Pool.slots_stats(lock_rows=True, session=session)
+        pools = Pool.slots_stats(lock_rows=True, session=session)
 
         # If the pools are full, there is no point doing anything!
         # If _somehow_ the pool is overfull, don't let the limit go negative - it breaks SQL
-        pool_slots_free = max(0, sum(pool['open'] for pool in pools.values()))
+        pool_slots_free = sum(max(0, pool["open"]) for pool in pools.values())
 
         if pool_slots_free == 0:
             self.log.debug("All pools are full!")
@@ -262,11 +289,11 @@ class SchedulerJob(BaseJob):
 
         max_tis = min(max_tis, pool_slots_free)
 
-        starved_pools = {pool_name for pool_name, stats in pools.items() if stats['open'] <= 0}
+        starved_pools = {pool_name for pool_name, stats in pools.items() if stats["open"] <= 0}
 
         # dag_id to # of running tasks and (dag_id, task_id) to # of running tasks.
         dag_active_tasks_map: DefaultDict[str, int]
-        task_concurrency_map: DefaultDict[Tuple[str, str], int]
+        task_concurrency_map: DefaultDict[tuple[str, str], int]
         dag_active_tasks_map, task_concurrency_map = self.__get_concurrency_maps(
             states=list(EXECUTION_STATES), session=session
         )
@@ -276,8 +303,8 @@ class SchedulerJob(BaseJob):
         num_starving_tasks_total = 0
 
         # dag and task ids that can't be queued because of concurrency limits
-        starved_dags: Set[str] = set()
-        starved_tasks: Set[Tuple[str, str]] = set()
+        starved_dags: set[str] = set()
+        starved_tasks: set[tuple[str, str]] = set()
 
         pool_num_starving_tasks: DefaultDict[str, int] = defaultdict(int)
 
@@ -292,21 +319,14 @@ class SchedulerJob(BaseJob):
             # and the dag is not paused
             query = (
                 session.query(TI)
-                ##################################################
-                # This patch was added - https://github.com/apache/airflow/issues/25627
-                # In the Scheduler, we are coming across instances where MySQL is inefficiently optimizing the
-                # critical section task queuing query. When a large number of task instances are scheduled,
-                # MySQL failing to use the ti_state index to filter the task_instance table,
-                # resulting in a full table scan (about 7.3 million rows).
-                .with_hint(TI, 'USE INDEX (ti_state)', dialect_name='mysql')
-                ##################################################
+                .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
                 .join(TI.dag_run)
                 .filter(DR.run_type != DagRunType.BACKFILL_JOB, DR.state == DagRunState.RUNNING)
                 .join(TI.dag_model)
                 .filter(not_(DM.is_paused))
                 .filter(TI.state == TaskInstanceState.SCHEDULED)
-                .options(selectinload('dag_model'))
-                .order_by(-TI.priority_weight, DR.execution_date)
+                .options(selectinload("dag_model"))
+                .order_by(-TI.priority_weight, DR.execution_date, TI.map_index)
             )
 
             if starved_pools:
@@ -316,27 +336,26 @@ class SchedulerJob(BaseJob):
                 query = query.filter(not_(TI.dag_id.in_(starved_dags)))
 
             if starved_tasks:
-                if settings.engine.dialect.name == 'mssql':
-                    task_filter = or_(
-                        and_(
-                            TaskInstance.dag_id == dag_id,
-                            TaskInstance.task_id == task_id,
-                        )
-                        for (dag_id, task_id) in starved_tasks
-                    )
-                else:
-                    task_filter = tuple_(TaskInstance.dag_id, TaskInstance.task_id).in_(starved_tasks)
-
+                task_filter = tuple_in_condition((TaskInstance.dag_id, TaskInstance.task_id), starved_tasks)
                 query = query.filter(not_(task_filter))
 
             query = query.limit(max_tis)
 
-            task_instances_to_examine: List[TI] = with_row_locks(
-                query,
-                of=TI,
-                session=session,
-                **skip_locked(session=session),
-            ).all()
+            timer = Stats.timer("scheduler.critical_section_query_duration")
+            timer.start()
+
+            try:
+                task_instances_to_examine: list[TI] = with_row_locks(
+                    query,
+                    of=TI,
+                    session=session,
+                    **skip_locked(session=session),
+                ).all()
+                timer.stop(send=True)
+            except OperationalError as e:
+                timer.stop(send=False)
+                raise e
+
             # TODO[HA]: This was wrong before anyway, as it only looked at a sub-set of dags, not everything.
             # Stats.gauge('scheduler.tasks.pending', len(task_instances_to_examine))
 
@@ -350,141 +369,126 @@ class SchedulerJob(BaseJob):
                 "%s tasks up for execution:\n\t%s", len(task_instances_to_examine), task_instance_str
             )
 
-            pool_to_task_instances: DefaultDict[str, List[TI]] = defaultdict(list)
             for task_instance in task_instances_to_examine:
-                pool_to_task_instances[task_instance.pool].append(task_instance)
+                pool_name = task_instance.pool
 
-            # Go through each pool, and queue up a task for execution if there are
-            # any open slots in the pool.
-
-            for pool, task_instances in pool_to_task_instances.items():
-                pool_name = pool
-                if pool not in pools:
-                    self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool)
+                pool_stats = pools.get(pool_name)
+                if not pool_stats:
+                    self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool_name)
                     starved_pools.add(pool_name)
                     continue
 
-                pool_total = pools[pool]["total"]
-                open_slots = pools[pool]["open"]
+                # Make sure to emit metrics if pool has no starving tasks
+                pool_num_starving_tasks.setdefault(pool_name, 0)
 
-                num_ready = len(task_instances)
-                self.log.info(
-                    "Figuring out tasks to run in Pool(name=%s) with %s open slots "
-                    "and %s task instances ready to be queued",
-                    pool,
-                    open_slots,
-                    num_ready,
-                )
+                pool_total = pool_stats["total"]
+                open_slots = pool_stats["open"]
 
-                priority_sorted_task_instances = sorted(
-                    task_instances, key=lambda ti: (-ti.priority_weight, ti.execution_date)
-                )
-
-                for current_index, task_instance in enumerate(priority_sorted_task_instances):
-                    if open_slots <= 0:
-                        self.log.info(
-                            "Not scheduling since there are %s open slots in pool %s", open_slots, pool
-                        )
-                        # Can't schedule any more since there are no more open slots.
-                        num_unhandled = len(priority_sorted_task_instances) - current_index
-                        pool_num_starving_tasks[pool_name] += num_unhandled
-                        num_starving_tasks_total += num_unhandled
-                        starved_pools.add(pool_name)
-                        break
-
-                    if task_instance.pool_slots > pool_total:
-                        self.log.warning(
-                            "Not executing %s. Requested pool slots (%s) are greater than "
-                            "total pool slots: '%s' for pool: %s.",
-                            task_instance,
-                            task_instance.pool_slots,
-                            pool_total,
-                            pool,
-                        )
-
-                        starved_tasks.add((task_instance.dag_id, task_instance.task_id))
-                        continue
-
-                    if task_instance.pool_slots > open_slots:
-                        self.log.info(
-                            "Not executing %s since it requires %s slots "
-                            "but there are %s open slots in the pool %s.",
-                            task_instance,
-                            task_instance.pool_slots,
-                            open_slots,
-                            pool,
-                        )
-                        pool_num_starving_tasks[pool_name] += 1
-                        num_starving_tasks_total += 1
-                        starved_tasks.add((task_instance.dag_id, task_instance.task_id))
-                        # Though we can execute tasks with lower priority if there's enough room
-                        continue
-
-                    # Check to make sure that the task max_active_tasks of the DAG hasn't been
-                    # reached.
-                    dag_id = task_instance.dag_id
-
-                    current_active_tasks_per_dag = dag_active_tasks_map[dag_id]
-                    max_active_tasks_per_dag_limit = task_instance.dag_model.max_active_tasks
+                if open_slots <= 0:
                     self.log.info(
-                        "DAG %s has %s/%s running and queued tasks",
+                        "Not scheduling since there are %s open slots in pool %s", open_slots, pool_name
+                    )
+                    # Can't schedule any more since there are no more open slots.
+                    pool_num_starving_tasks[pool_name] += 1
+                    num_starving_tasks_total += 1
+                    starved_pools.add(pool_name)
+                    continue
+
+                if task_instance.pool_slots > pool_total:
+                    self.log.warning(
+                        "Not executing %s. Requested pool slots (%s) are greater than "
+                        "total pool slots: '%s' for pool: %s.",
+                        task_instance,
+                        task_instance.pool_slots,
+                        pool_total,
+                        pool_name,
+                    )
+
+                    pool_num_starving_tasks[pool_name] += 1
+                    num_starving_tasks_total += 1
+                    starved_tasks.add((task_instance.dag_id, task_instance.task_id))
+                    continue
+
+                if task_instance.pool_slots > open_slots:
+                    self.log.info(
+                        "Not executing %s since it requires %s slots "
+                        "but there are %s open slots in the pool %s.",
+                        task_instance,
+                        task_instance.pool_slots,
+                        open_slots,
+                        pool_name,
+                    )
+                    pool_num_starving_tasks[pool_name] += 1
+                    num_starving_tasks_total += 1
+                    starved_tasks.add((task_instance.dag_id, task_instance.task_id))
+                    # Though we can execute tasks with lower priority if there's enough room
+                    continue
+
+                # Check to make sure that the task max_active_tasks of the DAG hasn't been
+                # reached.
+                dag_id = task_instance.dag_id
+
+                current_active_tasks_per_dag = dag_active_tasks_map[dag_id]
+                max_active_tasks_per_dag_limit = task_instance.dag_model.max_active_tasks
+                self.log.info(
+                    "DAG %s has %s/%s running and queued tasks",
+                    dag_id,
+                    current_active_tasks_per_dag,
+                    max_active_tasks_per_dag_limit,
+                )
+                if current_active_tasks_per_dag >= max_active_tasks_per_dag_limit:
+                    self.log.info(
+                        "Not executing %s since the number of tasks running or queued "
+                        "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
+                        task_instance,
                         dag_id,
-                        current_active_tasks_per_dag,
                         max_active_tasks_per_dag_limit,
                     )
-                    if current_active_tasks_per_dag >= max_active_tasks_per_dag_limit:
-                        self.log.info(
-                            "Not executing %s since the number of tasks running or queued "
-                            "from DAG %s is >= to the DAG's max_active_tasks limit of %s",
-                            task_instance,
+                    starved_dags.add(dag_id)
+                    continue
+
+                if task_instance.dag_model.has_task_concurrency_limits:
+                    # Many dags don't have a task_concurrency, so where we can avoid loading the full
+                    # serialized DAG the better.
+                    serialized_dag = self.dagbag.get_dag(dag_id, session=session)
+                    # If the dag is missing, fail the task and continue to the next task.
+                    if not serialized_dag:
+                        self.log.error(
+                            "DAG '%s' for task instance %s not found in serialized_dag table",
                             dag_id,
-                            max_active_tasks_per_dag_limit,
+                            task_instance,
                         )
-                        starved_dags.add(dag_id)
+                        session.query(TI).filter(
+                            TI.dag_id == dag_id, TI.state == TaskInstanceState.SCHEDULED
+                        ).update({TI.state: TaskInstanceState.FAILED}, synchronize_session="fetch")
                         continue
 
-                    if task_instance.dag_model.has_task_concurrency_limits:
-                        # Many dags don't have a task_concurrency, so where we can avoid loading the full
-                        # serialized DAG the better.
-                        serialized_dag = self.dagbag.get_dag(dag_id, session=session)
-                        # If the dag is missing, fail the task and continue to the next task.
-                        if not serialized_dag:
-                            self.log.error(
-                                "DAG '%s' for task instance %s not found in serialized_dag table",
-                                dag_id,
+                    task_concurrency_limit: int | None = None
+                    if serialized_dag.has_task(task_instance.task_id):
+                        task_concurrency_limit = serialized_dag.get_task(
+                            task_instance.task_id
+                        ).max_active_tis_per_dag
+
+                    if task_concurrency_limit is not None:
+                        current_task_concurrency = task_concurrency_map[
+                            (task_instance.dag_id, task_instance.task_id)
+                        ]
+
+                        if current_task_concurrency >= task_concurrency_limit:
+                            self.log.info(
+                                "Not executing %s since the task concurrency for"
+                                " this task has been reached.",
                                 task_instance,
                             )
-                            session.query(TI).filter(TI.dag_id == dag_id, TI.state == State.SCHEDULED).update(
-                                {TI.state: State.FAILED}, synchronize_session='fetch'
-                            )
+                            starved_tasks.add((task_instance.dag_id, task_instance.task_id))
                             continue
 
-                        task_concurrency_limit: Optional[int] = None
-                        if serialized_dag.has_task(task_instance.task_id):
-                            task_concurrency_limit = serialized_dag.get_task(
-                                task_instance.task_id
-                            ).max_active_tis_per_dag
+                executable_tis.append(task_instance)
+                open_slots -= task_instance.pool_slots
+                dag_active_tasks_map[dag_id] += 1
+                task_concurrency_map[(task_instance.dag_id, task_instance.task_id)] += 1
 
-                        if task_concurrency_limit is not None:
-                            current_task_concurrency = task_concurrency_map[
-                                (task_instance.dag_id, task_instance.task_id)
-                            ]
-
-                            if current_task_concurrency >= task_concurrency_limit:
-                                self.log.info(
-                                    "Not executing %s since the task concurrency for"
-                                    " this task has been reached.",
-                                    task_instance,
-                                )
-                                starved_tasks.add((task_instance.dag_id, task_instance.task_id))
-                                continue
-
-                    executable_tis.append(task_instance)
-                    open_slots -= task_instance.pool_slots
-                    dag_active_tasks_map[dag_id] += 1
-                    task_concurrency_map[(task_instance.dag_id, task_instance.task_id)] += 1
-
-                pools[pool]["open"] = open_slots
+                pool_stats["open"] = open_slots
 
             is_done = executable_tis or len(task_instances_to_examine) < max_tis
             # Check this to avoid accidental infinite loops
@@ -504,11 +508,11 @@ class SchedulerJob(BaseJob):
             )
 
         for pool_name, num_starving_tasks in pool_num_starving_tasks.items():
-            Stats.gauge(f'pool.starving_tasks.{pool_name}', num_starving_tasks)
+            Stats.gauge(f"pool.starving_tasks.{pool_name}", num_starving_tasks)
 
-        Stats.gauge('scheduler.tasks.starving', num_starving_tasks_total)
-        Stats.gauge('scheduler.tasks.running', num_tasks_in_executor)
-        Stats.gauge('scheduler.tasks.executable', len(executable_tis))
+        Stats.gauge("scheduler.tasks.starving", num_starving_tasks_total)
+        Stats.gauge("scheduler.tasks.running", num_tasks_in_executor)
+        Stats.gauge("scheduler.tasks.executable", len(executable_tis))
 
         if len(executable_tis) > 0:
             task_instance_str = "\n\t".join(repr(x) for x in executable_tis)
@@ -519,7 +523,11 @@ class SchedulerJob(BaseJob):
             session.query(TI).filter(filter_for_tis).update(
                 # TODO[ha]: should we use func.now()? How does that work with DB timezone
                 # on mysql when it's not UTC?
-                {TI.state: State.QUEUED, TI.queued_dttm: timezone.utcnow(), TI.queued_by_job_id: self.id},
+                {
+                    TI.state: TaskInstanceState.QUEUED,
+                    TI.queued_dttm: timezone.utcnow(),
+                    TI.queued_by_job_id: self.id,
+                },
                 synchronize_session=False,
             )
 
@@ -527,18 +535,12 @@ class SchedulerJob(BaseJob):
             make_transient(ti)
         return executable_tis
 
-    @provide_session
-    def _enqueue_task_instances_with_queued_state(
-        self, task_instances: List[TI], session: Session = None
-    ) -> None:
+    def _enqueue_task_instances_with_queued_state(self, task_instances: list[TI], session: Session) -> None:
         """
-        Takes task_instances, which should have been set to queued, and enqueues them
-        with the executor.
+        Enqueue task_instances which should have been set to queued with the executor.
 
         :param task_instances: TaskInstances to enqueue
-        :type task_instances: list[TaskInstance]
         :param session: The session object
-        :type session: Session
         """
         # actually enqueue them
         for ti in task_instances:
@@ -561,9 +563,9 @@ class SchedulerJob(BaseJob):
                 queue=queue,
             )
 
-    def _critical_section_execute_task_instances(self, session: Session) -> int:
+    def _critical_section_enqueue_task_instances(self, session: Session) -> int:
         """
-        Attempts to execute TaskInstances that should be executed by the scheduler.
+        Enqueues TaskInstances for execution.
 
         There are three steps:
         1. Pick TIs by priority with the constraint that they are in the expected states
@@ -578,7 +580,6 @@ class SchedulerJob(BaseJob):
         MariaDB or MySQL 5.x) the other schedulers will wait for the lock before continuing.
 
         :param session:
-        :type session: sqlalchemy.orm.Session
         :return: Number of task instance with state changed.
         """
         if self.max_tis_per_query == 0:
@@ -590,14 +591,13 @@ class SchedulerJob(BaseJob):
         self._enqueue_task_instances_with_queued_state(queued_tis, session=session)
         return len(queued_tis)
 
-    @provide_session
-    def _process_executor_events(self, session: Session = None) -> int:
+    def _process_executor_events(self, session: Session) -> int:
         """Respond to executor events."""
-        if not self.processor_agent:
+        if not self._standalone_dag_processor and not self.processor_agent:
             raise ValueError("Processor agent is not started.")
-        ti_primary_key_to_try_number_map: Dict[Tuple[str, str, datetime.datetime], int] = {}
+        ti_primary_key_to_try_number_map: dict[tuple[str, str, str, int], int] = {}
         event_buffer = self.executor.get_event_buffer()
-        tis_with_right_state: List[TaskInstanceKey] = []
+        tis_with_right_state: list[TaskInstanceKey] = []
 
         # Report execution
         for ti_key, value in event_buffer.items():
@@ -614,7 +614,7 @@ class SchedulerJob(BaseJob):
                 state,
                 ti_key.try_number,
             )
-            if state in (State.FAILED, State.SUCCESS, State.QUEUED):
+            if state in (TaskInstanceState.FAILED, TaskInstanceState.SUCCESS, TaskInstanceState.QUEUED):
                 tis_with_right_state.append(ti_key)
 
         # Return if no finished tasks
@@ -623,7 +623,7 @@ class SchedulerJob(BaseJob):
 
         # Check state of finished tasks
         filter_for_tis = TI.filter_for_tis(tis_with_right_state)
-        query = session.query(TI).filter(filter_for_tis).options(selectinload('dag_model'))
+        query = session.query(TI).filter(filter_for_tis).options(selectinload("dag_model"))
         # row lock this entire set of taskinstances to make sure the scheduler doesn't fail when we have
         # multi-schedulers
         tis: Iterator[TI] = with_row_locks(
@@ -637,23 +637,24 @@ class SchedulerJob(BaseJob):
             buffer_key = ti.key.with_try_number(try_number)
             state, info = event_buffer.pop(buffer_key)
 
-            # TODO: should we fail RUNNING as well, as we do in Backfills?
-            if state == State.QUEUED:
+            if state == TaskInstanceState.QUEUED:
                 ti.external_executor_id = info
                 self.log.info("Setting external_id for %s to %s", ti, info)
                 continue
 
             msg = (
-                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
+                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, map_index=%s, "
                 "run_start_date=%s, run_end_date=%s, "
                 "run_duration=%s, state=%s, executor_state=%s, try_number=%s, max_tries=%s, job_id=%s, "
-                "pool=%s, queue=%s, priority_weight=%d, operator=%s"
+                "pool=%s, queue=%s, priority_weight=%d, operator=%s, queued_dttm=%s, "
+                "queued_by_job_id=%s, pid=%s"
             )
             self.log.info(
                 msg,
                 ti.dag_id,
                 ti.task_id,
                 ti.run_id,
+                ti.map_index,
                 ti.start_date,
                 ti.end_date,
                 ti.duration,
@@ -666,10 +667,26 @@ class SchedulerJob(BaseJob):
                 ti.queue,
                 ti.priority_weight,
                 ti.operator,
+                ti.queued_dttm,
+                ti.queued_by_job_id,
+                ti.pid,
             )
 
-            if ti.try_number == buffer_key.try_number and ti.state == State.QUEUED:
-                Stats.incr('scheduler.tasks.killed_externally')
+            # There are two scenarios why the same TI with the same try_number is queued
+            # after executor is finished with it:
+            # 1) the TI was killed externally and it had no time to mark itself failed
+            # - in this case we should mark it as failed here.
+            # 2) the TI has been requeued after getting deferred - in this case either our executor has it
+            # or the TI is queued by another job. Either ways we should not fail it.
+
+            # All of this could also happen if the state is "running",
+            # but that is handled by the zombie detection.
+
+            ti_queued = ti.try_number == buffer_key.try_number and ti.state == TaskInstanceState.QUEUED
+            ti_requeued = ti.queued_by_job_id != self.id or self.executor.has_task(ti)
+
+            if ti_queued and not ti_requeued:
+                Stats.incr("scheduler.tasks.killed_externally")
                 msg = (
                     "Executor reports task instance %s finished (%s) although the "
                     "task says its %s. (Info: %s) Was the task killed externally?"
@@ -688,16 +705,19 @@ class SchedulerJob(BaseJob):
                 if task.on_retry_callback or task.on_failure_callback:
                     request = TaskCallbackRequest(
                         full_filepath=ti.dag_model.fileloc,
-                        simple_task_instance=SimpleTaskInstance(ti),
+                        simple_task_instance=SimpleTaskInstance.from_ti(ti),
                         msg=msg % (ti, state, ti.state, info),
+                        processor_subdir=ti.dag_model.processor_subdir,
                     )
-                    self.processor_agent.send_callback_to_execute(request)
+                    self.executor.send_callback(request)
                 else:
                     ti.handle_failure(error=msg % (ti, state, ti.state, info), session=session)
 
         return len(event_buffer)
 
     def _execute(self) -> None:
+        from airflow.dag_processing.manager import DagFileProcessorAgent
+
         self.log.info("Starting the scheduler")
 
         # DAGs can be pickled for easier remote execution by some executors
@@ -709,40 +729,54 @@ class SchedulerJob(BaseJob):
         # so the scheduler job and DAG parser don't access the DB at the same time.
         async_mode = not self.using_sqlite
 
-        processor_timeout_seconds: int = conf.getint('core', 'dag_file_processor_timeout')
+        processor_timeout_seconds: int = conf.getint("core", "dag_file_processor_timeout")
         processor_timeout = timedelta(seconds=processor_timeout_seconds)
-        self.processor_agent = DagFileProcessorAgent(
-            dag_directory=self.subdir,
-            max_runs=self.num_times_parse_dags,
-            processor_timeout=processor_timeout,
-            dag_ids=[],
-            pickle_dags=pickle_dags,
-            async_mode=async_mode,
-        )
+        if not self._standalone_dag_processor:
+            self.processor_agent = DagFileProcessorAgent(
+                dag_directory=Path(self.subdir),
+                max_runs=self.num_times_parse_dags,
+                processor_timeout=processor_timeout,
+                dag_ids=[],
+                pickle_dags=pickle_dags,
+                async_mode=async_mode,
+            )
 
         try:
             self.executor.job_id = self.id
+            if self.processor_agent:
+                self.log.debug("Using PipeCallbackSink as callback sink.")
+                self.executor.callback_sink = PipeCallbackSink(
+                    get_sink_pipe=self.processor_agent.get_callbacks_pipe
+                )
+            else:
+                from airflow.callbacks.database_callback_sink import DatabaseCallbackSink
+
+                self.log.debug("Using DatabaseCallbackSink as callback sink.")
+                self.executor.callback_sink = DatabaseCallbackSink()
+
             self.executor.start()
 
             self.register_signals()
 
-            self.processor_agent.start()
+            if self.processor_agent:
+                self.processor_agent.start()
 
             execute_start_time = timezone.utcnow()
 
             self._run_scheduler_loop()
 
-            # Stop any processors
-            self.processor_agent.terminate()
+            if self.processor_agent:
+                # Stop any processors
+                self.processor_agent.terminate()
 
-            # Verify that all files were processed, and if so, deactivate DAGs that
-            # haven't been touched by the scheduler as they likely have been
-            # deleted.
-            if self.processor_agent.all_files_processed:
-                self.log.info(
-                    "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
-                )
-                models.DAG.deactivate_stale_dags(execute_start_time)
+                # Verify that all files were processed, and if so, deactivate DAGs that
+                # haven't been touched by the scheduler as they likely have been
+                # deleted.
+                if self.processor_agent.all_files_processed:
+                    self.log.info(
+                        "Deactivating DAGs that haven't been touched since %s", execute_start_time.isoformat()
+                    )
+                    DAG.deactivate_stale_dags(execute_start_time)
 
             settings.Session.remove()  # type: ignore
         except Exception:
@@ -753,15 +787,45 @@ class SchedulerJob(BaseJob):
                 self.executor.end()
             except Exception:
                 self.log.exception("Exception when executing Executor.end")
-            try:
-                self.processor_agent.end()
-            except Exception:
-                self.log.exception("Exception when executing DagFileProcessorAgent.end")
+            if self.processor_agent:
+                try:
+                    self.processor_agent.end()
+                except Exception:
+                    self.log.exception("Exception when executing DagFileProcessorAgent.end")
             self.log.info("Exited execute loop")
+
+    @provide_session
+    def _update_dag_run_state_for_paused_dags(self, session: Session = NEW_SESSION) -> None:
+        try:
+            paused_runs = (
+                session.query(DagRun)
+                .join(DagRun.dag_model)
+                .join(TaskInstance)
+                .filter(
+                    DagModel.is_paused == expression.true(),
+                    DagRun.state == DagRunState.RUNNING,
+                    DagRun.run_type != DagRunType.BACKFILL_JOB,
+                )
+                .having(DagRun.last_scheduling_decision <= func.max(TaskInstance.updated_at))
+                .group_by(DagRun)
+            )
+            for dag_run in paused_runs:
+                dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
+                if dag is None:
+                    continue
+
+                dag_run.dag = dag
+                _, callback_to_run = dag_run.update_state(execute_callbacks=False, session=session)
+                if callback_to_run:
+                    self._send_dag_callbacks_to_processor(dag, callback_to_run)
+        except Exception as e:  # should not fail the scheduler
+            self.log.exception("Failed to update dag run state for paused dags due to %s", str(e))
 
     def _run_scheduler_loop(self) -> None:
         """
-        The actual scheduler loop. The main steps in the loop are:
+        The actual scheduler loop.
+
+        The main steps in the loop are:
             #. Harvest DAG parsing results through DagFileProcessorAgent
             #. Find and queue executable tasks
                 #. Change task instance state in DB
@@ -774,11 +838,10 @@ class SchedulerJob(BaseJob):
 
         .. image:: ../docs/apache-airflow/img/scheduler_loop.jpg
 
-        :rtype: None
         """
-        if not self.processor_agent:
+        if not self.processor_agent and not self._standalone_dag_processor:
             raise ValueError("Processor agent is not started.")
-        is_unit_test: bool = conf.getboolean('core', 'unit_test_mode')
+        is_unit_test: bool = conf.getboolean("core", "unit_test_mode")
 
         timers = EventScheduler()
 
@@ -786,47 +849,68 @@ class SchedulerJob(BaseJob):
         self.adopt_or_reset_orphaned_tasks()
 
         timers.call_regular_interval(
-            conf.getfloat('scheduler', 'orphaned_tasks_check_interval', fallback=300.0),
+            conf.getfloat("scheduler", "orphaned_tasks_check_interval", fallback=300.0),
             self.adopt_or_reset_orphaned_tasks,
         )
 
         timers.call_regular_interval(
-            conf.getfloat('scheduler', 'trigger_timeout_check_interval', fallback=15.0),
+            conf.getfloat("scheduler", "trigger_timeout_check_interval", fallback=15.0),
             self.check_trigger_timeouts,
         )
 
         timers.call_regular_interval(
-            conf.getfloat('scheduler', 'pool_metrics_interval', fallback=5.0),
+            conf.getfloat("scheduler", "pool_metrics_interval", fallback=5.0),
             self._emit_pool_metrics,
         )
 
-        for loop_count in itertools.count(start=1):
-            with Stats.timer() as timer:
+        timers.call_regular_interval(
+            conf.getfloat("scheduler", "zombie_detection_interval", fallback=10.0),
+            self._find_zombies,
+        )
+        timers.call_regular_interval(60.0, self._update_dag_run_state_for_paused_dags)
 
-                if self.using_sqlite:
+        timers.call_regular_interval(
+            conf.getfloat("scheduler", "parsing_cleanup_interval"),
+            self._orphan_unreferenced_datasets,
+        )
+
+        if self._standalone_dag_processor:
+            timers.call_regular_interval(
+                conf.getfloat("scheduler", "parsing_cleanup_interval"),
+                self._cleanup_stale_dags,
+            )
+
+        for loop_count in itertools.count(start=1):
+            with Stats.timer("scheduler.scheduler_loop_duration") as timer:
+
+                if self.using_sqlite and self.processor_agent:
                     self.processor_agent.run_single_parsing_loop()
                     # For the sqlite case w/ 1 thread, wait until the processor
                     # is finished to avoid concurrent access to the DB.
                     self.log.debug("Waiting for processors to finish since we're using sqlite")
                     self.processor_agent.wait_until_finished()
-                
+
                 for attempt in run_with_db_retries():
                     with attempt:
                         start_time = time.time()
                         try:
                             with create_session() as session:
                                 num_queued_tis = self._do_scheduling(session)
-    
+
                                 self.executor.heartbeat()
                                 session.expunge_all()
                                 num_finished_events = self._process_executor_events(session=session)
                                 break
                         except OperationalError as e:
                             end_time = time.time()
-                            self.log.error("got a MySql exception (retry:" + str(attempt.retry_state.attempt_number) + ", total time in seconds: " + str(end_time - start_time) + "), details: " + str(e))
+                            self.log.error("got a MySql exception (retry:" + str(
+                                attempt.retry_state.attempt_number) + ", total time in seconds: " + str(
+                                end_time - start_time) + "), details: " + str(e))
                             raise
-                self.processor_agent.heartbeat()
-                
+
+                if self.processor_agent:
+                    self.processor_agent.heartbeat()
+
                 # Heartbeat the scheduler periodically
                 self.heartbeat(only_if_necessary=True)
 
@@ -840,7 +924,7 @@ class SchedulerJob(BaseJob):
                 # If the scheduler is doing things, don't sleep. This means when there is work to do, the
                 # scheduler will run "as quick as possible", but when it's stopped, it can sleep, dropping CPU
                 # usage when "idle"
-                time.sleep(min(self._scheduler_idle_sleep_time, next_event))
+                time.sleep(min(self._scheduler_idle_sleep_time, next_event if next_event else 0))
 
             if loop_count >= self.num_runs > 0:
                 self.log.info(
@@ -849,7 +933,7 @@ class SchedulerJob(BaseJob):
                     loop_count,
                 )
                 break
-            if self.processor_agent.done:
+            if self.processor_agent and self.processor_agent.done:
                 self.log.info(
                     "Exiting scheduler loop as requested DAG parse count (%d) has been reached after %d"
                     " scheduler loops",
@@ -858,10 +942,11 @@ class SchedulerJob(BaseJob):
                 )
                 break
 
-    def _do_scheduling(self, session) -> int:
+    def _do_scheduling(self, session: Session) -> int:
         """
-        This function is where the main scheduling decisions take places. It:
+        This function is where the main scheduling decisions take places.
 
+        It:
         - Creates any necessary DAG runs by examining the next_dagrun_create_after column of DagModel
 
           Since creating Dag Runs is a relatively time consuming process, we select only 10 dags by default
@@ -875,7 +960,7 @@ class SchedulerJob(BaseJob):
 
           By "next oldest", we mean hasn't been examined/scheduled in the most time.
 
-          The reason we don't select all dagruns at once because the rows are selected with row locks, meaning
+          We don't select all dagruns at once, because the rows are selected with row locks, meaning
           that only one scheduler can "process them", even it is waiting behind other dags. Increasing this
           limit will allow more throughput for smaller DAGs but will likely slow down throughput for larger
           (>500 tasks.) DAGs
@@ -883,81 +968,86 @@ class SchedulerJob(BaseJob):
         - Then, via a Critical Section (locking the rows of the Pool model) we queue tasks, and then send them
           to the executor.
 
-          See docs of _critical_section_execute_task_instances for more.
+          See docs of _critical_section_enqueue_task_instances for more.
 
         :return: Number of TIs enqueued in this iteration
-        :rtype: int
         """
         # Put a check in place to make sure we don't commit unexpectedly
         with prohibit_commit(session) as guard:
-
             if settings.USE_JOB_SCHEDULE:
                 self._create_dagruns_for_dags(guard, session)
 
             self._start_queued_dagruns(session)
             guard.commit()
-            dag_runs = self._get_next_dagruns_to_examine(State.RUNNING, session)
+            dag_runs = self._get_next_dagruns_to_examine(DagRunState.RUNNING, session)
             # Bulk fetch the currently active dag runs for the dags we are
             # examining, rather than making one query per DagRun
 
-            callback_tuples = []
-            for dag_run in dag_runs:
-                callback_to_run = self._schedule_dag_run(dag_run, session)
-                callback_tuples.append((dag_run, callback_to_run))
+            callback_tuples = self._schedule_all_dag_runs(guard, dag_runs, session)
 
-            guard.commit()
+        # Send the callbacks after we commit to ensure the context is up to date when it gets run
+        for dag_run, callback_to_run in callback_tuples:
+            dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
+            if not dag:
+                self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
+                continue
+            # Sending callbacks there as in standalone_dag_processor they are adding to the database,
+            # so it must be done outside of prohibit_commit.
+            self._send_dag_callbacks_to_processor(dag, callback_to_run)
 
-            # Send the callbacks after we commit to ensure the context is up to date when it gets run
-            for dag_run, callback_to_run in callback_tuples:
-                dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
-                if not dag:
-                    self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
-                    continue
-
-                self._send_dag_callbacks_to_processor(dag, callback_to_run)
-
+        with prohibit_commit(session) as guard:
             # Without this, the session has an invalid view of the DB
             session.expunge_all()
             # END: schedule TIs
 
-            try:
-                if self.executor.slots_available <= 0:
-                    # We know we can't do anything here, so don't even try!
-                    self.log.debug("Executor full, skipping critical section")
-                    return 0
+            if self.executor.slots_available <= 0:
+                # We know we can't do anything here, so don't even try!
+                self.log.debug("Executor full, skipping critical section")
+                num_queued_tis = 0
+            else:
+                try:
+                    timer = Stats.timer("scheduler.critical_section_duration")
+                    timer.start()
 
-                timer = Stats.timer('scheduler.critical_section_duration')
-                timer.start()
+                    # Find anything TIs in state SCHEDULED, try to QUEUE it (send it to the executor)
+                    num_queued_tis = self._critical_section_enqueue_task_instances(session=session)
 
-                # Find anything TIs in state SCHEDULED, try to QUEUE it (send it to the executor)
-                num_queued_tis = self._critical_section_execute_task_instances(session=session)
+                    # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
+                    # metric, way down
+                    timer.stop(send=True)
+                except OperationalError as e:
+                    timer.stop(send=False)
 
-                # Make sure we only sent this metric if we obtained the lock, otherwise we'll skew the
-                # metric, way down
-                timer.stop(send=True)
-            except OperationalError as e:
-                timer.stop(send=False)
-
-                if is_lock_not_available_error(error=e):
-                    self.log.debug("Critical section lock held by another Scheduler")
-                    Stats.incr('scheduler.critical_section_busy')
-                    session.rollback()
-                    return 0
-                raise
+                    if is_lock_not_available_error(error=e):
+                        self.log.debug("Critical section lock held by another Scheduler")
+                        Stats.incr("scheduler.critical_section_busy")
+                        session.rollback()
+                        return 0
+                    raise
 
             guard.commit()
-            return num_queued_tis
+
+        return num_queued_tis
 
     @retry_db_transaction
     def _get_next_dagruns_to_examine(self, state: DagRunState, session: Session):
-        """Get Next DagRuns to Examine with retries"""
+        """Get Next DagRuns to Examine with retries."""
         return DagRun.next_dagruns_to_examine(state, session)
 
     @retry_db_transaction
-    def _create_dagruns_for_dags(self, guard, session):
-        """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError"""
-        query = DagModel.dags_needing_dagruns(session)
-        self._create_dag_runs(query.all(), session)
+    def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
+        """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError."""
+        query, dataset_triggered_dag_info = DagModel.dags_needing_dagruns(session)
+        all_dags_needing_dag_runs = set(query.all())
+        dataset_triggered_dags = [
+            dag for dag in all_dags_needing_dag_runs if dag.dag_id in dataset_triggered_dag_info
+        ]
+        non_dataset_dags = all_dags_needing_dag_runs.difference(dataset_triggered_dags)
+        self._create_dag_runs(non_dataset_dags, session)
+        if dataset_triggered_dags:
+            self._create_dag_runs_dataset_triggered(
+                dataset_triggered_dags, dataset_triggered_dag_info, session
+            )
 
         # commit the session - Release the write lock on DagModel table.
         guard.commit()
@@ -972,24 +1062,15 @@ class SchedulerJob(BaseJob):
         # as DagModel.dag_id and DagModel.next_dagrun
         # This list is used to verify if the DagRun already exist so that we don't attempt to create
         # duplicate dag runs
-
-        if session.bind.dialect.name == 'mssql':
-            existing_dagruns_filter = or_(
-                *(
-                    and_(
-                        DagRun.dag_id == dm.dag_id,
-                        DagRun.execution_date == dm.next_dagrun,
-                    )
-                    for dm in dag_models
-                )
-            )
-        else:
-            existing_dagruns_filter = tuple_(DagRun.dag_id, DagRun.execution_date).in_(
-                [(dm.dag_id, dm.next_dagrun) for dm in dag_models]
-            )
-
         existing_dagruns = (
-            session.query(DagRun.dag_id, DagRun.execution_date).filter(existing_dagruns_filter).all()
+            session.query(DagRun.dag_id, DagRun.execution_date)
+            .filter(
+                tuple_in_condition(
+                    (DagRun.dag_id, DagRun.execution_date),
+                    ((dm.dag_id, dm.next_dagrun) for dm in dag_models),
+                ),
+            )
+            .all()
         )
 
         active_runs_of_dags = defaultdict(
@@ -1019,7 +1100,7 @@ class SchedulerJob(BaseJob):
                 dag.create_dagrun(
                     run_type=DagRunType.SCHEDULED,
                     execution_date=dag_model.next_dagrun,
-                    state=State.QUEUED,
+                    state=DagRunState.QUEUED,
                     data_interval=data_interval,
                     external_trigger=False,
                     session=session,
@@ -1032,7 +1113,107 @@ class SchedulerJob(BaseJob):
         # TODO[HA]: Should we do a session.flush() so we don't have to keep lots of state/object in
         # memory for larger dags? or expunge_all()
 
-    def _should_update_dag_next_dagruns(self, dag, dag_model: DagModel, total_active_runs) -> bool:
+    def _create_dag_runs_dataset_triggered(
+        self,
+        dag_models: Collection[DagModel],
+        dataset_triggered_dag_info: dict[str, tuple[datetime, datetime]],
+        session: Session,
+    ) -> None:
+        """For DAGs that are triggered by datasets, create dag runs."""
+        # Bulk Fetch DagRuns with dag_id and execution_date same
+        # as DagModel.dag_id and DagModel.next_dagrun
+        # This list is used to verify if the DagRun already exist so that we don't attempt to create
+        # duplicate dag runs
+        exec_dates = {
+            dag_id: timezone.coerce_datetime(last_time)
+            for dag_id, (_, last_time) in dataset_triggered_dag_info.items()
+        }
+        existing_dagruns: set[tuple[str, timezone.DateTime]] = set(
+            session.query(DagRun.dag_id, DagRun.execution_date).filter(
+                tuple_in_condition((DagRun.dag_id, DagRun.execution_date), exec_dates.items())
+            )
+        )
+
+        for dag_model in dag_models:
+            dag = self.dagbag.get_dag(dag_model.dag_id, session=session)
+            if not dag:
+                self.log.error("DAG '%s' not found in serialized_dag table", dag_model.dag_id)
+                continue
+
+            if not isinstance(dag.timetable, DatasetTriggeredTimetable):
+                self.log.error(
+                    "DAG '%s' was dataset-scheduled, but didn't have a DatasetTriggeredTimetable!",
+                    dag_model.dag_id,
+                )
+                continue
+
+            dag_hash = self.dagbag.dags_hash.get(dag.dag_id)
+
+            # Explicitly check if the DagRun already exists. This is an edge case
+            # where a Dag Run is created but `DagModel.next_dagrun` and `DagModel.next_dagrun_create_after`
+            # are not updated.
+            # We opted to check DagRun existence instead
+            # of catching an Integrity error and rolling back the session i.e
+            # we need to set dag.next_dagrun_info if the Dag Run already exists or if we
+            # create a new one. This is so that in the next Scheduling loop we try to create new runs
+            # instead of falling in a loop of Integrity Error.
+            exec_date = exec_dates[dag.dag_id]
+            if (dag.dag_id, exec_date) not in existing_dagruns:
+
+                previous_dag_run = (
+                    session.query(DagRun)
+                    .filter(
+                        DagRun.dag_id == dag.dag_id,
+                        DagRun.execution_date < exec_date,
+                        DagRun.run_type == DagRunType.DATASET_TRIGGERED,
+                    )
+                    .order_by(DagRun.execution_date.desc())
+                    .first()
+                )
+                dataset_event_filters = [
+                    DagScheduleDatasetReference.dag_id == dag.dag_id,
+                    DatasetEvent.timestamp <= exec_date,
+                ]
+                if previous_dag_run:
+                    dataset_event_filters.append(DatasetEvent.timestamp > previous_dag_run.execution_date)
+
+                dataset_events = (
+                    session.query(DatasetEvent)
+                    .join(
+                        DagScheduleDatasetReference,
+                        DatasetEvent.dataset_id == DagScheduleDatasetReference.dataset_id,
+                    )
+                    .join(DatasetEvent.source_dag_run)
+                    .filter(*dataset_event_filters)
+                    .all()
+                )
+
+                data_interval = dag.timetable.data_interval_for_events(exec_date, dataset_events)
+                run_id = dag.timetable.generate_run_id(
+                    run_type=DagRunType.DATASET_TRIGGERED,
+                    logical_date=exec_date,
+                    data_interval=data_interval,
+                    session=session,
+                    events=dataset_events,
+                )
+
+                dag_run = dag.create_dagrun(
+                    run_id=run_id,
+                    run_type=DagRunType.DATASET_TRIGGERED,
+                    execution_date=exec_date,
+                    data_interval=data_interval,
+                    state=DagRunState.QUEUED,
+                    external_trigger=False,
+                    session=session,
+                    dag_hash=dag_hash,
+                    creating_job_id=self.id,
+                )
+                dag_run.consumed_dataset_events.extend(dataset_events)
+                session.query(DatasetDagRunQueue).filter(
+                    DatasetDagRunQueue.target_dag_id == dag_run.dag_id
+                ).delete()
+
+    def _should_update_dag_next_dagruns(self, dag, dag_model: DagModel, total_active_runs: int) -> bool:
         """Check if the dag's next_dagruns_create_after should be updated."""
         if total_active_runs >= dag.max_active_runs:
             self.log.info(
@@ -1045,12 +1226,9 @@ class SchedulerJob(BaseJob):
             return False
         return True
 
-    def _start_queued_dagruns(
-        self,
-        session: Session,
-    ) -> int:
-        """Find DagRuns in queued state and decide moving them to running state"""
-        dag_runs = self._get_next_dagruns_to_examine(State.QUEUED, session)
+    def _start_queued_dagruns(self, session: Session) -> None:
+        """Find DagRuns in queued state and decide moving them to running state."""
+        dag_runs = self._get_next_dagruns_to_examine(DagRunState.QUEUED, session)
 
         active_runs_of_dags = defaultdict(
             int,
@@ -1058,7 +1236,7 @@ class SchedulerJob(BaseJob):
         )
 
         def _update_state(dag: DAG, dag_run: DagRun):
-            dag_run.state = State.RUNNING
+            dag_run.state = DagRunState.RUNNING
             dag_run.start_date = timezone.utcnow()
             if dag.timetable.periodic:
                 # TODO: Logically, this should be DagRunInfo.run_after, but the
@@ -1068,10 +1246,9 @@ class SchedulerJob(BaseJob):
                 # always happening immediately after the data interval.
                 expected_start_date = dag.get_run_data_interval(dag_run).end
                 schedule_delay = dag_run.start_date - expected_start_date
-                Stats.timing(f'dagrun.schedule_delay.{dag.dag_id}', schedule_delay)
+                Stats.timing(f"dagrun.schedule_delay.{dag.dag_id}", schedule_delay)
 
         for dag_run in dag_runs:
-
             dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
             if not dag:
                 self.log.error("DAG '%s' not found in serialized_dag table", dag_run.dag_id)
@@ -1088,23 +1265,38 @@ class SchedulerJob(BaseJob):
             else:
                 active_runs_of_dags[dag_run.dag_id] += 1
                 _update_state(dag, dag_run)
+                dag_run.notify_dagrun_state_changed()
+
+    @retry_db_transaction
+    def _schedule_all_dag_runs(self, guard, dag_runs, session):
+        """Makes scheduling decisions for all `dag_runs`"""
+        callback_tuples = []
+        for dag_run in dag_runs:
+            callback_to_run = self._schedule_dag_run(dag_run, session)
+            callback_tuples.append((dag_run, callback_to_run))
+
+        guard.commit()
+
+        return callback_tuples
 
     def _schedule_dag_run(
         self,
         dag_run: DagRun,
         session: Session,
-    ) -> Optional[DagCallbackRequest]:
+    ) -> DagCallbackRequest | None:
         """
-        Make scheduling decisions about an individual dag run
+        Make scheduling decisions about an individual dag run.
 
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
         """
+        callback: DagCallbackRequest | None = None
+
         dag = dag_run.dag = self.dagbag.get_dag(dag_run.dag_id, session=session)
 
         if not dag:
             self.log.error("Couldn't find dag %s in DagBag/DB!", dag_run.dag_id)
-            return 0
+            return callback
         dag_model = DM.get_dagmodel(dag.dag_id, session)
 
         if (
@@ -1112,7 +1304,7 @@ class SchedulerJob(BaseJob):
             and dag.dagrun_timeout
             and dag_run.start_date < timezone.utcnow() - dag.dagrun_timeout
         ):
-            dag_run.set_state(State.FAILED)
+            dag_run.set_state(DagRunState.FAILED)
             unfinished_task_instances = (
                 session.query(TI)
                 .filter(TI.dag_id == dag_run.dag_id)
@@ -1120,7 +1312,7 @@ class SchedulerJob(BaseJob):
                 .filter(TI.state.in_(State.unfinished))
             )
             for task_instance in unfinished_task_instances:
-                task_instance.state = State.SKIPPED
+                task_instance.state = TaskInstanceState.SKIPPED
                 session.merge(task_instance)
             session.flush()
             self.log.info("Run %s of %s has timed-out", dag_run.run_id, dag_run.dag_id)
@@ -1134,19 +1326,20 @@ class SchedulerJob(BaseJob):
                 dag_id=dag.dag_id,
                 run_id=dag_run.run_id,
                 is_failure_callback=True,
-                msg='timed_out',
+                processor_subdir=dag_model.processor_subdir,
+                msg="timed_out",
             )
 
-            # Send SLA & DAG Success/Failure Callbacks to be executed
-            self._send_dag_callbacks_to_processor(dag, callback_to_execute)
-
-            return 0
+            dag_run.notify_dagrun_state_changed()
+            return callback_to_execute
 
         if dag_run.execution_date > timezone.utcnow() and not dag.allow_future_exec_dates:
             self.log.error("Execution date is in future: %s", dag_run.execution_date)
-            return 0
+            return callback
 
-        self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
+        if not self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session):
+            self.log.warning("The DAG disappeared before verifying integrity: %s. Skipping.", dag_run.dag_id)
+            return callback
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis, callback_to_run = dag_run.update_state(session=session, execute_callbacks=False)
         if dag_run.state in State.finished:
@@ -1154,7 +1347,6 @@ class SchedulerJob(BaseJob):
             # Work out if we should allow creating a new DagRun now?
             if self._should_update_dag_next_dagruns(dag, dag_model, active_runs):
                 dag_model.calculate_dagrun_date_fields(dag, dag.get_run_data_interval(dag_run))
-
         # This will do one query per dag run. We "could" build up a complex
         # query to update all the TIs across all the execution dates and dag
         # IDs in a single query, but it turns out that can be _very very slow_
@@ -1163,69 +1355,80 @@ class SchedulerJob(BaseJob):
 
         return callback_to_run
 
-    @provide_session
-    def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session=None):
-        """Only run DagRun.verify integrity if Serialized DAG has changed since it is slow"""
+    def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session: Session) -> bool:
+        """
+        Only run DagRun.verify integrity if Serialized DAG has changed since it is slow.
+
+        Return True if we determine that DAG still exists.
+        """
         latest_version = SerializedDagModel.get_latest_version_hash(dag_run.dag_id, session=session)
         if dag_run.dag_hash == latest_version:
             self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
-            return
+            return True
 
         dag_run.dag_hash = latest_version
 
         # Refresh the DAG
         dag_run.dag = self.dagbag.get_dag(dag_id=dag_run.dag_id, session=session)
+        if not dag_run.dag:
+            return False
 
         # Verify integrity also takes care of session.flush
         dag_run.verify_integrity(session=session)
+        return True
 
-    def _send_dag_callbacks_to_processor(self, dag: DAG, callback: Optional[DagCallbackRequest] = None):
-        if not self.processor_agent:
-            raise ValueError("Processor agent is not started.")
-
+    def _send_dag_callbacks_to_processor(self, dag: DAG, callback: DagCallbackRequest | None = None) -> None:
         self._send_sla_callbacks_to_processor(dag)
         if callback:
-            self.processor_agent.send_callback_to_execute(callback)
+            self.executor.send_callback(callback)
+        else:
+            self.log.debug("callback is empty")
 
-    def _send_sla_callbacks_to_processor(self, dag: DAG):
-        """Sends SLA Callbacks to DagFileProcessor if tasks have SLAs set and check_slas=True"""
+    def _send_sla_callbacks_to_processor(self, dag: DAG) -> None:
+        """Sends SLA Callbacks to DagFileProcessor if tasks have SLAs set and check_slas=True."""
         if not settings.CHECK_SLAS:
             return
 
-        if not any(isinstance(ti.sla, timedelta) for ti in dag.tasks):
+        if not any(isinstance(task.sla, timedelta) for task in dag.tasks):
             self.log.debug("Skipping SLA check for %s because no tasks in DAG have SLAs", dag)
             return
 
-        if not self.processor_agent:
-            raise ValueError("Processor agent is not started.")
+        if not dag.timetable.periodic:
+            self.log.debug("Skipping SLA check for %s because DAG is not scheduled", dag)
+            return
 
-        self.processor_agent.send_sla_callback_request_to_execute(
-            full_filepath=dag.fileloc, dag_id=dag.dag_id
+        dag_model = DagModel.get_dagmodel(dag.dag_id)
+        request = SlaCallbackRequest(
+            full_filepath=dag.fileloc,
+            dag_id=dag.dag_id,
+            processor_subdir=dag_model.processor_subdir,
         )
+        self.executor.send_callback(request)
 
     @provide_session
-    def _emit_pool_metrics(self, session: Session = None) -> None:
-        pools = models.Pool.slots_stats(session=session)
+    def _emit_pool_metrics(self, session: Session = NEW_SESSION) -> None:
+        from airflow.models.pool import Pool
+
+        pools = Pool.slots_stats(session=session)
         for pool_name, slot_stats in pools.items():
-            Stats.gauge(f'pool.open_slots.{pool_name}', slot_stats["open"])
-            Stats.gauge(f'pool.queued_slots.{pool_name}', slot_stats[State.QUEUED])  # type: ignore
-            Stats.gauge(f'pool.running_slots.{pool_name}', slot_stats[State.RUNNING])  # type: ignore
+            Stats.gauge(f"pool.open_slots.{pool_name}", slot_stats["open"])
+            Stats.gauge(f"pool.queued_slots.{pool_name}", slot_stats["queued"])
+            Stats.gauge(f"pool.running_slots.{pool_name}", slot_stats["running"])
 
     @provide_session
-    def heartbeat_callback(self, session: Session = None) -> None:
-        Stats.incr('scheduler_heartbeat', 1, 1)
+    def heartbeat_callback(self, session: Session = NEW_SESSION) -> None:
+        Stats.incr("scheduler_heartbeat", 1, 1)
 
     @provide_session
-    def adopt_or_reset_orphaned_tasks(self, session: Session = None):
+    def adopt_or_reset_orphaned_tasks(self, session: Session = NEW_SESSION) -> int:
         """
         Reset any TaskInstance still in QUEUED or SCHEDULED states that were
         enqueued by a SchedulerJob that is no longer running.
 
         :return: the number of TIs reset
-        :rtype: int
         """
         self.log.info("Resetting orphaned tasks for active dag runs")
-        timeout = conf.getint('scheduler', 'scheduler_health_check_threshold')
+        timeout = conf.getint("scheduler", "scheduler_health_check_threshold")
 
         for attempt in run_with_db_retries(logger=self.log):
             with attempt:
@@ -1248,9 +1451,9 @@ class SchedulerJob(BaseJob):
 
                     if num_failed:
                         self.log.info("Marked %d SchedulerJob instances as failed", num_failed)
-                        Stats.incr(self.__class__.__name__.lower() + '_end', num_failed)
+                        Stats.incr(self.__class__.__name__.lower() + "_end", num_failed)
 
-                    resettable_states = [State.QUEUED, State.RUNNING]
+                    resettable_states = [TaskInstanceState.QUEUED, TaskInstanceState.RUNNING]
                     query = (
                         session.query(TI)
                         .filter(TI.state.in_(resettable_states))
@@ -1283,11 +1486,11 @@ class SchedulerJob(BaseJob):
                     for ti in set(tis_to_reset_or_adopt) - set(to_reset):
                         ti.queued_by_job_id = self.id
 
-                    Stats.incr('scheduler.orphaned_tasks.cleared', len(to_reset))
-                    Stats.incr('scheduler.orphaned_tasks.adopted', len(tis_to_reset_or_adopt) - len(to_reset))
+                    Stats.incr("scheduler.orphaned_tasks.cleared", len(to_reset))
+                    Stats.incr("scheduler.orphaned_tasks.adopted", len(tis_to_reset_or_adopt) - len(to_reset))
 
                     if to_reset:
-                        task_instance_str = '\n\t'.join(reset_tis_message)
+                        task_instance_str = "\n\t".join(reset_tis_message)
                         self.log.info(
                             "Reset the following %s orphaned TaskInstances:\n\t%s",
                             len(to_reset),
@@ -1304,19 +1507,22 @@ class SchedulerJob(BaseJob):
         return len(to_reset)
 
     @provide_session
-    def check_trigger_timeouts(self, session: Session = None):
+    def check_trigger_timeouts(self, session: Session = NEW_SESSION) -> None:
         """
         Looks at all tasks that are in the "deferred" state and whose trigger
         or execution timeout has passed, so they can be marked as failed.
         """
         num_timed_out_tasks = (
             session.query(TaskInstance)
-            .filter(TaskInstance.state == State.DEFERRED, TaskInstance.trigger_timeout < timezone.utcnow())
+            .filter(
+                TaskInstance.state == TaskInstanceState.DEFERRED,
+                TaskInstance.trigger_timeout < timezone.utcnow(),
+            )
             .update(
                 # We have to schedule these to fail themselves so it doesn't
                 # happen inside the scheduler.
                 {
-                    "state": State.SCHEDULED,
+                    "state": TaskInstanceState.SCHEDULED,
                     "next_method": "__fail__",
                     "next_kwargs": {"error": "Trigger/execution timeout"},
                     "trigger_id": None,
@@ -1325,3 +1531,118 @@ class SchedulerJob(BaseJob):
         )
         if num_timed_out_tasks:
             self.log.info("Timed out %i deferred tasks without fired triggers", num_timed_out_tasks)
+
+    @provide_session
+    def _find_zombies(self, session: Session) -> None:
+        """
+        Find zombie task instances, which are tasks haven't heartbeated for too long
+        or have a no-longer-running LocalTaskJob, and create a TaskCallbackRequest
+        to be handled by the DAG processor.
+        """
+        from airflow.jobs.local_task_job import LocalTaskJob
+
+        self.log.debug("Finding 'running' jobs without a recent heartbeat")
+        limit_dttm = timezone.utcnow() - timedelta(seconds=self._zombie_threshold_secs)
+
+        zombies = (
+            session.query(TaskInstance, DagModel.fileloc)
+            .with_hint(TI, "USE INDEX (ti_state)", dialect_name="mysql")
+            .join(LocalTaskJob, TaskInstance.job_id == LocalTaskJob.id)
+            .join(DagModel, TaskInstance.dag_id == DagModel.dag_id)
+            .filter(TaskInstance.state == TaskInstanceState.RUNNING)
+            .filter(
+                or_(
+                    LocalTaskJob.state != State.RUNNING,
+                    LocalTaskJob.latest_heartbeat < limit_dttm,
+                )
+            )
+            .filter(TaskInstance.queued_by_job_id == self.id)
+            .all()
+        )
+
+        if zombies:
+            self.log.warning("Failing (%s) jobs without heartbeat after %s", len(zombies), limit_dttm)
+
+        for ti, file_loc in zombies:
+            zombie_message_details = self._generate_zombie_message_details(ti)
+            request = TaskCallbackRequest(
+                full_filepath=file_loc,
+                processor_subdir=ti.dag_model.processor_subdir,
+                simple_task_instance=SimpleTaskInstance.from_ti(ti),
+                msg=str(zombie_message_details),
+            )
+            self.log.error("Detected zombie job: %s", request)
+            self.executor.send_callback(request)
+            Stats.incr("zombies_killed")
+
+    @staticmethod
+    def _generate_zombie_message_details(ti: TaskInstance):
+        zombie_message_details = {
+            "DAG Id": ti.dag_id,
+            "Task Id": ti.task_id,
+            "Run Id": ti.run_id,
+        }
+
+        if ti.map_index != -1:
+            zombie_message_details["Map Index"] = ti.map_index
+        if ti.hostname:
+            zombie_message_details["Hostname"] = ti.hostname
+        if ti.external_executor_id:
+            zombie_message_details["External Executor Id"] = ti.external_executor_id
+
+        return zombie_message_details
+
+    @provide_session
+    def _cleanup_stale_dags(self, session: Session = NEW_SESSION) -> None:
+        """
+        Find all dags that were not updated by Dag Processor recently and mark them as inactive.
+
+        In case one of DagProcessors is stopped (in case there are multiple of them
+        for different dag folders), it's dags are never marked as inactive.
+        Also remove dags from SerializedDag table.
+        Executed on schedule only if [scheduler]standalone_dag_processor is True.
+        """
+        self.log.debug("Checking dags not parsed within last %s seconds.", self._dag_stale_not_seen_duration)
+        limit_lpt = timezone.utcnow() - timedelta(seconds=self._dag_stale_not_seen_duration)
+        stale_dags = (
+            session.query(DagModel).filter(DagModel.is_active, DagModel.last_parsed_time < limit_lpt).all()
+        )
+        if not stale_dags:
+            self.log.debug("Not stale dags found.")
+            return
+
+        self.log.info("Found (%d) stales dags not parsed after %s.", len(stale_dags), limit_lpt)
+        for dag in stale_dags:
+            dag.is_active = False
+            SerializedDagModel.remove_dag(dag_id=dag.dag_id, session=session)
+        session.flush()
+
+    @provide_session
+    def _orphan_unreferenced_datasets(self, session: Session = NEW_SESSION) -> None:
+        """
+        Detects datasets that are no longer referenced in any DAG schedule parameters or task outlets and
+        sets the dataset is_orphaned flag to True
+        """
+        orphaned_dataset_query = (
+            session.query(DatasetModel)
+            .join(
+                DagScheduleDatasetReference,
+                isouter=True,
+            )
+            .join(
+                TaskOutletDatasetReference,
+                isouter=True,
+            )
+            # MSSQL doesn't like it when we select a column that we haven't grouped by. All other DBs let us
+            # group by id and select all columns.
+            .group_by(DatasetModel if session.get_bind().dialect.name == "mssql" else DatasetModel.id)
+            .having(
+                and_(
+                    func.count(DagScheduleDatasetReference.dag_id) == 0,
+                    func.count(TaskOutletDatasetReference.dag_id) == 0,
+                )
+            )
+        )
+        for dataset in orphaned_dataset_query:
+            self.log.info("Orphaning unreferenced dataset '%s'", dataset.uri)
+            dataset.is_orphaned = expression.true()

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -891,7 +891,6 @@ class SchedulerJob(BaseJob):
                                 self.executor.heartbeat()
                                 session.expunge_all()
                                 num_finished_events = self._process_executor_events(session=session)
-                                break
                         except OperationalError as e:
                             end_time = time.time()
                             self.log.error("got a MySql exception (retry:" + str(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -880,8 +880,8 @@ class SchedulerJob(BaseJob):
                     # is finished to avoid concurrent access to the DB.
                     self.log.debug("Waiting for processors to finish since we're using sqlite")
                     self.processor_agent.wait_until_finished()
-
-                for retry_count in range(1, 5):
+                max_retry_count = conf.getint('scheduler', 'scheduler_loop_max_retries', fallback=5)
+                for retry_count in range(1, max_retry_count):
                     start_time = time.time()
                     try:
                         with create_session() as session:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -85,20 +85,17 @@ DM = DagModel
 
 def _is_parent_process() -> bool:
     """
-    Whether this is a parent process.
-
-    Return True if the current process is the parent process.
-    False if the current process is a child process started by multiprocessing.
+    Returns True if the current process is the parent process. False if the current process is a child
+    process started by multiprocessing.
     """
     return multiprocessing.current_process().name == "MainProcess"
 
 
 class SchedulerJob(BaseJob):
     """
-    SchedulerJob runs for a specific time interval and schedules jobs that are ready to run.
-
-    It figures out the latest runs for each task and sees if the dependencies
-    for the next schedules are met.
+    This SchedulerJob runs for a specific time interval and schedules the jobs
+    that are ready to run. It figures out the latest runs for each
+    task and sees if the dependencies for the next schedules are met.
     If so, it creates appropriate TaskInstances and sends run commands to the
     executor. It does this for each task in each DAG and repeats.
 
@@ -168,7 +165,7 @@ class SchedulerJob(BaseJob):
         self._paused_dag_without_running_dagruns: set = set()
 
     def register_signals(self) -> None:
-        """Register signals that stop child processes."""
+        """Register signals that stop child processes"""
         signal.signal(signal.SIGINT, self._exit_gracefully)
         signal.signal(signal.SIGTERM, self._exit_gracefully)
         signal.signal(signal.SIGUSR2, self._debug_dump)
@@ -201,7 +198,7 @@ class SchedulerJob(BaseJob):
 
     def is_alive(self, grace_multiplier: float | None = None) -> bool:
         """
-        Whether the SchedulerJob is alive.
+        Is this SchedulerJob alive?
 
         We define alive as in a state of running and a heartbeat within the
         threshold defined in the ``scheduler_health_check_threshold`` config
@@ -244,13 +241,8 @@ class SchedulerJob(BaseJob):
 
     def _executable_task_instances_to_queued(self, max_tis: int, session: Session) -> list[TI]:
         """
-        Find TIs that are ready for execution based on conditions.
-
-        Conditions include:
-        - pool limits
-        - DAG max_active_tasks
-        - executor state
-        - priority
+        Finds TIs that are ready for execution with respect to pool limits,
+        dag max_active_tasks, executor state, and priority.
 
         :param max_tis: Maximum number of TIs to queue in this loop.
         :return: list[airflow.models.TaskInstance]
@@ -537,7 +529,8 @@ class SchedulerJob(BaseJob):
 
     def _enqueue_task_instances_with_queued_state(self, task_instances: list[TI], session: Session) -> None:
         """
-        Enqueue task_instances which should have been set to queued with the executor.
+        Takes task_instances, which should have been set to queued, and enqueues them
+        with the executor.
 
         :param task_instances: TaskInstances to enqueue
         :param session: The session object
@@ -823,9 +816,7 @@ class SchedulerJob(BaseJob):
 
     def _run_scheduler_loop(self) -> None:
         """
-        The actual scheduler loop.
-
-        The main steps in the loop are:
+        The actual scheduler loop. The main steps in the loop are:
             #. Harvest DAG parsing results through DagFileProcessorAgent
             #. Find and queue executable tasks
                 #. Change task instance state in DB
@@ -889,7 +880,7 @@ class SchedulerJob(BaseJob):
                     # is finished to avoid concurrent access to the DB.
                     self.log.debug("Waiting for processors to finish since we're using sqlite")
                     self.processor_agent.wait_until_finished()
-
+                
                 for attempt in run_with_db_retries():
                     with attempt:
                         start_time = time.time()
@@ -907,7 +898,7 @@ class SchedulerJob(BaseJob):
                                 attempt.retry_state.attempt_number) + ", total time in seconds: " + str(
                                 end_time - start_time) + "), details: " + str(e))
                             raise
-
+                
                 if self.processor_agent:
                     self.processor_agent.heartbeat()
 
@@ -944,9 +935,8 @@ class SchedulerJob(BaseJob):
 
     def _do_scheduling(self, session: Session) -> int:
         """
-        This function is where the main scheduling decisions take places.
+        This function is where the main scheduling decisions take places. It:
 
-        It:
         - Creates any necessary DAG runs by examining the next_dagrun_create_after column of DagModel
 
           Since creating Dag Runs is a relatively time consuming process, we select only 10 dags by default
@@ -1031,12 +1021,12 @@ class SchedulerJob(BaseJob):
 
     @retry_db_transaction
     def _get_next_dagruns_to_examine(self, state: DagRunState, session: Session):
-        """Get Next DagRuns to Examine with retries."""
+        """Get Next DagRuns to Examine with retries"""
         return DagRun.next_dagruns_to_examine(state, session)
 
     @retry_db_transaction
     def _create_dagruns_for_dags(self, guard: CommitProhibitorGuard, session: Session) -> None:
-        """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError."""
+        """Find Dag Models needing DagRuns and Create Dag Runs with retries in case of OperationalError"""
         query, dataset_triggered_dag_info = DagModel.dags_needing_dagruns(session)
         all_dags_needing_dag_runs = set(query.all())
         dataset_triggered_dags = [
@@ -1227,7 +1217,7 @@ class SchedulerJob(BaseJob):
         return True
 
     def _start_queued_dagruns(self, session: Session) -> None:
-        """Find DagRuns in queued state and decide moving them to running state."""
+        """Find DagRuns in queued state and decide moving them to running state"""
         dag_runs = self._get_next_dagruns_to_examine(DagRunState.QUEUED, session)
 
         active_runs_of_dags = defaultdict(
@@ -1285,7 +1275,7 @@ class SchedulerJob(BaseJob):
         session: Session,
     ) -> DagCallbackRequest | None:
         """
-        Make scheduling decisions about an individual dag run.
+        Make scheduling decisions about an individual dag run
 
         :param dag_run: The DagRun to schedule
         :return: Callback that needs to be executed
@@ -1385,7 +1375,7 @@ class SchedulerJob(BaseJob):
             self.log.debug("callback is empty")
 
     def _send_sla_callbacks_to_processor(self, dag: DAG) -> None:
-        """Sends SLA Callbacks to DagFileProcessor if tasks have SLAs set and check_slas=True."""
+        """Sends SLA Callbacks to DagFileProcessor if tasks have SLAs set and check_slas=True"""
         if not settings.CHECK_SLAS:
             return
 


### PR DESCRIPTION
Add retry loop in case where sql query fails, this makes AF much more resilient to potential DB hiccups

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
