### PR TITLE
Migrate remaining API tests to `pytest`

### DIFF
--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import pytest
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import Connection
@@ -252,7 +251,8 @@ class TestGetConnections(TestConnectionEndpoint):
 
 
 class TestGetConnectionsPagination(TestConnectionEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_conn_ids",
         [
             ("/api/v1/connections?limit=1", ["TEST_CONN_ID1"]),
             ("/api/v1/connections?limit=2", ["TEST_CONN_ID1", "TEST_CONN_ID2"]),
@@ -287,7 +287,7 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
                 "/api/v1/connections?limit=2&offset=2",
                 ["TEST_CONN_ID3", "TEST_CONN_ID4"],
             ),
-        ]
+        ],
     )
     @provide_session
     def test_handle_limit_offset(self, url, expected_conn_ids, session):
@@ -354,11 +354,12 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
 
 
 class TestPatchConnection(TestConnectionEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload",
         [
-            ({"connection_id": "test-connection-id", "conn_type": "test_type", "extra": "{'key': 'var'}"},),
-            ({"extra": "{'key': 'var'}"},),
-        ]
+            {"connection_id": "test-connection-id", "conn_type": "test_type", "extra": "{'key': 'var'}"},
+            {"extra": "{'key': 'var'}"},
+        ],
     )
     @provide_session
     def test_patch_should_respond_200(self, payload, session):
@@ -399,7 +400,8 @@ class TestPatchConnection(TestConnectionEndpoint):
             "host": None,
         }
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, update_mask, error_message",
         [
             (
                 {
@@ -443,7 +445,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                 "",  # not necessary
                 "The connection_id cannot be updated.",
             ),
-        ]
+        ],
     )
     @provide_session
     def test_patch_should_respond_400_for_invalid_fields_in_update_mask(
@@ -458,7 +460,8 @@ class TestPatchConnection(TestConnectionEndpoint):
         assert response.status_code == 400
         assert response.json["detail"] == error_message
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, error_message",
         [
             (
                 {
@@ -485,7 +488,7 @@ class TestPatchConnection(TestConnectionEndpoint):
                 },
                 "_password",
             ),
-        ]
+        ],
     )
     @provide_session
     def test_patch_should_respond_400_for_invalid_update(self, payload, error_message, session):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -21,7 +21,6 @@ import unittest.mock
 from datetime import datetime
 
 import pytest
-from parameterized import parameterized
 
 from airflow import DAG
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
@@ -698,13 +697,14 @@ class TestGetDags(TestDagEndpoint):
             "total_entries": 2,
         } == response.json
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?tags=t1", ["TEST_DAG_1", "TEST_DAG_3"]),
             ("api/v1/dags?tags=t2", ["TEST_DAG_2", "TEST_DAG_3"]),
             ("api/v1/dags?tags=t1,t2", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3"]),
             ("api/v1/dags", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3", "TEST_DAG_4"]),
-        ]
+        ],
     )
     def test_filter_dags_by_tags_works(self, url, expected_dag_ids):
         # test filter by tags
@@ -723,7 +723,8 @@ class TestGetDags(TestDagEndpoint):
 
         assert expected_dag_ids == dag_ids
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?dag_id_pattern=DAG_1", {"TEST_DAG_1", "SAMPLE_DAG_1"}),
             ("api/v1/dags?dag_id_pattern=SAMPLE_DAG", {"SAMPLE_DAG_1", "SAMPLE_DAG_2"}),
@@ -731,7 +732,7 @@ class TestGetDags(TestDagEndpoint):
                 "api/v1/dags?dag_id_pattern=_DAG_",
                 {"TEST_DAG_1", "TEST_DAG_2", "SAMPLE_DAG_1", "SAMPLE_DAG_2"},
             ),
-        ]
+        ],
     )
     def test_filter_dags_by_dag_id_works(self, url, expected_dag_ids):
         # test filter by tags
@@ -759,7 +760,8 @@ class TestGetDags(TestDagEndpoint):
         assert len(response.json["dags"]) == 1
         assert response.json["dags"][0]["dag_id"] == "TEST_DAG_1"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?limit=1", ["TEST_DAG_1"]),
             ("api/v1/dags?limit=2", ["TEST_DAG_1", "TEST_DAG_10"]),
@@ -785,7 +787,7 @@ class TestGetDags(TestDagEndpoint):
             ("api/v1/dags?limit=1&offset=5", ["TEST_DAG_5"]),
             ("api/v1/dags?limit=1&offset=1", ["TEST_DAG_10"]),
             ("api/v1/dags?limit=2&offset=2", ["TEST_DAG_2", "TEST_DAG_3"]),
-        ]
+        ],
     )
     def test_should_respond_200_and_handle_pagination(self, url, expected_dag_ids):
         self._create_dag_models(10)
@@ -965,7 +967,8 @@ class TestPatchDag(TestDagEndpoint):
         }
         assert response.json == expected_response
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, update_mask, error_message",
         [
             (
                 {
@@ -981,7 +984,7 @@ class TestPatchDag(TestDagEndpoint):
                 "update_mask=schedule_interval, description",
                 "Only `is_paused` field can be updated through the REST API",
             ),
-        ]
+        ],
     )
     def test_should_respond_400_for_invalid_fields_in_update_mask(self, payload, update_mask, error_message):
         dag_model = self._create_dag_model()
@@ -1241,13 +1244,14 @@ class TestPatchDags(TestDagEndpoint):
             "total_entries": 2,
         } == response.json
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?tags=t1&dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_3"]),
             ("api/v1/dags?tags=t2&dag_id_pattern=~", ["TEST_DAG_2", "TEST_DAG_3"]),
             ("api/v1/dags?tags=t1,t2&dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3"]),
             ("api/v1/dags?dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3", "TEST_DAG_4"]),
-        ]
+        ],
     )
     def test_filter_dags_by_tags_works(self, url, expected_dag_ids):
         # test filter by tags
@@ -1271,7 +1275,8 @@ class TestPatchDags(TestDagEndpoint):
 
         assert expected_dag_ids == dag_ids
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?dag_id_pattern=DAG_1", {"TEST_DAG_1", "SAMPLE_DAG_1"}),
             ("api/v1/dags?dag_id_pattern=SAMPLE_DAG", {"SAMPLE_DAG_1", "SAMPLE_DAG_2"}),
@@ -1279,7 +1284,7 @@ class TestPatchDags(TestDagEndpoint):
                 "api/v1/dags?dag_id_pattern=_DAG_",
                 {"TEST_DAG_1", "TEST_DAG_2", "SAMPLE_DAG_1", "SAMPLE_DAG_2"},
             ),
-        ]
+        ],
     )
     def test_filter_dags_by_dag_id_works(self, url, expected_dag_ids):
         # test filter by tags
@@ -1317,7 +1322,8 @@ class TestPatchDags(TestDagEndpoint):
         assert len(response.json["dags"]) == 1
         assert response.json["dags"][0]["dag_id"] == "TEST_DAG_1"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_ids",
         [
             ("api/v1/dags?limit=1&dag_id_pattern=~", ["TEST_DAG_1"]),
             ("api/v1/dags?limit=2&dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_10"]),
@@ -1343,7 +1349,7 @@ class TestPatchDags(TestDagEndpoint):
             ("api/v1/dags?limit=1&offset=5&dag_id_pattern=~", ["TEST_DAG_5"]),
             ("api/v1/dags?limit=1&offset=1&dag_id_pattern=~", ["TEST_DAG_10"]),
             ("api/v1/dags?limit=2&offset=2&dag_id_pattern=~", ["TEST_DAG_2", "TEST_DAG_3"]),
-        ]
+        ],
     )
     def test_should_respond_200_and_handle_pagination(self, url, expected_dag_ids):
         self._create_dag_models(10)

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import pytest
 import time_machine
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.datasets import Dataset
@@ -420,7 +419,8 @@ class TestGetDagRuns(TestDagRunEndpoint):
 
 
 class TestGetDagRunsPagination(TestDagRunEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_run_ids",
         [
             ("api/v1/dags/TEST_DAG_ID/dagRuns?limit=1", ["TEST_DAG_RUN_ID1"]),
             (
@@ -458,7 +458,7 @@ class TestGetDagRunsPagination(TestDagRunEndpoint):
                 "api/v1/dags/TEST_DAG_ID/dagRuns?limit=2&offset=2",
                 ["TEST_DAG_RUN_ID3", "TEST_DAG_RUN_ID4"],
             ),
-        ]
+        ],
     )
     def test_handle_limit_and_offset(self, url, expected_dag_run_ids):
         self._create_dag_runs(10)
@@ -507,7 +507,8 @@ class TestGetDagRunsPagination(TestDagRunEndpoint):
 
 
 class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_run_ids",
         [
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
@@ -545,7 +546,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
                     "TEST_START_EXEC_DAY_19",
                 ],
             ),
-        ]
+        ],
     )
     @provide_session
     def test_date_filters_gte_and_lte(self, url, expected_dag_run_ids, session):
@@ -588,7 +589,8 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
 
 
 class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dag_run_ids",
         [
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte="
@@ -600,7 +602,7 @@ class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
                 f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
                 ["TEST_DAG_RUN_ID_1", "TEST_DAG_RUN_ID_2"],
             ),
-        ]
+        ],
     )
     def test_end_date_gte_lte(self, url, expected_dag_run_ids):
         self._create_test_dag_run("success")  # state==success, then end date is today
@@ -774,7 +776,8 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
             "total_entries": 2,
         }
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, error",
         [
             (
                 {"dag_ids": ["TEST_DAG_ID"], "page_offset": -1},
@@ -783,7 +786,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
             ({"dag_ids": ["TEST_DAG_ID"], "page_limit": 0}, "0 is less than the minimum of 1 - 'page_limit'"),
             ({"dag_ids": "TEST_DAG_ID"}, "'TEST_DAG_ID' is not of type 'array' - 'dag_ids'"),
             ({"start_date_gte": "2020-06-12T18"}, "{'start_date_gte': ['Not a valid datetime.']}"),
-        ]
+        ],
     )
     def test_payload_validation(self, payload, error):
         self._create_test_dag_run()
@@ -802,7 +805,8 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
 
 
 class TestGetDagRunBatchPagination(TestDagRunEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_dag_run_ids",
         [
             ({"page_limit": 1}, ["TEST_DAG_RUN_ID1"]),
             ({"page_limit": 2}, ["TEST_DAG_RUN_ID1", "TEST_DAG_RUN_ID2"]),
@@ -837,7 +841,7 @@ class TestGetDagRunBatchPagination(TestDagRunEndpoint):
                 {"page_offset": 2, "page_limit": 2},
                 ["TEST_DAG_RUN_ID3", "TEST_DAG_RUN_ID4"],
             ),
-        ]
+        ],
     )
     def test_handle_limit_and_offset(self, payload, expected_dag_run_ids):
         self._create_dag_runs(10)
@@ -880,7 +884,8 @@ class TestGetDagRunBatchPagination(TestDagRunEndpoint):
 
 
 class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_dag_run_ids",
         [
             (
                 {"start_date_gte": "2020-06-18T18:00:00+00:00"},
@@ -917,7 +922,7 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
                     "TEST_START_EXEC_DAY_19",
                 ],
             ),
-        ]
+        ],
     )
     def test_date_filters_gte_and_lte(self, payload, expected_dag_run_ids):
         self._create_dag_runs()
@@ -961,7 +966,8 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
             session.add(dag)
         return dag_runs
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_response",
         [
             ({"execution_date_gte": "2020-11-09T16:25:56.939143"}, "Naive datetime is disallowed"),
             (
@@ -981,7 +987,7 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
                 "Naive datetime is disallowed",
             ),
             ({"execution_date_gte": "2020-06-16T18:00:00.676443"}, "Naive datetime is disallowed"),
-        ]
+        ],
     )
     def test_naive_date_filters_raises_400(self, payload, expected_response):
         self._create_dag_runs()
@@ -992,7 +998,8 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
         assert response.status_code == 400
         assert response.json["detail"] == expected_response
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_dag_run_ids",
         [
             (
                 {"end_date_gte": f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}"},
@@ -1002,7 +1009,7 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
                 {"end_date_lte": f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}"},
                 ["TEST_DAG_RUN_ID_1", "TEST_DAG_RUN_ID_2"],
             ),
-        ]
+        ],
     )
     def test_end_date_gte_lte(self, payload, expected_dag_run_ids):
         self._create_test_dag_run("success")  # state==success, then end date is today
@@ -1134,13 +1141,14 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert response.json["title"] == "logical_date conflicts with execution_date"
         assert response.json["detail"] == (f"'{logical_date}' != '{execution_date}'")
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "data, expected",
         [
             ({"execution_date": "2020-11-10T08:25:56.939143"}, "Naive datetime is disallowed"),
             ({"execution_date": "2020-11-10T08:25:56P"}, "{'logical_date': ['Not a valid datetime.']}"),
             ({"logical_date": "2020-11-10T08:25:56.939143"}, "Naive datetime is disallowed"),
             ({"logical_date": "2020-11-10T08:25:56P"}, "{'logical_date': ['Not a valid datetime.']}"),
-        ]
+        ],
     )
     def test_should_response_400_for_naive_datetime_and_bad_datetime(self, data, expected):
         self._create_dag("TEST_DAG_ID")
@@ -1150,7 +1158,8 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert response.status_code == 400
         assert response.json["detail"] == expected
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "data, expected",
         [
             (
                 {
@@ -1160,7 +1169,7 @@ class TestPostDagRun(TestDagRunEndpoint):
                 },
                 "'some string' is not of type 'object' - 'conf'",
             )
-        ]
+        ],
     )
     def test_should_response_400_for_non_dict_dagrun_conf(self, data, expected):
         self._create_dag("TEST_DAG_ID")
@@ -1184,10 +1193,10 @@ class TestPostDagRun(TestDagRunEndpoint):
             "type": EXCEPTIONS_LINK_MAP[404],
         } == response.json
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, request_json, expected_response",
         [
-            (
-                "start_date in request json",
+            pytest.param(
                 "api/v1/dags/TEST_DAG_ID/dagRuns",
                 {
                     "start_date": "2020-06-11T18:00:00+00:00",
@@ -1199,9 +1208,9 @@ class TestPostDagRun(TestDagRunEndpoint):
                     "title": "Bad Request",
                     "type": EXCEPTIONS_LINK_MAP[400],
                 },
+                id="start_date in request json",
             ),
-            (
-                "state in request json",
+            pytest.param(
                 "api/v1/dags/TEST_DAG_ID/dagRuns",
                 {"state": "failed", "execution_date": "2020-06-12T18:00:00+00:00"},
                 {
@@ -1210,11 +1219,11 @@ class TestPostDagRun(TestDagRunEndpoint):
                     "title": "Bad Request",
                     "type": EXCEPTIONS_LINK_MAP[400],
                 },
+                id="state in request json",
             ),
-        ]
+        ],
     )
-    def test_response_400(self, name, url, request_json, expected_response):
-        del name
+    def test_response_400(self, url, request_json, expected_response):
         self._create_dag("TEST_DAG_ID")
         response = self.client.post(url, json=request_json, environ_overrides={"REMOTE_USER": "test"})
         assert response.status_code == 400, response.data
@@ -1271,8 +1280,9 @@ class TestPostDagRun(TestDagRunEndpoint):
 
         assert_401(response)
 
-    @parameterized.expand(
-        ["test_dag_view_only", "test_view_dags", "test_granular_permissions", "test_no_permissions"]
+    @pytest.mark.parametrize(
+        "username",
+        ["test_dag_view_only", "test_view_dags", "test_granular_permissions", "test_no_permissions"],
     )
     def test_should_raises_403_unauthorized(self, username):
         self._create_dag("TEST_DAG_ID")

--- a/tests/api_connexion/endpoints/test_dataset_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dataset_endpoint.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import urllib
 
 import pytest
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models.dagrun import DagRun
@@ -206,7 +205,8 @@ class TestGetDatasets(TestDatasetEndpoint):
 
         assert_401(response)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_datasets",
         [
             ("api/v1/datasets?uri_pattern=s3", {"s3://folder/key"}),
             ("api/v1/datasets?uri_pattern=bucket", {"gcp://bucket/key", "wasb://some_dataset_bucket_/key"}),
@@ -223,7 +223,7 @@ class TestGetDatasets(TestDatasetEndpoint):
                     "wasb://some_dataset_bucket_/key",
                 },
             ),
-        ]
+        ],
     )
     @provide_session
     def test_filter_datasets_by_uri_pattern_works(self, url, expected_datasets, session):
@@ -240,7 +240,8 @@ class TestGetDatasets(TestDatasetEndpoint):
 
 
 class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_dataset_uris",
         [
             # Limit test data
             ("/api/v1/datasets?limit=1", ["s3://bucket/key/1"]),
@@ -250,7 +251,7 @@ class TestGetDatasetsEndpointPagination(TestDatasetEndpoint):
             ("/api/v1/datasets?offset=3", [f"s3://bucket/key/{i}" for i in range(4, 104)]),
             # Limit and offset test data
             ("/api/v1/datasets?offset=3&limit=3", [f"s3://bucket/key/{i}" for i in [4, 5, 6]]),
-        ]
+        ],
     )
     @provide_session
     def test_limit_and_offset(self, url, expected_dataset_uris, session):
@@ -505,7 +506,8 @@ class TestGetDatasetEvents(TestDatasetEndpoint):
 
 
 class TestGetDatasetEventsEndpointPagination(TestDatasetEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_event_runids",
         [
             # Limit test data
             ("/api/v1/datasets/events?limit=1&order_by=source_run_id", ["run1"]),
@@ -527,7 +529,7 @@ class TestGetDatasetEventsEndpointPagination(TestDatasetEndpoint):
                 "/api/v1/datasets/events?offset=3&limit=3&order_by=source_run_id",
                 [f"run{i}" for i in [4, 5, 6]],
             ),
-        ]
+        ],
     )
     @provide_session
     def test_limit_and_offset(self, url, expected_event_runids, session):

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models.errors import ImportError
@@ -232,7 +231,8 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
 
 
 class TestGetImportErrorsEndpointPagination(TestBaseImportError):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_import_error_ids",
         [
             # Limit test data
             ("/api/v1/importErrors?limit=1", ["/tmp/file_1.py"]),
@@ -242,7 +242,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
             ("/api/v1/importErrors?offset=3", [f"/tmp/file_{i}.py" for i in range(4, 104)]),
             # Limit and offset test data
             ("/api/v1/importErrors?offset=3&limit=3", [f"/tmp/file_{i}.py" for i in [4, 5, 6]]),
-        ]
+        ],
     )
     @provide_session
     def test_limit_and_offset(self, url, expected_import_error_ids, session):

--- a/tests/api_connexion/endpoints/test_plugin_endpoint.py
+++ b/tests/api_connexion/endpoints/test_plugin_endpoint.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import pytest
-from parameterized import parameterized
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.security import permissions
@@ -106,7 +105,8 @@ class TestGetPlugins(TestPluginsEndpoint):
 
 
 class TestGetPluginsPagination(TestPluginsEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_plugin_names",
         [
             ("/api/v1/plugins?limit=1", ["TEST_PLUGIN_1"]),
             ("/api/v1/plugins?limit=2", ["TEST_PLUGIN_1", "TEST_PLUGIN_2"]),
@@ -141,7 +141,7 @@ class TestGetPluginsPagination(TestPluginsEndpoint):
                 "/api/v1/plugins?limit=2&offset=2",
                 ["TEST_PLUGIN_3", "TEST_PLUGIN_4"],
             ),
-        ]
+        ],
     )
     def test_handle_limit_offset(self, url, expected_plugin_names):
         plugins = self._create_plugins(10)

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import pytest
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.security import permissions
@@ -128,7 +127,8 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
 
 
 class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_roles",
         [
             ("/api/v1/roles?limit=1", ["Admin"]),
             ("/api/v1/roles?limit=2", ["Admin", "Op"]),
@@ -146,7 +146,7 @@ class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
                 "/api/v1/roles?limit=2&offset=2",
                 ["Public", "Test"],
             ),
-        ]
+        ],
     )
     def test_can_handle_limit_and_offset(self, url, expected_roles):
         response = self.client.get(url, environ_overrides={"REMOTE_USER": "test"})
@@ -190,7 +190,8 @@ class TestPostRole(TestRoleEndpoint):
         role = self.app.appbuilder.sm.find_role("Test2")
         assert role is not None
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, error_message",
         [
             (
                 {
@@ -252,7 +253,7 @@ class TestPostRole(TestRoleEndpoint):
                 },
                 "The specified action: 'can_amend' was not found",
             ),
-        ]
+        ],
     )
     def test_post_should_respond_400_for_invalid_payload(self, payload, error_message):
         response = self.client.post("/api/v1/roles", json=payload, environ_overrides={"REMOTE_USER": "test"})
@@ -334,7 +335,8 @@ class TestDeleteRole(TestRoleEndpoint):
 
 
 class TestPatchRole(TestRoleEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_name, expected_actions",
         [
             ({"name": "mytest"}, "mytest", []),
             (
@@ -345,7 +347,7 @@ class TestPatchRole(TestRoleEndpoint):
                 "mytest2",
                 [{"resource": {"name": "Connections"}, "action": {"name": "can_create"}}],
             ),
-        ]
+        ],
     )
     def test_patch_should_respond_200(self, payload, expected_name, expected_actions):
         role = create_role(self.app, "mytestrole")
@@ -377,7 +379,8 @@ class TestPatchRole(TestRoleEndpoint):
 
         assert len(self.app.appbuilder.sm.find_role("already_exists").permissions) == 0
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "update_mask, payload, expected_name, expected_actions",
         [
             (
                 "?update_mask=name",
@@ -397,7 +400,7 @@ class TestPatchRole(TestRoleEndpoint):
                 "mytest2",
                 [{"resource": {"name": "Connections"}, "action": {"name": "can_create"}}],
             ),
-        ]
+        ],
     )
     def test_patch_should_respond_200_with_update_mask(
         self, update_mask, payload, expected_name, expected_actions
@@ -424,7 +427,8 @@ class TestPatchRole(TestRoleEndpoint):
         assert response.status_code == 400
         assert response.json["detail"] == "'invalid_name' in update_mask is unknown"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "payload, expected_error",
         [
             (
                 {
@@ -471,7 +475,7 @@ class TestPatchRole(TestRoleEndpoint):
                 },
                 "The specified action: 'can_invalid' was not found",
             ),
-        ]
+        ],
     )
     def test_patch_should_respond_400_for_invalid_update(self, payload, expected_error):
         role = create_role(self.app, "mytestrole")

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import unittest.mock
 
 import pytest
-from parameterized import parameterized
 from sqlalchemy.sql.functions import count
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
@@ -231,7 +230,8 @@ class TestGetUsers(TestUserEndpoint):
 
 
 class TestGetUsersPagination(TestUserEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "url, expected_usernames",
         [
             ("/api/v1/users?limit=1", ["test"]),
             ("/api/v1/users?limit=2", ["test", "test_no_permissions"]),
@@ -270,7 +270,7 @@ class TestGetUsersPagination(TestUserEndpoint):
                 "/api/v1/users?limit=2&offset=2",
                 ["TEST_USER1", "TEST_USER2"],
             ),
-        ]
+        ],
     )
     def test_handle_limit_offset(self, url, expected_usernames):
         users = self._create_users(10)

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import urllib
 
 import pytest
-from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.models import Variable
@@ -142,7 +141,8 @@ class TestGetVariable(TestVariableEndpoint):
 
 
 class TestGetVariables(TestVariableEndpoint):
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "query, expected",
         [
             (
                 "/api/v1/variables?limit=2&offset=0",
@@ -173,7 +173,7 @@ class TestGetVariables(TestVariableEndpoint):
                     "total_entries": 3,
                 },
             ),
-        ]
+        ],
     )
     def test_should_get_list_variables(self, query, expected):
         Variable.set("var1", 1, "I am a variable")

--- a/tests/api_connexion/test_auth.py
+++ b/tests/api_connexion/test_auth.py
@@ -20,7 +20,6 @@ from base64 import b64encode
 
 import pytest
 from flask_login import current_user
-from parameterized import parameterized
 
 from tests.test_utils.api_connexion_utils import assert_401
 from tests.test_utils.config import conf_vars
@@ -86,17 +85,18 @@ class TestBasicAuth(BaseTestAuth):
             "total_entries": 1,
         }
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "token",
         [
-            ("basic",),
-            ("basic ",),
-            ("bearer",),
-            ("test:test",),
-            (b64encode(b"test:test").decode(),),
-            ("bearer ",),
-            ("basic: ",),
-            ("basic 123",),
-        ]
+            "basic",
+            "basic ",
+            "bearer",
+            "test:test",
+            b64encode(b"test:test").decode(),
+            "bearer ",
+            "basic: ",
+            "basic 123",
+        ],
     )
     def test_malformed_headers(self, token):
         with self.app.test_client() as test_client:
@@ -106,13 +106,14 @@ class TestBasicAuth(BaseTestAuth):
             assert response.headers["WWW-Authenticate"] == "Basic"
             assert_401(response)
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "token",
         [
-            ("basic " + b64encode(b"test").decode(),),
-            ("basic " + b64encode(b"test:").decode(),),
-            ("basic " + b64encode(b"test:123").decode(),),
-            ("basic " + b64encode(b"test test").decode(),),
-        ]
+            "basic " + b64encode(b"test").decode(),
+            "basic " + b64encode(b"test:").decode(),
+            "basic " + b64encode(b"test:123").decode(),
+            "basic " + b64encode(b"test test").decode(),
+        ],
     )
     def test_invalid_auth_header(self, token):
         with self.app.test_client() as test_client:


### PR DESCRIPTION
Migrate remaining tests from API  to `pytest` from selected directories:
- `tests/api/*`
- `tests/api_connexion/*`
- `tests/api_internal/*`

Most of them it just replace decorator `parameterized.expand` by `pytest.mark.parametrize`.

_As usual additional findings, info about significant changes and potential follow up in comments_