### PR TITLE
Better table name validation for db clean

### DIFF
--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -336,12 +336,12 @@ def run_cleanup(
     :param session: Session representing connection to the metadata database.
     """
     clean_before_timestamp = timezone.coerce_datetime(clean_before_timestamp)
-    desired_table_names = set(table_names if table_names else config_dict.keys())
+    desired_table_names = set(table_names or config_dict)
     effective_config_dict = {k: v for k, v in config_dict.items() if k in desired_table_names}
-    effective_table_names = set(effective_config_dict.keys())
+    effective_table_names = set(effective_config_dict)
     if desired_table_names != effective_table_names:
         outliers = desired_table_names - effective_table_names
-        logger.warning("The following table(s) are not valid choices and will be skipped: %s", outliers)
+        logger.warning("The following table(s) are not valid choices and will be skipped: %s", sorted(outliers))
     if not effective_table_names:
         raise SystemExit("No tables selected for db cleanup. Please choose valid table names.")
     if dry_run:
@@ -352,7 +352,7 @@ def run_cleanup(
         )
         _print_config(configs=effective_config_dict)
     if not dry_run and confirm:
-        _confirm_delete(date=clean_before_timestamp, tables=effective_table_names)
+        _confirm_delete(date=clean_before_timestamp, tables=sorted(effective_table_names))
     existing_tables = reflect_tables(tables=None, session=session).tables
     for table_name, table_config in effective_config_dict.items():
         if table_name not in existing_tables:

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -341,7 +341,9 @@ def run_cleanup(
     effective_table_names = set(effective_config_dict)
     if desired_table_names != effective_table_names:
         outliers = desired_table_names - effective_table_names
-        logger.warning("The following table(s) are not valid choices and will be skipped: %s", sorted(outliers))
+        logger.warning(
+            "The following table(s) are not valid choices and will be skipped: %s", sorted(outliers)
+        )
     if not effective_table_names:
         raise SystemExit("No tables selected for db cleanup. Please choose valid table names.")
     if dry_run:

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -270,7 +270,7 @@ def _cleanup_table(
     session.commit()
 
 
-def _confirm_delete(*, date: DateTime, tables: set[str]):
+def _confirm_delete(*, date: DateTime, tables: list[str]):
     for_tables = f" for tables {tables!r}" if tables else ""
     question = (
         f"You have requested that we purge all data prior to {date}{for_tables}.\n"

--- a/airflow/utils/db_cleanup.py
+++ b/airflow/utils/db_cleanup.py
@@ -270,7 +270,7 @@ def _cleanup_table(
     session.commit()
 
 
-def _confirm_delete(*, date: DateTime, tables: list[str]):
+def _confirm_delete(*, date: DateTime, tables: set[str]):
     for_tables = f" for tables {tables!r}" if tables else ""
     question = (
         f"You have requested that we purge all data prior to {date}{for_tables}.\n"
@@ -336,8 +336,14 @@ def run_cleanup(
     :param session: Session representing connection to the metadata database.
     """
     clean_before_timestamp = timezone.coerce_datetime(clean_before_timestamp)
-    effective_table_names = table_names if table_names else list(config_dict.keys())
-    effective_config_dict = {k: v for k, v in config_dict.items() if k in effective_table_names}
+    desired_table_names = set(table_names if table_names else config_dict.keys())
+    effective_config_dict = {k: v for k, v in config_dict.items() if k in desired_table_names}
+    effective_table_names = set(effective_config_dict.keys())
+    if desired_table_names != effective_table_names:
+        outliers = desired_table_names - effective_table_names
+        logger.warning("The following table(s) are not valid choices and will be skipped: %s", outliers)
+    if not effective_table_names:
+        raise SystemExit("No tables selected for db cleanup. Please choose valid table names.")
     if dry_run:
         print("Performing dry run for db cleanup.")
         print(
@@ -346,7 +352,7 @@ def run_cleanup(
         )
         _print_config(configs=effective_config_dict)
     if not dry_run and confirm:
-        _confirm_delete(date=clean_before_timestamp, tables=list(effective_config_dict.keys()))
+        _confirm_delete(date=clean_before_timestamp, tables=effective_table_names)
     existing_tables = reflect_tables(tables=None, session=session).tables
     for table_name, table_config in effective_config_dict.items():
         if table_name not in existing_tables:


### PR DESCRIPTION
We should warn users when they provide table names that are not valid, and make it clear no cleaning happens when you provide no valid tables.

e.g.

```
$ airflow db clean -t fake,task_instance --clean-before-timestamp 2022-12-08                  
[2022-12-08 17:03:33,729] {db_cleanup.py:345} WARNING - The following table(s) are not valid choices and will be skipped: {'fake'}
You have requested that we purge all data prior to 2022-12-08T00:00:00+00:00 for tables {'task_instance'}.
...
```

```
$ airflow db clean -t only,fake,tables --clean-before-timestamp 2022-12-08
[2022-12-08 17:04:20,060] {db_cleanup.py:345} WARNING - The following table(s) are not valid choices and will be skipped: {'only', 'tables', 'fake'}
No tables selected for db cleanup. Please choose valid table names.
```