### PR TITLE
[POC] Reset ResourceVersion.resource_version to default during tests

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -55,6 +55,14 @@ except ImportError:
     AirflowKubernetesScheduler = None  # type: ignore
 
 
+@pytest.fixture(autouse=True)
+def reset_resource_version():
+    """Reset ``ResourceVersion`` dictionary to empty before and after run each test."""
+    # ResourceVersion().resource_version = {}
+    yield
+    # ResourceVersion().resource_version = {}
+
+
 class TestAirflowKubernetesScheduler:
     @staticmethod
     def _gen_random_string(seed, str_len):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Check is any side-effects exists on changes in ResourceVersion.resource_version if use public runners

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
