### PR TITLE
Move min airflow version down for Docker Provider to 2.3.0

### DIFF
--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -45,7 +45,7 @@ versions:
   - 1.0.0
 
 dependencies:
-  - apache-airflow>=2.4.0
+  - apache-airflow>=2.3.0
   - docker>=5.0.3
   - python-dotenv>=0.21.0
 

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -259,7 +259,7 @@
   },
   "docker": {
     "deps": [
-      "apache-airflow>=2.4.0",
+      "apache-airflow>=2.3.0",
       "docker>=5.0.3",
       "python-dotenv>=0.21.0"
     ],


### PR DESCRIPTION
The #25780 has accidentally bumped min airflow version for the provider to 2.4.0, however the provider is fully capable to work in Airflow 2.3+.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
