### PR TITLE
Add `ensure_ascii=False` in trigger dag run API

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1994,7 +1994,7 @@ class Airflow(AirflowBaseView):
                     default_conf = json.dumps(
                         {str(k): v.resolve(suppress_exception=True) for k, v in dag.params.items()},
                         indent=4,
-                        ensure_ascii=False
+                        ensure_ascii=False,
                     )
                 except TypeError:
                     flash("Could not pre-populate conf field due to non-JSON-serializable data-types")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1992,7 +1992,9 @@ class Airflow(AirflowBaseView):
             else:
                 try:
                     default_conf = json.dumps(
-                        {str(k): v.resolve(suppress_exception=True) for k, v in dag.params.items()}, indent=4
+                        {str(k): v.resolve(suppress_exception=True) for k, v in dag.params.items()},
+                        indent=4,
+                        ensure_ascii=False
                     )
                 except TypeError:
                     flash("Could not pre-populate conf field due to non-JSON-serializable data-types")


### PR DESCRIPTION
In Trigger DAG Run UI, non-unicode character broken. This change only affect to UI.