### PR TITLE
Remove checks for 1.19 api checks

### DIFF
--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -20,12 +20,7 @@
 #################################
 {{- if .Values.flower.enabled }}
 {{- if and (or .Values.ingress.flower.enabled .Values.ingress.enabled) (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
-{{- $apiIsStable := semverCompare ">= 1.19.x" (include "kubeVersion" .) -}}
-{{- if $apiIsStable }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-flower-ingress
@@ -75,20 +70,13 @@ spec:
     - http:
         paths:
           - backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ $.Release.Name }}-flower
                 port:
                   name: flower-ui
-              {{- else }}
-              serviceName: {{ $.Release.Name }}-flower
-              servicePort: flower-ui
-              {{- end }}
             {{- if $.Values.ingress.flower.path }}
             path: {{ $.Values.ingress.flower.path }}
-            {{- if $apiIsStable }}
             pathType: {{ $.Values.ingress.flower.pathType }}
-            {{- end }}
             {{- end }}
       {{- $hostname := . -}}
       {{- if . | kindIs "string" | not }}
@@ -98,7 +86,7 @@ spec:
       host: {{ $hostname | quote }}
       {{- end }}
     {{- end }}
-  {{- if and .Values.ingress.flower.ingressClassName $apiIsStable }}
+  {{- if .Values.ingress.flower.ingressClassName }}
   ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
   {{- end }}
 {{- end }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -19,12 +19,7 @@
 ## Airflow Webserver Ingress
 #################################
 {{- if or .Values.ingress.web.enabled .Values.ingress.enabled }}
-{{- $apiIsStable := semverCompare ">= 1.19.x" (include "kubeVersion" .) -}}
-{{- if $apiIsStable }}
 apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
@@ -75,51 +70,30 @@ spec:
         paths:
           {{- range $.Values.ingress.web.precedingPaths }}
           - path: {{ .path }}
-            {{- if $apiIsStable }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
                 port:
                   name: {{ .servicePort }}
-              {{- else }}
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
-              {{- end }}
           {{- end }}
           - backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ $.Release.Name }}-webserver
                 port:
                   name: airflow-ui
-              {{- else }}
-              serviceName: {{ $.Release.Name }}-webserver
-              servicePort: airflow-ui
-              {{- end }}
             {{- if $.Values.ingress.web.path }}
             path: {{ $.Values.ingress.web.path }}
-            {{- if $apiIsStable }}
             pathType: {{ $.Values.ingress.web.pathType }}
-            {{- end }}
             {{- end }}
           {{- range $.Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
-            {{- if $apiIsStable }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
                 port:
                   name: {{ .servicePort }}
-              {{- else }}
-              serviceName: {{ .serviceName }}
-              servicePort: {{ .servicePort }}
-              {{- end }}
           {{- end }}
       {{- $hostname := . -}}
       {{- if . | kindIs "string" | not }}
@@ -129,7 +103,7 @@ spec:
       host: {{ $hostname | quote }}
       {{- end }}
     {{- end }}
-  {{- if and .Values.ingress.web.ingressClassName $apiIsStable }}
+  {{- if .Values.ingress.web.ingressClassName }}
   ingressClassName: {{ .Values.ingress.web.ingressClassName }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
There were checks for Kubernetes API >= 1.19 for ingress and they are not needed any more since we support 1.23+ only.

This was actually harmful in some cases as the checks were not perfect and caused failures in somke k8s implementations (microk8s for example).

Fixes: #22657

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
