### PR TITLE
Fix params passing to TaskFlow tasks run with CLI

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -34,6 +34,7 @@ from sqlalchemy.orm.session import Session
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole
 from airflow.configuration import conf
+from airflow.decorators.base import DecoratedOperator
 from airflow.exceptions import AirflowException, DagRunNotFound, TaskInstanceNotFound
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.local_task_job import LocalTaskJob
@@ -560,6 +561,9 @@ def task_test(args, dag=None):
     if args.task_params:
         passed_in_params = json.loads(args.task_params)
         task.params.update(passed_in_params)
+        if isinstance(task, DecoratedOperator):
+            task.op_args = []
+            task.op_kwargs.update(passed_in_params)
 
     if task.params:
         task.params.validate()

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -30,18 +30,15 @@ from airflow.operators.bash import BashOperator
 
 
 @task(task_id="run_this")
-def my_py_command(params, test_mode=None, task=None):
+def my_py_command(foo, test_mode=None):
     """
     Print out the "foo" param passed in via
     `airflow tasks test example_passing_params_via_test_command run_this <date>
     -t '{"foo":"bar"}'`
     """
-    if test_mode:
-        print(
-            f" 'foo' was passed in via test={test_mode} command : kwargs[params][foo] = {task.params['foo']}"
-        )
-    # Print out the value of "miff", passed in below via the Python Operator
-    print(f" 'miff' was passed in via task params = {params['miff']}")
+    print(
+        f" 'foo' was passed in via test={test_mode} command : kwargs[foo] = {foo}"
+    )
     return 1
 
 
@@ -65,7 +62,7 @@ with DAG(
     dagrun_timeout=datetime.timedelta(minutes=4),
     tags=["example"],
 ) as dag:
-    run_this = my_py_command(params={"miff": "agg"})
+    run_this = my_py_command(foo="bar")
 
     my_command = dedent(
         """

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -285,7 +285,21 @@ class TestCliTasks:
         with pytest.raises(DagRunNotFound):
             task_command.task_run(self.parser.parse_args(args0), dag=dag)
 
-    def test_cli_test_with_params(self):
+    def test_cli_test_python_operator_with_params(self, capsys):
+        task_command.task_test(
+            self.parser.parse_args(
+                [
+                    "tasks",
+                    "test",
+                    "example_passing_params_via_test_command",
+                    "run_this",
+                    DEFAULT_DATE.isoformat(),
+                ]
+            )
+        )
+        captured = capsys.readouterr()
+        assert f"'foo' was passed in via test=True command : kwargs[foo] = bar" in captured.out
+
         task_command.task_test(
             self.parser.parse_args(
                 [
@@ -295,10 +309,14 @@ class TestCliTasks:
                     "run_this",
                     DEFAULT_DATE.isoformat(),
                     "--task-params",
-                    '{"foo":"bar"}',
+                    '{"foo":"quux"}',
                 ]
             )
         )
+        captured = capsys.readouterr()
+        assert f"'foo' was passed in via test=True command : kwargs[foo] = quux" in captured.out
+
+    def test_cli_test_bash_operator_with_params(self):
         task_command.task_test(
             self.parser.parse_args(
                 [


### PR DESCRIPTION
Params passed to the TaskFlow tasks using the CLI `airflow tasks test` command aren't worked correctly (see the linked issue for the more details and examples). This PR is to fix it.

closes: #28287

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
