### PR TITLE
Fix next run datasets error

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -273,14 +273,14 @@ function dagStatsHandler(selector, json) {
   });
 }
 
-function nextRunDatasetsSummaryHandler(json) {
+function nextRunDatasetsSummaryHandler(_, json) {
   [...document.getElementsByClassName('next-dataset-triggered')].forEach((el) => {
     const dagId = $(el).attr('data-dag-id');
     const previousSummary = $(el).attr('data-summary');
     const nextDatasetsInfo = json[dagId];
 
     // Only update dags that depend on multiple datasets
-    if (!nextDatasetsInfo.uri) {
+    if (nextDatasetsInfo && !nextDatasetsInfo.uri) {
       const newSummary = `${nextDatasetsInfo.ready} of ${nextDatasetsInfo.total} datasets updated`;
 
       // Only update the element if the summary has changed
@@ -410,7 +410,7 @@ function handleRefresh({ activeDagsOnly = false } = {}) {
       .post(params, (error, json) => refreshDagStatsHandler(TASK_INSTANCE, json));
     d3.json(nextRunDatasetsSummaryUrl)
       .header('X-CSRFToken', csrfToken)
-      .post(params, (error, json) => nextRunDatasetsSummaryHandler(json));
+      .post(params, nextRunDatasetsSummaryHandler);
   }
   setTimeout(() => {
     $('#loading-dots').css('display', 'none');


### PR DESCRIPTION
There isn't always `nextDatasetsInfo` and that caused a js error. We should make sure it exists before trying to create the summary.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
