### PR TITLE
Fix providers documentation formatting

### DIFF
--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -344,8 +344,11 @@ class LivyHook(HttpHook, LoggingMixin):
     ) -> dict:
         """
         Build the post batch request body.
-        For more information about the format refer to
-        .. seealso:: https://livy.apache.org/docs/latest/rest-api.html
+
+        .. seealso::
+            For more information about the format refer to
+            https://livy.apache.org/docs/latest/rest-api.html
+
         :param file: Path of the file containing the application to execute (required).
         :param proxy_user: User to impersonate when running the job.
         :param class_name: Application Java/Spark main class string.

--- a/docs/apache-airflow-providers-apache-drill/operators.rst
+++ b/docs/apache-airflow-providers-apache-drill/operators.rst
@@ -22,14 +22,16 @@ Apache Drill Operators
 Prerequisite
 ------------
 
-To use ``DrillOperator``, you must configure a :doc:`Drill Connection <connections/drill>`.
+To use :class:`~airflow.providers.apache.drill.operators.drill.DrillOperator`,
+you must configure a :doc:`Drill Connection <connections/drill>`.
 
 .. _howto/operator:DrillOperator:
 
 DrillOperator
 -------------
 
-Executes one or more SQL queries on an Apache Drill server.  The ``sql`` parameter can be templated and be an external ``.sql`` file.
+Executes one or more SQL queries on an Apache Drill server.
+The ``sql`` parameter can be templated and be an external ``.sql`` file.
 
 Using the operator
 """"""""""""""""""

--- a/docs/apache-airflow-providers-apache-druid/operators.rst
+++ b/docs/apache-airflow-providers-apache-druid/operators.rst
@@ -22,7 +22,8 @@ Apache Druid Operators
 Prerequisite
 ------------
 
-To use ``DruidOperator``, you must configure a Druid Connection first.
+To use :class:`~airflow.providers.apache.druid.operators.druid.DruidOperator`,
+you must configure a Druid Connection first.
 
 DruidOperator
 -------------------

--- a/docs/apache-airflow-providers-apache-hdfs/operators/webhdfs.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/operators/webhdfs.rst
@@ -29,8 +29,8 @@ WebHdfsSensor
 Waits for a file or folder to land in HDFS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :class:`~airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor`. is used to check for a file or folder
-to land in HDFS
+The :class:`~airflow.providers.apache.hdfs.sensors.web_hdfs.WebHdfsSensor` is used to check for a file or folder
+to land in HDFS.
 
 Use the ``filepath`` parameter to poke until the provided file is found.
 

--- a/docs/apache-airflow-providers-apache-spark/operators.rst
+++ b/docs/apache-airflow-providers-apache-spark/operators.rst
@@ -22,9 +22,13 @@ Apache Spark Operators
 Prerequisite
 ------------
 
-To use ``SparkJDBCOperator`` and ``SparkSubmitOperator``, you must configure a :doc:`Spark Connection <connections/spark>`. For ``SparkJDBCOperator``, you must also configure a :doc:`JDBC connection <apache-airflow-providers-jdbc:connections/jdbc>`.
-
-``SparkSqlOperator`` gets all the configurations from operator parameters.
+* To use :class:`~airflow.providers.apache.spark.operators.spark_submit.SparkSubmitOperator`
+  you must configure :doc:`Spark Connection <connections/spark>`.
+* To use :class:`~airflow.providers.apache.spark.operators.spark_jdbc.SparkJDBCOperator`
+  you must configure both :doc:`Spark Connection <connections/spark>`
+  and :doc:`JDBC connection <apache-airflow-providers-jdbc:connections/jdbc>`.
+* :class:`~airflow.providers.apache.spark.operators.spark_sql.SparkSqlOperator`
+  gets all the configurations from operator parameters.
 
 .. _howto/operator:SparkJDBCOperator:
 

--- a/docs/apache-airflow-providers-arangodb/connections/arangodb.rst
+++ b/docs/apache-airflow-providers-arangodb/connections/arangodb.rst
@@ -24,10 +24,11 @@ The ArangoDB connection provides credentials for accessing the ArangoDB.
 Configuring the Connection
 --------------------------
 ArangoDB Host (required)
-    Specify ArangoDB Host URL or  comma separated list of URLs (coordinators in a cluster) `eg. "http://127.0.0.1:8529"` or `"http://127.0.0.1:8529,http://127.0.0.1:8530 so on.`
+    Specify ArangoDB Host URL or comma separated list of URLs (coordinators in a cluster),
+    e.g. ``http://127.0.0.1:8529`` or ``http://127.0.0.1:8529,http://127.0.0.1:8530``.
 ArangoDB Database/Schema (required)
-    Specify `Database/Schema` for the ArangoDB. eg. `_system`
+    Specify **Database/Schema** for the ArangoDB. eg. ``_system``.
 ArangoDB Username (required)
-    Specify `username` for the ArangoDB, eg. `root`
+    Specify **username** for the ArangoDB, e.g. ``root``.
 ArangoDB Password (required)
-    Specify `password` for the ArangoDB
+    Specify **password** for the ArangoDB

--- a/docs/apache-airflow-providers-arangodb/operators/index.rst
+++ b/docs/apache-airflow-providers-arangodb/operators/index.rst
@@ -21,14 +21,14 @@
 
 Operators
 =======================
-You can build your own Operator hook in :class:`~airflow.providers.arangodb.hooks.ArangoDBHook`,
+You can build your own Operator hook in :class:`~airflow.providers.arangodb.hooks.arangodb.ArangoDBHook`.
 
-
-Use the :class:`~airflow.providers.arangodb.operators.AQLOperator` to execute
+Use the :class:`~airflow.providers.arangodb.operators.arangodb.AQLOperator` to execute
 AQL query in `ArangoDB <https://www.arangodb.com/>`__.
 
-You can further process your result using :class:`~airflow.providers.arangodb.operators.AQLOperator` and
-further process the result using **result_processor** Callable as you like.
+You can further process your result using :class:`~airflow.providers.arangodb.operators.arangodb.AQLOperator` and
+further process the result using :class:`result_processor <airflow.providers.arangodb.operators.arangodb.AQLOperator>`
+Callable as you like.
 
 An example of Listing all Documents in **students** collection can be implemented as following:
 
@@ -48,7 +48,7 @@ please provide **template_searchpath** while creating **DAG** object,
 Sensors
 =======
 
-Use the :class:`~airflow.providers.arangodb.sensors.AQLSensor` to wait for a document or collection using
+Use the :class:`~airflow.providers.arangodb.sensors.arangodb.AQLSensor` to wait for a document or collection using
 AQL query in `ArangoDB <https://www.arangodb.com/>`__.
 
 An example for waiting a document in **students** collection with student name **judy** can be implemented as following:

--- a/docs/apache-airflow-providers-asana/index.rst
+++ b/docs/apache-airflow-providers-asana/index.rst
@@ -27,7 +27,7 @@ Content
     :caption: Guides
 
     Connection types <connections/asana>
-    Operators <operators/asana>
+    Operators <operators/index>
 
 .. toctree::
     :maxdepth: 1

--- a/docs/apache-airflow-providers-asana/operators/asana.rst
+++ b/docs/apache-airflow-providers-asana/operators/asana.rst
@@ -16,7 +16,6 @@
     under the License.
 
 
-
 .. _howto/operator:AsanaCreateTaskOperator:
 
 AsanaCreateTaskOperator
@@ -27,7 +26,7 @@ create an Asana task.
 
 
 Using the Operator
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The AsanaCreateTaskOperator minimally requires the new task's name and
 the Asana connection to use to connect to your account (``conn_id``). There are many other
@@ -46,7 +45,7 @@ delete an existing Asana task.
 
 
 Using the Operator
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The AsanaDeleteTaskOperator requires the task id to delete. Use the ``conn_id``
 parameter to specify the Asana connection to use to connect to your account.
@@ -55,14 +54,14 @@ parameter to specify the Asana connection to use to connect to your account.
 .. _howto/operator:AsanaFindTaskOperator:
 
 AsanaFindTaskOperator
-=======================
+=====================
 
 Use the :class:`~airflow.providers.asana.operators.AsanaFindTaskOperator` to
 search for Asana tasks that fit some criteria.
 
 
 Using the Operator
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The AsanaFindTaskOperator requires a dict of search parameters following the description
 `here <https://developers.asana.com/docs/get-multiple-tasks>`_.
@@ -80,7 +79,7 @@ update an existing Asana task.
 
 
 Using the Operator
-^^^^^^^^^^^^^^^^^^
+------------------
 
 The AsanaUpdateTaskOperator minimally requires the task id to update and
 the Asana connection to use to connect to your account (``conn_id``). There are many other

--- a/docs/apache-airflow-providers-asana/operators/index.rst
+++ b/docs/apache-airflow-providers-asana/operators/index.rst
@@ -15,18 +15,12 @@
     specific language governing permissions and limitations
     under the License.
 
+Asana Operators
+===============
 
 
-Apache Pig Operators
-====================
+.. toctree::
+    :maxdepth: 1
+    :glob:
 
-Apache Pig is a platform for analyzing large data sets that consists of a high-level language
-for expressing data analysis programs, coupled with infrastructure for evaluating these programs.
-Pig programs are amenable to substantial parallelization, which in turns enables them to handle very large data sets.
-
-Use the :class:`~airflow.providers.apache.pig.operators.pig.PigOperator` to execute a pig script.
-
-.. exampleinclude:: /../../tests/system/providers/apache/pig/example_pig.py
-    :language: python
-    :start-after: [START create_pig]
-    :end-before: [END create_pig]
+    *

--- a/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/connections/kubernetes.rst
@@ -26,14 +26,13 @@ The Kubernetes cluster Connection type enables connection to a Kubernetes cluste
 Authenticating to Kubernetes cluster
 ------------------------------------
 
-There are three ways to connect to Kubernetes using Airflow.
+There are different ways to connect to Kubernetes using Airflow.
 
-1. Use kube_config that reside in the default location on the machine(~/.kube/config) - just leave all fields empty
-2. Use in_cluster config, if Airflow runs inside Kubernetes cluster take the configuration from the cluster - mark:
-    In cluster configuration
-3. Use kube_config from different location - insert the path into ``Kube config path``
-4. Use kube_config in JSON format from connection configuration - paste  kube_config into
-    ``Kube config (JSON format)``
+#. Use kube_config that reside in the default location on the machine(~/.kube/config) - just leave all fields empty
+#. Use in_cluster config, if Airflow runs inside Kubernetes cluster take the configuration from the cluster - mark:
+   In cluster configuration
+#. Use kube_config from different location - insert the path into ``Kube config path``
+#. Use kube_config in JSON format from connection configuration - paste  kube_config into ``Kube config (JSON format)``
 
 
 Default Connection IDs

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -34,7 +34,8 @@ There are several ways to connect to Databricks using Airflow.
    i.e. add a token to the Airflow connection. This is the recommended method.
 2. Use Databricks login credentials
    i.e. add the username and password used to login to the Databricks account to the Airflow connection.
-   Note that username/password authentication is discouraged and not supported for ``DatabricksSqlOperator``.
+   Note that username/password authentication is discouraged and not supported for
+   :class:`~airflow.providers.databricks.operators.databricks_sql.DatabricksSqlOperator`.
 3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret
    (only on Azure Databricks).  Service principal could be defined as a
    `user inside workspace <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-azure-databricks-workspace-users-and-admins>`_, or `outside of workspace having Owner or Contributor permissions <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-not-workspace-users>`_
@@ -83,7 +84,8 @@ Extra (optional)
     * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if managed identity isn't
       a user inside workspace)
 
-    Following parameters could be set when using ``DatabricksSqlOperator``:
+    Following parameters could be set when using
+    :class:`~airflow.providers.databricks.operators.databricks_sql.DatabricksSqlOperator`:
 
     * ``http_path``: optional HTTP path of Databricks SQL endpoint or Databricks cluster. See `documentation <https://docs.databricks.com/dev-tools/python-sql-connector.html#get-started>`_.
     * ``session_configuration``: optional map containing Spark session configuration parameters.

--- a/docs/apache-airflow-providers-elasticsearch/hooks/elasticsearch_python_hook.rst
+++ b/docs/apache-airflow-providers-elasticsearch/hooks/elasticsearch_python_hook.rst
@@ -25,10 +25,11 @@ Elasticsearch Hook that is using the native Python client to communicate with El
 Parameters
 ------------
 hosts
-  A list of a single or many Elasticsearch instances. Example: ["http://localhost:9200"]
+  A list of a single or many Elasticsearch instances. Example: ``["http://localhost:9200"]``.
 es_conn_args
   Additional arguments you might need to enter to connect to Elasticsearch.
-  Example: {"ca_cert":"/path/to/cert", "basic_auth": "(user, pass)"}
+  Example: ``{"ca_cert":"/path/to/cert", "basic_auth": "(user, pass)"}``
+
   For all possible configurations, consult with Elasticsearch documentation.
   Reference: https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/connecting.html
 

--- a/docs/apache-airflow-providers-github/operators/index.rst
+++ b/docs/apache-airflow-providers-github/operators/index.rst
@@ -20,12 +20,16 @@
 Operators
 =========
 
-Use the :class:`~airflow.providers.github.operators.GithubOperator` to execute
+Use the :class:`~airflow.providers.github.operators.github.GithubOperator` to execute
 Operations in a `GitHub <https://www.github.com/>`__.
 
-You can build your own operator using :class:`~airflow.providers.github.operators.GithubOperator`
-and passing **github_method** and **github_method_args** from top level `PyGithub <https://pygithub.readthedocs.io/>`__ methods.
-You can further process the result using **result_processor** Callable as you like.
+You can build your own operator using :class:`~airflow.providers.github.operators.github.GithubOperator`
+and passing :class:`github_method <airflow.providers.github.operators.github.GithubOperator>`
+and :class:`github_method_args <airflow.providers.github.operators.github.GithubOperator>`
+from top level `PyGithub <https://pygithub.readthedocs.io/>`__ methods.
+
+You can further process the result using
+:class:`result_processor <airflow.providers.github.operators.github.GithubOperator>` Callable as you like.
 
 An example of Listing all Repositories owned by a user, **client.get_user().get_repos()** can be implemented as following:
 
@@ -55,7 +59,7 @@ You can also implement your own sensor on Repository using :class:`~airflow.prov
 an example of this is :class:`~airflow.providers.github.sensors.GithubTagSensor`
 
 
-Use the :class:`~airflow.providers.github.sensors.GithubTagSensor` to wait for creation of
+Use the :class:`~airflow.providers.github.sensors.github.GithubTagSensor` to wait for creation of
 a Tag in `GitHub <https://www.github.com/>`__.
 
 An example for tag **v1.0**:
@@ -66,7 +70,8 @@ An example for tag **v1.0**:
     :start-after: [START howto_tag_sensor_github]
     :end-before: [END howto_tag_sensor_github]
 
-Similar Functionality can be achieved by directly using :class:`~airflow.providers.github.sensors.GithubSensor` ,
+Similar Functionality can be achieved by directly using
+:class:`~from airflow.providers.github.sensors.github.GithubSensor`.
 
 .. exampleinclude:: /../../tests/system/providers/github/example_github.py
     :language: python

--- a/docs/apache-airflow-providers-influxdb/connections/influxdb.rst
+++ b/docs/apache-airflow-providers-influxdb/connections/influxdb.rst
@@ -31,19 +31,17 @@ Extra (required)
     Specify the extra parameters (as json dictionary) that can be used in InfluxDB
     connection.
 
-    The following extras are required:
+    ``token``: (required) `Create token <https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/>`_
+    using the influxdb cli or UI
 
-        - token - Create token - https://docs.influxdata.com/influxdb/cloud/security/tokens/create-token/
-        - org_name - Create organization - https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/org/create/
+    ``org_name``: (required) `Create org <https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/org/create/>`_
+    name using influxdb cli or UI
 
-      * ``token``: Create token using the influxdb cli or UI
-      * ``org_name``: Create org name using influxdb cli or UI
+    Example "extras" field:
 
-      Example "extras" field:
+    .. code-block:: JSON
 
-      .. code-block:: JSON
-
-         {
-            "token": "343434343423234234234343434",
-            "org_name": "Test"
-         }
+      {
+        "token": "343434343423234234234343434",
+        "org_name": "Test"
+      }

--- a/docs/apache-airflow-providers-influxdb/operators/index.rst
+++ b/docs/apache-airflow-providers-influxdb/operators/index.rst
@@ -22,7 +22,7 @@
 InfluxDBOperator
 =================
 
-Use the :class:`~airflow.providers.influxdb.operators.InfluxDBOperator` to execute
+Use the :class:`~airflow.providers.influxdb.operators.influxdb.InfluxDBOperator` to execute
 SQL commands in a `InfluxDB <https://www.influxdata.com/>`__ database.
 
 An example of running the query using the operator:

--- a/docs/apache-airflow-providers-neo4j/connections/neo4j.rst
+++ b/docs/apache-airflow-providers-neo4j/connections/neo4j.rst
@@ -43,12 +43,6 @@ Extra (optional)
     connection.
 
     The following extras are supported:
-
-        - Default - uses bolt scheme(bolt://)
-        - neo4j_scheme - neo4j://
-        - certs_self_signed - neo4j+ssc://
-        - certs_trusted_ca - neo4j+s://
-
       * ``encrypted``: Sets encrypted=True/False for GraphDatabase.driver, Set to ``True`` for Neo4j Aura.
       * ``neo4j_scheme``: Specifies the scheme to ``neo4j://``, default is ``bolt://``
       * ``certs_self_signed``: Sets the URI scheme to support self-signed certificates(``neo4j+ssc://``)

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -53,20 +53,21 @@ Extra (optional)
       The maximum length for this string is 48 and if you exceed this length you will get ORA-24960.
     * ``thick_mode`` (bool) - Specify whether to use python-oracledb in thick mode. Defaults to False.
       If set to True, you must have the Oracle Client libraries installed.
-      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html>` for more info.
+      See `oracledb docs <https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html>`__ for more info.
     * ``thick_mode_lib_dir`` (str) - Path to use to find the Oracle Client libraries when using thick mode.
       If not specified, defaults to the standard way of locating the Oracle Client library on the OS.
-      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#setting-the-oracle-client-library-directory>` for more info.
+      See `oracledb docs <https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#setting-the-oracle-client-library-directory>`__ for more info.
     * ``thick_mode_config_dir`` (str) - Path to use to find the Oracle Client library configuration files when using thick mode.
       If not specified, defaults to the standard way of locating the Oracle Client library configuration files on the OS.
-      See `oracledb docs<https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#optional-oracle-net-configuration-files>` for more info.
+      See `oracledb docs <https://python-oracledb.readthedocs.io/en/latest/user_guide/initialization.html#optional-oracle-net-configuration-files>`__ for more info.
     * ``fetch_decimals`` (bool) - Specify whether numbers should be fetched as ``decimal.Decimal`` values.
-      See `defaults.fetch_decimals<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
+      See `defaults.fetch_decimals <https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>`_ for more info.
     * ``fetch_lobs`` (bool) - Specify whether to fetch strings/bytes for CLOBs or BLOBs instead of locators.
-      See `defaults.fetch_lobs<https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>` for more info.
+      See `defaults.fetch_lobs <https://python-oracledb.readthedocs.io/en/latest/api_manual/defaults.html#defaults.fetch_decimals>`_ for more info.
 
 
-    Connect using `dsn`, Host and `sid`, Host and `service_name`, or only Host `(OracleHook.getconn Documentation) <https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/_modules/airflow/providers/oracle/hooks/oracle.html#OracleHook.get_conn>`_.
+    Connect using ``dsn``, Host and ``sid``, Host and ``service_name``,
+    or only Host `(OracleHook.getconn Documentation) <https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/_modules/airflow/providers/oracle/hooks/oracle.html#OracleHook.get_conn>`_.
 
     For example:
 

--- a/docs/apache-airflow-providers-papermill/operators.rst
+++ b/docs/apache-airflow-providers-papermill/operators.rst
@@ -23,8 +23,8 @@ Papermill
 Apache Airflow supports integration with Papermill_. Papermill is a tool for
 parameterizing and executing Jupyter Notebooks. Perhaps you have a financial
 report that you wish to run with different values on the first or last day of
-a month or at the beginning or end of the year. Using *parameters* in your
-notebook and using the *PapermillOperator* makes this a breeze.
+a month or at the beginning or end of the year. Using **parameters** in your
+notebook and using the :class:`~airflow.providers.papermill.operators.papermill.PapermillOperator` makes this a breeze.
 
 .. _Papermill: https://papermill.readthedocs.io/en/latest/
 
@@ -42,7 +42,7 @@ with input parameters in order to overwrite the values in parameters. If no cell
 tagged with parameters the injected cell will be inserted at the top of the notebook.
 
 Make sure that you save your notebook somewhere so that Airflow can access it. Papermill
-supports S3, GCS, Azure and Local. HDFS is *not* supported.
+supports S3, GCS, Azure and Local. HDFS is **not supported**.
 
 Example DAG
 '''''''''''

--- a/docs/apache-airflow-providers-postgres/connections/postgres.rst
+++ b/docs/apache-airflow-providers-postgres/connections/postgres.rst
@@ -35,8 +35,10 @@ Schema (optional)
 
         If you want to define a default database schema:
 
-        * using ``PostgresOperator`` see :ref:`Passing Server Configuration Parameters into PostgresOperator <howto/operators:postgres>`
-        * using ``PostgresHook`` see `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>_`
+        * using :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator`
+          see :ref:`Passing Server Configuration Parameters into PostgresOperator <howto/operators:postgres>`
+        * using :class:`~airflow.providers.postgres.hooks.postgres.PostgresHook`
+          see `search_path <https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH>`_
 
 Login (required)
     Specify the user name to connect.
@@ -88,7 +90,7 @@ Extra (optional)
       `Amazon Aurora <https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.html>`__
       or `Amazon Redshift <https://docs.aws.amazon.com/redshift/latest/mgmt/generating-user-credentials.html>`__.
     * ``aws_conn_id`` - AWS Connection ID which use for authentication via AWS IAM,
-      if not specified then **aws_conn_id** is used.
+      if not specified then **aws_default** is used.
     * ``redshift`` - Used when AWS IAM database authentication enabled.
       If set to ``True`` than authenticate to Amazon Redshift Cluster, otherwise to Amazon RDS or Amazon Aurora.
     * ``cluster-identifier`` - The unique identifier of the Amazon Redshift Cluster that contains the database

--- a/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
+++ b/docs/apache-airflow-providers-postgres/operators/postgres_operator_howto_guide.rst
@@ -28,8 +28,8 @@ workflow. Airflow is essentially a graph (Directed Acyclic Graph) made up of tas
 
 A task defined or implemented by a operator is a unit of work in your data pipeline.
 
-The purpose of Postgres Operator is to define tasks involving interactions with a PostgreSQL database.
- In ``Airflow-2.0``, the ``PostgresOperator`` class resides at ``airflow.providers.postgres.operators.postgres``.
+The purpose of :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator` is to define tasks involving
+interactions with a PostgreSQL database.
 
 Under the hood, the :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator` delegates its heavy lifting to the :class:`~airflow.providers.postgres.hooks.postgres.PostgresHook`.
 
@@ -183,8 +183,8 @@ Conclusion
 ----------
 
 In this how-to guide we explored the Apache Airflow PostgreOperator. Let's quickly highlight the key takeaways.
-In Airflow-2.0, PostgresOperator class now resides in the ``providers`` package. It is best practice to create subdirectory
-called ``sql`` in your ``dags`` directory where you can store your sql files. This will make your code more elegant and more
-maintainable. And finally, we looked at the different ways you can dynamically pass parameters into our PostgresOperator
+It is best practice to create subdirectory called ``sql`` in your ``dags`` directory where you can store your sql files.
+This will make your code more elegant and more maintainable.
+And finally, we looked at the different ways you can dynamically pass parameters into our PostgresOperator
 tasks using ``parameters`` or ``params`` attribute and how you can control the server configuration parameters by passing
 the ``runtime_parameters`` attribute.

--- a/docs/apache-airflow-providers-slack/index.rst
+++ b/docs/apache-airflow-providers-slack/index.rst
@@ -31,21 +31,14 @@ Content
     :maxdepth: 1
     :caption: Guides
 
-    How-to Guide <operators/slack_operator_howto_guide>
-
-.. toctree::
-    :maxdepth: 1
-    :caption: Guides
-
-    SqlToSlackOperator types <operators/sql_to_slack>
+    Connection Types <connections/index>
+    Operators <operators/index>
     Slack Notifications <notifications/slack_notifier_howto_guide>
-
 
 .. toctree::
     :maxdepth: 1
     :caption: References
 
-    Connection Types <connections/index>
     Python API <_api/airflow/providers/slack/index>
     Example DAGs <https://github.com/apache/airflow/tree/providers-slack/|version|/tests/system/providers/slack>
 

--- a/docs/apache-airflow-providers-slack/operators/index.rst
+++ b/docs/apache-airflow-providers-slack/operators/index.rst
@@ -17,16 +17,12 @@
 
 
 
-Apache Pig Operators
-====================
+Slack Operators
+===============
 
-Apache Pig is a platform for analyzing large data sets that consists of a high-level language
-for expressing data analysis programs, coupled with infrastructure for evaluating these programs.
-Pig programs are amenable to substantial parallelization, which in turns enables them to handle very large data sets.
 
-Use the :class:`~airflow.providers.apache.pig.operators.pig.PigOperator` to execute a pig script.
+.. toctree::
+    :maxdepth: 1
+    :glob:
 
-.. exampleinclude:: /../../tests/system/providers/apache/pig/example_pig.py
-    :language: python
-    :start-after: [START create_pig]
-    :end-before: [END create_pig]
+    *

--- a/docs/apache-airflow-providers-slack/operators/sql_to_slack.rst
+++ b/docs/apache-airflow-providers-slack/operators/sql_to_slack.rst
@@ -18,7 +18,7 @@
 .. _howto/operator:SqlToSlackOperator:
 
 SqlToSlackOperator
-========================
+==================
 
 Use the :class:`~airflow.providers.slack.transfers.sql_to_slack` to post messages to predefined Slack
 channel.

--- a/docs/apache-airflow-providers-snowflake/operators/snowflake_to_slack.rst
+++ b/docs/apache-airflow-providers-snowflake/operators/snowflake_to_slack.rst
@@ -20,8 +20,14 @@
 SnowflakeToSlackOperator
 ========================
 
-Use the :class:`~airflow.providers.snowflake.transfers.snowflake_to_slack.snowflake_to_slack` to post messages to predefined Slack
-channels.
+.. warning::
+    This operator is deprecated.
+    Please use :class:`airflow.providers.slack.transfers.sql_to_slack.SqlToSlackOperator` or
+    :class:`airflow.providers.slack.transfers.sql_to_slack.SqlToSlackApiFileOperator`.
+
+
+Use the :class:`~airflow.providers.snowflake.transfers.snowflake_to_slack.SnowflakeToSlackOperator` to post messages
+to predefined Slack channels.
 
 .. list-table:: Slack Webhook Airflow Connection Metadata
    :widths: 25 25

--- a/docs/apache-airflow-providers-sqlite/operators.rst
+++ b/docs/apache-airflow-providers-sqlite/operators.rst
@@ -22,7 +22,7 @@
 SqliteOperator
 ==============
 
-Use the :class:`~airflow.providers.sqlite.operators.SqliteOperator` to execute
+Use the :class:`~airflow.providers.sqlite.operators.sqlite.SqliteOperator` to execute
 Sqlite commands in a `Sqlite <https://sqlite.org/lang.html>`__ database.
 
 

--- a/docs/apache-airflow-providers-tableau/connections/tableau.rst
+++ b/docs/apache-airflow-providers-tableau/connections/tableau.rst
@@ -69,9 +69,9 @@ Extra (optional)
     The following parameters are all optional:
 
     * ``site_id``: This corresponds to the contentUrl attribute in the Tableau REST API. The ``site_id`` is the portion of
-      the URL that follows the /site/ in the URL. For example, "MarketingTeam" is the ``site_id`` in the following URL
-      MyServer/#/site/MarketingTeam/projects. To specify the default site on Tableau Server, you can use an empty string
-      '' (single quotes, no space). For Tableau Online, you must provide a value for the ``site_id.``
+      the URL that follows the **/site/** in the URL. For example, **MarketingTeam** is the ``site_id`` in the following URL
+      **MyServer/#/site/MarketingTeam/projects**. To specify the default site on Tableau Server, you can use an empty string
+      **''** (single quotes, no space). For Tableau Online, you must provide a value for the ``site_id.``
       This is used for both token and password Authentication.
     * ``token_name``: The personal access token name.
       This is used with token authentication.

--- a/docs/apache-airflow-providers-yandex/operators.rst
+++ b/docs/apache-airflow-providers-yandex/operators.rst
@@ -28,13 +28,6 @@ Apache Hadoop is used for storing and analyzing structured and unstructured big 
 
 Apache Spark is a tool for quick data-processing that can be integrated with Apache Hadoop as well as with other storage systems.
 
-Prerequisite Tasks
-^^^^^^^^^^^^^^^^^^
-#. Install the ``yandexcloud`` package first, like so: ``pip install 'apache-airflow[yandexcloud]'``.
-#. Restart the Airflow webserver and scheduler.
-#. Make sure the Yandex.Cloud connection type has been defined in Airflow. Open the connections list and look for a connection with 'yandexcloud' type.
-#. Fill the required fields in Yandex.Cloud connection.
-
 Using the operators
 ^^^^^^^^^^^^^^^^^^^^^
 See the usage examples in `example DAGs <https://github.com/apache/airflow/tree/providers-yandex/|version|/tests/system/providers/yandex/example_yandexcloud_dataproc.py>`_


### PR DESCRIPTION
Fix some selected things in provider documentation

1. Broken formatting
2. Broken links to classes
3. Non-relevant information

Examples
---

<details>
  <summary>Postgres Provider</summary>
  
**before**

![image](https://user-images.githubusercontent.com/3998685/210852169-45f7957c-820a-4ba7-9eaf-e865aebe26d7.png)
![image](https://user-images.githubusercontent.com/3998685/210852349-f129d7d9-39ac-462e-83cc-9efff556fa91.png)

**after**

![image](https://user-images.githubusercontent.com/3998685/210852501-7707cc09-0f36-4d9d-ac50-7b0cb84900eb.png)
![image](https://user-images.githubusercontent.com/3998685/210852592-4601dc18-003d-40c0-a00a-fe58efc9f913.png)
  
</details>


<details>
  <summary>K8S Provider</summary>

**before**

![image](https://user-images.githubusercontent.com/3998685/210852838-e9462bf5-6b58-4d11-8201-70eb2546266c.png)

**after**

![image](https://user-images.githubusercontent.com/3998685/210853012-075e7095-582e-463d-be54-8b90c94b6d7e.png)
</details>

<details>
  <summary>Slack Provider</summary>

**before**

![image](https://user-images.githubusercontent.com/3998685/210853154-3dd44d94-ef13-40e1-9ad4-21fba0acdd11.png)

**after**

![image](https://user-images.githubusercontent.com/3998685/210853326-bda51de2-62ae-45c1-9dd8-1483b1a2a9c4.png)
</details>

<details>
  <summary>Apache Livy Provider</summary>

**before**

![image](https://user-images.githubusercontent.com/3998685/210854325-91109914-0855-4360-af93-78bc4e806994.png)

**after**

![image](https://user-images.githubusercontent.com/3998685/210854445-2cfb1d9a-30d8-4953-869e-5351a573765a.png)


</details>
