### PR TITLE
Don't check rosetta on i386

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/main_command.py
+++ b/dev/breeze/src/airflow_breeze/commands/main_command.py
@@ -153,7 +153,7 @@ def check_for_python_emulation():
 
 
 def check_for_rosetta_environment():
-    if sys.platform != "darwin":
+    if sys.platform != "darwin" or platform.processor() == "i386":
         return
     try:
         runs_in_rosetta = subprocess.check_output(


### PR DESCRIPTION
@potiuk might just want to verify that platform.processor() is not 'i386' on your m1

Get this error when doing breeze operations on intel mac

```
...
Default value of mssql_version parameter 2017-latest used.

Traceback (most recent call last):
  File "/Users/dstandish/code/airflow/dev/breeze/src/airflow_breeze/commands/main_command.py", line 159, in check_for_rosetta_environment
    runs_in_rosetta = subprocess.check_output(
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/subprocess.py", line 415, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['sysctl', '-n', 'sysctl.proc_translated']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/dstandish/code/airflow/dev/breeze/src/airflow_breeze/breeze.py", line 49, in <module>
    main()
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/rich_click/rich_group.py", line 21, in main
    rv = super().main(*args, standalone_mode=False, **kwargs)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/core.py", line 1654, in invoke
    super().invoke(ctx)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/dstandish/.cache/pre-commit/repo9d4d9t30/py_env-python3/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dstandish/code/airflow/dev/breeze/src/airflow_breeze/commands/main_command.py", line 113, in main
    check_for_rosetta_environment()
  File "/Users/dstandish/code/airflow/dev/breeze/src/airflow_breeze/commands/main_command.py", line 192, in check_for_rosetta_environment
    except TimeoutOccurred:
UnboundLocalError: local variable 'TimeoutOccurred' referenced before assignment
```