### PR TITLE
Fix Docs Incorrect Example in  How To Create Custom Decorator

### DIFF
--- a/docs/apache-airflow/howto/create-custom-decorator.rst
+++ b/docs/apache-airflow/howto/create-custom-decorator.rst
@@ -77,7 +77,7 @@ tasks. The steps to create and register ``@task.foo`` are:
                     {
                         "name": "foo",
                         # "Import path" and function name of the `foo_task`
-                        "class-name": ["name.of.python.package.foo_task"],
+                        "class-name": "name.of.python.package.foo_task",
                     }
                 ],
                 # ...


### PR DESCRIPTION
Following the existing example to create a decorator results in this error: AttributeError: 'list' object has no attribute 'rsplit'

Changing it from a list to a string fixes this

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
