### PR TITLE
Fix test classes’ names so pytest discovers them

### DIFF
--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -20,14 +20,15 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
+
 import pytest
+
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator, JSONEncoder
 
 
 class TestJSONEncoder:
-
-    @pytest.mark.parametrize('value', ["102938.3043847474", 1.010001, 10, "100", "1E-128", 1e-128])
-    def test_jsonencoder_with_decimal(self,value):
+    @pytest.mark.parametrize("value", ["102938.3043847474", 1.010001, 10, "100", "1E-128", 1e-128])
+    def test_jsonencoder_with_decimal(self, value):
         """Test JSONEncoder correctly encodes and decodes decimal values."""
 
         org = Decimal(value)

--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
-import pytest 
+import pytest
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator, JSONEncoder
 
 
@@ -32,7 +32,7 @@ class TestJSONEncoder:
             org = Decimal(i)
             encoded = json.dumps(org, cls=JSONEncoder)
             decoded = json.loads(encoded, parse_float=Decimal)
-            pytest.approx(decoded, org)
+            assert org == pytest.approx(decoded)
 
 
 class TestDynamodbToS3:

--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -25,14 +25,15 @@ from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Op
 
 
 class TestJSONEncoder:
-    def test_jsonencoder_with_decimal(self):
+
+    @pytest.mark.parametrize('value', ["102938.3043847474", 1.010001, 10, "100", "1E-128", 1e-128])
+    def test_jsonencoder_with_decimal(self,value):
         """Test JSONEncoder correctly encodes and decodes decimal values."""
 
-        for i in ["102938.3043847474", 1.010001, 10, "100", "1E-128", 1e-128]:
-            org = Decimal(i)
-            encoded = json.dumps(org, cls=JSONEncoder)
-            decoded = json.loads(encoded, parse_float=Decimal)
-            assert org == pytest.approx(decoded)
+        org = Decimal(value)
+        encoded = json.dumps(org, cls=JSONEncoder)
+        decoded = json.loads(encoded, parse_float=Decimal)
+        assert org == pytest.approx(decoded)
 
 
 class TestDynamodbToS3:

--- a/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
-
+import pytest 
 from airflow.providers.amazon.aws.transfers.dynamodb_to_s3 import DynamoDBToS3Operator, JSONEncoder
 
 
-class JSONEncoderTest:
+class TestJSONEncoder:
     def test_jsonencoder_with_decimal(self):
         """Test JSONEncoder correctly encodes and decodes decimal values."""
 
@@ -32,10 +32,10 @@ class JSONEncoderTest:
             org = Decimal(i)
             encoded = json.dumps(org, cls=JSONEncoder)
             decoded = json.loads(encoded, parse_float=Decimal)
-            self.assertAlmostEqual(decoded, org)
+            pytest.approx(decoded, org)
 
 
-class DynamodbToS3Test:
+class TestDynamodbToS3:
     def setup_method(self):
         self.output_queue = []
 


### PR DESCRIPTION
https://github.com/apache/airflow/pull/28145 converted python unittest to pytest. 

@IAL32 
the tests in `tests/providers/amazon/aws/transfers/test_dynamodb_to_s3.py` was not discovered due to the test class name convention.  `DynamodbToS3Test` instead of `TestDynamodbToS3` 

also fixed issue with `self.assertAlmostEqual`. in the current main it is not failing since this test is not getting run by pytest. 



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
