### PR TITLE
Updating connections.rst to fix broken providers links

### DIFF
--- a/docs/apache-airflow/concepts/connections.rst
+++ b/docs/apache-airflow/concepts/connections.rst
@@ -44,8 +44,8 @@ Custom connections
 ------------------
 
 Airflow allows to define custom connection types. This is what is described in detail in
-:doc:`apache-airflow-providers:index` - providers give you the capability of defining your own connections.
+:doc:`apache-airflow-providers-imap:index` - providers give you the capability of defining your own connections.
 The connection customization can be done by any provider, but also
 many of the providers managed by the community define custom connection types.
 The full list of all providers delivered by ``Apache Airflow community managed providers`` can be found in
-:doc:`apache-airflow-providers:core-extensions/connections`.
+:doc:`apache-airflow-providers-imap:core-extensions/connections`.


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The links on the page: https://airflow.apache.org/docs/apache-airflow/stable/concepts/connections.html under custom connections are broken. This PR updates the links for the same. The domains might have changed and hence I have updated with the imap names. 
Broken Page: 
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/35884252/206407184-d2df745a-cb9d-4b0f-93c7-4c2e720b2f0d.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
