### PR TITLE
Fix flaky test_get_context_in_old_style_context_task test

### DIFF
--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -924,19 +924,7 @@ class TestPythonVirtualenvOperator(BasePythonTest):
             *PythonVirtualenvOperator.AIRFLOW_SERIALIZABLE_CONTEXT_KEYS,
             *intentionally_excluded_context_keys,
         }
-
         assert set(context) == declared_keys
-
-
-DEFAULT_ARGS = {
-    "owner": "test",
-    "depends_on_past": True,
-    "start_date": timezone.datetime(2022, 1, 1),
-    "end_date": datetime.today(),
-    "schedule_interval": "@once",
-    "retries": 1,
-    "retry_delay": timedelta(minutes=1),
-}
 
 
 class TestCurrentContext:
@@ -1000,14 +988,24 @@ def clear_db():
     clear_db_runs()
 
 
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": datetime(2022, 1, 1),
+    "end_date": datetime.today(),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
 @pytest.mark.usefixtures("clear_db")
 class TestCurrentContextRuntime:
     def test_context_in_task(self):
-        with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS):
+        with DAG(dag_id="assert_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = MyContextAssertOperator(task_id="assert_context")
             op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)
 
     def test_get_context_in_old_style_context_task(self):
-        with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS):
+        with DAG(dag_id="edge_case_context_dag", default_args=DEFAULT_ARGS, schedule="@once"):
             op = PythonOperator(python_callable=get_all_the_context, task_id="get_all_the_context")
             op.run(ignore_first_depends_on_past=True, ignore_ti_state=True)


### PR DESCRIPTION
The test was flaky because it was passing schedule "@once" as default_args (wrongly) - as the result this test was set to the default "daily" and since start date was set to 1st Jan 2022 it executed longer and longer every day (running the Python Operator for every day between 1st Jan and now.

This PR cahnges the test to correctly pass "@once" schedule via the `schedule' parameter.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
