### PR TITLE
css, cap dropdown menu size dynamically

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -64,7 +64,7 @@ div.container {
 /* If a category has a lot of menu items, we cap it, and
  add a scroll bar */
 .navbar li.dropdown .dropdown-menu {
-  max-height: 300px;
+  max-height: 85vh;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
In this PR: https://github.com/apache/airflow/pull/28561, I capped the dropdown menu size to 300px and made it scrollable past there. Instead, we should cap it at 85%.
<img width="1506" alt="Screen Shot 2023-01-04 at 1 56 38 PM" src="https://user-images.githubusercontent.com/40223998/210629721-3b8782fb-caac-4e25-aee2-c9ad9a7fcb16.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
