### PR TITLE
Fix output buffering for `breeze testing test`

### DIFF
--- a/scripts/in_container/filter_out_warnings.py
+++ b/scripts/in_container/filter_out_warnings.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 import fileinput
+import sys
 
 suppress = False
 
@@ -29,3 +30,4 @@ for line in fileinput.input():
         suppress = False
     if not suppress:
         print(line, end="")
+        sys.stdout.flush()


### PR DESCRIPTION
Since we disabled warnings and redirected them to the output file, we lost continuous output of the progress of tests when they were run as `breeze testing tests` command. The whole summary of the tests appeared only at the end of tests.

This turned out to be Python output buffering in "filter_out_warning" class. It is fixed by flushing sys.stdout after every printed line now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
