### PR TITLE
clean verify_providers.py warnings for `DummyOperator`

### DIFF
--- a/scripts/in_container/verify_providers.py
+++ b/scripts/in_container/verify_providers.py
@@ -183,16 +183,6 @@ KNOWN_DEPRECATED_MESSAGES: set[tuple[str, str]] = {
     ),
     ("SelectableGroups dict interface is deprecated. Use select.", "kombu"),
     ("The module cloudant is now deprecated. The replacement is ibmcloudant.", "cloudant"),
-    ("This module is deprecated. Please use `airflow.operators.empty`.", "dbt"),
-    ("This module is deprecated. Please use `airflow.operators.empty`.", "jdbc"),
-    ("This module is deprecated. Please use `airflow.operators.empty`.", "azure"),
-    ("This module is deprecated. Please use `airflow.operators.empty`.", "qubole"),
-    ("This module is deprecated. Please use `airflow.operators.empty`.", "winrm"),
-    ("This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.", "dbt"),
-    ("This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.", "jdbc"),
-    ("This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.", "azure"),
-    ("This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.", "qubole"),
-    ("This class is deprecated. Please use `airflow.operators.empty.EmptyOperator`.", "winrm"),
     (
         "'nteract-scrapbook' package has been renamed to `scrapbook`. No new releases are "
         "going out for this old package name.",


### PR DESCRIPTION
`EmptyOperator` was released in 2.3.0 now that all providers have minimum Airflow 2.3.0 version there is no reason for them to raise deprecation warning on `DummyOperator` thus we can remove these entries

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
