### PR TITLE
Change trigger name so kwargs arent logged

### DIFF
--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -264,7 +264,7 @@ class TriggerRunner(threading.Thread, LoggingMixin):
             if trigger_id not in self.triggers:
                 self.triggers[trigger_id] = {
                     "task": asyncio.create_task(self.run_trigger(trigger_id, trigger_instance)),
-                    "name": f"{trigger_instance!r} (ID {trigger_id})",
+                    "name": f"{trigger_instance.classpath} (ID {trigger_id})",
                     "events": 0,
                 }
             else:


### PR DESCRIPTION
I'm using the triggerer to make RPC calls and I'm passing in a bearer token as part of the trigger's kwargs. Because the name includes the `repr` of the whole instance it is logging the bearer token in the triggerer logs. This is as much a question as it is a suggestion. Could we possibly add the kwargs as another field in the dict and then only log at the DEBUG level?

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
