### PR TITLE
Make the policy functions pluggable

### DIFF
--- a/airflow/policies.py
+++ b/airflow/policies.py
@@ -1,0 +1,242 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+If you want to check or mutate DAGs or Tasks on a cluster-wide level, then a Cluster Policy will let you do
+that. They have three main purposes:
+
+* Checking that DAGs/Tasks meet a certain standard
+* Setting default arguments on DAGs/Tasks
+* Performing custom routing logic
+
+There are three main types of cluster policy:
+
+* ``dag_policy``: Takes a :class:`~airflow.models.dag.DAG` parameter called ``dag``. Runs at load time of the
+  DAG from DagBag :class:`~airflow.models.dagbag.DagBag`.
+* ``task_policy``: Takes a :class:`~airflow.models.baseoperator.BaseOperator` parameter called ``task``. The
+  policy gets executed when the task is created during parsing of the task from DagBag at load time. This
+  means that the whole task definition can be altered in the task policy. It does not relate to a specific
+  task running in a DagRun. The ``task_policy`` defined is applied to all the task instances that will be
+  executed in the future.
+* ``task_instance_mutation_hook``: Takes a :class:`~airflow.models.taskinstance.TaskInstance` parameter called
+  ``task_instance``. The ``task_instance_mutation`` applies not to a task but to the instance of a task that
+  relates to a particular DagRun. It is executed in a "worker", not in the dag file processor, just before the
+  task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that
+  task.
+
+The DAG and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation`
+exception to indicate that the dag/task they were passed is not compliant and should not be loaded.
+
+Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
+if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the
+cluster policy's value will take precedence.
+
+To configure cluster policies, you should create an ``airflow_local_settings.py`` file in either the
+``config/`` folder under your $AIRFLOW_HOME, or place it on the $PYTHONPATH, and then add callables to the
+file matching one or more of the cluster policy names above (e.g. ``dag_policy``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pluggy
+
+local_settings_hookspec = pluggy.HookspecMarker("airflow.policy")
+hookimpl = pluggy.HookimplMarker("airflow.policy")
+
+__all__: list[str] = ["hookimpl"]
+
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
+    from airflow.models.dag import DAG
+    from airflow.models.taskinstance import TaskInstance
+
+
+@local_settings_hookspec
+def task_policy(task: BaseOperator) -> None:
+    """
+    This policy setting allows altering tasks after they are loaded in the DagBag.
+
+    It allows administrator to rewire some task's parameters.  Alternatively you can raise
+    ``AirflowClusterPolicyViolation`` exception to stop DAG from being executed.
+
+    Here are a few examples of how this can be useful:
+
+    * You could enforce a specific queue (say the ``spark`` queue) for tasks using the ``SparkOperator`` to
+      make sure that these tasks get wired to the right workers
+    * You could enforce a task timeout policy, making sure that no tasks run for more than 48 hours
+
+    :param task: task to be mutated
+    """
+
+
+@local_settings_hookspec
+def dag_policy(dag: DAG) -> None:
+    """
+    This policy setting allows altering DAGs after they are loaded in the DagBag.
+
+    It allows administrator to rewire some DAG's parameters.
+    Alternatively you can raise ``AirflowClusterPolicyViolation`` exception
+    to stop DAG from being executed.
+
+    Here are a few examples of how this can be useful:
+
+    * You could enforce default user for DAGs
+    * Check if every DAG has configured tags
+
+    :param dag: dag to be mutated
+    """
+
+
+@local_settings_hookspec
+def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
+    """
+    This setting allows altering task instances before being queued by the Airflow scheduler.
+
+    This could be used, for instance, to modify the task instance during retries.
+
+    :param task_instance: task instance to be mutated
+    """
+
+
+@local_settings_hookspec
+def pod_mutation_hook(pod) -> None:
+    """
+    Mutate pod before scheduling.
+
+
+    This setting allows altering ``kubernetes.client.models.V1Pod`` object before they are passed to the
+    Kubernetes client for scheduling.
+
+    This could be used, for instance, to add sidecar or init containers to every worker pod launched by
+    KubernetesExecutor or KubernetesPodOperator.
+    """
+
+
+@local_settings_hookspec(firstresult=True)
+def get_airflow_context_vars(context) -> dict[str, str]:
+    """
+    This setting allows getting the airflow context vars, which are key value pairs.  They are then injected
+    to default airflow context vars, which in the end are available as environment variables when running
+    tasks dag_id, task_id, execution_date, dag_run_id, try_number are reserved keys.
+
+    :param context: The context for the task_instance of interest.
+    """
+    ...
+
+
+@local_settings_hookspec(firstresult=True)
+def get_dagbag_import_timeout(dag_file_path: str) -> int | float:
+    """
+    This setting allows for dynamic control of the DAG file parsing timeout based on the DAG file path.
+
+    It is useful when there are a few DAG files requiring longer parsing times, while others do not.
+    You can control them separately instead of having one value for all DAG files.
+
+    If the return value is less than or equal to 0, it means no timeout during the DAG parsing.
+    """
+    ...
+
+
+class DefaultPolicy:
+    """:meta private:"""
+
+    # Default implementations of the policy functions
+
+    @staticmethod
+    @hookimpl
+    def get_dagbag_import_timeout(dag_file_path: str):
+        from airflow.configuration import conf
+
+        return conf.getfloat("core", "DAGBAG_IMPORT_TIMEOUT")
+
+    @staticmethod
+    @hookimpl
+    def get_airflow_context_vars(context):
+        return {}
+
+
+def make_plugin_from_local_settings(pm: pluggy.PluginManager, module, names: list[str]):
+    """
+    Turn the functions from airflow_local_settings module into a custom/local plugin, so that
+    plugin-registered functions can co-operate with pluggy/setuptool entrypoint plugins of the same methods.
+
+    Airflow local settings will "win" as they are the last plugin registered.
+
+    :meta private:
+    """
+    import inspect
+    import textwrap
+
+    import attr
+
+    hook_methods = set()
+
+    def _make_shim_fn(name, desired_sig, target):
+        # Functions defined in airflow_local_settings are called by positional parameters, so the names don't
+        # have to match what we define in the "template" policy.
+        #
+        # However Pluggy validates the names match (and will raise an error if they don't!)
+        #
+        # To maintain compat, if we detect the names don't match, we will wrap it with a dynamically created
+        # shim function that looks somewhat like this:
+        #
+        #  def dag_policy_name_mistmatch_shim(dag):
+        #      airflow_local_settings.dag_policy(dag)
+        #
+        codestr = textwrap.dedent(
+            f"""
+            def {name}_name_mismatch_shim{str(desired_sig)}:
+                return __target({' ,'.join(desired_sig.parameters)})
+            """
+        )
+        code = compile(codestr, "<policy-shim>", "single")
+        scope = {"__target": target}
+        exec(code, scope, scope)
+        return scope[f"{name}_name_mismatch_shim"]
+
+    @attr.define(frozen=True)
+    class AirflowLocalSettingsPolicy:
+        hook_methods: tuple[str, ...]
+
+        __name__ = "AirflowLocalSettingsPolicy"
+
+        def __dir__(self):
+            return self.hook_methods
+
+    for name in names:
+        if not hasattr(pm.hook, name):
+            continue
+
+        policy = getattr(module, name)
+
+        if not policy:
+            continue
+
+        local_sig = inspect.signature(policy)
+        policy_sig = inspect.signature(globals()[name])
+        # We only care if names/order/number of parameters match, not type hints
+        if local_sig.parameters.keys() != policy_sig.parameters.keys():
+            policy = _make_shim_fn(name, policy_sig, target=policy)
+
+        setattr(AirflowLocalSettingsPolicy, name, staticmethod(hookimpl(policy, specname=name)))
+        hook_methods.add(name)
+
+    if hook_methods:
+        pm.register(AirflowLocalSettingsPolicy(hook_methods=tuple(hook_methods)))
+
+    return hook_methods

--- a/airflow/policies.py
+++ b/airflow/policies.py
@@ -93,7 +93,7 @@ def pod_mutation_hook(pod) -> None:
 
 
 @local_settings_hookspec(firstresult=True)
-def get_airflow_context_vars(context) -> dict[str, str]:
+def get_airflow_context_vars(context) -> dict[str, str]:  # type: ignore[empty-body]
     """
     This setting allows getting the airflow context vars, which are key value pairs.  They are then injected
     to default airflow context vars, which in the end are available as environment variables when running
@@ -101,11 +101,10 @@ def get_airflow_context_vars(context) -> dict[str, str]:
 
     :param context: The context for the task_instance of interest.
     """
-    ...
 
 
 @local_settings_hookspec(firstresult=True)
-def get_dagbag_import_timeout(dag_file_path: str) -> int | float:
+def get_dagbag_import_timeout(dag_file_path: str) -> int | float:  # type: ignore[empty-body]
     """
     This setting allows for dynamic control of the DAG file parsing timeout based on the DAG file path.
 
@@ -114,7 +113,6 @@ def get_dagbag_import_timeout(dag_file_path: str) -> int | float:
 
     If the return value is less than or equal to 0, it means no timeout during the DAG parsing.
     """
-    ...
 
 
 class DefaultPolicy:
@@ -140,7 +138,8 @@ def make_plugin_from_local_settings(pm: pluggy.PluginManager, module, names: lis
     Turn the functions from airflow_local_settings module into a custom/local plugin, so that
     plugin-registered functions can co-operate with pluggy/setuptool entrypoint plugins of the same methods.
 
-    Airflow local settings will be "win" (i.e. they have the final say) as they are the last plugin registered.
+    Airflow local settings will be "win" (i.e. they have the final say) as they are the last plugin
+    registered.
 
     :meta private:
     """

--- a/airflow/policies.py
+++ b/airflow/policies.py
@@ -84,7 +84,6 @@ def pod_mutation_hook(pod) -> None:
     """
     Mutate pod before scheduling.
 
-
     This setting allows altering ``kubernetes.client.models.V1Pod`` object before they are passed to the
     Kubernetes client for scheduling.
 
@@ -141,7 +140,7 @@ def make_plugin_from_local_settings(pm: pluggy.PluginManager, module, names: lis
     Turn the functions from airflow_local_settings module into a custom/local plugin, so that
     plugin-registered functions can co-operate with pluggy/setuptool entrypoint plugins of the same methods.
 
-    Airflow local settings will "win" as they are the last plugin registered.
+    Airflow local settings will be "win" (i.e. they have the final say) as they are the last plugin registered.
 
     :meta private:
     """

--- a/airflow/policies.py
+++ b/airflow/policies.py
@@ -195,7 +195,7 @@ def make_plugin_from_local_settings(pm: pluggy.PluginManager, module, names: lis
         # To maintain compat, if we detect the names don't match, we will wrap it with a dynamically created
         # shim function that looks somewhat like this:
         #
-        #  def dag_policy_name_mistmatch_shim(dag):
+        #  def dag_policy_name_mismatch_shim(dag):
         #      airflow_local_settings.dag_policy(dag)
         #
         codestr = textwrap.dedent(

--- a/airflow/policies.py
+++ b/airflow/policies.py
@@ -14,40 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-If you want to check or mutate DAGs or Tasks on a cluster-wide level, then a Cluster Policy will let you do
-that. They have three main purposes:
-
-* Checking that DAGs/Tasks meet a certain standard
-* Setting default arguments on DAGs/Tasks
-* Performing custom routing logic
-
-There are three main types of cluster policy:
-
-* ``dag_policy``: Takes a :class:`~airflow.models.dag.DAG` parameter called ``dag``. Runs at load time of the
-  DAG from DagBag :class:`~airflow.models.dagbag.DagBag`.
-* ``task_policy``: Takes a :class:`~airflow.models.baseoperator.BaseOperator` parameter called ``task``. The
-  policy gets executed when the task is created during parsing of the task from DagBag at load time. This
-  means that the whole task definition can be altered in the task policy. It does not relate to a specific
-  task running in a DagRun. The ``task_policy`` defined is applied to all the task instances that will be
-  executed in the future.
-* ``task_instance_mutation_hook``: Takes a :class:`~airflow.models.taskinstance.TaskInstance` parameter called
-  ``task_instance``. The ``task_instance_mutation`` applies not to a task but to the instance of a task that
-  relates to a particular DagRun. It is executed in a "worker", not in the dag file processor, just before the
-  task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that
-  task.
-
-The DAG and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation`
-exception to indicate that the dag/task they were passed is not compliant and should not be loaded.
-
-Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
-if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the
-cluster policy's value will take precedence.
-
-To configure cluster policies, you should create an ``airflow_local_settings.py`` file in either the
-``config/`` folder under your $AIRFLOW_HOME, or place it on the $PYTHONPATH, and then add callables to the
-file matching one or more of the cluster policy names above (e.g. ``dag_policy``).
-"""
 
 from __future__ import annotations
 

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -18,23 +18,11 @@
 Cluster Policies
 ================
 
-If you want to check or mutate DAGs or Tasks on a cluster-wide level, then a Cluster Policy will let you do that. They have three main purposes:
 
-* Checking that DAGs/Tasks meet a certain standard
-* Setting default arguments on DAGs/Tasks
-* Performing custom routing logic
-
-There are three types of cluster policy:
-
-* ``dag_policy``: Takes a :class:`~airflow.models.dag.DAG` parameter called ``dag``. Runs at load time of the DAG from DagBag :class:`~airflow.models.dagbag.DagBag`.
-* ``task_policy``: Takes a parameter called ``task`` that is of type either :class:`~airflow.models.baseoperator.BaseOperator` or :class:`~airflow.models.mappedoperator.MappedOperator` (for `dynamically expanded tasks <dynamic-task-mapping>`_). The policy gets executed when the task is created during parsing of the task from DagBag at load time. This means that the whole task definition can be altered in the task policy. It does not relate to a specific task running in a DagRun. The ``task_policy`` defined is applied to all the task instances that will be executed in the future.
-* ``task_instance_mutation_hook``: Takes a :class:`~airflow.models.taskinstance.TaskInstance` parameter called ``task_instance``. The ``task_instance_mutation`` applies not to a task but to the instance of a task that relates to a particular DagRun. It is executed in a "worker", not in the DAG file processor, just before the task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that task.
-
-The DAG and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation` exception to indicate that the DAG/task they were passed is not compliant and should not be loaded.
-
-Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example, if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the cluster policy's value will take precedence.
-
-To configure cluster policies, you should create an ``airflow_local_settings.py`` file in either the ``config`` folder under your ``$AIRFLOW_HOME``, or place it on the ``$PYTHONPATH``, and then add callables to the file matching one or more of the cluster policy names above (e.g. ``dag_policy``)
+.. autoapimodule:: airflow.policies
+  :no-members:
+  :members: task_policy, dag_policy, task_instance_mutation_hook, pod_mutation_hook
+  :member-order: bysource
 
 
 Examples

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -18,10 +18,60 @@
 Cluster Policies
 ================
 
+If you want to check or mutate DAGs or Tasks on a cluster-wide level, then a Cluster Policy will let you do
+that. They have three main purposes:
+
+* Checking that DAGs/Tasks meet a certain standard
+* Setting default arguments on DAGs/Tasks
+* Performing custom routing logic
+
+There are three main types of cluster policy:
+
+* ``dag_policy``: Takes a :class:`~airflow.models.dag.DAG` parameter called ``dag``. Runs at load time of the
+  DAG from DagBag :class:`~airflow.models.dagbag.DagBag`.
+* ``task_policy``: Takes a :class:`~airflow.models.baseoperator.BaseOperator` parameter called ``task``. The
+  policy gets executed when the task is created during parsing of the task from DagBag at load time. This
+  means that the whole task definition can be altered in the task policy. It does not relate to a specific
+  task running in a DagRun. The ``task_policy`` defined is applied to all the task instances that will be
+  executed in the future.
+* ``task_instance_mutation_hook``: Takes a :class:`~airflow.models.taskinstance.TaskInstance` parameter called
+  ``task_instance``. The ``task_instance_mutation`` applies not to a task but to the instance of a task that
+  relates to a particular DagRun. It is executed in a "worker", not in the dag file processor, just before the
+  task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that
+  task.
+
+The DAG and Task cluster policies can raise the  :class:`~airflow.exceptions.AirflowClusterPolicyViolation`
+exception to indicate that the dag/task they were passed is not compliant and should not be loaded.
+
+Any extra attributes set by a cluster policy take priority over those defined in your DAG file; for example,
+if you set an ``sla`` on your Task in the DAG file, and then your cluster policy also sets an ``sla``, the
+cluster policy's value will take precedence.
+
+
+How do define a policy function
+-------------------------------
+
+There are two ways to configure cluster policies:
+
+1. create an ``airflow_local_settings.py`` file somewhere in the python search path (the ``config/`` folder
+   under your $AIRFLOW_HOME is a good "default" location) and then add callables to the file matching one or more
+   of the cluster policy names above (e.g. ``dag_policy``).
+
+2. By using a setuptools entrypoint in a custom module
+
+   .. versionadded:: 2.6
+
+   .. note:: |experimental|
+
+One important thing to note (for either means of defining policy functions) is that the argument names must
+exactly match as documented below.
+
+Available Policy Functions
+--------------------------
 
 .. autoapimodule:: airflow.policies
   :no-members:
-  :members: task_policy, dag_policy, task_instance_mutation_hook, pod_mutation_hook
+  :members: task_policy, dag_policy, task_instance_mutation_hook, pod_mutation_hook, get_airflow_context_vars
   :member-order: bysource
 
 

--- a/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
+++ b/docs/apache-airflow/administration-and-deployment/cluster-policies.rst
@@ -35,7 +35,7 @@ There are three main types of cluster policy:
   task running in a DagRun. The ``task_policy`` defined is applied to all the task instances that will be
   executed in the future.
 * ``task_instance_mutation_hook``: Takes a :class:`~airflow.models.taskinstance.TaskInstance` parameter called
-  ``task_instance``. The ``task_instance_mutation`` applies not to a task but to the instance of a task that
+  ``task_instance``. The ``task_instance_mutation_hook`` applies not to a task but to the instance of a task that
   relates to a particular DagRun. It is executed in a "worker", not in the dag file processor, just before the
   task instance is executed. The policy is only applied to the currently executed run (i.e. instance) of that
   task.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,8 @@ if PACKAGE_NAME == "apache-airflow":
     exclude_patterns = [
         # We only link to selected subpackages.
         "_api/airflow/index.rst",
+        # Included in the cluster-policies doc
+        "_api/airflow/policies/index.rst",
         "README.rst",
     ]
 elif PACKAGE_NAME.startswith("apache-airflow-providers-"):
@@ -217,7 +219,7 @@ def _get_rst_filepath_from_path(filepath: pathlib.Path):
 if PACKAGE_NAME == "apache-airflow":
     # Exclude top-level packages
     # do not exclude these top-level modules from the doc build:
-    _allowed_top_level = ("exceptions.py",)
+    _allowed_top_level = ("exceptions.py", "policies.py")
 
     browsable_packages = {
         "hooks",

--- a/tests/core/test_policies.py
+++ b/tests/core/test_policies.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from argparse import Namespace
+
+import pluggy
+import pytest
+
+from airflow import policies
+
+
+@pytest.fixture
+def plugin_manager():
+    pm = pluggy.PluginManager(policies.local_settings_hookspec.project_name)
+    pm.add_hookspecs(policies)
+    return pm
+
+
+def test_local_settings_plain_function(plugin_manager: pluggy.PluginManager):
+    """Test that a "plain" function from airflow_local_settings is registered via a plugin"""
+    called = False
+
+    def dag_policy(dag):
+        nonlocal called
+        called = True
+
+    mod = Namespace(dag_policy=dag_policy)
+
+    policies.make_plugin_from_local_settings(plugin_manager, mod, ["dag_policy"])
+
+    plugin_manager.hook.dag_policy(dag="a")
+
+    assert called
+
+
+def test_local_settings_misnamed_argument(plugin_manager: pluggy.PluginManager):
+    """
+    If an function in local_settings doesn't have the "correct" name we can't naively turn it in to a
+    plugin.
+
+    This tests the sig-mismatch detection and shimming code path
+    """
+    called_with = None
+
+    def dag_policy(wrong_arg_name):
+        nonlocal called_with
+        called_with = wrong_arg_name
+
+    mod = Namespace(dag_policy=dag_policy)
+
+    policies.make_plugin_from_local_settings(plugin_manager, mod, ["dag_policy"])
+
+    plugin_manager.hook.dag_policy(dag="passed_dag_value")
+
+    assert called_with == "passed_dag_value"


### PR DESCRIPTION
Previously it was only possible to set "policy" functions via
airflow_local_settings.py which is fine for "small clusters" but being
able to control some of these policies from installed
plugins/distributions is helpful in a few circumstances: it lets
"platforms" (either of the SaaS variety, or internal platform teams)
specify some common policies, but still let local Ariflow teams define
other policies using airflow_local_settings

This uses Pluggy[[1]] for plugin management (that we are already using
for the listener interface), and out of the box that
gives us the ability to have multiple implementations of the policy
functions where it makes sense

- on all the "mutation" hooks all implementations will be called. (i.e.
  for the policies that don't return a value)
- for any policy function that returns a value (such as
  `get_dagbag_import_timeout`) then the plugins will be tried in LIFO
  order until a non-None value is returned. (No code needed for us --
  Pluggy handles this out of the box with the `firstresult=True`
  property on the hookspec decorator).

[1]: https://pluggy.readthedocs.io/en/latest/index.html


Todo:

- [x] Document the way of adding plugins (setuptools entrypoints) and mark it experimental
- [x] Document how multiple plugins hooking the same function interact.
- [x] Mention that the argument names must match 
- [x] Issue deprecation warning when arg names don't match
- [ ] ???
