### PR TITLE
Fix doc build error for `example_dataflow_template`

### DIFF
--- a/tests/system/providers/google/cloud/dataflow/example_dataflow_template.py
+++ b/tests/system/providers/google/cloud/dataflow/example_dataflow_template.py
@@ -17,7 +17,8 @@
 # under the License.
 
 """
-Example Airflow DAG for testing Google Dataflow "DataflowTemplatedJobStartOperator" operator.
+Example Airflow DAG for testing Google Dataflow
+:class:`~airflow.providers.google.cloud.operators.dataflow.DataflowTemplatedJobStartOperator` operator.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Fix google cloud system test "spelling" which locally raise an error

```console
File path: apache-airflow-providers-google/_api/tests/system/providers/google/cloud/dataflow/example_dataflow_template/index.rst
Incorrect Spelling: 'DataflowTemplatedJobStartOperator'
Line with Error: 'Example Airflow DAG for testing Google Dataflow “DataflowTemplatedJobStartOperator” operator.'
Line Number: 8
   3 | 
   4 | .. py:module:: tests.system.providers.google.cloud.dataflow.example_dataflow_template
   5 | 
   6 | .. autoapi-nested-parse::
   7 | 
>  8 |    Example Airflow DAG for testing Google Dataflow "DataflowTemplatedJobStartOperator" operator.
   9 | 
  10 | 
  11 | 
  12 | Module Contents
  13 | ---------------
====================================================================================================
```

Originally reported in [slack](https://apache-airflow.slack.com/archives/CJ1LVREHX/p1671890447727039).

cc: @vchiapaikeo 