### PR TITLE
Dont show task/run durations when there is no start_date

### DIFF
--- a/airflow/www/static/js/dag/InstanceTooltip.test.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.test.tsx
@@ -48,6 +48,7 @@ describe('Test Task InstanceTooltip', () => {
 
     expect(getByText('Status: success')).toBeDefined();
     expect(queryByText('Contains a note')).toBeNull();
+    expect(getByText('Duration: 00:00:00')).toBeDefined();
   });
 
   test('Displays a mapped task with overall status', () => {
@@ -110,5 +111,18 @@ describe('Test Task InstanceTooltip', () => {
     );
 
     expect(getByText('Contains a note')).toBeInTheDocument();
+  });
+
+  test('Hides duration if there is no start date', () => {
+    const { queryByText, getByText } = render(
+      <InstanceTooltip
+        group={{ id: 'task', label: 'task', instances: [] }}
+        instance={{ ...instance, startDate: null }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(getByText('Status: success')).toBeDefined();
+    expect(queryByText('Duration: 00:00:00')).toBeNull();
   });
 });

--- a/airflow/www/static/js/dag/InstanceTooltip.tsx
+++ b/airflow/www/static/js/dag/InstanceTooltip.tsx
@@ -96,16 +96,20 @@ const InstanceTooltip = ({
         {state || 'no status'}
       </Text>
       {(isGroup || isMapped) && summary}
-      <Text>
-        Started:
-        {' '}
-        <Time dateTime={startDate} />
-      </Text>
-      <Text>
-        Duration:
-        {' '}
-        {formatDuration(getDuration(startDate, endDate))}
-      </Text>
+      {startDate && (
+        <>
+          <Text>
+            Started:
+            {' '}
+            <Time dateTime={startDate} />
+          </Text>
+          <Text>
+            Duration:
+            {' '}
+            {formatDuration(getDuration(startDate, endDate))}
+          </Text>
+        </>
+      )}
       {note && (
         <Text>Contains a note</Text>
       )}

--- a/airflow/www/static/js/dag/details/dagRun/index.tsx
+++ b/airflow/www/static/js/dag/details/dagRun/index.tsx
@@ -144,12 +144,14 @@ const DagRun = ({ runId }: Props) => {
                 {runType}
               </Td>
             </Tr>
-            <Tr>
-              <Td>Run duration</Td>
-              <Td>
-                {formatDuration(getDuration(startDate, endDate))}
-              </Td>
-            </Tr>
+            {startDate && (
+              <Tr>
+                <Td>Run duration</Td>
+                <Td>
+                  {formatDuration(getDuration(startDate, endDate))}
+                </Td>
+              </Tr>
+            )}
             {lastSchedulingDecision && (
               <Tr>
                 <Td>Last scheduling decision</Td>

--- a/airflow/www/static/js/dag/details/taskInstance/Details.tsx
+++ b/airflow/www/static/js/dag/details/taskInstance/Details.tsx
@@ -200,13 +200,15 @@ const Details = ({ instance, group, dagId }: Props) => {
               <Td>{operator}</Td>
             </Tr>
           )}
-          <Tr>
-            <Td>
-              {isOverall}
-              Duration
-            </Td>
-            <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
-          </Tr>
+          {startDate && (
+            <Tr>
+              <Td>
+                {isOverall}
+                Duration
+              </Td>
+              <Td>{formatDuration(getDuration(startDate, endDate))}</Td>
+            </Tr>
+          )}
           {startDate && (
             <Tr>
               <Td>Started</Td>

--- a/airflow/www/yarn.lock
+++ b/airflow/www/yarn.lock
@@ -3947,20 +3947,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109:
-  version "1.0.30001355"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz#e240b7177443ed0198c737a7f609536976701c77"
-  integrity sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g==
-
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001312"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
-  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
-
-caniuse-lite@^1.0.30001349:
-  version "1.0.30001354"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001354.tgz#95c5efdb64148bb4870771749b9a619304755ce5"
-  integrity sha512-mImKeCkyGDAHNywYFA4bqnLAzTUvVkqPvhY4DV47X+Gl2c5Z8c3KNETnXp14GQt11LvxE8AwjzGxJ+rsikiOzg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001349:
+  version "1.0.30001439"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
+  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
 
 chakra-react-select@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
When start date isn't defined, the UI shouldn't try to show the task duration because it would be impossible to calculate.

Fixes: https://github.com/apache/airflow/issues/28070

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
