### PR TITLE
Make invalid characters exception more readable

### DIFF
--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -196,7 +196,8 @@ def stat_name_default_handler(stat_name, max_length=250) -> str:
         )
     if not all((c in ALLOWED_CHARACTERS) for c in stat_name):
         raise InvalidStatsNameException(
-            f"The stat name ({stat_name}) has to be composed with characters in {ALLOWED_CHARACTERS}."
+            f"The stat name ({stat_name}) has to be composed of ASCII "
+            f"alphabets, numbers, or the underscore, dot, or dash characters."
         )
     return stat_name
 


### PR DESCRIPTION
The InvalidStatsNameException message when a stats name contains invalid characters currently includes the set of allow characters, which is quite long and of underterministic order (bein formatted from a set), making the message impossible to decipher for a human.

This commit changes the message to describe what characters are allowed in a human-readable fashion instead.