### PR TITLE
Migrate Google Cloud hooks test to `pytest`

### DIFF
--- a/tests/providers/google/cloud/hooks/test_automl.py
+++ b/tests/providers/google/cloud/hooks/test_automl.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -51,8 +50,8 @@ DATASET = {"dataset_id": "data"}
 MASK = {"field": "mask"}
 
 
-class TestAuoMLHook(unittest.TestCase):
-    def setUp(self) -> None:
+class TestAuoMLHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.automl.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_bigquery_dts.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery_dts.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from copy import deepcopy
 from unittest import mock
 
@@ -50,8 +49,8 @@ TRANSFER_CONFIG_ID = "id1234"
 RUN_ID = "id1234"
 
 
-class BigQueryDataTransferHookTestCase(unittest.TestCase):
-    def setUp(self) -> None:
+class TestBigQueryDataTransferHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.bigquery_dts.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_bigtable.py
+++ b/tests/providers/google/cloud/hooks/test_bigtable.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -50,8 +49,8 @@ CBT_REPLICATE_CLUSTERS = [
 ]
 
 
-class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestBigtableHookNoDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -146,8 +145,8 @@ class TestBigtableHookNoDefaultProjectId(unittest.TestCase):
         table_delete_method.assert_called_once_with()
 
 
-class TestBigtableHookDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestBigtableHookDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -322,15 +321,13 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         )
         cluster.assert_has_calls(
             [
-                unittest.mock.call(
+                mock.call(
                     cluster_id=CBT_CLUSTER,
                     location_id=CBT_ZONE,
                     serve_nodes=1,
                     default_storage_type=enums.StorageType.SSD,
                 ),
-                unittest.mock.call(
-                    CBT_REPLICA_CLUSTER_ID, CBT_REPLICA_CLUSTER_ZONE, 1, enums.StorageType.SSD
-                ),
+                mock.call(CBT_REPLICA_CLUSTER_ID, CBT_REPLICA_CLUSTER_ZONE, 1, enums.StorageType.SSD),
             ],
             any_order=True,
         )
@@ -365,12 +362,10 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         )
         cluster.assert_has_calls(
             [
-                unittest.mock.call(
+                mock.call(
                     cluster_id=CBT_CLUSTER, location_id=CBT_ZONE, default_storage_type=enums.StorageType.SSD
                 ),
-                unittest.mock.call(
-                    CBT_REPLICA_CLUSTER_ID, CBT_REPLICA_CLUSTER_ZONE, 1, enums.StorageType.SSD
-                ),
+                mock.call(CBT_REPLICA_CLUSTER_ID, CBT_REPLICA_CLUSTER_ZONE, 1, enums.StorageType.SSD),
             ],
             any_order=True,
         )
@@ -404,15 +399,15 @@ class TestBigtableHookDefaultProjectId(unittest.TestCase):
         )
         cluster.assert_has_calls(
             [
-                unittest.mock.call(
+                mock.call(
                     cluster_id=CBT_CLUSTER,
                     location_id=CBT_ZONE,
                     serve_nodes=1,
                     default_storage_type=enums.StorageType.SSD,
                 ),
-                unittest.mock.call("replica-1", "us-west1-a", 1, enums.StorageType.SSD),
-                unittest.mock.call("replica-2", "us-central1-f", 1, enums.StorageType.SSD),
-                unittest.mock.call("replica-3", "us-east1-d", 1, enums.StorageType.SSD),
+                mock.call("replica-1", "us-west1-a", 1, enums.StorageType.SSD),
+                mock.call("replica-2", "us-central1-f", 1, enums.StorageType.SSD),
+                mock.call("replica-3", "us-east1-d", 1, enums.StorageType.SSD),
             ],
             any_order=True,
         )

--- a/tests/providers/google/cloud/hooks/test_cloud_build.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_build.py
@@ -21,7 +21,6 @@ functions in CloudBuildHook
 """
 from __future__ import annotations
 
-import unittest
 from concurrent.futures import Future
 from unittest import mock
 
@@ -60,8 +59,8 @@ OPERATION = {"metadata": {"build": {"id": BUILD_ID}}}
 TRIGGER_ID = "32488e7f-09d6-4fe9-a5fb-4ca1419a6e7a"
 
 
-class TestCloudBuildHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudBuildHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_composer.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_composer.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -60,8 +59,8 @@ def mock_init(*args, **kwargs):
     pass
 
 
-class TestCloudComposerHook(unittest.TestCase):
-    def setUp(self) -> None:
+class TestCloudComposerHook:
+    def setup_method(self):
         with mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = CloudComposerHook(gcp_conn_id="test")
 
@@ -197,7 +196,7 @@ class TestCloudComposerHook(unittest.TestCase):
 
 
 class TestCloudComposerAsyncHook:
-    def setup_method(self, method) -> None:
+    def setup_method(self, method):
         with async_mock.patch(BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_init):
             self.hook = CloudComposerAsyncHook(gcp_conn_id="test")
 

--- a/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_memorystore.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 from unittest.mock import PropertyMock
 
 import pytest
@@ -57,8 +57,8 @@ TEST_NAME_DEFAULT_PROJECT_ID = (
 )
 
 
-class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestCloudMemorystoreWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.cloud_memorystore.CloudMemorystoreHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -227,8 +227,8 @@ class TestCloudMemorystoreWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestCloudMemorystoreWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.cloud_memorystore.CloudMemorystoreHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -455,8 +455,8 @@ class TestCloudMemorystoreWithoutDefaultProjectIdHook(TestCase):
             )
 
 
-class TestCloudMemorystoreMemcachedWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestCloudMemorystoreMemcachedWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.cloud_memorystore.CloudMemorystoreMemcachedHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -18,14 +18,12 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
 import httplib2
 import pytest
 from googleapiclient.errors import HttpError
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
@@ -36,8 +34,8 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 )
 
 
-class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGcpSqlHookDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -508,8 +506,8 @@ class TestGcpSqlHookDefaultProjectId(unittest.TestCase):
         )
 
 
-class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
-    def setUp(self):
+class TestGcpSqlHookNoDefaultProjectID:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -751,7 +749,7 @@ class TestGcpSqlHookNoDefaultProjectID(unittest.TestCase):
         )
 
 
-class TestCloudSqlDatabaseHook(unittest.TestCase):
+class TestCloudSqlDatabaseHook:
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_cloudsql_database_hook_validate_ssl_certs_no_ssl(self, get_connection):
         connection = Connection()
@@ -764,21 +762,22 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         )
         hook.validate_ssl_certs()
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "cert_dict",
         [
-            [{}],
-            [{"sslcert": "cert_file.pem"}],
-            [{"sslkey": "cert_key.pem"}],
-            [{"sslrootcert": "root_cert_file.pem"}],
-            [{"sslcert": "cert_file.pem", "sslkey": "cert_key.pem"}],
-            [{"sslrootcert": "root_cert_file.pem", "sslkey": "cert_key.pem"}],
-            [{"sslrootcert": "root_cert_file.pem", "sslcert": "cert_file.pem"}],
-        ]
+            {},
+            {"sslcert": "cert_file.pem"},
+            {"sslkey": "cert_key.pem"},
+            {"sslrootcert": "root_cert_file.pem"},
+            {"sslcert": "cert_file.pem", "sslkey": "cert_key.pem"},
+            {"sslrootcert": "root_cert_file.pem", "sslkey": "cert_key.pem"},
+            {"sslrootcert": "root_cert_file.pem", "sslcert": "cert_file.pem"},
+        ],
     )
     @mock.patch("os.path.isfile")
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
     def test_cloudsql_database_hook_validate_ssl_certs_missing_cert_params(
-        self, cert_dict, get_connection, mock_is_file
+        self, get_connection, mock_is_file, cert_dict
     ):
         mock_is_file.side_effects = True
         connection = Connection()
@@ -891,19 +890,20 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         )
         hook.validate_socket_path_length()
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "uri",
         [
-            ["http://:password@host:80/database"],
-            ["http://user:@host:80/database"],
-            ["http://user:password@/database"],
-            ["http://user:password@host:80/"],
-            ["http://user:password@/"],
-            ["http://host:80/database"],
-            ["http://host:80/"],
-        ]
+            "http://:password@host:80/database",
+            "http://user:@host:80/database",
+            "http://user:password@/database",
+            "http://user:password@host:80/",
+            "http://user:password@/",
+            "http://host:80/database",
+            "http://host:80/",
+        ],
     )
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
-    def test_cloudsql_database_hook_create_connection_missing_fields(self, uri, get_connection):
+    def test_cloudsql_database_hook_create_connection_missing_fields(self, get_connection, uri):
         connection = Connection(uri=uri)
         params = {
             "location": "test",
@@ -986,11 +986,9 @@ class TestCloudSqlDatabaseHook(unittest.TestCase):
         assert db_hook is not None
 
 
-class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
+class TestCloudSqlDatabaseQueryHook:
     @mock.patch("airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook.get_connection")
-    def setUp(self, m):
-        super().setUp()
-
+    def setup_method(self, method, mock_get_conn):
         self.sql_connection = Connection(
             conn_id="my_gcp_sql_connection",
             conn_type="gcpcloudsql",
@@ -1022,7 +1020,7 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
         conn_extra_json = json.dumps(conn_extra)
         self.connection.set_extra(conn_extra_json)
 
-        m.side_effect = [self.sql_connection, self.connection]
+        mock_get_conn.side_effect = [self.sql_connection, self.connection]
         self.db_hook = CloudSQLDatabaseHook(
             gcp_cloudsql_conn_id="my_gcp_sql_connection", gcp_conn_id="my_gcp_connection"
         )

--- a/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_storage_transfer_service.py
@@ -19,14 +19,12 @@ from __future__ import annotations
 
 import json
 import re
-import unittest
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 from googleapiclient.errors import HttpError
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
@@ -108,8 +106,8 @@ class GCPRequestMock:
     status = TEST_HTTP_ERR_CODE
 
 
-class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
-    def setUp(self):
+class TestGCPTransferServiceHookWithPassedName:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -157,17 +155,16 @@ class TestGCPTransferServiceHookWithPassedName(unittest.TestCase):
         assert res == TEST_RESULT_STATUS_ENABLED
 
 
-class TestJobNames(unittest.TestCase):
-    def setUp(self) -> None:
-        self.re_suffix = re.compile("^[0-9]{10}$")
+class TestJobNames:
+    re_suffix = re.compile("^[0-9]{10}$")
 
-    def test_new_suffix(self):
-        for job_name in ["jobNames/new_job", "jobNames/new_job_h", "jobNames/newJob"]:
-            assert self.re_suffix.match(gen_job_name(job_name).split("_")[-1]) is not None
+    @pytest.mark.parametrize("job_name", ["jobNames/new_job", "jobNames/new_job_h", "jobNames/newJob"])
+    def test_new_suffix(self, job_name):
+        assert self.re_suffix.match(gen_job_name(job_name).split("_")[-1]) is not None
 
 
-class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGCPTransferServiceHookWithPassedProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -474,7 +471,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
                 expected_statuses=GcpTransferOperationStatus.SUCCESS,
             )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "statuses, expected_statuses",
         [
             ([GcpTransferOperationStatus.ABORTED], (GcpTransferOperationStatus.IN_PROGRESS,)),
             (
@@ -494,7 +492,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
                 [GcpTransferOperationStatus.PAUSED, GcpTransferOperationStatus.ABORTED],
                 (GcpTransferOperationStatus.IN_PROGRESS,),
             ),
-        ]
+        ],
     )
     def test_operations_contain_expected_statuses_red_path(self, statuses, expected_statuses):
         operations = [{NAME: TEST_TRANSFER_OPERATION_NAME, METADATA: {STATUS: status}} for status in statuses]
@@ -507,7 +505,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
                 operations, GcpTransferOperationStatus.IN_PROGRESS
             )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "statuses, expected_statuses",
         [
             ([GcpTransferOperationStatus.ABORTED], GcpTransferOperationStatus.ABORTED),
             (
@@ -527,7 +526,7 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
                 [GcpTransferOperationStatus.PAUSED, GcpTransferOperationStatus.ABORTED],
                 (GcpTransferOperationStatus.ABORTED,),
             ),
-        ]
+        ],
     )
     def test_operations_contain_expected_statuses_green_path(self, statuses, expected_statuses):
         operations = [
@@ -542,8 +541,8 @@ class TestGCPTransferServiceHookWithPassedProjectId(unittest.TestCase):
         assert result
 
 
-class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
-    def setUp(self):
+class TestGCPTransferServiceHookWithProjectIdFromConnection:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -743,8 +742,8 @@ class TestGCPTransferServiceHookWithProjectIdFromConnection(unittest.TestCase):
         return body
 
 
-class TestGCPTransferServiceHookWithoutProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGCPTransferServiceHookWithoutProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_compute.py
+++ b/tests/providers/google/cloud/hooks/test_compute.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -55,8 +54,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 COMPUTE_ENGINE_HOOK_PATH = "airflow.providers.google.cloud.hooks.compute.{}"
 
 
-class TestGcpComputeHookApiCall(unittest.TestCase):
-    def setUp(self):
+class TestGcpComputeHookApiCall:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),
             new=mock_base_gcp_hook_default_project_id,
@@ -504,8 +503,8 @@ class TestGcpComputeHookApiCall(unittest.TestCase):
         )
 
 
-class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGcpComputeHookNoDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -612,8 +611,8 @@ class TestGcpComputeHookNoDefaultProjectId(unittest.TestCase):
         )
 
 
-class TestGcpComputeHookDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGcpComputeHookDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_compute_ssh.py
+++ b/tests/providers/google/cloud/hooks/test_compute_ssh.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 from airflow.models import Connection
@@ -33,7 +32,7 @@ TEST_PUB_KEY = "root:NAME AYZ root"
 TEST_PUB_KEY2 = "root:NAME MNJ root"
 
 
-class TestComputeEngineHookWithPassedProjectId(unittest.TestCase):
+class TestComputeEngineHookWithPassedProjectId:
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.OSLoginHook")
     @mock.patch("airflow.providers.google.cloud.hooks.compute_ssh.paramiko")

--- a/tests/providers/google/cloud/hooks/test_datacatalog.py
+++ b/tests/providers/google/cloud/hooks/test_datacatalog.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import re
 from copy import deepcopy
 from typing import Sequence
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 from google.api_core.gapic_v1.method import _MethodDefault
@@ -82,8 +82,8 @@ TEST_PROJECT_ID_2 = "example-project-2"
 TEST_CREDENTIALS = mock.MagicMock()
 
 
-class TestCloudDataCatalog(TestCase):
-    def setUp(self) -> None:
+class TestCloudDataCatalog:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.datacatalog.CloudDataCatalogHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -161,8 +161,8 @@ class TestCloudDataCatalog(TestCase):
         )
 
 
-class TestCloudDataCatalogWithDefaultProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestCloudDataCatalogWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.datacatalog.CloudDataCatalogHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -690,8 +690,8 @@ class TestCloudDataCatalogWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestCloudDataCatalogWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestCloudDataCatalogWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.datacatalog.CloudDataCatalogHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -1226,8 +1226,8 @@ TEST_MESSAGE = re.escape(
 )
 
 
-class TestCloudDataCatalogMissingProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestCloudDataCatalogMissingProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.datacatalog.CloudDataCatalogHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -18,15 +18,14 @@
 from __future__ import annotations
 
 import copy
+import re
 import shlex
-import unittest
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.apache.beam.hooks.beam import BeamCommandRunner, BeamHook
@@ -119,7 +118,7 @@ TEST_SQL_JOB_ID = "test-job-id"
 DEFAULT_CANCEL_TIMEOUT = 5 * 60
 
 
-class TestFallbackToVariables(unittest.TestCase):
+class TestFallbackToVariables:
     def test_support_project_id_parameter(self):
         mock_instance = mock.MagicMock()
 
@@ -173,8 +172,8 @@ class TestFallbackToVariables(unittest.TestCase):
             FixtureFallback().test_fn({"project": "TEST"}, "TEST2")
 
 
-class TestDataflowHook(unittest.TestCase):
-    def setUp(self):
+class TestDataflowHook:
+    def setup_method(self):
         self.dataflow_hook = DataflowHook(gcp_conn_id="google_cloud_default")
         self.dataflow_hook.beam_hook = MagicMock()
 
@@ -197,7 +196,7 @@ class TestDataflowHook(unittest.TestCase):
         py_requirements = ["pandas", "numpy"]
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -242,7 +241,7 @@ class TestDataflowHook(unittest.TestCase):
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
         passed_variables["region"] = TEST_LOCATION
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -286,7 +285,7 @@ class TestDataflowHook(unittest.TestCase):
 
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -332,7 +331,7 @@ class TestDataflowHook(unittest.TestCase):
         passed_variables = copy.deepcopy(DATAFLOW_VARIABLES_PY)
         passed_variables["extra-package"] = ["a.whl", "b.whl"]
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -363,26 +362,19 @@ class TestDataflowHook(unittest.TestCase):
             job_id=mock.ANY, job_name=job_name, location=DEFAULT_DATAFLOW_LOCATION
         )
 
-    @parameterized.expand(
-        [
-            ("python3",),
-            ("python2",),
-            ("python3",),
-            ("python3.6",),
-        ]
-    )
+    @pytest.mark.parametrize("py_interpreter", ["python3", "python2", "python3.6"])
     @mock.patch(DATAFLOW_STRING.format("uuid.uuid4"))
     @mock.patch(DATAFLOW_STRING.format("DataflowHook.wait_for_done"))
     @mock.patch(DATAFLOW_STRING.format("process_line_and_extract_dataflow_job_id_callback"))
     def test_start_python_dataflow_with_custom_interpreter(
-        self, py_interpreter, mock_callback_on_job_id, mock_dataflow_wait_for_done, mock_uuid
+        self, mock_callback_on_job_id, mock_dataflow_wait_for_done, mock_uuid, py_interpreter
     ):
         mock_beam_start_python_pipeline = self.dataflow_hook.beam_hook.start_python_pipeline
         mock_uuid.return_value = MOCK_UUID
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -412,30 +404,31 @@ class TestDataflowHook(unittest.TestCase):
             job_id=mock.ANY, job_name=job_name, location=DEFAULT_DATAFLOW_LOCATION
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "current_py_requirements, current_py_system_site_packages",
         [
             (["foo-bar"], False),
             (["foo-bar"], True),
             ([], True),
-        ]
+        ],
     )
     @mock.patch(DATAFLOW_STRING.format("uuid.uuid4"))
     @mock.patch(DATAFLOW_STRING.format("DataflowHook.wait_for_done"))
     @mock.patch(DATAFLOW_STRING.format("process_line_and_extract_dataflow_job_id_callback"))
     def test_start_python_dataflow_with_non_empty_py_requirements_and_without_system_packages(
         self,
-        current_py_requirements,
-        current_py_system_site_packages,
         mock_callback_on_job_id,
         mock_dataflow_wait_for_done,
         mock_uuid,
+        current_py_requirements,
+        current_py_system_site_packages,
     ):
         mock_beam_start_python_pipeline = self.dataflow_hook.beam_hook.start_python_pipeline
         mock_uuid.return_value = MOCK_UUID
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_python_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_PY,
@@ -474,19 +467,17 @@ class TestDataflowHook(unittest.TestCase):
         self.dataflow_hook.beam_hook = BeamHook(runner="DataflowRunner")
         mock_uuid.return_value = MOCK_UUID
         on_new_job_id_callback = MagicMock()
-
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"), self.assertRaisesRegex(
-            AirflowException, "Invalid method invocation."
-        ):
-            self.dataflow_hook.start_python_dataflow(
-                job_name=JOB_NAME,
-                variables=DATAFLOW_VARIABLES_PY,
-                dataflow=PY_FILE,
-                py_options=PY_OPTIONS,
-                py_interpreter=DEFAULT_PY_INTERPRETER,
-                py_requirements=[],
-                on_new_job_id_callback=on_new_job_id_callback,
-            )
+        with pytest.raises(AirflowException, match=r"Invalid method invocation\."):
+            with pytest.warns(DeprecationWarning, match="This method is deprecated"):
+                self.dataflow_hook.start_python_dataflow(
+                    job_name=JOB_NAME,
+                    variables=DATAFLOW_VARIABLES_PY,
+                    dataflow=PY_FILE,
+                    py_options=PY_OPTIONS,
+                    py_interpreter=DEFAULT_PY_INTERPRETER,
+                    py_requirements=[],
+                    on_new_job_id_callback=on_new_job_id_callback,
+                )
 
         mock_dataflow_wait_for_done.assert_not_called()
 
@@ -499,7 +490,7 @@ class TestDataflowHook(unittest.TestCase):
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_JAVA,
@@ -539,7 +530,7 @@ class TestDataflowHook(unittest.TestCase):
         passed_variables: dict[str, Any] = copy.deepcopy(DATAFLOW_VARIABLES_JAVA)
         passed_variables["mock-option"] = ["a.whl", "b.whl"]
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -579,7 +570,7 @@ class TestDataflowHook(unittest.TestCase):
         passed_variables: dict[str, Any] = copy.deepcopy(DATAFLOW_VARIABLES_JAVA)
         passed_variables["region"] = TEST_LOCATION
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=passed_variables,
@@ -616,7 +607,7 @@ class TestDataflowHook(unittest.TestCase):
         on_new_job_id_callback = MagicMock()
         job_name = f"{JOB_NAME}-{MOCK_UUID_PREFIX}"
 
-        with self.assertWarnsRegex(DeprecationWarning, "This method is deprecated"):
+        with pytest.warns(DeprecationWarning, match="This method is deprecated"):
             self.dataflow_hook.start_java_dataflow(
                 job_name=JOB_NAME,
                 variables=DATAFLOW_VARIABLES_JAVA,
@@ -643,7 +634,8 @@ class TestDataflowHook(unittest.TestCase):
             job_id=mock.ANY, job_name=job_name, location=TEST_LOCATION, multiple_jobs=False
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "expected_result, job_name, append_job_name",
         [
             (JOB_NAME, JOB_NAME, False),
             ("test-example", "test_example", False),
@@ -653,24 +645,20 @@ class TestDataflowHook(unittest.TestCase):
             ("df-job", "df-job", False),
             ("dfjob", "dfjob", False),
             ("dfjob1", "dfjob1", False),
-        ]
+        ],
     )
     @mock.patch(DATAFLOW_STRING.format("uuid.uuid4"), return_value=MOCK_UUID)
-    def test_valid_dataflow_job_name(self, expected_result, job_name, append_job_name, mock_uuid4):
-        job_name = self.dataflow_hook.build_dataflow_job_name(
-            job_name=job_name, append_job_name=append_job_name
+    def test_valid_dataflow_job_name(self, _, expected_result, job_name, append_job_name):
+        assert (
+            self.dataflow_hook.build_dataflow_job_name(job_name=job_name, append_job_name=append_job_name)
+            == expected_result
         )
 
-        self.assertEqual(expected_result, job_name)
-
-    #
-    @parameterized.expand([("1dfjob@",), ("dfjob@",), ("df^jo",)])
+    @pytest.mark.parametrize("job_name", ["1dfjob@", "dfjob@", "df^jo"])
     def test_build_dataflow_job_name_with_invalid_value(self, job_name):
-        self.assertRaises(
-            ValueError, self.dataflow_hook.build_dataflow_job_name, job_name=job_name, append_job_name=False
-        )
+        with pytest.raises(ValueError, match=rf"Invalid job_name \({re.escape(job_name)}\);"):
+            self.dataflow_hook.build_dataflow_job_name(job_name=job_name, append_job_name=False)
 
-    #
     @mock.patch(DATAFLOW_STRING.format("_DataflowJobsController"))
     @mock.patch(DATAFLOW_STRING.format("DataflowHook.get_conn"))
     def test_get_job(self, mock_conn, mock_dataflowjob):
@@ -685,7 +673,6 @@ class TestDataflowHook(unittest.TestCase):
         )
         method_fetch_job_by_id.assert_called_once_with(TEST_JOB_ID)
 
-    #
     @mock.patch(DATAFLOW_STRING.format("_DataflowJobsController"))
     @mock.patch(DATAFLOW_STRING.format("DataflowHook.get_conn"))
     def test_fetch_job_metrics_by_id(self, mock_conn, mock_dataflowjob):
@@ -780,8 +767,8 @@ class TestDataflowHook(unittest.TestCase):
         method_wait_for_done.assert_called_once_with()
 
 
-class TestDataflowTemplateHook(unittest.TestCase):
-    def setUp(self):
+class TestDataflowTemplateHook:
+    def setup_method(self):
         self.dataflow_hook = DataflowHook(gcp_conn_id="google_cloud_default")
 
     @mock.patch(DATAFLOW_STRING.format("uuid.uuid4"), return_value=MOCK_UUID)
@@ -1127,8 +1114,8 @@ class TestDataflowTemplateHook(unittest.TestCase):
             )
 
 
-class TestDataflowJob(unittest.TestCase):
-    def setUp(self):
+class TestDataflowJob:
+    def setup_method(self):
         self.mock_dataflow = MagicMock()
 
     def test_dataflow_job_init_with_job_id(self):
@@ -1206,7 +1193,8 @@ class TestDataflowJob(unittest.TestCase):
 
         assert dataflow_job.get_jobs() == [job, job]
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "state, exception_regex",
         [
             (DataflowJobStatus.JOB_STATE_FAILED, "Google Cloud Dataflow job name-2 has failed\\."),
             (DataflowJobStatus.JOB_STATE_CANCELLED, "Google Cloud Dataflow job name-2 was cancelled\\."),
@@ -1216,7 +1204,7 @@ class TestDataflowJob(unittest.TestCase):
                 DataflowJobStatus.JOB_STATE_UNKNOWN,
                 "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN",
             ),
-        ]
+        ],
     )
     def test_dataflow_job_wait_for_multiple_jobs_and_one_in_terminal_state(self, state, exception_regex):
         # fmt: off
@@ -1373,24 +1361,25 @@ class TestDataflowJob(unittest.TestCase):
 
         assert result is False
 
-    # fmt: off
-    @parameterized.expand([
-        # RUNNING
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, None, False),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, None, True),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, True, False),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, True, False),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, False, True),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, False, True),
-        # AWAITING STATE
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, None, False),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, None, False),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, True, False),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, True, False),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, False, True),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, False, True),
-    ])
-    # fmt: on
+    @pytest.mark.parametrize(
+        "job_type, job_state, wait_until_finished, expected_result",
+        [
+            # RUNNING
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, None, False),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, None, True),
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, True, False),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, True, False),
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_RUNNING, False, True),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_RUNNING, False, True),
+            # AWAITING STATE
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, None, False),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, None, False),
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, True, False),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, True, False),
+            (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_PENDING, False, True),
+            (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_PENDING, False, True),
+        ],
+    )
     def test_check_dataflow_job_state_wait_until_finished(
         self, job_type, job_state, wait_until_finished, expected_result
     ):
@@ -1409,18 +1398,19 @@ class TestDataflowJob(unittest.TestCase):
         result = dataflow_job._check_dataflow_job_state(job)
         assert result == expected_result
 
-    # fmt: off
-    @parameterized.expand([
-        # RUNNING
-        (DataflowJobStatus.JOB_STATE_RUNNING, None, False),
-        (DataflowJobStatus.JOB_STATE_RUNNING, True, False),
-        (DataflowJobStatus.JOB_STATE_RUNNING, False, True),
-        # AWAITING STATE
-        (DataflowJobStatus.JOB_STATE_PENDING, None, False),
-        (DataflowJobStatus.JOB_STATE_PENDING, True, False),
-        (DataflowJobStatus.JOB_STATE_PENDING, False, True),
-    ])
-    # fmt: on
+    @pytest.mark.parametrize(
+        "job_state, wait_until_finished, expected_result",
+        [
+            # RUNNING
+            (DataflowJobStatus.JOB_STATE_RUNNING, None, False),
+            (DataflowJobStatus.JOB_STATE_RUNNING, True, False),
+            (DataflowJobStatus.JOB_STATE_RUNNING, False, True),
+            # AWAITING STATE
+            (DataflowJobStatus.JOB_STATE_PENDING, None, False),
+            (DataflowJobStatus.JOB_STATE_PENDING, True, False),
+            (DataflowJobStatus.JOB_STATE_PENDING, False, True),
+        ],
+    )
     def test_check_dataflow_job_state_without_job_type(self, job_state, wait_until_finished, expected_result):
         job = {"id": "id-2", "name": "name-2", "currentState": job_state}
         dataflow_job = _DataflowJobsController(
@@ -1437,30 +1427,61 @@ class TestDataflowJob(unittest.TestCase):
         result = dataflow_job._check_dataflow_job_state(job)
         assert result == expected_result
 
-    # fmt: off
-    @parameterized.expand([
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_FAILED,
-            "Google Cloud Dataflow job name-2 has failed\\."),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_FAILED,
-         "Google Cloud Dataflow job name-2 has failed\\."),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_UNKNOWN,
-         "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN"),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_UNKNOWN,
-         "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN"),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_CANCELLED,
-            "Google Cloud Dataflow job name-2 was cancelled\\."),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_CANCELLED,
-         "Google Cloud Dataflow job name-2 was cancelled\\."),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_DRAINED,
-            "Google Cloud Dataflow job name-2 was drained\\."),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_DRAINED,
-         "Google Cloud Dataflow job name-2 was drained\\."),
-        (DataflowJobType.JOB_TYPE_BATCH, DataflowJobStatus.JOB_STATE_UPDATED,
-            "Google Cloud Dataflow job name-2 was updated\\."),
-        (DataflowJobType.JOB_TYPE_STREAMING, DataflowJobStatus.JOB_STATE_UPDATED,
-         "Google Cloud Dataflow job name-2 was updated\\."),
-    ])
-    # fmt: on
+    @pytest.mark.parametrize(
+        "job_type, job_state, exception_regex",
+        [
+            (
+                DataflowJobType.JOB_TYPE_BATCH,
+                DataflowJobStatus.JOB_STATE_FAILED,
+                "Google Cloud Dataflow job name-2 has failed\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_STREAMING,
+                DataflowJobStatus.JOB_STATE_FAILED,
+                "Google Cloud Dataflow job name-2 has failed\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_STREAMING,
+                DataflowJobStatus.JOB_STATE_UNKNOWN,
+                "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_BATCH,
+                DataflowJobStatus.JOB_STATE_UNKNOWN,
+                "Google Cloud Dataflow job name-2 was unknown state: JOB_STATE_UNKNOWN",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_BATCH,
+                DataflowJobStatus.JOB_STATE_CANCELLED,
+                "Google Cloud Dataflow job name-2 was cancelled\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_STREAMING,
+                DataflowJobStatus.JOB_STATE_CANCELLED,
+                "Google Cloud Dataflow job name-2 was cancelled\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_BATCH,
+                DataflowJobStatus.JOB_STATE_DRAINED,
+                "Google Cloud Dataflow job name-2 was drained\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_STREAMING,
+                DataflowJobStatus.JOB_STATE_DRAINED,
+                "Google Cloud Dataflow job name-2 was drained\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_BATCH,
+                DataflowJobStatus.JOB_STATE_UPDATED,
+                "Google Cloud Dataflow job name-2 was updated\\.",
+            ),
+            (
+                DataflowJobType.JOB_TYPE_STREAMING,
+                DataflowJobStatus.JOB_STATE_UPDATED,
+                "Google Cloud Dataflow job name-2 was updated\\.",
+            ),
+        ],
+    )
     def test_check_dataflow_job_state_terminal_state(self, job_type, job_state, exception_regex):
         job = {"id": "id-2", "name": "name-2", "type": job_type, "currentState": job_state}
         dataflow_job = _DataflowJobsController(
@@ -1558,13 +1579,14 @@ class TestDataflowJob(unittest.TestCase):
             seconds=10, error_message="Canceling jobs failed due to timeout (10s): test-job-id"
         )
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "drain_pipeline, job_type, requested_state",
         [
             (False, "JOB_TYPE_BATCH", "JOB_STATE_CANCELLED"),
             (False, "JOB_TYPE_STREAMING", "JOB_STATE_CANCELLED"),
             (True, "JOB_TYPE_BATCH", "JOB_STATE_CANCELLED"),
             (True, "JOB_TYPE_STREAMING", "JOB_STATE_DRAINED"),
-        ]
+        ],
     )
     def test_dataflow_job_cancel_or_drain_job(self, drain_pipeline, job_type, requested_state):
         job = {
@@ -1798,15 +1820,15 @@ navigate to https://console.cloud.google.com/dataflow/jobs/us-central1/{TEST_JOB
 """
 
 
-class TestDataflow(unittest.TestCase):
-    @parameterized.expand(
+class TestDataflow:
+    @pytest.mark.parametrize(
+        "log",
         [
-            (APACHE_BEAM_V_2_14_0_JAVA_SDK_LOG,),
-            (APACHE_BEAM_V_2_22_0_JAVA_SDK_LOG,),
-            (APACHE_BEAM_V_2_14_0_PYTHON_SDK_LOG,),
-            (APACHE_BEAM_V_2_22_0_PYTHON_SDK_LOG,),
+            pytest.param(APACHE_BEAM_V_2_14_0_JAVA_SDK_LOG, id="apache-beam-2.14.0-JDK"),
+            pytest.param(APACHE_BEAM_V_2_22_0_JAVA_SDK_LOG, id="apache-beam-2.22.0-JDK"),
+            pytest.param(APACHE_BEAM_V_2_14_0_PYTHON_SDK_LOG, id="apache-beam-2.14.0-Python"),
+            pytest.param(APACHE_BEAM_V_2_22_0_PYTHON_SDK_LOG, id="apache-beam-2.22.0-Python"),
         ],
-        name_func=lambda func, num, p: f"{func.__name__}_{num}",
     )
     def test_data_flow_valid_job_id(self, log):
         echos = ";".join(f"echo {shlex.quote(line)}" for line in log.split("\n"))
@@ -1820,7 +1842,7 @@ class TestDataflow(unittest.TestCase):
         BeamCommandRunner(
             cmd, process_line_callback=process_line_and_extract_dataflow_job_id_callback(callback)
         ).wait_for_done()
-        self.assertEqual(found_job_id, TEST_JOB_ID)
+        assert found_job_id == TEST_JOB_ID
 
     def test_data_flow_missing_job_id(self):
         cmd = ["echo", "unit testing"]
@@ -1833,8 +1855,7 @@ class TestDataflow(unittest.TestCase):
         BeamCommandRunner(
             cmd, process_line_callback=process_line_and_extract_dataflow_job_id_callback(callback)
         ).wait_for_done()
-
-        self.assertEqual(found_job_id, None)
+        assert found_job_id is None
 
     @mock.patch("airflow.providers.apache.beam.hooks.beam.BeamCommandRunner.log")
     @mock.patch("subprocess.Popen")
@@ -1859,4 +1880,5 @@ class TestDataflow(unittest.TestCase):
         mock_popen.return_value = mock_proc
         dataflow = BeamCommandRunner(["test", "cmd"])
         mock_logging.info.assert_called_once_with("Running command: %s", "test cmd")
-        self.assertRaises(Exception, dataflow.wait_for_done)
+        with pytest.raises(Exception):
+            dataflow.wait_for_done()

--- a/tests/providers/google/cloud/hooks/test_dataform.py
+++ b/tests/providers/google/cloud/hooks/test_dataform.py
@@ -16,7 +16,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -53,8 +52,8 @@ FILEPATH = "path/to/file.txt"
 FILE_CONTENTS = b"test content"
 
 
-class TestDataflowHook(unittest.TestCase):
-    def setUp(self):
+class TestDataflowHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_dataplex.py
+++ b/tests/providers/google/cloud/hooks/test_dataplex.py
@@ -16,7 +16,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -37,8 +37,8 @@ DELEGATE_TO = "test-delegate-to"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 
-class TestDataplexHook(TestCase):
-    def setUp(self):
+class TestDataplexHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"),
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_dataprep.py
+++ b/tests/providers/google/cloud/hooks/test_dataprep.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 import os
-from unittest import TestCase, mock
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -40,7 +40,7 @@ URL = "https://api.clouddataprep.com/v4/jobGroups"
 
 
 class TestGoogleDataprepHook:
-    def setup(self):
+    def setup_method(self):
         with mock.patch("airflow.hooks.base.BaseHook.get_connection") as conn:
             conn.return_value.extra_dejson = EXTRA
             self.hook = GoogleDataprepHook(dataprep_conn_id="dataprep_default")
@@ -273,10 +273,10 @@ class TestGoogleDataprepHook:
             assert hook._base_url == "abc"
 
 
-class TestGoogleDataprepFlowPathHooks(TestCase):
+class TestGoogleDataprepFlowPathHooks:
     _url = "https://api.clouddataprep.com/v4/flows"
 
-    def setUp(self) -> None:
+    def setup_method(self):
         self._flow_id = 1234567
         self._expected_copy_flow_hook_data = json.dumps(
             {

--- a/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -59,8 +59,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 DATAPROC_METASTORE_STRING = "airflow.providers.google.cloud.hooks.dataproc_metastore.{}"
 
 
-class TestDataprocMetastoreWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestDataprocMetastoreWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -293,8 +293,8 @@ class TestDataprocMetastoreWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestDataprocMetastoreWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestDataprocMetastoreWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/test_datastore.py
+++ b/tests/providers/google/cloud/hooks/test_datastore.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import call, patch
 
@@ -38,8 +37,8 @@ def mock_init(
     pass
 
 
-class TestDatastoreHook(unittest.TestCase):
-    def setUp(self):
+class TestDatastoreHook:
+    def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__", new=mock_init
         ):

--- a/tests/providers/google/cloud/hooks/test_dlp.py
+++ b/tests/providers/google/cloud/hooks/test_dlp.py
@@ -21,7 +21,6 @@ functions in CloudDLPHook
 """
 from __future__ import annotations
 
-import unittest
 from typing import Any
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -54,8 +53,8 @@ STORED_INFO_TYPE_PROJECT_PATH = f"projects/{PROJECT_ID}/storedInfoTypes/{STORED_
 JOB_TRIGGER_PATH = f"projects/{PROJECT_ID}/jobTriggers/{TRIGGER_ID}"
 
 
-class TestCloudDLPHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudDLPHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_functions.py
+++ b/tests/providers/google/cloud/hooks/test_functions.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -36,8 +35,8 @@ GCF_LOCATION = "location"
 GCF_FUNCTION = "function"
 
 
-class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestFunctionHookNoDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -100,8 +99,8 @@ class TestFunctionHookNoDefaultProjectId(unittest.TestCase):
             )
 
 
-class TestFunctionHookDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestFunctionHookDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_gdm.py
+++ b/tests/providers/google/cloud/hooks/test_gdm.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -39,8 +38,8 @@ TEST_PROJECT = "my-project"
 TEST_DEPLOYMENT = "my-deployment"
 
 
-class TestDeploymentManagerHook(unittest.TestCase):
-    def setUp(self):
+class TestDeploymentManagerHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_init,

--- a/tests/providers/google/cloud/hooks/test_kms.py
+++ b/tests/providers/google/cloud/hooks/test_kms.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from base64 import b64decode, b64encode
 from collections import namedtuple
 from unittest import mock
@@ -57,8 +56,8 @@ def mock_init(
     pass
 
 
-class TestCloudKMSHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudKMSHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_init,

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -36,8 +35,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 GKE_STRING = "airflow.providers.google.cloud.hooks.kubernetes_engine.{}"
 
 
-class TestGKEHookClient(unittest.TestCase):
-    def setUp(self):
+class TestGKEHookClient:
+    def setup_method(self):
         self.gke_hook = GKEHook(location=GKE_ZONE)
 
     @mock.patch(GKE_STRING.format("GKEHook.get_credentials"))
@@ -50,8 +49,8 @@ class TestGKEHookClient(unittest.TestCase):
         assert self.gke_hook._client == result
 
 
-class TestGKEHookDelete(unittest.TestCase):
-    def setUp(self):
+class TestGKEHookDelete:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -103,8 +102,8 @@ class TestGKEHookDelete(unittest.TestCase):
             wait_mock.assert_not_called()
 
 
-class TestGKEHookCreate(unittest.TestCase):
-    def setUp(self):
+class TestGKEHookCreate:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -176,8 +175,8 @@ class TestGKEHookCreate(unittest.TestCase):
         log_mock.info.assert_any_call("Assuming Success: %s", message)
 
 
-class TestGKEHookGet(unittest.TestCase):
-    def setUp(self):
+class TestGKEHookGet:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -200,8 +199,8 @@ class TestGKEHookGet(unittest.TestCase):
         )
 
 
-class TestGKEHook(unittest.TestCase):
-    def setUp(self):
+class TestGKEHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/test_life_sciences.py
+++ b/tests/providers/google/cloud/hooks/test_life_sciences.py
@@ -20,7 +20,6 @@ Tests for Google Cloud Life Sciences Hook
 """
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -48,8 +47,8 @@ TEST_PROJECT_ID = "life-science-project-id"
 TEST_LOCATION = "test-location"
 
 
-class TestLifeSciencesHookWithPassedProjectId(unittest.TestCase):
-    def setUp(self):
+class TestLifeSciencesHookWithPassedProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -159,8 +158,8 @@ class TestLifeSciencesHookWithPassedProjectId(unittest.TestCase):
             self.hook.run_pipeline(body={}, location=TEST_LOCATION, project_id=TEST_PROJECT_ID)
 
 
-class TestLifeSciencesHookWithDefaultProjectIdFromConnection(unittest.TestCase):
-    def setUp(self):
+class TestLifeSciencesHookWithDefaultProjectIdFromConnection:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -265,8 +264,8 @@ class TestLifeSciencesHookWithDefaultProjectIdFromConnection(unittest.TestCase):
             self.hook.run_pipeline(body={}, location=TEST_LOCATION)
 
 
-class TestLifeSciencesHookWithoutProjectId(unittest.TestCase):
-    def setUp(self):
+class TestLifeSciencesHookWithoutProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_looker.py
+++ b/tests/providers/google/cloud/hooks/test_looker.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -37,8 +36,8 @@ SOURCE = f"airflow:{version}"
 CONN_EXTRA = {"verify_ssl": "true", "timeout": "120"}
 
 
-class TestLookerHook(unittest.TestCase):
-    def setUp(self):
+class TestLookerHook:
+    def setup_method(self):
         with mock.patch("airflow.hooks.base.BaseHook.get_connection") as conn:
             conn.return_value.extra_dejson = CONN_EXTRA
             self.hook = LookerHook(looker_conn_id="test")

--- a/tests/providers/google/cloud/hooks/test_mlengine.py
+++ b/tests/providers/google/cloud/hooks/test_mlengine.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import PropertyMock
@@ -33,9 +32,8 @@ from tests.providers.google.cloud.utils.base_gcp_mock import (
 )
 
 
-class TestMLEngineHook(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
+class TestMLEngineHook:
+    def setup_method(self):
         self.hook = hook.MLEngineHook()
 
     @mock.patch("airflow.providers.google.cloud.hooks.mlengine.MLEngineHook._authorize")
@@ -849,9 +847,8 @@ class TestMLEngineHook(unittest.TestCase):
         )
 
 
-class TestMLEngineHookWithDefaultProjectId(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
+class TestMLEngineHookWithDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.mlengine.MLEngineHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_natural_language.py
+++ b/tests/providers/google/cloud/hooks/test_natural_language.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from typing import Any
 from unittest import mock
 
@@ -35,8 +34,8 @@ DOCUMENT = Document(
 ENCODING_TYPE = "UTF32"
 
 
-class TestCloudNaturalLanguageHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudNaturalLanguageHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_os_login.py
+++ b/tests/providers/google/cloud/hooks/test_os_login.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import re
 from typing import Sequence
-from unittest import TestCase, mock
+from unittest import mock
 
 import pytest
 from google.api_core.gapic_v1.method import _MethodDefault
@@ -45,8 +45,8 @@ TEST_METADATA: Sequence[tuple[str, str]] = ()
 TEST_PARENT: str = "users/test-user"
 
 
-class TestOSLoginHook(TestCase):
-    def setUp(self) -> None:
+class TestOSLoginHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.os_login.OSLoginHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -79,8 +79,8 @@ class TestOSLoginHook(TestCase):
         )
 
 
-class TestOSLoginHookWithDefaultProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestOSLoginHookWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.os_login.OSLoginHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -113,8 +113,8 @@ class TestOSLoginHookWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestOSLoginHookWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestOSLoginHookWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.os_login.OSLoginHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,
@@ -149,8 +149,8 @@ TEST_MESSAGE = re.escape(
 )
 
 
-class TestOSLoginHookMissingProjectIdHook(TestCase):
-    def setUp(self) -> None:
+class TestOSLoginHookMissingProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.os_login.OSLoginHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_secret_manager.py
+++ b/tests/providers/google/cloud/hooks/test_secret_manager.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import MagicMock, patch
 
 from google.api_core.exceptions import NotFound
@@ -34,7 +33,7 @@ SECRETS_HOOK_PACKAGE = "airflow.providers.google.cloud.hooks.secret_manager."
 INTERNAL_CLIENT_PACKAGE = "airflow.providers.google.cloud._internal_client.secret_manager_client"
 
 
-class TestSecretsManagerHook(unittest.TestCase):
+class TestSecretsManagerHook:
     @patch(INTERNAL_CLIENT_PACKAGE + "._SecretManagerClient.client", return_value=MagicMock())
     @patch(
         SECRETS_HOOK_PACKAGE + "SecretsManagerHook.get_credentials_and_project_id",

--- a/tests/providers/google/cloud/hooks/test_spanner.py
+++ b/tests/providers/google/cloud/hooks/test_spanner.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 from unittest.mock import PropertyMock
 
@@ -34,8 +33,8 @@ SPANNER_CONFIGURATION = "configuration"
 SPANNER_DATABASE = "database-name"
 
 
-class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
-    def setUp(self):
+class TestGcpSpannerHookDefaultProjectId:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -427,8 +426,8 @@ class TestGcpSpannerHookDefaultProjectId(unittest.TestCase):
         assert res is None
 
 
-class TestGcpSpannerHookNoDefaultProjectID(unittest.TestCase):
-    def setUp(self):
+class TestGcpSpannerHookNoDefaultProjectID:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_speech_to_text.py
+++ b/tests/providers/google/cloud/hooks/test_speech_to_text.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -31,8 +30,8 @@ CONFIG = {"encryption": "LINEAR16"}
 AUDIO = {"uri": "gs://bucket/object"}
 
 
-class TestTextToSpeechOperator(unittest.TestCase):
-    def setUp(self):
+class TestTextToSpeechOperator:
+    def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_stackdriver.py
+++ b/tests/providers/google/cloud/hooks/test_stackdriver.py
@@ -18,7 +18,6 @@
 from __future__ import annotations
 
 import json
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -81,7 +80,7 @@ TEST_NOTIFICATION_CHANNEL_2 = {
 }
 
 
-class TestStackdriverHookMethods(unittest.TestCase):
+class TestStackdriverHookMethods:
     @mock.patch(
         "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.get_credentials_and_project_id",
         return_value=(CREDENTIALS, PROJECT_ID),

--- a/tests/providers/google/cloud/hooks/test_tasks.py
+++ b/tests/providers/google/cloud/hooks/test_tasks.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from typing import Any
 from unittest import mock
 
@@ -47,8 +46,8 @@ def mock_patch_return_object(attribute: str, return_value: Any) -> object:
     return obj
 
 
-class TestCloudTasksHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudTasksHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_no_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_text_to_speech.py
+++ b/tests/providers/google/cloud/hooks/test_text_to_speech.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest.mock import patch
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -31,8 +30,8 @@ VOICE = {"language_code": "en-US", "ssml_gender": "FEMALE"}
 AUDIO_CONFIG = {"audio_encoding": "MP3"}
 
 
-class TestTextToSpeechHook(unittest.TestCase):
-    def setUp(self):
+class TestTextToSpeechHook:
+    def setup_method(self):
         with patch(
             "airflow.providers.google.common.hooks.base_google.GoogleBaseHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_translate.py
+++ b/tests/providers/google/cloud/hooks/test_translate.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from airflow.providers.google.cloud.hooks.translate import CloudTranslateHook
@@ -27,8 +26,8 @@ from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_
 PROJECT_ID_TEST = "project-id"
 
 
-class TestCloudTranslateHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudTranslateHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.translate.CloudTranslateHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_video_intelligence.py
+++ b/tests/providers/google/cloud/hooks/test_video_intelligence.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
@@ -35,8 +34,8 @@ FEATURES = [enums.Feature.LABEL_DETECTION]
 ANNOTATE_VIDEO_RESPONSE = {"test": "test"}
 
 
-class TestCloudVideoIntelligenceHook(unittest.TestCase):
-    def setUp(self):
+class TestCloudVideoIntelligenceHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.video_intelligence.CloudVideoIntelligenceHook.__init__",
             new=mock_base_gcp_hook_default_project_id,

--- a/tests/providers/google/cloud/hooks/test_vision.py
+++ b/tests/providers/google/cloud/hooks/test_vision.py
@@ -17,7 +17,6 @@
 # under the License.
 from __future__ import annotations
 
-import unittest
 from unittest import mock
 
 import pytest
@@ -31,7 +30,6 @@ from google.cloud.vision_v1.proto.image_annotator_pb2 import (
 )
 from google.cloud.vision_v1.proto.product_search_service_pb2 import Product, ProductSet, ReferenceImage
 from google.protobuf.json_format import MessageToDict
-from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.hooks.vision import ERR_DIFF_NAMES, ERR_UNABLE_TO_CREATE, CloudVisionHook
@@ -73,10 +71,20 @@ REFERENCE_IMAGE_TEST = ReferenceImage(name=REFERENCE_IMAGE_GEN_ID_TEST)
 REFERENCE_IMAGE_WITHOUT_ID_NAME = ReferenceImage()
 DETECT_TEST_IMAGE = {"source": {"image_uri": "https://foo.com/image.jpg"}}
 DETECT_TEST_ADDITIONAL_PROPERTIES = {"test-property-1": "test-value-1", "test-property-2": "test-value-2"}
+LOCATION_PRODUCTSET_ID_TEST_PARAMS = [
+    pytest.param(None, None, id="both-empty"),
+    pytest.param(None, PRODUCTSET_ID_TEST, id="only-productset-id"),
+    pytest.param(LOC_ID_TEST, None, id="only-location"),
+]
+LOCATION_PRODUCT_ID_TEST_PARAMS = [
+    pytest.param(None, None, id="both-empty"),
+    pytest.param(None, PRODUCT_ID_TEST, id="only-product-id"),
+    pytest.param(LOC_ID_TEST, None, id="only-location"),
+]
 
 
-class TestGcpVisionHook(unittest.TestCase):
-    def setUp(self):
+class TestGcpVisionHook:
+    def setup_method(self):
         with mock.patch(
             "airflow.providers.google.cloud.hooks.vision.CloudVisionHook.__init__",
             new=mock_base_gcp_hook_default_project_id,
@@ -227,10 +235,10 @@ class TestGcpVisionHook(unittest.TestCase):
             update_mask=None,
         )
 
-    @parameterized.expand([(None, None), (None, PRODUCTSET_ID_TEST), (LOC_ID_TEST, None)])
+    @pytest.mark.parametrize("location, product_set_id", LOCATION_PRODUCTSET_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_productset_no_explicit_name_and_missing_params_for_constructed_name(
-        self, location, product_set_id, get_conn
+        self, get_conn, location, product_set_id
     ):
         # Given
         update_product_set_method = get_conn.return_value.update_product_set
@@ -253,10 +261,13 @@ class TestGcpVisionHook(unittest.TestCase):
         assert ERR_UNABLE_TO_CREATE.format(label="ProductSet", id_label="productset_id") in str(err)
         update_product_set_method.assert_not_called()
 
-    @parameterized.expand([(None, None), (None, PRODUCTSET_ID_TEST), (LOC_ID_TEST, None)])
+    @pytest.mark.parametrize("location, product_set_id", LOCATION_PRODUCTSET_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_productset_explicit_name_missing_params_for_constructed_name(
-        self, location, product_set_id, get_conn
+        self,
+        get_conn,
+        location,
+        product_set_id,
     ):
         # Given
         explicit_ps_name = ProductSearchClient.product_set_path(
@@ -570,10 +581,10 @@ class TestGcpVisionHook(unittest.TestCase):
             product=Product(name=product_name), metadata=(), retry=DEFAULT, timeout=None, update_mask=None
         )
 
-    @parameterized.expand([(None, None), (None, PRODUCT_ID_TEST), (LOC_ID_TEST, None)])
+    @pytest.mark.parametrize("location, product_id", LOCATION_PRODUCT_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_product_no_explicit_name_and_missing_params_for_constructed_name(
-        self, location, product_id, get_conn
+        self, get_conn, location, product_id
     ):
         # Given
         update_product_method = get_conn.return_value.update_product
@@ -596,10 +607,10 @@ class TestGcpVisionHook(unittest.TestCase):
         assert ERR_UNABLE_TO_CREATE.format(label="Product", id_label="product_id") in str(err)
         update_product_method.assert_not_called()
 
-    @parameterized.expand([(None, None), (None, PRODUCT_ID_TEST), (LOC_ID_TEST, None)])
+    @pytest.mark.parametrize("location, product_id", LOCATION_PRODUCT_ID_TEST_PARAMS)
     @mock.patch("airflow.providers.google.cloud.hooks.vision.CloudVisionHook.get_conn")
     def test_update_product_explicit_name_missing_params_for_constructed_name(
-        self, location, product_id, get_conn
+        self, get_conn, location, product_id
     ):
         # Given
         explicit_p_name = ProductSearchClient.product_path(

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_auto_ml.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_auto_ml.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -39,8 +39,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 CUSTOM_JOB_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.auto_ml.{}"
 
 
-class TestAutoMLWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestAutoMLWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -108,8 +108,8 @@ class TestAutoMLWithDefaultProjectIdHook(TestCase):
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
 
-class TestAutoMLWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestAutoMLWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_batch_prediction_job.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -40,8 +40,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 BATCH_PREDICTION_JOB_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.batch_prediction_job.{}"
 
 
-class TestBatchPredictionJobWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestBatchPredictionJobWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -113,8 +113,8 @@ class TestBatchPredictionJobWithDefaultProjectIdHook(TestCase):
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
 
-class TestBatchPredictionJobWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestBatchPredictionJobWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_custom_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_custom_job.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -39,8 +39,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 CUSTOM_JOB_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.custom_job.{}"
 
 
-class TestCustomJobWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestCustomJobWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -249,8 +249,8 @@ class TestCustomJobWithDefaultProjectIdHook(TestCase):
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
 
-class TestCustomJobWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestCustomJobWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_dataset.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_dataset.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -46,8 +46,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 DATASET_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.dataset.{}"
 
 
-class TestVertexAIWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestVertexAIWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -276,8 +276,8 @@ class TestVertexAIWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestVertexAIWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestVertexAIWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_endpoint_service.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_endpoint_service.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -42,8 +42,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 ENDPOINT_SERVICE_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.endpoint_service.{}"
 
 
-class TestEndpointServiceWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestEndpointServiceWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -213,8 +213,8 @@ class TestEndpointServiceWithDefaultProjectIdHook(TestCase):
         )
 
 
-class TestEndpointServiceWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestEndpointServiceWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_hyperparameter_tuning_job.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_hyperparameter_tuning_job.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -41,8 +41,8 @@ HYPERPARAMETER_TUNING_JOB_STRING = (
 )
 
 
-class TestHyperparameterTuningJobWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestHyperparameterTuningJobWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -114,8 +114,8 @@ class TestHyperparameterTuningJobWithDefaultProjectIdHook(TestCase):
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
 
-class TestHyperparameterTuningJobWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestHyperparameterTuningJobWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):

--- a/tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py
+++ b/tests/providers/google/cloud/hooks/vertex_ai/test_model_service.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from unittest import TestCase, mock
+from unittest import mock
 
 from google.api_core.gapic_v1.method import DEFAULT
 
@@ -38,8 +38,8 @@ BASE_STRING = "airflow.providers.google.common.hooks.base_google.{}"
 MODEL_SERVICE_STRING = "airflow.providers.google.cloud.hooks.vertex_ai.model_service.{}"
 
 
-class TestModelServiceWithDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestModelServiceWithDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_default_project_id
         ):
@@ -127,8 +127,8 @@ class TestModelServiceWithDefaultProjectIdHook(TestCase):
         mock_client.return_value.common_location_path.assert_called_once_with(TEST_PROJECT_ID, TEST_REGION)
 
 
-class TestModelServiceWithoutDefaultProjectIdHook(TestCase):
-    def setUp(self):
+class TestModelServiceWithoutDefaultProjectIdHook:
+    def setup_method(self):
         with mock.patch(
             BASE_STRING.format("GoogleBaseHook.__init__"), new=mock_base_gcp_hook_no_default_project_id
         ):


### PR DESCRIPTION
Migrate google cloud provider's hooks tests to `pytest`. ~This PR might conflict with https://github.com/apache/airflow/pull/28290 and do not change anything in legacy system tests~

All changes are more or less straightforward:
- Get rid of `unittests.TestCase` class and **TestCase.assert*** methods
- Replace decorator `parameterized.expand` by `pytest.mark.parametrize`.
- Convert **setUp*** and **tearDown*** methods to [appropriate pytest alternative](https://docs.pytest.org/en/6.2.x/xunit_setup.html#classic-xunit-style-setup)

_See additional findings, info about significant changes and potential follow up in comments_