### PR TITLE
collect sawarning as error in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ norecursedirs =
 log_level = INFO
 filterwarnings =
     error::pytest.PytestCollectionWarning
+    error:SELECT statement has a cartesian product between FROM element
     ignore::DeprecationWarning:flask_appbuilder.filemanager
     ignore::DeprecationWarning:flask_appbuilder.widgets
     ; https://github.com/dpgaspar/Flask-AppBuilder/pull/1940


### PR DESCRIPTION
Signed-off-by: BobDu <i@bobdu.cc>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #28198 #28544

Improve unit test make sure there isn't a regression in the future. 

when delete 
https://github.com/apache/airflow/blob/6dc28fb0278c1bdb096b75b6e19acbcb1019db02/airflow/jobs/scheduler_job.py#L1539
run `pytest tests/jobs/test_scheduler_job.py::TestSchedulerJob::test_find_zombies`
while have a error in unit test result
```
FAILED tests/jobs/test_scheduler_job.py::TestSchedulerJob::test_find_zombies - sqlalchemy.exc.SAWarning: SELECT statement has a cartesian product between FROM element(s) "dag" and FROM element "task_instance".  Apply join condition(s) between each element to...
```

ref: https://docs.python.org/3/library/warnings.html#the-warnings-filter

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
