### PR TITLE
Improve caching for pre-commits in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,7 @@ jobs:
         with:
           path: ~/.cache/pre-commit-full
           # yamllint disable-line rule:line-length
-          key: "pre-commit-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
+          key: "pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
           restore-keys: |
             pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}
             pre-commit-full
@@ -604,9 +604,13 @@ jobs:
           path: ~/.cache/pre-commit
           # yamllint disable-line rule:line-length
           key: "pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
-          restore-keys: |
-            pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}
-            pre-commit-basic-
+          restore-keys: "\
+            pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}-\
+            ${{ hashFiles('.pre-commit-config.yaml') }}\n
+            pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}\n
+            pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}\n
+            pre-commit-basic-\n
+            pre-commit-full-"
       - name: Fetch incoming commit ${{ github.sha }} with its parent
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Configuration of caching for pre-commits in CI has been broken:

* full pre-commit cache had `pre-commit-` instead of `pre-commit-full-`
* basic checks never run in "main" so the cache had not been stored in the main branch - thus pre-commits for the basic checks were never cached. However it is quite OK for pre-commit basic to use the full pre-commit package cache

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
