### PR TITLE
Reset AWS settings (env var) to mock values for each amazon unit test

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -27,6 +27,7 @@ import boto3
 import pytest
 from botocore.config import Config
 from botocore.credentials import ReadOnlyCredentials
+from botocore.exceptions import NoCredentialsError
 from moto import mock_dynamodb, mock_emr, mock_iam, mock_sts
 from moto.core import DEFAULT_ACCOUNT_ID
 
@@ -871,3 +872,19 @@ class TestRetryDecorator:  # ptlint: disable=invalid-name
         custom_fn = ThrowErrorUntilCount(count=2, quota_retry=None)
         with pytest.raises(Exception):
             _retryable_test(custom_fn)
+
+
+def test_raise_no_creds_default_credentials_strategy(tmp_path_factory, monkeypatch):
+    """Test raise an error if no credentials provided and default boto3 strategy unable to get creds."""
+    for env_key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_SECURITY_TOKEN"):
+        # Delete aws credentials environment variables
+        monkeypatch.delenv(env_key, raising=False)
+
+    hook = AwsBaseHook(aws_conn_id=None, client_type="sts")
+    with pytest.raises(NoCredentialsError):
+        # Call AWS STS API method GetCallerIdentity
+        # which should return result in case of valid credentials
+        result = hook.conn.get_caller_identity()
+        # In normal circumstances lines below should not execute.
+        # We want to show additional information why this test not passed
+        assert not result, f"Credentials Method: {hook.get_session().get_credentials().method}"

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -26,7 +26,7 @@ from unittest.mock import Mock
 
 import boto3
 import pytest
-from botocore.exceptions import ClientError, NoCredentialsError
+from botocore.exceptions import ClientError
 from moto import mock_s3
 
 from airflow.exceptions import AirflowException
@@ -46,21 +46,6 @@ def s3_bucket(mocked_s3_res):
     bucket = "airflow-test-s3-bucket"
     mocked_s3_res.create_bucket(Bucket=bucket)
     return bucket
-
-
-# This class needs to be separated out because if there are earlier mocks in the same class
-# the tests will fail on teardown.
-class TestAwsS3HookNoMock:
-    def test_check_for_bucket_raises_error_with_invalid_conn_id(self, monkeypatch):
-        monkeypatch.delenv("AWS_PROFILE", raising=False)
-        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
-        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-        hook = S3Hook(aws_conn_id="does_not_exist")
-        # We're mocking all actual AWS calls and don't need a connection. This
-        # avoids an Airflow warning about connection cannot be found.
-        hook.get_connection = lambda _: None
-        with pytest.raises(NoCredentialsError):
-            hook.check_for_bucket("test-non-existing-bucket")
 
 
 class TestAwsS3Hook:


### PR DESCRIPTION
Follow up: https://github.com/apache/airflow/pull/27823#issuecomment-1336217469

This PR add two changes in Amazon Provider tests

1. Move check no cred exception from `test_s3` to `test_base_aws`

2. Clear AWS environment variables to mocked values

- If developer set in `files/airflow-breeze-config/variables.env` or in IDE some [AWS specific variables](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables) it might affect local tests execution
- By default if credentials not set then `botocore`/`boto3` tried to use credentials/configs from `default` profile from `~/.aws/config` and `~/.aws/credentials` as well as legacy boto configuration. For prevent this behaviour create temporary empty configurations files (on session level) and set appropriate ENV variables
- Set fake AWS Credentials for prevent usage of actual credentials. In this case some tests might failed with `An error occurred (UnrecognizedClientException) when calling the FooBar operation: The security token included in the request is invalid.`
