### PR TITLE
Disable `flaky` plugin in pytest addopts config

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -19,8 +19,8 @@
 addopts =
     -rasl
     --verbosity=2
-;    This will treat all tests as flaky
-;    --force-flaky
+    ; Disable `flaky` plugin for pytest. This plugin conflicts with `rerunfailures` because provide same marker.
+    -p no:flaky
 norecursedirs =
     .eggs
     airflow


### PR DESCRIPTION
After #28562 PR Tests steps failed with error

```console
__________ ERROR at setup of TestSSHHook.test_exec_ssh_client_command __________

self = <flaky.flaky_pytest_plugin.FlakyPlugin object at 0x7fac59336b90>
item = <Function test_exec_ssh_client_command>

    def pytest_runtest_setup(self, item):
        """
        Pytest hook to modify the test before it's run.
    
        :param item:
            The test item.
        """
        if not self._has_flaky_attributes(item):
            if hasattr(item, 'iter_markers'):
                for marker in item.iter_markers(name='flaky'):
>                   self._make_test_flaky(item, *marker.args, **marker.kwargs)
E                   TypeError: _make_test_flaky() got an unexpected keyword argument 'reruns'

/usr/local/lib/python3.7/site-packages/flaky/flaky_pytest_plugin.py:244: TypeError
```

Seems like somewhere `flaky` still persist (docker cache?) but not affects main. This PR disable this plugin in `pytest` config which also useful if this plugin will distributed as some package dependency.