### PR TITLE
Proper Python Host output from composite tasks in CI

### DIFF
--- a/.github/actions/breeze/action.yml
+++ b/.github/actions/breeze/action.yml
@@ -18,6 +18,10 @@
 ---
 name: 'Setup Breeze'
 description: 'Sets up Python and Breeze'
+outputs:
+  host-python-version:
+    description: Python version used in host
+    value: ${{ steps.host-python-version.outputs.host-python-version }}
 runs:
   using: "composite"
   steps:

--- a/.github/actions/prepare_breeze_and_image/action.yml
+++ b/.github/actions/prepare_breeze_and_image/action.yml
@@ -22,11 +22,16 @@ inputs:
   pull-image-type:
     description: 'Which image to pull'
     default: CI
+outputs:
+  host-python-version:
+    description: Python version used in host
+    value: ${{ steps.breeze.outputs.host-python-version }}
 runs:
   using: "composite"
   steps:
     - name: "Install Breeze"
       uses: ./.github/actions/breeze
+      id: breeze
     - name: Pull CI image ${{ env.PYTHON_MAJOR_MINOR_VERSION }}:${{ env.IMAGE_TAG }}
       shell: bash
       run: breeze ci-image pull --tag-as-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,14 +551,15 @@ jobs:
       - name: >
           Prepare breeze & CI image: ${{needs.build-info.outputs.default-python-version}}:${{env.IMAGE_TAG}}
         uses: ./.github/actions/prepare_breeze_and_image
+        id: breeze
       - name: Cache pre-commit envs
         uses: actions/cache@v3
         with:
-          path: ~/.cache/pre-commit-full
+          path: ~/.cache/pre-commit
           # yamllint disable-line rule:line-length
-          key: "pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
+          key: "pre-commit-full-${{steps.breeze.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
           restore-keys: |
-            pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}
+            pre-commit-full-${{steps.breeze.outputs.host-python-version}}
             pre-commit-full
       - name: "Static checks"
         run: breeze static-checks --all-files --show-diff-on-failure --color always
@@ -598,17 +599,18 @@ jobs:
           cache-dependency-path: ./dev/breeze/setup*
       - name: "Install Breeze"
         uses: ./.github/actions/breeze
+        id: breeze
       - name: Cache pre-commit envs
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           # yamllint disable-line rule:line-length
-          key: "pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
+          key: "pre-commit-basic-${{steps.breeze.outputs.host-python-version}}-${{ hashFiles('.pre-commit-config.yaml') }}"
           restore-keys: "\
-            pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}-\
+            pre-commit-full-${{steps.breeze.outputs.host-python-version}}-\
             ${{ hashFiles('.pre-commit-config.yaml') }}\n
-            pre-commit-basic-${{steps.host-python-version.outputs.host-python-version}}\n
-            pre-commit-full-${{steps.host-python-version.outputs.host-python-version}}\n
+            pre-commit-basic-${{steps.breeze.outputs.host-python-version}}\n
+            pre-commit-full-${{steps.breeze.outputs.host-python-version}}\n
             pre-commit-basic-\n
             pre-commit-full-"
       - name: Fetch incoming commit ${{ github.sha }} with its parent


### PR DESCRIPTION
When we separated actions into composite workflows in #27369 and the #27371 we missed the fact that there was a step passing the host python version to static checks - to make sure we start with a fresh cache every time new python version is changed (this caused problems in the past)

The "host-python-version" was therefore empty and not really used in the cache key determining.

This has no bad effect when Python version does not change but when there is an upgrade of Python, the symbolic links in stored cache get broken, and next time new Python version is used in the AMIs, we might get them broken, so better to fix it now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
