### PR TITLE
Add IAM authentication to Amazon Redshift Connection by AWS Connection

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift_sql.py
+++ b/airflow/providers/amazon/aws/hooks/redshift_sql.py
@@ -16,15 +16,19 @@
 # under the License.
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import redshift_connector
 from redshift_connector import Connection as RedshiftConnection
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import URL
 
 from airflow.compat.functools import cached_property
-from airflow.models.connection import Connection
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.common.sql.hooks.sql import DbApiHook
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 class RedshiftSQLHook(DbApiHook):

--- a/docs/apache-airflow-providers-amazon/connections/redshift.rst
+++ b/docs/apache-airflow-providers-amazon/connections/redshift.rst
@@ -69,11 +69,19 @@ Examples
 * **Password**: ``********``
 * **Port**: ``5439``
 
-**IAM Authentication**
+**Credentials Authentication**
 
-Uses AWS IAM to retrieve a temporary password to connect to Amazon Redshift. Port is required.
+Uses the credentials in Connection to connect to Amazon Redshift. Port is required.
 If none is provided, default is used (5439). This assumes all other Connection fields e.g. **Login** are empty.
 In this method, **cluster_identifier** replaces **Host** and **Port** in order to uniquely identify the cluster.
+
+**IAM Authentication**
+
+Uses the AWS IAM profile given at hook initialization to retrieve a temporary password to connect
+to Amazon Redshift. **Port** is required. If none is provided, default is used (5439). **Login**
+and **Schema** are also required. This assumes all other Connection fields are empty.
+In this method, if **cluster_identifier** is not set within the extras, it is automatically
+inferred by the **Host** field in Connection.
 `More details about AWS IAM authentication to generate database user credentials <https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html>`_.
 
 * **Extra**:

--- a/tests/providers/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_sql.py
@@ -86,7 +86,7 @@ class TestRedshiftSQLHookConn:
     def test_get_conn_iam(self, mock_connect, mock_aws_hook_conn, aws_conn_id):
         mock_conn_extra = {"iam": True, "profile": "default", "cluster_identifier": "my-test-cluster"}
         if aws_conn_id is not NOTSET:
-            mock_conn_extra["aws_conn_id"] = aws_conn_id
+            self.db_hook.aws_conn_id = aws_conn_id
         self.connection.extra = json.dumps(mock_conn_extra)
 
         mock_db_user = f"IAM:{self.connection.login}"

--- a/tests/providers/amazon/aws/hooks/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/hooks/test_redshift_sql.py
@@ -23,12 +23,24 @@ import pytest
 
 from airflow.models import Connection
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+from airflow.utils.types import NOTSET
+
+LOGIN_USER = "login"
+LOGIN_PASSWORD = "password"
+LOGIN_HOST = "host"
+LOGIN_PORT = 5439
+LOGIN_SCHEMA = "dev"
 
 
 class TestRedshiftSQLHookConn:
     def setup_method(self):
         self.connection = Connection(
-            conn_type="redshift", login="login", password="password", host="host", port=5439, schema="dev"
+            conn_type="redshift",
+            login=LOGIN_USER,
+            password=LOGIN_PASSWORD,
+            host=LOGIN_HOST,
+            port=LOGIN_PORT,
+            schema=LOGIN_SCHEMA,
         )
 
         self.db_hook = RedshiftSQLHook()
@@ -51,20 +63,59 @@ class TestRedshiftSQLHookConn:
     def test_get_conn_extra(self, mock_connect):
         self.connection.extra = json.dumps(
             {
-                "iam": True,
+                "iam": False,
                 "cluster_identifier": "my-test-cluster",
                 "profile": "default",
             }
         )
         self.db_hook.get_conn()
         mock_connect.assert_called_once_with(
-            user="login",
-            password="password",
-            host="host",
-            port=5439,
+            user=LOGIN_USER,
+            password=LOGIN_PASSWORD,
+            host=LOGIN_HOST,
+            port=LOGIN_PORT,
             cluster_identifier="my-test-cluster",
             profile="default",
-            database="dev",
+            database=LOGIN_SCHEMA,
+            iam=False,
+        )
+
+    @mock.patch("airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.conn")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift_sql.redshift_connector.connect")
+    @pytest.mark.parametrize("aws_conn_id", [NOTSET, None, "mock_aws_conn"])
+    def test_get_conn_iam(self, mock_connect, mock_aws_hook_conn, aws_conn_id):
+        mock_conn_extra = {"iam": True, "profile": "default", "cluster_identifier": "my-test-cluster"}
+        if aws_conn_id is not NOTSET:
+            mock_conn_extra["aws_conn_id"] = aws_conn_id
+        self.connection.extra = json.dumps(mock_conn_extra)
+
+        mock_db_user = f"IAM:{self.connection.login}"
+        mock_db_pass = "aws_token"
+
+        # Mock AWS Connection
+        mock_aws_hook_conn.get_cluster_credentials.return_value = {
+            "DbPassword": mock_db_pass,
+            "DbUser": mock_db_user,
+        }
+
+        self.db_hook.get_conn()
+
+        # Check boto3 'redshift' client method `get_cluster_credentials` call args
+        mock_aws_hook_conn.get_cluster_credentials.assert_called_once_with(
+            DbUser=LOGIN_USER,
+            DbName=LOGIN_SCHEMA,
+            ClusterIdentifier="my-test-cluster",
+            AutoCreate=False,
+        )
+
+        mock_connect.assert_called_once_with(
+            user=mock_db_user,
+            password=mock_db_pass,
+            host=LOGIN_HOST,
+            port=LOGIN_PORT,
+            cluster_identifier="my-test-cluster",
+            profile="default",
+            database=LOGIN_SCHEMA,
             iam=True,
         )
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/28000

Using same technique as already implemented into PostgreSQL Hook - manual obtain credentials by call [GetClusterCredentials](https://docs.aws.amazon.com/redshift/latest/APIReference/API_GetClusterCredentials.html) thought Redshift API.

https://github.com/apache/airflow/blob/56b5f3f4eed6a48180e9d15ba9bb9664656077b1/airflow/providers/postgres/hooks/postgres.py#L221-L235
