### PR TITLE
Show mapped task groups in grid view

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -44,7 +44,7 @@ const InstanceTooltip = ({
 
   const numMap = finalStatesMap();
   let numMapped = 0;
-  if (isGroup && group.children) {
+  if (isGroup && group.children && !isMapped) {
     group.children.forEach((child) => {
       const taskInstance = child.instances.find((ti) => ti.runId === runId);
       if (taskInstance) {
@@ -52,7 +52,9 @@ const InstanceTooltip = ({
         if (numMap.has(stateKey)) numMap.set(stateKey, (numMap.get(stateKey) || 0) + 1);
       }
     });
-  } else if (isMapped && mappedStates) {
+  }
+
+  if (isMapped && mappedStates) {
     Object.keys(mappedStates).forEach((stateKey) => {
       const num = mappedStates[stateKey];
       numMapped += num;
@@ -83,6 +85,7 @@ const InstanceTooltip = ({
           {numMapped}
           {' '}
           mapped task
+          {isGroup && ' group'}
           {numMapped > 1 && 's'}
         </Text>
       )}

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -74,7 +74,7 @@ const Details = ({ instance, group, dagId }: Props) => {
 
   const numMap = finalStatesMap();
   let numMapped = 0;
-  if (isGroup) {
+  if (isGroup && !isMapped) {
     group.children?.forEach((child) => {
       const taskInstance = child.instances.find((ti) => ti.runId === runId);
       if (taskInstance) {
@@ -167,7 +167,8 @@ const Details = ({ instance, group, dagId }: Props) => {
               <Td colSpan={2}>
                 {numMapped}
                 {' '}
-                {numMapped === 1 ? 'Task ' : 'Tasks '}
+                {isGroup ? 'Task Group' : 'Task'}
+                {numMapped === 1 ? ' ' : 's '}
                 Mapped
               </Td>
             </Tr>

--- a/airflow/www/static/js/dag/details/taskInstance/index.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/index.tsx
@@ -101,7 +101,7 @@ const TaskInstance = ({
       isPreferedTabDisplayed = true;
       break;
     case 1:
-      isPreferedTabDisplayed = !isGroup;
+      isPreferedTabDisplayed = !isGroup || (isGroup && !!isMapped);
       break;
     default:
       isPreferedTabDisplayed = false;
@@ -139,7 +139,7 @@ const TaskInstance = ({
           <Tab>
             <Text as="strong">Details</Text>
           </Tab>
-          {isMappedTaskSummary && (
+          {isMappedTaskSummary && !isGroup && (
             <Tab>
               <Text as="strong">Mapped Tasks</Text>
             </Tab>
@@ -218,7 +218,7 @@ const TaskInstance = ({
 
           {/* Mapped Task Instances Tab */}
           {
-            isMappedTaskSummary && (
+            isMappedTaskSummary && !isGroup && (
               <TabPanel>
                 <MappedInstances
                   dagId={dagId}

--- a/airflow/www/static/js/dag/grid/renderTaskRows.tsx
+++ b/airflow/www/static/js/dag/grid/renderTaskRows.tsx
@@ -44,6 +44,7 @@ interface RowProps {
   openGroupIds?: string[];
   onToggleGroups?: (groupIds: string[]) => void;
   hoveredTaskState?: string | null;
+  isParentMapped?: boolean;
 }
 
 const renderTaskRows = ({
@@ -114,6 +115,7 @@ const Row = (props: RowProps) => {
     openGroupIds = [],
     onToggleGroups = () => {},
     hoveredTaskState,
+    isParentMapped,
   } = props;
   const { colors } = useTheme();
   const { selected, onSelect } = useSelection();
@@ -168,7 +170,7 @@ const Row = (props: RowProps) => {
           <TaskName
             onToggle={memoizedToggle}
             isGroup={isGroup}
-            isMapped={task.isMapped}
+            isMapped={task.isMapped && !isParentMapped}
             label={task.label || task.id || ''}
             isOpen={isOpen}
             level={level}
@@ -191,7 +193,10 @@ const Row = (props: RowProps) => {
       </Tr>
       {isGroup && isOpen && (
         renderTaskRows({
-          ...props, level: level + 1, openParentCount: openParentCount + 1,
+          ...props,
+          level: level + 1,
+          openParentCount: openParentCount + 1,
+          isParentMapped: task.isMapped,
         })
       )}
     </>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -392,16 +392,17 @@ def dag_to_grid(dag, dag_runs, session):
             }
 
         def get_mapped_group_summaries(run_ids, children):
-            child_ids = [child["id"] for child in children]
-            mappedGroupQuery = session.query(
-                TaskInstance.task_id, TaskInstance.state, TaskInstance.run_id, TaskInstance.map_index
-            ).filter(
-                TaskInstance.dag_id == dag.dag_id,
-                TaskInstance.task_id.in_(child_ids),
-                TaskInstance.run_id.in_(run_ids),
+            mapped_instances = (
+                session.query(
+                    TaskInstance.task_id, TaskInstance.state, TaskInstance.run_id, TaskInstance.map_index
+                )
+                .filter(
+                    TaskInstance.dag_id == dag.dag_id,
+                    TaskInstance.task_id.in_(child["id"] for child in children),
+                    TaskInstance.run_id.in_(run_ids),
+                )
+                .all()
             )
-
-            mapped_instances = list(mappedGroupQuery)
 
             def get_mapped_group_summary(run_id, mapped_instances):
                 map_length = max(mi.map_index for mi in mapped_instances) + 1

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -121,7 +121,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import State, TaskInstanceState
 from airflow.utils.strings import to_boolean
-from airflow.utils.task_group import task_group_to_dict
+from airflow.utils.task_group import MappedTaskGroup, task_group_to_dict
 from airflow.utils.timezone import td_format, utcnow
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
@@ -281,7 +281,7 @@ def dag_to_grid(dag, dag_runs, session):
 
     grouped_tis = {task_id: list(tis) for task_id, tis in itertools.groupby(query, key=lambda ti: ti.task_id)}
 
-    def task_group_to_grid(item, dag_runs, grouped_tis):
+    def task_group_to_grid(item, dag_runs, grouped_tis, is_parent_mapped=False):
         if isinstance(item, AbstractOperator):
 
             def _get_summary(task_instance):
@@ -341,7 +341,7 @@ def dag_to_grid(dag, dag_runs, session):
                     set_overall_state(record)
                     yield record
 
-            if isinstance(item, MappedOperator):
+            if isinstance(item, MappedOperator) or is_parent_mapped:
                 instances = list(_mapped_summary(grouped_tis.get(item.task_id, [])))
             else:
                 instances = list(map(_get_summary, grouped_tis.get(item.task_id, [])))
@@ -351,16 +351,18 @@ def dag_to_grid(dag, dag_runs, session):
                 "instances": instances,
                 "label": item.label,
                 "extra_links": item.extra_links,
-                "is_mapped": isinstance(item, MappedOperator),
+                "is_mapped": isinstance(item, MappedOperator) or is_parent_mapped,
                 "has_outlet_datasets": any(isinstance(i, Dataset) for i in (item.outlets or [])),
                 "operator": item.operator_name,
             }
 
         # Task Group
         task_group = item
+        group_is_mapped = isinstance(task_group, MappedTaskGroup)
 
         children = [
-            task_group_to_grid(child, dag_runs, grouped_tis) for child in task_group.topological_sort()
+            task_group_to_grid(child, dag_runs, grouped_tis, group_is_mapped)
+            for child in task_group.topological_sort()
         ]
 
         def get_summary(dag_run, children):
@@ -389,6 +391,65 @@ def dag_to_grid(dag, dag_runs, session):
                 "end_date": group_end_date,
             }
 
+        def get_mapped_group_summaries(run_ids, children):
+            child_ids = [child["id"] for child in children]
+            mappedGroupQuery = session.query(
+                TaskInstance.task_id, TaskInstance.state, TaskInstance.run_id, TaskInstance.map_index
+            ).filter(
+                TaskInstance.dag_id == dag.dag_id,
+                TaskInstance.task_id.in_(child_ids),
+                TaskInstance.run_id.in_(run_ids),
+            )
+
+            mapped_instances = list(mappedGroupQuery)
+
+            def get_mapped_group_summary(run_id, mapped_instances):
+                map_length = max(mi.map_index for mi in mapped_instances) + 1
+                child_instances = [child["instances"] for child in children if "instances" in child]
+                child_instances = [
+                    item for sublist in child_instances for item in sublist if item["run_id"] == run_id
+                ]
+
+                children_start_dates = (item["start_date"] for item in child_instances if item)
+                children_end_dates = (item["end_date"] for item in child_instances if item)
+                children_states = {item["state"] for item in child_instances if item}
+
+                mapped_states = {}
+                for i in range(0, map_length):
+                    child_states = [mi.state for mi in mapped_instances if mi.map_index == i]
+                    for state in wwwutils.priority:
+                        if state in child_states:
+                            value = state.value if state is not None else "no_status"
+                            if value in mapped_states:
+                                mapped_states[value] += 1
+                            else:
+                                mapped_states[value] = 1
+                            break
+
+                group_state = None
+                for state in wwwutils.priority:
+                    if state in children_states:
+                        group_state = state
+                        break
+                group_start_date = min(filter(None, children_start_dates), default=None)
+                group_end_date = max(filter(None, children_end_dates), default=None)
+
+                return {
+                    "task_id": task_group.group_id,
+                    "run_id": run_id,
+                    "state": group_state,
+                    "start_date": group_start_date,
+                    "end_date": group_end_date,
+                    "mapped_states": mapped_states,
+                }
+
+            return [
+                get_mapped_group_summary(
+                    run_id, mapped_instances=[mi for mi in mapped_instances if mi.run_id == run_id]
+                )
+                for run_id in run_ids
+            ]
+
         # We don't need to calculate summaries for the root
         if task_group.group_id is None:
             return {
@@ -396,6 +457,18 @@ def dag_to_grid(dag, dag_runs, session):
                 "label": task_group.label,
                 "children": children,
                 "instances": [],
+            }
+
+        if group_is_mapped:
+            mapped_group_summaries = get_mapped_group_summaries([dr.run_id for dr in dag_runs], children)
+
+            return {
+                "id": task_group.group_id,
+                "label": task_group.label,
+                "children": children,
+                "tooltip": task_group.tooltip,
+                "instances": mapped_group_summaries,
+                "is_mapped": group_is_mapped,
             }
 
         group_summaries = [get_summary(dr, children) for dr in dag_runs]


### PR DESCRIPTION
Show a user when a task group is mapped with a `mapped_states` summary. The children will appear as normal mapped tasks except without `[ ]` because it is the group that is actually being mapped.

In another PR, we should add a `Mapped Tasks` tab in the details for task groups to see how each group performed with each map_index.

<img width="915" alt="Screen Shot 2022-12-07 at 2 16 49 PM" src="https://user-images.githubusercontent.com/4600967/206307824-a229bc9e-1d80-4f18-b9ec-7e09641f1049.png">
<img width="865" alt="Screen Shot 2022-12-07 at 2 16 55 PM" src="https://user-images.githubusercontent.com/4600967/206307827-ecfddfa8-818e-43ec-a31d-2602cdc8eb89.png">
<img width="455" alt="Screen Shot 2022-12-07 at 2 17 03 PM" src="https://user-images.githubusercontent.com/4600967/206307821-0a263fe2-16de-4d90-8af4-fbd519160021.png">
<img width="457" alt="Screen Shot 2022-12-07 at 2 16 59 PM" src="https://user-images.githubusercontent.com/4600967/206307829-69dbc376-3fcc-453a-b760-e211257462fb.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
