### PR TITLE
Add .bash extension to SSHOperator

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -63,7 +63,10 @@ class SSHOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = ("command", "environment", "remote_host")
-    template_ext: Sequence[str] = (".sh",)
+    template_ext: Sequence[str] = (
+        ".sh",
+        ".bash",
+    )
     template_fields_renderers = {
         "command": "bash",
         "environment": "python",

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -66,6 +66,10 @@ class SSHOperator(BaseOperator):
     template_ext: Sequence[str] = (
         ".sh",
         ".bash",
+        ".csh",
+        ".zsh",
+        ".dash",
+        ".ksh",
     )
     template_fields_renderers = {
         "command": "bash",


### PR DESCRIPTION
New `.bash` extension was added to `SSHOperator` into template_ext