### PR TITLE
Add --overwrite option to `connections import` CLI command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -815,6 +815,12 @@ ARG_CONN_SERIALIZATION_FORMAT = Arg(
     choices=["json", "uri"],
 )
 ARG_CONN_IMPORT = Arg(("file",), help="Import connections from a file")
+ARG_CONN_OVERWRITE = Arg(
+    ("--overwrite",),
+    help="Overwrite existing entries if a conflict occurs",
+    required=False,
+    action="store_true",
+)
 
 # providers
 ARG_PROVIDER_NAME = Arg(
@@ -1602,6 +1608,7 @@ CONNECTIONS_COMMANDS = (
         func=lazy_load_command("airflow.cli.commands.connection_command.connections_import"),
         args=(
             ARG_CONN_IMPORT,
+            ARG_CONN_OVERWRITE,
             ARG_VERBOSE,
         ),
     ),

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -306,10 +306,10 @@ def connections_import(args):
         raise SystemExit("Missing connections file.")
 
 
-def _import_helper(file_path, overwrite):
-    """
-    Load connections from a file and save them to the DB.
-    If `overwrite` is set to true, overwrite on collision.
+def _import_helper(file_path: str, overwrite: bool) -> None:
+    """Load connections from a file and save them to the DB.
+
+    :param overwrite: Whether to skip or overwrite on collision.
     """
     connections_dict = load_connections_dict(file_path)
     with create_session() as session:

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -314,17 +314,14 @@ def _import_helper(file_path: str, overwrite: bool) -> None:
     connections_dict = load_connections_dict(file_path)
     with create_session() as session:
         for conn_id, conn in connections_dict.items():
-            existing_conn = session.query(Connection).filter(Connection.conn_id == conn_id).first()
+            existing_conn_id = session.query(Connection.id).filter(Connection.conn_id == conn_id).scalar()
+            if existing_conn_id is not None:
+                if not overwrite:
+                    print(f"Could not import connection {conn_id}: connection already exists.")
+                    continue
 
-            # Don't overwrite existing connections if overwrite is falsey
-            if not overwrite and existing_conn:
-                print(f"Could not import connection {conn_id}: connection already exists.")
-                continue
-
-            # Do overwrite existing connections
-            if overwrite and existing_conn:
                 # The conn_ids match, but the PK of the new entry must also be the same as the old
-                conn.id = existing_conn.id
+                conn.id = existing_conn_id
 
             session.merge(conn)
             session.commit()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The CLI command `airflow connections import <filepath>` cannot overwrite existing connections. Conflicts are skipped with the message `Could not import connection <connection_id>: connection already exists.`

**This PR adds functionality to set `--overwrite=true` to overwrite existing connections when there is a conflict.**

The existing behavior (no overwrites) is still the default behavior, the user must set `--overwrite=true` to enable overwrites.

Original idea for this: https://github.com/apache/airflow/pull/15177#issuecomment-1286555955