### PR TITLE
Rerun flaky PinotDB integration test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -374,7 +374,6 @@ devel_only = [
     "flake8>=3.9.0",
     "flake8-colors",
     "flake8-implicit-str-concat",
-    "flaky",
     "gitpython",
     "ipdb",
     # make sure that we are using stable sorting order from 5.* version (some changes were introduced

--- a/tests/integration/providers/apache/pinot/hooks/test_pinot.py
+++ b/tests/integration/providers/apache/pinot/hooks/test_pinot.py
@@ -26,6 +26,8 @@ from airflow.providers.apache.pinot.hooks.pinot import PinotDbApiHook
 
 @pytest.mark.integration("pinot")
 class TestPinotDbApiHookIntegration:
+    # This test occasionally fail in the CI. Re-run this test if it failed after timeout but only once.
+    @pytest.mark.flaky(reruns=1, reruns_delay=30)
     @mock.patch.dict("os.environ", AIRFLOW_CONN_PINOT_BROKER_DEFAULT="pinot://pinot:8000/")
     def test_should_return_records(self):
         hook = PinotDbApiHook()

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -890,7 +890,7 @@ class TestSSHHook:
                 session.delete(conn)
                 session.commit()
 
-    @pytest.mark.flaky(max_runs=5, min_passes=1)
+    @pytest.mark.flaky(reruns=5)
     def test_exec_ssh_client_command(self):
         hook = SSHHook(
             ssh_conn_id="ssh_default",
@@ -907,7 +907,7 @@ class TestSSHHook:
             )
             assert ret == (0, b"airflow\n", b"")
 
-    @pytest.mark.flaky(max_runs=5, min_passes=1)
+    @pytest.mark.flaky(reruns=5)
     def test_command_timeout(self):
         hook = SSHHook(
             ssh_conn_id="ssh_default",


### PR DESCRIPTION
Time to time we have this error on public runner.

```console
self = <tests.integration.providers.apache.pinot.hooks.test_pinot.TestPinotDbApiHookIntegration object at 0x7f36f132d450>

    @mock.patch.dict("os.environ", AIRFLOW_CONN_PINOT_BROKER_DEFAULT="pinot://pinot:8000/")
    def test_should_return_records(self):
        hook = PinotDbApiHook()
        sql = "select playerName from baseballStats  ORDER BY playerName limit 5"
        records = hook.get_records(sql)
>       assert [["A. Harry"], ["A. Harry"], ["Aaron"], ["Aaron Albert"], ["Aaron Albert"]] == records
E       AssertionError: assert [['A. Harry']...aron Albert']] == []
E         Left contains 5 more items, first extra item: ['A. Harry']
E         Use -v to get the full diff

tests/integration/providers/apache/pinot/hooks/test_pinot.py:34: AssertionError
```

Most probably the nature of this error some kind of race condition:
1. PinotDB test service marked healthy before data actually persist into test database
2. Test get 0 record as result test failed.

In case of failure test will rerun after 30 seconds but only once.

In additional I remove [flaky](https://pypi.org/project/flaky/) as dev-dependency because it use the same marker `@pytest.mark.flaky` as [pytest-rerunfailures](https://github.com/pytest-dev/pytest-rerunfailures) plugin.