### PR TITLE
Add execution role parameter to AddStepsOperator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -140,9 +140,10 @@ class EmrHook(AwsBaseHook):
         :param wait_for_completion: If True, wait for the steps to be completed. Default is False
         :param execution_role_arn: The ARN of the runtime role for a step on the cluster.
         """
-        response = self.get_conn().add_job_flow_steps(
-            JobFlowId=job_flow_id, Steps=steps, ExecutionRoleArn=execution_role_arn
-        )
+        config = {}
+        if execution_role_arn:
+            config["ExecutionRoleArn"] = execution_role_arn
+        response = self.get_conn().add_job_flow_steps(JobFlowId=job_flow_id, Steps=steps, **config)
 
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Adding steps failed: {response}")

--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -126,7 +126,11 @@ class EmrHook(AwsBaseHook):
         return response
 
     def add_job_flow_steps(
-        self, job_flow_id: str, steps: list[dict] | str | None = None, wait_for_completion: bool = False
+        self,
+        job_flow_id: str,
+        steps: list[dict] | str | None = None,
+        wait_for_completion: bool = False,
+        execution_role_arn: str | None = None,
     ) -> list[str]:
         """
         Add new steps to a running cluster.
@@ -134,8 +138,11 @@ class EmrHook(AwsBaseHook):
         :param job_flow_id: The id of the job flow to which the steps are being added
         :param steps: A list of the steps to be executed by the job flow
         :param wait_for_completion: If True, wait for the steps to be completed. Default is False
+        :param execution_role_arn: The ARN of the runtime role for a step on the cluster.
         """
-        response = self.get_conn().add_job_flow_steps(JobFlowId=job_flow_id, Steps=steps)
+        response = self.get_conn().add_job_flow_steps(
+            JobFlowId=job_flow_id, Steps=steps, ExecutionRoleArn=execution_role_arn
+        )
 
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise AirflowException(f"Adding steps failed: {response}")

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -53,10 +53,17 @@ class EmrAddStepsOperator(BaseOperator):
     :param steps: boto3 style steps or reference to a steps file (must be '.json') to
         be added to the jobflow. (templated)
     :param wait_for_completion: If True, the operator will wait for all the steps to be completed.
+    :param execution_role_arn: The ARN of the runtime role for a step on the cluster.
     :param do_xcom_push: if True, job_flow_id is pushed to XCom with key job_flow_id.
     """
 
-    template_fields: Sequence[str] = ("job_flow_id", "job_flow_name", "cluster_states", "steps")
+    template_fields: Sequence[str] = (
+        "job_flow_id",
+        "job_flow_name",
+        "cluster_states",
+        "steps",
+        "execution_role_arn",
+    )
     template_ext: Sequence[str] = (".json",)
     template_fields_renderers = {"steps": "json"}
     ui_color = "#f9c915"
@@ -71,6 +78,7 @@ class EmrAddStepsOperator(BaseOperator):
         aws_conn_id: str = "aws_default",
         steps: list[dict] | str | None = None,
         wait_for_completion: bool = False,
+        execution_role_arn: str | None = None,
         **kwargs,
     ):
         if not exactly_one(job_flow_id is None, job_flow_name is None):
@@ -84,6 +92,7 @@ class EmrAddStepsOperator(BaseOperator):
         self.cluster_states = cluster_states
         self.steps = steps
         self.wait_for_completion = wait_for_completion
+        self.execution_role_arn = execution_role_arn
 
     def execute(self, context: Context) -> list[str]:
         emr_hook = EmrHook(aws_conn_id=self.aws_conn_id)
@@ -116,7 +125,10 @@ class EmrAddStepsOperator(BaseOperator):
             steps = ast.literal_eval(steps)
 
         return emr_hook.add_job_flow_steps(
-            job_flow_id=job_flow_id, steps=steps, wait_for_completion=wait_for_completion
+            job_flow_id=job_flow_id,
+            steps=steps,
+            wait_for_completion=self.wait_for_completion,
+            execution_role_arn=self.execution_role_arn,
         )
 
 

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -120,7 +120,6 @@ class EmrAddStepsOperator(BaseOperator):
         # steps may arrive as a string representing a list
         # e.g. if we used XCom or a file then: steps="[{ step1 }, { step2 }]"
         steps = self.steps
-        wait_for_completion = self.wait_for_completion
         if isinstance(steps, str):
             steps = ast.literal_eval(steps)
         return emr_hook.add_job_flow_steps(

--- a/airflow/providers/amazon/aws/operators/emr.py
+++ b/airflow/providers/amazon/aws/operators/emr.py
@@ -123,7 +123,6 @@ class EmrAddStepsOperator(BaseOperator):
         wait_for_completion = self.wait_for_completion
         if isinstance(steps, str):
             steps = ast.literal_eval(steps)
-
         return emr_hook.add_job_flow_steps(
             job_flow_id=job_flow_id,
             steps=steps,

--- a/tests/providers/amazon/aws/operators/test_emr_add_steps.py
+++ b/tests/providers/amazon/aws/operators/test_emr_add_steps.py
@@ -224,4 +224,5 @@ class TestEmrAddStepsOperator:
             job_flow_id=job_flow_id,
             steps=[],
             wait_for_completion=False,
+            execution_role_arn=None,
         )


### PR DESCRIPTION
EMR launched a new [feature](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-steps-runtime-roles.html) which allows configuring runtime roles for EMR steps. This PR allows users to use this feature with the `EmrAddStepsOperator`. System test has been updated to use this feature.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
