### PR TITLE
Better error message for bad stat name

### DIFF
--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -193,7 +193,7 @@ def stat_name_default_handler(stat_name, max_length=250) -> str:
 
     pattern = r"^[A-Za-z0-9_.-]+$"
     if not re.match(pattern, stat_name):
-        raise InvalidStatsNameException(f"The stat name ({stat_name}) must match regex {pattern}.")
+        raise InvalidStatsNameException(f"The stat name '{stat_name}' must match regex {pattern}.")
     return stat_name
 
 


### PR DESCRIPTION
Old error looked a bit silly, printing out the repr of the set.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/airflow/stats.py", line 232, in wrapper
    stat = handler_stat_name_func(stat)
  File "/usr/local/lib/python3.9/site-packages/airflow/stats.py", line 201, in stat_name_default_handler
    raise InvalidStatsNameException(
airflow.exceptions.InvalidStatsNameException: The stat name (dag_processing.last_duration.intldldat-k1wm-full-dev-k1-local-tables-wfoptimizedlayer - Copy) has to be composed with characters in
{'j', 'Q', 'G', 'v', 'l', 'y', '4', 'N', 'f', 'U', 'F', 'P', 'w', 'V', '.', '-', 't', 'T', 'p', '1', 'D', 'd', 'I', 'C', 'k', 'A', 'a', 'q', 'c', 'i', 'o', 'e', 'u', 'X', 'O', '0', 'g', '6', '5', 's', 'Y', 'n', 'E', 'H', 'Z', 'L', 'h', 'b', 'z', '3', 'x', 'B', 'K', 'S', 'W', '2', '_', 'r', 'm', 'J', '9', '7', 'R', '8', 'M'}.
```

Using regex is more compact.  

```
Traceback (most recent call last):
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
  File "/Users/dstandish/code/airflow/airflow/stats.py", line 196, in stat_name_default_handler
    raise InvalidStatsNameException(f"The stat name ({stat_name}) must match regex {pattern}.")
airflow.exceptions.InvalidStatsNameException: The stat name (abc abc) must match regex ^[A-Za-z0-9_.-]+$.
```

We could improve the message without removing constant, but i'm not sure we need the constant (it's not used elsewhere)