### PR TITLE
List specific config section and its values using the cli

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -905,6 +905,10 @@ ARG_OPTION = Arg(
     ("option",),
     help="The option name",
 )
+ARG_OPTIONAL_SECTION = Arg(
+    ("--section",),
+    help="The section name",
+)
 
 # kubernetes cleanup-pods
 ARG_NAMESPACE = Arg(
@@ -1823,7 +1827,7 @@ CONFIG_COMMANDS = (
         name="list",
         help="List options for the configuration",
         func=lazy_load_command("airflow.cli.commands.config_command.show_config"),
-        args=(ARG_COLOR, ARG_VERBOSE),
+        args=(ARG_OPTIONAL_SECTION, ARG_COLOR, ARG_VERBOSE),
     ),
 )
 

--- a/airflow/cli/commands/config_command.py
+++ b/airflow/cli/commands/config_command.py
@@ -30,7 +30,7 @@ from airflow.utils.code_utils import get_terminal_formatter
 def show_config(args):
     """Show current application configuration."""
     with io.StringIO() as output:
-        conf.write(output)
+        conf.write(output, section=args.section)
         code = output.getvalue()
         if should_use_colors(args):
             code = pygments.highlight(code=code, formatter=get_terminal_formatter(), lexer=IniLexer())

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -930,7 +930,9 @@ class AirflowConfigParser(ConfigParser):
                         _section[key] = False
         return _section
 
-    def write(self, fp: IO, space_around_delimiters: bool = True):  # type: ignore[override]
+    def write(  # type: ignore[override]
+        self, fp: IO, space_around_delimiters: bool = True, section: str | None = None
+    ) -> None:
         # This is based on the configparser.RawConfigParser.write method code to add support for
         # reading options from environment variables.
         # Various type ignores below deal with less-than-perfect RawConfigParser superclass typing
@@ -942,9 +944,14 @@ class AirflowConfigParser(ConfigParser):
             self._write_section(  # type: ignore[attr-defined]
                 fp, self.default_section, self._defaults.items(), delimiter  # type: ignore[attr-defined]
             )
-        for section in self._sections:  # type: ignore[attr-defined]
-            item_section: ConfigOptionsDictType = self.getsection(section)  # type: ignore[assignment]
-            self._write_section(fp, section, item_section.items(), delimiter)  # type: ignore[attr-defined]
+        sections = (
+            {section: dict(self.getsection(section))}  # type: ignore[arg-type]
+            if section
+            else self._sections  # type: ignore[attr-defined]
+        )
+        for sect in sections:
+            item_section: ConfigOptionsDictType = self.getsection(sect)  # type: ignore[assignment]
+            self._write_section(fp, sect, item_section.items(), delimiter)  # type: ignore[attr-defined]
 
     def as_dict(
         self,

--- a/tests/cli/commands/test_config_command.py
+++ b/tests/cli/commands/test_config_command.py
@@ -36,7 +36,19 @@ class TestCliConfigList:
     @mock.patch("airflow.cli.commands.config_command.conf")
     def test_cli_show_config_should_write_data(self, mock_conf, mock_stringio):
         config_command.show_config(self.parser.parse_args(["config", "list", "--color", "off"]))
-        mock_conf.write.assert_called_once_with(mock_stringio.return_value.__enter__.return_value)
+        mock_conf.write.assert_called_once_with(
+            mock_stringio.return_value.__enter__.return_value, section=None
+        )
+
+    @mock.patch("airflow.cli.commands.config_command.io.StringIO")
+    @mock.patch("airflow.cli.commands.config_command.conf")
+    def test_cli_show_config_should_write_data_specific_section(self, mock_conf, mock_stringio):
+        config_command.show_config(
+            self.parser.parse_args(["config", "list", "--section", "core", "--color", "off"])
+        )
+        mock_conf.write.assert_called_once_with(
+            mock_stringio.return_value.__enter__.return_value, section="core"
+        )
 
     @conf_vars({("core", "testkey"): "test_value"})
     def test_cli_show_config_should_display_key(self):


### PR DESCRIPTION
This adds an option to list a specific config section with its values through the cli.
e.g for core: `airflow config list --section core`

```
(env) ➜  airflow git:(list-section) airflow config list --section database 
[database]
sql_alchemy_conn = sqlite:////Users/ephraimbuddy/airflow/airflow.db
sql_engine_encoding = utf-8
sql_alchemy_pool_enabled = True
sql_alchemy_pool_size = 5
sql_alchemy_max_overflow = 10
sql_alchemy_pool_recycle = 1800
sql_alchemy_pool_pre_ping = True
sql_alchemy_schema = 
load_default_connections = True
max_db_retries = 3
```
