### PR TITLE
# 28470 Azure doc updates

### DIFF
--- a/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
@@ -16,7 +16,7 @@
     specific language governing permissions and limitations
     under the License.
 
-Azure Blob Storage Transfer Operator
+Azure Blob Storage to Google Cloud Storage (GCS) Transfer Operator
 ====================================
 The Blob service stores text and binary data as objects in the cloud.
 The Blob service offers the following three resources: the storage account, containers, and blobs.

--- a/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
@@ -17,7 +17,7 @@
     under the License.
 
 Azure Blob Storage to Google Cloud Storage (GCS) Transfer Operator
-====================================
+==================================================================
 The Blob service stores text and binary data as objects in the cloud.
 The Blob service offers the following three resources: the storage account, containers, and blobs.
 Within your storage account, containers provide a way to organize sets of blobs.

--- a/docs/apache-airflow-providers-microsoft-azure/operators/sftp_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/sftp_to_wasb.rst
@@ -18,7 +18,7 @@
 
 
 
-Azure Blob Storage Transfer Operator
+SFTP to Azure Blob Storage Transfer Operator
 ====================================
 The Blob service stores text and binary data as objects in the cloud.
 The Blob service offers the following three resources: the storage account, containers, and blobs.

--- a/docs/apache-airflow-providers-microsoft-azure/operators/sftp_to_wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/sftp_to_wasb.rst
@@ -19,7 +19,7 @@
 
 
 SFTP to Azure Blob Storage Transfer Operator
-====================================
+============================================
 The Blob service stores text and binary data as objects in the cloud.
 The Blob service offers the following three resources: the storage account, containers, and blobs.
 Within your storage account, containers provide a way to organize sets of blobs.


### PR DESCRIPTION
#28470  

Due to titles of documentation pages there is some slight confusion in the microsoft azure docs operators page.

By changing the titles of the documentation pages to more accurately reflect what is going on it should ease the confusion.

Current documentation:

<img width="1004" alt="Screen Shot 2022-12-23 at 11 40 52 AM" src="https://user-images.githubusercontent.com/6012231/209369518-e50678a7-4e78-4b8c-abd3-6e0f2f815445.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
