### PR TITLE
Fix example import sentence in dates.py

### DIFF
--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -48,7 +48,7 @@ def date_range(
     or a cron expression as a `str`
 
     .. code-block:: pycon
-        >>> from airflow.utils.dates import datterange
+        >>> from airflow.utils.dates import date_range
         >>> from datetime import datetime, timedelta
         >>> date_range(datetime(2016, 1, 1), datetime(2016, 1, 3), delta=timedelta(1))
         [datetime.datetime(2016, 1, 1, 0, 0, tzinfo=Timezone('UTC')),


### PR DESCRIPTION
The example import sentence in line 51  is incorrect

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
