### PR TITLE
Bring back psycopg2-binary as dependency instead of psycopg

### DIFF
--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -45,7 +45,7 @@ versions:
 dependencies:
   - apache-airflow>=2.3.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - psycopg2>=2.8.0
+  - psycopg2-binary>=2.8.0
 
 integrations:
   - integration-name: PostgreSQL

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -564,7 +564,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
-      "psycopg2>=2.8.0"
+      "psycopg2-binary>=2.8.0"
     ],
     "cross-providers-deps": [
       "amazon",


### PR DESCRIPTION
The psycopg dependency is slightly more optimized than than the binary one, but the problems it creates when it is used as dependency are numerous - it always expects to compile the psycopg dependencies, so you cannot install it when there are no build-essentials installed and on some systems additional libraries are needed.

We introduced it in #25710 for optimisation reasons.

However, the optimisations it brings are not really justified with the installation complexities it introduces, that's why we revert it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
