### PR TITLE
Remove/silence warnings generated from tests/dag_processing/test_manager.py

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,12 @@ norecursedirs =
 log_level = INFO
 filterwarnings =
     error::pytest.PytestCollectionWarning
+    ignore::DeprecationWarning:flask_appbuilder.filemanager
+    ignore::DeprecationWarning:flask_appbuilder.widgets
+    ; https://github.com/dpgaspar/Flask-AppBuilder/pull/1940
+    ignore::DeprecationWarning:flask_sqlalchemy
+    ; https://github.com/dpgaspar/Flask-AppBuilder/pull/1903
+    ignore::DeprecationWarning:apispec.utils
 markers =
     need_serialized_dag
 asyncio_mode = strict

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -511,7 +511,7 @@ class TestDagFileProcessorManager:
         )
 
         test_dag_path = str(TEST_DAG_FOLDER / "test_example_bash_operator.py")
-        dagbag = DagBag(test_dag_path, read_dags_from_db=False)
+        dagbag = DagBag(test_dag_path, read_dags_from_db=False, include_examples=False)
 
         with create_session() as session:
             # Add stale DAG to the DB


### PR DESCRIPTION
- For the warnings from FAB silence them, as FAB will have to fix them
- Update one test to not load the example dags (they weren't needed for
  the test anyway and caused some warnings from subdag examples to be
  emitted)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
