### PR TITLE
Fix is_local for LocalKubernetesExecutor

### DIFF
--- a/airflow/executors/local_kubernetes_executor.py
+++ b/airflow/executors/local_kubernetes_executor.py
@@ -43,6 +43,8 @@ class LocalKubernetesExecutor(LoggingMixin):
 
     KUBERNETES_QUEUE = conf.get("local_kubernetes_executor", "kubernetes_queue")
 
+    is_local: bool = False
+
     def __init__(self, local_executor: LocalExecutor, kubernetes_executor: KubernetesExecutor):
         super().__init__()
         self._job_id: str | None = None

--- a/tests/executors/test_local_kubernetes_executor.py
+++ b/tests/executors/test_local_kubernetes_executor.py
@@ -26,6 +26,9 @@ from airflow.executors.local_kubernetes_executor import LocalKubernetesExecutor
 
 
 class TestLocalKubernetesExecutor:
+    def test_is_local_default_value(self):
+        assert not LocalKubernetesExecutor.is_local
+
     def test_queued_tasks(self):
         local_executor_mock = mock.MagicMock()
         k8s_executor_mock = mock.MagicMock()


### PR DESCRIPTION
`LocalKurbernetesExecutor` does not extends the `BaseExecutor` class, and therefore does not inherit `is_local` attribute.

See https://github.com/apache/airflow/issues/28276 general discussion on how to handle mixed executor API.


cc: @dstandish @o-nikolas 