### PR TITLE
Fix serialize() usages in custom JSON encoders

### DIFF
--- a/airflow/serialization/serde.py
+++ b/airflow/serialization/serde.py
@@ -262,11 +262,7 @@ def _convert(old: dict) -> dict:
 
 
 def _match(classname: str) -> bool:
-    for p in _patterns:
-        if p.match(classname):
-            return True
-
-    return False
+    return any(p.match(classname) is not None for p in _patterns)
 
 
 def _stringify(classname: str, version: int, value: T | None) -> str:

--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -56,12 +56,12 @@ class WebEncoder(json.JSONEncoder):
             return o.strftime("%Y-%m-%d")
 
         if isinstance(o, Decimal):
-            data = serialize(o)
+            data = serialize(o, ensure_json_compatible=True)
             if isinstance(data, dict) and DATA in data:
                 return data[DATA]
 
         try:
-            data = serialize(o)
+            data = serialize(o, ensure_json_compatible=True)
             if isinstance(data, dict) and CLASSNAME in data:
                 # this is here for backwards compatibility
                 if (
@@ -79,7 +79,7 @@ class XComEncoder(json.JSONEncoder):
 
     def default(self, o: object) -> Any:
         try:
-            return serialize(o)
+            return serialize(o, ensure_json_compatible=True)
         except TypeError:
             return super().default(o)
 


### PR DESCRIPTION
Fix #28741.

Our custom JSON encoders call `serialize()` in their `default()` hooks. However, `serialize()` does not guarantee to return a JSON-serializable type, and when it does not (e.g. a set object), the JSON encoder would infinitely recurse into `serialize()` trying to coerce the object into JSON-serializable.

This patch adds an additional `ensure_json_compatible` parameter to `serialize()`, so JSON encoders can use it to require `serialize()` to always return JSON-compatible values.

Some minor refactoring is also applied to `serialize()` to ensure the flag is correctly passed down through recursive visits, and also hide the `depth` tracking parameter (which is internal to the function) from outside access.

The `_reverse_cache` global variable is also deleted since it is not used anywhere, even before this patch.