### PR TITLE
Update S3ToRedshift Operator docs to indicate multiple key functionality

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -42,7 +42,7 @@ class S3ToRedshiftOperator(BaseOperator):
     :param schema: reference to a specific schema in redshift database
     :param table: reference to a specific table in redshift database
     :param s3_bucket: reference to a specific S3 bucket
-    :param s3_key: reference to a specific S3 key
+    :param s3_key: key prefix that selects single or multiple objects from S3
     :param redshift_conn_id: reference to a specific redshift database
     :param aws_conn_id: reference to a specific S3 connection
         If the AWS connection contains 'aws_iam_role' in ``extras``

--- a/docs/apache-airflow-providers-amazon/operators/transfer/s3_to_redshift.rst
+++ b/docs/apache-airflow-providers-amazon/operators/transfer/s3_to_redshift.rst
@@ -48,6 +48,14 @@ Example usage:
     :start-after: [START howto_transfer_s3_to_redshift]
     :end-before: [END howto_transfer_s3_to_redshift]
 
+Example of ingesting multiple keys:
+
+.. exampleinclude:: /../../tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_transfer_s3_to_redshift_multiple_keys]
+    :end-before: [END howto_transfer_s3_to_redshift_multiple_keys]
+
 You can find more information to the ``COPY`` command used
 `here <https://docs.aws.amazon.com/us_en/redshift/latest/dg/copy-parameters-data-source-s3.html>`__.
 

--- a/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
+++ b/tests/system/providers/amazon/aws/example_redshift_s3_transfers.py
@@ -56,6 +56,7 @@ IP_PERMISSION = {
 
 S3_KEY = "s3_key"
 S3_KEY_2 = "s3_key_2"
+S3_KEY_PREFIX = "s3_"
 REDSHIFT_TABLE = "test_table"
 
 SQL_CREATE_TABLE = f"""
@@ -207,6 +208,18 @@ with DAG(
     )
     # [END howto_transfer_s3_to_redshift]
 
+    # [START howto_transfer_s3_to_redshift_multiple_keys]
+    transfer_s3_to_redshift_multiple = S3ToRedshiftOperator(
+        task_id="transfer_s3_to_redshift_multiple",
+        redshift_conn_id=conn_id_name,
+        s3_bucket=bucket_name,
+        s3_key=S3_KEY_PREFIX,
+        schema="PUBLIC",
+        table=REDSHIFT_TABLE,
+        copy_options=["csv"],
+    )
+    # [END howto_transfer_s3_to_redshift_multiple_keys]
+
     drop_table = RedshiftSQLOperator(
         task_id="drop_table",
         redshift_conn_id=conn_id_name,
@@ -246,6 +259,7 @@ with DAG(
         transfer_redshift_to_s3,
         check_if_key_exists,
         transfer_s3_to_redshift,
+        transfer_s3_to_redshift_multiple,
         # TEST TEARDOWN
         drop_table,
         delete_cluster,


### PR DESCRIPTION
As shown in issue #27957, the current documentation for the `S3ToRedshift` Operator seems to indicate that only one key from S3 can be transferred to Redshift. However, as elaborated [here](https://stackoverflow.com/questions/30869340/aws-redshift-copy-data-from-s3-with-wildcard) and in the aws docs [here](https://docs.aws.amazon.com/redshift/latest/dg/copy-parameters-data-source-s3.html#copy-parameters-data-source-s3-examples), the `COPY` command from S3 to Redshift automatically looks for **all** keys that matches the given prefix, and then copies all of them to redshift. 

For this PR, I wanted to update the docs to make this clear to Airflow users. I also added a system test that displays this functionality.