### PR TITLE
Add `KubernetesPodOperatorAsync`

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -294,6 +294,7 @@ class KubernetesPodOperator(BaseOperator):
         base_container_name: str | None = None,
         deferrable: bool = False,
         poll_interval: float = 2,
+        logging_interval: int | None = None,
         **kwargs,
     ) -> None:
         # TODO: remove in provider 6.0.0 release. This is a mitigate step to advise users to switch to the
@@ -363,6 +364,7 @@ class KubernetesPodOperator(BaseOperator):
         self.base_container_name = base_container_name or self.BASE_CONTAINER_NAME
         self.deferrable = deferrable
         self.poll_interval = poll_interval
+        self.logging_interval = logging_interval
         self.remote_pod: k8s.V1Pod | None = None
 
         self._config_dict: dict | None = None
@@ -565,7 +567,103 @@ class KubernetesPodOperator(BaseOperator):
             context=context,
         )
         self.convert_config_file_to_dict()
-        self.invoke_defer_method()
+        self.defer()
+
+    def defer(self, last_log_time: DateTime | None = None, **kwargs: Any) -> None:
+        """Defers to ``WaitContainerTrigger`` optionally with last log time."""
+        if kwargs:
+            raise ValueError(
+                f"Received keyword arguments {list(kwargs.keys())} but "
+                f"they are not used in this implementation of `defer`."
+            )
+        super().defer(
+            trigger=WaitContainerTrigger(
+                kubernetes_conn_id=self.kubernetes_conn_id,
+                hook_params={
+                    "cluster_context": self.cluster_context,
+                    "config_file": self.config_file,
+                    "in_cluster": self.in_cluster,
+                },
+                pod_name=self.pod.metadata.name,
+                container_name=self.BASE_CONTAINER_NAME,
+                pod_namespace=self.pod.metadata.namespace,
+                pending_phase_timeout=self.startup_timeout_seconds,
+                poll_interval=self.poll_interval,
+                logging_interval=self.logging_interval,
+                last_log_time=last_log_time,
+            ),
+            method_name=self.trigger_reentry.__name__,
+        )
+
+    @staticmethod
+    def raise_for_trigger_status(event: dict[str, Any]) -> None:
+        """Raise exception if pod is not in expected state."""
+        if event["status"] == "error":
+            error_type = event["error_type"]
+            description = event["description"]
+            if error_type == "PodLaunchTimeoutException":
+                raise PodLaunchTimeoutException(description)
+            else:
+                raise AirflowException(description)
+
+    def trigger_reentry(self, context: Context, event: dict[str, Any]) -> Any:
+        """
+        Point of re-entry from trigger.
+
+        If ``logging_interval`` is None, then at this point the pod should be done and we'll just fetch
+        the logs and exit.
+
+        If ``logging_interval`` is not None, it could be that the pod is still running and we'll just
+        grab the latest logs and defer back to the trigger again.
+        """
+        remote_pod = None
+        try:
+            self.pod_request_obj = self.build_pod_request_obj(context)
+            self.pod = self.find_pod(
+                namespace=self.namespace or self.pod_request_obj.metadata.namespace,
+                context=context,
+            )
+
+            # we try to find pod before possibly raising so that on_kill will have `pod` attr
+            self.raise_for_trigger_status(event)
+
+            if not self.pod:
+                raise PodNotFoundException("Could not find pod after resuming from deferral")
+
+            if self.get_logs:
+                last_log_time = event and event.get("last_log_time")
+                if last_log_time:
+                    self.log.info("Resuming logs read from time %r", last_log_time)
+                pod_log_status = self.pod_manager.fetch_container_logs(
+                    pod=self.pod,
+                    container_name=self.BASE_CONTAINER_NAME,
+                    follow=self.logging_interval is None,
+                    since_time=last_log_time,
+                )
+                if pod_log_status.running:
+                    self.log.info("Container still running; deferring again.")
+                    self.defer(pod_log_status.last_log_time)
+
+            if self.do_xcom_push:
+                result = self.extract_xcom(pod=self.pod)
+            remote_pod = self.pod_manager.await_pod_completion(self.pod)
+        except TaskDeferred:
+            raise
+        except Exception:
+            self.cleanup(
+                pod=self.pod or self.pod_request_obj,
+                remote_pod=remote_pod,
+            )
+            raise
+        self.cleanup(
+            pod=self.pod or self.pod_request_obj,
+            remote_pod=remote_pod,
+        )
+        ti = context["ti"]
+        ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
+        ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
+        if self.do_xcom_push:
+            return result
 
     def convert_config_file_to_dict(self):
         """Converts passed config_file to dict format."""
@@ -576,65 +674,13 @@ class KubernetesPodOperator(BaseOperator):
         else:
             self._config_dict = None
 
-    def invoke_defer_method(self):
-        """Method to easily redefine triggers which are being used in child classes."""
-        trigger_start_time = utcnow()
-        self.defer(
-            trigger=KubernetesPodTrigger(
-                pod_name=self.pod.metadata.name,
-                pod_namespace=self.pod.metadata.namespace,
-                trigger_start_time=trigger_start_time,
-                kubernetes_conn_id=self.kubernetes_conn_id,
-                cluster_context=self.cluster_context,
-                config_dict=self._config_dict,
-                in_cluster=self.in_cluster,
-                poll_interval=self.poll_interval,
-                should_delete_pod=self.is_delete_operator_pod,
-                get_logs=self.get_logs,
-                startup_timeout=self.startup_timeout_seconds,
-                base_container_name=self.base_container_name,
-            ),
-            method_name="execute_complete",
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
+        """Deprecated; replaced by trigger_reentry."""
+        warnings.warn(
+            "Method `execute_complete` is deprecated and replaced with method `trigger_reentry`.",
+            DeprecationWarning,
         )
-
-    def execute_complete(self, context: Context, event: dict, **kwargs):
-        pod = None
-        remote_pod = None
-        try:
-            pod = self.hook.get_pod(
-                event["name"],
-                event["namespace"],
-            )
-            # It is done to coincide with the current implementation of the general logic of the cleanup
-            # method. If it's going to be remade in future then it must be changed
-            remote_pod = pod
-            if event["status"] in ("error", "failed", "timeout"):
-                # fetch some logs when pod is failed
-                if self.get_logs:
-                    self.write_logs(pod)
-                raise AirflowException(event["message"])
-            elif event["status"] == "success":
-                ti = context["ti"]
-                ti.xcom_push(key="pod_name", value=pod.metadata.name)
-                ti.xcom_push(key="pod_namespace", value=pod.metadata.namespace)
-
-                # fetch some logs when pod is executed successfully
-                if self.get_logs:
-                    self.write_logs(pod)
-
-                if self.do_xcom_push:
-                    xcom_sidecar_output = self.extract_xcom(pod=pod)
-                    pod = self.pod_manager.await_pod_completion(pod)
-                    # It is done to coincide with the current implementation of the general logic of
-                    # the cleanup method. If it's going to be remade in future then it must be changed
-                    remote_pod = pod
-                    return xcom_sidecar_output
-        finally:
-            if pod is not None and remote_pod is not None:
-                self.post_complete_action(
-                    pod=pod,
-                    remote_pod=remote_pod,
-                )
+        self.trigger_reentry(context=context, event=event)
 
     def write_logs(self, pod: k8s.V1Pod):
         try:
@@ -883,131 +929,4 @@ class PodNotFoundException(AirflowException):
     """Expected pod does not exist in kube-api."""
 
 
-class KubernetesPodAsyncOperator(KubernetesPodOperator):
-    """
-    Async (deferring) version of KubernetesPodOperator
 
-    .. warning::
-        By default, logs will not be available in the Airflow Webserver until the task completes. However,
-        you can configure ``KubernetesPodAsyncOperator`` to periodically resume and fetch logs.  This behavior
-        is controlled by param ``logging_interval``.
-
-    :param poll_interval: interval in seconds to sleep between checking pod status
-    :param logging_interval: max time in seconds that task should be in deferred state before
-        resuming to fetch latest logs. If ``None``, then the task will remain in deferred state until pod
-        is done, and no logs will be visible until that time.
-    """
-
-    def __init__(self, *, poll_interval: int = 5, logging_interval: int | None = None, **kwargs: Any):
-        self.poll_interval = poll_interval
-        self.logging_interval = logging_interval
-        super().__init__(**kwargs)
-
-    @staticmethod
-    def raise_for_trigger_status(event: dict[str, Any]) -> None:
-        """Raise exception if pod is not in expected state."""
-        if event["status"] == "error":
-            error_type = event["error_type"]
-            description = event["description"]
-            if error_type == "PodLaunchTimeoutException":
-                raise PodLaunchTimeoutException(description)
-            else:
-                raise AirflowException(description)
-
-    def defer(self, last_log_time: DateTime | None = None, **kwargs: Any) -> None:
-        """Defers to ``WaitContainerTrigger`` optionally with last log time."""
-        if kwargs:
-            raise ValueError(
-                f"Received keyword arguments {list(kwargs.keys())} but "
-                f"they are not used in this implementation of `defer`."
-            )
-        super().defer(
-            trigger=WaitContainerTrigger(
-                kubernetes_conn_id=self.kubernetes_conn_id,
-                hook_params={
-                    "cluster_context": self.cluster_context,
-                    "config_file": self.config_file,
-                    "in_cluster": self.in_cluster,
-                },
-                pod_name=self.pod.metadata.name,
-                container_name=self.BASE_CONTAINER_NAME,
-                pod_namespace=self.pod.metadata.namespace,
-                pending_phase_timeout=self.startup_timeout_seconds,
-                poll_interval=self.poll_interval,
-                logging_interval=self.logging_interval,
-                last_log_time=last_log_time,
-            ),
-            method_name=self.trigger_reentry.__name__,
-        )
-
-    def execute(self, context: Context) -> None:
-        self.pod_request_obj = self.build_pod_request_obj(context)
-        self.pod: k8s.V1Pod = self.get_or_create_pod(self.pod_request_obj, context)
-        self.defer()
-
-    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
-        """Deprecated; replaced by trigger_reentry."""
-        warnings.warn(
-            "Method `execute_complete` is deprecated and replaced with method `trigger_reentry`.",
-            DeprecationWarning,
-        )
-        self.trigger_reentry(context=context, event=event)
-
-    def trigger_reentry(self, context: Context, event: dict[str, Any]) -> Any:
-        """
-        Point of re-entry from trigger.
-
-        If ``logging_interval`` is None, then at this point the pod should be done and we'll just fetch
-        the logs and exit.
-
-        If ``logging_interval`` is not None, it could be that the pod is still running and we'll just
-        grab the latest logs and defer back to the trigger again.
-        """
-        remote_pod = None
-        try:
-            self.pod_request_obj = self.build_pod_request_obj(context)
-            self.pod = self.find_pod(
-                namespace=self.namespace or self.pod_request_obj.metadata.namespace,
-                context=context,
-            )
-
-            # we try to find pod before possibly raising so that on_kill will have `pod` attr
-            self.raise_for_trigger_status(event)
-
-            if not self.pod:
-                raise PodNotFoundException("Could not find pod after resuming from deferral")
-
-            if self.get_logs:
-                last_log_time = event and event.get("last_log_time")
-                if last_log_time:
-                    self.log.info("Resuming logs read from time %r", last_log_time)
-                pod_log_status = self.pod_manager.fetch_container_logs(
-                    pod=self.pod,
-                    container_name=self.BASE_CONTAINER_NAME,
-                    follow=self.logging_interval is None,
-                    since_time=last_log_time,
-                )
-                if pod_log_status.running:
-                    self.log.info("Container still running; deferring again.")
-                    self.defer(pod_log_status.last_log_time)
-
-            if self.do_xcom_push:
-                result = self.extract_xcom(pod=self.pod)
-            remote_pod = self.pod_manager.await_pod_completion(self.pod)
-        except TaskDeferred:
-            raise
-        except Exception:
-            self.cleanup(
-                pod=self.pod or self.pod_request_obj,
-                remote_pod=remote_pod,
-            )
-            raise
-        self.cleanup(
-            pod=self.pod or self.pod_request_obj,
-            remote_pod=remote_pod,
-        )
-        ti = context["ti"]
-        ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
-        ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
-        if self.do_xcom_push:
-            return result

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -65,7 +65,6 @@ from airflow.providers.cncf.kubernetes.utils.pod_manager import (
 from airflow.settings import pod_mutation_hook
 from airflow.utils import yaml
 from airflow.utils.helpers import prune_dict, validate_key
-from airflow.utils.timezone import utcnow
 from airflow.version import version as airflow_version
 
 if TYPE_CHECKING:
@@ -927,6 +926,3 @@ class _optionally_suppress(AbstractContextManager):
 
 class PodNotFoundException(AirflowException):
     """Expected pod does not exist in kube-api."""
-
-
-

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -29,11 +29,12 @@ from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any, Sequence
 
 from kubernetes.client import CoreV1Api, models as k8s
+from pendulum import DateTime
 from slugify import slugify
 from urllib3.exceptions import HTTPError
 
 from airflow.compat.functools import cached_property
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.kubernetes import pod_generator
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.kubernetes.secret import Secret
@@ -50,7 +51,10 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume_mount,
 )
 from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesHook
-from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import KubernetesPodTrigger
+from airflow.providers.cncf.kubernetes.triggers.wait_container import (
+    PodLaunchTimeoutException,
+    WaitContainerTrigger,
+)
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar  # type: ignore[attr-defined]
 from airflow.providers.cncf.kubernetes.utils.pod_manager import (
     PodLaunchFailedException,
@@ -873,3 +877,137 @@ class _optionally_suppress(AbstractContextManager):
             return True
         else:
             return True
+
+
+class PodNotFoundException(AirflowException):
+    """Expected pod does not exist in kube-api."""
+
+
+class KubernetesPodAsyncOperator(KubernetesPodOperator):
+    """
+    Async (deferring) version of KubernetesPodOperator
+
+    .. warning::
+        By default, logs will not be available in the Airflow Webserver until the task completes. However,
+        you can configure ``KubernetesPodAsyncOperator`` to periodically resume and fetch logs.  This behavior
+        is controlled by param ``logging_interval``.
+
+    :param poll_interval: interval in seconds to sleep between checking pod status
+    :param logging_interval: max time in seconds that task should be in deferred state before
+        resuming to fetch latest logs. If ``None``, then the task will remain in deferred state until pod
+        is done, and no logs will be visible until that time.
+    """
+
+    def __init__(self, *, poll_interval: int = 5, logging_interval: int | None = None, **kwargs: Any):
+        self.poll_interval = poll_interval
+        self.logging_interval = logging_interval
+        super().__init__(**kwargs)
+
+    @staticmethod
+    def raise_for_trigger_status(event: dict[str, Any]) -> None:
+        """Raise exception if pod is not in expected state."""
+        if event["status"] == "error":
+            error_type = event["error_type"]
+            description = event["description"]
+            if error_type == "PodLaunchTimeoutException":
+                raise PodLaunchTimeoutException(description)
+            else:
+                raise AirflowException(description)
+
+    def defer(self, last_log_time: DateTime | None = None, **kwargs: Any) -> None:
+        """Defers to ``WaitContainerTrigger`` optionally with last log time."""
+        if kwargs:
+            raise ValueError(
+                f"Received keyword arguments {list(kwargs.keys())} but "
+                f"they are not used in this implementation of `defer`."
+            )
+        super().defer(
+            trigger=WaitContainerTrigger(
+                kubernetes_conn_id=self.kubernetes_conn_id,
+                hook_params={
+                    "cluster_context": self.cluster_context,
+                    "config_file": self.config_file,
+                    "in_cluster": self.in_cluster,
+                },
+                pod_name=self.pod.metadata.name,
+                container_name=self.BASE_CONTAINER_NAME,
+                pod_namespace=self.pod.metadata.namespace,
+                pending_phase_timeout=self.startup_timeout_seconds,
+                poll_interval=self.poll_interval,
+                logging_interval=self.logging_interval,
+                last_log_time=last_log_time,
+            ),
+            method_name=self.trigger_reentry.__name__,
+        )
+
+    def execute(self, context: Context) -> None:
+        self.pod_request_obj = self.build_pod_request_obj(context)
+        self.pod: k8s.V1Pod = self.get_or_create_pod(self.pod_request_obj, context)
+        self.defer()
+
+    def execute_complete(self, context: Context, event: dict[str, Any]) -> Any:
+        """Deprecated; replaced by trigger_reentry."""
+        warnings.warn(
+            "Method `execute_complete` is deprecated and replaced with method `trigger_reentry`.",
+            DeprecationWarning,
+        )
+        self.trigger_reentry(context=context, event=event)
+
+    def trigger_reentry(self, context: Context, event: dict[str, Any]) -> Any:
+        """
+        Point of re-entry from trigger.
+
+        If ``logging_interval`` is None, then at this point the pod should be done and we'll just fetch
+        the logs and exit.
+
+        If ``logging_interval`` is not None, it could be that the pod is still running and we'll just
+        grab the latest logs and defer back to the trigger again.
+        """
+        remote_pod = None
+        try:
+            self.pod_request_obj = self.build_pod_request_obj(context)
+            self.pod = self.find_pod(
+                namespace=self.namespace or self.pod_request_obj.metadata.namespace,
+                context=context,
+            )
+
+            # we try to find pod before possibly raising so that on_kill will have `pod` attr
+            self.raise_for_trigger_status(event)
+
+            if not self.pod:
+                raise PodNotFoundException("Could not find pod after resuming from deferral")
+
+            if self.get_logs:
+                last_log_time = event and event.get("last_log_time")
+                if last_log_time:
+                    self.log.info("Resuming logs read from time %r", last_log_time)
+                pod_log_status = self.pod_manager.fetch_container_logs(
+                    pod=self.pod,
+                    container_name=self.BASE_CONTAINER_NAME,
+                    follow=self.logging_interval is None,
+                    since_time=last_log_time,
+                )
+                if pod_log_status.running:
+                    self.log.info("Container still running; deferring again.")
+                    self.defer(pod_log_status.last_log_time)
+
+            if self.do_xcom_push:
+                result = self.extract_xcom(pod=self.pod)
+            remote_pod = self.pod_manager.await_pod_completion(self.pod)
+        except TaskDeferred:
+            raise
+        except Exception:
+            self.cleanup(
+                pod=self.pod or self.pod_request_obj,
+                remote_pod=remote_pod,
+            )
+            raise
+        self.cleanup(
+            pod=self.pod or self.pod_request_obj,
+            remote_pod=remote_pod,
+        )
+        ti = context["ti"]
+        ti.xcom_push(key="pod_name", value=self.pod.metadata.name)
+        ti.xcom_push(key="pod_namespace", value=self.pod.metadata.namespace)
+        if self.do_xcom_push:
+            return result

--- a/airflow/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/airflow/providers/cncf/kubernetes/triggers/wait_container.py
@@ -26,7 +26,7 @@ from kubernetes_asyncio.client import CoreV1Api
 from pendulum import DateTime
 
 from airflow.exceptions import AirflowException
-from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesAsyncHook
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import AsyncKubernetesHook
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase, container_is_running
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils import timezone
@@ -93,8 +93,8 @@ class WaitContainerTrigger(BaseTrigger):
             },
         )
 
-    async def get_hook(self) -> KubernetesAsyncHook:
-        return KubernetesAsyncHook(conn_id=self.kubernetes_conn_id, **(self.hook_params or {}))
+    async def get_hook(self) -> AsyncKubernetesHook:
+        return AsyncKubernetesHook(conn_id=self.kubernetes_conn_id, **(self.hook_params or {}))
 
     async def wait_for_pod_start(self, v1_api: CoreV1Api) -> Any:
         """

--- a/airflow/providers/cncf/kubernetes/triggers/wait_container.py
+++ b/airflow/providers/cncf/kubernetes/triggers/wait_container.py
@@ -1,0 +1,163 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+import asyncio
+import traceback
+from datetime import timedelta
+from typing import Any, AsyncIterator
+
+from kubernetes_asyncio.client import CoreV1Api
+from pendulum import DateTime
+
+from airflow.exceptions import AirflowException
+from airflow.providers.cncf.kubernetes.hooks.kubernetes import KubernetesAsyncHook
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodPhase, container_is_running
+from airflow.triggers.base import BaseTrigger, TriggerEvent
+from airflow.utils import timezone
+
+
+class PodLaunchTimeoutException(AirflowException):
+    """When pod does not leave the ``Pending`` phase within specified timeout."""
+
+
+class WaitContainerTrigger(BaseTrigger):
+    """
+    First, waits for pod ``pod_name`` to reach running state within ``pending_phase_timeout``.
+    Next, waits for ``container_name`` to reach a terminal state.
+
+    :param kubernetes_conn_id: Airflow connection ID to use
+    :param hook_params: kwargs for hook
+    :param container_name: container to wait for
+    :param pod_name: name of pod to monitor
+    :param pod_namespace: pod namespace
+    :param pending_phase_timeout: max time in seconds to wait for pod to leave pending phase
+    :param poll_interval: number of seconds between reading pod state
+    :param logging_interval: number of seconds to wait before kicking it back to
+        the operator to print latest logs. If ``None`` will wait until container done.
+    :param last_log_time: where to resume logs from
+    """
+
+    def __init__(
+        self,
+        *,
+        container_name: str,
+        pod_name: str,
+        pod_namespace: str,
+        kubernetes_conn_id: str | None = None,
+        hook_params: dict[str, Any] | None = None,
+        pending_phase_timeout: float = 120,
+        poll_interval: float = 5,
+        logging_interval: int | None = None,
+        last_log_time: DateTime | None = None,
+    ):
+        super().__init__()
+        self.kubernetes_conn_id = kubernetes_conn_id
+        self.hook_params = hook_params
+        self.container_name = container_name
+        self.pod_name = pod_name
+        self.pod_namespace = pod_namespace
+        self.pending_phase_timeout = pending_phase_timeout
+        self.poll_interval = poll_interval
+        self.logging_interval = logging_interval
+        self.last_log_time = last_log_time
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "airflow.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger",
+            {
+                "kubernetes_conn_id": self.kubernetes_conn_id,
+                "hook_params": self.hook_params,
+                "pod_name": self.pod_name,
+                "container_name": self.container_name,
+                "pod_namespace": self.pod_namespace,
+                "pending_phase_timeout": self.pending_phase_timeout,
+                "poll_interval": self.poll_interval,
+                "logging_interval": self.logging_interval,
+                "last_log_time": self.last_log_time,
+            },
+        )
+
+    async def get_hook(self) -> KubernetesAsyncHook:
+        return KubernetesAsyncHook(conn_id=self.kubernetes_conn_id, **(self.hook_params or {}))
+
+    async def wait_for_pod_start(self, v1_api: CoreV1Api) -> Any:
+        """
+        Loops until pod phase leaves ``PENDING``
+        If timeout is reached, throws error.
+        """
+        start_time = timezone.utcnow()
+        timeout_end = start_time + timedelta(seconds=self.pending_phase_timeout)
+        while timeout_end > timezone.utcnow():
+            pod = await v1_api.read_namespaced_pod(self.pod_name, self.pod_namespace)
+            if not pod.status.phase == "Pending":
+                return pod.status.phase
+            await asyncio.sleep(self.poll_interval)
+        raise PodLaunchTimeoutException("Pod did not leave 'Pending' phase within specified timeout")
+
+    async def wait_for_container_completion(self, v1_api: CoreV1Api) -> "TriggerEvent":
+        """
+        Waits until container ``self.container_name`` is no longer in running state.
+        If trigger is configured with a logging period, then will emit an event to
+        resume the task for the purpose of fetching more logs.
+        """
+        time_begin = timezone.utcnow()
+        time_get_more_logs = None
+        if self.logging_interval is not None:
+            time_get_more_logs = time_begin + timedelta(seconds=self.logging_interval)
+        while True:
+            pod = await v1_api.read_namespaced_pod(self.pod_name, self.pod_namespace)
+            if not container_is_running(pod=pod, container_name=self.container_name):
+                return TriggerEvent({"status": "done"})
+            if time_get_more_logs and timezone.utcnow() > time_get_more_logs:
+                return TriggerEvent({"status": "running", "last_log_time": self.last_log_time})
+            await asyncio.sleep(self.poll_interval)
+
+    async def run(self) -> AsyncIterator["TriggerEvent"]:
+        self.log.debug("Checking pod %r in namespace %r.", self.pod_name, self.pod_namespace)
+        try:
+            hook = await self.get_hook()
+            async with await hook.get_api_client_async() as api_client:
+                v1_api = CoreV1Api(api_client)
+                state = await self.wait_for_pod_start(v1_api)
+                if state in PodPhase.terminal_states:
+                    event = TriggerEvent({"status": "done"})
+                else:
+                    event = await self.wait_for_container_completion(v1_api)
+            yield event
+        except Exception as e:
+            description = self._format_exception_description(e)
+            yield TriggerEvent(
+                {
+                    "status": "error",
+                    "error_type": e.__class__.__name__,
+                    "description": description,
+                }
+            )
+
+    def _format_exception_description(self, exc: Exception) -> Any:
+        if isinstance(exc, PodLaunchTimeoutException):
+            return exc.args[0]
+
+        description = f"Trigger {self.__class__.__name__} failed with exception {exc.__class__.__name__}."
+        message = exc.args and exc.args[0] or ""
+        if message:
+            description += f"\ntrigger exception message: {message}"
+        curr_traceback = traceback.format_exc()
+        description += f"\ntrigger traceback:\n{curr_traceback}"
+        return description

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -208,6 +208,7 @@
   },
   "cncf.kubernetes": {
     "deps": [
+      "aiofiles",
       "apache-airflow>=2.3.0",
       "asgiref>=3.5.2",
       "cryptography>=2.0.0",

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -208,7 +208,6 @@
   },
   "cncf.kubernetes": {
     "deps": [
-      "aiofiles",
       "apache-airflow>=2.3.0",
       "asgiref>=3.5.2",
       "cryptography>=2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -339,6 +339,7 @@ mypy_dependencies = [
     # Make sure to upgrade the mypy version in update-common-sql-api-stubs in .pre-commit-config.yaml
     # when you upgrade it here !!!!
     "mypy==0.971",
+    "types-aiofiles",
     "types-boto",
     "types-certifi",
     "types-croniter",

--- a/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/hooks/test_kubernetes_pod.py
@@ -562,3 +562,15 @@ class TestAsyncKubernetesHook:
             timestamps=True,
         )
         assert "Container logs from 2023-01-11 Some string logs..." in caplog.text
+
+    @pytest.mark.asyncio
+    @mock.patch("airflow.hooks.base.BaseHook.get_connection")
+    async def test_load_config_with_more_than_one_config(self, mock_get_connection):
+        """Assert that raise exception if more than on config provided"""
+        hook = AsyncKubernetesHook(in_cluster=True, config_file="kube_config_path")
+        mock_get_connection.return_value = Connection(
+            conn_id="test_conn",
+            extra={"kubernetes": {"in_cluster": True, "kube_config": {}, "kube_config_path": "config_file"}},
+        )
+        with pytest.raises(AirflowException):
+            await hook._load_config()

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -33,15 +33,21 @@ from airflow.kubernetes.secret import Secret
 from airflow.models import DAG, DagModel, DagRun, TaskInstance
 from airflow.models.xcom import XCom
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+    KubernetesPodAsyncOperator,
     KubernetesPodOperator,
+    PodNotFoundException,
     _optionally_suppress,
 )
-from airflow.providers.cncf.kubernetes.triggers.kubernetes_pod import KubernetesPodTrigger
+from airflow.providers.cncf.kubernetes.triggers.wait_container import PodLaunchTimeoutException
+from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLoggingStatus
 from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
+
+# from tests.providers.cncf.kubernetes.utils.airflow_util import create_context
 from tests.test_utils import db
 
+KUBE_POD_MOD = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod"
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
 KPO_MODULE = "airflow.providers.cncf.kubernetes.operators.kubernetes_pod"
 POD_MANAGER_CLASS = "airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager"
@@ -1355,3 +1361,126 @@ class TestKubernetesPodOperatorAsync:
             post_complete_action.assert_called_once()
         else:
             mock_manager.return_value.read_pod_logs.assert_not_called()
+
+    def test_raise_for_trigger_status_pending_timeout(self):
+        """Assert trigger raise exception in case of timeout"""
+        with pytest.raises(PodLaunchTimeoutException):
+            KubernetesPodAsyncOperator.raise_for_trigger_status(
+                {
+                    "status": "error",
+                    "error_type": "PodLaunchTimeoutException",
+                    "description": "any message",
+                }
+            )
+
+    def test_raise_for_trigger_status_done(self):
+        """Assert trigger don't raise exception in case of status is done"""
+        assert KubernetesPodAsyncOperator.raise_for_trigger_status({"status": "done"}) is None
+
+    @mock.patch("airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.client")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.cleanup")
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.raise_for_trigger_status")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.find_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    def test_get_logs_running(
+        self,
+        mock_get_default_client,
+        fetch_container_logs,
+        await_pod_completion,
+        find_pod,
+        raise_for_trigger_status,
+        get_kube_client,
+        cleanup,
+        mock_client,
+    ):
+        """When logs fetch exits with status running, raise task deferred"""
+        pod = MagicMock()
+        find_pod.return_value = pod
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        mock_client.return_value = {}
+        context = create_context(op)
+        await_pod_completion.return_value = None
+        fetch_container_logs.return_value = PodLoggingStatus(True, None)
+        with pytest.raises(TaskDeferred):
+            op.trigger_reentry(context, None)
+        fetch_container_logs.is_called_with(pod, "base")
+
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.cleanup")
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.raise_for_trigger_status")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.find_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    def test_no_pod(
+        self,
+        mock_get_default_client,
+        fetch_container_logs,
+        await_pod_completion,
+        find_pod,
+        raise_for_trigger_status,
+        get_kube_client,
+        cleanup,
+    ):
+        """Assert if pod not found then raise exception"""
+        find_pod.return_value = None
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        context = create_context(op)
+        with pytest.raises(PodNotFoundException):
+            op.trigger_reentry(context, None)
+
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.cleanup")
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.find_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.await_pod_completion")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_manager.PodManager.fetch_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook._get_default_client")
+    def test_trigger_error(
+        self,
+        mock_get_default_client,
+        fetch_container_logs,
+        await_pod_completion,
+        find_pod,
+        get_kube_client,
+        cleanup,
+    ):
+        """Assert that trigger_reentry raise exception in case of error"""
+        find_pod.return_value = MagicMock()
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        with pytest.raises(PodLaunchTimeoutException):
+            context = create_context(op)
+            op.trigger_reentry(
+                context,
+                {
+                    "status": "error",
+                    "error_type": "PodLaunchTimeoutException",
+                    "description": "any message",
+                },
+            )
+
+    def test_defer_with_kwargs(self):
+        """Assert that with kwargs throw exception"""
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        with pytest.raises(ValueError):
+            op.defer(kwargs={"timeout": 10})
+
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.build_pod_request_obj")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.get_or_create_pod")
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.defer")
+    def test_execute(self, mock_defer, mock_get_or_create_pod, mock_build_pod_request_obj):
+        """Assert that execute succeeded"""
+        mock_get_or_create_pod.return_value = {}
+        mock_build_pod_request_obj.return_value = {}
+        mock_defer.return_value = {}
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        assert op.execute(context=create_context(op)) is None
+
+    @mock.patch(f"{KUBE_POD_MOD}.KubernetesPodAsyncOperator.trigger_reentry")
+    def test_execute_complete(self, mock_trigger_reentry):
+        """Assert that execute_complete succeeded"""
+        mock_trigger_reentry.return_value = {}
+        op = KubernetesPodAsyncOperator(task_id="test_task", name="test-pod", get_logs=True)
+        assert op.execute_complete(context=create_context(op), event={}) is None

--- a/tests/providers/cncf/kubernetes/triggers/test_wait_container.py
+++ b/tests/providers/cncf/kubernetes/triggers/test_wait_container.py
@@ -1,0 +1,79 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from airflow.providers.cncf.kubernetes.triggers.wait_container import WaitContainerTrigger
+
+TRIGGER_CLASS = "airflow.providers.cncf.kubernetes.triggers.wait_container.WaitContainerTrigger"
+READ_NAMESPACED_POD_PATH = "kubernetes_asyncio.client.CoreV1Api.read_namespaced_pod"
+
+
+def get_read_pod_mock_phases(phases_to_emit=None):
+    """emit pods with given phases sequentially"""
+
+    async def mock_read_namespaced_pod(*args, **kwargs):
+        event_mock = MagicMock()
+        event_mock.status.phase = phases_to_emit.pop(0)
+        return event_mock
+
+    return mock_read_namespaced_pod
+
+
+def get_read_pod_mock_containers(statuses_to_emit=None):
+    """
+    Emit pods with given phases sequentially.
+    `statuses_to_emit` should be a list of bools indicating running or not.
+    """
+
+    async def mock_read_namespaced_pod(*args, **kwargs):
+        container_mock = MagicMock()
+        container_mock.state.running = statuses_to_emit.pop(0)
+        event_mock = MagicMock()
+        event_mock.status.container_statuses = [container_mock]
+        return event_mock
+
+    return mock_read_namespaced_pod
+
+
+class TestWaitContainerTrigger:
+    def test_serialize(self):
+        """
+        Asserts that the Trigger correctly serializes its arguments
+        and classpath.
+        """
+        expected_kwargs = {
+            "kubernetes_conn_id": None,
+            "hook_params": {
+                "cluster_context": "cluster_context",
+                "config_file": "config_file",
+                "in_cluster": "in_cluster",
+            },
+            "pod_name": "pod_name",
+            "container_name": "container_name",
+            "pod_namespace": "pod_namespace",
+            "pending_phase_timeout": 120,
+            "poll_interval": 5,
+            "logging_interval": None,
+            "last_log_time": None,
+        }
+        trigger = WaitContainerTrigger(**expected_kwargs)
+        classpath, actual_kwargs = trigger.serialize()
+        assert classpath == TRIGGER_CLASS
+        assert actual_kwargs == expected_kwargs

--- a/tests/providers/cncf/kubernetes/utils/airflow_util.py
+++ b/tests/providers/cncf/kubernetes/utils/airflow_util.py
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pendulum
+
+from airflow.models import DAG, Connection
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.dagrun import DagRun
+from airflow.models.taskinstance import TaskInstance
+from airflow.utils import timezone
+
+
+def get_dag_run(dag_id: str = "test_dag_id", run_id: str = "test_dag_id") -> DagRun:
+    dag_run = DagRun(
+        dag_id=dag_id, run_type="manual", execution_date=timezone.datetime(2022, 1, 1), run_id=run_id
+    )
+    return dag_run
+
+
+def get_task_instance(task: BaseOperator) -> TaskInstance:
+    return TaskInstance(task, timezone.datetime(2022, 1, 1))
+
+
+def get_conn() -> Connection:
+    return Connection(
+        conn_id="test_conn",
+        extra={},
+    )
+
+
+def create_context(task):
+    dag = DAG(dag_id="dag")
+    tzinfo = pendulum.timezone("Europe/Amsterdam")
+    execution_date = timezone.datetime(2016, 1, 1, 1, 0, 0, tzinfo=tzinfo)
+    dag_run = DagRun(dag_id=dag.dag_id, execution_date=execution_date)
+    task_instance = TaskInstance(task=task)
+    task_instance.dag_run = dag_run
+    task_instance.xcom_push = mock.Mock()
+    return {
+        "dag": dag,
+        "ts": execution_date.isoformat(),
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+        "run_id": dag_run.run_id,
+    }


### PR DESCRIPTION
This PR donates the `KubernetesPodOperatorAsync` from [astronomer-providers](https://github.com/astronomer/astronomer-providers) repo to Airflow.

Astronomer and its customers have been running this in production since last 6 months

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
