### PR TITLE
Fix helm chart NOTES.txt to show correct URL

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -75,8 +75,8 @@ Airflow Webserver:
       {{- $hostname := $.Values.ingress.web.host -}}
       {{- if . | kindIs "string" | not }}
       {{- if .tls }}
-      {{- $tlsEnabled := .tls.enabled -}}
-      {{- $hostname := $.name -}}
+      {{- $tlsEnabled = .tls.enabled -}}
+      {{- $hostname = .name -}}
       {{- end }}
       {{- end }}
       http{{ if $tlsEnabled }}s{{ end }}://{{ $hostname }}{{ $.Values.ingress.web.path }}/
@@ -89,8 +89,8 @@ Flower dashboard:
       {{- $hostname := $.Values.ingress.flower.host -}}
       {{- if . | kindIs "string" | not }}
       {{- if .tls }}
-      {{- $tlsEnabled := .tls.enabled -}}
-      {{- $hostname := $.name -}}
+      {{- $tlsEnabled = .tls.enabled -}}
+      {{- $hostname = .name -}}
       {{- end }}
       {{- end }}
       http{{ if $tlsEnabled }}s{{ end }}://{{ $hostname }}{{ $.Values.ingress.flower.path }}/


### PR DESCRIPTION
## What happened
Airflow Webserver URL is incorrect shown by `helm install/upgrade`.

https://helm.sh/docs/chart_template_guide/notes_files/

### How to reproduce

`values.yaml`:
```yaml
ingress:
  web:
    enabled: true
    annotations: {}
    path: "/path"
    pathType: "ImplementationSpecific"
    hosts:
     - name: "localhost"
       tls:
         enabled: false
         secretName: ""
```

`breeze k8s deploy-airflow --upgrade` results is
<img width="450" alt="image" src="https://user-images.githubusercontent.com/13622816/206770161-43f78979-1e31-4c87-acab-4df62c80271c.png">


## What you think should happen instead

```
Airflow Webserver:
      http:////
```

should be

```
Airflow Webserver:
      http://localhost/path/
```


## Modifications in this PR
- Fix NOTES.txt


## Result
<img width="500" alt="image" src="https://user-images.githubusercontent.com/13622816/206769547-c6dc0995-53ad-4ab5-9275-f0f638b2eef9.png">



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message: http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
