### PR TITLE
fix bugs in release_management_commands.py

### DIFF
--- a/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
+++ b/dev/breeze/src/airflow_breeze/commands/release_management_commands.py
@@ -809,14 +809,14 @@ def generate_issue_content(
         all_prs: set[int] = set()
         provider_prs: dict[str, list[int]] = {}
         if only_available_in_dist:
-            files_in_dist = os.listdir(str(APACHE_AIRFLOW_GITHUB_REPOSITORY / "dist"))
+            files_in_dist = os.listdir(str(AIRFLOW_SOURCES_ROOT / "dist"))
         prepared_package_ids = []
         for package_id in packages:
             if not only_available_in_dist or is_package_in_dist(files_in_dist, package_id):
                 get_console().print(f"Extracting PRs for provider {package_id}")
                 prepared_package_ids.append(package_id)
             else:
-                get_console.print(
+                get_console().print(
                     f"Skipping extracting PRs for provider {package_id} as it is missing in dist"
                 )
                 continue


### PR DESCRIPTION
fixes errors:

```
Traceback (most recent call last):
  File "/Users/eladkal/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/rich_click/rich_group.py", line 21, in main
    rv = super().main(*args, standalone_mode=False, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/eladkal/PycharmProjects/airflow/dev/breeze/src/airflow_breeze/commands/release_management_commands.py", line 812, in generate_issue_content
    files_in_dist = os.listdir(str(APACHE_AIRFLOW_GITHUB_REPOSITORY / "dist"))
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```



And
```
Traceback (most recent call last):
  File "/Users/eladkal/.local/bin/breeze", line 8, in <module>
    sys.exit(main())
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/rich_click/rich_group.py", line 21, in main
    rv = super().main(*args, standalone_mode=False, **kwargs)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/eladkal/.local/pipx/venvs/apache-airflow-breeze/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/eladkal/PycharmProjects/airflow/dev/breeze/src/airflow_breeze/commands/release_management_commands.py", line 819, in generate_issue_content
    get_console.print(
AttributeError: 'functools._lru_cache_wrapper' object has no attribute 'print'
```



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
