### PR TITLE
Correctly select a mapped task's "previous" task

### DIFF
--- a/airflow/ti_deps/deps/prev_dagrun_dep.py
+++ b/airflow/ti_deps/deps/prev_dagrun_dep.py
@@ -70,7 +70,7 @@ class PrevDagrunDep(BaseTIDep):
             yield self._passing_status(reason="This task instance was the first task instance for its task.")
             return
 
-        previous_ti = last_dagrun.get_task_instance(ti.task_id, session=session)
+        previous_ti = last_dagrun.get_task_instance(ti.task_id, map_index=ti.map_index, session=session)
         if not previous_ti:
             if ti.task.ignore_first_depends_on_past:
                 has_historical_ti = (


### PR DESCRIPTION
This allows PrevDagrunDep to correctly identify where to look when depends_on_past is True.

Fix #28296.