### PR TITLE
mkdirs should set mode correctly

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -143,14 +143,14 @@ def mkdirs(path, mode):
     :param path: The directory to create
     :param mode: The mode to give to the directory e.g. 0o755, ignores umask
     """
-    import warnings
-
-    warnings.warn(
-        f"This function is deprecated. Please use `pathlib.Path({path}).mkdir`",
-        RemovedInAirflow3Warning,
-        stacklevel=2,
-    )
-    Path(path).mkdir(mode=mode, parents=True, exist_ok=True)
+    try:
+        o_umask = os.umask(0)
+        os.makedirs(path, mode)
+    except OSError:
+        if not os.path.isdir(path):
+            raise
+    finally:
+        os.umask(o_umask)
 
 
 ZIP_REGEX = re.compile(rf"((.*\.zip){re.escape(os.sep)})?(.*)")

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -20,12 +20,23 @@ from __future__ import annotations
 import os
 import os.path
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 
-from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, open_maybe_zipped
+from airflow.utils.file import correct_maybe_zipped, find_path_from_directory, mkdirs, open_maybe_zipped
 from tests.models import TEST_DAGS_FOLDER
+
+
+def test_mkdirs():
+    with TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, str(uuid4()), str(uuid4()))
+        mkdirs(path, 0o777)
+
+        mode = oct(os.stat(path).st_mode)[-3:]
+        assert mode == "777"
 
 
 class TestCorrectMaybeZipped:


### PR DESCRIPTION

With Path.mkdirs, If mode is given, it is combined with the process’ umask value to determine the file mode and access flags. if parents is true, any missing parents of this path are created as needed; they are created with the default permissions without taking mode into account. However, in the `mkdirs`, it specifies the `umask` is ignored

This `mkdirs` was replaced by `Path(xx).mkdir` in the current codebase, e.g. https://github.com/apache/airflow/blob/b263dbcb0f84fd9029591d1447a7c843cb970f15/airflow/utils/log/file_task_handler.py#L345. 

But I think we should use `mkdirs`, as the `Path(xx).mkdir` does not set the mode correctly, since it factors in the `umask` , see this code:

e.g. code:

```
import os
from tempfile import TemporaryDirectory
from uuid import uuid4
from pathlib import Path

with TemporaryDirectory() as tmpdir:
    path = os.path.join(tmpdir, str(uuid4()), str(uuid4()))
    Path(path).mkdir(mode=0o777, parents=True, exist_ok=True)
    mode = oct(os.stat(path).st_mode)[-3:]
    print('mode is', mode) 
    assert mode == "777"
```

The output is :`mode is, 755`, which is not `777`

see: https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
