### PR TITLE
Add is_local to CeleryKubernetesExecutor

### DIFF
--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -43,6 +43,8 @@ class CeleryKubernetesExecutor(LoggingMixin):
 
     KUBERNETES_QUEUE = conf.get("celery_kubernetes_executor", "kubernetes_queue")
 
+    is_local: bool = False
+
     def __init__(self, celery_executor: CeleryExecutor, kubernetes_executor: KubernetesExecutor):
         super().__init__()
         self._job_id: int | None = None

--- a/tests/executors/test_celery_kubernetes_executor.py
+++ b/tests/executors/test_celery_kubernetes_executor.py
@@ -31,6 +31,9 @@ KUBERNETES_QUEUE = CeleryKubernetesExecutor.KUBERNETES_QUEUE
 
 
 class TestCeleryKubernetesExecutor:
+    def test_is_local_default_value(self):
+        assert not CeleryKubernetesExecutor.is_local
+
     def test_queued_tasks(self):
         celery_executor_mock = mock.MagicMock()
         k8s_executor_mock = mock.MagicMock()


### PR DESCRIPTION
Fix `is_local` attribute for CeleryKubernetesExecutor. (Doesn't extend BaseExecutor)