### PR TITLE
Add tests to document current s3 hook decorator behavior

### DIFF
--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import boto3
 import pytest
@@ -896,3 +896,52 @@ def test_dec_no_get_connection_call(mock_base, expected, request):
             hook.do_something(**kwargs)
     else:
         assert list(hook.do_something(**kwargs)) == expected
+
+
+@pytest.mark.parametrize(
+    "expected",
+    [
+        # full key
+        # no conn - no bucket - full key
+        param(["key_bucket", "key.txt"], id="no_conn-no_bucket-full_key"),
+        # no conn - with bucket - full key
+        param(["kwargs_bucket", "s3://key_bucket/key.txt"], id="no_conn-with_bucket-full_key"),
+        # with conn - no bucket - full key
+        param(["conn_bucket", "s3://key_bucket/key.txt"], id="with_conn-no_bucket-full_key"),
+        # with conn - with bucket - full key
+        param(["kwargs_bucket", "s3://key_bucket/key.txt"], id="with_conn-with_bucket-full_key"),
+        # rel key
+        # no conn - no bucket - rel key
+        param("__fail__", id="no_conn-no_bucket-rel_key"),
+        # no conn - with bucket - rel key
+        param(["kwargs_bucket", "key.txt"], id="no_conn-with_bucket-rel_key"),
+        # with conn - no bucket - rel key
+        param(["conn_bucket", "key.txt"], id="with_conn-no_bucket-rel_key"),
+        # with conn - with bucket - rel key
+        param(["kwargs_bucket", "key.txt"], id="with_conn-with_bucket-rel_key"),
+    ],
+)
+@patch("airflow.hooks.base.BaseHook.get_connection")
+def test_s3_head_object_decorated_behavior(mock_conn, request, expected):
+    tokens = request.node.callspec.id.split("-")
+    assert len(tokens) == 3
+    if "with_conn" in tokens:
+        c = Connection(schema="conn_bucket")
+    else:
+        c = Connection(schema=None)
+    mock_conn.return_value = c
+    key = "key.txt" if "rel_key" in tokens else "s3://key_bucket/key.txt"
+    if "with_bucket" in tokens:
+        kwargs = {"bucket_name": "kwargs_bucket", "key": key}
+    else:
+        kwargs = {"key": key}
+
+    hook = S3Hook()
+    mock = MagicMock()
+    hook.get_conn = mock
+    if expected == "__fail__":
+        with pytest.raises(Exception, match='Please provide a bucket name using a valid format: "key.txt"'):
+            hook.head_object(**kwargs)
+    else:
+        hook.head_object(**kwargs)
+        assert list(mock.mock_calls[1][2].values()) == expected

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -860,7 +860,7 @@ class TestAwsS3Hook:
         param(["kwargs_bucket", "key.txt"], id="unify-with_conn-with_bucket-rel_key"),
     ],
 )
-def test_dec_no_get_connection_call(mock_base, expected, request):
+def test_unify_and_provide_bucket_name_combination(mock_base, expected, request):
     tokens = request.node.callspec.id.split("-")
     assert len(tokens) == 4
     if "with_conn" in tokens:
@@ -930,7 +930,9 @@ def test_s3_head_object_decorated_behavior(mock_conn, request, expected):
     else:
         c = Connection(schema=None)
     mock_conn.return_value = c
-    key = "key.txt" if "rel_key" in tokens else "s3://key_bucket/key.txt"
+    rel_key = "key.txt"
+    full_key = f"s3://key_bucket/{rel_key}"
+    key = rel_key if "rel_key" in tokens else full_key
     if "with_bucket" in tokens:
         kwargs = {"bucket_name": "kwargs_bucket", "key": key}
     else:

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -861,6 +861,10 @@ class TestAwsS3Hook:
     ],
 )
 def test_unify_and_provide_bucket_name_combination(mock_base, expected, request):
+    """
+    Verify what is the outcome when the unify_bucket_name_and_key and provide_bucket_name
+    decorators are combined.
+    """
     tokens = request.node.callspec.id.split("-")
     assert len(tokens) == 4
     if "with_conn" in tokens:


### PR DESCRIPTION
This just adds tests to verify what happens when these decorators are combined in different orders and documents the current behavior of the hook.  Later, we may attempt to change the order.