### PR TITLE
Add Mateusz Henc to list of collaborators and remove Andrey

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,8 +73,8 @@ github:
     - petedejoy
     - gmcdonald
     - o-nikolas
+    - mhenc
     - ferruzzi
-    - Taragolis
 
 notifications:
   jobs: jobs@airflow.apache.org


### PR DESCRIPTION
Mateusz is workin on AIP-44 and needs to become collaborator to manage issues in the project.

Andrey is now committer and does not need to be in collaborators any more.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
