### PR TITLE
Make sure the key for k8s environment changes with requirements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,7 +1243,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ".build/.k8s-env"
-          key: "k8s-env"
+          key: "\
+            k8s-env-${{ hashFiles('scripts/ci/kubernetes/k8s_requirements.txt','setup.cfg',\
+            'setup.py','pyproject.toml','generated/provider_dependencies.json') }}"
       - name: Run complete K8S tests ${{needs.build-info.outputs.kubernetes-combos}}
         run: breeze k8s run-complete-tests --run-in-parallel --upgrade
         env:


### PR DESCRIPTION
Previously, caching key for k8s environment was static - it did not take into account that some of the file changes should invalidate the cache. This PR changes it so that it changes wheneve one of the contributing factors change:

* requirements
* airflow setup files
* airflow pyproject.toml
* generated provider dependencies

Changes in any of those should cause recreation of the venv.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
