### PR TITLE
Improve run/task grid view actions

### DIFF
--- a/airflow/www/static/js/api/useClearRun.ts
+++ b/airflow/www/static/js/api/useClearRun.ts
@@ -49,10 +49,11 @@ export default function useClearRun(dagId: string, runId: string) {
       });
     },
     {
-      onSuccess: () => {
-        // Invalidating the query will force a new API request
-        queryClient.invalidateQueries('gridData');
-        startRefresh();
+      onSuccess: (_, { confirmed }) => {
+        if (confirmed) {
+          queryClient.invalidateQueries('gridData');
+          startRefresh();
+        }
       },
       onError: (error: Error) => errorToast({ error }),
     },

--- a/airflow/www/static/js/api/useClearRun.ts
+++ b/airflow/www/static/js/api/useClearRun.ts
@@ -42,7 +42,7 @@ export default function useClearRun(dagId: string, runId: string) {
         dag_run_id: runId,
       }).toString();
 
-      return axios.post<AxiosResponse, string>(clearRunUrl, params, {
+      return axios.post<AxiosResponse, string[]>(clearRunUrl, params, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/airflow/www/static/js/api/useClearTask.ts
+++ b/airflow/www/static/js/api/useClearTask.ts
@@ -74,7 +74,7 @@ export default function useClearTask({
         params.append('map_index', mi.toString());
       });
 
-      return axios.post<AxiosResponse, string>(clearUrl, params.toString(), {
+      return axios.post<AxiosResponse, string[]>(clearUrl, params.toString(), {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/airflow/www/static/js/api/useClearTask.ts
+++ b/airflow/www/static/js/api/useClearTask.ts
@@ -81,10 +81,12 @@ export default function useClearTask({
       });
     },
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries('gridData');
-        queryClient.invalidateQueries(['mappedInstances', dagId, runId, taskId]);
-        startRefresh();
+      onSuccess: (_, { confirmed }) => {
+        if (confirmed) {
+          queryClient.invalidateQueries('gridData');
+          queryClient.invalidateQueries(['mappedInstances', dagId, runId, taskId]);
+          startRefresh();
+        }
       },
       onError: (error: Error) => errorToast({ error }),
     },

--- a/airflow/www/static/js/api/useMarkFailedRun.ts
+++ b/airflow/www/static/js/api/useMarkFailedRun.ts
@@ -49,9 +49,11 @@ export default function useMarkFailedRun(dagId: string, runId: string) {
       });
     },
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries('gridData');
-        startRefresh();
+      onSuccess: (_, { confirmed }) => {
+        if (confirmed) {
+          queryClient.invalidateQueries('gridData');
+          startRefresh();
+        }
       },
       onError: (error: Error) => errorToast({ error }),
     },

--- a/airflow/www/static/js/api/useMarkFailedRun.ts
+++ b/airflow/www/static/js/api/useMarkFailedRun.ts
@@ -42,7 +42,7 @@ export default function useMarkFailedRun(dagId: string, runId: string) {
         dag_run_id: runId,
       }).toString();
 
-      return axios.post<AxiosResponse, string>(markFailedUrl, params, {
+      return axios.post<AxiosResponse, string[]>(markFailedUrl, params, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/airflow/www/static/js/api/useMarkSuccessRun.ts
+++ b/airflow/www/static/js/api/useMarkSuccessRun.ts
@@ -48,9 +48,11 @@ export default function useMarkSuccessRun(dagId: string, runId: string) {
       });
     },
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries('gridData');
-        startRefresh();
+      onSuccess: (_, { confirmed }) => {
+        if (confirmed) {
+          queryClient.invalidateQueries('gridData');
+          startRefresh();
+        }
       },
       onError: (error: Error) => errorToast({ error }),
     },

--- a/airflow/www/static/js/api/useMarkSuccessRun.ts
+++ b/airflow/www/static/js/api/useMarkSuccessRun.ts
@@ -41,7 +41,7 @@ export default function useMarkSuccessRun(dagId: string, runId: string) {
         dag_run_id: runId,
       }).toString();
 
-      return axios.post<AxiosResponse, string>(markSuccessUrl, params, {
+      return axios.post<AxiosResponse, string[]>(markSuccessUrl, params, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/airflow/www/static/js/api/useQueueRun.ts
+++ b/airflow/www/static/js/api/useQueueRun.ts
@@ -40,7 +40,7 @@ export default function useQueueRun(dagId: string, runId: string) {
         dag_id: dagId,
         dag_run_id: runId,
       }).toString();
-      return axios.post<AxiosResponse, string>(queuedUrl, params, {
+      return axios.post<AxiosResponse, string[]>(queuedUrl, params, {
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/airflow/www/static/js/api/useQueueRun.ts
+++ b/airflow/www/static/js/api/useQueueRun.ts
@@ -47,9 +47,11 @@ export default function useQueueRun(dagId: string, runId: string) {
       });
     },
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries('gridData');
-        startRefresh();
+      onSuccess: (_, { confirmed }) => {
+        if (confirmed) {
+          queryClient.invalidateQueries('gridData');
+          startRefresh();
+        }
       },
       onError: (error: Error) => errorToast({ error }),
     },

--- a/airflow/www/static/js/components/ConfirmDialog.tsx
+++ b/airflow/www/static/js/components/ConfirmDialog.tsx
@@ -37,7 +37,7 @@ interface Props extends PropsWithChildren {
   onClose: () => void;
   title?: string;
   description: string;
-  affectedTasks: string[] | string;
+  affectedTasks: string[];
   onConfirm: () => void;
   isLoading?: boolean;
 }
@@ -67,11 +67,11 @@ const ConfirmDialog = ({
           <AlertDialogBody overflowY="auto">
             {children}
             <Text mb={2}>{description}</Text>
-            {Array.isArray(affectedTasks) && affectedTasks.map((ti) => (
+            {affectedTasks.map((ti) => (
               <Code width="100%" key={ti} fontSize="lg">{ti}</Code>
             ))}
-            {((Array.isArray(affectedTasks) && !affectedTasks.length) || !affectedTasks) && (
-              <Text>No task instances found.</Text>
+            {!affectedTasks.length && (
+              <Text>No task instances to change.</Text>
             )}
           </AlertDialogBody>
 

--- a/airflow/www/static/js/components/ConfirmDialog.tsx
+++ b/airflow/www/static/js/components/ConfirmDialog.tsx
@@ -37,13 +37,13 @@ interface Props extends PropsWithChildren {
   onClose: () => void;
   title?: string;
   description: string;
-  body?: string[] | string;
+  affectedTasks: string[] | string;
   onConfirm: () => void;
   isLoading?: boolean;
 }
 
 const ConfirmDialog = ({
-  isOpen, onClose, title = 'Wait a minute', description, body = [], onConfirm, isLoading = false, children,
+  isOpen, onClose, title = 'Wait a minute', description, affectedTasks, onConfirm, isLoading = false, children,
 }: Props) => {
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const containerRef = useContainerRef();
@@ -67,7 +67,12 @@ const ConfirmDialog = ({
           <AlertDialogBody overflowY="auto">
             {children}
             <Text mb={2}>{description}</Text>
-            {Array.isArray(body) && body.map((ti) => (<Code width="100%" key={ti} fontSize="lg">{ti}</Code>))}
+            {Array.isArray(affectedTasks) && affectedTasks.map((ti) => (
+              <Code width="100%" key={ti} fontSize="lg">{ti}</Code>
+            ))}
+            {((Array.isArray(affectedTasks) && !affectedTasks.length) || !affectedTasks) && (
+              <Text>No task instances found.</Text>
+            )}
           </AlertDialogBody>
 
           <AlertDialogFooter>

--- a/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const ClearRun = ({ dagId, runId }: Props) => {
-  const [affectedTasks, setAffectedTasks] = useState('');
+  const [affectedTasks, setAffectedTasks] = useState<string[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { mutateAsync: onClear, isLoading } = useClearRun(dagId, runId);
 
@@ -44,7 +44,7 @@ const ClearRun = ({ dagId, runId }: Props) => {
 
   const onConfirm = async () => {
     await onClear({ confirmed: true });
-    setAffectedTasks('');
+    setAffectedTasks([]);
     onClose();
   };
 

--- a/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/ClearRun.tsx
@@ -63,7 +63,7 @@ const ClearRun = ({ dagId, runId }: Props) => {
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to clear:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </>
   );

--- a/airflow/www/static/js/dag/details/dagRun/MarkFailedRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/MarkFailedRun.tsx
@@ -57,7 +57,7 @@ const MarkFailedRun = ({ dagId, runId }: Props) => {
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to mark as failed or skipped:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </>
   );

--- a/airflow/www/static/js/dag/details/dagRun/MarkFailedRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/MarkFailedRun.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const MarkFailedRun = ({ dagId, runId }: Props) => {
-  const [affectedTasks, setAffectedTasks] = useState('');
+  const [affectedTasks, setAffectedTasks] = useState<string[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { mutateAsync: markFailed, isLoading } = useMarkFailedRun(dagId, runId);
 
@@ -44,7 +44,7 @@ const MarkFailedRun = ({ dagId, runId }: Props) => {
 
   const onConfirm = () => {
     markFailed({ confirmed: true });
-    setAffectedTasks('');
+    setAffectedTasks([]);
     onClose();
   };
 

--- a/airflow/www/static/js/dag/details/dagRun/MarkSuccessRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/MarkSuccessRun.tsx
@@ -57,7 +57,7 @@ const MarkSuccessRun = ({ dagId, runId }: Props) => {
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to mark as success:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </>
   );

--- a/airflow/www/static/js/dag/details/dagRun/MarkSuccessRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/MarkSuccessRun.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const MarkSuccessRun = ({ dagId, runId }: Props) => {
-  const [affectedTasks, setAffectedTasks] = useState('');
+  const [affectedTasks, setAffectedTasks] = useState<string[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { mutateAsync: markSuccess, isLoading } = useMarkSuccessRun(dagId, runId);
 
@@ -44,7 +44,7 @@ const MarkSuccessRun = ({ dagId, runId }: Props) => {
 
   const onConfirm = async () => {
     await markSuccess({ confirmed: true });
-    setAffectedTasks('');
+    setAffectedTasks([]);
     onClose();
   };
 

--- a/airflow/www/static/js/dag/details/dagRun/QueueRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/QueueRun.tsx
@@ -32,7 +32,7 @@ interface Props {
 }
 
 const QueueRun = ({ dagId, runId }: Props) => {
-  const [affectedTasks, setAffectedTasks] = useState('');
+  const [affectedTasks, setAffectedTasks] = useState<string[]>([]);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { mutateAsync: onQueue, isLoading } = useQueueRun(dagId, runId);
 
@@ -46,7 +46,7 @@ const QueueRun = ({ dagId, runId }: Props) => {
   // Confirm changes
   const onConfirm = async () => {
     await onQueue({ confirmed: true });
-    setAffectedTasks('');
+    setAffectedTasks([]);
     onClose();
   };
 

--- a/airflow/www/static/js/dag/details/dagRun/QueueRun.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/QueueRun.tsx
@@ -67,7 +67,7 @@ const QueueRun = ({ dagId, runId }: Props) => {
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to queue:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
@@ -127,7 +127,7 @@ const Run = ({
         onConfirm={onConfirm}
         isLoading={isLoading}
         description={`Task instances you are about to clear (${affectedTasks.length}):`}
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       >
         { isGroup && (past || future) && (
           <Alert status="warning" mb={3}>

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/Clear.tsx
@@ -44,7 +44,7 @@ const Run = ({
   mapIndexes,
   isGroup,
 }: CommonActionProps) => {
-  const [affectedTasks, setAffectedTasks] = useState('');
+  const [affectedTasks, setAffectedTasks] = useState<string[]>([]);
 
   // Options check/unchecked
   const [past, setPast] = useState(false);
@@ -98,7 +98,7 @@ const Run = ({
       confirmed: true,
       mapIndexes,
     });
-    setAffectedTasks('');
+    setAffectedTasks([]);
     onClose();
   };
 

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkFailed.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkFailed.tsx
@@ -116,7 +116,7 @@ const MarkFailed = ({
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to mark as failed:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </Flex>
   );

--- a/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkSuccess.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/taskActions/MarkSuccess.tsx
@@ -111,7 +111,7 @@ const MarkSuccess = ({
         onConfirm={onConfirm}
         isLoading={isLoading}
         description="Task instances you are about to mark as success:"
-        body={affectedTasks}
+        affectedTasks={affectedTasks}
       />
     </Flex>
   );


### PR DESCRIPTION
After #28066, I figured there were a few things with run/task actions we could clean up.

1. Include a "No instances to change" text when our confirmation returns nothing
2. Don't invalidate grid queries when we're just checking what changes we're making
3. Clean up some variable names (`body` is very ambiguous)
4. Clean up some type checking (all our confirm returns can be `string[]` instead of mixing with just `string`)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
