### PR TITLE
Use time not tries for queued & running re-checks.

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -257,13 +257,12 @@ class BaseExecutor(LoggingMixin):
                     # if it hasn't been much time since first check, let it be checked again next time
                     self.log.info("queued but still running; attempt=%s task=%s", attempt.total_tries, key)
                     continue
-                else:
-                    # Otherwise, we give up and remove the task from the queue.
-                    self.log.error(
-                        "could not queue task %s (still running after %d attempts)", key, attempt.total_tries
-                    )
-                    del self.attempts[key]
-                    del self.queued_tasks[key]
+                # Otherwise, we give up and remove the task from the queue.
+                self.log.error(
+                    "could not queue task %s (still running after %d attempts)", key, attempt.total_tries
+                )
+                del self.attempts[key]
+                del self.queued_tasks[key]
             else:
                 if key in self.attempts:
                     del self.attempts[key]

--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -69,7 +69,7 @@ class RunningRetryAttemptType:
     re-checked for at least MIN_SECONDS seconds.
     """
 
-    MIN_SECONDS = 5
+    MIN_SECONDS = 10
     total_tries: int = field(default=0, init=False)
     tries_after_min: int = field(default=0, init=False)
     first_attempt_time: datetime = field(default_factory=lambda: pendulum.now("UTC"), init=False)

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -163,7 +163,7 @@ def test_trigger_running_tasks(can_try_mock, dag_maker, can_try_num, change_stat
     if second_exec is True:
         expected_calls += 1
 
-    assert len(executor.execute_async.mock_calls) == expected_calls
+    assert executor.execute_async.call_count == expected_calls
 
 
 def test_validate_airflow_tasks_run_command(dag_maker):

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -20,9 +20,12 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest import mock
 
+import pendulum
+import pytest
+import time_machine
 from pytest import mark
 
-from airflow.executors.base_executor import QUEUEING_ATTEMPTS, BaseExecutor
+from airflow.executors.base_executor import BaseExecutor, RunningRetryAttemptType
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskinstance import TaskInstanceKey
 from airflow.utils import timezone
@@ -104,8 +107,17 @@ def test_trigger_queued_tasks(dag_maker, open_slots):
     assert len(executor.execute_async.mock_calls) == open_slots
 
 
-@mark.parametrize("change_state_attempt", range(QUEUEING_ATTEMPTS + 2))
-def test_trigger_running_tasks(dag_maker, change_state_attempt):
+@pytest.mark.parametrize(
+    "can_try_num, change_state_num, second_exec",
+    [
+        (2, 3, False),
+        (3, 3, True),
+        (4, 3, True),
+    ],
+)
+@mock.patch("airflow.executors.base_executor.RunningRetryAttemptType.can_try_again")
+def test_trigger_running_tasks(can_try_mock, dag_maker, can_try_num, change_state_num, second_exec):
+    can_try_mock.side_effect = [True for _ in range(can_try_num)] + [False]
     executor, dagrun = setup_trigger_tasks(dag_maker)
     open_slots = 100
     executor.trigger_tasks(open_slots)
@@ -114,21 +126,44 @@ def test_trigger_running_tasks(dag_maker, change_state_attempt):
 
     # All the tasks are now "running", so while we enqueue them again here,
     # they won't be executed again until the executor has been notified of a state change.
-    enqueue_tasks(executor, dagrun)
+    ti = dagrun.task_instances[0]
+    assert ti.key in executor.running
+    assert ti.key not in executor.queued_tasks
+    executor.queue_command(ti, ["airflow"])
 
-    for attempt in range(QUEUEING_ATTEMPTS + 2):
-        # On the configured attempt, we notify the executor that the task has succeeded.
-        if attempt == change_state_attempt:
-            executor.change_state(dagrun.task_instances[0].key, State.SUCCESS)
-            # If we have not exceeded QUEUEING_ATTEMPTS, we should expect an additional "execute" call
-            if attempt < QUEUEING_ATTEMPTS:
-                expected_calls += 1
+    # this is the problem we're dealing with: ti.key both queued and running
+    assert ti.key in executor.queued_tasks and ti.key in executor.running
+    assert len(executor.attempts) == 0
+    executor.trigger_tasks(open_slots)
+
+    # first trigger call after queueing again creates an attempt object
+    assert len(executor.attempts) == 1
+    assert ti.key in executor.attempts
+
+    for attempt in range(2, change_state_num + 2):
         executor.trigger_tasks(open_slots)
-        assert len(executor.execute_async.mock_calls) == expected_calls
-    if change_state_attempt < QUEUEING_ATTEMPTS:
-        assert len(executor.execute_async.mock_calls) == len(dagrun.task_instances) + 1
-    else:
-        assert len(executor.execute_async.mock_calls) == len(dagrun.task_instances)
+        if attempt <= min(can_try_num, change_state_num):
+            assert ti.key in executor.queued_tasks and ti.key in executor.running
+        # On the configured attempt, we notify the executor that the task has succeeded.
+        if attempt == change_state_num:
+            executor.change_state(ti.key, State.SUCCESS)
+            assert ti.key not in executor.running
+    # retry was ok when state changed, ti.key will be in running (for the second time
+    if can_try_num >= change_state_num:
+        assert ti.key in executor.running
+    else:  # otherwise, it won't be
+        assert ti.key not in executor.running
+    # either way, ti.key not in queued -- it was either removed because never left running
+    # or it was moved out when run 2nd time
+    assert ti.key not in executor.queued_tasks
+    assert not executor.attempts
+
+    # we expect one more "execute_async" if TI was marked successful
+    # this would move it out of running set and free the queued TI to be executed again
+    if second_exec is True:
+        expected_calls += 1
+
+    assert len(executor.execute_async.mock_calls) == expected_calls
 
 
 def test_validate_airflow_tasks_run_command(dag_maker):
@@ -136,3 +171,22 @@ def test_validate_airflow_tasks_run_command(dag_maker):
     tis = dagrun.task_instances
     dag_id, task_id = BaseExecutor.validate_airflow_tasks_run_command(tis[0].command_as_list())
     assert dag_id == dagrun.dag_id and task_id == tis[0].task_id
+
+
+@pytest.mark.parametrize("loop_duration, total_tries", [(0.5, 12), (1.0, 7), (1.7, 4), (10, 2)])
+def test_running_retry_attempt_type(loop_duration, total_tries):
+    """
+    Verify can_try_again returns True until at least 5 seconds have passed.
+
+    For faster loops, we total tries will be higher.  If loops take longer than 5 seconds, still should
+    end up trying 2 times.
+    """
+    with time_machine.travel(pendulum.now("UTC"), tick=False) as t:
+        a = RunningRetryAttemptType()
+        while True:
+            if not a.can_try_again():
+                break
+            t.shift(loop_duration)
+        assert a.elapsed > 5
+    assert a.total_tries == total_tries
+    assert a.tries_after_min == 1

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -148,7 +148,7 @@ def test_trigger_running_tasks(can_try_mock, dag_maker, can_try_num, change_stat
         if attempt == change_state_num:
             executor.change_state(ti.key, State.SUCCESS)
             assert ti.key not in executor.running
-    # retry was ok when state changed, ti.key will be in running (for the second time
+    # retry was ok when state changed, ti.key will be in running (for the second time)
     if can_try_num >= change_state_num:
         assert ti.key in executor.running
     else:  # otherwise, it won't be


### PR DESCRIPTION
Followup for https://github.com/apache/airflow/pull/21316

Turns out if the loop is not super busy, 5 tries may not be enough.  Using time instead of tries is a more direct way to achieve the desired outcome.

Here's some debug logging with my fix:
```
[2022-12-27 23:22:39,311] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:40,359] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:41,702] {base_executor.py:93} DEBUG - elapsed=7.2e-05 tries=1
[2022-12-27 23:22:41,703] {base_executor.py:256} INFO - queued but still running; attempt=1 task=TaskInstanceKey(dag_id='example_time_delta_sensor_async', task_id='wait', run_id='manual__2022-12-28T07:22:37.719521+00:00', try_number=1, map_index=-1)
[2022-12-27 23:22:41,716] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:41,767] {base_executor.py:93} DEBUG - elapsed=0.064726 tries=2
[2022-12-27 23:22:41,767] {base_executor.py:256} INFO - queued but still running; attempt=2 task=TaskInstanceKey(dag_id='example_time_delta_sensor_async', task_id='wait', run_id='manual__2022-12-28T07:22:37.719521+00:00', try_number=1, map_index=-1)
[2022-12-27 23:22:41,772] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:41,971] {base_executor.py:93} DEBUG - elapsed=0.269365 tries=3
[2022-12-27 23:22:41,972] {base_executor.py:256} INFO - queued but still running; attempt=3 task=TaskInstanceKey(dag_id='example_time_delta_sensor_async', task_id='wait', run_id='manual__2022-12-28T07:22:37.719521+00:00', try_number=1, map_index=-1)
[2022-12-27 23:22:41,976] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:43,028] {base_executor.py:93} DEBUG - elapsed=1.326199 tries=4
[2022-12-27 23:22:43,028] {base_executor.py:256} INFO - queued but still running; attempt=4 task=TaskInstanceKey(dag_id='example_time_delta_sensor_async', task_id='wait', run_id='manual__2022-12-28T07:22:37.719521+00:00', try_number=1, map_index=-1)
[2022-12-27 23:22:43,033] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:44,072] {base_executor.py:93} DEBUG - elapsed=2.369759 tries=5
[2022-12-27 23:22:44,072] {base_executor.py:256} INFO - queued but still running; attempt=5 task=TaskInstanceKey(dag_id='example_time_delta_sensor_async', task_id='wait', run_id='manual__2022-12-28T07:22:37.719521+00:00', try_number=1, map_index=-1)
[2022-12-27 23:22:44,077] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
[2022-12-27 23:22:45,141] {celery_executor.py:607} DEBUG - Fetched 1 state(s) for 1 task(s)
```

I simulated slow celery completion by sleeping 3 seconds after task defers.  You can see that in this time, we already have 5 retries, which is the current max.