### PR TITLE
Move Provider Manager test to "Always"

### DIFF
--- a/tests/always/test_providers_manager.py
+++ b/tests/always/test_providers_manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -157,8 +158,12 @@ class TestProviderManager:
                 provider_manager = ProvidersManager()
                 connections_list = list(provider_manager.hooks.keys())
                 assert len(connections_list) > 60
+        if len(self._caplog.records) != 0:
+            for record in self._caplog.records:
+                print(record.message, file=sys.stderr)
+                print(record.exc_info, file=sys.stderr)
+            raise AssertionError("There are warnings generated during hook imports. Please fix them")
         assert [] == [w.message for w in warning_records.list if "hook-class-names" in str(w.message)]
-        assert len(self._caplog.records) == 0
 
     def test_hook_values(self):
         with pytest.warns(expected_warning=None) as warning_records:
@@ -166,8 +171,12 @@ class TestProviderManager:
                 provider_manager = ProvidersManager()
                 connections_list = list(provider_manager.hooks.values())
                 assert len(connections_list) > 60
+        if len(self._caplog.records) != 0:
+            for record in self._caplog.records:
+                print(record.message, file=sys.stderr)
+                print(record.exc_info, file=sys.stderr)
+            raise AssertionError("There are warnings generated during hook imports. Please fix them")
         assert [] == [w.message for w in warning_records.list if "hook-class-names" in str(w.message)]
-        assert len(self._caplog.records) == 0
 
     def test_connection_form_widgets(self):
         provider_manager = ProvidersManager()


### PR DESCRIPTION
Those tests are running various tests with Providers Manager and could catch errors introduced by provider-only changes so they should be added to "Always" tests to be "always" run in our CI.

Skipping this test was the main reason why #28700 change was needed after the #28363 was merged.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
