### PR TITLE
AIP-44 Add CLI command for running standalone Internal API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -489,6 +489,7 @@ repos:
           ^airflow/api_connexion/openapi/v1.yaml$|
           ^tests/cli/commands/test_webserver_command.py$|
           ^airflow/cli/commands/webserver_command.py$|
+          ^tests/cli/commands/test_internal_api_command.py$|
           ^airflow/config_templates/default_airflow.cfg$|
           ^airflow/config_templates/config.yml$|
           ^docs/*.*$|

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -678,6 +678,50 @@ ARG_ACCESS_LOGFORMAT = Arg(
     help="The access log format for gunicorn logs",
 )
 
+
+# internal-api
+ARG_INTERNAL_API_PORT = Arg(
+    ("-p", "--port"),
+    default=9080,
+    type=int,
+    help="The port on which to run the server",
+)
+ARG_INTERNAL_API_WORKERS = Arg(
+    ("-w", "--workers"),
+    default=4,
+    type=int,
+    help="Number of workers to run the Internal API-on",
+)
+ARG_INTERNAL_API_WORKERCLASS = Arg(
+    ("-k", "--workerclass"),
+    default="sync",
+    choices=["sync", "eventlet", "gevent", "tornado"],
+    help="The worker class to use for Gunicorn",
+)
+ARG_INTERNAL_API_WORKER_TIMEOUT = Arg(
+    ("-t", "--worker-timeout"),
+    default=120,
+    type=int,
+    help="The timeout for waiting on Internal API workers",
+)
+ARG_INTERNAL_API_HOSTNAME = Arg(
+    ("-H", "--hostname"),
+    default="0.0.0.0",
+    help="Set the hostname on which to run the web server",
+)
+ARG_INTERNAL_API_ACCESS_LOGFILE = Arg(
+    ("-A", "--access-logfile"),
+    help="The logfile to store the webserver access log. Use '-' to print to stderr",
+)
+ARG_INTERNAL_API_ERROR_LOGFILE = Arg(
+    ("-E", "--error-logfile"),
+    help="The logfile to store the webserver error log. Use '-' to print to stderr",
+)
+ARG_INTERNAL_API_ACCESS_LOGFORMAT = Arg(
+    ("-L", "--access-logformat"),
+    help="The access log format for gunicorn logs",
+)
+
 # scheduler
 ARG_NUM_RUNS = Arg(
     ("-n", "--num-runs"),
@@ -1962,6 +2006,29 @@ airflow_commands: list[CLICommand] = [
             ARG_ACCESS_LOGFILE,
             ARG_ERROR_LOGFILE,
             ARG_ACCESS_LOGFORMAT,
+            ARG_LOG_FILE,
+            ARG_SSL_CERT,
+            ARG_SSL_KEY,
+            ARG_DEBUG,
+        ),
+    ),
+    ActionCommand(
+        name="internal-api",
+        help="Start a Airflow Internal API instance",
+        func=lazy_load_command("airflow.cli.commands.internal_api_command.internal_api"),
+        args=(
+            ARG_INTERNAL_API_PORT,
+            ARG_INTERNAL_API_WORKERS,
+            ARG_INTERNAL_API_WORKERCLASS,
+            ARG_INTERNAL_API_WORKER_TIMEOUT,
+            ARG_INTERNAL_API_HOSTNAME,
+            ARG_PID,
+            ARG_DAEMON,
+            ARG_STDOUT,
+            ARG_STDERR,
+            ARG_INTERNAL_API_ACCESS_LOGFILE,
+            ARG_INTERNAL_API_ERROR_LOGFILE,
+            ARG_INTERNAL_API_ACCESS_LOGFORMAT,
             ARG_LOG_FILE,
             ARG_SSL_CERT,
             ARG_SSL_KEY,

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -711,7 +711,7 @@ ARG_INTERNAL_API_HOSTNAME = Arg(
 )
 ARG_INTERNAL_API_ACCESS_LOGFILE = Arg(
     ("-A", "--access-logfile"),
-    help="The logfile to store the webserver access log. Use '-' to print to stderr",
+    help="The logfile to store the webserver access log. Use '-' to print to stdout",
 )
 ARG_INTERNAL_API_ERROR_LOGFILE = Arg(
     ("-E", "--error-logfile"),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -711,11 +711,11 @@ ARG_INTERNAL_API_HOSTNAME = Arg(
 )
 ARG_INTERNAL_API_ACCESS_LOGFILE = Arg(
     ("-A", "--access-logfile"),
-    help="The logfile to store the webserver access log. Use '-' to print to stdout",
+    help="The logfile to store the access log. Use '-' to print to stdout",
 )
 ARG_INTERNAL_API_ERROR_LOGFILE = Arg(
     ("-E", "--error-logfile"),
-    help="The logfile to store the webserver error log. Use '-' to print to stderr",
+    help="The logfile to store the error log. Use '-' to print to stderr",
 )
 ARG_INTERNAL_API_ACCESS_LOGFORMAT = Arg(
     ("-L", "--access-logformat"),

--- a/airflow/cli/commands/internal_api_command.py
+++ b/airflow/cli/commands/internal_api_command.py
@@ -1,0 +1,268 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Internal API command."""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+from contextlib import suppress
+from tempfile import gettempdir
+from time import sleep
+
+import daemon
+import psutil
+from daemon.pidfile import TimeoutPIDLockFile
+from flask import Flask
+from flask_appbuilder import SQLA
+from flask_caching import Cache
+from flask_wtf.csrf import CSRFProtect
+from lockfile.pidlockfile import read_pid_from_pidfile
+from sqlalchemy.engine.url import make_url
+
+from airflow import settings
+from airflow.cli.commands.webserver_command import GunicornMonitor
+from airflow.configuration import conf
+from airflow.exceptions import AirflowConfigException
+from airflow.logging_config import configure_logging
+from airflow.models import import_all_models
+from airflow.utils import cli as cli_utils
+from airflow.utils.cli import setup_locations, setup_logging
+from airflow.utils.process_utils import check_if_pidfile_process_is_running
+from airflow.www.extensions.init_dagbag import init_dagbag
+from airflow.www.extensions.init_jinja_globals import init_jinja_globals
+from airflow.www.extensions.init_manifest_files import configure_manifest_files
+from airflow.www.extensions.init_security import init_xframe_protection
+from airflow.www.extensions.init_views import init_api_internal, init_error_handlers
+
+log = logging.getLogger(__name__)
+app: Flask | None = None
+
+
+@cli_utils.action_cli
+def internal_api(args):
+    """Starts Airflow Internal API."""
+    print(settings.HEADER)
+
+    access_logfile = args.access_logfile if args.access_logfile is not None else "-"
+    error_logfile = args.error_logfile if args.error_logfile is not None else "-"
+    access_logformat = args.access_logformat
+    num_workers = args.workers
+    worker_timeout = args.worker_timeout
+
+    if args.debug:
+        log.info(f"Starting the Internal API server on port {args.port} and host {args.hostname}.")
+        app = create_app(testing=conf.getboolean("core", "unit_test_mode"))
+        app.run(
+            debug=True,
+            use_reloader=not app.config["TESTING"],
+            port=args.port,
+            host=args.hostname,
+        )
+    else:
+        pid_file, stdout, stderr, log_file = setup_locations(
+            "internal-api", args.pid, args.stdout, args.stderr, args.log_file
+        )
+
+        # Check if Internal APi is already running if not, remove old pidfile
+        check_if_pidfile_process_is_running(pid_file=pid_file, process_name="internal-api")
+
+        log.info(
+            textwrap.dedent(
+                f"""\
+                Running the Gunicorn Server with:
+                Workers: {num_workers} {args.workerclass}
+                Host: {args.hostname}:{args.port}
+                Timeout: {worker_timeout}
+                Logfiles: {access_logfile} {error_logfile}
+                Access Logformat: {access_logformat}
+                ================================================================="""
+            )
+        )
+
+        run_args = [
+            sys.executable,
+            "-m",
+            "gunicorn",
+            "--workers",
+            str(num_workers),
+            "--worker-class",
+            str(args.workerclass),
+            "--timeout",
+            str(worker_timeout),
+            "--bind",
+            args.hostname + ":" + str(args.port),
+            "--name",
+            "airflow-internal-api",
+            "--pid",
+            pid_file,
+            "--access-logfile",
+            str(access_logfile),
+            "--error-logfile",
+            str(error_logfile),
+        ]
+
+        if args.access_logformat and args.access_logformat.strip():
+            run_args += ["--access-logformat", str(args.access_logformat)]
+
+        if args.daemon:
+            run_args += ["--daemon"]
+
+        run_args += ["airflow.cli.commands.internal_api_command:cached_app()"]
+
+        # To prevent different workers creating the web app and
+        # all writing to the database at the same time, we use the --preload option.
+        # With the preload option, the app is loaded before the workers are forked, and each worker will
+        # then have a copy of the app
+        run_args += ["--preload"]
+
+        gunicorn_master_proc = None
+
+        def kill_proc(signum, _):
+            log.info("Received signal: %s. Closing gunicorn.", signum)
+            gunicorn_master_proc.terminate()
+            with suppress(TimeoutError):
+                gunicorn_master_proc.wait(timeout=30)
+            if gunicorn_master_proc.poll() is not None:
+                gunicorn_master_proc.kill()
+            sys.exit(0)
+
+        def monitor_gunicorn(gunicorn_master_pid: int):
+            # Register signal handlers
+            signal.signal(signal.SIGINT, kill_proc)
+            signal.signal(signal.SIGTERM, kill_proc)
+
+            # These run forever until SIG{INT, TERM, KILL, ...} signal is sent
+            GunicornMonitor(
+                gunicorn_master_pid=gunicorn_master_pid,
+                num_workers_expected=num_workers,
+                master_timeout=conf.getint("webserver", "web_server_master_timeout"),
+                worker_refresh_interval=conf.getint("webserver", "worker_refresh_interval", fallback=30),
+                worker_refresh_batch_size=conf.getint("webserver", "worker_refresh_batch_size", fallback=1),
+                reload_on_plugin_change=conf.getboolean(
+                    "webserver", "reload_on_plugin_change", fallback=False
+                ),
+            ).start()
+
+        if args.daemon:
+            # This makes possible errors get reported before daemonization
+            os.environ["SKIP_DAGS_PARSING"] = "True"
+            app = create_app(None)
+            os.environ.pop("SKIP_DAGS_PARSING")
+
+            handle = setup_logging(log_file)
+
+            base, ext = os.path.splitext(pid_file)
+            with open(stdout, "a") as stdout, open(stderr, "a") as stderr:
+                stdout.truncate(0)
+                stderr.truncate(0)
+
+                ctx = daemon.DaemonContext(
+                    pidfile=TimeoutPIDLockFile(f"{base}-monitor{ext}", -1),
+                    files_preserve=[handle],
+                    stdout=stdout,
+                    stderr=stderr,
+                    umask=int(settings.DAEMON_UMASK, 8),
+                )
+                with ctx:
+                    subprocess.Popen(run_args, close_fds=True)
+
+                    # Reading pid of gunicorn main process as it will be different that
+                    # the one of process spawned above.
+                    while True:
+                        sleep(0.1)
+                        gunicorn_master_proc_pid = read_pid_from_pidfile(pid_file)
+                        if gunicorn_master_proc_pid:
+                            break
+
+                    # Run Gunicorn monitor
+                    gunicorn_master_proc = psutil.Process(gunicorn_master_proc_pid)
+                    monitor_gunicorn(gunicorn_master_proc.pid)
+
+        else:
+            with subprocess.Popen(run_args, close_fds=True) as gunicorn_master_proc:
+                monitor_gunicorn(gunicorn_master_proc.pid)
+
+
+def create_app(config=None, testing=False):
+    """Create a new instance of Airflow Internal API app"""
+    flask_app = Flask(__name__)
+
+    flask_app.config["APP_NAME"] = "Airflow Internal API"
+    flask_app.config["TESTING"] = testing
+    flask_app.config["SQLALCHEMY_DATABASE_URI"] = conf.get("database", "SQL_ALCHEMY_CONN")
+
+    url = make_url(flask_app.config["SQLALCHEMY_DATABASE_URI"])
+    if url.drivername == "sqlite" and url.database and not url.database.startswith("/"):
+        raise AirflowConfigException(
+            f'Cannot use relative path: `{conf.get("database", "SQL_ALCHEMY_CONN")}` to connect to sqlite. '
+            "Please use absolute path such as `sqlite:////tmp/airflow.db`."
+        )
+
+    flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    flask_app.config["SESSION_COOKIE_HTTPONLY"] = True
+    flask_app.config["SESSION_COOKIE_SECURE"] = conf.getboolean("webserver", "COOKIE_SECURE")
+    flask_app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+
+    if config:
+        flask_app.config.from_mapping(config)
+
+    if "SQLALCHEMY_ENGINE_OPTIONS" not in flask_app.config:
+        flask_app.config["SQLALCHEMY_ENGINE_OPTIONS"] = settings.prepare_engine_args()
+
+    csrf = CSRFProtect()
+    csrf.init_app(flask_app)
+
+    db = SQLA()
+    db.session = settings.Session
+    db.init_app(flask_app)
+
+    init_dagbag(flask_app)
+
+    cache_config = {"CACHE_TYPE": "flask_caching.backends.filesystem", "CACHE_DIR": gettempdir()}
+    Cache(app=flask_app, config=cache_config)
+
+    configure_logging()
+    configure_manifest_files(flask_app)
+
+    import_all_models()
+
+    with flask_app.app_context():
+        init_error_handlers(flask_app)
+        init_api_internal(flask_app, standalone_api=True)
+
+        init_jinja_globals(flask_app)
+        init_xframe_protection(flask_app)
+    return flask_app
+
+
+def cached_app(config=None, testing=False):
+    """Return cached instance of Airflow Internal API app"""
+    global app
+    if not app:
+        app = create_app(config=config, testing=testing)
+    return app
+
+
+def purge_cached_app():
+    """Removes the cached version of the app in global state."""
+    global app
+    app = None

--- a/airflow/cli/commands/internal_api_command.py
+++ b/airflow/cli/commands/internal_api_command.py
@@ -61,8 +61,8 @@ def internal_api(args):
     """Starts Airflow Internal API."""
     print(settings.HEADER)
 
-    access_logfile = args.access_logfile if args.access_logfile is not None else "-"
-    error_logfile = args.error_logfile if args.error_logfile is not None else "-"
+    access_logfile = args.access_logfile or "-"
+    error_logfile = args.error_logfile or "-"
     access_logformat = args.access_logformat
     num_workers = args.workers
     worker_timeout = args.worker_timeout

--- a/airflow/cli/commands/internal_api_command.py
+++ b/airflow/cli/commands/internal_api_command.py
@@ -153,12 +153,10 @@ def internal_api(args):
             GunicornMonitor(
                 gunicorn_master_pid=gunicorn_master_pid,
                 num_workers_expected=num_workers,
-                master_timeout=conf.getint("webserver", "web_server_master_timeout"),
-                worker_refresh_interval=conf.getint("webserver", "worker_refresh_interval", fallback=30),
-                worker_refresh_batch_size=conf.getint("webserver", "worker_refresh_batch_size", fallback=1),
-                reload_on_plugin_change=conf.getboolean(
-                    "webserver", "reload_on_plugin_change", fallback=False
-                ),
+                master_timeout=120,
+                worker_refresh_interval=30,
+                worker_refresh_batch_size=1,
+                reload_on_plugin_change=False,
             ).start()
 
         if args.daemon:
@@ -219,7 +217,6 @@ def create_app(config=None, testing=False):
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     flask_app.config["SESSION_COOKIE_HTTPONLY"] = True
-    flask_app.config["SESSION_COOKIE_SECURE"] = conf.getboolean("webserver", "COOKIE_SECURE")
     flask_app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
 
     if config:
@@ -260,9 +257,3 @@ def cached_app(config=None, testing=False):
     if not app:
         app = create_app(config=config, testing=testing)
     return app
-
-
-def purge_cached_app():
-    """Removes the cached version of the app in global state."""
-    global app
-    app = None

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -221,9 +221,9 @@ def init_api_connexion(app: Flask) -> None:
     app.extensions["csrf"].exempt(api_bp)
 
 
-def init_api_internal(app: Flask) -> None:
+def init_api_internal(app: Flask, standalone_api: bool = False) -> None:
     """Initialize Internal API"""
-    if not conf.getboolean("webserver", "run_internal_api", fallback=False):
+    if not standalone_api and not conf.getboolean("webserver", "run_internal_api", fallback=False):
         return
     base_path = "/internal_api/v1"
 

--- a/tests/cli/commands/test_internal_api_command.py
+++ b/tests/cli/commands/test_internal_api_command.py
@@ -1,0 +1,250 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from unittest import mock
+
+import psutil
+import pytest
+
+from airflow import settings
+from airflow.cli import cli_parser
+from airflow.cli.commands import internal_api_command
+from airflow.cli.commands.internal_api_command import GunicornMonitor
+from airflow.utils.cli import setup_locations
+
+
+class TestCLIGetNumReadyWorkersRunning:
+    @classmethod
+    def setup_class(cls):
+        cls.parser = cli_parser.get_parser()
+
+    def setup_method(self):
+        self.children = mock.MagicMock()
+        self.child = mock.MagicMock()
+        self.process = mock.MagicMock()
+        self.monitor = GunicornMonitor(
+            gunicorn_master_pid=1,
+            num_workers_expected=4,
+            master_timeout=60,
+            worker_refresh_interval=60,
+            worker_refresh_batch_size=2,
+            reload_on_plugin_change=True,
+        )
+
+    def test_ready_prefix_on_cmdline(self):
+        self.child.cmdline.return_value = [settings.GUNICORN_WORKER_READY_PREFIX]
+        self.process.children.return_value = [self.child]
+
+        with mock.patch("psutil.Process", return_value=self.process):
+            assert self.monitor._get_num_ready_workers_running() == 1
+
+    def test_ready_prefix_on_cmdline_no_children(self):
+        self.process.children.return_value = []
+
+        with mock.patch("psutil.Process", return_value=self.process):
+            assert self.monitor._get_num_ready_workers_running() == 0
+
+    def test_ready_prefix_on_cmdline_zombie(self):
+        self.child.cmdline.return_value = []
+        self.process.children.return_value = [self.child]
+
+        with mock.patch("psutil.Process", return_value=self.process):
+            assert self.monitor._get_num_ready_workers_running() == 0
+
+    def test_ready_prefix_on_cmdline_dead_process(self):
+        self.child.cmdline.side_effect = psutil.NoSuchProcess(11347)
+        self.process.children.return_value = [self.child]
+
+        with mock.patch("psutil.Process", return_value=self.process):
+            assert self.monitor._get_num_ready_workers_running() == 0
+
+
+class TestCliInternalAPi:
+    @pytest.fixture(autouse=True)
+    def _make_parser(self):
+        self.parser = cli_parser.get_parser()
+
+    @pytest.fixture(autouse=True)
+    def _cleanup(self):
+        self._check_processes()
+        self._clean_pidfiles()
+
+        yield
+
+        self._check_processes(ignore_running=True)
+        self._clean_pidfiles()
+
+    def _check_processes(self, ignore_running=False):
+        # Confirm that internal-api hasn't been launched.
+        # pgrep returns exit status 1 if no process matched.
+        # Use more specific regexps (^) to avoid matching pytest run when running specific method.
+        # For instance, we want to be able to do: pytest -k 'gunicorn'
+        exit_code_pgrep_internal_api = subprocess.Popen(["pgrep", "-c", "-f", "airflow internal-api"]).wait()
+        exit_code_pgrep_gunicorn = subprocess.Popen(["pgrep", "-c", "-f", "^gunicorn"]).wait()
+        if exit_code_pgrep_internal_api != 1 or exit_code_pgrep_gunicorn != 1:
+            subprocess.Popen(["ps", "-ax"]).wait()
+            if exit_code_pgrep_internal_api != 1:
+                subprocess.Popen(["pkill", "-9", "-f", "airflow-internal-api"]).wait()
+            if exit_code_pgrep_gunicorn != 1:
+                subprocess.Popen(["pkill", "-9", "-f", "^gunicorn"]).wait()
+            if not ignore_running:
+                raise AssertionError(
+                    "Background processes are running that prevent the test from passing successfully."
+                )
+
+    def _clean_pidfiles(self):
+        pidfile_internal_api = setup_locations("internal-api")[0]
+        pidfile_monitor = setup_locations("internal-api-monitor")[0]
+        if os.path.exists(pidfile_internal_api):
+            os.remove(pidfile_internal_api)
+        if os.path.exists(pidfile_monitor):
+            os.remove(pidfile_monitor)
+
+    def _wait_pidfile(self, pidfile):
+        start_time = time.monotonic()
+        while True:
+            try:
+                with open(pidfile) as file:
+                    return int(file.read())
+            except Exception:
+                if start_time - time.monotonic() > 60:
+                    raise
+                time.sleep(1)
+
+    @pytest.mark.execution_timeout(210)
+    def test_cli_internal_api_background(self):
+        with tempfile.TemporaryDirectory(prefix="gunicorn") as tmpdir:
+            pidfile_internal_api = f"{tmpdir}/pidflow-internal-api.pid"
+            pidfile_monitor = f"{tmpdir}/pidflow-internal-api-monitor.pid"
+            stdout = f"{tmpdir}/airflow-internal-api.out"
+            stderr = f"{tmpdir}/airflow-internal-api.err"
+            logfile = f"{tmpdir}/airflow-internal-api.log"
+            try:
+                # Run internal-api as daemon in background. Note that the wait method is not called.
+
+                proc = subprocess.Popen(
+                    [
+                        "airflow",
+                        "internal-api",
+                        "--daemon",
+                        "--pid",
+                        pidfile_internal_api,
+                        "--stdout",
+                        stdout,
+                        "--stderr",
+                        stderr,
+                        "--log-file",
+                        logfile,
+                    ]
+                )
+                assert proc.poll() is None
+
+                pid_monitor = self._wait_pidfile(pidfile_monitor)
+                self._wait_pidfile(pidfile_internal_api)
+
+                # Assert that gunicorn and its monitor are launched.
+                assert 0 == subprocess.Popen(["pgrep", "-f", "-c", "airflow internal-api --daemon"]).wait()
+                # wait for gunicorn to start
+                for i in range(30):
+                    if 0 == subprocess.Popen(["pgrep", "-f", "-c", "^gunicorn"]).wait():
+                        break
+                    time.sleep(1)
+                assert (
+                    0 == subprocess.Popen(["pgrep", "-c", "-f", "gunicorn: master"]).wait()
+                )  # NOT inclusive
+
+                # Terminate monitor process.
+                proc = psutil.Process(pid_monitor)
+                proc.terminate()
+                assert proc.wait(120) in (0, None)
+
+                self._check_processes()
+            except Exception:
+                # List all logs
+                subprocess.Popen(["ls", "-lah", tmpdir]).wait()
+                # Dump all logs
+                subprocess.Popen(["bash", "-c", f"ls {tmpdir}/* | xargs -n 1 -t cat"]).wait()
+                raise
+
+    def test_cli_internal_api_debug(self, app):
+        with mock.patch(
+            "airflow.cli.commands.internal_api_command.create_app", return_value=app
+        ), mock.patch.object(app, "run") as app_run:
+            args = self.parser.parse_args(
+                [
+                    "internal-api",
+                    "--debug",
+                ]
+            )
+            internal_api_command.internal_api(args)
+
+            app_run.assert_called_with(
+                debug=True,
+                use_reloader=False,
+                port=9080,
+                host="0.0.0.0",
+            )
+
+    def test_cli_internal_api_args(self):
+        with mock.patch("subprocess.Popen") as Popen, mock.patch.object(
+            internal_api_command, "GunicornMonitor"
+        ):
+            args = self.parser.parse_args(
+                [
+                    "internal-api",
+                    "--access-logformat",
+                    "custom_log_format",
+                    "--pid",
+                    "/tmp/x.pid",
+                ]
+            )
+            internal_api_command.internal_api(args)
+
+            Popen.assert_called_with(
+                [
+                    sys.executable,
+                    "-m",
+                    "gunicorn",
+                    "--workers",
+                    "4",
+                    "--worker-class",
+                    "sync",
+                    "--timeout",
+                    "120",
+                    "--bind",
+                    "0.0.0.0:9080",
+                    "--name",
+                    "airflow-internal-api",
+                    "--pid",
+                    "/tmp/x.pid",
+                    "--access-logfile",
+                    "-",
+                    "--error-logfile",
+                    "-",
+                    "--access-logformat",
+                    "custom_log_format",
+                    "airflow.cli.commands.internal_api_command:cached_app()",
+                    "--preload",
+                ],
+                close_fds=True,
+            )


### PR DESCRIPTION
Introduce `airflow internal-api` CLI command that starts intependent Internal API server.

closes: #28266 



