### PR TITLE
ability to set referenceId in ECSRunTaskOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -370,6 +370,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
         reattach: bool = False,
         number_logs_exception: int = 10,
         wait_for_completion: bool = True,
+        reference_id: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -384,6 +385,7 @@ class EcsRunTaskOperator(EcsBaseOperator):
         self.placement_strategy = placement_strategy
         self.platform_version = platform_version
         self.network_configuration = network_configuration
+        self.reference_id = reference_id
 
         self.tags = tags
         self.awslogs_group = awslogs_group
@@ -479,6 +481,8 @@ class EcsRunTaskOperator(EcsBaseOperator):
             run_opts["tags"] = [{"key": k, "value": v} for (k, v) in self.tags.items()]
         if self.propagate_tags is not None:
             run_opts["propagateTags"] = self.propagate_tags
+        if self.reference_id is not None:
+            run_opts["referenceId"] = self.reference_id
 
         response = self.client.run_task(**run_opts)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR adds the ability to set a reference id when using the ECSRunTaskOperator.  This is particularly useful because tags are automatically deleted when tasks stop.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
