### PR TITLE
Ensure the dagbag_size metric decreases when files are deleted

### DIFF
--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -257,6 +257,7 @@ class TestDagFileProcessorManager:
 
         manager.set_file_paths(["abc.txt"])
         assert manager._processors == {}
+        assert "missing_file.txt" not in manager._file_stats
 
     def test_set_file_paths_when_processor_file_path_is_in_new_file_paths(self):
         manager = DagFileProcessorManager(


### PR DESCRIPTION
If a dag file is _deleted_ the entry stayed in _file_stats until the
process was restarted, meaning the dag count was never accurate again.

Additionally in mtime mode, each time around the loop you would get a
warning that the file was missing which is also fixed here.

