### PR TITLE
Propagate logs to stdout when in k8s executor pod

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -313,9 +313,8 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     # If k8s executor, we need to ensure that root logger has a console handler, so that
     # task logs propagate to stdout (this is how webserver retrieves them while task is running).
     root_logger = logging.getLogger()
-    task_logger = ti.log
     console_handler = get_console_handler(root_logger)
-    with LoggerMutationHelper(root_logger), LoggerMutationHelper(task_logger) as task_helper:
+    with LoggerMutationHelper(root_logger), LoggerMutationHelper(ti.log) as task_helper:
         task_helper.move(root_logger)
         if IS_K8S_EXECUTOR_POD:
             ensure_handler(root_logger, console_handler)

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -411,9 +411,11 @@ def task_run(args, dag=None):
     try:
         if args.interactive:
             _run_task_by_selected_method(args, dag, ti)
-        else:
+        elif not args.raw:
             with _capture_task_logs(ti):
                 _run_task_by_selected_method(args, dag, ti)
+        else:
+            _run_task_by_selected_method(args, dag, ti)
     finally:
         try:
             get_listener_manager().hook.before_stopping(component=TaskCommandMarker())

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -293,6 +293,10 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     If running in a k8s executor pod, also keep the stream handler on root logger
     so that logs are still emitted to stdout.
     """
+    # nothing to do
+    if not ti.log.handlers or settings.DONOT_MODIFY_HANDLERS:
+        yield
+        return
 
     def get_console_handler(logger):
         for h in logger.handlers:
@@ -304,11 +308,6 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
             return
         if handler not in logger.handlers:
             logger.addHandler(handler)
-
-    # nothing to do
-    if not ti.log.handlers or settings.DONOT_MODIFY_HANDLERS:
-        yield
-        return
 
     # Move task handlers to root and reset task logger and restore original logger settings after exit.
     # If k8s executor, we need to ensure that root logger has a console handler, so that

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -296,7 +296,7 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     # because either the handlers were already moved by the LocalTaskJob
     # invocation of task_run (which wraps the --raw invocation), or
     # user is doing something custom / unexpected
-    if not ti.log.handlers or not settings.DONOT_MODIFY_HANDLERS:
+    if not ti.log.handlers or settings.DONOT_MODIFY_HANDLERS:
         yield
         return
     is_k8s_executor_pod = os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD")

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -44,6 +44,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.operator import needs_expansion
+from airflow.settings import IS_K8S_EXECUTOR_POD
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import SCHEDULER_QUEUED_DEPS
 from airflow.typing_compat import Literal
@@ -320,7 +321,7 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     task_logger.propagate = True
     root_logger.setLevel(task_logger.level)
     root_logger.handlers[:] = orig_task_handlers
-    if console_handler:
+    if console_handler and IS_K8S_EXECUTOR_POD:
         root_logger.addHandler(console_handler)
     try:
         yield

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -284,47 +284,6 @@ def _extract_external_executor_id(args) -> str | None:
     return os.environ.get("external_executor_id", None)
 
 
-class LoggerAttrs:
-    """
-    Helper for moving and resetting handlers and other logger attrs.
-
-    :meta private:
-    """
-
-    def __init__(self, logger):
-        self.handlers = logger.handlers[:]
-        self.level = logger.level
-        self.propagate = logger.propagate
-        self.source_logger = logger
-
-    def apply(self, logger, replace=True):
-        """
-        Set ``logger`` with attrs stored on instance.
-
-        If ``logger`` is root logger, don't change propagate.
-        """
-        if replace:
-            logger.handlers[:] = self.handlers
-        else:
-            for h in self.handlers:
-                if h not in logger.handlers:
-                    logger.addHandler(h)
-        logger.level = self.level
-        if logger is not logging.getLogger():
-            logger.propagate = self.propagate
-
-    def move(self, logger, replace=True):
-        """
-        Replace ``logger`` attrs with those from source.
-
-        :param logger: target logger
-        :param replace: if True, remove all handlers from target first; otherwise add if not present.
-        """
-        self.apply(logger, replace=replace)
-        self.source_logger.propagate = True
-        self.source_logger.handlers[:] = []
-
-
 @contextmanager
 def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]:
     """
@@ -718,3 +677,44 @@ def task_clear(args):
         include_subdags=not args.exclude_subdags,
         include_parentdag=not args.exclude_parentdag,
     )
+
+
+class LoggerAttrs:
+    """
+    Helper for moving and resetting handlers and other logger attrs.
+
+    :meta private:
+    """
+
+    def __init__(self, logger):
+        self.handlers = logger.handlers[:]
+        self.level = logger.level
+        self.propagate = logger.propagate
+        self.source_logger = logger
+
+    def apply(self, logger, replace=True):
+        """
+        Set ``logger`` with attrs stored on instance.
+
+        If ``logger`` is root logger, don't change propagate.
+        """
+        if replace:
+            logger.handlers[:] = self.handlers
+        else:
+            for h in self.handlers:
+                if h not in logger.handlers:
+                    logger.addHandler(h)
+        logger.level = self.level
+        if logger is not logging.getLogger():
+            logger.propagate = self.propagate
+
+    def move(self, logger, replace=True):
+        """
+        Replace ``logger`` attrs with those from source.
+
+        :param logger: target logger
+        :param replace: if True, remove all handlers from target first; otherwise add if not present.
+        """
+        self.apply(logger, replace=replace)
+        self.source_logger.propagate = True
+        self.source_logger.handlers[:] = []

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -437,6 +437,7 @@ def task_run(args, dag=None):
     # easily exceed the database connection limit when
     # processing hundreds of simultaneous tasks.
     # this should be last thing before running, to reduce likelihood of an open session
+    # which can cause trouble if running process in a fork.
     settings.reconfigure_orm(disable_connection_pool=True)
 
     try:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -299,6 +299,12 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
             if h.name == "console":
                 return h
 
+    def add_handler_if_not_exists(logger, handler):
+        if not handler:
+            return
+        if handler not in logger.handlers:
+            logger.addHandler(handler)
+
     # if there are no task handlers, then we should not do anything
     # because either the handlers were already moved by the LocalTaskJob
     # invocation of task_run (which wraps the --raw invocation), or
@@ -317,9 +323,8 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     # task logs propagate to stdout (this is how webserver retrieves them while task is running).
     with LoggerMutationHelper(task_logger) as task_logger_helper, LoggerMutationHelper(root_logger):
         task_logger_helper.move(root_logger)
-        if console_handler and IS_K8S_EXECUTOR_POD:
-            if console_handler not in root_logger.handlers:
-                root_logger.addHandler(console_handler)
+        if IS_K8S_EXECUTOR_POD:
+            add_handler_if_not_exists(root_logger, console_handler)
         yield
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -324,16 +324,18 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
                     if isinstance(h, RedirectStdHandler):
                         root_logger.addHandler(h)
                         h.respect_redirection = False
-    yield
-    if did_modify:
-        task_logger.propagate = task_propagate
-        root_logger.setLevel(root_level)
-        root_logger.handlers[:] = root_handlers
-        task_logger.handlers[:] = task_handlers
-        if is_k8s_executor_pod:
-            for h in root_handlers:
-                if isinstance(h, RedirectStdHandler):
-                    h.respect_redirection = True
+    try:
+        yield
+    finally:
+        if did_modify:
+            task_logger.propagate = task_propagate
+            root_logger.setLevel(root_level)
+            root_logger.handlers[:] = root_handlers
+            task_logger.handlers[:] = task_handlers
+            if is_k8s_executor_pod:
+                for h in root_handlers:
+                    if isinstance(h, RedirectStdHandler):
+                        h.respect_redirection = True
 
 
 @contextmanager

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -317,7 +317,7 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     task_logger = ti.log
     console_handler = get_console_handler(root_logger)
 
-    # Below is the operative section we move task handlers to root and reset task logger.
+    # Below is the operative section. We move task handlers to root and reset task logger.
     # After exit, we restore original logger settings.
     # If k8s executor, we need to ensure that root logger has a console handler, so that
     # task logs propagate to stdout (this is how webserver retrieves them while task is running).

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -318,8 +318,13 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     # we move task handlers to root and reset task logger
     # after exit, we restore original logger settings
     task_logger_helper.move(root_logger)
-    if console_handler and IS_K8S_EXECUTOR_POD:
+
+    # if k8s executor, we need to ensure that root logger has a console handler
+    # so that task logs propagate to stdout (this is how webserver retrieves them
+    # while task is running)
+    if console_handler and IS_K8S_EXECUTOR_POD and console_handler not in root_logger.handlers:
         root_logger.addHandler(console_handler)
+
     try:
         yield
     finally:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -309,10 +309,10 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
 
     root_logger = logging.getLogger()
     task_logger = ti.log
+    console_handler = get_console_handler(root_logger)
 
     task_logger_helper = LoggerMutationHelper(task_logger)
     root_logger_helper = LoggerMutationHelper(root_logger)
-    console_handler = get_console_handler(root_logger)
 
     # below is the operative section
     # we move task handlers to root and reset task logger
@@ -322,8 +322,9 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     # if k8s executor, we need to ensure that root logger has a console handler
     # so that task logs propagate to stdout (this is how webserver retrieves them
     # while task is running)
-    if console_handler and IS_K8S_EXECUTOR_POD and console_handler not in root_logger.handlers:
-        root_logger.addHandler(console_handler)
+    if console_handler and IS_K8S_EXECUTOR_POD:
+        if console_handler not in root_logger.handlers:
+            root_logger.addHandler(console_handler)
 
     try:
         yield

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -314,7 +314,7 @@ def _move_task_handlers_to_root(ti: TaskInstance) -> Generator[None, None, None]
     root_logger_helper = LoggerMutationHelper(root_logger)
     console_handler = get_console_handler(root_logger)
 
-    # below is operative section
+    # below is the operative section
     # we move task handlers to root and reset task logger
     # after exit, we restore original logger settings
     task_logger_helper.move(root_logger)

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -624,6 +624,8 @@ IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get("core", "EXECUTOR") in {
     executor_constants.CELERY_KUBERNETES_EXECUTOR,
     executor_constants.LOCAL_KUBERNETES_EXECUTOR,
 }
+IS_K8S_EXECUTOR_POD = bool(os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", ""))
+"""Will be True if running in kubernetes executor pod."""
 
 HIDE_SENSITIVE_VAR_CONN_FIELDS = conf.getboolean("core", "hide_sensitive_var_conn_fields")
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -102,16 +102,17 @@ class FileTaskHandler(logging.Handler):
         with create_session() as session:
             dag_run = ti.get_dagrun(session=session)
             template = dag_run.get_log_template(session=session).filename
-        str_tpl, jinja_tpl = parse_template_string(template)
+            str_tpl, jinja_tpl = parse_template_string(template)
 
-        if jinja_tpl:
-            if hasattr(ti, "task"):
-                context = ti.get_template_context()
-            else:
-                context = Context(ti=ti, ts=dag_run.logical_date.isoformat())
-            context["try_number"] = try_number
-            return render_template_to_string(jinja_tpl, context)
-        elif str_tpl:
+            if jinja_tpl:
+                if hasattr(ti, "task"):
+                    context = ti.get_template_context(session=session)
+                else:
+                    context = Context(ti=ti, ts=dag_run.logical_date.isoformat())
+                context["try_number"] = try_number
+                return render_template_to_string(jinja_tpl, context)
+
+        if str_tpl:
             try:
                 dag = ti.task.dag
             except AttributeError:  # ti.task is not always set.

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -65,7 +65,7 @@ class FileTaskHandler(logging.Handler):
         self.maintain_propagate: bool = False
         """
         If true, overrides default behavior of setting propagate=False
-        
+
         :meta private:
         """
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -63,6 +63,9 @@ class FileTaskHandler(logging.Handler):
                 stacklevel=(2 if type(self) == FileTaskHandler else 3),
             )
         self.maintain_propagate: bool = False
+        """If true, overrides default behavior of setting propagate=False
+        :meta private:
+        """
 
     def set_context(self, ti: TaskInstance) -> None | SetContextPropagate:
         """

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -76,11 +76,14 @@ class FileTaskHandler(logging.Handler):
 
         :param ti: task instance object
         """
-        local_loc = self._init_file(ti)
-        self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")
-        if self.formatter:
-            self.handler.setFormatter(self.formatter)
-        self.handler.setLevel(self.level)
+        from airflow.models.taskinstance import TaskInstance
+
+        if isinstance(ti, TaskInstance):
+            local_loc = self._init_file(ti)
+            self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")
+            if self.formatter:
+                self.handler.setFormatter(self.formatter)
+            self.handler.setLevel(self.level)
         return SetContextPropagate.MAINTAIN_PROPAGATE if self.maintain_propagate else None
 
     def emit(self, record):

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -63,7 +63,9 @@ class FileTaskHandler(logging.Handler):
                 stacklevel=(2 if type(self) == FileTaskHandler else 3),
             )
         self.maintain_propagate: bool = False
-        """If true, overrides default behavior of setting propagate=False
+        """
+        If true, overrides default behavior of setting propagate=False
+        
         :meta private:
         """
 

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -76,14 +76,11 @@ class FileTaskHandler(logging.Handler):
 
         :param ti: task instance object
         """
-        from airflow.models.taskinstance import TaskInstance
-
-        if isinstance(ti, TaskInstance):
-            local_loc = self._init_file(ti)
-            self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")
-            if self.formatter:
-                self.handler.setFormatter(self.formatter)
-            self.handler.setLevel(self.level)
+        local_loc = self._init_file(ti)
+        self.handler = NonCachingFileHandler(local_loc, encoding="utf-8")
+        if self.formatter:
+            self.handler.setFormatter(self.formatter)
+        self.handler.setLevel(self.level)
         return SetContextPropagate.MAINTAIN_PROPAGATE if self.maintain_propagate else None
 
     def emit(self, record):

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -171,6 +171,7 @@ class RedirectStdHandler(StreamHandler):
     """
 
     def __init__(self, stream):
+        self.respect_redirection = True
         if not isinstance(stream, str):
             raise Exception(
                 "Cannot use file like objects. Use 'stdout' or 'stderr' as a str and without 'ext://'."
@@ -179,13 +180,17 @@ class RedirectStdHandler(StreamHandler):
         self._use_stderr = True
         if "stdout" in stream:
             self._use_stderr = False
-
+            self._orig_stream = sys.stdout
+        else:
+            self._orig_stream = sys.stderr
         # StreamHandler tries to set self.stream
         Handler.__init__(self)
 
     @property
     def stream(self):
         """Returns current stream."""
+        if self.respect_redirection is False:
+            return self._orig_stream
         if self._use_stderr:
             return sys.stderr
 

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -33,7 +33,6 @@ from unittest.mock import sentinel
 
 import pendulum
 import pytest
-import time_machine
 from parameterized import parameterized
 
 from airflow import DAG

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -72,15 +72,6 @@ def move_back(old_path, new_path):
     shutil.move(new_path, old_path)
 
 
-@pytest.fixture()
-def freeze_time():
-    timestamp = "2022-06-10T12:02:44+00:00"
-    freezer = time_machine.travel(timestamp, tick=False)
-    freezer.start()
-    yield
-    freezer.stop()
-
-
 # TODO: Check if tests needs side effects - locally there's missing DAG
 class TestCliTasks:
     run_id = "TEST_RUN_ID"

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -615,7 +615,7 @@ class TestLogsfromTaskRunCommand:
     @pytest.mark.parametrize("is_k8s", ["true", ""])
     def test_logging_with_run_task_stdout_k8s_executor_pod(self, is_k8s):
         """
-        When running task --local as k8l executor pod, all logging should make it to stdout.
+        When running task --local as k8s executor pod, all logging should make it to stdout.
         Otherwise, all logging after "running TI" is redirected to logs (and the actual log
         file content is tested elsewhere in this module).
 

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -32,6 +32,7 @@ from unittest import mock
 
 import pendulum
 import pytest
+import time_machine
 from parameterized import parameterized
 
 from airflow import DAG
@@ -67,6 +68,15 @@ def move_back(old_path, new_path):
     shutil.move(old_path, new_path)
     yield
     shutil.move(new_path, old_path)
+
+
+@pytest.fixture()
+def freeze_time():
+    timestamp = "2022-06-10T12:02:44+00:00"
+    freezer = time_machine.travel(timestamp, tick=False)
+    freezer.start()
+    yield
+    freezer.stop()
 
 
 # TODO: Check if tests needs side effects - locally there's missing DAG
@@ -599,6 +609,56 @@ class TestLogsfromTaskRunCommand:
                 pool=None,
                 external_executor_id="ABCD12345",
             )
+
+    def test_logging_with_run_task_stdout(self, capsys, freeze_time):
+        with conf_vars({("core", "dags_folder"): self.dag_path}):
+            task_command.task_run(self.parser.parse_args(self.task_args))
+        out, err = capsys.readouterr()
+        lines = []
+        found_start = False
+        for line in out.splitlines():
+            if "Running <TaskInstance: test_logging_dag.test_task test_run" in line:
+                found_start = True
+            if found_start:
+                lines.append(line)
+        assert lines == [
+            "[\x1b[34m2022-06-10 05:02:44,000\x1b[0m] "
+            "{\x1b[34mtask_command.py:\x1b[0m435} INFO\x1b[0m - Running <TaskInstance: "
+            "test_logging_dag.test_task test_run [None]> on host daniels-mbp-2.lan\x1b[0m",
+        ]
+
+    @mock.patch.dict("os.environ", AIRFLOW_IS_K8S_EXECUTOR_POD="True")
+    def test_logging_with_run_task_stdout_k8s_executor_pod(self, capfd, freeze_time):
+        """
+        When running task --local as k8l executor pod, all logging should make it to stdout.
+
+        Unfortunately, we have to test this by running as a subprocess because
+        the stdout redirection & log capturing behavior is not compatible with pytest's stdout
+        capturing behavior.  Running as subprocess takes pytest out of the equation and
+        verifies with certainty the behavior.
+        """
+        import subprocess
+
+        with subprocess.Popen(
+            args=["airflow", *self.task_args, "-S", self.dag_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) as process:
+            output, err = process.communicate()
+        lines = []
+        found_start = False
+        for line_ in output.splitlines():
+            line = line_.decode("utf-8")
+            if "Running <TaskInstance: test_logging_dag.test_task test_run" in line:
+                found_start = True
+            if found_start:
+                lines.append(line)
+        self.assert_log_line("Starting attempt 1 of 1", lines)
+        self.assert_log_line("Exporting the following env vars", lines)
+        self.assert_log_line("Log from DAG Logger", lines)
+        self.assert_log_line("Log from TI Logger", lines)
+        self.assert_log_line("Log from Print statement", lines, expect_from_logging_mixin=True)
+        self.assert_log_line("Task exited with return code 0", lines)
 
     @unittest.skipIf(not hasattr(os, "fork"), "Forking not available")
     def test_logging_with_run_task(self):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -888,6 +888,6 @@ class TestLoggerMutationHelper:
         src.addHandler(sentinel.h2)
         src.setLevel(-2)
         obj.reset()
-        assert src.propagate == True
+        assert src.propagate is True
         assert src.handlers == [sentinel.h1]
         assert src.level == -1

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -29,6 +29,7 @@ import pytest
 
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.listeners.listener import get_listener_manager
+from airflow.logging_config import configure_logging
 from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import TaskInstance
 from airflow.task.task_runner.standard_task_runner import StandardTaskRunner
@@ -76,7 +77,6 @@ def propagate_task_logger():
             h.maintain_propagate = _propagate
 
 
-@pytest.mark.usefixtures("reset_logging_config")
 class TestStandardTaskRunner:
     @pytest.fixture(autouse=True, scope="class")
     def setup_db(self):
@@ -90,6 +90,11 @@ class TestStandardTaskRunner:
         yield
         clear_db_runs()
         get_listener_manager().clear()
+
+    def teardown_method(self):
+        for handler_ref in logging._handlerList[:]:  # type: ignore
+            logging._removeHandlerRef(handler_ref)  # type: ignore
+        configure_logging()
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -35,7 +35,6 @@ from airflow.task.task_runner.standard_task_runner import StandardTaskRunner
 from airflow.utils import timezone
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.platform import getuser
-from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from tests.listeners.file_write_listener import FileWriteListener
@@ -140,23 +139,15 @@ class TestStandardTaskRunner:
         )
         dag = dagbag.dags.get("test_example_bash_operator")
         task = dag.get_task("runme_1")
-
-        with create_session() as session:
-            dag.create_dagrun(
-                run_id="test",
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                state=State.RUNNING,
-                start_date=DEFAULT_DATE,
-                session=session,
-            )
-            ti = TaskInstance(task=task, run_id="test")
-            job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
-
-            # we must create runner within same session
-            runner = StandardTaskRunner(job1)
-
-        # we need to get out of session before starting runner
-        # because of the way things behave re sessions after forking
+        dag.create_dagrun(
+            run_id="test",
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            state=State.RUNNING,
+            start_date=DEFAULT_DATE,
+        )
+        ti = TaskInstance(task=task, run_id="test")
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+        runner = StandardTaskRunner(job1)
         runner.start()
 
         # Wait until process sets its pgid to be equal to pid
@@ -267,21 +258,15 @@ class TestStandardTaskRunner:
         )
         dag = dagbag.dags.get("test_on_kill")
         task = dag.get_task("task1")
-
-        with create_session() as session:
-            dag.create_dagrun(
-                run_id="test",
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                state=State.RUNNING,
-                start_date=DEFAULT_DATE,
-                session=session,
-            )
-            ti = TaskInstance(task=task, run_id="test")
-            job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
-            runner = StandardTaskRunner(job1)
-
-        # we need to get out of session before starting runner
-        # because of the way things behave re sessions after forking
+        dag.create_dagrun(
+            run_id="test",
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            state=State.RUNNING,
+            start_date=DEFAULT_DATE,
+        )
+        ti = TaskInstance(task=task, run_id="test")
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+        runner = StandardTaskRunner(job1)
         runner.start()
 
         with timeout(seconds=3):
@@ -333,20 +318,15 @@ class TestStandardTaskRunner:
         dag = dagbag.dags.get("test_parsing_context")
         task = dag.get_task("task1")
 
-        with create_session() as session:
-            dag.create_dagrun(
-                run_id="test",
-                data_interval=(DEFAULT_DATE, DEFAULT_DATE),
-                state=State.RUNNING,
-                start_date=DEFAULT_DATE,
-                session=session,
-            )
-            ti = TaskInstance(task=task, run_id="test")
-            job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
-            runner = StandardTaskRunner(job1)
-
-        # we need to get out of session before starting runner
-        # because of the way things behave re sessions after forking
+        dag.create_dagrun(
+            run_id="test",
+            data_interval=(DEFAULT_DATE, DEFAULT_DATE),
+            state=State.RUNNING,
+            start_date=DEFAULT_DATE,
+        )
+        ti = TaskInstance(task=task, run_id="test")
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+        runner = StandardTaskRunner(job1)
         runner.start()
 
         # Wait until process sets its pgid to be equal to pid

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -152,7 +152,7 @@ class TestStandardTaskRunner:
         runner = StandardTaskRunner(job1)
         runner.start()
 
-        # Wait until process sets its pgid to be equal to pid
+        # Wait until process makes itself the leader of it's own process group
         with timeout(seconds=1):
             while True:
                 runner_pgid = os.getpgid(runner.process.pid)

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -23,7 +23,6 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 from unittest import mock
-from unittest.mock import patch
 
 import psutil
 import pytest
@@ -46,20 +45,6 @@ TEST_DAG_FOLDER = os.environ["AIRFLOW__CORE__DAGS_FOLDER"]
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
 TASK_FORMAT = "%(filename)s:%(lineno)d %(levelname)s - %(message)s"
-
-
-@pytest.fixture()
-def mock_fth():
-    """
-    _render_filename creates a session and this does not behave well with
-    the forking behavior in StandardTaskRunner in the test context.
-    If we do not mock, then we get errors during test cleanup.
-    """
-    patch_log_init = patch("airflow.utils.log.file_task_handler.FileTaskHandler._render_filename")
-    mock_log_init = patch_log_init.start()
-    mock_log_init.return_value = "/tmp/my_file.txt"
-    yield mock_log_init
-    patch_log_init.stop()
 
 
 @contextmanager
@@ -139,7 +124,7 @@ class TestStandardTaskRunner:
 
         assert runner.return_code() is not None
 
-    def test_notifies_about_start_and_stop(self, mock_fth):
+    def test_notifies_about_start_and_stop(self):
         path_listener_writer = "/tmp/path_listener_writer"
         try:
             os.unlink(path_listener_writer)
@@ -164,7 +149,6 @@ class TestStandardTaskRunner:
         ti = TaskInstance(task=task, run_id="test")
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
         runner = StandardTaskRunner(job1)
-
         runner.start()
 
         # Wait until process sets its pgid to be equal to pid
@@ -253,7 +237,7 @@ class TestStandardTaskRunner:
         assert runner.return_code() == -9
         assert "running out of memory" in caplog.text
 
-    def test_on_kill(self, mock_fth):
+    def test_on_kill(self):
         """
         Test that ensures that clearing in the UI SIGTERMS
         the task
@@ -320,7 +304,7 @@ class TestStandardTaskRunner:
         for process in processes:
             assert not psutil.pid_exists(process.pid), f"{process} is still alive"
 
-    def test_parsing_context(self, mock_fth):
+    def test_parsing_context(self):
         context_file = Path("/tmp/airflow_parsing_context")
         try:
             context_file.unlink()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -289,8 +289,6 @@ class TestStandardTaskRunner:
         logging.info("Terminating processes %s belonging to %s group", processes, runner_pgid)
         runner.terminate()
 
-        ti.refresh_from_db()
-
         logging.info("Waiting for the on kill killed file to appear")
         with timeout(seconds=4):
             while True:

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -29,7 +29,6 @@ import pytest
 
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.listeners.listener import get_listener_manager
-from airflow.logging_config import configure_logging
 from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import TaskInstance
 from airflow.task.task_runner.standard_task_runner import StandardTaskRunner
@@ -77,6 +76,7 @@ def propagate_task_logger():
             h.maintain_propagate = _propagate
 
 
+@pytest.mark.usefixtures("reset_logging_config")
 class TestStandardTaskRunner:
     @pytest.fixture(autouse=True, scope="class")
     def setup_db(self):
@@ -90,11 +90,6 @@ class TestStandardTaskRunner:
         yield
         clear_db_runs()
         get_listener_manager().clear()
-
-    def teardown_method(self):
-        for handler_ref in logging._handlerList[:]:  # type: ignore
-            logging._removeHandlerRef(handler_ref)  # type: ignore
-        configure_logging()
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -77,8 +77,7 @@ def propagate_task_logger():
 
 @pytest.mark.usefixtures("reset_logging_config")
 class TestStandardTaskRunner:
-    @pytest.fixture(autouse=True, scope="class")
-    def setup_db(self):
+    def setup_class(self):
         """
         This fixture sets up logging to have a different setup on the way in
         (as the test environment does not have enough context for the normal
@@ -89,7 +88,6 @@ class TestStandardTaskRunner:
         yield
         clear_db_runs()
         get_listener_manager().clear()
-        logging.shutdown()
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()


### PR DESCRIPTION
Currently live logging (viewing from webserver while task running) for k8s executor pods doesn't work.

The cause has a few components from things we do during task run:
1. we remove the console handler from root logger.  So any logs that make it to root don't get emitted.
2. even if we keep console handler at root, it is designed to respect stdout redirection
3. even if we make it not respect stdout redirection in this context, task logger does not propagate, so anything going through task logger does not make it to root logger

The reason for (3) is we *copy* the task handler to root logger instead of *move*, which requires that we disable propagation at the task logger.

This PR fixes all of these things and, ultimately, simplifies the setup.

1. instead of keeping task handler in two places during execution -- airflow.task and root -- we keep it just in root.  This means we can let airflow.task logger propagate. this we now do always.
2. when running k8s executor pod, we keep the console handler at root and set it to not respect redirection, so that even though stdout gets redirected to task logger, when it makes it to root logger, it is still emitted to stdout.

