### PR TITLE
Fix Google Cloud async tests

### DIFF
--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -18,9 +18,9 @@
 from __future__ import annotations
 
 import re
-import sys
 import unittest
 from datetime import datetime
+from unittest import mock
 
 import pytest
 from gcloud.aio.bigquery import Job, Table as Table_async
@@ -42,13 +42,7 @@ from airflow.providers.google.cloud.hooks.bigquery import (
     _validate_value,
     split_tablename,
 )
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-    from asynctest.mock import CoroutineMock as AsyncMock
-else:
-    from unittest import mock
-    from unittest.mock import AsyncMock
+from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 
 PROJECT_ID = "bq-project"
 CREDENTIALS = "bq-credentials"
@@ -2090,14 +2084,14 @@ class _BigQueryBaseAsyncTestClass:
 
 class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.ClientSession")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.ClientSession")
     async def test_get_job_instance(self, mock_session):
         hook = BigQueryAsyncHook()
         result = await hook.get_job_instance(project_id=PROJECT_ID, job_id=JOB_ID, session=mock_session)
         assert isinstance(result, Job)
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
     async def test_get_job_status_success(self, mock_job_instance):
         hook = BigQueryAsyncHook()
         mock_job_client = AsyncMock(Job)
@@ -2108,7 +2102,7 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
         assert resp == response
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
     async def test_get_job_status_oserror(self, mock_job_instance):
         """Assets that the BigQueryAsyncHook returns a pending response when OSError is raised"""
         mock_job_instance.return_value.result.side_effect = OSError()
@@ -2117,7 +2111,7 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
         assert job_status == "pending"
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
     async def test_get_job_status_exception(self, mock_job_instance, caplog):
         """Assets that the logging is done correctly when BigQueryAsyncHook raises Exception"""
         mock_job_instance.return_value.result.side_effect = Exception()
@@ -2126,7 +2120,7 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
         assert "Query execution finished with errors..." in caplog.text
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
     async def test_get_job_output_assert_once_with(self, mock_job_instance):
         hook = BigQueryAsyncHook()
         mock_job_client = AsyncMock(Job)
@@ -2189,7 +2183,7 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
         assert response is None
 
     @pytest.mark.asyncio
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+    @async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
     async def test_get_job_output(self, mock_job_instance):
         """
         Tests to check if a particular object in Google Cloud Storage
@@ -2269,7 +2263,7 @@ class TestBigQueryAsyncHookMethods(_BigQueryBaseAsyncTestClass):
         assert BigQueryAsyncHook._convert_to_float_if_possible(test_input) == expected
 
     @pytest.mark.asyncio
-    @mock.patch("aiohttp.client.ClientSession")
+    @async_mock.patch("aiohttp.client.ClientSession")
     async def test_get_table_client(self, mock_session):
         """Test get_table_client async function and check whether the return value is a
         Table instance object"""

--- a/tests/providers/google/cloud/hooks/test_cloud_composer.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_composer.py
@@ -22,8 +22,10 @@ from unittest import mock
 
 import pytest
 from google.api_core.gapic_v1.method import DEFAULT
+from google.cloud.orchestration.airflow.service_v1 import EnvironmentsAsyncClient
 
 from airflow.providers.google.cloud.hooks.cloud_composer import CloudComposerAsyncHook, CloudComposerHook
+from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 
 TEST_GCP_REGION = "global"
 TEST_GCP_PROJECT = "test-project"
@@ -194,14 +196,16 @@ class TestCloudComposerHook(unittest.TestCase):
         )
 
 
-class TestCloudComposerAsyncHook(unittest.TestCase):
-    def setUp(self) -> None:
-        with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
+class TestCloudComposerAsyncHook:
+    def setup_method(self, method) -> None:
+        with async_mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = CloudComposerAsyncHook(gcp_conn_id="test")
 
     @pytest.mark.asyncio
-    @mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
+    @async_mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
     async def test_create_environment(self, mock_client) -> None:
+        mock_env_client = AsyncMock(EnvironmentsAsyncClient)
+        mock_client.return_value = mock_env_client
         await self.hook.create_environment(
             project_id=TEST_GCP_PROJECT,
             region=TEST_GCP_REGION,
@@ -222,8 +226,10 @@ class TestCloudComposerAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
+    @async_mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
     async def test_delete_environment(self, mock_client) -> None:
+        mock_env_client = AsyncMock(EnvironmentsAsyncClient)
+        mock_client.return_value = mock_env_client
         await self.hook.delete_environment(
             project_id=TEST_GCP_PROJECT,
             region=TEST_GCP_REGION,
@@ -243,8 +249,10 @@ class TestCloudComposerAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
+    @async_mock.patch(COMPOSER_STRING.format("CloudComposerAsyncHook.get_environment_client"))
     async def test_update_environment(self, mock_client) -> None:
+        mock_env_client = AsyncMock(EnvironmentsAsyncClient)
+        mock_client.return_value = mock_env_client
         await self.hook.update_environment(
             project_id=TEST_GCP_PROJECT,
             region=TEST_GCP_REGION,

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -23,13 +23,20 @@ from unittest.mock import ANY
 
 import pytest
 from google.api_core.gapic_v1.method import DEFAULT
-from google.cloud.dataproc_v1 import JobStatus
+from google.cloud.dataproc_v1 import (
+    BatchControllerAsyncClient,
+    ClusterControllerAsyncClient,
+    JobControllerAsyncClient,
+    JobStatus,
+    WorkflowTemplateServiceAsyncClient,
+)
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.dataproc import DataprocAsyncHook, DataprocHook, DataProcJobBuilder
 from airflow.providers.google.common.consts import CLIENT_INFO
 from airflow.version import version
+from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 
 AIRFLOW_VERSION = "v" + version.replace(".", "-").replace("+", "-")
 
@@ -57,6 +64,10 @@ DATAPROC_STRING = "airflow.providers.google.cloud.hooks.dataproc.{}"
 
 
 def mock_init(*args, **kwargs):
+    pass
+
+
+async def mock_awaitable(*args, **kwargs):
     pass
 
 
@@ -463,8 +474,8 @@ class TestDataprocHook(unittest.TestCase):
         )
 
 
-class TestDataprocAsyncHook(unittest.TestCase):
-    def setUp(self):
+class TestDataprocAsyncHook:
+    def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = DataprocAsyncHook(gcp_conn_id="test")
 
@@ -547,8 +558,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_create_cluster(self, mock_client):
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.create_cluster(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -570,8 +583,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_delete_cluster(self, mock_client):
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.delete_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.delete_cluster.assert_called_once_with(
@@ -588,8 +603,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_diagnose_cluster(self, mock_client):
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.diagnose_cluster(
             project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME
         )
@@ -607,8 +624,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         mock_client.return_value.diagnose_cluster.return_value.result.assert_called_once_with()
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_get_cluster(self, mock_client):
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.get_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.get_cluster.assert_called_once_with(
@@ -623,10 +642,11 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_list_clusters(self, mock_client):
         filter_ = "filter"
-
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.list_clusters(project_id=GCP_PROJECT, region=GCP_LOCATION, filter_=filter_)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.list_clusters.assert_called_once_with(
@@ -642,9 +662,11 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_cluster_client"))
     async def test_update_cluster(self, mock_client):
         update_mask = "update-mask"
+        mock_cluster_client = AsyncMock(ClusterControllerAsyncClient)
+        mock_client.return_value = mock_cluster_client
         await self.hook.update_cluster(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -679,10 +701,12 @@ class TestDataprocAsyncHook(unittest.TestCase):
             )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
     async def test_create_workflow_template(self, mock_client):
         template = {"test": "test"}
         parent = f"projects/{GCP_PROJECT}/regions/{GCP_LOCATION}"
+        mock_template_client = AsyncMock(WorkflowTemplateServiceAsyncClient)
+        mock_client.return_value = mock_template_client
         await self.hook.create_workflow_template(
             region=GCP_LOCATION, template=template, project_id=GCP_PROJECT
         )
@@ -691,10 +715,12 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
     async def test_instantiate_workflow_template(self, mock_client):
         template_name = "template_name"
         name = f"projects/{GCP_PROJECT}/regions/{GCP_LOCATION}/workflowTemplates/{template_name}"
+        mock_template_client = AsyncMock(WorkflowTemplateServiceAsyncClient)
+        mock_client.return_value = mock_template_client
         await self.hook.instantiate_workflow_template(
             region=GCP_LOCATION, template_name=template_name, project_id=GCP_PROJECT
         )
@@ -711,10 +737,12 @@ class TestDataprocAsyncHook(unittest.TestCase):
             self.hook.instantiate_workflow_template(template_name="template_name", project_id=GCP_PROJECT)
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_template_client"))
     async def test_instantiate_inline_workflow_template(self, mock_client):
         template = {"test": "test"}
         parent = f"projects/{GCP_PROJECT}/regions/{GCP_LOCATION}"
+        mock_template_client = AsyncMock(WorkflowTemplateServiceAsyncClient)
+        mock_client.return_value = mock_template_client
         await self.hook.instantiate_inline_workflow_template(
             region=GCP_LOCATION, template=template, project_id=GCP_PROJECT
         )
@@ -731,8 +759,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
             self.hook.instantiate_inline_workflow_template(template={"test": "test"}, project_id=GCP_PROJECT)
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
     async def test_get_job(self, mock_client):
+        mock_job_client = AsyncMock(JobControllerAsyncClient)
+        mock_client.return_value = mock_job_client
         await self.hook.get_job(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.get_job.assert_called_once_with(
@@ -752,8 +782,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
             self.hook.get_job(job_id=JOB_ID, project_id=GCP_PROJECT)
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
     async def test_submit_job(self, mock_client):
+        mock_job_client = AsyncMock(JobControllerAsyncClient)
+        mock_client.return_value = mock_job_client
         await self.hook.submit_job(region=GCP_LOCATION, job=JOB, project_id=GCP_PROJECT)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.submit_job.assert_called_once_with(
@@ -774,8 +806,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
             self.hook.submit_job(job=JOB, project_id=GCP_PROJECT)
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_job_client"))
     async def test_cancel_job(self, mock_client):
+        mock_job_client = AsyncMock(JobControllerAsyncClient)
+        mock_client.return_value = mock_job_client
         await self.hook.cancel_job(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.cancel_job.assert_called_once_with(
@@ -790,8 +824,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
     async def test_create_batch(self, mock_client):
+        mock_batch_client = AsyncMock(BatchControllerAsyncClient)
+        mock_client.return_value = mock_batch_client
         await self.hook.create_batch(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -812,8 +848,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
     async def test_delete_batch(self, mock_client):
+        mock_batch_client = AsyncMock(BatchControllerAsyncClient)
+        mock_client.return_value = mock_batch_client
         await self.hook.delete_batch(
             batch_id=BATCH_ID,
             region=GCP_LOCATION,
@@ -830,8 +868,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
     async def test_get_batch(self, mock_client):
+        mock_batch_client = AsyncMock(BatchControllerAsyncClient)
+        mock_client.return_value = mock_batch_client
         await self.hook.get_batch(
             batch_id=BATCH_ID,
             region=GCP_LOCATION,
@@ -848,8 +888,10 @@ class TestDataprocAsyncHook(unittest.TestCase):
         )
 
     @pytest.mark.asyncio
-    @mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
+    @async_mock.patch(DATAPROC_STRING.format("DataprocAsyncHook.get_batch_client"))
     async def test_list_batches(self, mock_client):
+        mock_batch_client = AsyncMock(BatchControllerAsyncClient)
+        mock_client.return_value = mock_batch_client
         await self.hook.list_batches(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,

--- a/tests/providers/google/cloud/triggers/test_bigquery.py
+++ b/tests/providers/google/cloud/triggers/test_bigquery.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 from typing import Any
 
 import pytest
@@ -37,13 +36,7 @@ from airflow.providers.google.cloud.triggers.bigquery import (
     BigQueryValueCheckTrigger,
 )
 from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-    from asynctest.mock import CoroutineMock as AsyncMock
-else:
-    from unittest import mock
-    from unittest.mock import AsyncMock
+from tests.providers.google.cloud.utils.compat import AsyncMock, async_mock
 
 TEST_CONN_ID = "bq_default"
 TEST_JOB_ID = "1234"
@@ -94,7 +87,7 @@ def test_bigquery_insert_job_op_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_insert_job_op_trigger_success(mock_job_status):
     """
     Tests the BigQueryInsertJobTrigger only fires once the query execution reaches a successful state.
@@ -116,7 +109,7 @@ async def test_bigquery_insert_job_op_trigger_success(mock_job_status):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
 async def test_bigquery_insert_job_trigger_running(mock_job_instance, caplog):
     """
     Test that BigQuery Triggers do not fire while a query is still running.
@@ -153,7 +146,7 @@ async def test_bigquery_insert_job_trigger_running(mock_job_instance, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
 async def test_bigquery_get_data_trigger_running(mock_job_instance, caplog):
     """
     Test that BigQuery Triggers do not fire while a query is still running.
@@ -190,7 +183,7 @@ async def test_bigquery_get_data_trigger_running(mock_job_instance, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_instance")
 async def test_bigquery_check_trigger_running(mock_job_instance, caplog):
     """
     Test that BigQuery Triggers do not fire while a query is still running.
@@ -227,7 +220,7 @@ async def test_bigquery_check_trigger_running(mock_job_instance, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_op_trigger_terminated(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -251,7 +244,7 @@ async def test_bigquery_op_trigger_terminated(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_check_trigger_terminated(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -275,7 +268,7 @@ async def test_bigquery_check_trigger_terminated(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_get_data_trigger_terminated(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -299,7 +292,7 @@ async def test_bigquery_get_data_trigger_terminated(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_op_trigger_exception(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -321,7 +314,7 @@ async def test_bigquery_op_trigger_exception(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_check_trigger_exception(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -343,7 +336,7 @@ async def test_bigquery_check_trigger_exception(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_get_data_trigger_exception(mock_job_status, caplog):
     """
     Test that BigQuery Triggers fire the correct event in case of an error.
@@ -390,8 +383,8 @@ def test_bigquery_check_op_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
 async def test_bigquery_check_op_trigger_success_with_data(mock_job_output, mock_job_status):
     """
     Test the BigQueryCheckTrigger only fires once the query execution reaches a successful state.
@@ -429,8 +422,8 @@ async def test_bigquery_check_op_trigger_success_with_data(mock_job_output, mock
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
 async def test_bigquery_check_op_trigger_success_without_data(mock_job_output, mock_job_status):
     """
     Tests that BigQueryCheckTrigger sends TriggerEvent as  { "status": "success", "records": None}
@@ -497,8 +490,8 @@ def test_bigquery_get_data_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
 async def test_bigquery_get_data_trigger_success_with_data(mock_job_output, mock_job_status):
     """
     Tests that BigQueryGetDataTrigger only fires once the query execution reaches a successful state.
@@ -590,8 +583,8 @@ def test_bigquery_interval_check_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
 async def test_bigquery_interval_check_trigger_success(mock_get_job_output, mock_job_status):
     """
     Tests the BigQueryIntervalCheckTrigger only fires once the query execution reaches a successful state.
@@ -621,7 +614,7 @@ async def test_bigquery_interval_check_trigger_success(mock_get_job_output, mock
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_interval_check_trigger_pending(mock_job_status, caplog):
     """
     Tests that the BigQueryIntervalCheckTrigger do not fire while a query is still running.
@@ -660,7 +653,7 @@ async def test_bigquery_interval_check_trigger_pending(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_interval_check_trigger_terminated(mock_job_status):
     """
     Tests the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
@@ -690,7 +683,7 @@ async def test_bigquery_interval_check_trigger_terminated(mock_job_status):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_interval_check_trigger_exception(mock_job_status, caplog):
     """
     Tests that the BigQueryIntervalCheckTrigger fires the correct event in case of an error.
@@ -759,9 +752,9 @@ def test_bigquery_value_check_op_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_records")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_records")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_output")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_value_check_op_trigger_success(mock_job_status, get_job_output, get_records):
     """
     Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
@@ -791,7 +784,7 @@ async def test_bigquery_value_check_op_trigger_success(mock_job_status, get_job_
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_value_check_op_trigger_pending(mock_job_status, caplog):
     """
     Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
@@ -826,7 +819,7 @@ async def test_bigquery_value_check_op_trigger_pending(mock_job_status, caplog):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_value_check_op_trigger_fail(mock_job_status):
     """
     Tests that the BigQueryValueCheckTrigger only fires once the query execution reaches a successful state.
@@ -851,7 +844,7 @@ async def test_bigquery_value_check_op_trigger_fail(mock_job_status):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryAsyncHook.get_job_status")
 async def test_bigquery_value_check_trigger_exception(mock_job_status):
     """
     Tests the BigQueryValueCheckTrigger does not fire if there is an exception.
@@ -904,7 +897,9 @@ def test_big_query_table_existence_trigger_serialization():
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
+@async_mock.patch(
+    "airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
+)
 async def test_big_query_table_existence_trigger_success(mock_table_exists):
     """
     Tests success case BigQueryTableExistenceTrigger
@@ -926,7 +921,9 @@ async def test_big_query_table_existence_trigger_success(mock_table_exists):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
+@async_mock.patch(
+    "airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
+)
 async def test_big_query_table_existence_trigger_pending(mock_table_exists):
     """
     Test that BigQueryTableExistenceTrigger is in loop till the table exist.
@@ -950,7 +947,9 @@ async def test_big_query_table_existence_trigger_pending(mock_table_exists):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists")
+@async_mock.patch(
+    "airflow.providers.google.cloud.triggers.bigquery.BigQueryTableExistenceTrigger._table_exists"
+)
 async def test_big_query_table_existence_trigger_exception(mock_table_exists):
     """
     Test BigQueryTableExistenceTrigger throws exception if any error.
@@ -971,7 +970,7 @@ async def test_big_query_table_existence_trigger_exception(mock_table_exists):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
 async def test_table_exists(mock_get_table_client):
     """Test BigQueryTableExistenceTrigger._table_exists async function with mocked value
     and mocked return value"""
@@ -990,7 +989,7 @@ async def test_table_exists(mock_get_table_client):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
 async def test_table_exists_exception(mock_get_table_client):
     """Test BigQueryTableExistenceTrigger._table_exists async function with exception and return False"""
     hook = BigQueryTableAsyncHook()
@@ -1019,7 +1018,7 @@ async def test_table_exists_exception(mock_get_table_client):
 
 
 @pytest.mark.asyncio
-@mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
+@async_mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryTableAsyncHook.get_table_client")
 async def test_table_exists_raise_exception(mock_get_table_client):
     """Test BigQueryTableExistenceTrigger._table_exists async function with raise exception"""
     hook = BigQueryTableAsyncHook()

--- a/tests/providers/google/cloud/triggers/test_cloud_build.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_build.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import sys
 
 import pytest
 from google.cloud.devtools.cloudbuild_v1 import CloudBuildAsyncClient
@@ -27,11 +26,7 @@ from google.cloud.devtools.cloudbuild_v1.types import Build, BuildStep
 from airflow.providers.google.cloud.hooks.cloud_build import CloudBuildAsyncHook
 from airflow.providers.google.cloud.triggers.cloud_build import CloudBuildCreateBuildTrigger
 from airflow.triggers.base import TriggerEvent
-
-if sys.version_info < (3, 8):
-    from asynctest import mock
-else:
-    from unittest import mock
+from tests.providers.google.cloud.utils.compat import async_mock
 
 CLOUD_BUILD_PATH = "airflow.providers.google.cloud.hooks.cloud_build.{}"
 TEST_PROJECT_ID = "cloud-build-project"
@@ -119,8 +114,8 @@ def test_async_create_build_trigger_serialization_should_execute_successfully():
 
 
 @pytest.mark.asyncio
-@mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
-@mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
+@async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
+@async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
 async def test_async_create_build_trigger_triggers_on_success_should_execute_successfully(
     mock_get_build, hook
 ):
@@ -156,8 +151,8 @@ async def test_async_create_build_trigger_triggers_on_success_should_execute_suc
 
 
 @pytest.mark.asyncio
-@mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
-@mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
+@async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
+@async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
 async def test_async_create_build_trigger_triggers_on_running_should_execute_successfully(
     mock_get_build, hook, caplog
 ):
@@ -191,8 +186,8 @@ async def test_async_create_build_trigger_triggers_on_running_should_execute_suc
 
 
 @pytest.mark.asyncio
-@mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
-@mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
+@async_mock.patch.object(CloudBuildAsyncClient, "__init__", lambda self: None)
+@async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncClient.get_build"))
 async def test_async_create_build_trigger_triggers_on_error_should_execute_successfully(
     mock_get_build, hook, caplog
 ):
@@ -219,7 +214,7 @@ async def test_async_create_build_trigger_triggers_on_error_should_execute_succe
 
 
 @pytest.mark.asyncio
-@mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook.get_cloud_build"))
+@async_mock.patch(CLOUD_BUILD_PATH.format("CloudBuildAsyncHook.get_cloud_build"))
 async def test_async_create_build_trigger_triggers_on_excp_should_execute_successfully(mock_build_inst):
     """
     Test that CloudBuildCreateBuildTrigger fires the correct event in case of an error.

--- a/tests/providers/google/cloud/utils/compat.py
+++ b/tests/providers/google/cloud/utils/compat.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+__all__ = ["async_mock", "AsyncMock"]
+
+import sys
+
+if sys.version_info < (3, 8):
+    # For compatibility with Python 3.7
+    from asynctest import mock as async_mock
+
+    # ``asynctest.mock.CoroutineMock`` which provide compatibility not working well with autospec=True
+    # as result "TypeError: object MagicMock can't be used in 'await' expression" could be raised.
+    # Best solution in this case provide as spec actual awaitable object
+    # >>> from tests.providers.google.cloud.utils.compat import AsyncMock
+    # >>> from foo.bar import SpamEgg
+    # >>> mock_something = AsyncMock(SpamEgg)
+    from asynctest.mock import CoroutineMock as AsyncMock
+else:
+    from unittest import mock as async_mock
+    from unittest.mock import AsyncMock


### PR DESCRIPTION
Some async tests not properly mocked return objects
- `tests/providers/google/cloud/hooks/test_cloud_composer.py`
- `tests/providers/google/cloud/hooks/test_dataproc.py`

Within `unittests.TestCase` it do actually nothing:
```console
 RuntimeWarning: coroutine 'FooBar.spam_egg' was never awaited method()
```

When this tests migrate to `pytest` it raises different errors.

This PR:
- Move compat (with python 3.7) mockers to separate module
- Migrate async tests to `pytest` and fix them