### PR TITLE
Guard not-yet-expanded ti in trigger rule dep

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -105,6 +105,8 @@ class TriggerRuleDep(BaseTIDep):
         :param dep_context: The current dependency context.
         :param session: Database session.
         """
+        from airflow.models.abstractoperator import NotMapped
+        from airflow.models.expandinput import NotFullyPopulated
         from airflow.models.operator import needs_expansion
         from airflow.models.taskinstance import TaskInstance
 
@@ -129,9 +131,13 @@ class TriggerRuleDep(BaseTIDep):
             and at most once for each task (instead of once for each expanded
             task instance of the same task).
             """
+            try:
+                expanded_ti_count = _get_expanded_ti_count()
+            except (NotFullyPopulated, NotMapped):
+                return None
             return ti.get_relevant_upstream_map_indexes(
                 upstream_tasks[upstream_id],
-                _get_expanded_ti_count(),
+                expanded_ti_count,
                 session=session,
             )
 


### PR DESCRIPTION
Previously, if a mapped task is not yet expanded when the trigger rule dep is evaluated, it would raise an exception and fail the scheduler. This adds an additional try-except to guard against this.

The problematic scenario is when a mapped task depends on another mapped task, and its trigger rule is evaluated before that other mapped task is expanded (e.g. the other task also has a task-mapping dependency that is not yet finished). Since we can be certain the upstream task has not yet satisfy the expansion dep, we can simply declare the task we're checking as unsatisfied.