### PR TITLE
Reduce logging level of `gunicorn.access` to warning

### DIFF
--- a/airflow/www/gunicorn_config.py
+++ b/airflow/www/gunicorn_config.py
@@ -18,6 +18,8 @@
 # under the License.
 from __future__ import annotations
 
+import logging
+
 import setproctitle
 
 from airflow import settings
@@ -31,6 +33,7 @@ def post_worker_init(_):
     """
     old_title = setproctitle.getproctitle()
     setproctitle.setproctitle(settings.GUNICORN_WORKER_READY_PREFIX + old_title)
+    logging.getLogger("gunicorn.access").setLevel(logging.WARNING)
 
 
 def on_starting(server):


### PR DESCRIPTION
When running webserver in debug mode, we can control this with airflow_local_settings because it's in-process.  But in production mode, gunicorn workers run in subprocesses, and we have to set this within the process.

We could make this configurable.  But, I'm not sure it's necessary.  Maybe we don't, and then do if asked?

The type of message this filters out is this:
```
127.0.0.1 - - [27/Dec/2022:19:22:58 -0800] "GET /static/appbuilder/datepicker/bootstrap-datepicker.js HTTP/1.1" 304 0 "http://localhost:8080/home" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
127.0.0.1 - - [27/Dec/2022:19:22:58 -0800] "GET /static/appbuilder/select2/select2.js HTTP/1.1" 304 0 "http://localhost:8080/home" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
127.0.0.1 - - [27/Dec/2022:19:22:58 -0800] "GET /static/appbuilder/js/ab.js HTTP/1.1" 304 0 "http://localhost:8080/home" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
127.0.0.1 - - [27/Dec/2022:19:22:58 -0800] "GET /static/dist/moment.197a6f3cab42e240f8bd.js HTTP/1.1" 304 0 "http://localhost:8080/home" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
127.0.0.1 - - [27/Dec/2022:19:22:58 -0800] "GET /static/dist/main.f64802c246d907b57425.js HTTP/1.1" 304 0 "http://localhost:8080/home" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
```

It tends to be a lot, and it's not usually something that we care about AFAIK.

It actually is emitted from a werkzeug module, but when webserver not run in debug mode, it comes through the `gunicorn.access` logger.