### PR TITLE
Dynamically forward ports from trino integration service to host

### DIFF
--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -32,9 +32,12 @@ services:
       retries: 50
     restart: "on-failure"
 
+    # For avoid 'Error starting userland proxy: listen tcp4 0.0.0.0:38080: bind: address already in use'
+    # we forward container port to first available port in defined range.
+    # For get actual port we need to run `docker port {CONTAINER_NAME|CONTAINER_ID}`.
     ports:
-      - "38080:8080"
-      - "37778:7778"
+      - "38080-38089:8080"
+      - "37778-37786:7778"
 
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source


### PR DESCRIPTION
Time to time we got annoying error in CI

```
ERROR: for trino  Cannot start service trino: driver failed programming external connectivity on endpoint airflow-test-integration_trino_1 (SOMEDIGEST): Error starting userland proxy: listen tcp4 0.0.0.0:38080: bind: address already in use
```

Looks like we do not actually use this forwarded ports in our integrations test that mean we might also remove forwarding.
However better just forward from to first available port instead.

**How to validate and check locally**

_Terminal Session 1_
```console
❯ docker run -p 38080:8080 nginx
```

_Terminal Session 2_
```console
❯ breeze stop
❯ breeze --python 3.7 --backend postgres shell --integration trino
...
Checking backend and integrations.

PostgreSQL: OK.  

Kerberos: OK.  
Trino (HTTP): OK.  
Trino (HTTPS): OK.  
Trino (API): OK. 
...

root@krb5-machine-example-com:/opt/airflow# pytest --integration trino tests/integration
...
============================================================ 9 passed, 36 skipped, 8 warnings in 11.83s ============================================================

```

_Terminal Session 3_
```console
❯ docker port docker-compose_trino_1
7778/tcp -> 0.0.0.0:37780
8080/tcp -> 0.0.0.0:38086
```