### PR TITLE
Speed up most Users/Role CLI commands

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -33,7 +33,6 @@ from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.jobs.triggerer_job import TriggererJob
 from airflow.utils import db
-from airflow.www.app import cached_app
 
 
 class StandaloneCommand:
@@ -180,8 +179,10 @@ class StandaloneCommand:
         # server. Thus, we make a random password and store it in AIRFLOW_HOME,
         # with the reasoning that if you can read that directory, you can see
         # the database credentials anyway.
-        appbuilder = cached_app().appbuilder
-        user_exists = appbuilder.sm.find_user("admin")
+        from airflow.utils.cli_app_builder import get_application_builder
+
+        with get_application_builder() as appbuilder:
+            user_exists = appbuilder.sm.find_user("admin")
         password_path = os.path.join(AIRFLOW_HOME, "standalone_admin_password.txt")
         we_know_password = os.path.isfile(password_path)
         # If the user does not exist, make a random password and make it

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -28,26 +28,26 @@ class TestCliSyncPerm:
     def setup_class(cls):
         cls.parser = cli_parser.get_parser()
 
-    @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
-    def test_cli_sync_perm(self, mock_cached_app):
-        appbuilder = mock_cached_app.return_value.appbuilder
-        appbuilder.sm = mock.Mock()
+    @mock.patch("airflow.utils.cli_app_builder.get_application_builder")
+    def test_cli_sync_perm(self, mock_get_application_builder):
+        mock_appbuilder = mock.MagicMock()
+        mock_get_application_builder.return_value.__enter__.return_value = mock_appbuilder
 
         args = self.parser.parse_args(["sync-perm"])
         sync_perm_command.sync_perm(args)
 
-        appbuilder.add_permissions.assert_called_once_with(update_perms=True)
-        appbuilder.sm.sync_roles.assert_called_once_with()
-        appbuilder.sm.create_dag_specific_permissions.assert_not_called()
+        mock_appbuilder.add_permissions.assert_called_once_with(update_perms=True)
+        mock_appbuilder.sm.sync_roles.assert_called_once_with()
+        mock_appbuilder.sm.create_dag_specific_permissions.assert_not_called()
 
-    @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
-    def test_cli_sync_perm_include_dags(self, mock_cached_app):
-        appbuilder = mock_cached_app.return_value.appbuilder
-        appbuilder.sm = mock.Mock()
+    @mock.patch("airflow.utils.cli_app_builder.get_application_builder")
+    def test_cli_sync_perm_include_dags(self, mock_get_application_builder):
+        mock_appbuilder = mock.MagicMock()
+        mock_get_application_builder.return_value.__enter__.return_value = mock_appbuilder
 
         args = self.parser.parse_args(["sync-perm", "--include-dags"])
         sync_perm_command.sync_perm(args)
 
-        appbuilder.add_permissions.assert_called_once_with(update_perms=True)
-        appbuilder.sm.sync_roles.assert_called_once_with()
-        appbuilder.sm.create_dag_specific_permissions.assert_called_once_with()
+        mock_appbuilder.add_permissions.assert_called_once_with(update_perms=True)
+        mock_appbuilder.sm.sync_roles.assert_called_once_with()
+        mock_appbuilder.sm.create_dag_specific_permissions.assert_called_once_with()


### PR DESCRIPTION
Originally those command were initializing whole Airflow Flask webserver, which was much more than what was needed - we only need to initialize Flask Appblication Builder. In case you have slow DB this limits significantly not only a number of imported classses but also a number of DB connections.

In some cases the speed of those CLI commands will visibly go down from 10s of seonds to individual seconds (3x - 5x times).

Follow up after #28242, #28244

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
