### PR TITLE
Fix for issue with reading schema fields for JSON files in GCSToBigQueryOperator

### DIFF
--- a/airflow/providers/google/cloud/triggers/bigquery.py
+++ b/airflow/providers/google/cloud/triggers/bigquery.py
@@ -88,12 +88,14 @@ class BigQueryInsertJobTrigger(BaseTrigger):
                             "message": "Job completed",
                         }
                     )
+                    return
                 elif response_from_hook == "pending":
                     self.log.info("Query is still running...")
                     self.log.info("Sleeping for %s seconds.", self.poll_interval)
                     await asyncio.sleep(self.poll_interval)
                 else:
                     yield TriggerEvent({"status": "error", "message": response_from_hook})
+                    return
 
             except Exception as e:
                 self.log.exception("Exception occurred while checking for query completion")

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -56,6 +56,7 @@ SCHEMA_BUCKET = "test-schema-bucket"
 SCHEMA_OBJECT = "test/schema/schema.json"
 TEST_SOURCE_OBJECTS = ["test/objects/test.csv"]
 TEST_SOURCE_OBJECTS_AS_STRING = "test/objects/test.csv"
+TEST_SOURCE_OBJECTS_JSON = "test/objects/test.json"
 LABELS = {"k1": "v1"}
 DESCRIPTION = "Test Description"
 
@@ -63,9 +64,11 @@ job_id = "123456"
 hash_ = "hash"
 pytest.real_job_id = f"{job_id}_{hash_}"
 
+GCS_TO_BQ_PATH = "airflow.providers.google.cloud.transfers.gcs_to_bigquery.{}"
+
 
 class TestGCSToBigQueryOperator(unittest.TestCase):
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_max_value_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -89,28 +92,29 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         assert result == "1"
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+            },
         )
         hook.return_value.insert_job.assert_called_once_with(
             configuration={
@@ -123,7 +127,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             project_id=hook.return_value.project_id,
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_max_value_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -150,35 +154,28 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "writeDisposition": WRITE_DISPOSITION,
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
             ),
             call(
                 configuration={
@@ -194,7 +191,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_max_value_should_throw_ex_when_query_returns_no_rows(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -218,35 +215,28 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
             ),
             call(
                 configuration={
@@ -262,7 +252,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_labels_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -284,31 +274,32 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         operator.execute(context=MagicMock())
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                 "labels": LABELS,
-                "description": None,
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+            },
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_labels_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -332,41 +323,35 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": LABELS,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "destinationTableProperties": {"labels": LABELS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
-            ),
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
         ]
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_description_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -388,31 +373,33 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         operator.execute(context=MagicMock())
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": DESCRIPTION,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+                "description": DESCRIPTION,
+            },
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_description_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -442,7 +429,6 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         destinationTableProperties={
                             "description": DESCRIPTION,
-                            "labels": None,
                         },
                         sourceFormat="CSV",
                         skipLeadingRows=None,
@@ -452,11 +438,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         allowQuotedNewlines=False,
                         encoding="UTF-8",
                         schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
                         quote=None,
-                        schemaUpdateOptions=(),
+                        fieldDelimiter=",",
                     ),
                 },
                 project_id=hook.return_value.project_id,
@@ -467,10 +450,9 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 nowait=True,
             ),
         ]
-
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_source_objs_as_list_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -491,33 +473,34 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         operator.execute(context=MagicMock())
 
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [
+                    "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [
                         f"gs://{TEST_BUCKET}/{source_object}" for source_object in TEST_SOURCE_OBJECTS
                     ],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
-                    "autodetect": True,
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+            },
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_source_objs_as_list_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -540,43 +523,38 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {
+                            "projectId": "test-project",
+                            "datasetId": "dataset",
+                            "tableId": "table",
                         },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[
-                            f"gs://{TEST_BUCKET}/{source_object}" for source_object in TEST_SOURCE_OBJECTS
-                        ],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                        "sourceFormat": "CSV",
+                        "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
-            ),
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
         ]
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_source_objs_as_string_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -597,31 +575,32 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         operator.execute(context=MagicMock())
 
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+            },
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_source_objs_as_string_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -644,36 +623,33 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {
+                            "projectId": "test-project",
+                            "datasetId": "dataset",
+                            "tableId": "table",
                         },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                        "sourceFormat": "CSV",
+                        "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
-            ),
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
         ]
 
         hook.return_value.insert_job.assert_has_calls(calls)
@@ -972,7 +948,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_should_throw_ex_when_no_bucket_specified(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -992,9 +968,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_should_throw_ex_when_no_source_objects_specified(self, hook):
-
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
             pytest.real_job_id,
@@ -1013,7 +988,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_should_throw_ex_when_no_destination_project_dataset_table_specified(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -1035,78 +1010,11 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-    def test_schema_fields_scanner_external_table_should_execute_successfully(self, bq_hook, gcs_hook):
-        """
-        Check detection of schema fields if schema_fields parameter is not
-        specified and fields are read from source objects correctly by the operator
-        if all fields are characters. In this case operator searches for fields in source object
-        and update configuration with constructed schema_fields.
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            max_id_key=MAX_ID_KEY,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=True,
-            autodetect=True,
-        )
-
-        result = operator.execute(context=MagicMock())
-
-        assert result == "1"
-        bq_hook.return_value.create_empty_table.assert_called_once_with(
-            table_resource={
-                "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
-                "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
-                    "autodetect": True,
-                    "compression": "NONE",
-                    "csvOptions": {
-                        "fieldDelimeter": ",",
-                        "skipLeadingRows": 1,
-                        "quote": None,
-                        "allowQuotedNewlines": False,
-                        "allowJaggedRows": False,
-                    },
-                },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
-        )
-        bq_hook.return_value.insert_job.assert_called_once_with(
-            configuration={
-                "query": {
-                    "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
-                    "useLegacySql": False,
-                    "schemaUpdateOptions": [],
-                }
-            },
-            project_id=bq_hook.return_value.project_id,
-        )
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-    def test_schema_fields_scanner_without_external_table_should_execute_successfully(
-        self, bq_hook, gcs_hook
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_external_table_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
     ):
         """
         Check detection of schema fields if schema_fields parameter is not
@@ -1130,62 +1038,115 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
             write_disposition=WRITE_DISPOSITION,
-            max_id_key=MAX_ID_KEY,
+            external_table=True,
+            autodetect=True,
+        )
+
+        operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_called_once()
+
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_should_not_called_on_json_ex_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check not calling check_schema_fields method in case if input file is of JSON type on external table
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
+
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS_JSON,
+            source_format="NEWLINE_DELIMITED_JSON",
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            autodetect=True,
+        )
+
+        operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_not_called()
+
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_should_not_called_on_json_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check not calling check_schema_fields method in case if input file is of JSON type
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
+
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS_JSON,
+            source_format="NEWLINE_DELIMITED_JSON",
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
             external_table=False,
             autodetect=True,
         )
 
-        result = operator.execute(context=MagicMock())
+        operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_not_called()
 
-        assert result == "1"
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=1,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
-                },
-                project_id=bq_hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-            call(
-                configuration={
-                    "query": {
-                        "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
-                        "useLegacySql": False,
-                        "schemaUpdateOptions": [],
-                    }
-                },
-                project_id=bq_hook.return_value.project_id,
-            ),
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_without_external_table_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check detection of schema fields if schema_fields parameter is not
+        specified and fields are read from source objects correctly by the operator
+        if all fields are characters. In this case operator searches for fields in source object
+        and update configuration with constructed schema_fields.
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
         ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-        bq_hook.return_value.insert_job.assert_has_calls(calls)
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=False,
+            autodetect=True,
+        )
+
+        operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_called_once()
+
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_scanner_external_table_should_throw_ex_when_autodetect_not_specified(
         self,
         hook,
@@ -1198,7 +1159,10 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
         hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-        with pytest.raises(RuntimeError, match=r"Table schema was not found."):
+        with pytest.raises(
+            AirflowException,
+            match=r"Table schema was not found. Neither schema object nor schema fields were specified",
+        ):
             operator = GCSToBigQueryOperator(
                 task_id=TASK_ID,
                 bucket=TEST_BUCKET,
@@ -1211,7 +1175,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_scanner_without_external_table_should_throw_ex_when_autodetect_not_specified(
         self,
         hook,
@@ -1224,7 +1188,10 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
         hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-        with pytest.raises(RuntimeError, match=r"Table schema was not found."):
+        with pytest.raises(
+            AirflowException,
+            match=r"Table schema was not found. Neither schema object nor schema fields were specified",
+        ):
             operator = GCSToBigQueryOperator(
                 task_id=TASK_ID,
                 bucket=TEST_BUCKET,
@@ -1237,8 +1204,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_integer_scanner_external_table_should_execute_successfully(
         self, bq_hook, gcs_hook
     ):
@@ -1271,27 +1238,28 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         assert result == "1"
         bq_hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-            }
+            },
         )
         bq_hook.return_value.insert_job.assert_called_once_with(
             configuration={
@@ -1304,8 +1272,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             project_id=bq_hook.return_value.project_id,
         )
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_integer_scanner_without_external_table_should_execute_successfully(
         self, bq_hook, gcs_hook
     ):
@@ -1340,34 +1308,27 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "writeDisposition": WRITE_DISPOSITION,
+                        "ignoreUnknownValues": False,
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=bq_hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
+                project_id=bq_hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
             ),
             call(
                 configuration={
@@ -1383,7 +1344,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         bq_hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_without_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -1408,41 +1369,34 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS_INT},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "writeDisposition": WRITE_DISPOSITION,
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS_INT},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
-                project_id=hook.return_value.project_id,
-                location=None,
                 job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
+                location=None,
                 nowait=True,
-            ),
+                project_id=hook.return_value.project_id,
+                retry=DEFAULT_RETRY,
+                timeout=None,
+            )
         ]
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_fields_external_table_should_execute_successfully(self, hook):
         hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -1465,68 +1419,44 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         operator.execute(context=MagicMock())
         hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS_INT},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS_INT},
-            }
+            },
         )
 
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_execute_without_external_table_async_should_execute_successfully(hook):
-    """
-    Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
-    when Operator is executed in deferrable.
-    """
-    hook.return_value.insert_job.return_value = MagicMock(job_id=pytest.real_job_id, error_result=False)
-    hook.return_value.generate_job_id.return_value = pytest.real_job_id
-    hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-    hook.return_value.get_job.return_value.result.return_value = ("1",)
+class TestAsyncGCSToBigQueryOperator(unittest.TestCase):
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_execute_without_external_table_async_should_execute_successfully(self, hook):
+        """
+        Asserts that a task is deferred and a BigQueryInsertJobTrigger will be fired
+        when Operator is executed in deferrable.
+        """
+        hook.return_value.insert_job.return_value = MagicMock(job_id=pytest.real_job_id, error_result=False)
+        hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
-
-    with pytest.raises(TaskDeferred) as exc:
-        operator.execute(create_context(operator))
-
-    assert isinstance(
-        exc.value.trigger, BigQueryInsertJobTrigger
-    ), "Trigger is not a BigQueryInsertJobTrigger"
-
-
-def test_execute_without_external_table_async_should_throw_ex_when_event_status_error():
-    """
-    Tests that an AirflowException is raised in case of error event.
-    """
-
-    with pytest.raises(AirflowException):
         operator = GCSToBigQueryOperator(
             task_id=TASK_ID,
             bucket=TEST_BUCKET,
@@ -1538,313 +1468,450 @@ def test_execute_without_external_table_async_should_throw_ex_when_event_status_
             autodetect=True,
             deferrable=True,
         )
-        operator.execute_complete(context=None, event={"status": "error", "message": "test failure message"})
 
+        with pytest.raises(TaskDeferred) as exc:
+            operator.execute(self.create_context(operator))
 
-def test_execute_logging_without_external_table_async_should_execute_successfully():
-    """
-    Asserts that logging occurs as expected.
-    """
+        assert isinstance(
+            exc.value.trigger, BigQueryInsertJobTrigger
+        ), "Trigger is not a BigQueryInsertJobTrigger"
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
-    with mock.patch.object(operator.log, "info") as mock_log_info:
-        operator.execute_complete(
-            context=create_context(operator),
-            event={"status": "success", "message": "Job completed", "job_id": job_id},
+    def test_execute_without_external_table_async_should_throw_ex_when_event_status_error(self):
+        """
+        Tests that an AirflowException is raised in case of error event.
+        """
+
+        with pytest.raises(AirflowException):
+            operator = GCSToBigQueryOperator(
+                task_id=TASK_ID,
+                bucket=TEST_BUCKET,
+                source_objects=TEST_SOURCE_OBJECTS,
+                destination_project_dataset_table=TEST_EXPLICIT_DEST,
+                write_disposition=WRITE_DISPOSITION,
+                schema_fields=SCHEMA_FIELDS,
+                external_table=False,
+                autodetect=True,
+                deferrable=True,
+            )
+            operator.execute_complete(
+                context=None, event={"status": "error", "message": "test failure message"}
+            )
+
+    def test_execute_logging_without_external_table_async_should_execute_successfully(self):
+        """
+        Asserts that logging occurs as expected.
+        """
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
         )
-    mock_log_info.assert_called_with(
-        "%s completed with response %s ", "test-gcs-to-bq-operator", "Job completed"
-    )
+        with mock.patch.object(operator.log, "info") as mock_log_info:
+            operator.execute_complete(
+                context=self.create_context(operator),
+                event={"status": "success", "message": "Job completed", "job_id": job_id},
+            )
+        mock_log_info.assert_called_with(
+            "%s completed with response %s ", "test-gcs-to-bq-operator", "Job completed"
+        )
 
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_execute_without_external_table_generate_job_id_async_should_execute_successfully(self, hook):
+        hook.return_value.insert_job.side_effect = Conflict("any")
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        job = MagicMock(
+            job_id=pytest.real_job_id,
+            error_result=False,
+            state="PENDING",
+            done=lambda: False,
+        )
+        hook.return_value.get_job.return_value = job
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_execute_without_external_table_generate_job_id_async_should_execute_successfully(hook):
-    hook.return_value.insert_job.side_effect = Conflict("any")
-    hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-    job = MagicMock(
-        job_id=pytest.real_job_id,
-        error_result=False,
-        state="PENDING",
-        done=lambda: False,
-    )
-    hook.return_value.get_job.return_value = job
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            reattach_states={"PENDING"},
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        reattach_states={"PENDING"},
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
+        with pytest.raises(TaskDeferred):
+            operator.execute(self.create_context(operator))
 
-    with pytest.raises(TaskDeferred):
-        operator.execute(create_context(operator))
+        hook.return_value.generate_job_id.assert_called_once_with(
+            job_id=None,
+            dag_id="adhoc_airflow",
+            task_id=TASK_ID,
+            logical_date=datetime(2022, 1, 1, 0, 0),
+            configuration={},
+            force_rerun=True,
+        )
 
-    hook.return_value.generate_job_id.assert_called_once_with(
-        job_id=None,
-        dag_id="adhoc_airflow",
-        task_id=TASK_ID,
-        logical_date=datetime(2022, 1, 1, 0, 0),
-        configuration={},
-        force_rerun=True,
-    )
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_execute_without_external_table_reattach_async_should_execute_successfully(self, hook):
+        hook.return_value.generate_job_id.return_value = pytest.real_job_id
 
+        hook.return_value.insert_job.side_effect = Conflict("any")
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        job = MagicMock(
+            job_id=pytest.real_job_id,
+            error_result=False,
+            state="PENDING",
+            done=lambda: False,
+        )
+        hook.return_value.get_job.return_value = job
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_execute_without_external_table_reattach_async_should_execute_successfully(hook):
-    hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            location=TEST_DATASET_LOCATION,
+            reattach_states={"PENDING"},
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
 
-    hook.return_value.insert_job.side_effect = Conflict("any")
-    hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-    job = MagicMock(
-        job_id=pytest.real_job_id,
-        error_result=False,
-        state="PENDING",
-        done=lambda: False,
-    )
-    hook.return_value.get_job.return_value = job
+        with pytest.raises(TaskDeferred):
+            operator.execute(self.create_context(operator))
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        location=TEST_DATASET_LOCATION,
-        reattach_states={"PENDING"},
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
+        hook.return_value.get_job.assert_called_once_with(
+            location=TEST_DATASET_LOCATION,
+            job_id=pytest.real_job_id,
+            project_id=hook.return_value.project_id,
+        )
 
-    with pytest.raises(TaskDeferred):
-        operator.execute(create_context(operator))
+        job._begin.assert_called_once_with()
 
-    hook.return_value.get_job.assert_called_once_with(
-        location=TEST_DATASET_LOCATION,
-        job_id=pytest.real_job_id,
-        project_id=hook.return_value.project_id,
-    )
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_execute_without_external_table_force_rerun_async_should_execute_successfully(self, hook):
+        hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
+        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
 
-    job._begin.assert_called_once_with()
+        hook.return_value.insert_job.side_effect = Conflict("any")
+        job = MagicMock(
+            job_id=pytest.real_job_id,
+            error_result=False,
+            state="DONE",
+            done=lambda: False,
+        )
+        hook.return_value.get_job.return_value = job
 
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            location=TEST_DATASET_LOCATION,
+            reattach_states={"PENDING"},
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_execute_without_external_table_force_rerun_async_should_execute_successfully(hook):
-    hook.return_value.generate_job_id.return_value = f"{job_id}_{hash_}"
-    hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        with pytest.raises(AirflowException) as exc:
+            operator.execute(self.create_context(operator))
 
-    hook.return_value.insert_job.side_effect = Conflict("any")
-    job = MagicMock(
-        job_id=pytest.real_job_id,
-        error_result=False,
-        state="DONE",
-        done=lambda: False,
-    )
-    hook.return_value.get_job.return_value = job
+        expected_exception_msg = (
+            f"Job with id: {pytest.real_job_id} already exists and is in {job.state} state. "
+            f"If you want to force rerun it consider setting `force_rerun=True`."
+            f"Or, if you want to reattach in this scenario add {job.state} to `reattach_states`"
+        )
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        location=TEST_DATASET_LOCATION,
-        reattach_states={"PENDING"},
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
+        assert str(exc.value) == expected_exception_msg
 
-    with pytest.raises(AirflowException) as exc:
-        operator.execute(create_context(operator))
+        hook.return_value.get_job.assert_called_once_with(
+            location=TEST_DATASET_LOCATION,
+            job_id=pytest.real_job_id,
+            project_id=hook.return_value.project_id,
+        )
 
-    expected_exception_msg = (
-        f"Job with id: {pytest.real_job_id} already exists and is in {job.state} state. "
-        f"If you want to force rerun it consider setting `force_rerun=True`."
-        f"Or, if you want to reattach in this scenario add {job.state} to `reattach_states`"
-    )
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_without_external_table_async_should_execute_successfully(self, bq_hook, gcs_hook):
+        bq_hook.return_value.insert_job.return_value = MagicMock(
+            job_id=pytest.real_job_id, error_result=False
+        )
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
 
-    assert str(exc.value) == expected_exception_msg
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            max_id_key=MAX_ID_KEY,
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
 
-    hook.return_value.get_job.assert_called_once_with(
-        location=TEST_DATASET_LOCATION,
-        job_id=pytest.real_job_id,
-        project_id=hook.return_value.project_id,
-    )
+        with pytest.raises(TaskDeferred):
+            result = operator.execute(self.create_context(operator))
+            assert result == "1"
 
+            calls = [
+                call(
+                    configuration={
+                        "load": dict(
+                            autodetect=True,
+                            createDisposition="CREATE_IF_NEEDED",
+                            destinationTable={
+                                "projectId": PROJECT_ID,
+                                "datasetId": DATASET,
+                                "tableId": TABLE,
+                            },
+                            destinationTableProperties={
+                                "description": None,
+                                "labels": None,
+                            },
+                            sourceFormat="CSV",
+                            skipLeadingRows=None,
+                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                            writeDisposition=WRITE_DISPOSITION,
+                            ignoreUnknownValues=False,
+                            allowQuotedNewlines=False,
+                            encoding="UTF-8",
+                            schema={"fields": SCHEMA_FIELDS},
+                        ),
+                    },
+                    project_id=bq_hook.return_value.project_id,
+                    location=None,
+                    job_id=pytest.real_job_id,
+                    timeout=None,
+                    retry=DEFAULT_RETRY,
+                    nowait=True,
+                ),
+                call(
+                    configuration={
+                        "query": {
+                            "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
+                            "useLegacySql": False,
+                            "schemaUpdateOptions": [],
+                        }
+                    },
+                    project_id=bq_hook.return_value.project_id,
+                ),
+            ]
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_schema_fields_without_external_table_async_should_execute_successfully(bq_hook, gcs_hook):
-    bq_hook.return_value.insert_job.return_value = MagicMock(job_id=pytest.real_job_id, error_result=False)
-    bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-    bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-    bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-    gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
+            bq_hook.return_value.insert_job.assert_has_calls(calls)
 
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        max_id_key=MAX_ID_KEY,
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_int_without_external_table_async_should_execute_successfully(
+        self, bq_hook, gcs_hook
+    ):
+        bq_hook.return_value.insert_job.return_value = MagicMock(
+            job_id=pytest.real_job_id, error_result=False
+        )
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
+        gcs_hook.return_value.download.return_value = b"id,name\r\n1,Anna"
 
-    with pytest.raises(TaskDeferred):
-        result = operator.execute(create_context(operator))
-        assert result == "1"
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            schema_fields=SCHEMA_FIELDS,
+            max_id_key=MAX_ID_KEY,
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
 
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                    ),
-                },
-                project_id=bq_hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-            call(
-                configuration={
-                    "query": {
-                        "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
-                        "useLegacySql": False,
-                        "schemaUpdateOptions": [],
-                    }
-                },
-                project_id=bq_hook.return_value.project_id,
-            ),
+        with pytest.raises(TaskDeferred):
+            result = operator.execute(self.create_context(operator))
+            assert result == "1"
+
+            calls = [
+                call(
+                    configuration={
+                        "load": dict(
+                            autodetect=True,
+                            createDisposition="CREATE_IF_NEEDED",
+                            destinationTable={
+                                "projectId": PROJECT_ID,
+                                "datasetId": DATASET,
+                                "tableId": TABLE,
+                            },
+                            destinationTableProperties={
+                                "description": None,
+                                "labels": None,
+                            },
+                            sourceFormat="CSV",
+                            skipLeadingRows=None,
+                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                            writeDisposition=WRITE_DISPOSITION,
+                            ignoreUnknownValues=False,
+                            allowQuotedNewlines=False,
+                            encoding="UTF-8",
+                        ),
+                    },
+                    project_id=bq_hook.return_value.project_id,
+                    location=None,
+                    job_id=pytest.real_job_id,
+                    timeout=None,
+                    retry=DEFAULT_RETRY,
+                    nowait=True,
+                ),
+                call(
+                    configuration={
+                        "query": {
+                            "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
+                            "useLegacySql": False,
+                            "schemaUpdateOptions": [],
+                        }
+                    },
+                    project_id=bq_hook.return_value.project_id,
+                ),
+            ]
+
+            bq_hook.return_value.insert_job.assert_has_calls(calls)
+
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_async_schema_fields_scanner_external_table_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check detection of schema fields if schema_fields parameter is not
+        specified and fields are read from source objects correctly by the operator
+        if all fields are characters. In this case operator searches for fields in source object
+        and update configuration with constructed schema_fields.
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
         ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-        bq_hook.return_value.insert_job.assert_has_calls(calls)
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
 
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
+        with pytest.raises(TaskDeferred):
+            operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_called_once()
 
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-@mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-def test_schema_fields_int_without_external_table_async_should_execute_successfully(bq_hook, gcs_hook):
-    bq_hook.return_value.insert_job.return_value = MagicMock(job_id=pytest.real_job_id, error_result=False)
-    bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-    bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-    bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-    gcs_hook.return_value.download.return_value = b"id,name\r\n1,Anna"
-
-    operator = GCSToBigQueryOperator(
-        task_id=TASK_ID,
-        bucket=TEST_BUCKET,
-        source_objects=TEST_SOURCE_OBJECTS,
-        destination_project_dataset_table=TEST_EXPLICIT_DEST,
-        write_disposition=WRITE_DISPOSITION,
-        schema_fields=SCHEMA_FIELDS,
-        max_id_key=MAX_ID_KEY,
-        external_table=False,
-        autodetect=True,
-        deferrable=True,
-    )
-
-    with pytest.raises(TaskDeferred):
-        result = operator.execute(create_context(operator))
-        assert result == "1"
-
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                    ),
-                },
-                project_id=bq_hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-            call(
-                configuration={
-                    "query": {
-                        "query": f"SELECT MAX({MAX_ID_KEY}) AS max_value FROM {TEST_EXPLICIT_DEST}",
-                        "useLegacySql": False,
-                        "schemaUpdateOptions": [],
-                    }
-                },
-                project_id=bq_hook.return_value.project_id,
-            ),
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_should_not_called_on_json_ex_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check not calling check_schema_fields method in case if input file is of JSON type on external table
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
         ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
 
-        bq_hook.return_value.insert_job.assert_has_calls(calls)
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
 
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS_JSON,
+            source_format="NEWLINE_DELIMITED_JSON",
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=True,
+            autodetect=True,
+            deferrable=True,
+        )
+        operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_not_called()
 
-def create_context(task):
-    dag = DAG(dag_id="dag")
-    logical_date = datetime(2022, 1, 1, 0, 0, 0)
-    dag_run = DagRun(
-        dag_id=dag.dag_id,
-        execution_date=logical_date,
-        run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
-    )
-    task_instance = TaskInstance(task=task)
-    task_instance.dag_run = dag_run
-    task_instance.dag_id = dag.dag_id
-    task_instance.xcom_push = mock.Mock()
-    return {
-        "dag": dag,
-        "run_id": dag_run.run_id,
-        "task": task,
-        "ti": task_instance,
-        "task_instance": task_instance,
-        "logical_date": logical_date,
-    }
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
+    def test_schema_fields_scanner_should_not_called_on_json_should_execute_successfully(
+        self, bq_hook, gcs_hook, mocked_check_fileds
+    ):
+        """
+        Check not calling check_schema_fields method in case if input file is of JSON type
+        """
+        bq_hook.return_value.insert_job.side_effect = [
+            MagicMock(job_id=pytest.real_job_id, error_result=False),
+            pytest.real_job_id,
+        ]
+        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
+        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
+        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
+
+        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS_JSON,
+            source_format="NEWLINE_DELIMITED_JSON",
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            write_disposition=WRITE_DISPOSITION,
+            external_table=False,
+            autodetect=True,
+            deferrable=True,
+        )
+        with pytest.raises(TaskDeferred):
+            operator.execute(context=MagicMock())
+        mocked_check_fileds.assert_not_called()
+
+    def create_context(self, task):
+        dag = DAG(dag_id="dag")
+        logical_date = datetime(2022, 1, 1, 0, 0, 0)
+        dag_run = DagRun(
+            dag_id=dag.dag_id,
+            execution_date=logical_date,
+            run_id=DagRun.generate_run_id(DagRunType.MANUAL, logical_date),
+        )
+        task_instance = TaskInstance(task=task)
+        task_instance.dag_run = dag_run
+        task_instance.dag_id = dag.dag_id
+        task_instance.xcom_push = mock.Mock()
+        return {
+            "dag": dag,
+            "run_id": dag_run.run_id,
+            "task": task,
+            "ti": task_instance,
+            "task_instance": task_instance,
+            "logical_date": logical_date,
+        }

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -54,8 +54,8 @@ SCHEMA_FIELDS_INT = [
 ]
 SCHEMA_BUCKET = "test-schema-bucket"
 SCHEMA_OBJECT = "test/schema/schema.json"
-TEST_SOURCE_OBJECTS = ["test/objects/test.csv"]
-TEST_SOURCE_OBJECTS_AS_STRING = "test/objects/test.csv"
+TEST_SOURCE_OBJECTS_LIST = ["test/objects/test.csv"]
+TEST_SOURCE_OBJECTS = "test/objects/test.csv"
 TEST_SOURCE_OBJECTS_JSON = "test/objects/test.json"
 LABELS = {"k1": "v1"}
 DESCRIPTION = "Test Description"
@@ -101,7 +101,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -159,7 +159,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         "sourceFormat": "CSV",
-                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": WRITE_DISPOSITION,
                         "ignoreUnknownValues": False,
                         "schema": {"fields": SCHEMA_FIELDS},
@@ -220,7 +220,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         "sourceFormat": "CSV",
-                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": "WRITE_TRUNCATE",
                         "ignoreUnknownValues": False,
                         "schema": {"fields": SCHEMA_FIELDS},
@@ -283,7 +283,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -328,7 +328,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         "sourceFormat": "CSV",
-                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": "WRITE_TRUNCATE",
                         "ignoreUnknownValues": False,
                         "schema": {"fields": SCHEMA_FIELDS},
@@ -382,7 +382,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -432,7 +432,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         },
                         sourceFormat="CSV",
                         skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         writeDisposition=WRITE_DISPOSITION,
                         ignoreUnknownValues=False,
                         allowQuotedNewlines=False,
@@ -483,7 +483,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                     "autodetect": True,
                     "sourceFormat": "CSV",
                     "sourceUris": [
-                        f"gs://{TEST_BUCKET}/{source_object}" for source_object in TEST_SOURCE_OBJECTS
+                        f"gs://{TEST_BUCKET}/{source_object}" for source_object in TEST_SOURCE_OBJECTS_LIST
                     ],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
@@ -584,7 +584,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -627,12 +627,12 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "autodetect": True,
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {
-                            "projectId": "test-project",
-                            "datasetId": "dataset",
+                            "projectId": PROJECT_ID,
+                            "datasetId": DATASET,
                             "tableId": "table",
                         },
                         "sourceFormat": "CSV",
-                        "sourceUris": ["gs://test-bucket/test/objects/test.csv"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": "WRITE_TRUNCATE",
                         "ignoreUnknownValues": False,
                         "schema": {"fields": SCHEMA_FIELDS},
@@ -654,8 +654,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
 
         hook.return_value.insert_job.assert_has_calls(calls)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_obj_external_table_should_execute_successfully(self, bq_hook, gcs_hook):
         bq_hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -678,33 +678,34 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         operator.execute(context=MagicMock())
 
         bq_hook.return_value.create_empty_table.assert_called_once_with(
+            exists_ok=True,
+            location=None,
+            project_id=PROJECT_ID,
             table_resource={
                 "tableReference": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                "labels": None,
-                "description": None,
+                "labels": {},
                 "externalDataConfiguration": {
-                    "source_uris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                    "source_format": "CSV",
-                    "maxBadRecords": 0,
                     "autodetect": True,
+                    "sourceFormat": "CSV",
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
+                    "ignoreUnknownValues": False,
                     "csvOptions": {
-                        "fieldDelimeter": ",",
                         "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
                         "quote": None,
                         "allowQuotedNewlines": False,
                         "allowJaggedRows": False,
+                        "encoding": "UTF-8",
                     },
+                    "schema": {"fields": SCHEMA_FIELDS},
                 },
-                "location": None,
-                "encryptionConfiguration": None,
-                "schema": {"fields": SCHEMA_FIELDS},
-            }
+            },
         )
         gcs_hook.return_value.download.assert_called_once_with(SCHEMA_BUCKET, SCHEMA_OBJECT)
 
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSHook")
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
+    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
+    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_schema_obj_without_external_table_should_execute_successfully(self, bq_hook, gcs_hook):
         bq_hook.return_value.insert_job.side_effect = [
             MagicMock(job_id=pytest.real_job_id, error_result=False),
@@ -730,28 +731,21 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         calls = [
             call(
                 configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                    ),
+                    "load": {
+                        "autodetect": True,
+                        "createDisposition": "CREATE_IF_NEEDED",
+                        "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
+                        "sourceFormat": "CSV",
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
+                        "writeDisposition": "WRITE_TRUNCATE",
+                        "ignoreUnknownValues": False,
+                        "schema": {"fields": SCHEMA_FIELDS},
+                        "skipLeadingRows": None,
+                        "fieldDelimiter": ",",
+                        "quote": None,
+                        "allowQuotedNewlines": False,
+                        "encoding": "UTF-8",
+                    }
                 },
                 project_id=bq_hook.return_value.project_id,
                 location=None,
@@ -759,194 +753,11 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 timeout=None,
                 retry=DEFAULT_RETRY,
                 nowait=True,
-            ),
+            )
         ]
 
         bq_hook.return_value.insert_job.assert_has_calls(calls)
         gcs_hook.return_value.download.assert_called_once_with(SCHEMA_BUCKET, SCHEMA_OBJECT)
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-    def test_all_fields_should_be_present(self, hook):
-        hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            schema_fields=SCHEMA_FIELDS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            field_delimiter=";",
-            max_bad_records=13,
-            quote_character="|",
-            schema_update_options={"foo": "bar"},
-            allow_jagged_rows=True,
-            encryption_configuration={"bar": "baz"},
-            cluster_fields=["field_1", "field_2"],
-        )
-
-        operator.execute(context=MagicMock())
-
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=True,
-                        fieldDelimiter=";",
-                        maxBadRecords=13,
-                        quote="|",
-                        schemaUpdateOptions={"foo": "bar"},
-                        destinationEncryptionConfiguration={"bar": "baz"},
-                        clustering={"fields": ["field_1", "field_2"]},
-                    ),
-                },
-                project_id=hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-        ]
-
-        hook.return_value.insert_job.assert_has_calls(calls)
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-    def test_date_partitioned_explicit_setting_should_be_found(self, hook):
-        hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            schema_fields=SCHEMA_FIELDS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            time_partitioning={"type": "DAY"},
-        )
-
-        operator.execute(context=MagicMock())
-
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                        timePartitioning={"type": "DAY"},
-                    ),
-                },
-                project_id=hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-        ]
-
-        hook.return_value.insert_job.assert_has_calls(calls)
-
-    @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook")
-    def test_date_partitioned_implied_in_table_name_should_be_found(self, hook):
-        hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            schema_fields=SCHEMA_FIELDS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST + "$20221123",
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-        )
-
-        operator.execute(context=MagicMock())
-
-        calls = [
-            call(
-                configuration={
-                    "load": dict(
-                        autodetect=True,
-                        createDisposition="CREATE_IF_NEEDED",
-                        destinationTable={"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
-                        destinationTableProperties={
-                            "description": None,
-                            "labels": None,
-                        },
-                        sourceFormat="CSV",
-                        skipLeadingRows=None,
-                        sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
-                        writeDisposition=WRITE_DISPOSITION,
-                        ignoreUnknownValues=False,
-                        allowQuotedNewlines=False,
-                        encoding="UTF-8",
-                        schema={"fields": SCHEMA_FIELDS},
-                        allowJaggedRows=False,
-                        fieldDelimiter=",",
-                        maxBadRecords=0,
-                        quote=None,
-                        schemaUpdateOptions=(),
-                        timePartitioning={"type": "DAY"},
-                    ),
-                },
-                project_id=hook.return_value.project_id,
-                location=None,
-                job_id=pytest.real_job_id,
-                timeout=None,
-                retry=DEFAULT_RETRY,
-                nowait=True,
-            ),
-        ]
-
-        hook.return_value.insert_job.assert_has_calls(calls)
 
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
     def test_execute_should_throw_ex_when_no_bucket_specified(self, hook):
@@ -1010,144 +821,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
             )
             operator.execute(context=MagicMock())
 
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
     @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_external_table_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check detection of schema fields if schema_fields parameter is not
-        specified and fields are read from source objects correctly by the operator
-        if all fields are characters. In this case operator searches for fields in source object
-        and update configuration with constructed schema_fields.
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=True,
-            autodetect=True,
-        )
-
-        operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_called_once()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_should_not_called_on_json_ex_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check not calling check_schema_fields method in case if input file is of JSON type on external table
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS_JSON,
-            source_format="NEWLINE_DELIMITED_JSON",
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=True,
-            autodetect=True,
-        )
-
-        operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_not_called()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_should_not_called_on_json_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check not calling check_schema_fields method in case if input file is of JSON type
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS_JSON,
-            source_format="NEWLINE_DELIMITED_JSON",
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            autodetect=True,
-        )
-
-        operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_not_called()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_without_external_table_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check detection of schema fields if schema_fields parameter is not
-        specified and fields are read from source objects correctly by the operator
-        if all fields are characters. In this case operator searches for fields in source object
-        and update configuration with constructed schema_fields.
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            autodetect=True,
-        )
-
-        operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_called_once()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_external_table_should_throw_ex_when_autodetect_not_specified(
+    def test_source_format_check_should_throw_ex_when_incorrect_source_type(
         self,
         hook,
     ):
@@ -1160,37 +835,8 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
         hook.return_value.get_job.return_value.result.return_value = ("1",)
 
         with pytest.raises(
-            AirflowException,
-            match=r"Table schema was not found. Neither schema object nor schema fields were specified",
-        ):
-            operator = GCSToBigQueryOperator(
-                task_id=TASK_ID,
-                bucket=TEST_BUCKET,
-                source_objects=TEST_SOURCE_OBJECTS,
-                destination_project_dataset_table=TEST_EXPLICIT_DEST,
-                max_id_key=MAX_ID_KEY,
-                write_disposition=WRITE_DISPOSITION,
-                external_table=True,
-                autodetect=False,
-            )
-            operator.execute(context=MagicMock())
-
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_without_external_table_should_throw_ex_when_autodetect_not_specified(
-        self,
-        hook,
-    ):
-        hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        with pytest.raises(
-            AirflowException,
-            match=r"Table schema was not found. Neither schema object nor schema fields were specified",
+            ValueError,
+            match=r"is not a valid source format.",
         ):
             operator = GCSToBigQueryOperator(
                 task_id=TASK_ID,
@@ -1201,6 +847,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 write_disposition=WRITE_DISPOSITION,
                 external_table=False,
                 autodetect=False,
+                source_format="incorrect",
             )
             operator.execute(context=MagicMock())
 
@@ -1247,7 +894,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -1313,7 +960,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         "sourceFormat": "CSV",
-                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": WRITE_DISPOSITION,
                         "ignoreUnknownValues": False,
                         "skipLeadingRows": None,
@@ -1374,7 +1021,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                         "createDisposition": "CREATE_IF_NEEDED",
                         "destinationTable": {"projectId": PROJECT_ID, "datasetId": DATASET, "tableId": TABLE},
                         "sourceFormat": "CSV",
-                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                        "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                         "writeDisposition": WRITE_DISPOSITION,
                         "ignoreUnknownValues": False,
                         "schema": {"fields": SCHEMA_FIELDS_INT},
@@ -1428,7 +1075,7 @@ class TestGCSToBigQueryOperator(unittest.TestCase):
                 "externalDataConfiguration": {
                     "autodetect": True,
                     "sourceFormat": "CSV",
-                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                    "sourceUris": [f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                     "compression": "NONE",
                     "ignoreUnknownValues": False,
                     "csvOptions": {
@@ -1688,7 +1335,7 @@ class TestAsyncGCSToBigQueryOperator(unittest.TestCase):
                             },
                             sourceFormat="CSV",
                             skipLeadingRows=None,
-                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                             writeDisposition=WRITE_DISPOSITION,
                             ignoreUnknownValues=False,
                             allowQuotedNewlines=False,
@@ -1764,7 +1411,7 @@ class TestAsyncGCSToBigQueryOperator(unittest.TestCase):
                             },
                             sourceFormat="CSV",
                             skipLeadingRows=None,
-                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}"],
+                            sourceUris=[f"gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS}"],
                             writeDisposition=WRITE_DISPOSITION,
                             ignoreUnknownValues=False,
                             allowQuotedNewlines=False,
@@ -1791,109 +1438,6 @@ class TestAsyncGCSToBigQueryOperator(unittest.TestCase):
             ]
 
             bq_hook.return_value.insert_job.assert_has_calls(calls)
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_async_schema_fields_scanner_external_table_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check detection of schema fields if schema_fields parameter is not
-        specified and fields are read from source objects correctly by the operator
-        if all fields are characters. In this case operator searches for fields in source object
-        and update configuration with constructed schema_fields.
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS,
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            autodetect=True,
-            deferrable=True,
-        )
-        with pytest.raises(TaskDeferred):
-            operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_called_once()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_should_not_called_on_json_ex_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check not calling check_schema_fields method in case if input file is of JSON type on external table
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS_JSON,
-            source_format="NEWLINE_DELIMITED_JSON",
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=True,
-            autodetect=True,
-            deferrable=True,
-        )
-        operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_not_called()
-
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSToBigQueryOperator._check_schema_fields"))
-    @mock.patch(GCS_TO_BQ_PATH.format("GCSHook"))
-    @mock.patch(GCS_TO_BQ_PATH.format("BigQueryHook"))
-    def test_schema_fields_scanner_should_not_called_on_json_should_execute_successfully(
-        self, bq_hook, gcs_hook, mocked_check_fileds
-    ):
-        """
-        Check not calling check_schema_fields method in case if input file is of JSON type
-        """
-        bq_hook.return_value.insert_job.side_effect = [
-            MagicMock(job_id=pytest.real_job_id, error_result=False),
-            pytest.real_job_id,
-        ]
-        bq_hook.return_value.generate_job_id.return_value = pytest.real_job_id
-        bq_hook.return_value.split_tablename.return_value = (PROJECT_ID, DATASET, TABLE)
-        bq_hook.return_value.get_job.return_value.result.return_value = ("1",)
-
-        gcs_hook.return_value.download.return_value = b"id,name\r\none,Anna"
-
-        operator = GCSToBigQueryOperator(
-            task_id=TASK_ID,
-            bucket=TEST_BUCKET,
-            source_objects=TEST_SOURCE_OBJECTS_JSON,
-            source_format="NEWLINE_DELIMITED_JSON",
-            destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            write_disposition=WRITE_DISPOSITION,
-            external_table=False,
-            autodetect=True,
-            deferrable=True,
-        )
-        with pytest.raises(TaskDeferred):
-            operator.execute(context=MagicMock())
-        mocked_check_fileds.assert_not_called()
 
     def create_context(self, task):
         dag = DAG(dag_id="dag")

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
@@ -37,8 +37,12 @@ DAG_ID = "gcs_to_bigquery_operator_async"
 
 DATASET_NAME_STR = f"dataset_{DAG_ID}_{ENV_ID}_STR"
 DATASET_NAME_DATE = f"dataset_{DAG_ID}_{ENV_ID}_DATE"
+DATASET_NAME_JSON = f"dataset_{DAG_ID}_{ENV_ID}_JSON"
+DATASET_NAME_DELIMITER = f"dataset_{DAG_ID}_{ENV_ID}_DELIMITER"
 TABLE_NAME_STR = "test_str"
 TABLE_NAME_DATE = "test_date"
+TABLE_NAME_JSON = "test_json"
+TABLE_NAME_DELIMITER = "test_delimiter"
 MAX_ID_STR = "name"
 MAX_ID_DATE = "date"
 
@@ -49,12 +53,22 @@ with models.DAG(
     catchup=False,
     tags=["example", "gcs"],
 ) as dag:
-    create_test_dataset_for_string_fileds = BigQueryCreateEmptyDatasetOperator(
+    create_test_dataset_for_string_fields = BigQueryCreateEmptyDatasetOperator(
         task_id="create_airflow_test_dataset_str", dataset_id=DATASET_NAME_STR, project_id=PROJECT_ID
     )
 
-    create_test_dataset_for_date_fileds = BigQueryCreateEmptyDatasetOperator(
+    create_test_dataset_for_date_fields = BigQueryCreateEmptyDatasetOperator(
         task_id="create_airflow_test_dataset_date", dataset_id=DATASET_NAME_DATE, project_id=PROJECT_ID
+    )
+
+    create_test_dataset_for_json_fields = BigQueryCreateEmptyDatasetOperator(
+        task_id="create_airflow_test_dataset_json", dataset_id=DATASET_NAME_JSON, project_id=PROJECT_ID
+    )
+
+    create_test_dataset_for_delimiter_fields = BigQueryCreateEmptyDatasetOperator(
+        task_id="create_airflow_test_dataset_delimiter",
+        dataset_id=DATASET_NAME_DELIMITER,
+        project_id=PROJECT_ID,
     )
 
     # [START howto_operator_gcs_to_bigquery_async]
@@ -87,14 +101,28 @@ with models.DAG(
         bucket="cloud-samples-data",
         source_objects=["bigquery/us-states/us-states.json"],
         source_format="NEWLINE_DELIMITED_JSON",
-        destination_project_dataset_table=f"{DATASET_NAME_DATE}.{TABLE_NAME_DATE}",
+        destination_project_dataset_table=f"{DATASET_NAME_JSON}.{TABLE_NAME_JSON}",
         write_disposition="WRITE_TRUNCATE",
         external_table=False,
         autodetect=True,
-        max_id_key=MAX_ID_DATE,
+        max_id_key=MAX_ID_STR,
         deferrable=True,
     )
 
+    load_csv_delimiter = GCSToBigQueryOperator(
+        task_id="gcs_to_bigquery_example_delimiter_async",
+        bucket="big-query-samples",
+        source_objects=["employees-tabular.csv"],
+        source_format="csv",
+        destination_project_dataset_table=f"{DATASET_NAME_DELIMITER}.{TABLE_NAME_DELIMITER}",
+        write_disposition="WRITE_TRUNCATE",
+        external_table=False,
+        autodetect=True,
+        field_delimiter="\t",
+        quote_character="",
+        max_id_key=MAX_ID_STR,
+        deferrable=True,
+    )
     # [END howto_operator_gcs_to_bigquery_async]
 
     delete_test_dataset_str = BigQueryDeleteDatasetOperator(
@@ -111,17 +139,36 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
+    delete_test_dataset_json = BigQueryDeleteDatasetOperator(
+        task_id="delete_airflow_test_json_dataset",
+        dataset_id=DATASET_NAME_JSON,
+        delete_contents=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_test_dataset_delimiter = BigQueryDeleteDatasetOperator(
+        task_id="delete_airflow_test_delimiter",
+        dataset_id=DATASET_NAME_JSON,
+        delete_contents=True,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
     (
         # TEST SETUP
-        create_test_dataset_for_string_fileds
-        >> create_test_dataset_for_date_fileds
+        create_test_dataset_for_string_fields
+        >> create_test_dataset_for_date_fields
+        >> create_test_dataset_for_json_fields
+        >> create_test_dataset_for_delimiter_fields
         # TEST BODY
         >> load_string_based_csv
         >> load_date_based_csv
         >> load_json
+        >> load_csv_delimiter
         # TEST TEARDOWN
         >> delete_test_dataset_str
         >> delete_test_dataset_date
+        >> delete_test_dataset_json
+        >> delete_test_dataset_delimiter
     )
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
@@ -81,6 +81,20 @@ with models.DAG(
         max_id_key=MAX_ID_DATE,
         deferrable=True,
     )
+
+    load_json = GCSToBigQueryOperator(
+        task_id="gcs_to_bigquery_example_date_csv_async",
+        bucket="cloud-samples-data",
+        source_objects=["bigquery/us-states/us-states.json"],
+        source_format="NEWLINE_DELIMITED_JSON",
+        destination_project_dataset_table=f"{DATASET_NAME_DATE}.{TABLE_NAME_DATE}",
+        write_disposition="WRITE_TRUNCATE",
+        external_table=False,
+        autodetect=True,
+        max_id_key=MAX_ID_DATE,
+        deferrable=True,
+    )
+
     # [END howto_operator_gcs_to_bigquery_async]
 
     delete_test_dataset_str = BigQueryDeleteDatasetOperator(
@@ -104,6 +118,7 @@ with models.DAG(
         # TEST BODY
         >> load_string_based_csv
         >> load_date_based_csv
+        >> load_json
         # TEST TEARDOWN
         >> delete_test_dataset_str
         >> delete_test_dataset_date

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_bigquery_async.py
@@ -83,7 +83,7 @@ with models.DAG(
     )
 
     load_json = GCSToBigQueryOperator(
-        task_id="gcs_to_bigquery_example_date_csv_async",
+        task_id="gcs_to_bigquery_example_date_json_async",
         bucket="cloud-samples-data",
         source_objects=["bigquery/us-states/us-states.json"],
         source_format="NEWLINE_DELIMITED_JSON",


### PR DESCRIPTION
This fix includes changes for issue with incorrect reading schema_fields in case of using JSON files.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
