### PR TITLE
'task_ids' expects a list (syntax suggestion)

### DIFF
--- a/docs/apache-airflow/core-concepts/xcoms.rst
+++ b/docs/apache-airflow/core-concepts/xcoms.rst
@@ -30,7 +30,7 @@ XComs are explicitly "pushed" and "pulled" to/from their storage using the ``xco
 ``xcom_pull`` defaults to using this key if no key is passed to it, meaning it's possible to write code like this::
 
     # Pulls the return_value XCOM from "pushing_task"
-    value = task_instance.xcom_pull(task_ids='pushing_task')
+    value = task_instance.xcom_pull(task_ids=['pushing_task'])
 
 You can also use XComs in :ref:`templates <concepts:jinja-templating>`::
 


### PR DESCRIPTION
- The `task_ids` parameter in `xcom_pull` method doesn't work on strings like mentioned in the example :  
`value = task_instance.xcom_pull(task_ids='pushing_task')`
 
- Passing a list of `task_ids` (as the name suggests) seems to work
`value = task_instance.xcom_pull(task_ids=['pushing_task'])`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
