### PR TITLE
Fix flaky test_recover_from_resource_too_old exception 

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -1249,12 +1249,13 @@ class TestKubernetesJobWatcher:
             try:
                 # self.watcher._run() is mocked and return "500" as last resource_version
                 self.watcher.run()
+                assert False, "Should have raised Exception"
             except Exception as e:
                 assert e.args == ("sentinel",)
 
             # both resource_version should be 0 after _run raises an exception
             assert self.watcher.resource_version == "0"
-            assert ResourceVersion().resource_version == {self.test_namespace: "0"}
+            assert ResourceVersion().resource_version[self.test_namespace] == "0"
 
             # check that in the next run, _run is invoked with resource_version = 0
             mock_underscore_run.reset_mock()


### PR DESCRIPTION
After #28047 the test_recover_from_resource_too_old started to fail in a flaky way. Turned out that - depend on some other test run the Singleton ResourceVersion could containt not one but two namespaces (including default namespace).

Also while fixing the tests it's been noticed that the test missed an assert - it did not assert that the Exception was in fact thrown, so the test could have succeeded even if the exception was not really thrown (there was assert in "except" clause but if the exception was not thrown, it would not have been called at all).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
