### PR TITLE
Move TI setNote endpoints under TaskInstance

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -599,7 +599,7 @@ paths:
         *New in version 2.5.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
       operationId: set_task_instance_note
-      tags: [DAG]
+      tags: [TaskInstance]
       requestBody:
         description: Parameters of set Task Instance note.
         required: true
@@ -639,7 +639,7 @@ paths:
         *New in version 2.5.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.task_instance_endpoint
       operationId: set_mapped_task_instance_note
-      tags: [DAG]
+      tags: [TaskInstance]
       requestBody:
         description: Parameters of set Task Instance note.
         required: true


### PR DESCRIPTION
These endpoints were accidentally under DAG instead of TaskInstance where they belong.

Before:
![Screen Shot 2022-12-23 at 4 00 55 PM](https://user-images.githubusercontent.com/66968678/209412072-27fd2200-71ea-4715-b638-61780d706947.png)

After:
![Screen Shot 2022-12-23 at 4 01 38 PM](https://user-images.githubusercontent.com/66968678/209412081-ad3756de-0f98-4cd2-a073-8ccb4a3a60d0.png)
