### PR TITLE
Revert "Migrate remaining core sensors tests to `pytest` (#28177)"

### DIFF
--- a/tests/sensors/test_date_time.py
+++ b/tests/sensors/test_date_time.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from parameterized import parameterized
 
 from airflow.models.dag import DAG
 from airflow.sensors.date_time import DateTimeSensor
@@ -34,8 +35,7 @@ class TestDateTimeSensor:
         args = {"owner": "airflow", "start_date": DEFAULT_DATE}
         cls.dag = DAG("test_dag", default_args=args)
 
-    @pytest.mark.parametrize(
-        "task_id, target_time, expected",
+    @parameterized.expand(
         [
             (
                 "valid_datetime",
@@ -52,7 +52,7 @@ class TestDateTimeSensor:
                 "{{ ds }}",
                 "{{ ds }}",
             ),
-        ],
+        ]
     )
     def test_valid_input(self, task_id, target_time, expected):
         """target_time should be a string as it is a template field"""
@@ -71,8 +71,7 @@ class TestDateTimeSensor:
                 dag=self.dag,
             )
 
-    @pytest.mark.parametrize(
-        "task_id, target_time, expected",
+    @parameterized.expand(
         [
             (
                 "poke_datetime",
@@ -81,12 +80,12 @@ class TestDateTimeSensor:
             ),
             ("poke_str_extended", "2020-01-01T23:00:00.001+00:00", False),
             ("poke_str_basic_with_tz", "20200102T065959+8", True),
-        ],
+        ]
     )
     @patch(
         "airflow.sensors.date_time.timezone.utcnow",
         return_value=timezone.datetime(2020, 1, 1, 23, 0, tzinfo=timezone.utc),
     )
-    def test_poke(self, mock_utcnow, task_id, target_time, expected):
+    def test_poke(self, task_id, target_time, expected, mock_utcnow):
         op = DateTimeSensor(task_id=task_id, target_time=target_time, dag=self.dag)
         assert op.poke(None) == expected

--- a/tests/sensors/test_time_sensor.py
+++ b/tests/sensors/test_time_sensor.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import freezegun
 import pendulum
 import pytest
+from parameterized import parameterized
 
 from airflow.exceptions import TaskDeferred
 from airflow.models.dag import DAG
@@ -40,13 +41,12 @@ DEFAULT_DATE_WITH_TZ = datetime(2015, 1, 1, tzinfo=pendulum.tz.timezone(DEFAULT_
     return_value=timezone.datetime(2020, 1, 1, 23, 0).replace(tzinfo=timezone.utc),
 )
 class TestTimeSensor:
-    @pytest.mark.parametrize(
-        "default_timezone, start_date, expected",
+    @parameterized.expand(
         [
             ("UTC", DEFAULT_DATE_WO_TZ, True),
             ("UTC", DEFAULT_DATE_WITH_TZ, False),
             (DEFAULT_TIMEZONE, DEFAULT_DATE_WO_TZ, False),
-        ],
+        ]
     )
     def test_timezone(self, mock_utcnow, default_timezone, start_date, expected):
         with patch("airflow.settings.TIMEZONE", pendulum.timezone(default_timezone)):


### PR DESCRIPTION
This reverts commit 529f11b4e3ee5dcd7c9f435a1962c981a20746ba.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
