### PR TITLE
Allow XComArgs for external_task_ids of ExternalTaskSensor

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -31,7 +31,6 @@ from airflow.models.dag import DagModel
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
 from airflow.models.taskinstance import TaskInstance
-from airflow.models.xcom_arg import XComArg
 from airflow.operators.empty import EmptyOperator
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.file import correct_maybe_zipped
@@ -163,8 +162,6 @@ class ExternalTaskSensor(BaseSensorOperator):
                     f"when `external_task_id` or `external_task_ids` or `external_task_group_id` "
                     f"is not `None`: {State.task_states}"
                 )
-            if external_task_ids and not any(map(lambda x: isinstance(x, XComArg), external_task_ids)):
-                self._check_duplicate_task_ids(external_task_ids)
 
         elif not total_states <= set(State.dag_states):
             raise ValueError(
@@ -196,13 +193,10 @@ class ExternalTaskSensor(BaseSensorOperator):
             dttm = context["logical_date"]
         return dttm if isinstance(dttm, list) else [dttm]
 
-    def _check_duplicate_task_ids(self, external_task_ids):
-        if external_task_ids and len(external_task_ids) > len(set(external_task_ids)):
-            raise ValueError("Duplicate task_ids passed in external_task_ids parameter")
-
     @provide_session
     def poke(self, context, session=None):
-        self._check_duplicate_task_ids(self.external_task_ids)
+        if self.external_task_ids and len(self.external_task_ids) > len(set(self.external_task_ids)):
+            raise ValueError("Duplicate task_ids passed in external_task_ids parameter")
 
         dttm_filter = self._get_dttm_filter(context)
         serialized_dttm_filter = ",".join(dt.isoformat() for dt in dttm_filter)

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -32,8 +32,10 @@ from airflow.exceptions import AirflowException, AirflowSensorTimeout
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.models.dag import DAG
 from airflow.models.serialized_dag import SerializedDagModel
+from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator
 from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor, ExternalTaskSensorLink
 from airflow.sensors.time_sensor import TimeSensor
 from airflow.serialization.serialized_objects import SerializedBaseOperator
@@ -44,6 +46,7 @@ from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 from tests.models import TEST_DAGS_FOLDER
 from tests.test_utils.db import clear_db_runs
+from tests.test_utils.mock_operators import MockOperator
 
 DEFAULT_DATE = datetime(2015, 1, 1)
 TEST_DAG_ID = "unit_test_dag"
@@ -576,6 +579,20 @@ exit 0
                 dag=self.dag,
             )
 
+    def test_external_task_sensor_with_xcom_arg_does_not_fail_on_init(self):
+        self.add_time_sensor()
+
+        op1 = MockOperator(task_id="op1", dag=self.dag)
+        op2 = MockOperator(task_id="op2", dag=self.dag)
+        op3 = ExternalTaskSensor(
+            task_id="test_external_task_sensor_with_xcom_arg_does_not_fail_on_init",
+            external_dag_id=TEST_DAG_ID,
+            external_task_ids=[XComArg(op1), XComArg(op2)],
+            allowed_states=["success"],
+            dag=self.dag,
+        )
+        assert all(map(lambda tid: isinstance(tid, XComArg), op3.external_task_ids))
+
     def test_catch_duplicate_task_ids(self):
         self.add_time_sensor()
         # Test By passing same task_id multiple times
@@ -587,6 +604,27 @@ exit 0
                 allowed_states=["success"],
                 dag=self.dag,
             )
+
+    def test_catch_duplicate_task_ids_with_xcom_arg(self):
+        self.add_time_sensor()
+
+        op1 = PythonOperator(
+            python_callable=lambda: "value",
+            task_id="op1",
+            do_xcom_push=True,
+            dag=self.dag,
+        )
+
+        op2 = ExternalTaskSensor(
+            task_id="test_external_task_duplicate_task_ids_with_xcom_arg",
+            external_dag_id=TEST_DAG_ID,
+            external_task_ids=[XComArg(op1), XComArg(op1)],
+            allowed_states=["success"],
+            dag=self.dag,
+        )
+        with pytest.raises(ValueError):
+            op1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+            op2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
     def test_catch_invalid_allowed_states(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/27952

To test, I used the dag provided by @MaiHoangViet1809 in the above linked issue:

```py
from airflow.decorators import dag, task
from airflow.operators.python import get_current_context

from airflow.sensors.external_task import ExternalTaskSensor
from datetime import datetime

configure = {
    "dag_id": "test_new_skeleton",
    "schedule": "@daily",
    "start_date": datetime(2022, 1, 1),
    "catchup": False,
}


@task
def preprocess_dependency() -> list:
    return ["test_postgres_to_gcs"]


@dag(**configure)
def pipeline():
    t_preprocess = preprocess_dependency()
    task_dependency = ExternalTaskSensor(
        task_id=f"Check_Dependency",
        external_dag_id="test_postgres",
        external_task_ids=t_preprocess,
        poke_interval=60,
        mode="reschedule",
        timeout=172800,
        allowed_states=["success"],
        failed_states=["failed", "skipped"],
        check_existence=True,
    )


dag = pipeline()
```

Ran a dependent dag (test_potgres) and then ran this one:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/9200263/210380143-e03ff967-28a7-4179-9f0e-64877eee4885.png">

Task logs:

```
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1093} INFO - Dependencies all met for <TaskInstance: test_new_skeleton.Check_Dependency scheduled__2023-01-02T00:00:00+00:00 [queued]>
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1093} INFO - Dependencies all met for <TaskInstance: test_new_skeleton.Check_Dependency scheduled__2023-01-02T00:00:00+00:00 [queued]>
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1295} INFO - 
--------------------------------------------------------------------------------
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1296} INFO - Starting attempt 1 of 1
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1297} INFO - 
--------------------------------------------------------------------------------
[2023-01-03, 14:45:43 UTC] {taskinstance.py:1316} INFO - Executing <Task(ExternalTaskSensor): Check_Dependency> on 2023-01-02 00:00:00+00:00
[2023-01-03, 14:45:43 UTC] {standard_task_runner.py:55} INFO - Started process 400 to run task
[2023-01-03, 14:45:43 UTC] {standard_task_runner.py:82} INFO - Running: ['***', 'tasks', 'run', 'test_new_skeleton', 'Check_Dependency', 'scheduled__2023-01-02T00:00:00+00:00', '--job-id', '7', '--raw', '--subdir', 'DAGS_FOLDER/test_external_task_with_task_dec.py', '--cfg-path', '/tmp/tmp1wualdyq']
[2023-01-03, 14:45:43 UTC] {standard_task_runner.py:83} INFO - Job 7: Subtask Check_Dependency
[2023-01-03, 14:45:44 UTC] {task_command.py:391} INFO - Running <TaskInstance: test_new_skeleton.Check_Dependency scheduled__2023-01-02T00:00:00+00:00 [running]> on host d39b84574015
[2023-01-03, 14:45:44 UTC] {taskinstance.py:1525} INFO - Exporting the following env vars:
AIRFLOW_CTX_DAG_OWNER=***
AIRFLOW_CTX_DAG_ID=test_new_skeleton
AIRFLOW_CTX_TASK_ID=Check_Dependency
AIRFLOW_CTX_EXECUTION_DATE=2023-01-02T00:00:00+00:00
AIRFLOW_CTX_TRY_NUMBER=1
AIRFLOW_CTX_DAG_RUN_ID=scheduled__2023-01-02T00:00:00+00:00
[2023-01-03, 14:45:44 UTC] {external_task.py:209} INFO - Poking for tasks ['test_postgres_to_gcs'] in dag test_postgres on 2023-01-02T00:00:00+00:00 ... 
[2023-01-03, 14:45:44 UTC] {dagbag.py:538} INFO - Filling up the DagBag from /files/dags/test_postgres.py
[2023-01-03, 14:45:45 UTC] {logging_mixin.py:137} WARNING - /opt/***/***/models/dagbag.py:339 RemovedInAirflow3Warning: The 'concurrency' parameter is deprecated. Please use 'max_active_tasks'.
[2023-01-03, 14:45:45 UTC] {logging_mixin.py:137} WARNING - /opt/***/***/models/dagbag.py:339 RemovedInAirflow3Warning: Param `schedule_interval` is deprecated and will be removed in a future release. Please use `schedule` instead.
[2023-01-03, 14:45:45 UTC] {base.py:228} INFO - Success criteria met. Exiting.
[2023-01-03, 14:45:45 UTC] {taskinstance.py:1339} INFO - Marking task as SUCCESS. dag_id=test_new_skeleton, task_id=Check_Dependency, execution_date=20230102T000000, start_date=20230103T144543, end_date=20230103T144545
[2023-01-03, 14:45:45 UTC] {local_task_job.py:211} INFO - Task exited with return code 0
[2023-01-03, 14:45:45 UTC] {taskinstance.py:2613} INFO - 0 downstream tasks scheduled from follow-on schedule check
```

cc @uranusjr 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
