### PR TITLE
Consider previous run in CronTriggerTimetable

### DIFF
--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -140,12 +140,18 @@ def test_hourly_cron_trigger_no_catchup_next_info(
             DagRunInfo.exact(pendulum.DateTime(2022, 7, 27, 1, 0, 0, tzinfo=TIMEZONE)),
             id="no_last_automated_with_earliest_not_on_boundary",
         ),
+        pytest.param(
+            None,
+            None,
+            None,
+            id="no_last_automated_no_earliest",
+        ),
     ],
 )
 def test_hourly_cron_trigger_catchup_next_info(
-    last_automated_data_interval: DataInterval,
-    earliest: pendulum.DateTime,
-    expected: DagRunInfo,
+    last_automated_data_interval: DataInterval | None,
+    earliest: pendulum.DateTime | None,
+    expected: DagRunInfo | None,
 ) -> None:
     next_info = HOURLY_CRON_TRIGGER_TIMETABLE.next_dagrun_info(
         last_automated_data_interval=last_automated_data_interval,

--- a/tests/timetables/test_trigger_timetable.py
+++ b/tests/timetables/test_trigger_timetable.py
@@ -44,12 +44,29 @@ DELTA_FROM_MIDNIGHT = datetime.timedelta(minutes=30, hours=16)
 
 
 @pytest.mark.parametrize(
-    "last_automated_data_interval",
-    [pytest.param(None, id="first-run"), pytest.param(PREV_DATA_INTERVAL_EXACT, id="subsequent")],
+    "last_automated_data_interval, next_start_time",
+    [
+        pytest.param(
+            None,
+            CURRENT_TIME + DELTA_FROM_MIDNIGHT,
+            id="first-run",
+        ),
+        pytest.param(
+            PREV_DATA_INTERVAL_EXACT,
+            CURRENT_TIME + DELTA_FROM_MIDNIGHT,
+            id="before-now",
+        ),
+        pytest.param(
+            DataInterval.exact(CURRENT_TIME + DELTA_FROM_MIDNIGHT),
+            CURRENT_TIME + datetime.timedelta(days=1) + DELTA_FROM_MIDNIGHT,
+            id="after-now",
+        ),
+    ],
 )
 @time_machine.travel(CURRENT_TIME)
 def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
     last_automated_data_interval: DataInterval | None,
+    next_start_time: pendulum.DateTime,
 ) -> None:
     """If ``catchup=False`` and start_date is a day before"""
     timetable = CronTriggerTimetable("30 16 * * *", timezone=TIMEZONE)
@@ -57,8 +74,7 @@ def test_daily_cron_trigger_no_catchup_first_starts_at_next_schedule(
         last_automated_data_interval=last_automated_data_interval,
         restriction=TimeRestriction(earliest=YESTERDAY, latest=None, catchup=False),
     )
-    expected = CURRENT_TIME + DELTA_FROM_MIDNIGHT
-    assert next_info == DagRunInfo.exact(expected)
+    assert next_info == DagRunInfo.exact(next_start_time)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Previously, when catchup is False, the timetable always calculate the next run against utcnow(), which is incorrect. This new implementation takes the previous run info into account and promises the next run will be after that.

See threadd in https://github.com/apache/airflow/pull/28411#discussion_r1053453973