### PR TITLE
Use dagrun instead of DagFileProcessor in backfill_job test

### DIFF
--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -154,12 +154,11 @@ class TestBackfillJob:
         assert State.SUCCESS == dag_run.state
 
     @pytest.mark.backend("postgres", "mysql")
-    def test_trigger_controller_dag(self):
+    def test_trigger_controller_dag(self, session):
         dag = self.dagbag.get_dag("example_trigger_controller_dag")
         target_dag = self.dagbag.get_dag("example_trigger_target_dag")
         target_dag.sync_to_db()
 
-        session = settings.Session()
         target_dag_run = session.query(DagRun).filter(DagRun.dag_id == target_dag.dag_id).one_or_none()
         assert not target_dag_run
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -160,7 +160,7 @@ class TestBackfillJob:
         target_dag.sync_to_db()
 
         target_dag_run = session.query(DagRun).filter(DagRun.dag_id == target_dag.dag_id).one_or_none()
-        assert not target_dag_run
+        assert target_dag_run is None
 
         job = BackfillJob(
             dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_first_depends_on_past=True
@@ -168,7 +168,7 @@ class TestBackfillJob:
         job.run()
 
         dag_run = session.query(DagRun).filter(DagRun.dag_id == dag.dag_id).one_or_none()
-        assert dag_run
+        assert dag_run is not None
 
         task_instances_list = job._task_instances_for_dag_run(dag=dag, dag_run=dag_run)
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -153,31 +153,22 @@ class TestBackfillJob:
 
         assert State.SUCCESS == dag_run.state
 
-    @pytest.mark.xfail(condition=True, reason="This test is flaky")
     @pytest.mark.backend("postgres", "mysql")
     def test_trigger_controller_dag(self):
         dag = self.dagbag.get_dag("example_trigger_controller_dag")
         target_dag = self.dagbag.get_dag("example_trigger_target_dag")
         target_dag.sync_to_db()
 
-        # dag_file_processor = DagFileProcessor(dag_ids=[], log=Mock())
-        task_instances_list = []
-        # task_instances_list = dag_file_processor._process_task_instances(
-        #    target_dag,
-        #    dag_runs=DagRun.find(dag_id='example_trigger_target_dag')
-        # )
-        assert not task_instances_list
+        target_dag_run = target_dag.get_last_dagrun()
+        assert not target_dag_run
 
         job = BackfillJob(
             dag=dag, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_first_depends_on_past=True
         )
         job.run()
 
-        task_instances_list = []
-        # task_instances_list = dag_file_processor._process_task_instances(
-        #    target_dag,
-        #    dag_runs=DagRun.find(dag_id='example_trigger_target_dag')
-        # )
+        dag_run = dag.get_last_dagrun()
+        task_instances_list = job._task_instances_for_dag_run(dag=dag, dag_run=dag_run)
 
         assert task_instances_list
 

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1786,6 +1786,7 @@ class TestBackfillJob:
 
     def test_mapped_dag_unexpandable(self, dag_maker, session):
         with dag_maker(session=session) as dag:
+
             @dag.task
             def get_things():
                 return [1, 2]


### PR DESCRIPTION
related: #23539

Fix xfail test in `tests/jobs/test_backfill_job.py::test_trigger_controller_dag` test
