### PR TITLE
Output of the "dev" asset compilation for breeze available in file

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets.py
@@ -44,6 +44,6 @@ if __name__ == "__main__":
         sys.exit(0)
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
-    subprocess.check_call(["yarn", "install", "--frozen-lockfile"], cwd=str(www_directory))
-    subprocess.check_call(["yarn", "run", "build"], cwd=str(www_directory), env=env)
+    subprocess.check_call(["yarn", "install", "--frozen-lockfile"], cwd=os.fspath(www_directory))
+    subprocess.check_call(["yarn", "run", "build"], cwd=os.fspath(www_directory), env=env)
     WWW_HASH_FILE.write_text(new_hash)

--- a/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
+++ b/scripts/ci/pre_commit/pre_commit_compile_www_assets_dev.py
@@ -28,14 +28,30 @@ if __name__ not in ("__main__", "__mp_main__"):
     )
 
 AIRFLOW_SOURCES_PATH = Path(__file__).parents[3].resolve()
-WWW_HASH_FILE = AIRFLOW_SOURCES_PATH / ".build" / "www" / "hash.txt"
+WWW_CACHE_DIR = AIRFLOW_SOURCES_PATH / ".build" / "www"
+WWW_HASH_FILE = WWW_CACHE_DIR / "hash.txt"
+WWW_ASSET_OUT_FILE = WWW_CACHE_DIR / "asset_compile.out"
 
 if __name__ == "__main__":
-    www_directory = Path("airflow") / "www"
+    www_directory = AIRFLOW_SOURCES_PATH / "airflow" / "www"
     if WWW_HASH_FILE.exists():
         # cleanup hash of www so that next compile-assets recompiles them
         WWW_HASH_FILE.unlink()
     env = os.environ.copy()
     env["FORCE_COLOR"] = "true"
-    subprocess.check_call(["yarn", "install", "--frozen-lockfile"], cwd=str(www_directory))
-    subprocess.check_call(["yarn", "dev"], cwd=str(www_directory), env=env)
+    with open(WWW_ASSET_OUT_FILE, "w") as f:
+        subprocess.run(
+            ["yarn", "install", "--frozen-lockfile"],
+            cwd=os.fspath(www_directory),
+            check=True,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+        )
+        subprocess.run(
+            ["yarn", "dev"],
+            check=True,
+            cwd=os.fspath(www_directory),
+            env=env,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+        )


### PR DESCRIPTION
When you start airflow in `dev-mode`, the output of asset compilation (which run continuously) is now available in a file that you can run `tail -f` on to see the output.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
