### PR TITLE
Ensure that warnings from `@dag` decorator are reported in dag file

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -90,6 +90,7 @@ from airflow.typing_compat import Literal
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
+from airflow.utils.decorators import fixup_decorator_warning_stack
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import at_most_one, exactly_one, validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
@@ -3543,6 +3544,8 @@ def dag(
             # Return dag object such that it's accessible in Globals.
             return dag_obj
 
+        # Ensure that warnings from inside DAG() are emitted from the caller, not here
+        fixup_decorator_warning_stack(factory)
         return factory
 
     return wrapper


### PR DESCRIPTION
It's no use to a user if the warnings appear from `airflow/models/dag.py`!

This hacky magic has been in place for the apply_defaults metaclass for a couple of releases, and for all it's evil hackiness, it works, I've just extracted it out to be reusable.

Also I wish Python had something like this built in, as it's _really_ hard to get this right otherwise
