### PR TITLE
Add setters for on_*_callbacks to MappedOperator

### DIFF
--- a/airflow/models/mappedoperator.py
+++ b/airflow/models/mappedoperator.py
@@ -450,17 +450,33 @@ class MappedOperator(AbstractOperator):
     def on_execute_callback(self) -> TaskStateChangeCallback | None:
         return self.partial_kwargs.get("on_execute_callback")
 
+    @on_execute_callback.setter
+    def on_execute_callback(self, value: TaskStateChangeCallback | None) -> None:
+        self.partial_kwargs["on_execute_callback"] = value
+
     @property
     def on_failure_callback(self) -> TaskStateChangeCallback | None:
         return self.partial_kwargs.get("on_failure_callback")
+
+    @on_failure_callback.setter
+    def on_failure_callback(self, value: TaskStateChangeCallback | None) -> None:
+        self.partial_kwargs["on_failure_callback"] = value
 
     @property
     def on_retry_callback(self) -> TaskStateChangeCallback | None:
         return self.partial_kwargs.get("on_retry_callback")
 
+    @on_retry_callback.setter
+    def on_retry_callback(self, value: TaskStateChangeCallback | None) -> None:
+        self.partial_kwargs["on_retry_callback"] = value
+
     @property
     def on_success_callback(self) -> TaskStateChangeCallback | None:
         return self.partial_kwargs.get("on_success_callback")
+
+    @on_success_callback.setter
+    def on_success_callback(self, value: TaskStateChangeCallback | None) -> None:
+        self.partial_kwargs["on_success_callback"] = value
 
     @property
     def run_as_user(self) -> str | None:


### PR DESCRIPTION
Some plugins use cluster/task policies to modify on_*_callbacks to perform auditing, lineage, etc. An example of one such plugin would be DataHub's lineage plugin.

These changes will allow such policies to modify the tasks the same way as BaseOperator as opposed to detecting MappedOperator and then modifying partial_kwargs directly.

Related issues: 
Airflow: https://github.com/apache/airflow/issues/24547
DataHub: https://github.com/datahub-project/datahub/issues/6606


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
