### PR TITLE
Add note for pymssql requirement

### DIFF
--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -91,7 +91,7 @@ PIP package                              Version required
 ``pymssql``                              ``>=2.1.5; platform_machine != "aarch64"``
 =======================================  ==========================================
 
-.. note:: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. More details can be found on `PyPI <https://pypi.org/project/pymssql/>`_.
+.. note:: ``pip`` version on some Linux distributions ``pip`` might be outdated and not support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. More details can be found on `PyPI <https://pypi.org/project/pymssql/>`_.
 
 Cross provider package dependencies
 -----------------------------------

--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -91,6 +91,8 @@ PIP package                              Version required
 ``pymssql``                              ``>=2.1.5; platform_machine != "aarch64"``
 =======================================  ==========================================
 
+Note: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. An example of such distributions would be Ubuntu 18.04 or Python3.6 module in RHEL8 and CentOS8.
+
 Cross provider package dependencies
 -----------------------------------
 

--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -91,7 +91,7 @@ PIP package                              Version required
 ``pymssql``                              ``>=2.1.5; platform_machine != "aarch64"``
 =======================================  ==========================================
 
-Note: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. An example of such distributions would be Ubuntu 18.04 or Python3.6 module in RHEL8 and CentOS8.
+.. note:: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. An example of such distributions would be Ubuntu 18.04 or Python3.6 module in RHEL8 and CentOS8.
 
 Cross provider package dependencies
 -----------------------------------

--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -91,7 +91,7 @@ PIP package                              Version required
 ``pymssql``                              ``>=2.1.5; platform_machine != "aarch64"``
 =======================================  ==========================================
 
-.. note:: ``pip`` version on some Linux distributions ``pip`` might be outdated and not support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. More details can be found on `PyPI <https://pypi.org/project/pymssql/>`_.
+.. note:: ``pip`` version on some Linux distributions might be outdated and not support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. More details can be found on `PyPI <https://pypi.org/project/pymssql/>`_.
 
 Cross provider package dependencies
 -----------------------------------

--- a/docs/apache-airflow-providers-microsoft-mssql/index.rst
+++ b/docs/apache-airflow-providers-microsoft-mssql/index.rst
@@ -91,7 +91,7 @@ PIP package                              Version required
 ``pymssql``                              ``>=2.1.5; platform_machine != "aarch64"``
 =======================================  ==========================================
 
-.. note:: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. An example of such distributions would be Ubuntu 18.04 or Python3.6 module in RHEL8 and CentOS8.
+.. note:: For ``pymssql`` installation some Linux distributions ``pip`` version is too old to support all the flavors of ``manylinux`` wheels, so upgrading ``pip`` is necessary. More details can be found on `PyPI <https://pypi.org/project/pymssql/>`_.
 
 Cross provider package dependencies
 -----------------------------------


### PR DESCRIPTION
A user reported an issue on Slack with `MsSqlHook` resulting in a segmentation fault. This issue was resolved by following the instructions on the `pymssql` PyPI. I added this note to the documentation for the mssql provider package.
