### PR TITLE
Update config hash in Breeze's README.md during reinstalllation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -675,7 +675,7 @@ repos:
         name: Update Breeze README.md with config files hash
         language: python
         entry: ./scripts/ci/pre_commit/pre_commit_update_breeze_config_hash.py
-        files: ^dev/breeze/setup.*$|^dev/breeze/pyproject.toml$|^dev/breeze/README.md$
+        files: dev/breeze/setup.py|dev/breeze/setup.cfg|dev/breeze/pyproject.toml|dev/breeze/README.md
         pass_filenames: false
         require_serial: true
       - id: check-breeze-top-dependencies-limited

--- a/dev/breeze/src/airflow_breeze/utils/path_utils.py
+++ b/dev/breeze/src/airflow_breeze/utils/path_utils.py
@@ -140,6 +140,17 @@ def set_forced_answer_for_upgrade_check():
         set_forced_answer("quit")
 
 
+def process_breeze_readme(breeze_sources: Path, sources_hash: str):
+    breeze_readme = breeze_sources / "README.md"
+    lines = breeze_readme.read_text().splitlines(keepends=True)
+    result_lines = []
+    for line in lines:
+        if line.startswith("Package config hash:"):
+            line = f"Package config hash: {sources_hash}\n"
+        result_lines.append(line)
+    breeze_readme.write_text("".join(result_lines))
+
+
 def reinstall_if_setup_changed() -> bool:
     """
     Prints warning if detected airflow sources are not the ones that Breeze was installed with.
@@ -162,6 +173,7 @@ def reinstall_if_setup_changed() -> bool:
         if installation_sources is not None:
             breeze_sources = installation_sources / "dev" / "breeze"
             warn_dependencies_changed()
+            process_breeze_readme(breeze_sources, sources_hash)
             set_forced_answer_for_upgrade_check()
             reinstall_breeze(breeze_sources)
             set_forced_answer(None)

--- a/images/breeze/output_static-checks.svg
+++ b/images/breeze/output_static-checks.svg
@@ -212,9 +212,9 @@
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
-        
+
     <g transform="translate(9, 41)" clip-path="url(#breeze-static-checks-clip-terminal)">
-    
+
     <g class="breeze-static-checks-matrix">
     <text class="breeze-static-checks-r2" x="1464" y="20" textLength="12.2" clip-path="url(#breeze-static-checks-line-0)">
 </text><text class="breeze-static-checks-r3" x="12.2" y="44.4" textLength="85.4" clip-path="url(#breeze-static-checks-line-1)">Usage:&#160;</text><text class="breeze-static-checks-r1" x="97.6" y="44.4" textLength="268.4" clip-path="url(#breeze-static-checks-line-1)">breeze&#160;static-checks&#160;[</text><text class="breeze-static-checks-r4" x="366" y="44.4" textLength="85.4" clip-path="url(#breeze-static-checks-line-1)">OPTIONS</text><text class="breeze-static-checks-r1" x="451.4" y="44.4" textLength="36.6" clip-path="url(#breeze-static-checks-line-1)">]&#160;[</text><text class="breeze-static-checks-r4" x="488" y="44.4" textLength="170.8" clip-path="url(#breeze-static-checks-line-1)">PRECOMMIT_ARGS</text><text class="breeze-static-checks-r1" x="658.8" y="44.4" textLength="48.8" clip-path="url(#breeze-static-checks-line-1)">]...</text><text class="breeze-static-checks-r2" x="1464" y="44.4" textLength="12.2" clip-path="url(#breeze-static-checks-line-1)">


### PR DESCRIPTION
Previously we updated Breeze's config hash using pre-commit whenever setup files changed. This has proven to be brittle:

When you locally work and add new dependencies, breeze would keep reinstalling every time you run it locally - without the README being updated. You'd have to manually run pre-commit in order to get it regenerated.

This PR changes the flow slightly. Whenever you automatically re-install breeze, the README.md file of the folder from which you reinstall breeze gets updated with the new hash **just** before reinstalling. This means that after installation the new hash is already present in the package, and next time you run breeze it will match the changed hash of your dependencies.

The only thing left is to commit the changed README to the repo together with setup.py/cfg changes of yours.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
