### PR TITLE
Remove outdated Optional Provider Feature outdated documentation

### DIFF
--- a/docs/apache-airflow-providers/howto/create-update-providers.rst
+++ b/docs/apache-airflow-providers/howto/create-update-providers.rst
@@ -267,7 +267,7 @@ main Airflow documentation that involves some steps with the providers is also w
 Optional provider features
 --------------------------
 
-  .. note::
+  .. versionadded:: 2.3.0
 
     This feature is available in Airflow 2.3+.
 
@@ -279,37 +279,6 @@ However until Airflow 2.3, Airflow had no mechanism to selectively ignore "known
 Airflow 2.1 and 2.2 silently ignored all ImportErrors coming from providers with actually lead to
 ignoring even important import errors - without giving the clue to Airflow users that there is something
 missing in provider dependencies.
-
-In Airflow 2.3, new exception :class:`~airflow.exceptions.OptionalProviderFeatureException` has been
-introduced and Providers can use the exception to signal that the ImportError (or any other error) should
-be ignored by Airflow ProvidersManager. However this Exception is only available in Airflow 2.3 so if
-providers would like to remain compatible with 2.2, they should continue throwing
-the ImportError exception.
-
-Example code (from Plyvel Hook, part of the Google Provider) explains how such conditional error handling
-should be implemented to keep compatibility with 2.2
-
-  .. code-block:: python
-
-    try:
-        import plyvel
-        from plyvel import DB
-
-        from airflow.exceptions import AirflowException
-        from airflow.hooks.base import BaseHook
-
-    except ImportError as e:
-        # Plyvel is an optional feature and if imports are missing, it should be silently ignored
-        # As of Airflow 2.3  and above the operator can throw OptionalProviderFeatureException
-        try:
-            from airflow.exceptions import AirflowOptionalProviderFeatureException
-        except ImportError:
-            # However, in order to keep backwards-compatibility with Airflow 2.1 and 2.2, if the
-            # 2.3 exception cannot be imported, the original ImportError should be raised.
-            # This try/except can be removed when the provider depends on Airflow >= 2.3.0
-            raise e
-        raise AirflowOptionalProviderFeatureException(e)
-
 
 Using Providers with dynamic task mapping
 -----------------------------------------


### PR DESCRIPTION
After bumping min_airflow_version to 2.3 the section about optional provider feature and the way to add it for pre-2.3 compatible providers is outdated and should be removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
