### PR TITLE
Run kubernetes executor tasks in interactive mode for live logs

### DIFF
--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -53,7 +53,7 @@ def generate_pod_yaml(args):
             try_number=ti.try_number,
             kube_image=kube_config.kube_image,
             date=ti.execution_date,
-            args=ti.command_as_list(),
+            args=ti.command_as_list(interactive=True),
             pod_override_object=PodGenerator.from_obj(ti.executor_config),
             scheduler_job_id="worker-config",
             namespace=kube_config.executor_namespace,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -389,7 +389,6 @@ def task_run(args, dag=None):
     log.info("Running %s on host %s", ti, hostname)
 
     try:
-        assert args.interactive
         if args.interactive:
             _run_task_by_selected_method(args, dag, ti)
         else:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -247,6 +247,7 @@ def _run_task_by_local_task_job(args, ti):
         ignore_ti_state=args.force,
         pool=args.pool,
         external_executor_id=_extract_external_executor_id(args),
+        interactive=args.interactive,
     )
     try:
         run_job.run()
@@ -388,6 +389,7 @@ def task_run(args, dag=None):
     log.info("Running %s on host %s", ti, hostname)
 
     try:
+        assert args.interactive
         if args.interactive:
             _run_task_by_selected_method(args, dag, ti)
         else:

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -128,6 +128,7 @@ class BaseExecutor(LoggingMixin):
             pool=pool,
             pickle_id=pickle_id,
             cfg_path=cfg_path,
+            interactive=self.__class__.__name__ == "KubernetesExecutor",
         )
         self.log.debug("created command %s", command_list_to_run)
         self.queue_command(

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -81,6 +81,7 @@ class LocalTaskJob(BaseJob):
         pickle_id: str | None = None,
         pool: str | None = None,
         external_executor_id: str | None = None,
+        interactive: bool = False,
         *args,
         **kwargs,
     ):
@@ -94,6 +95,7 @@ class LocalTaskJob(BaseJob):
         self.pickle_id = pickle_id
         self.mark_success = mark_success
         self.external_executor_id = external_executor_id
+        self.interactive = interactive
 
         # terminating state is used so that a job don't try to
         # terminate multiple times

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -550,6 +550,7 @@ class SchedulerJob(BaseJob):
             command = ti.command_as_list(
                 local=True,
                 pickle_id=ti.dag_model.pickle_id,
+                interactive=self.executor_class == "KubernetesExecutor",
             )
 
             priority = ti.priority_weight

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -585,6 +585,7 @@ class TaskInstance(Base, LoggingMixin):
         job_id=None,
         pool=None,
         cfg_path=None,
+        interactive=False,
     ):
         """
         Returns a command that can be executed anywhere where airflow is
@@ -628,6 +629,7 @@ class TaskInstance(Base, LoggingMixin):
             pool=pool,
             cfg_path=cfg_path,
             map_index=self.map_index,
+            interactive=interactive,
         )
 
     @staticmethod
@@ -648,6 +650,7 @@ class TaskInstance(Base, LoggingMixin):
         pool: str | None = None,
         cfg_path: str | None = None,
         map_index: int = -1,
+        interactive: bool = False,
     ) -> list[str]:
         """
         Generates the shell command required to execute this task instance.
@@ -671,6 +674,7 @@ class TaskInstance(Base, LoggingMixin):
         :param job_id: job ID (needs more details)
         :param pool: the Airflow pool that the task should run in
         :param cfg_path: the Path to the configuration file
+        :param interactive: if interactive option should be included
         :return: shell command that can be used to run the task instance
         """
         cmd = ["airflow", "tasks", "run", dag_id, task_id, run_id]
@@ -694,6 +698,8 @@ class TaskInstance(Base, LoggingMixin):
             cmd.extend(["--pool", pool])
         if raw:
             cmd.extend(["--raw"])
+        if interactive:
+            cmd.extend(["--interactive"])
         if file_path:
             cmd.extend(["--subdir", file_path])
         if cfg_path:
@@ -2136,7 +2142,7 @@ class TaskInstance(Base, LoggingMixin):
             pod_id=create_pod_id(self.dag_id, self.task_id),
             try_number=self.try_number,
             kube_image=kube_config.kube_image,
-            args=self.command_as_list(),
+            args=self.command_as_list(interactive=True),
             pod_override_object=PodGenerator.from_obj(self.executor_config),
             scheduler_job_id="0",
             namespace=kube_config.executor_namespace,

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import subprocess
 import threading
+from typing import TYPE_CHECKING
 
 from airflow.utils.dag_parsing_context import _airflow_parsing_context_manager
 from airflow.utils.platform import IS_WINDOWS
@@ -37,6 +38,9 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
 from airflow.utils.platform import getuser
 
+if TYPE_CHECKING:
+    from airflow.jobs.local_task_job import LocalTaskJob
+
 PYTHONPATH_VAR = "PYTHONPATH"
 
 
@@ -50,7 +54,7 @@ class BaseTaskRunner(LoggingMixin):
         associated task instance.
     """
 
-    def __init__(self, local_task_job):
+    def __init__(self, local_task_job: LocalTaskJob):
         # Pass task instance context into log handlers to setup the logger.
         super().__init__(local_task_job.task_instance)
         self._task_instance = local_task_job.task_instance
@@ -99,6 +103,7 @@ class BaseTaskRunner(LoggingMixin):
             job_id=local_task_job.id,
             pool=local_task_job.pool,
             cfg_path=cfg_path,
+            interactive=local_task_job.interactive,
         )
         self.process = None
 


### PR DESCRIPTION
For k8s executor, task log handler reads from pod logs while task is running.

By running in "interactive" mode we avoid redirecting stdout, which keeps the logs visible when reading from pod.  Otherwise, we can't get any logs til task is complete and logs are uploaded to cloud storage (assuming user enables remote logging).
