### PR TITLE
Remove deprecated AIPlatformConsoleLink from google/provider.yaml

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -965,7 +965,6 @@ connection-types:
 extra-links:
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink
-  - airflow.providers.google.cloud.operators.mlengine.AIPlatformConsoleLink
   - airflow.providers.google.cloud.links.dataform.DataformRepositoryLink
   - airflow.providers.google.cloud.links.dataform.DataformWorkspaceLink
   - airflow.providers.google.cloud.links.dataform.DataformWorkflowInvocationLink


### PR DESCRIPTION
Exception is raised on webserver because a deprecated extra link was not removed from google/provider.yaml. This was removed as part of this PR: https://github.com/apache/airflow/pull/26836/files#diff-ee2dc8677bb15f1b09b5cf14d16fde2b48c0712cc3d4d2b08d478855634b4266L980

Webserver Logs:
```
10.253.8.251 - - [15/Dec/2022:18:32:58 +0000] "GET /object/next_run_datasets/recs_ranking_purchase_ranker_dag HTTP/1.1" 200 2 "https://web.airflow.etsy-syseng-gke-prod.etsycloud.com/dags/recs_ranking_purchase_ranker_dag/code" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
    raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute/class')
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/module_loading.py", line 38, in import_string
    imported_class = import_string(class_name)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/providers_manager.py", line 275, in _sanity_check
Traceback (most recent call last):

During handling of the above exception, another exception occurred:

AttributeError: module 'airflow.providers.google.cloud.operators.mlengine' has no attribute 'AIPlatformConsoleLink'
    return getattr(module, class_name)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/module_loading.py", line 36, in import_string
Traceback (most recent call last):
[2022-12-15 18:32:58,068] {providers_manager.py:243} WARNING - Exception when importing 'airflow.providers.google.cloud.operators.mlengine.AIPlatformConsoleLink' from 'apache-airflow-providers-google' package
ImportError: Module "airflow.providers.google.cloud.operators.mlengine" does not define a "AIPlatformConsoleLink" attribute/class
```
Fixes: https://github.com/apache/airflow/issues/28393

cc @uranusjr

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
