### PR TITLE
CustomTTYColoredFormatter should inherit TimezoneAware formatter

### DIFF
--- a/airflow/utils/log/colored_log.py
+++ b/airflow/utils/log/colored_log.py
@@ -26,6 +26,8 @@ from typing import Any
 from colorlog import TTYColoredFormatter
 from colorlog.escape_codes import esc, escape_codes
 
+from airflow.utils.log.timezone_aware import TimezoneAware
+
 DEFAULT_COLORS = {
     "DEBUG": "green",
     "INFO": "",
@@ -38,7 +40,7 @@ BOLD_ON = escape_codes["bold"]
 BOLD_OFF = esc("22")
 
 
-class CustomTTYColoredFormatter(TTYColoredFormatter):
+class CustomTTYColoredFormatter(TTYColoredFormatter, TimezoneAware):
     """
     Custom log formatter which extends `colored.TTYColoredFormatter`
     by adding attributes to message arguments and coloring error

--- a/tests/utils/log/test_colored_log.py
+++ b/tests/utils/log/test_colored_log.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from airflow.utils.log.colored_log import CustomTTYColoredFormatter
+
+
+@patch("airflow.utils.log.timezone_aware.TimezoneAware.formatTime")
+def test_format_time_uses_tz_aware(mock_fmt):
+    # get a logger that uses CustomTTYColoredFormatter
+    logger = logging.getLogger("test_format_time")
+    h = logging.StreamHandler()
+    h.setFormatter(CustomTTYColoredFormatter())
+    logger.addHandler(h)
+
+    # verify that it uses TimezoneAware.formatTime
+    logger.info("hi")
+    mock_fmt.assert_called()


### PR DESCRIPTION
So that the timestamp format is the same for both.

Before:
```
[2022-12-18 00:14:38,268] {python.py:178} INFO - Done. Returned value was: None
[2022-12-18 00:14:38,279] {taskinstance.py:1320} INFO - Marking task as SUCCESS. dag_id=example_bash_operator, task_id=hihi, execution_date=20221216T000000, start_date=20221217T225759, end_date=20221218T081438
```
After:
```
[2022-12-18T00:17:00.315-0800] {python.py:178} INFO - Done. Returned value was: None
[2022-12-18T00:17:00.328-0800] {taskinstance.py:1320} INFO - Marking task as SUCCESS. dag_id=example_bash_operator, task_id=hihi, execution_date=20221216T000000, start_date=20221217T225759, end_date=20221218T081700
```