### PR TITLE
Disable the dag file processor agent when dag_dir_list_interval is negative value

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2025,7 +2025,7 @@ scheduler:
     dag_dir_list_interval:
       description: |
         How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
-        Setting to negative value will disable the dag processor.
+        Setting this to a negative value disables the DAG processor.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2025,6 +2025,7 @@ scheduler:
     dag_dir_list_interval:
       description: |
         How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
+        Setting to negative value will disable the dag processor.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1030,6 +1030,7 @@ min_file_process_interval = 30
 parsing_cleanup_interval = 60
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
+# Setting to negative value will disable the dag processor.
 dag_dir_list_interval = 300
 
 # How often should stats be printed to the logs. Setting to 0 will disable printing stats

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1030,7 +1030,7 @@ min_file_process_interval = 30
 parsing_cleanup_interval = 60
 
 # How often (in seconds) to scan the DAGs directory for new files. Default to 5 minutes.
-# Setting to negative value will disable the dag processor.
+# Setting this to a negative value disables the DAG processor.
 dag_dir_list_interval = 300
 
 # How often should stats be printed to the logs. Setting to 0 will disable printing stats

--- a/docs/apache-airflow/administration-and-deployment/scheduler.rst
+++ b/docs/apache-airflow/administration-and-deployment/scheduler.rst
@@ -354,6 +354,7 @@ However you can also look at other non-performance-related scheduler configurati
 
 - :ref:`config:scheduler__dag_dir_list_interval`
   How often (in seconds) to scan the DAGs directory for new files.
+  Setting this to a negative value disables the DAG processor.
 
 - :ref:`config:scheduler__file_parsing_sort_mode`
   The scheduler will list and sort the DAG files to decide the parsing order.


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #28678
---

Disable the dag file processor agent when `dag_dir_list_interval`  is negative. It's similar to setting `standalone_dag_processor` to `true`, but with this conf, we would never check stale dags for cleaning.