### PR TITLE
Fix "airflow tasks render" cli command for mapped task instances

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -594,21 +594,22 @@ def task_test(args, dag=None):
 
 @cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
-def task_render(args):
+def task_render(args, dag=None):
     """Renders and displays templated fields for a given task."""
-    dag = get_dag(args.subdir, args.dag_id)
+    if not dag:
+        dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
     ti, _ = _get_ti(
         task, args.map_index, exec_date_or_run_id=args.execution_date_or_run_id, create_if_necessary="memory"
     )
     ti.render_templates()
-    for attr in task.__class__.template_fields:
+    for attr in task.template_fields:
         print(
             textwrap.dedent(
                 f"""        # ----------------------------------------------------------
         # property: {attr}
         # ----------------------------------------------------------
-        {getattr(task, attr)}
+        {getattr(ti.task, attr)}
         """
             )
         )


### PR DESCRIPTION
The fix was to use the 'template_fields' attr directly since both mapped and unmapped tasks now have that attribute.
I also had to use ti.task instead of the task from dag.get_task due to this error: `AttributeError: 'DecoratedMappedOperator' object has no attribute 'templates_dict'` and I wonder if this is a bug

Closes: https://github.com/apache/airflow/issues/26555