### PR TITLE
Increase execution timeout for webserver background test

### DIFF
--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -281,6 +281,7 @@ class TestCliWebServer:
                     raise
                 time.sleep(1)
 
+    @pytest.mark.execution_timeout(210)
     def test_cli_webserver_background(self):
         with tempfile.TemporaryDirectory(prefix="gunicorn") as tmpdir, mock.patch.dict(
             "os.environ",


### PR DESCRIPTION
Follow up: #28249

```text
  self = <tests.cli.commands.test_webserver_command.TestCliWebServer object at 0x7f3773510730>
  pidfile = '/tmp/gunicornpid0e9jv/pidflow-webserver.pid'
  
      def _wait_pidfile(self, pidfile):
          start_time = time.monotonic()
          while True:
              try:
                  with open(pidfile) as file:
                      return int(file.read())
              except Exception:
                  if start_time - time.monotonic() > 60:
                      raise
  >               time.sleep(1)
  E               Failed: Timeout >60.0s
  
  tests/cli/commands/test_webserver_command.py:282: Failed
```