### PR TITLE
Re-enable azure service bus on ARM as it now builds cleanly

### DIFF
--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -63,8 +63,7 @@ dependencies:
   - azure-storage-blob>=12.14.0
   - azure-storage-common>=2.1.0
   - azure-storage-file>=2.1.0
-  # Limited due to https://github.com/Azure/azure-uamqp-python/issues/191
-  - azure-servicebus>=7.6.1; platform_machine != "aarch64"
+  - azure-servicebus>=7.6.1
   - azure-synapse-spark
   - adal>=1.2.7
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -440,7 +440,7 @@
       "azure-mgmt-datafactory>=1.0.0,<2.0",
       "azure-mgmt-datalake-store>=0.5.0",
       "azure-mgmt-resource>=2.2.0",
-      "azure-servicebus>=7.6.1; platform_machine != \"aarch64\"",
+      "azure-servicebus>=7.6.1",
       "azure-storage-blob>=12.14.0",
       "azure-storage-common>=2.1.0",
       "azure-storage-file>=2.1.0",


### PR DESCRIPTION
Previously, the Azure Service Bus had to be disabled in order to get ARM compatibility (it failed to build cleanly as uampq did not have binary wheels released and they failed to compile cleanly on debian). But the last problem is fixed now, so we can re-enable it for ARM.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
