### PR TITLE
Use connection URI in SqliteHook

### DIFF
--- a/docs/apache-airflow-providers-sqlite/connections/sqlite.rst
+++ b/docs/apache-airflow-providers-sqlite/connections/sqlite.rst
@@ -23,14 +23,51 @@ The SQLite connection type provides connection to a SQLite database.
 
 Configuring the Connection
 --------------------------
-Host (required)
-    The host to connect to.
+Host (optional)
+    The host to connect to. This can either be a file on disk or an in-memory database. If not set, an in-memory database is being used.
 
-Schema (optional)
-    Specify the schema name to be used in the database.
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in the sqlite connection.
+    See `Recognized Query Parameters <https://www.sqlite.org/uri.html>`_ for all supported parameters.
 
-Login (required)
-    Specify the user name to connect.
+URI format example
+^^^^^^^^^^^^^^^^^^
 
-Password (required)
-    Specify the password to connect.
+If serializing with Airflow URI:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_SQLITE_DEFAULT='sqlite://relative/path/to/db?mode=ro'
+
+or using an absolute path:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_SQLITE_DEFAULT='sqlite:///absolute/path/to/db?mode=ro'
+
+Note the **three** slashes after the connection type.
+
+Or using an in-memory database:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_SQLITE_DEFAULT='sqlite://?mode=ro'
+
+When specifying the connection as an environment variable in Airflow versions prior to 2.3.0, you need to specify the connection using the URI format.
+
+Note that all components of the URI should be URL-encoded.
+
+JSON format example
+^^^^^^^^^^^^^^^^^^^
+
+If serializing with JSON:
+
+.. code-block:: bash
+
+    export AIRFLOW_CONN_SQLITE_DEFAULT='{
+        "conn_type": "sqlite",
+        "host": "relative/path/to/db",
+        "extra": {
+            "mode": "ro"
+        }
+    }'

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 import sqlalchemy
 
 from airflow.models import Connection
@@ -28,26 +29,35 @@ from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 
 class TestSqliteHookConn:
     def setup_method(self):
-
-        self.connection = Connection(host="host")
-
         class UnitTestSqliteHook(SqliteHook):
             conn_name_attr = "test_conn_id"
 
         self.db_hook = UnitTestSqliteHook()
-        self.db_hook.get_connection = mock.Mock()
-        self.db_hook.get_connection.return_value = self.connection
 
+    @pytest.mark.parametrize(
+        "connection, uri",
+        [
+            (Connection(host="host"), "file:host"),
+            (Connection(host="host", extra='{"mode":"ro"}'), "file:host?mode=ro"),
+            (Connection(host=":memory:"), "file::memory:"),
+            (Connection(), "file:"),
+            (Connection(uri="sqlite://relative/path/to/db?mode=ro"), "file:relative/path/to/db?mode=ro"),
+            (Connection(uri="sqlite:///absolute/path/to/db?mode=ro"), "file:/absolute/path/to/db?mode=ro"),
+            (Connection(uri="sqlite://?mode=ro"), "file:?mode=ro"),
+        ],
+    )
     @patch("airflow.providers.sqlite.hooks.sqlite.sqlite3.connect")
-    def test_get_conn(self, mock_connect):
+    def test_get_conn(self, mock_connect, connection, uri):
+        self.db_hook.get_connection = mock.Mock(return_value=connection)
         self.db_hook.get_conn()
-        mock_connect.assert_called_once_with("host")
+        mock_connect.assert_called_once_with(uri, uri=True)
 
     @patch("airflow.providers.sqlite.hooks.sqlite.sqlite3.connect")
     def test_get_conn_non_default_id(self, mock_connect):
+        self.db_hook.get_connection = mock.Mock(return_value=Connection(host="host"))
         self.db_hook.test_conn_id = "non_default"
         self.db_hook.get_conn()
-        mock_connect.assert_called_once_with("host")
+        mock_connect.assert_called_once_with("file:host", uri=True)
         self.db_hook.get_connection.assert_called_once_with("non_default")
 
 


### PR DESCRIPTION
We use the uri syntax for connecting to a sqlite database.
This allows the user to define more sqlite args such as mode. See https://docs.sqlalchemy.org/en/14/dialects/sqlite.html#uri-connections for details.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
