### PR TITLE
Change Architecture and OperatingSystem classes into Enums

### DIFF
--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -23,6 +23,7 @@ import os
 import platform
 import subprocess
 import sys
+from enum import Enum
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -124,16 +125,17 @@ class PiiAnonymizer(Anonymizer):
         return urlunsplit((url_parts.scheme, netloc, url_parts.path, url_parts.query, url_parts.fragment))
 
 
-class OperatingSystem:
+class OperatingSystem(Enum):
     """Operating system."""
 
     WINDOWS = "Windows"
     LINUX = "Linux"
     MACOSX = "Mac OS"
     CYGWIN = "Cygwin"
+    UNKNOWN = "Unknown"
 
     @staticmethod
-    def get_current() -> str | None:
+    def get_current() -> OperatingSystem:
         """Get current operating system."""
         if os.name == "nt":
             return OperatingSystem.WINDOWS
@@ -143,24 +145,26 @@ class OperatingSystem:
             return OperatingSystem.MACOSX
         elif "cygwin" in sys.platform:
             return OperatingSystem.CYGWIN
-        return None
+        return OperatingSystem.UNKNOWN
 
 
-class Architecture:
+class Architecture(Enum):
     """Compute architecture."""
 
     X86_64 = "x86_64"
     X86 = "x86"
     PPC = "ppc"
     ARM = "arm"
+    UNKNOWN = "unknown"
 
     @staticmethod
-    def get_current():
+    def get_current() -> Architecture:
         """Get architecture."""
-        return _MACHINE_TO_ARCHITECTURE.get(platform.machine().lower())
+        current_architecture = _MACHINE_TO_ARCHITECTURE.get(platform.machine().lower())
+        return current_architecture if current_architecture else Architecture.UNKNOWN
 
 
-_MACHINE_TO_ARCHITECTURE = {
+_MACHINE_TO_ARCHITECTURE: dict[str, Architecture] = {
     "amd64": Architecture.X86_64,
     "x86_64": Architecture.X86_64,
     "i686-64": Architecture.X86_64,
@@ -259,8 +263,8 @@ class AirflowInfo:
         python_version = sys.version.replace("\n", " ")
 
         return [
-            ("OS", operating_system or "NOT AVAILABLE"),
-            ("architecture", arch or "NOT AVAILABLE"),
+            ("OS", operating_system.value),
+            ("architecture", arch.value),
             ("uname", str(uname)),
             ("locale", str(_locale)),
             ("python_version", python_version),

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -460,7 +460,7 @@ def check_providers_have_all_documentation_files(yaml_files: dict[str, dict]):
 
 
 if __name__ == "__main__":
-    architecture = Architecture().get_current()
+    architecture = Architecture.get_current()
     console.print(f"Verifying packages on {architecture} architecture. Platform: {platform.machine()}.")
     provider_files_pattern = pathlib.Path(ROOT_DIR).glob("airflow/providers/**/provider.yaml")
     all_provider_files = sorted(str(path) for path in provider_files_pattern)


### PR DESCRIPTION
Since they are objects already, there is a very little overhead
into making them Enums and it has the nice property of being able
to add type hinting for the returned values.
@[potiuk](https://github.com/potiuk/airflow/commits?author=potiuk)
potiuk committed now


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
