### PR TITLE
Nest header blocks in divs to fix dagid copy nit on dag.html

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -102,74 +102,78 @@
   {% endif %}
 
   <div>
-    <h3 class="pull-left">
-      {% if dag.parent_dag is defined and dag.parent_dag %}
-        <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
-      {% else %}
-        {% set can_edit = appbuilder.sm.can_edit_dag(dag.dag_id) %}
-        {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
-          {% set switch_tooltip = 'Pause/Unpause DAG' %}
+    <div>
+      <h3 class="pull-left">
+        {% if dag.parent_dag is defined and dag.parent_dag %}
+          <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
         {% else %}
-          {% set switch_tooltip = 'DAG is Paused' if dag_is_paused else 'DAG is Active' %}
+          {% set can_edit = appbuilder.sm.can_edit_dag(dag.dag_id) %}
+          {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
+            {% set switch_tooltip = 'Pause/Unpause DAG' %}
+          {% else %}
+            {% set switch_tooltip = 'DAG is Paused' if dag_is_paused else 'DAG is Active' %}
+          {% endif %}
+          <label class="switch-label{{' disabled' if not can_edit else ''  }} js-tooltip" title="{{ switch_tooltip }}">
+            <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
+                   type="checkbox"{{ " checked" if not dag_is_paused else "" }}
+                   {{ " disabled" if not can_edit else "" }}>
+            <span class="switch" aria-hidden="true"></span>
+          </label>
+          <span class="text-muted">DAG:</span> {{ dag.dag_id }}
+          <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
         {% endif %}
-        <label class="switch-label{{' disabled' if not can_edit else ''  }} js-tooltip" title="{{ switch_tooltip }}">
-          <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
-                 type="checkbox"{{ " checked" if not dag_is_paused else "" }}
-                 {{ " disabled" if not can_edit else "" }}>
-          <span class="switch" aria-hidden="true"></span>
-        </label>
-        <span class="text-muted">DAG:</span> {{ dag.dag_id }}
-        <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
-      {% endif %}
-      {% if root %}
-        <span class="text-muted">ROOT:</span> {{ root }}
-      {% endif %}
-    </h3>
-    <h4 class="pull-right js-dataset-triggered" style="user-select: none;-moz-user-select: auto;">
-      {% if state_token is defined and state_token %}
-        {{ state_token }}
-      {% endif %}
-      <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
-        Schedule: {{ dag_model is defined and dag_model and dag_model.schedule_interval }}
-      </a>
-      {% if dag_model is defined and dag_model and dag_model.timetable_description %}
-          <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Schedule: {{ dag_model.timetable_description|string }}">info</span>
-      {% endif %}
-      {% if dag_model is defined and dag_model.next_dagrun is defined and dag_model.schedule_interval != 'Dataset' %}
-        <p class="label label-default js-tooltip" style="margin-left: 5px" id="next-run" data-html="true" data-placement="bottom">
-          Next Run: <time datetime="{{ dag_model.next_dagrun }}">{{ dag_model.next_dagrun }}</time>
-        </p>
-      {% endif %}
-      {% if dag_model is defined and dag_model.schedule_interval is defined and dag_model.schedule_interval == 'Dataset' %}
-        {%- with ds_info = dag_model.get_dataset_triggered_next_run_info() -%}
-          <span
-            id="next-dataset-tooltip"
-            class="js-tooltip"
-            title="Click to see dataset details."
-            data-html="true"
-            data-placement="bottom"
-            data-uri="{{ ds_info.uri }}"
-          >
-              <p
-                class="label label-default next-dataset-triggered"
-                style="margin-left: 5px;"
-                data-summary="
-                  {%- if ds_info.total == 1 -%}
-                  On {{ ds_info.uri }}
+        {% if root %}
+          <span class="text-muted">ROOT:</span> {{ root }}
+        {% endif %}
+      </h3>
+    </div>
+    <div>
+      <h4 class="pull-right js-dataset-triggered" style="user-select: none;-moz-user-select: auto;">
+        {% if state_token is defined and state_token %}
+          {{ state_token }}
+        {% endif %}
+        <a class="label label-default" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
+          Schedule: {{ dag_model is defined and dag_model and dag_model.schedule_interval }}
+        </a>
+        {% if dag_model is defined and dag_model and dag_model.timetable_description %}
+            <span class="material-icons text-muted js-tooltip" aria-hidden="true" data-original-title="Schedule: {{ dag_model.timetable_description|string }}">info</span>
+        {% endif %}
+        {% if dag_model is defined and dag_model.next_dagrun is defined and dag_model.schedule_interval != 'Dataset' %}
+          <p class="label label-default js-tooltip" style="margin-left: 5px" id="next-run" data-html="true" data-placement="bottom">
+            Next Run: <time datetime="{{ dag_model.next_dagrun }}">{{ dag_model.next_dagrun }}</time>
+          </p>
+        {% endif %}
+        {% if dag_model is defined and dag_model.schedule_interval is defined and dag_model.schedule_interval == 'Dataset' %}
+          {%- with ds_info = dag_model.get_dataset_triggered_next_run_info() -%}
+            <span
+              id="next-dataset-tooltip"
+              class="js-tooltip"
+              title="Click to see dataset details."
+              data-html="true"
+              data-placement="bottom"
+              data-uri="{{ ds_info.uri }}"
+            >
+                <p
+                  class="label label-default next-dataset-triggered"
+                  style="margin-left: 5px;"
+                  data-summary="
+                    {%- if ds_info.total == 1 -%}
+                    On {{ ds_info.uri }}
+                    {%- else -%}
+                    {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
+                    {%- endif -%}"
+                  >
+                  {% if ds_info.total == 1 -%}
+                    On {{ ds_info.uri }}
                   {%- else -%}
                   {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
-                  {%- endif -%}"
-                >
-                {% if ds_info.total == 1 -%}
-                  On {{ ds_info.uri }}
-                {%- else -%}
-                {{ ds_info.ready }} of {{ ds_info.total }} datasets updated
-                {%- endif %}
-              </p>
-          </span>
-        {%- endwith -%}
-      {% endif %}
-    </h4>
+                  {%- endif %}
+                </p>
+            </span>
+          {%- endwith -%}
+        {% endif %}
+      </h4>
+    </div>
   </div>
   <div class="clearfix"></div>
   <br>


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/22320

Fixes a UI nit where copying the dag_id on dag.html causes the schedule to get copied with it. I am separating the inline header blocks with divs.

Before:

https://user-images.githubusercontent.com/9200263/210018907-e2b12faa-be7c-486d-97b7-74b93b38fd45.mov

After:

https://user-images.githubusercontent.com/9200263/210018922-528d14ca-9802-4e42-801c-b1fd927c3972.mov




---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
