### PR TITLE
navbar, cap dropdown size, and add scroll bar

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -73,7 +73,6 @@ div.container {
   display: block;
 }
 
-
 /* If a menu remains open due to focus, a menu
   opened via hover will always be displayed on top */
 .navbar-nav li.dropdown:hover > .dropdown-menu {

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -66,6 +66,13 @@ div.container {
   display: block;
 }
 
+/* If a category has a lot of menu items, we cap it, and
+ add a scroll bar */
+.navbar li.dropdown .dropdown-menu {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
 /* If a menu remains open due to focus, a menu
   opened via hover will always be displayed on top */
 .navbar-nav li.dropdown:hover > .dropdown-menu {

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -61,17 +61,18 @@ div.container {
   color: #e2d2e2;
 }
 
-.navbar-nav li.dropdown:hover > .dropdown-menu,
-.navbar-nav li.dropdown:focus-within > .dropdown-menu {
-  display: block;
-}
-
 /* If a category has a lot of menu items, we cap it, and
  add a scroll bar */
 .navbar li.dropdown .dropdown-menu {
   max-height: 300px;
   overflow-y: auto;
 }
+
+.navbar-nav li.dropdown:hover > .dropdown-menu,
+.navbar-nav li.dropdown:focus-within > .dropdown-menu {
+  display: block;
+}
+
 
 /* If a menu remains open due to focus, a menu
   opened via hover will always be displayed on top */


### PR DESCRIPTION
This PR caps the size of a dropdown menu category, and adds a scrollbar past that level.

Closes: #28483

<img width="382" alt="Screen Shot 2022-12-23 at 1 17 31 PM" src="https://user-images.githubusercontent.com/40223998/209390328-786ab8f0-9e21-44b6-b6e6-7bf6a4375219.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #28483 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
