### PR TITLE
Defer to hook setting for split_statements in SQLExecuteQueryOperator

### DIFF
--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -198,7 +198,8 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
     :param autocommit: (optional) if True, each command is automatically committed (default: False).
     :param parameters: (optional) the parameters to render the SQL query with.
     :param handler: (optional) the function that will be applied to the cursor (default: fetch_all_handler).
-    :param split_statements: (optional) if split single SQL string into statements (default: see hook.run).
+    :param split_statements: (optional) if split single SQL string into statements. By default, defers
+        to the default value in the ``run`` method in the configured hook.
     :param return_last: (optional) return the result of only last statement (default: True).
 
     .. seealso::

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -26,7 +26,6 @@ from airflow.exceptions import AirflowException, AirflowFailException
 from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, SkipMixin
 from airflow.providers.common.sql.hooks.sql import DbApiHook, fetch_all_handler, return_single_query_results
-from airflow.utils.types import NOTSET
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -261,7 +261,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
             parameters=self.parameters,
             handler=self.handler if self.do_xcom_push else None,
             return_last=self.return_last,
-            **extra_kwargs
+            **extra_kwargs,
         )
         if return_single_query_results(self.sql, self.return_last, self.split_statements):
             # For simplicity, we pass always list as input to _process_output, regardless if

--- a/airflow/providers/common/sql/operators/sql.py
+++ b/airflow/providers/common/sql/operators/sql.py
@@ -199,7 +199,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
     :param parameters: (optional) the parameters to render the SQL query with.
     :param handler: (optional) the function that will be applied to the cursor (default: fetch_all_handler).
     :param split_statements: (optional) if split single SQL string into statements. By default, defers
-        to the default value in the ``run`` method in the configured hook.
+        to the default value in the ``run`` method of the configured hook.
     :param return_last: (optional) return the result of only last statement (default: True).
 
     .. seealso::
@@ -253,9 +253,10 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
     def execute(self, context):
         self.log.info("Executing: %s", self.sql)
         hook = self.get_db_hook()
-        extra_kwargs = {}
         if self.split_statements is not None:
-            extra_kwargs.update(split_statements=self.split_statements)
+            extra_kwargs = {"split_statements": self.split_statements}
+        else:
+            extra_kwargs = {}
         output = hook.run(
             sql=self.sql,
             autocommit=self.autocommit,

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -75,7 +75,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         autocommit: bool = ...,
         parameters: Union[Mapping, Iterable, None] = ...,
         handler: Callable[[Any], Any] = ...,
-        split_statements: bool = ...,
+        split_statements: Union[bool, None] = ...,
         return_last: bool = ...,
         **kwargs,
     ) -> None: ...

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -75,7 +75,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         autocommit: bool = ...,
         parameters: Union[Mapping, Iterable, None] = ...,
         handler: Callable[[Any], Any] = ...,
-        split_statements: Union[bool, None] = ...,
+        split_statements: Optional[bool] = ...,
         return_last: bool = ...,
         **kwargs,
     ) -> None: ...

--- a/airflow/providers/common/sql/operators/sql.pyi
+++ b/airflow/providers/common/sql/operators/sql.pyi
@@ -75,7 +75,7 @@ class SQLExecuteQueryOperator(BaseSQLOperator):
         autocommit: bool = ...,
         parameters: Union[Mapping, Iterable, None] = ...,
         handler: Callable[[Any], Any] = ...,
-        split_statements: Optional[bool] = ...,
+        split_statements: Union[bool, None] = ...,
         return_last: bool = ...,
         **kwargs,
     ) -> None: ...

--- a/tests/providers/amazon/aws/operators/test_redshift_sql.py
+++ b/tests/providers/amazon/aws/operators/test_redshift_sql.py
@@ -43,5 +43,4 @@ class TestRedshiftSQLOperator:
             parameters=test_parameters,
             handler=fetch_all_handler,
             return_last=True,
-            split_statements=False,
         )

--- a/tests/providers/common/sql/operators/test_sql.py
+++ b/tests/providers/common/sql/operators/test_sql.py
@@ -75,7 +75,6 @@ class TestSQLExecuteQueryOperator:
             handler=fetch_all_handler,
             parameters=None,
             return_last=True,
-            split_statements=False,
         )
 
     @mock.patch.object(SQLExecuteQueryOperator, "get_db_hook")
@@ -87,7 +86,6 @@ class TestSQLExecuteQueryOperator:
             sql="SELECT 1;",
             autocommit=False,
             parameters=None,
-            split_statements=False,
             handler=None,
             return_last=True,
         )

--- a/tests/providers/exasol/operators/test_exasol.py
+++ b/tests/providers/exasol/operators/test_exasol.py
@@ -34,7 +34,6 @@ class TestExasol:
             parameters=None,
             handler=fetch_all_handler,
             return_last=True,
-            split_statements=False,
         )
 
     @mock.patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
@@ -47,7 +46,6 @@ class TestExasol:
             parameters={"value": 1},
             handler=fetch_all_handler,
             return_last=True,
-            split_statements=False,
         )
 
     @mock.patch("airflow.providers.common.sql.operators.sql.BaseSQLOperator.__init__")

--- a/tests/providers/jdbc/operators/test_jdbc.py
+++ b/tests/providers/jdbc/operators/test_jdbc.py
@@ -38,7 +38,6 @@ class TestJdbcOperator:
             handler=fetch_all_handler,
             parameters=jdbc_operator.parameters,
             return_last=True,
-            split_statements=False,
         )
 
     @patch("airflow.providers.common.sql.operators.sql.SQLExecuteQueryOperator.get_db_hook")
@@ -52,5 +51,4 @@ class TestJdbcOperator:
             parameters=jdbc_operator.parameters,
             handler=None,
             return_last=True,
-            split_statements=False,
         )

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -54,7 +54,6 @@ class TestOracleOperator:
             parameters=parameters,
             handler=fetch_all_handler,
             return_last=True,
-            split_statements=False,
         )
 
 

--- a/tests/providers/trino/operators/test_trino.py
+++ b/tests/providers/trino/operators/test_trino.py
@@ -47,5 +47,4 @@ class TestTrinoOperator:
             handler=list,
             parameters=None,
             return_last=True,
-            split_statements=False,
         )

--- a/tests/providers/vertica/operators/test_vertica.py
+++ b/tests/providers/vertica/operators/test_vertica.py
@@ -35,5 +35,4 @@ class TestVerticaOperator:
             handler=fetch_all_handler,
             parameters=None,
             return_last=True,
-            split_statements=False,
         )


### PR DESCRIPTION
Some databases, such as snowflake, require you to split statements in order to submit multi-statement sql.  For such databases, splitting is the natural default and most intuitive setting, and we should defer to the hook to control that.

cc @potiuk @eladkal @kazanzhy @pgagnon