### PR TITLE
Replace `len(mock_calls)` with `call_count/assert_called_once`

### DIFF
--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -101,7 +101,7 @@ def setup_trigger_tasks(dag_maker):
 def test_trigger_queued_tasks(dag_maker, open_slots):
     executor, _ = setup_trigger_tasks(dag_maker)
     executor.trigger_tasks(open_slots)
-    assert len(executor.execute_async.mock_calls) == open_slots
+    assert executor.execute_async.call_count == open_slots
 
 
 @mark.parametrize("change_state_attempt", range(QUEUEING_ATTEMPTS + 2))

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2569,7 +2569,7 @@ class TestTaskInstance:
         ti.task = task
         with patch.object(TI, "log") as log, pytest.raises(AirflowException):
             ti.run()
-        assert len(log.error.mock_calls) == 1
+        log.error.assert_called_once()
         assert log.error.call_args[0] == ("Task failed with exception",)
         exc_info = log.error.call_args[1]["exc_info"]
         filename = exc_info[2].tb_frame.f_code.co_filename

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -166,7 +166,7 @@ class TestSubDagOperator:
             external_trigger=True,
         )
 
-        assert 3 == len(subdag_task._get_dagrun.mock_calls)
+        assert 3 == subdag_task._get_dagrun.call_count
 
     def test_execute_create_dagrun_with_conf(self):
         """
@@ -203,7 +203,7 @@ class TestSubDagOperator:
             external_trigger=True,
         )
 
-        assert 3 == len(subdag_task._get_dagrun.mock_calls)
+        assert 3 == subdag_task._get_dagrun.call_count
 
     def test_execute_dagrun_failed(self):
         """
@@ -253,7 +253,7 @@ class TestSubDagOperator:
         subdag_task.post_execute(context=context)
 
         subdag.create_dagrun.assert_not_called()
-        assert 3 == len(subdag_task._get_dagrun.mock_calls)
+        assert 3 == subdag_task._get_dagrun.call_count
 
     def test_rerun_failed_subdag(self, dag_maker):
         """

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -348,7 +348,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -391,7 +391,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=training_input, use_existing_job_fn=ANY
         )
@@ -435,7 +435,7 @@ class TestMLEngineStartTrainingJobOperator:
             delegate_to=None,
             impersonation_chain=None,
         )
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project",
             job=request,
@@ -510,7 +510,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=training_input, use_existing_job_fn=ANY
         )
@@ -533,7 +533,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -557,7 +557,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -587,7 +587,7 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
             impersonation_chain=None,
         )
         # Make sure only 'cancel_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.cancel_job.assert_called_once_with(
             project_id=self.TRAINING_DEFAULT_ARGS["project_id"], job_id=self.TRAINING_DEFAULT_ARGS["job_id"]
         )
@@ -610,7 +610,7 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
             impersonation_chain=None,
         )
         # Make sure only 'cancel_job' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.cancel_job.assert_called_once_with(
             project_id=self.TRAINING_DEFAULT_ARGS["project_id"], job_id=self.TRAINING_DEFAULT_ARGS["job_id"]
         )
@@ -775,7 +775,7 @@ class TestMLEngineVersionOperator(unittest.TestCase):
             impersonation_chain=None,
         )
         # Make sure only 'create_version' is invoked on hook instance
-        hook_instance.assert_called_once()
+        assert len(hook_instance.mock_calls) == 1
         hook_instance.create_version.assert_called_once_with(
             project_id="test-project", model_name="test-model", version_spec=TEST_VERSION
         )

--- a/tests/providers/google/cloud/operators/test_mlengine.py
+++ b/tests/providers/google/cloud/operators/test_mlengine.py
@@ -348,7 +348,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -391,7 +391,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=training_input, use_existing_job_fn=ANY
         )
@@ -435,7 +435,7 @@ class TestMLEngineStartTrainingJobOperator:
             delegate_to=None,
             impersonation_chain=None,
         )
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project",
             job=request,
@@ -510,7 +510,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=training_input, use_existing_job_fn=ANY
         )
@@ -533,7 +533,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -557,7 +557,7 @@ class TestMLEngineStartTrainingJobOperator:
             impersonation_chain=None,
         )
         # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_job.assert_called_once_with(
             project_id="test-project", job=self.TRAINING_INPUT, use_existing_job_fn=ANY
         )
@@ -587,7 +587,7 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
             impersonation_chain=None,
         )
         # Make sure only 'cancel_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.cancel_job.assert_called_once_with(
             project_id=self.TRAINING_DEFAULT_ARGS["project_id"], job_id=self.TRAINING_DEFAULT_ARGS["job_id"]
         )
@@ -609,8 +609,8 @@ class TestMLEngineTrainingCancelJobOperator(unittest.TestCase):
             delegate_to=None,
             impersonation_chain=None,
         )
-        # Make sure only 'create_job' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        # Make sure only 'cancel_job' is invoked on hook instance
+        hook_instance.assert_called_once()
         hook_instance.cancel_job.assert_called_once_with(
             project_id=self.TRAINING_DEFAULT_ARGS["project_id"], job_id=self.TRAINING_DEFAULT_ARGS["job_id"]
         )
@@ -775,7 +775,7 @@ class TestMLEngineVersionOperator(unittest.TestCase):
             impersonation_chain=None,
         )
         # Make sure only 'create_version' is invoked on hook instance
-        assert len(hook_instance.mock_calls) == 1
+        hook_instance.assert_called_once()
         hook_instance.create_version.assert_called_once_with(
             project_id="test-project", model_name="test-model", version_spec=TEST_VERSION
         )

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -61,7 +61,7 @@ class TestSambaHook:
             cache["foo"] = mock_connection
 
         # Test that the connection was disconnected upon exit.
-        assert len(mock_connection.disconnect.mock_calls) == 1
+        mock_connection.disconnect.assert_called_once()
 
     @pytest.mark.parametrize(
         "name",


### PR DESCRIPTION
Just easier to read, and in the case of `assert_called_once`, you get a better error message.