### PR TITLE
Simplify log context setting / propagation handling

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -122,7 +122,6 @@ DEFAULT_LOGGING_CONFIG: dict[str, Any] = {
         "airflow.task": {
             "handlers": ["task"],
             "level": LOG_LEVEL,
-            # Set to true here (and reset via set_context) so that if no file is configured we still get logs!
             "propagate": True,
             "filters": ["mask_secrets"],
         },

--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from airflow import settings
 from airflow.utils.helpers import parse_template_string
-from airflow.utils.log.logging_mixin import DISABLE_PROPOGATE
+from airflow.utils.log.logging_mixin import SetContextPropagate
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 
 
@@ -65,7 +65,7 @@ class FileProcessorHandler(logging.Handler):
             self._symlink_latest_log_directory()
             self._cur_date = datetime.today()
 
-        return DISABLE_PROPOGATE
+        return SetContextPropagate.DISABLE_PROPAGATE
 
     def emit(self, record):
         if self.handler is not None:

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -31,7 +31,6 @@ from airflow.exceptions import AirflowConfigException, RemovedInAirflow3Warning
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.utils.context import Context
 from airflow.utils.helpers import parse_template_string, render_template_to_string
-from airflow.utils.log.logging_mixin import SetContextPropagate
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.session import create_session
 from airflow.utils.state import State
@@ -63,22 +62,10 @@ class FileTaskHandler(logging.Handler):
                 # handler, not the one that calls super()__init__.
                 stacklevel=(2 if type(self) == FileTaskHandler else 3),
             )
-        self.maintain_propagate: bool = False
-        """
-        If true, overrides default behavior of setting propagate=False
 
-        :meta private:
-        """
-
-    def set_context(self, ti: TaskInstance) -> None | SetContextPropagate:
+    def set_context(self, ti: TaskInstance) -> None:
         """
         Provide task_instance context to airflow task handler.
-
-        Generally speaking returns None.  But if attr `maintain_propagate` has
-        been set to propagate, then returns sentinel MAINTAIN_PROPAGATE. This
-        has the effect of overriding the default behavior to set `propagate`
-        to False whenever set_context is called.  At time of writing, this
-        functionality is only used in unit testing.
 
         :param ti: task instance object
         """
@@ -87,7 +74,6 @@ class FileTaskHandler(logging.Handler):
         if self.formatter:
             self.handler.setFormatter(self.formatter)
         self.handler.setLevel(self.level)
-        return SetContextPropagate.MAINTAIN_PROPAGATE if self.maintain_propagate else None
 
     def emit(self, record):
         if self.handler:

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -687,7 +687,7 @@ class TestBaseOperator:
 
     # ensure the default logging config is used for this test, no matter what ran before
     @pytest.mark.usefixtures("reset_logging_config")
-    def test_logging_propogated_by_default(self, caplog):
+    def test_logging_propagated_by_default(self, caplog):
         """Test that when set_context hasn't been called that log records are emitted"""
         BaseOperator(task_id="test").log.warning("test")
         # This looks like "how could it fail" but this actually checks that the handler called `emit`. Testing


### PR DESCRIPTION
Assumes https://github.com/apache/airflow/pull/28440 merged first.

After https://github.com/apache/airflow/pull/28440, instead of having a task logger both at `airflow.task` and root logger, we only have it at root logger.  This means we can remove the logic to set propagate=False, because there's no longer a risk of record processed by FTH twice.  

It also means we can remove the logic to walk up the logger hierarchy and set context because we don't need to hit both airflow.task and root -- there will only ever be one such handler instance.

For file processor, we can go back to the old approach where we optionally disable propagation by returning a sentinel value, rather than disabling by default.  Though we probably could remove it entirely.