### PR TITLE
Add correct widgets in Docker Hook

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -164,8 +164,20 @@ class DockerHook(BaseHook):
             self.log.error("Login failed")
             raise
 
+    @staticmethod
+    def get_connection_form_widgets() -> dict[str, Any]:
+        """Returns connection form widgets"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import BooleanField, StringField
+
+        return {
+            "reauth": BooleanField(lazy_gettext("Disable SSL")),
+            "email": StringField(lazy_gettext("Email"), widget=BS3TextFieldWidget()),
+        }
+
     @classmethod
-    def get_connection_form_widgets(cls) -> dict[str, Any]:
+    def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Returns custom field behaviour"""
         return {
             "hidden_fields": ["schema"],


### PR DESCRIPTION
The change #28363  refactored DockerHook and by mistake it missed the
propoer widget specification. For some reason the tests did not
catch it (to be investigated) but this should fix the failing
tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
