### PR TITLE
Add `pytest.mark.filterwarnings` to date_range() unit test

### DIFF
--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -105,6 +105,7 @@ class TestDates:
         assert arr4 == approx([2.3147, 1.1574], rel=1e-3)
 
 
+@pytest.mark.filterwarnings("ignore:`airflow.utils.dates.date_range:DeprecationWarning")
 class TestUtilsDatesDateRange:
     def test_no_delta(self):
         assert dates.date_range(datetime(2016, 1, 1), datetime(2016, 1, 3)) == []


### PR DESCRIPTION
It would be nice to ignore the deprecation warnings from the date_range() unit test since [airflow.utils.dates.date_range() is deprecated](https://github.com/apache/airflow/blob/68217f5df872a0098496cf75937dbf3d994d0549/airflow/utils/dates.py#L74).

**Before**
```
----------- generated xml file: /files/test_result-All-postgres.xml ------------
============================ slowest 100 durations =============================
6.41s setup    tests/utils/test_dates.py::TestDates::test_days_ago

(35 durations < 0.005s hidden.  Use -vv to show these durations.)

All Warning errors can be found in the /files/warnings-All-postgres.txt file.
============================== 12 passed in 6.47s ==============================
Number of warnings: 9 /files/warnings-All-postgres.txt

$ cat files/warnings-All-postgres.txt
tests/utils/test_dates.py:110: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:114: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:118: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:123: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:127: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:135: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:142: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:143: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
tests/utils/test_dates.py:144: [W0513(warning), ] `airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.
```

**After**
```
----------- generated xml file: /files/test_result-All-postgres.xml ------------
============================ slowest 100 durations =============================
6.38s setup    tests/utils/test_dates.py::TestDates::test_days_ago

(35 durations < 0.005s hidden.  Use -vv to show these durations.)
============================== 12 passed in 6.44s ==============================
Number of warnings: 0 /files/warnings-All-postgres.txt
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
