### PR TITLE
Fix the sql syntax in merge_data

### DIFF
--- a/docs/apache-airflow/tutorial/pipeline.rst
+++ b/docs/apache-airflow/tutorial/pipeline.rst
@@ -168,7 +168,7 @@ Here we select completely unique records from the retrieved data, then we check 
           FROM (
               SELECT DISTINCT *
               FROM employees_temp
-          )
+          ) t
           ON CONFLICT ("Serial Number") DO UPDATE
           SET "Serial Number" = excluded."Serial Number";
       """
@@ -283,7 +283,7 @@ Putting all of the pieces together, we have our completed DAG.
               FROM (
                   SELECT DISTINCT *
                   FROM employees_temp
-              )
+              ) t
               ON CONFLICT ("Serial Number") DO UPDATE
               SET "Serial Number" = excluded."Serial Number";
           """


### PR DESCRIPTION
After running the DAG the employees table is empty.
The reason is the sql syntax error:
 
ERROR:  subquery in FROM must have an alias
LINE 3: FROM (
             ^
HINT:  For example, FROM (SELECT ...) [AS] foo.
SQL state: 42601
Character: 37

The change fixes the sql syntax in merge_data.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
