### PR TITLE
Remove outdated comments from base hook

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -81,8 +81,6 @@ class BaseHook(LoggingMixin):
         :param conn_id: connection id
         :return: default hook for this connection
         """
-        # TODO: set method return type to BaseHook class when on 3.7+.
-        #  See https://stackoverflow.com/a/33533514/3066428
         connection = cls.get_connection(conn_id)
         return connection.get_hook()
 


### PR DESCRIPTION
since we have now the return type for `get_hook`  is BaseHook so the comment is outdated
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
