### PR TITLE
Check if ghcr.io is reachable before network-bound breeze operations

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/ci_image_commands.py
@@ -76,6 +76,7 @@ from airflow_breeze.utils.confirm import STANDARD_TIMEOUT, Answer, user_confirm
 from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.docker_command_utils import (
     build_cache,
+    check_remote_ghcr_io_commands,
     make_sure_builder_configured,
     perform_environment_checks,
     prepare_docker_build_command,
@@ -216,6 +217,7 @@ def build(
             sys.exit(return_code)
 
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     parameters_passed = filter_out_none(**kwargs)
     parameters_passed["force_build"] = True
     fix_group_permissions()
@@ -277,6 +279,7 @@ def pull(
 ):
     """Pull and optionally verify CI images - possibly in parallel for all Python versions."""
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)
         ci_image_params_list = [
@@ -344,6 +347,7 @@ def verify(
         build_params = BuildCiParams(python=python, image_tag=image_tag, github_repository=github_repository)
         image_name = build_params.airflow_image_name_with_tag
     if pull:
+        check_remote_ghcr_io_commands()
         command_to_run = ["docker", "pull", image_name]
         run_command(command_to_run, check=True)
     get_console().print(f"[info]Verifying CI image: {image_name}[/]")

--- a/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/production_image_commands.py
@@ -78,6 +78,7 @@ from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.docker_command_utils import (
     build_cache,
+    check_remote_ghcr_io_commands,
     make_sure_builder_configured,
     perform_environment_checks,
     prepare_docker_build_command,
@@ -245,6 +246,7 @@ def build(
             sys.exit(return_code)
 
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     parameters_passed = filter_out_none(**kwargs)
 
     fix_group_permissions()
@@ -305,6 +307,7 @@ def pull_prod_image(
 ):
     """Pull and optionally verify Production images - possibly in parallel for all Python versions."""
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     if run_in_parallel:
         python_version_list = get_python_version_list(python_versions)
         prod_image_params_list = [
@@ -381,6 +384,7 @@ def verify(
         )
         image_name = build_params.airflow_image_name_with_tag
     if pull:
+        check_remote_ghcr_io_commands()
         command_to_run = ["docker", "pull", image_name]
         run_command(command_to_run, check=True)
     get_console().print(f"[info]Verifying PROD image: {image_name}[/]")

--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -64,6 +64,7 @@ from airflow_breeze.utils.confirm import Answer, user_confirm
 from airflow_breeze.utils.console import Output, get_console
 from airflow_breeze.utils.custom_param_types import BetterChoice
 from airflow_breeze.utils.docker_command_utils import (
+    check_remote_ghcr_io_commands,
     get_env_variables_for_docker_commands,
     get_extra_docker_flags,
     perform_environment_checks,
@@ -216,6 +217,7 @@ def prepare_provider_documentation(
     packages: list[str],
 ):
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     cleanup_python_generated_files()
     shell_params = ShellParams(
         mount_sources=MOUNT_ALL,
@@ -383,6 +385,7 @@ def generate_constraints(
     github_repository: str,
 ):
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     cleanup_python_generated_files()
     if debug and run_in_parallel:
         get_console().print("\n[error]Cannot run --debug and --run-in-parallel at the same time[/]\n")
@@ -568,6 +571,7 @@ def release_prod_images(
     skip_latest: bool,
 ):
     perform_environment_checks()
+    check_remote_ghcr_io_commands()
     rebuild_or_pull_ci_image_if_needed(command_params=ShellParams(python=DEFAULT_PYTHON_MAJOR_MINOR_VERSION))
     if not match(r"^\d*\.\d*\.\d*$", airflow_version):
         get_console().print(

--- a/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/docker_command_utils.py
@@ -262,6 +262,34 @@ Please upgrade to at least {MIN_DOCKER_VERSION}[/]
                 )
 
 
+def check_remote_ghcr_io_commands():
+    """
+    Checks if you have permissions to pull an empty image from ghcr.io. Unfortunately, GitHub packages
+    treat expired login as "no-access" even on public repos. We need to detect that situation and suggest
+    user to log-out.
+    :return:
+    """
+    response = run_command(
+        ["docker", "pull", "ghcr.io/apache/airflow-hello-world"],
+        no_output_dump_on_exception=True,
+        text=False,
+        capture_output=True,
+        check=False,
+    )
+    if response.returncode != 0:
+        if "no such host" in response.stderr.decode("utf-8"):
+            get_console().print(
+                "[error]\nYou seem to be offline. This command requires access to network.[/]\n"
+            )
+            sys.exit(2)
+        get_console().print(
+            "[error]\nYou seem to have expired permissions on ghcr.io.[/]\n"
+            "[warning]Please logout. Run this command:[/]\n\n"
+            "   docker logout ghcr.io\n\n"
+        )
+        sys.exit(1)
+
+
 DOCKER_COMPOSE_COMMAND = ["docker-compose"]
 
 


### PR DESCRIPTION
Unfortunately, ghcr.io behaves nasty when token you logged in with to it expired. It refuses to pull the images, even if they are public.

This PR adds extra check for all network-bound commands that require ghcr.io access.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
