### PR TITLE
Remove noisy warning

### DIFF
--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -199,11 +199,9 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
             # If this task does not yet have a dag, add it to the same dag as the other task.
             self.dag = dag
 
-        def add_only_new(obj, item_set: set[str], item: str) -> None:
+        def add_only_new(item_set: set[str], item: str) -> None:
             """Adds only new items to item set"""
-            if item in item_set:
-                self.log.warning("Dependency %s, %s already registered for DAG: %s", obj, item, dag.dag_id)
-            else:
+            if item not in item_set:
                 item_set.add(item)
 
         for task in task_list:
@@ -211,13 +209,13 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
                 # If the other task does not yet have a dag, add it to the same dag as this task and
                 dag.add_task(task)
             if upstream:
-                add_only_new(task, task.downstream_task_ids, self.node_id)
-                add_only_new(self, self.upstream_task_ids, task.node_id)
+                add_only_new(task.downstream_task_ids, self.node_id)
+                add_only_new(self.upstream_task_ids, task.node_id)
                 if edge_modifier:
                     edge_modifier.add_edge_info(self.dag, task.node_id, self.node_id)
             else:
-                add_only_new(self, self.downstream_task_ids, task.node_id)
-                add_only_new(task, task.upstream_task_ids, self.node_id)
+                add_only_new(self.downstream_task_ids, task.node_id)
+                add_only_new(task.upstream_task_ids, self.node_id)
                 if edge_modifier:
                     edge_modifier.add_edge_info(self.dag, self.node_id, task.node_id)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I have been using this type of pattern in some of my DAGs:
```
@task(multiple_outputs=True)
def calc_range():
    return {
        'min': 0,
        'max': 1,
    }
    
@task
def other_method(range_min, range_max):
    pass
    
    
r = calc_range()
other_method(r['min'], r['max'])
```

This will flood scheduler logs with these warnings:
```
{taskmixin.py:205} WARNING - Dependency <Task(_PythonDecoratedOperator): calc_range>, other_method already registered for DAG: example_dag
{taskmixin.py:205} WARNING - Dependency <Task(_PythonDecoratedOperator): other_method>, calc_range already registered for DAG: example_dag
```

I do not think that this is any way a anti-pattern and we should not spam these warnings 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
