### PR TITLE
Make arguments 'offset' and 'length' not required

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -385,7 +385,7 @@ class WasbHook(BaseHook):
         return blob_client.upload_blob(data, blob_type, length=length, **kwargs)
 
     def download(
-        self, container_name, blob_name, offset: int, length: int, **kwargs
+        self, container_name, blob_name, offset: int | None = None, length: int | None = None, **kwargs
     ) -> StorageStreamDownloader:
         """
         Downloads a blob to the StorageStreamDownloader

--- a/setup.cfg
+++ b/setup.cfg
@@ -191,5 +191,5 @@ no_implicit_optional = False
 #Let's assume all azure packages have no implicit optional
 [mypy-azure.batch.*]
 no_implicit_optional = False
-[mypy-azure.batch.models.*]
+[mypy-azure.storage.*]
 no_implicit_optional = False


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

In https://github.com/apache/airflow/pull/25426, the `offset` and `length` arguments were made required. But this is not in line with the Azure blob client interface.

The `length` argument is a hint to optimize performance for larger reads, while `offset` is used only for more advanced reading. We're currently using neither for log reading.