### PR TITLE
Handle OverflowError on exponential backof in next_run_calculation

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -277,6 +277,14 @@
       type: integer
       example: ~
       default: "300"
+    - name: max_task_retry_delay
+      description: |
+        The maximum delay (in seconds) each task is going to wait by default between retries.
+        This is a global setting and cannot be overridden at task or DAG level.
+      version_added: 2.6.0
+      type: integer
+      default: "86400"
+      example: ~
     - name: default_task_weight_rule
       description: |
         The weighting method used for the effective total priority weight of the task
@@ -431,7 +439,6 @@
       type: string
       default: ~
       example: 'http://localhost:8080'
-
 - name: database
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -163,6 +163,10 @@ default_task_retries = 0
 # dag or task level.
 default_task_retry_delay = 300
 
+# The maximum delay (in seconds) each task is going to wait by default between retries.
+# This is a global setting and cannot be overridden at task or DAG level.
+max_task_retry_delay = 86400
+
 # The weighting method used for the effective total priority weight of the task
 default_task_weight_rule = downstream
 

--- a/airflow/models/abstractoperator.py
+++ b/airflow/models/abstractoperator.py
@@ -59,6 +59,8 @@ DEFAULT_RETRIES: int = conf.getint("core", "default_task_retries", fallback=0)
 DEFAULT_RETRY_DELAY: datetime.timedelta = datetime.timedelta(
     seconds=conf.getint("core", "default_task_retry_delay", fallback=300)
 )
+MAX_RETRY_DELAY: int = conf.getint("core", "max_task_retry_delay", fallback=24 * 60 * 60)
+
 DEFAULT_WEIGHT_RULE: WeightRule = WeightRule(
     conf.get("core", "default_task_weight_rule", fallback=WeightRule.DOWNSTREAM)
 )

--- a/newsfragments/28172.misc.rst
+++ b/newsfragments/28172.misc.rst
@@ -1,0 +1,1 @@
+Maximum retry task delay is set to be 24h (86400s) by default. You can change it globally via ``core.max_task_retry_delay`` parameter.


### PR DESCRIPTION
Fixes: #28171

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
