### PR TITLE
Adjust HyperParameterTuningJobConfig values 

### DIFF
--- a/tests/system/providers/amazon/aws/example_sagemaker.py
+++ b/tests/system/providers/amazon/aws/example_sagemaker.py
@@ -328,9 +328,8 @@ def set_up(env_id, role_arn):
                 "Type": "Maximize",
             },
             "ResourceLimits": {
-                # You would bump these up in production as appropriate.
-                "MaxNumberOfTrainingJobs": 2,
-                "MaxParallelTrainingJobs": 2,
+                "MaxNumberOfTrainingJobs": 10,
+                "MaxParallelTrainingJobs": 10,
             },
             "ParameterRanges": {
                 "CategoricalParameterRanges": [],


### PR DESCRIPTION
**TL;DR:**
The Sagemaker System Test is flaky and fails occasionally because Reasons.  This change greatly reduces the frequency of the failures.  

**Long version:**
The Sagemaker Tuning Job fails from time to time, partially because the test is being run on a small dataset for the sake of time and resources.  The tuning task will only fail if every retry of the tuning job fails.  Previously increasing MaxNumberOfTrainingJobs from 1 to 2 reduced failure rate from roughly 50% of the time down to roughly failing once every 7 runs.  After increasing it from 2 to 10 I have run this text 60 times locally and it failed only one of those.  10 is the largest value allowed by the API.  Since we are automatically running the tests internally now on AWS infrastructure, we can afford to throw a little more compute power behind it to get the tests passing more reliably.