### PR TITLE
Add to audit log when notes are set

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -58,6 +58,7 @@ from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.types import DagRunType
+from airflow.www.decorators import action_logging
 
 
 @security.requires_access(
@@ -423,6 +424,7 @@ def clear_dag_run(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSIO
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
     ],
 )
+@action_logging(event="dagrun.set_note", add_json_request_data_to_extra=True)
 @provide_session
 def set_dag_run_note(*, dag_id: str, dag_run_id: str, session: Session = NEW_SESSION) -> APIResponse:
     """Set the note for a dag run."""

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -51,6 +51,7 @@ from airflow.security import permissions
 from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State
+from airflow.www.decorators import action_logging
 
 T = TypeVar("T")
 
@@ -629,6 +630,7 @@ def patch_mapped_task_instance(
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
     ],
 )
+@action_logging(event="taskinstance.set_note", add_json_request_data_to_extra=True)
 @provide_session
 def set_task_instance_note(
     *, dag_id: str, dag_run_id: str, task_id: str, map_index: int = -1, session: Session = NEW_SESSION


### PR DESCRIPTION
We should add an entry into the audit log when a dagrun or ti note is set.

![Screen Shot 2022-12-23 at 3 41 11 PM](https://user-images.githubusercontent.com/66968678/209411090-76352a6e-1230-4a41-91a9-9c4b58b1aa6a.png)

Edit: This has secret masking issues. I'll fix it up next week.