### PR TITLE
Re-enable `pymsql` on ARM as it now builds cleanly

### DIFF
--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -41,7 +41,7 @@ versions:
 dependencies:
   - apache-airflow>=2.3.0
   - apache-airflow-providers-common-sql>=1.3.1
-  - pymssql>=2.1.5; platform_machine != "aarch64"
+  - pymssql>=2.1.5
 
 integrations:
   - integration-name: Microsoft SQL Server (MSSQL)

--- a/dev/breeze/src/airflow_breeze/commands/developer_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/developer_commands.py
@@ -549,7 +549,7 @@ def enter_shell(**kwargs) -> RunCommandResult:
             sys.exit(1)
         if shell_params.backend == "mssql":
             get_console().print("\n[error]MSSQL is not supported on ARM architecture[/]\n")
-            return 1
+            sys.exit(1)
     command_result = run_command(
         cmd, env=env_variables, text=True, check=False, output_outside_the_group=True
     )

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -465,7 +465,7 @@
     "deps": [
       "apache-airflow-providers-common-sql>=1.3.1",
       "apache-airflow>=2.3.0",
-      "pymssql>=2.1.5; platform_machine != \"aarch64\""
+      "pymssql>=2.1.5"
     ],
     "cross-providers-deps": [
       "common.sql"

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -165,7 +165,7 @@ def check_if_object_exist(object_name: str, resource_type: str, yaml_file_path: 
             raise RuntimeError(f"Wrong enum {object_type}???")
     except Exception as e:
         if architecture == Architecture.ARM:
-            if "pymssql" in str(e) or "MySQLdb" in str(e):
+            if "MySQLdb" in str(e):
                 console.print(
                     f"[yellow]The imports fail on ARM: {object_name} in {resource_type} {e}, "
                     f"but it is expected.[/]"


### PR DESCRIPTION
Previously, the `pymsql` had to be disabled in order to get ARM compatibility https://github.com/apache/airflow/pull/22127.

Unfortunetly there is no pre-built wheels for ARM64 linux (https://github.com/pymssql/pymssql/issues/692, https://github.com/pymssql/pymssql/issues/763) however there is no problem to build this package into our CI image and local checks shows that integration with MS SQL Server also works.

We still unable to run Airflow with `mssql` backend in `breeze` on ARM due to issues with execution MS SQL docker images on ARM https://github.com/microsoft/mssql-docker/issues/734, to be honest it required run in specific VM under Roseta 2 and Microsoft doesn't support any architecture for MS SQL Server rather than x86_64

---

![image](https://user-images.githubusercontent.com/3998685/209090785-a160aa87-1d70-49ec-9589-f7c6216dcbdf.png)

```console
AIRFLOW_CTX_DAG_OWNER=***
AIRFLOW_CTX_DAG_ID=example_sql_execute_query
AIRFLOW_CTX_TASK_ID=execute_query
AIRFLOW_CTX_EXECUTION_DATE=2022-12-22T07:58:14.543233+00:00
AIRFLOW_CTX_TRY_NUMBER=1
AIRFLOW_CTX_DAG_RUN_ID=manual__2022-12-22T07:58:14.543233+00:00
[2022-12-22, 07:58:16 UTC] {sql.py:253} INFO - Executing: SELECT * FROM INFORMATION_SCHEMA.TABLES;
[2022-12-22, 07:58:16 UTC] {base.py:73} INFO - Using connection ID 'mssql_default' for task execution.
[2022-12-22, 07:58:17 UTC] {base.py:73} INFO - Using connection ID 'mssql_default' for task execution.
[2022-12-22, 07:58:17 UTC] {sql.py:365} INFO - Running statement: SELECT * FROM INFORMATION_SCHEMA.TABLES;, parameters: None
[2022-12-22, 07:58:17 UTC] {taskinstance.py:1325} INFO - Marking task as SUCCESS. dag_id=example_sql_execute_query, task_id=execute_query, execution_date=20221222T075814, start_date=20221222T075816, end_date=20221222T075817
[2022-12-22, 07:58:17 UTC] {local_task_job.py:208} INFO - Task exited with return code 0
[2022-12-22, 07:58:17 UTC] {taskinstance.py:2586} INFO - 0 downstream tasks scheduled from follow-on schedule check
```
