### PR TITLE
Mark all our local sphinx exts as parallel safe

### DIFF
--- a/docs/exts/exampleinclude.py
+++ b/docs/exts/exampleinclude.py
@@ -250,4 +250,4 @@ def setup(app):
     if not airflow_theme_is_available:
         # Sphinx airflow theme has its own styles.
         app.add_css_file("exampleinclude.css")
-    return {"version": "builtin", "parallel_read_safe": False, "parallel_write_safe": False}
+    return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/exts/extra_files_with_substitutions.py
+++ b/docs/exts/extra_files_with_substitutions.py
@@ -53,4 +53,5 @@ def setup(app):
 
     return {
         "parallel_write_safe": True,
+        "parallel_read_safe": True,
     }

--- a/docs/exts/extra_provider_files_with_substitutions.py
+++ b/docs/exts/extra_provider_files_with_substitutions.py
@@ -43,4 +43,5 @@ def setup(app):
 
     return {
         "parallel_write_safe": True,
+        "parallel_read_safe": True,
     }

--- a/docs/exts/redirects.py
+++ b/docs/exts/redirects.py
@@ -74,3 +74,4 @@ def setup(app):
     """Setup plugin"""
     app.add_config_value("redirects_file", "redirects", "env")
     app.connect("builder-inited", generate_redirects)
+    return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/exts/removemarktransform.py
+++ b/docs/exts/removemarktransform.py
@@ -71,4 +71,4 @@ def setup(app):
     """Sets the transform up"""
     app.add_post_transform(TrimDocMarkerFlagsTransform)
 
-    return {"version": "builtin", "parallel_read_safe": False, "parallel_write_safe": False}
+    return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/exts/sphinx_script_update.py
+++ b/docs/exts/sphinx_script_update.py
@@ -121,3 +121,4 @@ def setup(app):
     app.add_config_value("redoc_script_url", None, "env")
     app.connect("builder-inited", builder_inited)
     app.connect("build-finished", build_finished)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/exts/substitution_extensions.py
+++ b/docs/exts/substitution_extensions.py
@@ -125,4 +125,4 @@ def setup(app: Sphinx) -> dict:
     app.add_role("subst-code", substitution_code_role)
     app.add_post_transform(SubstitutionCodeBlockTransform)
     app.add_post_transform(AddSpacepadSubstReference)
-    return {"parallel_write_safe": True}
+    return {"parallel_write_safe": True, "parallel_read_safe": True}


### PR DESCRIPTION
We don't do anything fancy in any of them that wouldn't work across multiple processes.

By default/as invoked right now this makes no difference to performance, but if we add `-j auto` it shaves about 30s off a clean docs build for the main project. (~2m40s down to ~2m10s)

This change is part of a prep work on investigating ways of speeding up the docs build -- in a future PR I'll investigate if it makes sense to set `-j auto` on CI (probably not, as we already parallelise the builds across multiple providers) or locally (likely, at least in the case when a package filter is provided)