### PR TITLE
Fix scheduler-deployment.yaml

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -275,10 +275,11 @@ spec:
         {{- else if .Values.dags.gitSync.enabled }}
         - name: dags
           emptyDir: {}
+        {{- end}}
         {{- if .Values.dags.gitSync.sshKeySecret }}
         {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
-        {{- end}}
+        
 {{- end }}
 {{- if .Values.volumes }}
 {{- toYaml .Values.volumes | nindent 8 }}


### PR DESCRIPTION
While installing the chart with the git-sync, I was facing an issue, volume name was not available, This was just a typo!