### PR TITLE
Set pip install opts in _PIP_ADDITIONAL_REQUIREMENTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -991,7 +991,9 @@ if [[ -n "${_PIP_ADDITIONAL_REQUIREMENTS=}" ]] ; then
     >&2 echo "         the container starts, so it is onlny useful for testing and trying out"
     >&2 echo "         of adding dependencies."
     >&2 echo
-    pip install --root-user-action ignore --no-cache-dir ${_PIP_ADDITIONAL_REQUIREMENTS}
+    pip install --root-user-action ignore --no-cache-dir \
+        ${ADDITIONAL_PIP_INSTALL_FLAGS} \
+        ${_PIP_ADDITIONAL_REQUIREMENTS}
 fi
 
 


### PR DESCRIPTION
The entrypoint exposes _PIP_ADDITIONAL_REQUIREMENTS to allow installing packages. While it is clearly stated that this option should only be used in tests it is still common to make multiple attempts. Thus requiring to install multiple packages multiple times.

To improve the installation speeds in such a scenario a practical solution is to use a pypi cache. A simple example is with running [epicwink/proxpi](https://github.com/EpicWink/proxpi). To enable the usage one will need to specify the relevant pip install flags.

```
pip install --index-url http://127.0.0.1:5000/index/ simplejson
```

Or when using a different ip (e.g a host in the local network)

```
pip install \
        --trusted-host 172.31.234.147 \
        --index-url http://172.31.234.147:5000/index/ \
        simplejson
```

To do this we reuse the existing flag ADDITIONAL_PIP_INSTALL_FLAGS and pass it to the relevant place.

**Note**: for any users interested in using a proxy without this patch you can simply pass the extra options in the `_PIP_ADDITIONAL_REQUIREMENTS ` variable.
Example: `_PIP_ADDITIONAL_REQUIREMENTS="--trusted-host 172.31.234.147 --index-url http://172.31.234.147:5000/index/ great_expectations snowflake-connector-python snowflake-sqlalchemy apache-airflow-providers-snowflake"`