### PR TITLE
WIP: Improve audit logging for FAB-controlled models

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -154,6 +154,7 @@ def patch_connection(
         prefix=RESOURCE_EVENT_PREFIX,
         permission=permissions.ACTION_CAN_CREATE,
     ),
+    add_json_request_data_to_extra=True,
 )
 def post_connection(*, session: Session = NEW_SESSION) -> APIResponse:
     """Create connection entry."""

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -120,6 +120,7 @@ def patch_variable(*, variable_key: str, update_mask: UpdateMask = None) -> Resp
         prefix=RESOURCE_EVENT_PREFIX,
         permission=permissions.ACTION_CAN_CREATE,
     ),
+    add_json_request_data_to_extra=True,
 )
 def post_variables() -> Response:
     """Create a variable."""

--- a/airflow/models/log.py
+++ b/airflow/models/log.py
@@ -71,4 +71,4 @@ class Log(Base):
         self.owner = owner or task_owner
 
     def __str__(self) -> str:
-        return f"Log({self.event}, {self.task_id}, {self.owner}, {self.extra})"
+        return f"Log({self.dttm}, {self.event}, {self.task_id}, {self.owner}, {self.extra})"

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -19,109 +19,32 @@ from __future__ import annotations
 
 import functools
 import gzip
-import json
 import logging
 from io import BytesIO as IO
-from itertools import chain
 from typing import Callable, TypeVar, cast
 
-import pendulum
-from flask import after_this_request, g, request
-from pendulum.parsing.exceptions import ParserError
-
-from airflow.models import Log
-from airflow.utils.log import secrets_masker
-from airflow.utils.session import create_session
+from flask import after_this_request, request
 
 T = TypeVar("T", bound=Callable)
 
 logger = logging.getLogger(__name__)
 
 
-def _mask_variable_fields(extra_fields):
-    """
-    The variable requests values and args comes in this form:
-    [('key', 'key_content'),('val', 'val_content'), ('description', 'description_content')]
-    So we need to mask the 'val_content' field if 'key_content' is in the mask list.
-    """
-    result = []
-    keyname = None
-    for k, v in extra_fields:
-        if k == "key":
-            keyname = v
-            result.append((k, v))
-        elif keyname and k == "val":
-            x = secrets_masker.redact(v, keyname)
-            result.append((k, x))
-            keyname = None
-        else:
-            result.append((k, v))
-    return result
-
-
-def _mask_connection_fields(extra_fields):
-    """Mask connection fields"""
-    result = []
-    for k, v in extra_fields:
-        if k == "extra":
-            try:
-                extra = json.loads(v)
-                extra = [(k, secrets_masker.redact(v, k)) for k, v in extra.items()]
-                result.append((k, json.dumps(dict(extra))))
-            except json.JSONDecodeError:
-                result.append((k, "Encountered non-JSON in `extra` field"))
-        else:
-            result.append((k, secrets_masker.redact(v, k)))
-    return result
-
-
-def action_logging(func: Callable | None = None, event: str | None = None) -> Callable[[T], T]:
+def action_logging(
+    func: Callable | None = None,
+    event: str | None = None,
+    *,
+    add_json_request_data_to_extra: bool = False,
+) -> Callable[[T], T]:
     """Decorator to log user actions"""
 
     def log_action(f: T) -> T:
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             __tracebackhide__ = True  # Hide from pytest traceback.
-
-            with create_session() as session:
-                if g.user.is_anonymous:
-                    user = "anonymous"
-                else:
-                    user = g.user.username
-
-                fields_skip_logging = {"csrf_token", "_csrf_token"}
-                extra_fields = [
-                    (k, secrets_masker.redact(v, k))
-                    for k, v in chain(request.values.items(multi=True), request.view_args.items())
-                    if k not in fields_skip_logging
-                ]
-                if event and event.startswith("variable."):
-                    extra_fields = _mask_variable_fields(extra_fields)
-                if event and event.startswith("connection."):
-                    extra_fields = _mask_connection_fields(extra_fields)
-
-                params = {k: v for k, v in chain(request.values.items(), request.view_args.items())}
-
-                log = Log(
-                    event=event or f.__name__,
-                    task_instance=None,
-                    owner=user,
-                    extra=str(extra_fields),
-                    task_id=params.get("task_id"),
-                    dag_id=params.get("dag_id"),
-                )
-
-                if "execution_date" in request.values:
-                    execution_date_value = request.values.get("execution_date")
-                    try:
-                        log.execution_date = pendulum.parse(execution_date_value, strict=False)
-                    except ParserError:
-                        logger.exception(
-                            "Failed to parse execution_date from the request: %s", execution_date_value
-                        )
-
-                session.add(log)
-
+            log_action(
+                event=event or f.__name__, add_json_request_data_to_extra=add_json_request_data_to_extra
+            )
             return f(*args, **kwargs)
 
         return cast(T, wrapper)

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -25,7 +25,7 @@ from airflow.utils.session import provide_session
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_connections
-from tests.test_utils.www import _check_last_log
+from tests.test_utils.www import get_last_log
 
 
 @pytest.fixture(scope="module")
@@ -81,7 +81,8 @@ class TestDeleteConnection(TestConnectionEndpoint):
         assert response.status_code == 204
         connection = session.query(Connection).all()
         assert len(connection) == 0
-        _check_last_log(session, dag_id=None, event="connection.delete", execution_date=None)
+        log = get_last_log(session=session, event="connection.delete")
+        assert "test-connect" in log.extra
 
     def test_delete_should_respond_404(self):
         response = self.client.delete(
@@ -369,7 +370,8 @@ class TestPatchConnection(TestConnectionEndpoint):
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={"REMOTE_USER": "test"}
         )
         assert response.status_code == 200
-        _check_last_log(session, dag_id=None, event="connection.edit", execution_date=None)
+        log = get_last_log(session=session, event="connection.edit")
+        assert "test-connection-id" in log.extra
 
     def test_patch_should_respond_200_with_update_mask(self, session):
         self._create_connection(session)
@@ -533,7 +535,8 @@ class TestPostConnection(TestConnectionEndpoint):
         connection = session.query(Connection).all()
         assert len(connection) == 1
         assert connection[0].conn_id == "test-connection-id"
-        _check_last_log(session, dag_id=None, event="connection.create", execution_date=None)
+        log = get_last_log(session=session, event="connection.create")
+        assert "test-connection-id" in log.extra
 
     def test_post_should_respond_200_extra_null(self, session):
         payload = {"connection_id": "test-connection-id", "conn_type": "test_type", "extra": None}

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -16,8 +16,9 @@
 # under the License.
 from __future__ import annotations
 
-import ast
 from unittest import mock
+
+from sqlalchemy.orm.session import Session
 
 from airflow.models import Log
 
@@ -52,77 +53,8 @@ def check_content_not_in_response(text, resp, resp_code=200):
         assert text not in resp_html
 
 
-def _check_last_log(session, dag_id, event, execution_date):
-    logs = (
-        session.query(
-            Log.dag_id,
-            Log.task_id,
-            Log.event,
-            Log.execution_date,
-            Log.owner,
-            Log.extra,
-        )
-        .filter(
-            Log.dag_id == dag_id,
-            Log.event == event,
-            Log.execution_date == execution_date,
-        )
-        .order_by(Log.dttm.desc())
-        .limit(5)
-        .all()
-    )
-    assert len(logs) >= 1
-    assert logs[0].extra
-    session.query(Log).delete()
-
-
-def _check_last_log_masked_connection(session, dag_id, event, execution_date):
-    logs = (
-        session.query(
-            Log.dag_id,
-            Log.task_id,
-            Log.event,
-            Log.execution_date,
-            Log.owner,
-            Log.extra,
-        )
-        .filter(
-            Log.dag_id == dag_id,
-            Log.event == event,
-            Log.execution_date == execution_date,
-        )
-        .order_by(Log.dttm.desc())
-        .limit(5)
-        .all()
-    )
-    assert len(logs) >= 1
-    extra = ast.literal_eval(logs[0].extra)
-    for k, v in extra:
-        if k == "password":
-            assert v == "***"
-        if k == "extra":
-            assert v == '{"x_secret": "***", "y_secret": "***"}'
-
-
-def _check_last_log_masked_variable(session, dag_id, event, execution_date):
-    logs = (
-        session.query(
-            Log.dag_id,
-            Log.task_id,
-            Log.event,
-            Log.execution_date,
-            Log.owner,
-            Log.extra,
-        )
-        .filter(
-            Log.dag_id == dag_id,
-            Log.event == event,
-            Log.execution_date == execution_date,
-        )
-        .order_by(Log.dttm.desc())
-        .limit(5)
-        .all()
-    )
-    assert len(logs) >= 1
-    extra_dict = ast.literal_eval(logs[0].extra)
-    assert extra_dict == [("key", "x_secret"), ("val", "***")]
+def get_last_log(*, session: Session, **kwargs) -> Log:
+    query = session.query(Log).order_by(Log.dttm.desc())
+    for key, val in kwargs.items():
+        query = query.filter(getattr(Log, key) == val)
+    return query.limit(1).one()

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -256,6 +256,13 @@ class TestSecretsMasker:
                 {"api_key": "masked based on key name", "other": "foo"},
                 {"api_key": "***", "other": "foo"},
             ),
+            # Test that "value" is redacted based on "key" in a dict, when they are split across keys
+            (
+                set(),
+                "dict",
+                {"key": "api_key", "value": "masked based on key name", "other": "foo"},
+                {"key": "api_key", "value": "***", "other": "foo"},
+            ),
         ],
     )
     def test_redact(self, patterns, name, value, expected):

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -51,6 +51,7 @@ def app(examples_dag_bag):
     @dont_initialize_flask_app_submodules(
         skip_all_except=[
             "init_api_connexion",
+            "init_api_experimental_auth",
             "init_appbuilder",
             "init_appbuilder_links",
             "init_appbuilder_views",


### PR DESCRIPTION
This solves a number of issues with our existing (new) audit logging on things like variables and connections.

Still a WIP, need to verify and add tests for other ViewModels inheriting from AirflowViewModel.