### PR TITLE
Amazon Provider Package release 7.0.0 - Add description of breaking changes

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -30,12 +30,19 @@ Changelog
 Breaking changes
 ~~~~~~~~~~~~~~~~
 
-TODO: add good description of Secrets Backend breaking changes as implemented in
-https://github.com/apache/airflow/pull/27920
+JSON secrets in the 'SecretsManagerBackend' are never interpreted as urlencoded. In ``5.x`` and ``6.x``, the
+code would infer whether the JSON secret values were urlencoded based on context clues; now the unaltered
+values are *always* used to construct ``Connection`` objects.
 
 Pandas is now an optional dependency of the provider. The ``SqlToS3Operator`` and ``HiveToDynamoDBOperator``
 require Pandas to be installed (you can install it automatically by adding ``[pandas]`` extra when installing
 the provider.
+
+Features
+~~~~~~~~
+
+* ``Deprecate 'full_url_mode' for SecretsManagerBackend; whether a secret is a JSON or URL is inferred (#27920)``
+
 
 6.2.0
 .....


### PR DESCRIPTION
This PR is by request from @potiuk here: https://github.com/apache/airflow/pull/28505#discussion_r1053738869

He wanted a succinct description of the breaking changes I introduced. I mention that JSON secrets for the AWS `SecretsManagerBackend` no longer do anything regarding urlencoding. I added a sub-bullet to clarify how this differs from the 5.x change, since at first glance they seem like they're indistinguishable changes.

The changelog is meant to be very short and to the point. To keep things brief, I omitted two things:

* I do _not_ mention the removal of `ast.literal_eval()` for `json.loads` because this was never a documented behavior, and a reasonable coder should have known better than to use invalid JSONs.
* I also never mention that `get_conn_value()` can return a JSON because as of 6.1.0, the AWS provider package was already locked in base Airflow version `>=2.3.0` where this behavior is already assumed to be a supported (i.e. the base implementation for the method `get_connection()` calls `get_conn_value()`, and then checks whether it is a JSON or URL).

---

I'm not sure exactly how you want this formatted so let me know.