### PR TITLE
Clear DB before individual module tests

### DIFF
--- a/tests/api/client/test_local_client.py
+++ b/tests/api/client/test_local_client.py
@@ -44,7 +44,7 @@ EXECDATE_ISO = EXECDATE_NOFRACTIONS.isoformat()
 class TestLocalClient:
     @classmethod
     def setup_class(cls):
-        DagBag(example_bash_operator.__file__).get_dag("example_bash_operator").sync_to_db()
+        DagBag(example_bash_operator.__file__, include_examples=False).sync_to_db()
 
     def setup_method(self):
         clear_db_pools()

--- a/tests/api/common/test_mark_tasks.py
+++ b/tests/api/common/test_mark_tasks.py
@@ -49,7 +49,7 @@ def dagbag():
     from airflow.models.dagbag import DagBag
 
     # Ensure the DAGs we are looking at from the DB are up-to-date
-    non_serialized_dagbag = DagBag(read_dags_from_db=False, include_examples=False)
+    non_serialized_dagbag = DagBag(read_dags_from_db=False, include_examples=True)
     non_serialized_dagbag.sync_to_db()
     return DagBag(read_dags_from_db=True)
 

--- a/tests/api_connexion/conftest.py
+++ b/tests/api_connexion/conftest.py
@@ -52,7 +52,7 @@ def session():
         yield session
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def dagbag():
     from airflow.models import DagBag
 

--- a/tests/integration/api/auth/backend/test_kerberos_auth.py
+++ b/tests/integration/api/auth/backend/test_kerberos_auth.py
@@ -46,11 +46,9 @@ def app_for_kerberos():
         yield app.create_app(testing=True)
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def dagbag_to_db():
-    dagbag = DagBag(include_examples=True)
-    for dag in dagbag.dags.values():
-        dag.sync_to_db()
+    DagBag(include_examples=True).sync_to_db()
     yield
     clear_db_dags()
 
@@ -58,7 +56,7 @@ def dagbag_to_db():
 @pytest.mark.integration("kerberos")
 class TestApiKerberos:
     @pytest.fixture(autouse=True)
-    def _set_attrs(self, app_for_kerberos):
+    def _set_attrs(self, app_for_kerberos, dagbag_to_db):
         self.app = app_for_kerberos
 
     def test_trigger_dag(self):

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -185,3 +185,25 @@ def clear_dag_specific_permissions():
             synchronize_session=False
         )
         session.query(Resource).filter(Resource.id.in_(dag_resource_ids)).delete(synchronize_session=False)
+
+
+def clear_all():
+    clear_db_runs()
+    clear_db_datasets()
+    clear_db_dags()
+    clear_db_serialized_dags()
+    clear_db_sla_miss()
+    clear_db_dag_code()
+    clear_db_callbacks()
+    clear_rendered_ti_fields()
+    clear_db_import_errors()
+    clear_db_dag_warnings()
+    clear_db_logs()
+    clear_db_jobs()
+    clear_db_task_fail()
+    clear_db_task_reschedule()
+    clear_db_xcom()
+    clear_db_variables()
+    clear_db_pools()
+    clear_db_connections(add_default_connections_back=True)
+    clear_dag_specific_permissions()


### PR DESCRIPTION
Follow-up: https://github.com/apache/airflow/pull/28337#issuecomment-1348771336

Some hacks which uses in PR
1. ~`module` scope with parsing "provider name" instead of `package` scope. pytest decide that package is `airflow` and run only once~
2. Use separate clear tests helpers instead of `airflow.utils.db.resetdb()`. locally cause some errors with duplicate constraint.