### PR TITLE
Limit Telegram to < 20.0.0

### DIFF
--- a/airflow/providers/telegram/provider.yaml
+++ b/airflow/providers/telegram/provider.yaml
@@ -35,7 +35,10 @@ versions:
 
 dependencies:
   - apache-airflow>=2.3.0
-  - python-telegram-bot>=13.0
+  # The telegram bot 20.0.0 is not yet compatible with our provider as documented in
+  # https://github.com/apache/airflow/issues/28670. This limit should be removed (and likely replaced
+  # with >=20.0.0) once the issue is fixed.
+  - python-telegram-bot>=13.0,<20.0.0
 
 integrations:
   - integration-name: Telegram

--- a/generated/provider_dependencies.json
+++ b/generated/provider_dependencies.json
@@ -708,7 +708,7 @@
   "telegram": {
     "deps": [
       "apache-airflow>=2.3.0",
-      "python-telegram-bot>=13.0"
+      "python-telegram-bot>=13.0,<20.0.0"
     ],
     "cross-providers-deps": []
   },


### PR DESCRIPTION
The telegram bot 20.0.0 is not yet compatible with our provider as documented in https://github.com/apache/airflow/issues/28670. This limit should be removed (and likely replaced with >=20.0.0) once the issue is fixed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
