### PR TITLE
Allow setting the name for the base container and fix longstanding bug with running quick pods

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -167,7 +167,7 @@ class KubernetesPodOperator(BaseOperator):
         during the next try. If False, always create a new pod for each try.
     :param labels: labels to apply to the Pod. (templated)
     :param startup_timeout_seconds: timeout in seconds to startup the pod.
-    :param get_logs: get the stdout of the container as logs of the tasks.
+    :param get_logs: get the stdout of the base container as logs of the tasks.
     :param image_pull_policy: Specify a policy to cache or always pull an image.
     :param annotations: non-identifying metadata you can attach to the Pod.
         Can be a large range of data, and can include characters
@@ -206,9 +206,10 @@ class KubernetesPodOperator(BaseOperator):
         to populate the environment variables with. The contents of the target
         ConfigMap's Data field will represent the key-value pairs as environment variables.
         Extends env_from.
+    :param base_container_name: The name of the base container in the pod. This container's logs
+        will appear as part of this task's logs if get_logs is True. Defaults to "base".
     """
 
-    BASE_CONTAINER_NAME = "base"
     POD_CHECKED_KEY = "already_checked"
 
     template_fields: Sequence[str] = (
@@ -272,6 +273,7 @@ class KubernetesPodOperator(BaseOperator):
         pod_runtime_info_envs: list[k8s.V1EnvVar] | None = None,
         termination_grace_period: int | None = None,
         configmaps: list[str] | None = None,
+        base_container_name: str = "base",
         **kwargs,
     ) -> None:
         # TODO: remove in provider 6.0.0 release. This is a mitigate step to advise users to switch to the
@@ -338,6 +340,7 @@ class KubernetesPodOperator(BaseOperator):
         self.termination_grace_period = termination_grace_period
         self.pod_request_obj: k8s.V1Pod | None = None
         self.pod: k8s.V1Pod | None = None
+        self.base_container_name = base_container_name
 
     @cached_property
     def _incluster_namespace(self):
@@ -498,12 +501,12 @@ class KubernetesPodOperator(BaseOperator):
             if self.get_logs:
                 self.pod_manager.fetch_container_logs(
                     pod=self.pod,
-                    container_name=self.BASE_CONTAINER_NAME,
+                    container_name=self.base_container_name,
                     follow=True,
                 )
             else:
                 self.pod_manager.await_container_completion(
-                    pod=self.pod, container_name=self.BASE_CONTAINER_NAME
+                    pod=self.pod, container_name=self.base_container_name
                 )
 
             if self.do_xcom_push:
@@ -535,7 +538,7 @@ class KubernetesPodOperator(BaseOperator):
             if self.log_events_on_failure:
                 self._read_pod_log_events(pod, reraise=False)
             self.process_pod_deletion(remote_pod, reraise=False)
-            error_message = get_container_termination_message(remote_pod, self.BASE_CONTAINER_NAME)
+            error_message = get_container_termination_message(remote_pod, self.base_container_name)
             raise AirflowException(
                 f"Pod {pod and pod.metadata.name} returned a failure:\n{error_message}\n"
                 f"remote_pod: {remote_pod}"
@@ -621,7 +624,7 @@ class KubernetesPodOperator(BaseOperator):
                 containers=[
                     k8s.V1Container(
                         image=self.image,
-                        name=self.BASE_CONTAINER_NAME,
+                        name=self.base_container_name,
                         command=self.cmds,
                         ports=self.ports,
                         image_pull_policy=self.image_pull_policy,

--- a/airflow/providers/cncf/kubernetes/utils/pod_manager.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_manager.py
@@ -265,7 +265,7 @@ class PodManager(LoggingMixin):
                 time.sleep(1)
 
     def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
-        while not self.container_is_running(pod=pod, container_name=container_name):
+        while self.container_is_running(pod=pod, container_name=container_name):
             time.sleep(1)
 
     def await_pod_completion(self, pod: V1Pod) -> V1Pod:

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1142,3 +1142,23 @@ class TestKubernetesPodOperatorSystem:
                 do_xcom_push=False,
                 resources=resources,
             )
+
+    def test_changing_base_container_name(self):
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels=self.labels,
+            task_id=str(uuid4()),
+            in_cluster=False,
+            do_xcom_push=False,
+            hostnetwork=True,
+            base_container_name="apple-sauce",
+        )
+        assert k.base_container_name == "apple-sauce"
+        context = create_context(k)
+        k.execute(context)
+        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        self.expected_pod["spec"]["containers"][0]["name"] == "apple-sauce"
+        assert self.expected_pod["spec"] == actual_pod["spec"]

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1025,7 +1025,6 @@ class TestKubernetesPodOperatorSystem:
                 do_xcom_push=False,
             )
 
-    @mock.patch(f"{POD_MANAGER_CLASS}.await_pod_completion", new=MagicMock)
     def test_on_kill(self):
         hook = KubernetesHook(conn_id=None, in_cluster=False)
         client = hook.core_v1_client
@@ -1045,8 +1044,20 @@ class TestKubernetesPodOperatorSystem:
             termination_grace_period=0,
         )
         context = create_context(k)
-        with pytest.raises(AirflowException):
-            k.execute(context)
+
+        class ShortCircuitException(Exception):
+            pass
+
+        # use this mock to short circuit and NOT wait for container completion
+        with mock.patch.object(
+            k.pod_manager, "await_container_completion", side_effect=ShortCircuitException()
+        ):
+            # cleanup will be upset since the pod should not be completed.. so skip it
+            with mock.patch.object(k, "cleanup"):
+                with pytest.raises(ShortCircuitException):
+                    k.execute(context)
+
+        # when we get here, the pod should still be running
         name = k.pod.metadata.name
         pod = client.read_namespaced_pod(name=name, namespace=namespace)
         assert pod.status.phase == "Running"
@@ -1169,6 +1180,11 @@ class TestKubernetesPodOperatorSystem:
         assert self.expected_pod["spec"] == actual_pod["spec"]
 
     def test_changing_base_container_name_no_logs(self):
+        """
+        This test checks BOTH a modified base container name AND the get_logs=False flow..
+          and as a result, also checks that the flow works with fast containers
+          See #26796
+        """
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -1191,6 +1207,36 @@ class TestKubernetesPodOperatorSystem:
         assert mock_await_container_completion.call_args[1]["container_name"] == "apple-sauce"
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
         self.expected_pod["spec"]["containers"][0]["name"] = "apple-sauce"
+        assert self.expected_pod["spec"] == actual_pod["spec"]
+
+    def test_changing_base_container_name_no_logs_long(self):
+        """
+        Similar to test_changing_base_container_name_no_logs, but ensures that
+        pods running longer than 1 second work too. See #26796
+        """
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["sleep 3"],
+            labels=self.labels,
+            task_id=str(uuid4()),
+            in_cluster=False,
+            do_xcom_push=False,
+            get_logs=False,
+            base_container_name="apple-sauce",
+        )
+        assert k.base_container_name == "apple-sauce"
+        context = create_context(k)
+        with mock.patch.object(
+            k.pod_manager, "await_container_completion", wraps=k.pod_manager.await_container_completion
+        ) as mock_await_container_completion:
+            k.execute(context)
+
+        assert mock_await_container_completion.call_args[1]["container_name"] == "apple-sauce"
+        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        self.expected_pod["spec"]["containers"][0]["name"] = "apple-sauce"
+        self.expected_pod["spec"]["containers"][0]["args"] = ["sleep 3"]
         assert self.expected_pod["spec"] == actual_pod["spec"]
 
     def test_changing_base_container_name_failure(self):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1143,7 +1143,7 @@ class TestKubernetesPodOperatorSystem:
                 resources=resources,
             )
 
-    def test_changing_base_container_name(self):
+    def test_changing_base_container_name_with_get_logs(self):
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -1153,12 +1153,69 @@ class TestKubernetesPodOperatorSystem:
             task_id=str(uuid4()),
             in_cluster=False,
             do_xcom_push=False,
-            hostnetwork=True,
+            get_logs=True,
             base_container_name="apple-sauce",
         )
         assert k.base_container_name == "apple-sauce"
         context = create_context(k)
-        k.execute(context)
+        with mock.patch.object(
+            k.pod_manager, "fetch_container_logs", wraps=k.pod_manager.fetch_container_logs
+        ) as mock_fetch_container_logs:
+            k.execute(context)
+
+        assert mock_fetch_container_logs.call_args[1]["container_name"] == "apple-sauce"
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-        self.expected_pod["spec"]["containers"][0]["name"] == "apple-sauce"
+        self.expected_pod["spec"]["containers"][0]["name"] = "apple-sauce"
         assert self.expected_pod["spec"] == actual_pod["spec"]
+
+    def test_changing_base_container_name_no_logs(self):
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels=self.labels,
+            task_id=str(uuid4()),
+            in_cluster=False,
+            do_xcom_push=False,
+            get_logs=False,
+            base_container_name="apple-sauce",
+        )
+        assert k.base_container_name == "apple-sauce"
+        context = create_context(k)
+        with mock.patch.object(
+            k.pod_manager, "await_container_completion", wraps=k.pod_manager.await_container_completion
+        ) as mock_await_container_completion:
+            k.execute(context)
+
+        assert mock_await_container_completion.call_args[1]["container_name"] == "apple-sauce"
+        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        self.expected_pod["spec"]["containers"][0]["name"] = "apple-sauce"
+        assert self.expected_pod["spec"] == actual_pod["spec"]
+
+    def test_changing_base_container_name_failure(self):
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["exit"],
+            arguments=["1"],
+            labels=self.labels,
+            task_id=str(uuid4()),
+            in_cluster=False,
+            do_xcom_push=False,
+            base_container_name="apple-sauce",
+        )
+        assert k.base_container_name == "apple-sauce"
+        context = create_context(k)
+
+        class ShortCircuitException(Exception):
+            pass
+
+        with mock.patch(
+            "airflow.providers.cncf.kubernetes.operators.kubernetes_pod.get_container_termination_message",
+            side_effect=ShortCircuitException(),
+        ) as mock_get_container_termination_message:
+            with pytest.raises(ShortCircuitException):
+                k.execute(context)
+
+        assert mock_get_container_termination_message.call_args[0][1] == "apple-sauce"


### PR DESCRIPTION
Some downstream machinery may require a specific name for the 'base' container.

This change should be backwards compatible since the default base container name is still base.. it can just now be changed to something besides base.