### PR TITLE
Simplify ResolveMixin interface

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -21,7 +21,7 @@ import copy
 import json
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, ClassVar, ItemsView, Iterable, MutableMapping, ValuesView
+from typing import TYPE_CHECKING, Any, ClassVar, ItemsView, MutableMapping, ValuesView
 
 from airflow.exceptions import AirflowException, ParamValidationError, RemovedInAirflow3Warning
 from airflow.utils.context import Context
@@ -283,9 +283,6 @@ class DagParam(ResolveMixin):
             current_dag.params[name] = default
         self._name = name
         self._default = default
-
-    def iter_references(self) -> Iterable[tuple[Operator, str]]:
-        return ()
 
     def resolve(self, context: Context) -> Any:
         """Pull DagParam value from DagRun context. This method is run during ``op.execute()``."""

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Mapping, Sequence, Union, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, Sequence, Union, overload
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -98,7 +98,7 @@ class XComArg(ResolveMixin, DependencyMixin):
         Recursively traverse ``arg`` and look for XComArg instances in any
         collection objects, and instances with ``template_fields`` set.
         """
-        if isinstance(arg, ResolveMixin):
+        if isinstance(arg, XComArg):
             yield from arg.iter_references()
         elif isinstance(arg, (tuple, set, list)):
             for elem in arg:
@@ -188,6 +188,15 @@ class XComArg(ResolveMixin, DependencyMixin):
         *None* may be returned if the depended XCom has not been pushed.
         """
         raise NotImplementedError()
+
+    def iter_references(self) -> Iterable[tuple[Operator, str]]:
+        """Find underlying XCom references this contains.
+
+        This is used by the DAG parser to recursively find task dependencies.
+
+        :meta private:
+        """
+        raise NotImplementedError
 
     def resolve(self, context: Context, session: Session = NEW_SESSION) -> Any:
         """Pull XCom value.

--- a/airflow/utils/mixins.py
+++ b/airflow/utils/mixins.py
@@ -24,9 +24,6 @@ import typing
 from airflow.configuration import conf
 from airflow.utils.context import Context
 
-if typing.TYPE_CHECKING:
-    from airflow.models.operator import Operator
-
 
 class MultiprocessingStartMethodMixin:
     """Convenience class to add support for different types of multiprocessing."""
@@ -47,15 +44,6 @@ class MultiprocessingStartMethodMixin:
 
 class ResolveMixin:
     """A runtime-resolved value."""
-
-    def iter_references(self) -> typing.Iterable[tuple[Operator, str]]:
-        """Find underlying XCom references this contains.
-
-        This is used by the DAG parser to recursively find task dependencies.
-
-        :meta private:
-        """
-        raise NotImplementedError
 
     def resolve(self, context: Context) -> typing.Any:
         """Resolve this value for runtime.


### PR DESCRIPTION
Minor refactoring. The `iter_references()` function only actually works for XComArg, and should therefore be put there.